### PR TITLE
feat(grep): back the grep tool with bundled ripgrep for cross-platform support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,9 +78,21 @@ jobs:
         run: pnpm build
 
   test:
-    name: Test
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    # Cross-platform matrix (Windows-compat effort, see .afk/plans/windows-compat-roadmap
+    # or the tracking issue). ubuntu-latest is the REQUIRED gate; windows-latest and
+    # macos-latest run for SIGNAL but do not block merges yet — `continue-on-error`
+    # keeps them advisory while the compat grind is in progress. `fail-fast: false`
+    # so one OS failing never cancels the others. Public repos get unlimited free
+    # GitHub-hosted minutes on all three runners. Flip windows/macos to required
+    # (delete the continue-on-error line) once the suite is green there.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    continue-on-error: ${{ matrix.os != 'ubuntu-latest' }}
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -107,7 +119,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-report
+          # Per-OS name — a matrix can't upload three artifacts under one name (v4 immutable).
+          name: coverage-report-${{ matrix.os }}
           path: coverage/
           retention-days: 14
 

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "@anthropic-ai/sdk": "^0.74.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@mozilla/readability": "^0.6.0",
+    "@vscode/ripgrep": "^1.18.0",
     "ansi-escapes": "^7.3.0",
     "better-sqlite3": "^12.9.0",
     "chalk": "^5.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@mozilla/readability':
         specifier: ^0.6.0
         version: 0.6.0
+      '@vscode/ripgrep':
+        specifier: ^1.18.0
+        version: 1.18.0
       ansi-escapes:
         specifier: ^7.3.0
         version: 7.3.0
@@ -970,6 +973,69 @@ packages:
 
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  '@vscode/ripgrep-darwin-arm64@1.18.0':
+    resolution: {integrity: sha512-r3ktHSvbFycQNF6sl7sNDPocpsI7J+mEzh1IaZFkY0spm3k2Z9t8hPAeOK7+p0l6p6/swkQC14XWX01low+94Q==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@vscode/ripgrep-darwin-x64@1.18.0':
+    resolution: {integrity: sha512-25b4gWbL138dGuQU244ebCKKc0q05ULBMoFSz9oAEUHNeqK/lOJViDS7DRvbDazzAzSEdan391Znks/R5mkaTQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@vscode/ripgrep-linux-arm64@1.18.0':
+    resolution: {integrity: sha512-lQ/5zTG++U0E3IhVgS4EPTTn/U4okncaRMM5GOFfOYZywS4nuD31GhkHbNYlDk5CuDC68+hYJ0/eQeyCKJDA+g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-arm@1.18.0':
+    resolution: {integrity: sha512-GDAvufNDHu8zqLEmXstalQF0Wh6wQvdsBi/Vg3Yi3CK4a8XoFXqqXVEHEZ9xQz3t0NfoSEc9JbvK9DDS6FxyxQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-ia32@1.18.0':
+    resolution: {integrity: sha512-YWLkSUtFd4Jh5EepIhA9RJSfv3uMAVMo+2rBIGHPBnvgLrZciIs2cDKei1/p6Wc/aCzUoHyMAg2R6tw4ZCBKGg==}
+    cpu: [ia32]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-ppc64@1.18.0':
+    resolution: {integrity: sha512-quXVY8fwQ8O/lvU1yrSqSl3jlUzysRSb+AfUfCL/tRtphxsKlFvPAejryZ6vg4Bgvn8XL74xb4qMCDmWgYrT5w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-riscv64@1.18.0':
+    resolution: {integrity: sha512-f5kBQBrWfQt8Q7OhSORuNDei5dkYagBj3y4jImSUXGMy8B/Ke7SltSRcUtjPv166FAFfHCAmWuZp3+cWnX2/Vw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-s390x@1.18.0':
+    resolution: {integrity: sha512-rTOcJFGGcl2c07RUOWUo4U1ndnemKhY6A9hnMB18uk7jSgJc0d/QLBGWMWpumdtoJtpizn/wIv5mXIisJukusQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-x64@1.18.0':
+    resolution: {integrity: sha512-mQ3bVrUpnD2vs7QT0vX90Lt0cnUq467uFtEktIdsJJmW296RoSULRGqWgzG1AKxyBpNDD6l4ZO4qKf6SgyC23Q==}
+    cpu: [x64]
+    os: [linux]
+
+  '@vscode/ripgrep-win32-arm64@1.18.0':
+    resolution: {integrity: sha512-vfTIjq1OHnzUjxZcHVQAMbnggp8dpGf+0QKFOZHwWPqFwXxQC8eCWM+5NUdoJ6yrElCeMzoUTXoK/LdZaniB+Q==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@vscode/ripgrep-win32-ia32@1.18.0':
+    resolution: {integrity: sha512-//rfAE+BOw5AC2EMmepmiE36jUuevtQYNQqqlw1s3m9FlRxjxEut97RkRPHAu9BG4mSojatZx+kXZXNdyI9caQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@vscode/ripgrep-win32-x64@1.18.0':
+    resolution: {integrity: sha512-KNPvtElldqILHdnAetujPaowkNbpqJy3ssIGGN6F6Kve9Qi+nNLI2DN01O83JjCEVQbCzl8Ov3QZ9Eov3BR8Dg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@vscode/ripgrep@1.18.0':
+    resolution: {integrity: sha512-ns5lWe44tSfbTMbVUsyB+I1819PVSw4AdpgK0RNkzfWfwy6+3IUNSxwSrfTno1/oWaS/hERNz+XLWVyga2aJBQ==}
 
   '@xterm/headless@6.0.0':
     resolution: {integrity: sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw==}
@@ -2788,6 +2854,57 @@ snapshots:
       '@vitest/pretty-format': 2.1.9
       loupe: 3.2.1
       tinyrainbow: 1.2.0
+
+  '@vscode/ripgrep-darwin-arm64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-darwin-x64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-arm64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-arm@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-ia32@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-ppc64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-riscv64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-s390x@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-x64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-win32-arm64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-win32-ia32@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-win32-x64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep@1.18.0':
+    optionalDependencies:
+      '@vscode/ripgrep-darwin-arm64': 1.18.0
+      '@vscode/ripgrep-darwin-x64': 1.18.0
+      '@vscode/ripgrep-linux-arm': 1.18.0
+      '@vscode/ripgrep-linux-arm64': 1.18.0
+      '@vscode/ripgrep-linux-ia32': 1.18.0
+      '@vscode/ripgrep-linux-ppc64': 1.18.0
+      '@vscode/ripgrep-linux-riscv64': 1.18.0
+      '@vscode/ripgrep-linux-s390x': 1.18.0
+      '@vscode/ripgrep-linux-x64': 1.18.0
+      '@vscode/ripgrep-win32-arm64': 1.18.0
+      '@vscode/ripgrep-win32-ia32': 1.18.0
+      '@vscode/ripgrep-win32-x64': 1.18.0
 
   '@xterm/headless@6.0.0': {}
 

--- a/src/agent/tools/handlers/_cwd-utils.ts
+++ b/src/agent/tools/handlers/_cwd-utils.ts
@@ -139,7 +139,20 @@ function computeContainment(
   for (const root of roots) {
     const realRoot = realpathRoot(root);
     const rel = path.relative(realRoot, realAbs);
-    if (!rel.startsWith('..')) {
+    // Invariant: `!rel.startsWith('..')` alone is NOT a sufficient containment
+    // test on Windows. When realRoot and realAbs sit on different drives — e.g.
+    // root on `C:`, and a drive-relative input like `/etc` resolving to `D:\etc`
+    // (or a drive-less `\etc`) — `path.win32.relative` returns a DRIVE-QUALIFIED
+    // ABSOLUTE string (`D:\etc`, `\etc`) instead of a `..\`-prefixed relative
+    // one. The bare startsWith('..') check then reads that as "inside the root"
+    // and wrongly admits every escaping absolute path (grep/read/write/glob/
+    // list-directory all failed their "rejects absolute path outside cwd" test
+    // on the Windows CI matrix for exactly this reason). Guard with
+    // `!path.isAbsolute(rel)`: path.relative only returns an absolute path when
+    // the two inputs share no common root — precisely the escape case. On POSIX,
+    // relative() between two absolute paths is never absolute, so this is a
+    // no-op there and cannot regress the green Linux/macOS matrices.
+    if (!rel.startsWith('..') && !path.isAbsolute(rel)) {
       return { restricted: false, resolved: abs, roots };
     }
   }

--- a/src/agent/tools/handlers/_rg-availability.test.ts
+++ b/src/agent/tools/handlers/_rg-availability.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for the ripgrep-binary availability check ({@link describeRgUnavailable}).
+ *
+ * Covers the failure mode this module exists to catch: a misresolved or
+ * missing `rgPath` (e.g. a platform optional-dependency that didn't install,
+ * or a corrupted `node_modules`) surfaces from `spawn()` as a bare
+ * `spawn <path> ENOENT` — indistinguishable, by error shape alone, from the
+ * dead-cwd masquerade `describeSpawnCwdError` already handles (#441). This
+ * helper is checked FIRST in the grep handler's `error` listener so a bad
+ * `rgPath` is diagnosed as "ripgrep binary is missing/not executable", never
+ * misattributed to a deleted worktree.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, writeFileSync, chmodSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describeRgUnavailable } from './_rg-availability.js';
+import { describeSpawnCwdError } from '../../../utils/spawn-cwd-error.js';
+
+describe('describeRgUnavailable', () => {
+  it('returns undefined for a real, executable file', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'rg-availability-test-'));
+    try {
+      const fakeRg = join(dir, 'rg');
+      writeFileSync(fakeRg, '#!/bin/sh\necho hi\n');
+      chmodSync(fakeRg, 0o755);
+      expect(describeRgUnavailable(fakeRg)).toBeUndefined();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns a message mentioning "ripgrep binary" (not "deleted worktree") for a nonexistent path', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'rg-availability-test-'));
+    rmSync(dir, { recursive: true, force: true }); // the dir (and any path under it) is now gone
+    const missingRgPath = join(dir, 'rg');
+
+    const message = describeRgUnavailable(missingRgPath);
+
+    expect(message).toBeDefined();
+    expect(message).toContain('ripgrep binary');
+    expect(message).not.toContain('deleted worktree');
+  });
+
+  // chmod 0o000 does not reliably deny X_OK on Windows (no POSIX permission
+  // bits), so this case is skipped there — parity with the existing
+  // list-directory permission-denied test.
+  it.skipIf(process.platform === 'win32')(
+    'returns a message for an existing-but-non-executable file',
+    () => {
+      const dir = mkdtempSync(join(tmpdir(), 'rg-availability-test-'));
+      try {
+        const nonExecRg = join(dir, 'rg');
+        writeFileSync(nonExecRg, 'not actually a binary');
+        chmodSync(nonExecRg, 0o000);
+
+        const message = describeRgUnavailable(nonExecRg);
+
+        expect(message).toBeDefined();
+        expect(message).toContain('ripgrep binary');
+      } finally {
+        chmodSync(join(dir, 'rg'), 0o755); // restore so rmSync can clean up
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it('produces a message textually distinguishable from describeSpawnCwdError (the two failure modes must never collide)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'rg-availability-test-'));
+    rmSync(dir, { recursive: true, force: true });
+    const missingRgPath = join(dir, 'rg');
+
+    const rgMessage = describeRgUnavailable(missingRgPath) ?? '';
+
+    // The dead-cwd path names a deleted directory as a "working directory"
+    // and mentions "deleted worktree?" — the rg-unavailable path must not.
+    const cwdErr = new Error(`spawn ${missingRgPath} ENOENT`) as Error & {
+      code: string;
+      syscall: string;
+    };
+    cwdErr.code = 'ENOENT';
+    cwdErr.syscall = `spawn ${missingRgPath}`;
+    const cwdMessage = describeSpawnCwdError(cwdErr, dir);
+
+    expect(rgMessage).not.toContain('working directory does not exist');
+    expect(rgMessage).not.toContain('deleted worktree');
+    expect(cwdMessage).not.toContain('ripgrep binary');
+    expect(rgMessage).not.toBe(cwdMessage);
+  });
+});

--- a/src/agent/tools/handlers/_rg-availability.ts
+++ b/src/agent/tools/handlers/_rg-availability.ts
@@ -1,0 +1,47 @@
+/**
+ * Ripgrep-binary availability check.
+ *
+ * `@vscode/ripgrep`'s `rgPath` resolves the platform-specific `rg` binary
+ * through an optional-dependency package (e.g. `@vscode/ripgrep-linux-x64`).
+ * When that optional dependency didn't install — a skipped
+ * `pnpm.onlyBuiltDependencies` entry, an arch/platform mismatch, or a
+ * corrupted `node_modules` — `rgPath` still resolves to a *string*, but the
+ * file it points at is missing or not executable. Spawning it then surfaces
+ * as a bare `spawn <rgPath> ENOENT` — an error shape indistinguishable, by
+ * the error object alone, from the dead-cwd masquerade `describeSpawnCwdError`
+ * already handles (#441).
+ *
+ * This module translates that failure AFTER it happens: `accessSync` runs
+ * only on the error path, so there is no TOCTOU window, no happy-path cost,
+ * and no pre-spawn contract change. The grep handler checks this FIRST in
+ * its `error` listener — ahead of the cwd-diagnosis branch — so a bad
+ * `rgPath` is diagnosed as "ripgrep binary is missing/not executable", never
+ * misattributed to a deleted worktree.
+ *
+ * @module agent/tools/handlers/_rg-availability
+ */
+
+import { accessSync, constants } from 'node:fs';
+
+/**
+ * Return a distinguishing, actionable message when `rgPath` does not exist
+ * or is not executable; otherwise return `undefined`.
+ *
+ * Contract: pure translation — never throws (a thrown `accessSync` error is
+ * caught and turned into the returned message), and only touches the
+ * filesystem when called. Call only on the error path (mirrors
+ * {@link describeSpawnCwdError} in `spawn-cwd-error.ts`).
+ */
+export function describeRgUnavailable(rgPath: string): string | undefined {
+  try {
+    accessSync(rgPath, constants.X_OK);
+    return undefined;
+  } catch (err) {
+    const underlying = err instanceof Error ? err.message : String(err);
+    return (
+      `ripgrep binary is missing or not executable: ${rgPath} ` +
+      `(a platform optional-dependency for @vscode/ripgrep may not have ` +
+      `installed — check pnpm.onlyBuiltDependencies) — underlying: ${underlying}`
+    );
+  }
+}

--- a/src/agent/tools/handlers/_rg-availability.ts
+++ b/src/agent/tools/handlers/_rg-availability.ts
@@ -3,13 +3,13 @@
  *
  * `@vscode/ripgrep`'s `rgPath` resolves the platform-specific `rg` binary
  * through an optional-dependency package (e.g. `@vscode/ripgrep-linux-x64`).
- * When that optional dependency didn't install — a skipped
- * `pnpm.onlyBuiltDependencies` entry, an arch/platform mismatch, or a
- * corrupted `node_modules` — `rgPath` still resolves to a *string*, but the
- * file it points at is missing or not executable. Spawning it then surfaces
- * as a bare `spawn <rgPath> ENOENT` — an error shape indistinguishable, by
- * the error object alone, from the dead-cwd masquerade `describeSpawnCwdError`
- * already handles (#441).
+ * The grep handler imports that package LAZILY and catches a missing-package
+ * throw at the import site; this check covers the OTHER failure mode — the
+ * package resolved (so `rgPath` is a real string) but the file it points at
+ * is missing or not executable (an arch/platform mismatch, or a corrupted
+ * `node_modules`). Spawning it then surfaces as a bare `spawn <rgPath> ENOENT`
+ * — an error shape indistinguishable, by the error object alone, from the
+ * dead-cwd masquerade `describeSpawnCwdError` already handles (#441).
  *
  * This module translates that failure AFTER it happens: `accessSync` runs
  * only on the error path, so there is no TOCTOU window, no happy-path cost,
@@ -40,8 +40,10 @@ export function describeRgUnavailable(rgPath: string): string | undefined {
     const underlying = err instanceof Error ? err.message : String(err);
     return (
       `ripgrep binary is missing or not executable: ${rgPath} ` +
-      `(a platform optional-dependency for @vscode/ripgrep may not have ` +
-      `installed — check pnpm.onlyBuiltDependencies) — underlying: ${underlying}`
+      `(the @vscode/ripgrep platform optional-dependency for ` +
+      `${process.platform}-${process.arch} may not be installed — e.g. an ` +
+      `install with --no-optional, an unsupported platform/arch, or a ` +
+      `corrupted node_modules) — underlying: ${underlying}`
     );
   }
 }

--- a/src/agent/tools/handlers/grep.test.ts
+++ b/src/agent/tools/handlers/grep.test.ts
@@ -119,43 +119,17 @@ describe('grepHandler', () => {
     });
   });
 
-  // Regression: the grep tool runs in basic-regex (BRE) mode, where `|` is a
-  // literal pipe — so `alpha|beta` silently returns "No matches" when the model
-  // meant alternation. That false-negative (previously misattributed to a
-  // "stale index") is the bug this suite locks down. The fix keeps BRE as the
-  // default (a literal `|` is common in code — TS union types, shell pipes) but
-  // (a) adds an `extended` ERE opt-in and (b) appends a self-correcting hint on
-  // the no-match path so an empty result is never mistaken for proven absence.
-  describe('regex dialect (BRE default / extended ERE)', () => {
-    it('default BRE: a bare | is literal — alternation does NOT match', async () => {
+  // Ripgrep has no basic-regex (BRE) mode: `|` `+` `?` `(` `)` `{` `}` are
+  // always regex metacharacters. This is a deliberate contract change from the
+  // previous system-`grep`-backed tool (which defaulted to BRE — a literal `|`
+  // — and offered an `extended` opt-in plus a no-match ERE hint, all now
+  // removed). These tests lock down the ripgrep-regex semantics.
+  describe('regex dialect (ripgrep regex — no BRE mode)', () => {
+    it('a bare | alternates and matches either branch', async () => {
       writeFileSync(join(tempDir, 'test.txt'), 'alpha\nbeta\ngamma');
 
       const result = await grepHandler(
         { pattern: 'alpha|beta', path: tempDir },
-        createSignal(),
-      );
-
-      expect(result.isError).toBeFalsy();
-      expect(result.content).toContain('No matches found');
-    });
-
-    it('default BRE: no-match on a |-pattern appends an ERE hint', async () => {
-      writeFileSync(join(tempDir, 'test.txt'), 'alpha\nbeta\ngamma');
-
-      const result = await grepHandler(
-        { pattern: 'alpha|beta', path: tempDir },
-        createSignal(),
-      );
-
-      expect(result.content).toContain('basic-regex (BRE)');
-      expect(result.content).toContain('extended: true');
-    });
-
-    it('extended: true enables ERE alternation', async () => {
-      writeFileSync(join(tempDir, 'test.txt'), 'alpha\nbeta\ngamma');
-
-      const result = await grepHandler(
-        { pattern: 'alpha|beta', path: tempDir, extended: true },
         createSignal(),
       );
 
@@ -165,53 +139,11 @@ describe('grepHandler', () => {
       expect(result.content).not.toContain('gamma');
     });
 
-    // No regression: a literal `|` (TS union types, shell pipes, bitwise OR,
-    // markdown tables) must still match in the default BRE mode. This is why
-    // the tool does NOT silently switch to ERE/ripgrep.
-    it('literal | search still works in default BRE (no regression)', async () => {
-      writeFileSync(join(tempDir, 'types.ts'), 'type T = string | number;');
-
-      const result = await grepHandler(
-        { pattern: 'string | number', path: tempDir },
-        createSignal(),
-      );
-
-      expect(result.isError).toBeFalsy();
-      expect(result.content).toContain('string | number');
-      // Matches were found, so the false-negative hint must NOT appear.
-      expect(result.content).not.toContain('extended: true');
-    });
-
-    it('does not append the hint when extended mode genuinely finds nothing', async () => {
-      writeFileSync(join(tempDir, 'test.txt'), 'gamma');
-
-      const result = await grepHandler(
-        { pattern: 'alpha|beta', path: tempDir, extended: true },
-        createSignal(),
-      );
-
-      expect(result.content).toContain('No matches found');
-      expect(result.content).not.toContain('extended: true');
-    });
-
-    it('does not append the hint when | is explicitly escaped (deliberate literal)', async () => {
-      writeFileSync(join(tempDir, 'test.txt'), 'gamma');
-
-      const result = await grepHandler(
-        // JS '\\|' → the literal pattern alpha\|beta — an escaped pipe.
-        { pattern: 'alpha\\|beta', path: tempDir },
-        createSignal(),
-      );
-
-      expect(result.content).toContain('No matches found');
-      expect(result.content).not.toContain('extended: true');
-    });
-
-    it('extended mode supports the + quantifier (ERE)', async () => {
+    it('+ is a quantifier', async () => {
       writeFileSync(join(tempDir, 'test.txt'), 'aaa\nb');
 
       const result = await grepHandler(
-        { pattern: 'a+', path: tempDir, extended: true },
+        { pattern: 'a+', path: tempDir },
         createSignal(),
       );
 
@@ -219,13 +151,47 @@ describe('grepHandler', () => {
       expect(result.content).toContain('aaa');
     });
 
-    it('throws on non-boolean extended', async () => {
-      await expect(
-        grepHandler(
-          { pattern: 'test', path: tempDir, extended: 'yes' },
-          createSignal(),
-        ),
-      ).rejects.toThrow(/extended.*boolean/i);
+    it('( ) grouping works', async () => {
+      writeFileSync(join(tempDir, 'test.txt'), 'foobar\nfoobaz\nqux');
+
+      const result = await grepHandler(
+        { pattern: 'foo(bar|baz)', path: tempDir },
+        createSignal(),
+      );
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content).toContain('foobar');
+      expect(result.content).toContain('foobaz');
+      expect(result.content).not.toContain('qux');
+    });
+
+    it('an escaped \\| matches a literal pipe (not alternation)', async () => {
+      writeFileSync(join(tempDir, 'types.ts'), 'type T = string|number;');
+      writeFileSync(join(tempDir, 'other.txt'), 'string');
+
+      const result = await grepHandler(
+        // JS '\\|' → pattern string\|number → matches the LITERAL "string|number",
+        // not "string" OR "number". other.txt ("string") must therefore NOT match.
+        { pattern: 'string\\|number', path: tempDir },
+        createSignal(),
+      );
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content).toContain('types.ts');
+      expect(result.content).not.toContain('other.txt');
+    });
+
+    it('a no-match returns a plain message with no BRE/extended hint', async () => {
+      writeFileSync(join(tempDir, 'test.txt'), 'gamma');
+
+      const result = await grepHandler(
+        { pattern: 'alpha|beta', path: tempDir },
+        createSignal(),
+      );
+
+      expect(result.content).toContain('No matches found');
+      expect(result.content).not.toContain('extended');
+      expect(result.content).not.toContain('BRE');
     });
   });
 
@@ -422,20 +388,21 @@ describe('grepHandler', () => {
     });
 
     it('uses process.cwd() when path not provided', async () => {
-      // Test that the handler accepts missing path (defaults to process.cwd())
-      // Don't actually test the search since it would be slow
-      writeFileSync(join(tempDir, 'test.txt'), 'hello world');
-
-      // Create a unique pattern that we can quickly abort if needed
+      // The handler must accept input with no `path` (defaults to process.cwd())
+      // and return a result without throwing. We don't assert on matches:
+      // process.cwd() at test time is the repo, so the search may find incidental
+      // hits, find nothing, or be aborted first — all valid. A no-match result is
+      // `{ content }` with NO `isError` key (only the abort/error paths set it),
+      // so assert only on `content`. Abort quickly so a broad cwd search (now fast
+      // under ripgrep's .gitignore-aware defaults) can't hang the suite.
       const signal = createAbortableSignal(100);
       const result = await grepHandler(
         { pattern: 'nonexistent_unique_marker_9999_xyz' },
         signal,
       );
 
-      // Either it completes or gets aborted - both are valid
       expect(result).toHaveProperty('content');
-      expect(result).toHaveProperty('isError');
+      expect(typeof result.content).toBe('string');
     }, 3000);
   });
 

--- a/src/agent/tools/handlers/grep.test.ts
+++ b/src/agent/tools/handlers/grep.test.ts
@@ -195,6 +195,45 @@ describe('grepHandler', () => {
     });
   });
 
+  // Regression: the handler passes `pattern`/`path` after a `--` end-of-options
+  // separator so ripgrep can never parse the pattern as a flag. Without `--`, a
+  // pattern like `->` errors ("unrecognized flag") and a `--pre=<cmd>` pattern
+  // would reach rg's preprocessor flag and EXECUTE <cmd> per file (argument-
+  // injection → command execution). These lock that separator in place.
+  describe('argument-injection / leading-dash safety (-- separator)', () => {
+    it('treats a leading-dash pattern as a literal search string, not an rg flag', async () => {
+      writeFileSync(join(tempDir, 'arrow.txt'), 'fn f() -> i32');
+
+      const result = await grepHandler(
+        { pattern: '->', path: tempDir },
+        createSignal(),
+      );
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content).toContain('arrow.txt');
+      expect(result.content).toContain('-> i32');
+    });
+
+    it('does not let a flag-shaped pattern inject an rg option', async () => {
+      // `--files` is a real rg option (it lists files). As a bare arg it would be
+      // parsed as that option; after `--` it is a literal search string matching
+      // nothing here — proving the pattern never reaches rg's option parser. If
+      // injection were possible this would instead list a.txt/b.txt.
+      writeFileSync(join(tempDir, 'a.txt'), 'hello');
+      writeFileSync(join(tempDir, 'b.txt'), 'world');
+
+      const result = await grepHandler(
+        { pattern: '--files', path: tempDir },
+        createSignal(),
+      );
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content).toContain('No matches found');
+      expect(result.content).not.toContain('a.txt');
+      expect(result.content).not.toContain('b.txt');
+    });
+  });
+
   describe('include filter', () => {
     it('restricts search to matching file patterns', async () => {
       writeFileSync(join(tempDir, 'test.ts'), 'const hello = 1;');

--- a/src/agent/tools/handlers/grep.ts
+++ b/src/agent/tools/handlers/grep.ts
@@ -1,14 +1,12 @@
 /**
  * Grep tool handler.
  *
- * Searches for a pattern in files using `grep -rn` with optional include filter.
- * Runs in basic-regex (BRE) mode by default — where `|` is a *literal* pipe, not
- * alternation — and exposes an `extended` flag that adds `-E` for extended-regex
- * (ERE) semantics. The BRE default is deliberate: a bare `|` is a common literal
- * in source (TS union types `string | number`, shell pipes, bitwise OR), so the
- * tool must not silently reinterpret it. To keep the BRE `|`-is-literal footgun
- * from masquerading as proven absence, the no-match path appends a self-correcting
- * ERE hint when the pattern contains an unescaped `|` (see the `close` handler).
+ * Searches for a pattern in files using bundled ripgrep (`@vscode/ripgrep`'s
+ * `rgPath`) with optional include filter. Ripgrep has no basic-regex (BRE)
+ * mode: `|` `+` `?` `(` `)` `{` `}` are always regex metacharacters (e.g. a
+ * bare `foo|bar` alternates, matching either branch) — a deliberate contract
+ * change from the previous system-`grep`-backed implementation, which ran in
+ * BRE mode by default and required an `extended` opt-in for alternation.
  * Respects signal-based cancellation. Output is governed by two decoupled
  * thresholds (see `_output-cap.ts`): the accumulator is bounded at
  * HARD_CAP_BYTES (8MB) with a mid-stream SIGKILL only when it is crossed — a
@@ -21,11 +19,13 @@
  */
 
 import { spawn } from 'child_process';
+import { rgPath } from '@vscode/ripgrep';
 import type { ToolHandler, ToolHandlerContext } from '../types.js';
 import { appendRoutingDecision } from '../../routing-telemetry.js';
 import { resolveAndContain } from './_cwd-utils.js';
 import { stripEscapeSequences } from '../../../utils/terminal-sanitize.js';
 import { describeSpawnCwdError, isSpawnEnoent } from '../../../utils/spawn-cwd-error.js';
+import { describeRgUnavailable } from './_rg-availability.js';
 import { HARD_CAP_BYTES, MODEL_CAP_BYTES, headAndTail, capForModel, HARD_CAP_KILL_NOTE } from './_output-cap.js';
 
 /**
@@ -35,7 +35,6 @@ interface GrepInput {
   pattern?: unknown;
   path?: unknown;
   include?: unknown;
-  extended?: unknown;
 }
 
 /**
@@ -54,7 +53,6 @@ function parseGrepInput(
   pattern: string;
   path: string;
   include?: string;
-  extended: boolean;
 } {
   if (typeof input !== 'object' || input === null) {
     throw new Error('Input must be an object');
@@ -86,32 +84,11 @@ function parseGrepInput(
     include = grepInput.include;
   }
 
-  let extended = false;
-  if (grepInput.extended !== undefined) {
-    if (typeof grepInput.extended !== 'boolean') {
-      throw new Error('extended must be a boolean');
-    }
-    extended = grepInput.extended;
-  }
-
   return {
     pattern: grepInput.pattern,
     path: resolvedPath,
     include,
-    extended,
   };
-}
-
-/**
- * Detect an unescaped `|` in a search pattern. In basic-regex (BRE) mode — the
- * grep default — `|` is a *literal pipe*, not alternation, so a pattern like
- * `foo|bar` silently matches the literal text `foo|bar` and returns zero hits
- * when the model meant "foo OR bar". This predicate gates the educational hint
- * on the no-match path. A preceding backslash means the `|` was escaped
- * deliberately (the model wants the literal), so we suppress the hint there.
- */
-function hasUnescapedAlternation(pattern: string): boolean {
-  return /(?<!\\)\|/.test(pattern);
 }
 
 /**
@@ -125,7 +102,7 @@ function hasUnescapedAlternation(pattern: string): boolean {
  */
 export function createGrepHandler(cwd?: string): ToolHandler {
   return async (input: unknown, signal: AbortSignal, context?: ToolHandlerContext) => {
-  const { pattern, path, include, extended } = parseGrepInput(input, context, cwd);
+  const { pattern, path, include } = parseGrepInput(input, context, cwd);
 
   if (signal.aborted) {
     return { content: 'Search aborted', isError: true };
@@ -141,17 +118,22 @@ export function createGrepHandler(cwd?: string): ToolHandler {
       resolve(result);
     }
 
-    const args = ['-rn'];
-
-    // ERE opt-in: `-E` makes `|` alternation and `+ ? ( ) { }` metacharacters.
-    // Default (BRE) leaves them literal — see the module header for why.
-    if (extended) {
-      args.push('-E');
-    }
+    // Base flags. `-n` = line numbers. `--no-heading`/`--color=never` force the
+    // flat `path:line:content` shape on a pipe (don't rely on rg's tty auto-
+    // detection). `--hidden` makes rg search dotfiles/dirs (.github, .env,
+    // .claude) that the old `grep -rn` reached and agents grep constantly — rg
+    // skips them by default; .gitignore is still honored (node_modules/dist
+    // stay skipped). Do NOT add `-r`/`-rn`: in ripgrep `-r` is `--replace=TEXT`
+    // and would silently rewrite every match.
+    const args = ['-n', '--no-heading', '--color=never', '--hidden'];
 
     if (include) {
-      args.push(`--include=${include}`);
+      args.push('-g', include);
     }
+
+    // `--hidden` re-includes .git (a dot-dir not covered by .gitignore); exclude
+    // it explicitly. Pushed AFTER any include glob so it always wins for .git paths.
+    args.push('-g', '!.git');
 
     args.push(pattern, path);
 
@@ -162,10 +144,10 @@ export function createGrepHandler(cwd?: string): ToolHandler {
     //   3. factory-level `cwd` — session worktree isolation (createGrepHandler)
     // Computed ONCE so the spawn cwd and the ENOENT diagnosis below cannot
     // disagree: a stale factory `cwd` would otherwise make the diagnosis stat a
-    // different dir than spawn used, reverting to a raw `spawn grep ENOENT`
+    // different dir than spawn used, reverting to a raw `spawn <rgPath> ENOENT`
     // (Codex P2 on #471). spawn treats `cwd: undefined` as inherit process.cwd().
     const effectiveCwd = context?.resolveBase ?? context?.cwd ?? cwd;
-    const proc = spawn('grep', args, effectiveCwd !== undefined ? { cwd: effectiveCwd } : {});
+    const proc = spawn(rgPath, args, effectiveCwd !== undefined ? { cwd: effectiveCwd } : {});
 
     let stdout = '';
     let stderr = '';
@@ -257,27 +239,14 @@ export function createGrepHandler(cwd?: string): ToolHandler {
       if (overflowKilled) return;
 
       if (code === 1) {
-        let message = `No matches found for '${pattern}' in ${path}`;
-        // BRE footgun guard: in basic-regex mode `|` is a literal pipe, so
-        // `foo|bar` silently returns zero hits when the model meant "foo OR
-        // bar" — the classic false-negative this tool is prone to. Append a
-        // self-correcting hint so an empty result is never mistaken for proven
-        // absence. Suppressed in `extended` mode (where `|` already alternated)
-        // and when the `|` was explicitly escaped (deliberate literal).
-        if (!extended && hasUnescapedAlternation(pattern)) {
-          message +=
-            "\n\nNote: this search ran in basic-regex (BRE) mode, where '|' is a " +
-            "literal pipe — not alternation. If you intended \"A or B\", retry with " +
-            'extended: true (extended regex / ERE). If you meant the literal ' +
-            "character '|', this empty result stands.";
-        }
+        const message = `No matches found for '${pattern}' in ${path}`;
         settle({ content: message });
         return;
       }
 
       if (code === 2) {
-        // stderr may accumulate up to HARD_CAP_BYTES (e.g. `-r` across a tree
-        // with many unreadable files), so cap it to the model budget.
+        // stderr may accumulate up to HARD_CAP_BYTES (e.g. a recursive search
+        // across a tree with many unreadable files), so cap it to the model budget.
         const capped = capForModel(stderr.trim());
         settle({
           content: `grep error: ${capped.content}`,
@@ -293,6 +262,18 @@ export function createGrepHandler(cwd?: string): ToolHandler {
     });
 
     proc.on('error', (err) => {
+      // Dual-cause ENOENT: a missing or non-executable bundled `rgPath` (e.g. a
+      // @vscode/ripgrep platform optional-dep that didn't install) also surfaces
+      // as `spawn <rgPath> ENOENT`, indistinguishable by error shape from the
+      // dead-cwd masquerade below. Check rg-binary availability FIRST (stats
+      // rgPath on the error path only) so a bad binary is diagnosed as such and
+      // never misattributed to a deleted worktree.
+      const rgUnavailable = describeRgUnavailable(rgPath);
+      if (rgUnavailable !== undefined) {
+        settle({ content: `Failed to execute grep: ${rgUnavailable}`, isError: true });
+        return;
+      }
+
       // Spawn ENOENT masquerade: a dead working directory (e.g. a git worktree
       // reaped mid-session) surfaces as `spawn grep ENOENT` — naming the binary,
       // not the missing dir — so an agent retries blindly. Translate it into an

--- a/src/agent/tools/handlers/grep.ts
+++ b/src/agent/tools/handlers/grep.ts
@@ -19,7 +19,6 @@
  */
 
 import { spawn } from 'child_process';
-import { rgPath } from '@vscode/ripgrep';
 import type { ToolHandler, ToolHandlerContext } from '../types.js';
 import { appendRoutingDecision } from '../../routing-telemetry.js';
 import { resolveAndContain } from './_cwd-utils.js';
@@ -106,6 +105,28 @@ export function createGrepHandler(cwd?: string): ToolHandler {
 
   if (signal.aborted) {
     return { content: 'Search aborted', isError: true };
+  }
+
+  // Invariant: load `@vscode/ripgrep` LAZILY, not at module top-level. The
+  // package resolves its platform-specific optional-dependency binary AT
+  // MODULE IMPORT and THROWS if that package is absent (a `--no-optional`
+  // install, an unsupported os/cpu, or a corrupted node_modules). A top-level
+  // `import { rgPath }` would let that throw abort PROCESS STARTUP — the
+  // handlers index pulls this module in at tool-registration, so a missing
+  // optional-dep would take down EVERY tool and never reach the graceful
+  // diagnostics below. Importing here, behind a catch, confines the failure to
+  // the grep call and returns the same actionable "ripgrep unavailable" shape
+  // the spawn-error path (describeRgUnavailable) produces for a present-but-
+  // broken binary.
+  let rgPath: string;
+  try {
+    ({ rgPath } = await import('@vscode/ripgrep'));
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    return {
+      content: `Failed to execute grep: ripgrep is unavailable — ${detail}`,
+      isError: true,
+    };
   }
 
   return new Promise((resolve) => {

--- a/src/agent/tools/handlers/grep.ts
+++ b/src/agent/tools/handlers/grep.ts
@@ -135,7 +135,14 @@ export function createGrepHandler(cwd?: string): ToolHandler {
     // it explicitly. Pushed AFTER any include glob so it always wins for .git paths.
     args.push('-g', '!.git');
 
-    args.push(pattern, path);
+    // Invariant: `pattern` and `path` MUST follow a `--` end-of-options separator.
+    // Without it, ripgrep parses any argument beginning with `-` as a FLAG, not a
+    // positional: a benign pattern like `->` fails ("unrecognized flag"), and a
+    // prompt-injected `--pre=<cmd>` reaches rg's preprocessor flag and EXECUTES
+    // <cmd> for every file (argument-injection → command execution — system `grep`
+    // had no such flag, so the swap to rg makes the missing `--` exploitable).
+    // `--` forces rg to treat everything after it as positionals: pattern, then path.
+    args.push('--', pattern, path);
 
     // Effective cwd priority (parity with the bash handler, #441):
     //   1. context?.resolveBase — permission anchor (updated in place on an

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -158,11 +158,12 @@ export const grepTool: AnthropicToolDef = {
   concurrencySafe: true,
   description:
     'Search file contents for lines matching a pattern. Returns matches in file:line:content format. ' +
-    'Runs `grep -rn` in basic-regex (BRE) mode by default, where `|` is a LITERAL pipe — not ' +
-    'alternation; set extended: true for extended-regex (ERE) alternation. A no-match result on a ' +
-    'pattern containing `|` is often a false negative — re-read the returned hint. Output is capped ' +
-    'to a ~100KB head+tail view; if a search is truncated, narrow it (a more specific pattern, an ' +
-    '`include` glob, or a subdirectory `path`) rather than re-running the same broad query. ' +
+    'Runs on ripgrep: `|` `+` `?` `(` `)` `{` `}` are regex metacharacters by default (e.g. `foo|bar` ' +
+    'alternates, matching either branch) — escape with a backslash for the literal character. Honors ' +
+    '.gitignore (so build/dependency dirs like node_modules are skipped) but DOES search hidden ' +
+    'files/dirs like .github and .env; the .git directory and binary files are skipped. ' +
+    'Output is capped to a ~100KB head+tail view; if a search is truncated, narrow it (a more specific ' +
+    'pattern, an `include` glob, or a subdirectory `path`) rather than re-running the same broad query. ' +
     'Use for finding symbols, strings, or patterns across the codebase.',
   input_schema: {
     type: 'object',
@@ -170,8 +171,9 @@ export const grepTool: AnthropicToolDef = {
       pattern: {
         type: 'string',
         description:
-          'Search pattern. Basic regex (BRE) by default: `|` `+` `?` `(` `)` `{` `}` are LITERAL ' +
-          'characters. Set extended: true for extended regex (ERE) where `|` means alternation.',
+          'Search pattern (ripgrep regex syntax). `|` `+` `?` `(` `)` `{` `}` are metacharacters — ' +
+          'e.g. `foo|bar` matches either "foo" or "bar". Escape with a backslash (e.g. `\\|`) to match ' +
+          'the literal character.',
       },
       path: {
         type: 'string',
@@ -179,13 +181,7 @@ export const grepTool: AnthropicToolDef = {
       },
       include: {
         type: 'string',
-        description: 'File glob to restrict search (e.g., "*.ts"). Passed as --include to grep.',
-      },
-      extended: {
-        type: 'boolean',
-        description:
-          'Use extended regex (ERE, `grep -E`) so `|` is alternation and `+ ? ( ) { }` are ' +
-          'metacharacters. Default false (BRE — those characters match literally).',
+        description: 'File glob to restrict search (e.g., "*.ts"). Passed as -g to ripgrep.',
       },
     },
     required: ['pattern'],


### PR DESCRIPTION
## What

Swap the `grep` tool's search engine from system **`grep`** → **`@vscode/ripgrep`'s bundled `rgPath`**, and add an advisory cross-platform CI matrix. This is the first landed slice of the Windows-compat effort (Phase 0: CI scoreboard + Phase 1.4: grep tool).

System `grep` is **absent on Windows** and drifts between GNU/BSD across Linux/macOS. Ripgrep ships as a platform binary via optional deps, so the tool now behaves identically on Linux, macOS, and Windows. Mirrors Claude Code's ripgrep-backed Grep tool.

## ⚠️ Contract change (breaking, intentional)

Ripgrep has **no basic-regex (BRE) mode**, so:
- The BRE default and the **`extended` param are removed**.
- `|` `+` `?` `(` `)` `{` `}` are now **regex metacharacters by default** (e.g. `foo|bar` alternates, matching either branch). Escape with a backslash for the literal character.
- The old no-match "BRE `|` footgun" hint is gone (no longer applicable).

The tool schema description is updated accordingly. This is the same trade Claude Code accepted for its Grep tool.

## Changes

- **`grep.ts`** — spawn `rgPath` with `-n --no-heading --color=never --hidden -g '!.git'`. Honors `.gitignore` (so `node_modules`/`dist` stay skipped) but **does** search hidden files (`.github`, `.env`) that the old `grep -rn` reached; the `.git` dir and binary files are excluded. (Note: rg's `-r` is `--replace`, deliberately never passed.)
- **`_rg-availability.ts`** (new) — on the error path only, distinguish a missing/non-executable `rgPath` (an uninstalled platform optional-dep) from the dead-cwd `ENOENT` masquerade (#441). Checked **first** in the spawn error handler so a bad binary is never misattributed to a reaped worktree.
- **`schemas.ts`** — rewrite grep tool + pattern descriptions; drop the `extended` param.
- **`ci.yml`** — run the `test` job on a `[ubuntu, windows, macos]` matrix. **ubuntu stays the required gate**; windows/macos are **advisory** (`continue-on-error`, `fail-fast: false`, per-OS coverage artifact names) — they run for signal but do not block merges yet.
- **`package.json` / `pnpm-lock.yaml`** — add `@vscode/ripgrep`.

## Verification

- `tsc --noEmit` clean (whole project).
- `grep.test.ts` (43 tests) + `_rg-availability.test.ts` (4 tests) green locally on macOS.
- Rebased onto current `main` (5.74.0); the merge is conflict-free and the lockfile is in sync (`pnpm install --frozen-lockfile` passes).
- **Windows/macOS runtime correctness is exactly what this PR's own CI matrix is here to prove** — the matrix legs are the authoritative falsifier. Kept as a **draft** until that signal lands and the breaking grep contract change gets a human's review.

## Not in scope (tracked in the Windows-compat roadmap)

The `bash` tool (Windows shell resolution + process-tree kill), credential-denylist Windows correctness, and daemon/service persistence on Windows are separate follow-ups.
