### PR TITLE
fix(subagent): coerce Claude-family child models under openai-compatible routing (#652)

### DIFF
--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -781,8 +781,10 @@ export class OpenAICompatibleQuery implements ProviderQuery {
           error: new Error(
             `Model "${this.currentModel}" can't run on a ChatGPT subscription — the ChatGPT/Codex ` +
               `backend only supports OpenAI gpt-5.x models. This usually means a subagent or skill ` +
-              `requested a Claude model. Pass a gpt-5.x model to it (e.g. model: "gpt-5.5"), or run ` +
-              `it on a provider configured with the matching API key.`,
+              `requested a Claude model. Pass a gpt-5.x model to it (e.g. model: "gpt-5.5"); for an ` +
+              `auto-dispatched agent you can't pass a model to (e.g. git-investigator), set ` +
+              `AFK_DEFAULT_SUBAGENT_MODEL to a gpt-5.x id. Or run it on a provider configured with ` +
+              `the matching API key.`,
           ),
         };
         return null;

--- a/src/agent/subagent.test.ts
+++ b/src/agent/subagent.test.ts
@@ -485,6 +485,79 @@ describe('SubagentManager', () => {
     });
   });
 
+  describe('cross-provider child model coercion (#652)', () => {
+    // providerForModel reads AFK_PROVIDER transitively; scrub to a known
+    // baseline per-test and restore the ambient value after.
+    const savedProvider = process.env['AFK_PROVIDER'];
+    beforeEach(() => {
+      delete process.env['AFK_PROVIDER'];
+    });
+    afterEach(() => {
+      if (savedProvider === undefined) delete process.env['AFK_PROVIDER'];
+      else process.env['AFK_PROVIDER'] = savedProvider;
+    });
+
+    it('coerces a Claude-family child onto the parent gpt model under AFK_PROVIDER=openai-compatible', async () => {
+      shared.lastConfig = null;
+      process.env['AFK_PROVIDER'] = 'openai-compatible';
+      const warn = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+      let warned = '';
+      try {
+        const mgr = new SubagentManager({ parentModel: 'gpt-5.5' });
+        await mgr.forkSubagent({
+          parent: { sessionId: 'p' },
+          config: { model: 'sonnet' },
+          idPrefix: 'coerce-check',
+        });
+        // Capture BEFORE mockRestore (restore resets mock.calls).
+        warned = warn.mock.calls.map((c) => String(c[0])).join('');
+      } finally {
+        warn.mockRestore();
+      }
+      // The child that would have hard-errored on the ChatGPT backend now runs
+      // the parent's gpt model instead.
+      expect((shared.lastConfig as Record<string, unknown>)['model']).toBe('gpt-5.5');
+      // The override is observable (not silent).
+      expect(warned).toContain('sonnet');
+      expect(warned).toContain('gpt-5.5');
+    });
+
+    it('does not coerce in a normal Anthropic session (no force)', async () => {
+      shared.lastConfig = null;
+      const mgr = new SubagentManager({ parentModel: 'gpt-5.5' });
+      await mgr.forkSubagent({
+        parent: { sessionId: 'p' },
+        config: { model: 'sonnet' },
+        idPrefix: 'no-coerce-check',
+      });
+      expect((shared.lastConfig as Record<string, unknown>)['model']).toBe('sonnet');
+    });
+
+    it('leaves a gpt child unchanged under force', async () => {
+      shared.lastConfig = null;
+      process.env['AFK_PROVIDER'] = 'openai-compatible';
+      const mgr = new SubagentManager({ parentModel: 'gpt-5.5' });
+      await mgr.forkSubagent({
+        parent: { sessionId: 'p' },
+        config: { model: 'gpt-5.5' },
+        idPrefix: 'gpt-child',
+      });
+      expect((shared.lastConfig as Record<string, unknown>)['model']).toBe('gpt-5.5');
+    });
+
+    it('does not coerce when the manager has no parentModel (no substitute)', async () => {
+      shared.lastConfig = null;
+      process.env['AFK_PROVIDER'] = 'openai-compatible';
+      const mgr = new SubagentManager();
+      await mgr.forkSubagent({
+        parent: { sessionId: 'p' },
+        config: { model: 'sonnet' },
+        idPrefix: 'no-parent-model',
+      });
+      expect((shared.lastConfig as Record<string, unknown>)['model']).toBe('sonnet');
+    });
+  });
+
   it('lets explicit child baseUrl override the manager default', async () => {
     shared.lastConfig = null;
     const mgr = new SubagentManager({ baseUrl: 'http://127.0.0.1:8080' });

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -48,6 +48,7 @@ import {
   SubagentHandleImpl,
   type SubagentHandle,
 } from './subagent/handle.js';
+import { coerceCrossProviderChildModel } from './subagent/child-model-fallback.js';
 import type { SubagentStatus, SubagentResult, SubagentTrace } from './subagent/result.js';
 
 // Re-export types for public API
@@ -414,6 +415,11 @@ export class SubagentManager {
   // the both-direction cross-provider credential gate in forkSubagent —
   // avoids guessing the parent's provider from the key's shape at fork time.
   private readonly parentProvider: BundledProviderName | undefined;
+  // Parent session model string, retained for the #652 cross-provider child
+  // model coercion in forkSubagent: coerceCrossProviderChildModel needs the
+  // concrete parent model as the OpenAI/gpt substitute target, not just the
+  // derived parentProvider above.
+  private readonly parentModel: string | undefined;
   // Mutable so AgentSession.setCwd can re-anchor forks after a born-named
   // `afk -w` worktree is created mid-session. Read at fork time (forkSubagent),
   // so updating it makes every subsequent fork inherit the new worktree cwd.
@@ -446,6 +452,7 @@ export class SubagentManager {
     this.parentBaseUrl = options.baseUrl;
     this.parentProvider =
       options.parentModel !== undefined ? providerForModel(options.parentModel) : undefined;
+    this.parentModel = options.parentModel;
     this.parentCwd = options.cwd;
     this.parentReadRoots = options.parentReadRoots;
     this.parentTraceWriter = options.traceWriter;
@@ -746,8 +753,39 @@ export class SubagentManager {
       composedWriteRoots = [...new Set([...base, ...options.config.writeRoots])];
     }
 
+    // #652: a Claude-family child model that this session's routing sends to the
+    // openai-compatible provider (a global AFK_PROVIDER=openai-compatible force
+    // or a chatgpt-oauth/openai slot) cannot run — the OpenAI/ChatGPT backend
+    // serves no Claude model and hard-errors. Substitute the parent's own model
+    // (the OpenAI/gpt target the session already uses) so the child runs instead
+    // of dying. Applied HERE because forkSubagent is the single choke point
+    // through which the agent-tool, skill, and compose paths all create their
+    // child session (see the subagentToolOutputCapBytes note below), and it must
+    // be threaded into EVERY model-derived field of childConfig — most critically
+    // the read-only phase provider (buildPhaseRestrictedProvider re-derives the
+    // provider from the model), or a read-only fork would re-trigger the bug.
+    const childModelCoercion = coerceCrossProviderChildModel(
+      options.config.model,
+      this.parentModel,
+    );
+    // `?? options.config.model` keeps the type as the required AgentModelInput:
+    // the helper only returns undefined when given an undefined model, and
+    // options.config.model is always defined here.
+    const effectiveChildModel = childModelCoercion.model ?? options.config.model;
+    if (childModelCoercion.coercedFrom !== undefined) {
+      process.stderr.write(
+        `[afk] subagent: child model "${childModelCoercion.coercedFrom}" cannot run on this ` +
+          `session's OpenAI/ChatGPT backend — running it as "${effectiveChildModel ?? ''}" instead ` +
+          `(set AFK_DEFAULT_SUBAGENT_MODEL to choose a different one).\n`,
+      );
+    }
+
     const childConfig: AgentConfig = {
       ...options.config,
+      // Effective model after the cross-provider coercion above (#652). Placed
+      // AFTER the spread so it overrides options.config.model; a no-op on the
+      // common path where nothing was coerced.
+      model: effectiveChildModel,
       resume,
       forkSession: resume ? true : options.config.forkSession,
       // Witness attribution: stamp THIS fork's own id onto its config so the
@@ -792,7 +830,7 @@ export class SubagentManager {
       // keys and same-provider inheritance are preserved; only cross-provider
       // combinations resolve to undefined.
       apiKey: applyManagerApiKeyFallback({
-        childModel: options.config.model,
+        childModel: effectiveChildModel,
         configApiKey: options.config.apiKey,
         parentApiKey: this.parentApiKey,
         parentProvider: this.parentProvider,
@@ -802,7 +840,7 @@ export class SubagentManager {
       // parent's Anthropic base URL. Explicit caller values still win.
       baseUrl:
         options.config.baseUrl ??
-        (providerForModel(options.config.model) === 'openai-compatible'
+        (providerForModel(effectiveChildModel) === 'openai-compatible'
           ? undefined
           : this.parentBaseUrl),
       // External constraint: a forked sub-agent has no human relationship of its
@@ -909,7 +947,7 @@ export class SubagentManager {
       // mutual-exclusion check above ensures we don't clobber a caller's
       // explicit provider here.
       ...(options.phaseRole === 'read-only'
-        ? { provider: buildPhaseRestrictedProvider('read-only', options.config.model) }
+        ? { provider: buildPhaseRestrictedProvider('read-only', effectiveChildModel) }
         : {}),
     };
 
@@ -1006,9 +1044,9 @@ export class SubagentManager {
     // honest answer when present; for a top-level fork from a session
     // that hasn't initialized yet, we fall back to the manager's rootId
     // so the schema's `parentId: string` requirement stays satisfied.
-    const modelString = typeof options.config.model === 'string'
-      ? options.config.model
-      : JSON.stringify(options.config.model);
+    const modelString = typeof effectiveChildModel === 'string'
+      ? effectiveChildModel
+      : JSON.stringify(effectiveChildModel);
     void emitSubagentLifecycle(effectiveTraceWriter, {
       transition: 'started',
       subagentId: id,

--- a/src/agent/subagent/child-model-fallback.test.ts
+++ b/src/agent/subagent/child-model-fallback.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { coerceCrossProviderChildModel } from './child-model-fallback.js';
+
+/**
+ * `coerceCrossProviderChildModel` reads `AFK_PROVIDER` (and `AFK_OPENAI_BASE_URL`)
+ * transitively via `providerForModel`, so scrub them to a known baseline and set
+ * them explicitly per-case — mirroring providers/routing.test.ts.
+ */
+describe('coerceCrossProviderChildModel (#652)', () => {
+  const ENV_KEYS_TO_SCRUB = ['AFK_PROVIDER', 'AFK_OPENAI_BASE_URL'] as const;
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS_TO_SCRUB) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+  afterEach(() => {
+    for (const key of ENV_KEYS_TO_SCRUB) {
+      const saved = savedEnv[key];
+      if (saved === undefined) delete process.env[key];
+      else process.env[key] = saved;
+    }
+  });
+
+  describe('no global force (normal Anthropic routing)', () => {
+    it('leaves a Claude-family child untouched — it routes to anthropic-direct', () => {
+      expect(coerceCrossProviderChildModel('sonnet', 'gpt-5.5')).toEqual({ model: 'sonnet' });
+      expect(coerceCrossProviderChildModel('claude-sonnet-5', 'gpt-5.5')).toEqual({
+        model: 'claude-sonnet-5',
+      });
+    });
+
+    it('leaves a local-* Anthropic-shim child untouched (Tier-2 → anthropic-direct)', () => {
+      // The local-shim protection case: local-* routes to anthropic-direct
+      // without a force, so it must never be coerced onto the parent's model.
+      expect(coerceCrossProviderChildModel('local-qwen-3-6', 'gpt-5.5')).toEqual({
+        model: 'local-qwen-3-6',
+      });
+    });
+  });
+
+  describe('AFK_PROVIDER=openai-compatible force (the #652 trigger)', () => {
+    beforeEach(() => {
+      process.env['AFK_PROVIDER'] = 'openai-compatible';
+    });
+
+    it('coerces a defaulted sonnet child onto the parent gpt model', () => {
+      expect(coerceCrossProviderChildModel('sonnet', 'gpt-5.5')).toEqual({
+        model: 'gpt-5.5',
+        coercedFrom: 'sonnet',
+      });
+    });
+
+    it.each(['opus', 'haiku', 'claude-sonnet-5', 'local-qwen-3-6'])(
+      'coerces Claude-family / shim pin %s (all rejected by the ChatGPT backend under force)',
+      (child) => {
+        expect(coerceCrossProviderChildModel(child, 'gpt-5.5')).toEqual({
+          model: 'gpt-5.5',
+          coercedFrom: child,
+        });
+      },
+    );
+
+    it('leaves a gpt child untouched (not Claude-family)', () => {
+      expect(coerceCrossProviderChildModel('gpt-5.5', 'gpt-5.5')).toEqual({ model: 'gpt-5.5' });
+    });
+
+    it('does NOT coerce when the parent is not a usable substitute (undefined)', () => {
+      expect(coerceCrossProviderChildModel('sonnet', undefined)).toEqual({ model: 'sonnet' });
+    });
+
+    it('does NOT coerce when the parent is itself Claude-family (misconfigured parent)', () => {
+      // A claude parent under force is broken on its own; let the provider's
+      // actionable error fire rather than substituting one broken model for another.
+      expect(coerceCrossProviderChildModel('sonnet', 'opus')).toEqual({ model: 'sonnet' });
+    });
+  });
+
+  it('passes an undefined child through unchanged', () => {
+    expect(coerceCrossProviderChildModel(undefined, 'gpt-5.5')).toEqual({ model: undefined });
+  });
+});

--- a/src/agent/subagent/child-model-fallback.ts
+++ b/src/agent/subagent/child-model-fallback.ts
@@ -1,0 +1,82 @@
+/**
+ * Cross-provider child-model fallback for forked sub-agents (issue #652).
+ *
+ * A forked child (agent-tool dispatch, skill fork, or compose node) resolves its
+ * model from a `?? 'sonnet'`-terminated chain, or inherits an explicitly
+ * Claude-pinned auto-dispatched agent (`git-investigator` → `sonnet`, `Explore`
+ * → `haiku`; see `src/agent/agents/builtins.ts`). When the session is routed to
+ * the `openai-compatible` provider — a global `AFK_PROVIDER=openai-compatible`
+ * force, or a `chatgpt-oauth` / `openai` model slot — that Claude-family child
+ * cannot run: the OpenAI / ChatGPT backend serves no Claude model and hard-errors
+ * (`openai-compatible/query.ts`, the `isClaudeFamilyModel` guard). The child then
+ * never executes, and for the auto-dispatched agents the operator has no recourse
+ * (the pins are vendored / byte-locked).
+ *
+ * This module coerces such a child onto a provider-appropriate substitute — the
+ * parent session's own model, which under this routing is the concrete
+ * OpenAI/gpt target the session is already using — so the child runs instead of
+ * dying. It is applied at `SubagentManager.forkSubagent`, the single choke point
+ * through which every fork path converges.
+ */
+
+import { providerForModel } from '../providers/index.js';
+import { isClaudeFamilyModel } from '../providers/openai-compatible/responses-config.js';
+
+export interface ChildModelCoercion {
+  /** The model the child should actually run — the substitute when coerced. */
+  model: string | undefined;
+  /**
+   * The original model, set ONLY when a coercion happened. Callers use its
+   * presence as the "did we override the caller's model" signal (for a warning
+   * / trace note); left undefined on the common no-op path.
+   */
+  coercedFrom?: string;
+}
+
+/**
+ * Decide the effective model for a forked child, substituting a Claude-family
+ * model that would starve on this session's `openai-compatible` routing.
+ *
+ * Coerces iff ALL hold:
+ *   1. `childModel` is a Claude-family id (`isClaudeFamilyModel`), AND
+ *   2. it currently ROUTES to `openai-compatible` — i.e. a global
+ *      `AFK_PROVIDER` force (or a chatgpt-oauth/openai slot) has overridden the
+ *      id's natural anthropic-direct routing, AND
+ *   3. `parentModel` is a usable substitute: defined, not itself Claude-family,
+ *      and itself routing to `openai-compatible`.
+ *
+ * The `providerForModel(childModel) === 'openai-compatible'` conjunct keeps this
+ * false-positive-safe. `providerForModel` routes `claude-*` / `opus` / `sonnet`
+ * / `haiku` AND the local Anthropic-shim `local-*` ids to `anthropic-direct`
+ * (Tier 2) UNLESS a Tier-1 force overrides — so a Claude-family child in a normal
+ * Anthropic session, and a `local-*` model on a local Anthropic shim, both route
+ * anthropic-direct and are left untouched. Only the genuinely-broken
+ * "Claude id forced onto an OpenAI endpoint" combination is coerced.
+ *
+ * When the parent is NOT a usable substitute (undefined, or itself a Claude id
+ * force-routed to OpenAI — a misconfigured parent that fails on its own), the
+ * child model is left unchanged so the provider's actionable error can fire.
+ *
+ * `providerForModel` reads env on every call, so this reflects the live
+ * `AFK_PROVIDER` / slot routing at fork time without any threaded hints.
+ */
+export function coerceCrossProviderChildModel(
+  childModel: string | undefined,
+  parentModel: string | undefined,
+): ChildModelCoercion {
+  if (
+    childModel === undefined ||
+    !isClaudeFamilyModel(childModel) ||
+    providerForModel(childModel) !== 'openai-compatible'
+  ) {
+    return { model: childModel };
+  }
+  if (
+    parentModel === undefined ||
+    isClaudeFamilyModel(parentModel) ||
+    providerForModel(parentModel) !== 'openai-compatible'
+  ) {
+    return { model: childModel };
+  }
+  return { model: parentModel, coercedFrom: childModel };
+}


### PR DESCRIPTION
## Summary
Fixes #652. Forked skill/agent/compose children that resolve a Claude-family model — via the `?? 'sonnet'` default chain, or by inheriting a Claude-pinned auto-dispatched agent (`git-investigator` → `sonnet`, `Explore` → `haiku`) — hard-error under a `chatgpt-oauth` / `AFK_PROVIDER=openai-compatible` session. That routing sends the child to the ChatGPT/Codex backend, which serves no Claude model and fails fast at `openai-compatible/query.ts` (`isClaudeFamilyModel` guard). The child never runs, and for the vendored/byte-locked agent pins the operator has **no recourse** (can't pass a model to an auto-dispatched agent, can't edit the pin).

The issue as filed cites two lines, but this is a **class** bug: the same `?? 'sonnet'` default appears at 6 child-dispatch sites (`fork-dispatch.ts:121,206`, `compose-executor.ts:650`, `subagent/child-config.ts:167`, `background-branch.ts:72`, `foreground-promotion.ts:207`) plus the two explicit `builtins.ts` pins. All converge on one choke point.

## Fix (issue Option 1, generalized + Option 2)
**Coerce at the single choke point.** `SubagentManager.forkSubagent` is documented in-code as "the single choke point through which the agent-tool, skill, and compose paths all create their child session." New helper `coerceCrossProviderChildModel` substitutes such a child onto the **parent's own model** (the concrete gpt target the session already uses — no hardcoded gpt literal, respects the no-`src/cli`-import layering).

Predicate — `isClaudeFamilyModel(child) && providerForModel(child) === 'openai-compatible'` — is **false-positive-safe**:
- `providerForModel` routes `claude-*` / `opus` / `sonnet` / `haiku` **and** local Anthropic-shim `local-*` ids to `anthropic-direct` (Tier 2) *unless* a Tier-1 force overrides. So a normal Anthropic session and a local shim are **never** coerced — only the genuinely-broken "Claude id forced onto an OpenAI endpoint" combination.
- Skips when the parent isn't a usable substitute (undefined / itself Claude-family) so the actionable provider error still fires.

The coerced model is threaded into **every** model-derived `childConfig` field — `model`, `apiKey` (credential anti-leak), `baseUrl`, the **read-only-phase provider** (`buildPhaseRestrictedProvider` re-derives the provider from the model — miss this and a read-only fork re-triggers the bug), and the trace event. The override is written to stderr (not silent).

**Option 2 (backstop):** enriched the `query.ts` hard-error to point at `AFK_DEFAULT_SUBAGENT_MODEL` for auto-dispatched agents you can't pass a model to.

## Testing
- `src/agent/subagent/child-model-fallback.test.ts` — 11 unit tests (force/no-force, local-shim protection, gpt passthrough, unusable-parent guards).
- `src/agent/subagent.test.ts` — 4 integration tests at the fork boundary (coercion under force, no-op without force, gpt unchanged, no-parentModel no-op; asserts the stderr warning).
- `pnpm lint`, `pnpm test` (116 tests across the 4 relevant files), and `audit:sdk:check` / `audit:env:check` / `scan:env:check` all pass.

## Notes / scope
- Top-level sessions are intentionally **not** coerced (a user who explicitly runs a Claude model under chatgpt-oauth gets the clear error — correct). Only *forked* children, which inherit/default their model, are coerced.
- Does not address the per-slot `chatgpt-oauth` variant where a `sonnet` child routes to `anthropic-direct` and dies for lack of an Anthropic credential (a different failure path / #555 territory) — the enriched error covers that case.
