### PR TITLE
feat(trace): record resolved agent_type distinctly from the render label

### DIFF
--- a/src/agent/routing-telemetry.test.ts
+++ b/src/agent/routing-telemetry.test.ts
@@ -59,3 +59,23 @@ describe('buildRoutingDecisionRow — session identity', () => {
     expect('actor' in row).toBe(false);
   });
 });
+
+describe('buildRoutingDecisionRow — resolved_agent_type', () => {
+  it('carries the resolved registered type on a named dispatch', () => {
+    const row = buildRoutingDecisionRow({
+      event: 'subagent.dispatched',
+      subagent_id: 'c1',
+      resolved_agent_type: 'research-agent',
+    });
+    expect(row['resolved_agent_type']).toBe('research-agent');
+  });
+
+  it('omits resolved_agent_type for a bare/unnamed dispatch (undefined dropped)', () => {
+    const row = buildRoutingDecisionRow({
+      event: 'subagent.dispatched',
+      subagent_id: 'c2',
+      resolved_agent_type: undefined,
+    });
+    expect('resolved_agent_type' in row).toBe(false);
+  });
+});

--- a/src/agent/routing-telemetry.ts
+++ b/src/agent/routing-telemetry.ts
@@ -68,6 +68,16 @@ export interface RoutingDecisionEntry {
   /** Model name when relevant (dispatched events). */
   model?: string | undefined;
   /**
+   * Resolved *registered* agent type on `subagent.dispatched` rows — set only
+   * when the dispatch named an `agent_type` that resolved to a registry entry
+   * (research-agent, Explore, general-purpose, plugin/user agents). Absent for
+   * bare/unnamed dispatches, compose nodes, and skill id_prefix forks. Lets a
+   * usage query group dispatches by real agent type. Privacy: a
+   * framework-controlled type name validated at registration — not user
+   * content (mirrors `model` / `requested_name`).
+   */
+  resolved_agent_type?: string | undefined;
+  /**
    * Skill dispatch mode for `skill.*` events: "inline" | "fork" | "load".
    * Operational metadata only (no user content) — lets usage queries
    * distinguish in-context `load` dispatches from forked ones.

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -243,6 +243,16 @@ export interface ForkSubagentOptions<T = unknown> {
    */
   agentType: string;
   /**
+   * The resolved *registered* agent type for this fork — the clean, enumerable
+   * counterpart to the {@link agentType} render label. Callers set this ONLY
+   * when the dispatch named an `agent_type` that resolved to a registry entry
+   * (see SubagentExecutor). Absent for bare/unnamed dispatches, compose node
+   * labels, and skill id_prefix forks. Flows verbatim into the
+   * `subagent_lifecycle.started` trace event and the routing-decision row so
+   * cross-session telemetry can group by real type without the label noise.
+   */
+  resolvedAgentType?: string;
+  /**
    * Optional parent identifier for the renderer's nesting machinery. When
    * provided, overrides the default of `parent.sessionId`. Used by the
    * `compose` tool to pass its own `tool_use_id` so spawned subagents render
@@ -944,6 +954,7 @@ export class SubagentManager {
     // otherwise produce an empty Agent() label / empty agentContext anchor
     // rather than the intended fallback (idPrefix / parent.sessionId).
     const effectiveAgentType = options.agentType?.trim() || undefined;
+    const effectiveResolvedAgentType = options.resolvedAgentType?.trim() || undefined;
     const effectiveParentId = options.parentId?.trim() || undefined;
     const handle = new SubagentHandleImpl<T>(
       id,
@@ -1026,6 +1037,10 @@ export class SubagentManager {
         ? { promptHead: options.promptHead.slice(0, 80) }
         : {}),
       ...(effectiveAgentType ? { agentType: effectiveAgentType } : {}),
+      // resolvedAgentType: the clean registered type (set only for named
+      // dispatches). Carried separately from the agentType render label so a
+      // trace reader can group by real type without the label-fallback noise.
+      ...(effectiveResolvedAgentType ? { resolvedAgentType: effectiveResolvedAgentType } : {}),
     });
 
     await appendRoutingDecision({
@@ -1034,6 +1049,10 @@ export class SubagentManager {
       id_prefix: options.idPrefix,
       model: modelString,
       parent_session_id: options.parent.sessionId,
+      // Persist the resolved registered type into routing-decisions.jsonl so
+      // "which agent types get dispatched, how often" is a one-line query on
+      // the durable telemetry stream (undefined is dropped at write time).
+      resolved_agent_type: effectiveResolvedAgentType,
     });
 
     return handle;

--- a/src/agent/tools/subagent-executor.named-agents.test.ts
+++ b/src/agent/tools/subagent-executor.named-agents.test.ts
@@ -190,6 +190,9 @@ describe('SubagentExecutor named-agent dispatch', () => {
     const forkArgs = forkSubagent.mock.calls[0]?.[0];
     expect(forkArgs.config.systemPrompt).toBe('You are the research agent system prompt.');
     expect(forkArgs.agentType).toBe('research-agent');
+    // A resolved registered type is threaded separately from the render label,
+    // for clean telemetry grouping.
+    expect(forkArgs.resolvedAgentType).toBe('research-agent');
 
     // Allowlist reaches the child provider factory in AFK runtime names.
     expect(factoryCalls).toHaveLength(1);
@@ -301,6 +304,10 @@ describe('SubagentExecutor named-agent dispatch', () => {
     expect(forkArgs.config.systemPrompt).toContain(SUBAGENT_HANDOFF_CONTRACT);
     expect(factoryCalls[0]?.['allowedTools']).toBeUndefined();
     expect(forkArgs.agentType).toBe('plain dispatch');
+    // No registered agent resolved → resolvedAgentType stays absent, so
+    // telemetry can tell a bare dispatch from a named one (which agentType,
+    // being a render-label fallback, cannot).
+    expect(forkArgs.resolvedAgentType).toBeUndefined();
   });
 
   describe('nested-dispatch scope gate', () => {

--- a/src/agent/tools/subagent-executor.ts
+++ b/src/agent/tools/subagent-executor.ts
@@ -608,6 +608,12 @@ export class SubagentExecutor implements SubagentControl {
           : (parsed.id_prefix && parsed.id_prefix !== 'agent-tool')
             ? stripEscapeSequences(parsed.id_prefix).replace(/[\r\n]+/g, ' ').trim() || 'agent'
             : stripEscapeSequences(parsed.prompt).replace(/[\r\n]+/g, ' ').slice(0, 40).trim() || 'agent',
+        // resolvedAgentType: the clean, enumerable counterpart to the agentType
+        // render label above — set ONLY when the dispatch named an agent_type
+        // that resolved to a registry entry. Absent for bare/id_prefix/prompt
+        // dispatches, so telemetry can distinguish a real named-agent dispatch
+        // from a render-label fallback (which agentType alone cannot).
+        ...(namedAgent !== undefined ? { resolvedAgentType: namedAgent.name } : {}),
         // Forensic prompt slice for the `subagent_lifecycle.started` event: sanitized
         // like agentType but kept at 80 chars (the emit in subagent.ts re-clamps to
         // 80 and drops it when blank), so real CLI/daemon dispatches carry WHAT the

--- a/src/agent/trace/events.test.ts
+++ b/src/agent/trace/events.test.ts
@@ -273,6 +273,18 @@ describe('subagent_lifecycle payload', () => {
     });
   });
 
+  it('accepts started variant with resolvedAgentType (clean registered type)', () => {
+    const parsed = SubagentLifecyclePayloadSchema.parse({
+      transition: 'started',
+      subagentId: 'child-1',
+      parentId: 'root',
+      model: 'claude-haiku-4',
+      agentType: 'Explore',
+      resolvedAgentType: 'Explore',
+    });
+    expect(parsed).toMatchObject({ resolvedAgentType: 'Explore' });
+  });
+
   it("accepts failed variant with failureClass 'timeout'", () => {
     const parsed = SubagentLifecyclePayloadSchema.parse({
       transition: 'failed',

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -108,6 +108,7 @@ export const SubagentStartedPayloadSchema = z.object({
   systemPromptHash: z.string().optional(),
   promptHead: z.string().optional(),
   agentType: z.string().optional(),
+  resolvedAgentType: z.string().optional(),
 });
 
 export const SubagentSucceededPayloadSchema = z.object({

--- a/src/agent/trace/types.ts
+++ b/src/agent/trace/types.ts
@@ -215,8 +215,23 @@ export interface SubagentStartedPayload {
    * `research-agent`, a compose node label, or a prompt-derived slice). Present
    * so a reader can attribute a lifecycle event to a role without cross-refing
    * the routing telemetry. Absent when no label was resolved.
+   *
+   * NOTE: this is a *display label*, not a clean type — it is a 3-leg fallback
+   * (registered name → id_prefix → prompt slice), so telemetry cannot tell a
+   * real `agent_type` dispatch from an id_prefix/prompt-derived one. For that,
+   * use {@link resolvedAgentType}.
    */
   agentType?: string;
+  /**
+   * The resolved *registered* agent type for this fork — set ONLY when the
+   * dispatch named an `agent_type` that resolved to an entry in the agent
+   * registry (builtin/plugin/user). Absent for bare/unnamed dispatches,
+   * compose nodes, and skill-internal id_prefix forks. Unlike {@link agentType}
+   * (a render label), this field carries clean, enumerable semantics: grouping
+   * lifecycle events by it answers "how often was each named agent type
+   * dispatched?" without the render-label noise.
+   */
+  resolvedAgentType?: string;
 }
 
 export interface SubagentSucceededPayload {

--- a/src/cli/commands/trace.test.ts
+++ b/src/cli/commands/trace.test.ts
@@ -178,6 +178,31 @@ describe('formatTrace — subagent timeout markers', () => {
   });
 });
 
+describe('formatTrace — started-line agent role', () => {
+  // PR (resolved agent type): the started line surfaces WHICH agent ran. A
+  // resolved registered type renders with a leading `@`; when only the render
+  // label is present, it renders bare.
+  it('renders @<type> for a resolved registered agent type', () => {
+    const events: EventObj[] = [
+      { ts: '2026-06-05T12:30:00.000Z', seq: 0, kind: 'subagent_lifecycle', payload: { transition: 'started', subagentId: 'sub1', parentId: 'root', model: 'haiku', agentType: 'Explore', resolvedAgentType: 'Explore' } },
+      { ts: '2026-06-05T12:35:00.000Z', seq: 1, kind: 'session_sealed', payload: { status: 'succeeded', finalCostUsd: 0.01, finalTurnCount: 1, closedAt: '2026-06-05T12:35:00.000Z' } },
+    ];
+    const out = formatTrace('s', '/p', parseTrace(toJsonl(events)));
+    expect(out).toContain('@Explore');
+    expect(out).toContain('[sub1]');
+  });
+
+  it('renders the bare render label when no registered type resolved', () => {
+    const events: EventObj[] = [
+      { ts: '2026-06-05T12:30:00.000Z', seq: 0, kind: 'subagent_lifecycle', payload: { transition: 'started', subagentId: 'sub2', parentId: 'root', model: 'sonnet', agentType: 'correctness [1/6]' } },
+      { ts: '2026-06-05T12:35:00.000Z', seq: 1, kind: 'session_sealed', payload: { status: 'succeeded', finalCostUsd: 0.01, finalTurnCount: 1, closedAt: '2026-06-05T12:35:00.000Z' } },
+    ];
+    const out = formatTrace('s', '/p', parseTrace(toJsonl(events)));
+    expect(out).toContain('correctness [1/6]');
+    expect(out).not.toContain('@correctness');
+  });
+});
+
 describe('formatTrace — subagentId attribution on tool_call (issue #612)', () => {
   // A forked child resumes the parent's sessionId and writes into the shared
   // parent trace, so `afk trace show` must render `[subagentId]` on the child's

--- a/src/cli/commands/trace.ts
+++ b/src/cli/commands/trace.ts
@@ -327,8 +327,16 @@ function renderEvent(event: TraceEvent, ctx: RenderContext): string | null {
     case 'subagent_lifecycle': {
       const p = event.payload;
       switch (p.transition) {
-        case 'started':
-          return line('subagent', `started  ${p.model}  [${p.subagentId}]`);
+        case 'started': {
+          // Prefer the clean registered type; fall back to the render label.
+          // A leading `@` marks a resolved registered agent type (vs a label).
+          const role = p.resolvedAgentType
+            ? `  @${p.resolvedAgentType}`
+            : p.agentType
+              ? `  ${p.agentType}`
+              : '';
+          return line('subagent', `started  ${p.model}${role}  [${p.subagentId}]`);
+        }
         case 'succeeded': {
           const cost = p.totalCostUsd !== undefined ? `  ${fmtUsd(p.totalCostUsd)}` : '';
           return line(


### PR DESCRIPTION
## Why

Investigating *"how often does each named agent type (e.g. `Explore`) actually get dispatched?"* required hand-parsing ~12k witness trace files — because the one field that carries the type, `subagent_lifecycle.started.agentType`, is a **3-leg render-label fallback**: registered name -> id_prefix -> prompt slice (`subagent-executor.ts`, and its own type doc). So the field mixes real `agent_type` dispatches with values like `"correctness [1/6]"` or a 40-char prompt slice, and telemetry can't cleanly separate them. It also isn't in `routing-decisions.jsonl` (the durable, queryable dispatch log) at all.

## What

Add a clean, enumerable **`resolvedAgentType`** — set **only** when a dispatch names an `agent_type` that resolves to a registry entry (builtin/plugin/user) — carried alongside the existing render label, and pipe it to the two durable sinks + the reader:

- `trace/{types,events}.ts` — optional `resolvedAgentType` on `SubagentStartedPayload` (+ zod).
- `subagent.ts` — thread `ForkSubagentOptions.resolvedAgentType` into the `started` emit and the routing-decisions row (undefined dropped at write time).
- `subagent-executor.ts` — `resolvedAgentType = namedAgent.name`, set only for registered dispatches.
- `routing-telemetry.ts` — add `resolved_agent_type` to `RoutingDecisionEntry`. Privacy-safe: a framework-controlled type name, not user content (mirrors `model` / `requested_name`).
- `trace.ts` reader — surface the role on the `started` line; a leading `@` marks a resolved registered type vs a render label.

Now a one-line `jq` over `routing-decisions.jsonl` answers the original question directly.

## Notes

- Additive & backward-compatible — all-new optional fields; legacy rows/events unchanged.
- Foreground and background dispatches both fork via `forkSubagent`, so both inherit the field.
- Deferred follow-up: the separate `background_agent` started payload is still type-blind; enriching it is a small future change.

## Test

Schema round-trip, routing-row shape (incl. undefined-drop), reader `@type` vs bare label, and the named-vs-bare dispatch integration assertion. `pnpm lint` clean; 5 touched test files pass (128 tests).
