### PR TITLE
fix(mint): thread traceWriter into phase forks so they emit lifecycle events

### DIFF
--- a/src/skills/mint-parallelize-dispatch.test.ts
+++ b/src/skills/mint-parallelize-dispatch.test.ts
@@ -148,14 +148,34 @@ describe('runParallelizeDispatch — discriminated union', () => {
   });
 
   it('returns plan from the registry handler when it succeeds', async () => {
+    const handler = vi.fn(async () => ({ wave: ['agent-a', 'agent-b'] }));
     registryParallelize = {
-      handler: async () => ({ wave: ['agent-a', 'agent-b'] }),
+      handler,
     };
-    const result = await runParallelizeDispatch(MANY_FILES_PLAN, mockSession());
+    const parentSession = mockSession();
+    const traceWriter = { write: vi.fn() };
+    const result = await runParallelizeDispatch(
+      MANY_FILES_PLAN,
+      parentSession,
+      'mint-call-id',
+      'haiku',
+      undefined,
+      traceWriter,
+    );
     expect(result.kind).toBe('plan');
     if (result.kind === 'plan') {
       expect(result.plan).toEqual({ wave: ['agent-a', 'agent-b'] });
     }
+    expect(handler).toHaveBeenCalledWith(
+      { plan: MANY_FILES_PLAN },
+      parentSession,
+      {
+        defaultModel: 'haiku',
+        defaultSubagentModel: 'haiku',
+        callId: 'mint-call-id',
+        traceWriter,
+      },
+    );
   });
 
   it('falls through to plugin body when registry throws "not found", and returns plan on success', async () => {

--- a/src/skills/mint.test.ts
+++ b/src/skills/mint.test.ts
@@ -11,7 +11,10 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { loadSkillPrompts } from './_lib/prompt-loader.js';
 import { getSkill, registerSkill } from './index.js';
+import type { SkillExecutionContext } from './index.js';
+import { SubagentManager } from '../agent/subagent.js';
 import type { MintState } from './mint/index.js';
+import type { TraceWriter } from '../agent/trace/index.js';
 import type { IAgentSession, OutputEvent, SubagentProgressMeta } from '../agent/types.js';
 import { runWithSink } from '../agent/_lib/skill-sink-channel.js';
 import { useUnsetAfkHome } from '../__test-utils__/unset-afk-home.js';
@@ -994,6 +997,62 @@ describe('Mint Skill', () => {
       );
       for (const v of verifyOptions) {
         expect(v.phaseRole).not.toBe('read-only');
+      }
+    });
+  });
+
+  describe('Witness-trace coverage — traceWriter threading', () => {
+    // Regression for the gap where /mint phase forks emitted NO
+    // subagent_lifecycle events: their fork managers were constructed without
+    // the session's trace writer. Every phase must thread ctx.traceWriter into
+    // its SubagentManager so the phase subagent is visible in the witness trace.
+    it('threads ctx.traceWriter into every phase fork manager', async () => {
+      const skill = getSkill('mint');
+      const mockSession: IAgentSession = {
+        sessionId: 'test-session',
+        sendMessage: vi.fn(),
+        interrupt: vi.fn(),
+        close: vi.fn(),
+        getInputStreamRef: vi.fn(),
+        abortSignal: new AbortController().signal,
+      };
+      const traceWriter = { write: vi.fn() } as unknown as TraceWriter;
+
+      // autoApprove runs spec → research → plan → parallelize → build → verify →
+      // heal loop; every phase constructs a fork manager along the way.
+      await skill.handler(
+        { idea: 'Test feature', autoApprove: true },
+        mockSession,
+        { traceWriter } as unknown as SkillExecutionContext,
+      );
+
+      // The mocked SubagentManager is a vi.fn, so its constructor calls are
+      // recorded. Assert EVERY phase manager received the writer.
+      const ctorCalls = vi.mocked(SubagentManager).mock.calls;
+      expect(ctorCalls.length, 'at least one phase fork manager constructed').toBeGreaterThan(0);
+      for (const [opts] of ctorCalls) {
+        expect((opts as { traceWriter?: unknown } | undefined)?.traceWriter).toBe(traceWriter);
+      }
+    });
+
+    it('omits traceWriter when ctx has none (no writer available)', async () => {
+      const skill = getSkill('mint');
+      const mockSession: IAgentSession = {
+        sessionId: 'test-session',
+        sendMessage: vi.fn(),
+        interrupt: vi.fn(),
+        close: vi.fn(),
+        getInputStreamRef: vi.fn(),
+        abortSignal: new AbortController().signal,
+      };
+
+      // No ctx → ctx?.traceWriter is undefined → the spread drops the key.
+      await skill.handler({ idea: 'Test feature', autoApprove: true }, mockSession);
+
+      const ctorCalls = vi.mocked(SubagentManager).mock.calls;
+      expect(ctorCalls.length).toBeGreaterThan(0);
+      for (const [opts] of ctorCalls) {
+        expect((opts as { traceWriter?: unknown } | undefined)?.traceWriter).toBeUndefined();
       }
     });
   });

--- a/src/skills/mint.test.ts
+++ b/src/skills/mint.test.ts
@@ -29,6 +29,7 @@ useUnsetAfkHome();
 
 const sharedMintMock = vi.hoisted(() => ({
   forkOptions: [] as Array<Record<string, unknown>>,
+  completeAllPhases: false,
 }));
 
 let tmpHome: string;
@@ -64,8 +65,8 @@ vi.mock('../agent/subagent.js', () => {
           };
         } else if (idPrefix.startsWith('mint-verify-')) {
           output = {
-            status: 'FAIL',
-            issues: ['mocked verify failure'],
+            status: sharedMintMock.completeAllPhases ? 'PASS' : 'FAIL',
+            issues: sharedMintMock.completeAllPhases ? [] : ['mocked verify failure'],
             summary: 'Mocked',
           };
         }
@@ -73,6 +74,8 @@ vi.mock('../agent/subagent.js', () => {
         const messageContent =
           idPrefix === 'mint-heal'
             ? 'FIX_APPLIED: true\n\nMocked heal narrative'
+            : idPrefix === 'mint-plan' && sharedMintMock.completeAllPhases
+              ? 'Update src/a.ts, src/b.ts, and src/c.ts.'
             : `Mocked ${idPrefix} output`;
 
         return {
@@ -91,6 +94,7 @@ vi.mock('../agent/subagent.js', () => {
           teardown: vi.fn(async () => undefined),
         };
       }),
+      teardownAll: vi.fn(async () => undefined),
     })),
   };
 });
@@ -98,6 +102,7 @@ vi.mock('../agent/subagent.js', () => {
 describe('Mint Skill', () => {
   beforeEach(() => {
     sharedMintMock.forkOptions.length = 0;
+    sharedMintMock.completeAllPhases = false;
     vi.clearAllMocks();
     originalHome = process.env['HOME'];
     tmpHome = join(tmpdir(), `afk-mint-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -1007,6 +1012,7 @@ describe('Mint Skill', () => {
     // the session's trace writer. Every phase must thread ctx.traceWriter into
     // its SubagentManager so the phase subagent is visible in the witness trace.
     it('threads ctx.traceWriter into every phase fork manager', async () => {
+      sharedMintMock.completeAllPhases = true;
       const skill = getSkill('mint');
       const mockSession: IAgentSession = {
         sessionId: 'test-session',
@@ -1018,8 +1024,8 @@ describe('Mint Skill', () => {
       };
       const traceWriter = { write: vi.fn() } as unknown as TraceWriter;
 
-      // autoApprove runs spec → research → plan → parallelize → build → verify →
-      // heal loop; every phase constructs a fork manager along the way.
+      // Supply a three-file plan and passing verification so autoApprove runs
+      // spec → research → plan → parallelize → build → verify → ship.
       await skill.handler(
         { idea: 'Test feature', autoApprove: true },
         mockSession,
@@ -1029,10 +1035,23 @@ describe('Mint Skill', () => {
       // The mocked SubagentManager is a vi.fn, so its constructor calls are
       // recorded. Assert EVERY phase manager received the writer.
       const ctorCalls = vi.mocked(SubagentManager).mock.calls;
-      expect(ctorCalls.length, 'at least one phase fork manager constructed').toBeGreaterThan(0);
+      // Verify creates one manager per verification mode, so the eight phase
+      // construction sites produce nine manager instances in this full run.
+      expect(ctorCalls).toHaveLength(9);
       for (const [opts] of ctorCalls) {
         expect((opts as { traceWriter?: unknown } | undefined)?.traceWriter).toBe(traceWriter);
       }
+      expect(sharedMintMock.forkOptions.map((opts) => opts['idPrefix'])).toEqual([
+        'mint-spec',
+        'mint-research',
+        'mint-plan',
+        'mint-parallelize',
+        'mint-build',
+        'mint-verify-test',
+        'mint-verify-lint',
+        'mint-verify-design-review',
+        'mint-ship',
+      ]);
     });
 
     it('omits traceWriter when ctx has none (no writer available)', async () => {

--- a/src/skills/mint/_phases/build.ts
+++ b/src/skills/mint/_phases/build.ts
@@ -9,6 +9,7 @@ import { describeFailure } from '../../../agent/subagent/result.js';
 import { resolveCredentialForModel } from '../../../agent/auth/credential-resolver.js';
 import { loadSkillPrompts } from '../../_lib/prompt-loader.js';
 import type { AgentModelInput } from '../../../agent/types.js';
+import type { TraceWriter } from '../../../agent/trace/index.js';
 import { emitCard } from '../../_lib/emit-card.js';
 
 const BuildOutputSchema = z.object({
@@ -40,6 +41,9 @@ export async function runBuildPhase(
   // by the mint handler); seeds the fork manager's parentReadRoots so the phase
   // subagent's reads ⊇ the parent session's. Undefined leaves cwd-derivation.
   parentReadRoots?: string[],
+  // Witness layer: parent trace writer (ctx.traceWriter) so this phase's fork
+  // emits subagent_lifecycle events. Mirrors research.ts.
+  traceWriter?: TraceWriter,
 ): Promise<BuildResult> {
   const prompts = loadSkillPrompts('mint');
   const buildPrompt = prompts['build.md'];
@@ -54,6 +58,7 @@ export async function runBuildPhase(
   const manager = new SubagentManager({
     ...(parentCwd !== undefined ? { cwd: parentCwd } : {}),
     ...(parentReadRoots !== undefined ? { parentReadRoots } : {}),
+    ...(traceWriter !== undefined ? { traceWriter } : {}),
   });
   const buildHandle = await manager.forkSubagent({
     parent: { sessionId: parentSessionId },

--- a/src/skills/mint/_phases/heal.ts
+++ b/src/skills/mint/_phases/heal.ts
@@ -5,6 +5,7 @@
  */
 
 import type { AgentModelInput, IAgentSession } from '../../../agent/types.js';
+import type { TraceWriter } from '../../../agent/trace/index.js';
 import { SubagentManager } from '../../../agent/subagent.js';
 import { describeFailure, isIncompleteStopReason } from '../../../agent/subagent/result.js';
 import { resolveCredentialForModel } from '../../../agent/auth/credential-resolver.js';
@@ -35,6 +36,9 @@ export async function runHealPhase(
   // forwarded to the re-run verify phase so both inherit reads ⊇ the parent
   // session's. Undefined leaves cwd-derivation intact.
   parentReadRoots?: string[],
+  // Witness layer: parent trace writer (ctx.traceWriter) so the heal fork AND
+  // the re-run verify subagents emit subagent_lifecycle events. Mirrors research.ts.
+  traceWriter?: TraceWriter,
 ): Promise<{
   healed: boolean;
   newHealIterations: number;
@@ -97,6 +101,7 @@ export async function runHealPhase(
     const manager = new SubagentManager({
       ...(parentSession.cwd !== undefined ? { cwd: parentSession.cwd } : {}),
       ...(parentReadRoots !== undefined ? { parentReadRoots } : {}),
+      ...(traceWriter !== undefined ? { traceWriter } : {}),
     });
     const healHandle = await manager.forkSubagent({
       parent: { sessionId: parentSession.sessionId },
@@ -164,6 +169,7 @@ export async function runHealPhase(
       skillCallId,
       defaultSubagentModel,
       parentReadRoots,
+      traceWriter,
     );
 
     return {

--- a/src/skills/mint/_phases/parallelize-dispatch.ts
+++ b/src/skills/mint/_phases/parallelize-dispatch.ts
@@ -20,6 +20,7 @@ import { SubagentManager } from '../../../agent/subagent.js';
 import { isIncompleteStopReason } from '../../../agent/subagent/result.js';
 import { resolveCredentialForModel } from '../../../agent/auth/credential-resolver.js';
 import type { AgentModelInput, IAgentSession } from '../../../agent/types.js';
+import type { TraceWriter } from '../../../agent/trace/index.js';
 
 export type ParallelizeDispatchResult =
   | { kind: 'skipped'; reason: 'too-few-files' | 'skill-body-missing' }
@@ -63,6 +64,9 @@ export async function runParallelizeDispatch(
   // parallelize subagent's reads ⊇ the parent session's. Undefined leaves
   // cwd-derivation intact.
   parentReadRoots?: string[],
+  // Witness layer: parent trace writer (ctx.traceWriter) so each dispatched
+  // wave subagent emits subagent_lifecycle events. Mirrors research.ts.
+  traceWriter?: TraceWriter,
 ): Promise<ParallelizeDispatchResult> {
   const fileCount = countFileReferences(plan);
 
@@ -108,6 +112,7 @@ export async function runParallelizeDispatch(
       parentAbortSignal: parentSession.abortSignal,
       ...(parentSession.cwd !== undefined ? { cwd: parentSession.cwd } : {}),
       ...(parentReadRoots !== undefined ? { parentReadRoots } : {}),
+      ...(traceWriter !== undefined ? { traceWriter } : {}),
     });
     try {
       // PLUGIN_ROOT injection mirrors `executePluginSkill` — see

--- a/src/skills/mint/_phases/parallelize-dispatch.ts
+++ b/src/skills/mint/_phases/parallelize-dispatch.ts
@@ -14,7 +14,7 @@
  * fallback after delegation failure is forbidden").
  */
 
-import { getSkill } from '../../index.js';
+import { getSkill, type SkillExecutionContext } from '../../index.js';
 import { discoverPluginSkillBodies } from '../../../agent/tools/skill-bridge.js';
 import { SubagentManager } from '../../../agent/subagent.js';
 import { isIncompleteStopReason } from '../../../agent/subagent/result.js';
@@ -82,7 +82,17 @@ export async function runParallelizeDispatch(
   try {
     const parallelize = getSkill('parallelize');
     registryHit = true;
-    const waveOrchestration = await parallelize.handler({ plan });
+    const handlerContext: SkillExecutionContext = {
+      defaultModel: defaultSubagentModel,
+      defaultSubagentModel,
+      ...(skillCallId !== undefined ? { callId: skillCallId } : {}),
+      ...(traceWriter !== undefined ? { traceWriter } : {}),
+    };
+    const waveOrchestration = await parallelize.handler(
+      { plan },
+      parentSession,
+      handlerContext,
+    );
     return { kind: 'plan', plan: waveOrchestration };
   } catch (err) {
     if (registryHit) {

--- a/src/skills/mint/_phases/plan.ts
+++ b/src/skills/mint/_phases/plan.ts
@@ -8,6 +8,7 @@ import { describeFailure, isIncompleteStopReason } from '../../../agent/subagent
 import { resolveCredentialForModel } from '../../../agent/auth/credential-resolver.js';
 import { loadSkillPrompts } from '../../_lib/prompt-loader.js';
 import type { AgentModelInput } from '../../../agent/types.js';
+import type { TraceWriter } from '../../../agent/trace/index.js';
 
 export async function runPlanPhase(
   spec: string,
@@ -22,6 +23,9 @@ export async function runPlanPhase(
   // by the mint handler); seeds the fork manager's parentReadRoots so the phase
   // subagent's reads ⊇ the parent session's. Undefined leaves cwd-derivation.
   parentReadRoots?: string[],
+  // Witness layer: parent trace writer (ctx.traceWriter) so this phase's fork
+  // emits subagent_lifecycle events. Mirrors research.ts.
+  traceWriter?: TraceWriter,
 ): Promise<string> {
   const prompts = loadSkillPrompts('mint');
   const planPrompt = prompts['plan.md'];
@@ -34,6 +38,7 @@ export async function runPlanPhase(
   const manager = new SubagentManager({
     ...(parentCwd !== undefined ? { cwd: parentCwd } : {}),
     ...(parentReadRoots !== undefined ? { parentReadRoots } : {}),
+    ...(traceWriter !== undefined ? { traceWriter } : {}),
   });
   const planHandle = await manager.forkSubagent({
     parent: { sessionId: parentSessionId },

--- a/src/skills/mint/_phases/research.ts
+++ b/src/skills/mint/_phases/research.ts
@@ -8,6 +8,7 @@ import { describeFailure, isIncompleteStopReason } from '../../../agent/subagent
 import { resolveCredentialForModel } from '../../../agent/auth/credential-resolver.js';
 import { loadSkillPrompts } from '../../_lib/prompt-loader.js';
 import type { AgentModelInput } from '../../../agent/types.js';
+import type { TraceWriter } from '../../../agent/trace/index.js';
 
 export async function runResearchPhase(
   spec: string,
@@ -22,6 +23,11 @@ export async function runResearchPhase(
   // by the mint handler); seeds the fork manager's parentReadRoots so the phase
   // subagent's reads ⊇ the parent session's. Undefined leaves cwd-derivation.
   parentReadRoots?: string[],
+  // Witness layer: the parent session's trace writer (from ctx.traceWriter).
+  // Without it this phase's fork manager has no writer, so its subagent emits
+  // NO subagent_lifecycle events — mint phases were the last dispatch path
+  // still invisible in the trace. Mirrors the root/skill-fork managers.
+  traceWriter?: TraceWriter,
 ): Promise<string> {
   const prompts = loadSkillPrompts('mint');
   const researchPrompt = prompts['research.md'];
@@ -34,6 +40,7 @@ export async function runResearchPhase(
   const manager = new SubagentManager({
     ...(parentCwd !== undefined ? { cwd: parentCwd } : {}),
     ...(parentReadRoots !== undefined ? { parentReadRoots } : {}),
+    ...(traceWriter !== undefined ? { traceWriter } : {}),
   });
   const researchHandle = await manager.forkSubagent({
     parent: { sessionId: parentSessionId },

--- a/src/skills/mint/_phases/ship.ts
+++ b/src/skills/mint/_phases/ship.ts
@@ -8,6 +8,7 @@ import { describeFailure, isIncompleteStopReason } from '../../../agent/subagent
 import { resolveCredentialForModel } from '../../../agent/auth/credential-resolver.js';
 import { loadSkillPrompts } from '../../_lib/prompt-loader.js';
 import type { AgentModelInput } from '../../../agent/types.js';
+import type { TraceWriter } from '../../../agent/trace/index.js';
 import { emitCard } from '../../_lib/emit-card.js';
 import type { MintState } from '../index.js';
 
@@ -23,6 +24,9 @@ export async function runShipPhase(
   // by the mint handler); seeds the fork manager's parentReadRoots so the phase
   // subagent's reads ⊇ the parent session's. Undefined leaves cwd-derivation.
   parentReadRoots?: string[],
+  // Witness layer: parent trace writer (ctx.traceWriter) so this phase's fork
+  // emits subagent_lifecycle events. Mirrors research.ts.
+  traceWriter?: TraceWriter,
 ): Promise<string> {
   const prompts = loadSkillPrompts('mint');
   const shipPrompt = prompts['ship.md'];
@@ -36,6 +40,7 @@ export async function runShipPhase(
   const manager = new SubagentManager({
     ...(parentCwd !== undefined ? { cwd: parentCwd } : {}),
     ...(parentReadRoots !== undefined ? { parentReadRoots } : {}),
+    ...(traceWriter !== undefined ? { traceWriter } : {}),
   });
   const shipHandle = await manager.forkSubagent({
     parent: { sessionId: parentSessionId },

--- a/src/skills/mint/_phases/spec.ts
+++ b/src/skills/mint/_phases/spec.ts
@@ -8,6 +8,7 @@ import { describeFailure, isIncompleteStopReason } from '../../../agent/subagent
 import { resolveCredentialForModel } from '../../../agent/auth/credential-resolver.js';
 import { loadSkillPrompts } from '../../_lib/prompt-loader.js';
 import type { AgentModelInput } from '../../../agent/types.js';
+import type { TraceWriter } from '../../../agent/trace/index.js';
 
 export async function runSpecPhase(
   idea: string,
@@ -24,6 +25,9 @@ export async function runSpecPhase(
   // (#544). Undefined (the common case, where the mint worktree IS the session
   // cwd) leaves the manager's cwd-derivation intact.
   parentReadRoots?: string[],
+  // Witness layer: parent trace writer (ctx.traceWriter) so this phase's fork
+  // emits subagent_lifecycle events. Mirrors research.ts.
+  traceWriter?: TraceWriter,
 ): Promise<string> {
   const prompts = loadSkillPrompts('mint');
   const specPrompt = prompts['spec.md'];
@@ -41,6 +45,7 @@ export async function runSpecPhase(
   const manager = new SubagentManager({
     ...(parentCwd !== undefined ? { cwd: parentCwd } : {}),
     ...(parentReadRoots !== undefined ? { parentReadRoots } : {}),
+    ...(traceWriter !== undefined ? { traceWriter } : {}),
   });
   const specHandle = await manager.forkSubagent({
     parent: { sessionId: parentSessionId },

--- a/src/skills/mint/_phases/verify.ts
+++ b/src/skills/mint/_phases/verify.ts
@@ -11,6 +11,7 @@ import { loadSkillPrompts } from '../../_lib/prompt-loader.js';
 import { emitCard } from '../../_lib/emit-card.js';
 import type { BuildResult } from './build.js';
 import type { AgentModelInput } from '../../../agent/types.js';
+import type { TraceWriter } from '../../../agent/trace/index.js';
 
 const VerifyModeOutputSchema = z.object({
   status: z.enum(['PASS', 'FAIL']),
@@ -41,12 +42,16 @@ async function forkVerifyMode(
   // by the mint handler); seeds the fork manager's parentReadRoots so the phase
   // subagent's reads ⊇ the parent session's. Undefined leaves cwd-derivation.
   parentReadRoots?: string[],
+  // Witness layer: parent trace writer, forwarded to the fork manager so this
+  // verify-mode subagent emits subagent_lifecycle events. Mirrors research.ts.
+  traceWriter?: TraceWriter,
 ): Promise<{ passed: boolean; issues?: string[] }> {
   // Propagate parent worktree — verify subagents run tests/lint/grep in
   // the right working tree.
   const manager = new SubagentManager({
     ...(parentCwd !== undefined ? { cwd: parentCwd } : {}),
     ...(parentReadRoots !== undefined ? { parentReadRoots } : {}),
+    ...(traceWriter !== undefined ? { traceWriter } : {}),
   });
   const verifyHandle = await manager.forkSubagent({
     parent: { sessionId: parentSessionId },
@@ -106,6 +111,9 @@ export async function runVerifyPhase(
   // every verify subagent's reads ⊇ the parent session's. Undefined leaves
   // cwd-derivation intact.
   parentReadRoots?: string[],
+  // Witness layer: forwarded to each parallel forkVerifyMode so every verify
+  // subagent's fork emits subagent_lifecycle events. Mirrors research.ts.
+  traceWriter?: TraceWriter,
 ): Promise<VerifyResult> {
   const prompts = loadSkillPrompts('mint');
   const verifyPrompt = prompts['verify.md'];
@@ -116,9 +124,9 @@ export async function runVerifyPhase(
 
   // Run test, lint, and design-review in parallel
   const [testResult, lintResult, designResult] = await Promise.all([
-    forkVerifyMode('test', plan, buildResults, parentSessionId, verifyPrompt, parentCwd, skillCallId, defaultSubagentModel, parentReadRoots),
-    forkVerifyMode('lint', plan, buildResults, parentSessionId, verifyPrompt, parentCwd, skillCallId, defaultSubagentModel, parentReadRoots),
-    forkVerifyMode('design-review', plan, buildResults, parentSessionId, verifyPrompt, parentCwd, skillCallId, defaultSubagentModel, parentReadRoots),
+    forkVerifyMode('test', plan, buildResults, parentSessionId, verifyPrompt, parentCwd, skillCallId, defaultSubagentModel, parentReadRoots, traceWriter),
+    forkVerifyMode('lint', plan, buildResults, parentSessionId, verifyPrompt, parentCwd, skillCallId, defaultSubagentModel, parentReadRoots, traceWriter),
+    forkVerifyMode('design-review', plan, buildResults, parentSessionId, verifyPrompt, parentCwd, skillCallId, defaultSubagentModel, parentReadRoots, traceWriter),
   ]);
 
   const allIssues: string[] = [];

--- a/src/skills/mint/index.ts
+++ b/src/skills/mint/index.ts
@@ -18,6 +18,7 @@
 
 import { registerSkill, type SkillExecutionContext, type SkillMetadata } from '../index.js';
 import type { AgentModelInput, IAgentSession } from '../../agent/types.js';
+import type { TraceWriter } from '../../agent/trace/index.js';
 import {
   resolveChildManagerReadRoots,
   type ReadScopeInputs,
@@ -190,6 +191,11 @@ async function runPhasesAfterSpec(
   // invariant the `agent` tool enforces (#544). Optional so resume/test paths
   // without a ctx degrade to cwd-derivation, unchanged.
   parentReadScope?: ReadScopeInputs,
+  // Witness layer: the parent session's trace writer (from ctx.traceWriter),
+  // threaded to every phase so their forked subagents emit subagent_lifecycle
+  // events. Without it, mint phase forks were invisible in the witness trace
+  // (their fork managers had no writer). Optional so resume/test paths degrade.
+  traceWriter?: TraceWriter,
 ): Promise<MintResult> {
   if (!parentSession.sessionId) {
     throw new Error('runPhasesAfterSpec requires parentSession.sessionId');
@@ -207,11 +213,11 @@ async function runPhasesAfterSpec(
   const parentReadRoots = resolveChildManagerReadRoots(parentReadScope, parentCwd);
   try {
     state.currentPhase = 'research';
-    state.research = await runResearchPhase(state.spec!, parentSessionId, parentCwd, skillCallId, defaultSubagentModel, parentReadRoots);
+    state.research = await runResearchPhase(state.spec!, parentSessionId, parentCwd, skillCallId, defaultSubagentModel, parentReadRoots, traceWriter);
     appendHistory(state, 'research', state.research);
 
     state.currentPhase = 'plan';
-    state.plan = await runPlanPhase(state.spec!, state.research, parentSessionId, parentCwd, skillCallId, defaultSubagentModel, parentReadRoots);
+    state.plan = await runPlanPhase(state.spec!, state.research, parentSessionId, parentCwd, skillCallId, defaultSubagentModel, parentReadRoots, traceWriter);
     appendHistory(state, 'plan', state.plan);
 
     state.currentPhase = 'parallelize';
@@ -221,6 +227,7 @@ async function runPhasesAfterSpec(
       skillCallId,
       defaultSubagentModel,
       parentReadRoots,
+      traceWriter,
     );
     if (parallelizeResult.kind === 'plan') {
       state.waveOrchestrationPlan = parallelizeResult.plan;
@@ -269,6 +276,7 @@ async function runPhasesAfterSpec(
       skillCallId,
       defaultSubagentModel,
       parentReadRoots,
+      traceWriter,
     );
     appendHistory(state, 'build', JSON.stringify(state.buildResults));
 
@@ -281,6 +289,7 @@ async function runPhasesAfterSpec(
       skillCallId,
       defaultSubagentModel,
       parentReadRoots,
+      traceWriter,
     );
     appendHistory(state, 'verify', JSON.stringify(state.verifyResults));
 
@@ -302,6 +311,7 @@ async function runPhasesAfterSpec(
         defaultSubagentModel,
         dispatchSkill,
         parentReadRoots,
+        traceWriter,
       );
       state.healIterations = healResult.newHealIterations;
       state.verifyResults = healResult.newVerifyResults;
@@ -325,7 +335,7 @@ async function runPhasesAfterSpec(
     }
 
     state.currentPhase = 'ship';
-    const artifact = await runShipPhase(state, parentSessionId, parentCwd, skillCallId, defaultSubagentModel, parentReadRoots);
+    const artifact = await runShipPhase(state, parentSessionId, parentCwd, skillCallId, defaultSubagentModel, parentReadRoots, traceWriter);
     appendHistory(state, 'ship', artifact);
 
     return { completed: true, artifact, state };
@@ -373,7 +383,7 @@ async function handler(
         'mint: no paused spec found for this session to continue. Run /mint <idea> first, then /mint --continue approved.',
       );
     }
-    const result = await runPhasesAfterSpec(resumeState, parentSession, skillCallId, defaultSubagentModel, ctx?.dispatchSkill, ctx?.getReadScopeInputs?.());
+    const result = await runPhasesAfterSpec(resumeState, parentSession, skillCallId, defaultSubagentModel, ctx?.dispatchSkill, ctx?.getReadScopeInputs?.(), ctx?.traceWriter);
     return finalizeAfterSpec(parentSessionId, result);
   }
 
@@ -394,7 +404,7 @@ async function handler(
   };
 
   try {
-    state.spec = await runSpecPhase(mintInput.idea, parentSessionId, parentSession.cwd, skillCallId, defaultSubagentModel);
+    state.spec = await runSpecPhase(mintInput.idea, parentSessionId, parentSession.cwd, skillCallId, defaultSubagentModel, undefined, ctx?.traceWriter);
     appendHistory(state, 'spec', state.spec);
   } catch (err) {
     throw new Error(`mint failed at spec: ${err}`);
@@ -413,7 +423,7 @@ async function handler(
     return pausedResult;
   }
 
-  const result = await runPhasesAfterSpec(state, parentSession, skillCallId, defaultSubagentModel, ctx?.dispatchSkill, ctx?.getReadScopeInputs?.());
+  const result = await runPhasesAfterSpec(state, parentSession, skillCallId, defaultSubagentModel, ctx?.dispatchSkill, ctx?.getReadScopeInputs?.(), ctx?.traceWriter);
   return finalizeAfterSpec(parentSessionId, result);
 }
 


### PR DESCRIPTION
## Why

`/mint`'s 8 phase functions (`src/skills/mint/_phases/*.ts`) each construct their own `SubagentManager` **without** the session's trace writer:

```ts
const manager = new SubagentManager({
  ...(parentCwd !== undefined ? { cwd: parentCwd } : {}),
  ...(parentReadRoots !== undefined ? { parentReadRoots } : {}),
  // no traceWriter
});
```

`emitSubagentLifecycle` no-ops without a writer (`trace/emit.ts`), so mint phase forks emitted **zero** `subagent_lifecycle` events — the last dispatch path still invisible in the witness trace after #466 fixed the agent-tool and compose paths. Confirmed by absence: no trace in the corpus ever carried a `mint-*` agentType, even though the phases set one (e.g. `agentType: 'mint-research'`).

## What

Thread `ctx.traceWriter` — already available on `SkillExecutionContext` (`skills/index.ts`) and used identically by `user-skills.ts` — from the mint handler through `runPhasesAfterSpec` into every phase and into their fork managers:

- `mint/index.ts` — resolve `ctx.traceWriter` once, thread it to `runSpecPhase` and `runPhasesAfterSpec`, and from there to all 7 downstream phase calls.
- `_phases/*.ts` (all 8) — accept an optional trailing `traceWriter?: TraceWriter` and spread it into the `SubagentManager` options (mirrors the existing `parentReadRoots` threading). `heal.ts` also forwards it to its re-run `runVerifyPhase`.

## Scope / notes

- **Additive & backward-compatible** — optional trailing param; resume/test paths without a `ctx` degrade to the prior no-writer behavior, unchanged.
- Mirrors the merged root-manager fix (#466) and `user-skills.ts` — same pattern, same `ctx.traceWriter` source.
- Complements the sibling PR that adds `resolvedAgentType` to the trace/routing telemetry: once both land, a mint run's phase forks are both visible AND type-attributed.
- **Deferred follow-up:** a CI `audit:trace-writer` gate (mirroring `audit:env:check`) asserting every `new SubagentManager(` in `src/skills`/`src/agent/tools` threads a writer would prevent this class of gap from recurring (it recurred once — roots fixed in #466, mint missed).

## Test

`mint.test.ts` (the mocked-`SubagentManager` suite) asserts every phase's fork manager is constructed **with** the writer when `ctx.traceWriter` is set, and **without** it when absent. `pnpm lint` clean; all 55 mint tests pass (53 existing + 2 new).
