### PR TITLE
fix(cli): colorize aliased slash commands (e.g. /quit) as brand, not dim

### DIFF
--- a/src/cli/_lib/stream-renderer.ts
+++ b/src/cli/_lib/stream-renderer.ts
@@ -35,7 +35,7 @@ import { isPlainOutputRequested } from '../../config/env.js';
 import type { IHistoryRing } from '../input/types.js';
 import type { AutocompleteState } from '../input/autocomplete-state.js';
 import { colorizeInputBuffer, type SlashRegistryView } from '../input-highlight.js';
-import { list as listSlashCommands, registryVersion } from '../slash/registry.js';
+import { createSlashRegistryView } from '../slash/registry.js';
 import { ToolLane } from '../commands/interactive/tool-lane.js';
 import { ThinkingLane } from '../commands/interactive/thinking-lane.js';
 import { StreamingMarkdownRenderer } from '../markdown-stream.js';
@@ -400,19 +400,13 @@ export class StreamRenderer {
         compositor.setOnCancel(this.onCancel);
       }
     } else {
-      // Live-registry adapter — queried fresh on every render so plugins that
-      // register slash commands mid-session colorize correctly without a
-      // restart. Mirrors the closure used by `readWithAutocompleteTty` at
-      // src/cli/input/reader.ts:103-105. `listSlashCommands()` returns names
-      // prefixed with `/`; the highlighter passes the bare name, so we
-      // re-add the prefix in the predicate.
-      const slashRegistryView: SlashRegistryView = {
-        has: (name) => listSlashCommands().some((c) => c.name === `/${name}`),
-        // Enables the `colorizeInputBuffer` single-entry memo across repaints;
-        // the version bumps on any mid-session command registration so the
-        // cache never serves a stale-colored buffer.
-        version: registryVersion,
-      };
+      // Live-registry adapter for the slash colorizer, built via
+      // `createSlashRegistryView()`. Membership delegates to the registry's
+      // alias-aware `has()` (queried fresh per render) so plugins that register
+      // slash commands mid-session — and aliased commands like `/quit` —
+      // colorize correctly without a restart. Mirrors the surface used by
+      // `InputSurface` and `readWithAutocompleteTty`.
+      const slashRegistryView: SlashRegistryView = createSlashRegistryView();
       compositor = new TerminalCompositor({
         stdout: process.stdout,
         stdin: process.stdin,

--- a/src/cli/input/input-surface.ts
+++ b/src/cli/input/input-surface.ts
@@ -50,7 +50,7 @@ import {
 } from '../terminal-compositor.js';
 import { colorizeInputBuffer, type SlashRegistryView } from '../input-highlight.js';
 import { detectCaptureMode, detectCaretBlink, detectReducedMotion, detectGoblinSpinner } from '../_lib/capture-mode.js';
-import { list as listSlashCommands, registryVersion } from '../slash/registry.js';
+import { createSlashRegistryView } from '../slash/registry.js';
 import { formatSubmittedEcho } from './echo.js';
 import { describeAttachmentSummary } from './attachments.js';
 import { commitBlockAbove } from '../_lib/commit-block.js';
@@ -272,21 +272,17 @@ export class InputSurface {
   private pendingReadResolve: ((value: ReadWithAutocompleteResult) => void) | null = null;
 
   /**
-   * Live-registry adapter — queried fresh via `listSlashCommands()` on
-   * every call so plugins that register slash commands mid-session
-   * colorize correctly. Held as a class field (not an `armCompositor`
-   * local) because two call sites need it: the compositor's
-   * `formatInputBuffer` live-typing hook AND the `readLine` submit-echo
-   * which must colorize `payload.text` before committing to scrollback
-   * — without that second call, the submitted slash command appears as
-   * plain text in history (parity bug vs. `reader.ts:329-330`).
+   * Live-registry adapter for the slash colorizer, built via
+   * `createSlashRegistryView()`. Membership delegates to the registry's
+   * alias-aware `has()` (queried fresh per call) so plugins that register
+   * slash commands mid-session — and aliased commands like `/quit` — colorize
+   * correctly. Held as a class field (not an `armCompositor` local) because
+   * two call sites need it: the compositor's `formatInputBuffer` live-typing
+   * hook AND the `readLine` submit-echo which must colorize `payload.text`
+   * before committing to scrollback — without that second call, the submitted
+   * slash command appears as plain text in history (parity bug vs. `reader.ts`).
    */
-  private readonly slashRegistryView: SlashRegistryView = {
-    has: (name) => listSlashCommands().some((c) => c.name === `/${name}`),
-    // Enables the `colorizeInputBuffer` memo (per-keystroke repaints share a
-    // buffer) while still invalidating on any mid-session command hot-swap.
-    version: registryVersion,
-  };
+  private readonly slashRegistryView: SlashRegistryView = createSlashRegistryView();
 
   constructor(opts: InputSurfaceOptions) {
     this.rl = opts.rl;

--- a/src/cli/input/reader.ts
+++ b/src/cli/input/reader.ts
@@ -16,7 +16,7 @@
 import { emitKeypressEventsImmediateEscape } from './emit-keypress.js';
 import * as ansiEscapes from 'ansi-escapes';
 import stringWidth from 'string-width';
-import { list as listSlashCommands, aliasEntries, registryVersion } from '../slash/registry.js';
+import { list as listSlashCommands, aliasEntries, createSlashRegistryView } from '../slash/registry.js';
 import { stripAnsi } from '../display.js';
 import { acquireStdinClaim } from './stdin-claim.js';
 import { isPrintableGrapheme } from './printable.js';
@@ -115,16 +115,11 @@ export async function readWithAutocompleteTty(
       let repaintPending = false;
       const PASTE_WINDOW_MS = 8;
 
-      // Adapter for the slash highlighter — registered command names from
-      // `listSlashCommands()` include the leading `/`, so we strip it before
-      // membership-check so the highlighter (which passes the bare name)
-      // matches correctly.
-      const slashRegistryView: SlashRegistryView = {
-        has: (name) => listSlashCommands().some((c) => c.name === `/${name}`),
-        // Lets `colorizeInputBuffer` memoize per-keystroke repaints and drop
-        // the cache the instant a plugin/skill command is hot-swapped in.
-        version: registryVersion,
-      };
+      // Adapter for the slash highlighter. Delegates membership to the
+      // registry's alias-aware `has()` (via `createSlashRegistryView`) so
+      // aliased commands (e.g. `/quit`) colorize brand, not dim — and so the
+      // per-keystroke memo still invalidates on any mid-session hot-swap.
+      const slashRegistryView: SlashRegistryView = createSlashRegistryView();
 
       /**
        * Fully redraw the input line (and optional dropdown) at whatever row the

--- a/src/cli/slash/registry.test.ts
+++ b/src/cli/slash/registry.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for src/cli/slash/registry.ts — focused on `createSlashRegistryView`,
+ * the adapter the input-buffer colorizer (`colorizeInputBuffer`) uses to decide
+ * brand (known command → orange) vs meta (unknown token → dim) coloring.
+ *
+ * Regression context: aliased commands (e.g. `/quit` → `/exit`, `/t` →
+ * `/transcript`) previously colorized DIM in the input line, because all three
+ * input surfaces (reader, input-surface, stream-renderer) each built the view
+ * from `list()` — which returns canonical commands only — instead of the
+ * registry's alias-aware `has()`. This factory is the single source of truth
+ * that keeps those surfaces correct together.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import chalk from 'chalk';
+import {
+  register,
+  resetRegistry,
+  registryVersion,
+  createSlashRegistryView,
+  list,
+} from './registry.js';
+import type { SlashCommand } from './types.js';
+import { colorizeInputBuffer } from '../input-highlight.js';
+import { palette } from '../palette.js';
+
+const noopHandler: SlashCommand['handler'] = async () => 'continue';
+
+const makeCmd = (name: string, aliases?: string[]): SlashCommand => ({
+  name,
+  summary: `test ${name}`,
+  handler: noopHandler,
+  ...(aliases ? { aliases } : {}),
+});
+
+describe('createSlashRegistryView', () => {
+  beforeEach(() => {
+    resetRegistry();
+  });
+  afterEach(() => {
+    resetRegistry();
+  });
+
+  it('reports a canonical command name as known', () => {
+    register(makeCmd('/exit', ['/quit']));
+    // The colorizer strips the leading slash before calling has().
+    expect(createSlashRegistryView().has('exit')).toBe(true);
+  });
+
+  it('reports an alias as known (regression: /quit rendered dim)', () => {
+    register(makeCmd('/exit', ['/quit']));
+    expect(createSlashRegistryView().has('quit')).toBe(true);
+  });
+
+  it('reports an unknown token as not known', () => {
+    register(makeCmd('/exit', ['/quit']));
+    expect(createSlashRegistryView().has('notreal')).toBe(false);
+  });
+
+  it('documents why the old list()-based adapter mis-colored aliases', () => {
+    register(makeCmd('/exit', ['/quit']));
+    // list() returns canonical commands only — the alias is absent, which is
+    // exactly why an adapter built on `list().some(c => c.name === '/quit')`
+    // returned false and painted /quit with the dim/meta tone.
+    const canonicalNames = list().map((c) => c.name);
+    expect(canonicalNames).toContain('/exit');
+    expect(canonicalNames).not.toContain('/quit');
+  });
+
+  it('wires version() to registryVersion so the colorizer memo invalidates', () => {
+    const view = createSlashRegistryView();
+    const before = view.version!();
+    expect(before).toBe(registryVersion());
+    register(makeCmd('/exit', ['/quit']));
+    expect(view.version!()).toBeGreaterThan(before);
+  });
+
+  describe('end-to-end via colorizeInputBuffer', () => {
+    let prevLevel: 0 | 1 | 2 | 3;
+    beforeEach(() => {
+      prevLevel = chalk.level;
+      // Truecolor so brand (#E67E4C) and meta (blackBright) never collapse to
+      // the same downsampled ANSI code — the brand-vs-meta discriminator below
+      // must be exact.
+      chalk.level = 3;
+    });
+    afterEach(() => {
+      chalk.level = prevLevel;
+    });
+
+    it('colors an aliased command with the brand tone, not meta', () => {
+      register(makeCmd('/exit', ['/quit']));
+      const out = colorizeInputBuffer('/quit', createSlashRegistryView());
+      // Known command → brand orange (the same tone its canonical form gets),
+      // NOT the dim/meta tone reserved for unknown tokens.
+      expect(out).toBe(palette.brand('/quit'));
+      expect(out).not.toBe(palette.meta('/quit'));
+    });
+
+    it('colors the alias and its canonical form identically', () => {
+      register(makeCmd('/exit', ['/quit']));
+      const view = createSlashRegistryView();
+      expect(colorizeInputBuffer('/quit', view)).toBe(palette.brand('/quit'));
+      expect(colorizeInputBuffer('/exit', view)).toBe(palette.brand('/exit'));
+    });
+  });
+});

--- a/src/cli/slash/registry.ts
+++ b/src/cli/slash/registry.ts
@@ -9,6 +9,7 @@
 
 import type { SlashCommand, SlashContext, SlashResult } from './types.js';
 import type { ImageAttachment } from '../input/attachments.js';
+import type { SlashRegistryView } from '../input-highlight.js';
 
 const commands: Map<string, SlashCommand> = new Map();
 const aliases: Map<string, string> = new Map();
@@ -74,6 +75,33 @@ export function registerIfAbsent(cmd: SlashCommand): void {
 /** Whether a name is registered (canonical or alias). */
 export function has(nameOrAlias: string): boolean {
   return commands.has(nameOrAlias) || aliases.has(nameOrAlias);
+}
+
+/**
+ * Build the {@link SlashRegistryView} consumed by the input-buffer colorizer
+ * (`colorizeInputBuffer`). Membership delegates to this module's alias-aware
+ * `has()`, so an aliased command (e.g. `/quit` → `/exit`, `/t` → `/transcript`)
+ * colorizes as a known command (brand orange) instead of falling through to the
+ * unknown-token tone (dim). The colorizer passes the bare token name (leading
+ * `/` already stripped), while commands AND aliases are keyed WITH the `/`, so
+ * we re-add it before the lookup.
+ *
+ * Wiring membership through here — rather than each input surface re-deriving
+ * it from `list()` — is deliberate: `list()` returns canonical commands only,
+ * so any adapter built on it silently mis-colors every alias. Three surfaces
+ * (reader, input-surface, stream-renderer) shared that bug; this factory is the
+ * single source of truth that keeps them correct together.
+ *
+ * `version` is wired to `registryVersion` so the colorizer's per-keystroke memo
+ * invalidates the instant registry membership changes (plugin/skill hot-swap).
+ * Call ONCE per input surface and reuse the returned object — the colorizer's
+ * memo also keys on view identity.
+ */
+export function createSlashRegistryView(): SlashRegistryView {
+  return {
+    has: (name) => has(`/${name}`),
+    version: registryVersion,
+  };
 }
 
 /** Clear the registry — exposed for tests. */


### PR DESCRIPTION
## Problem

`/quit` (and every other slash-command **alias**) rendered dim in the REPL input buffer instead of brand orange like real commands/skills. Reported: "notice how /quit isn't orange like the skills?"

## Root cause

`colorizeInputBuffer` paints a `/token` brand-orange when `SlashRegistryView.has(name)` is true, dim otherwise. Three surfaces build that view — `reader.ts`, `input-surface.ts`, `_lib/stream-renderer.ts` — and all three used the **same** canonical-only predicate:

```ts
has: (name) => listSlashCommands().some((c) => c.name === `/${name}`)
```

`listSlashCommands()` is the registry's `list()`, which returns **canonical commands only** — aliases live in a separate map. So `has('quit')` was `false` and the token fell through to the unknown-token (dim / `meta`) tone. The registry's own `has()` (`registry.ts`) already resolves aliases; the adapters just bypassed it.

Because the buggy predicate was copy-pasted into three call sites, the bug landed in triplicate.

### Every affected alias

| Alias | Canonical | Source |
|-------|-----------|--------|
| `/quit` | `/exit` | `commands/core.ts` |
| `/ctx` | `/tokens` | `commands/info.ts` |
| `/edit` | `/editor` | `commands/editor.ts` |
| `/thinking-ui` | `/thinking` | `commands/thinking.ts` |
| `/branch` | `/fork` | `commands/fork.ts` |
| `/t` | `/transcript` | `commands/transcript.ts` |
| `/builtin-skills` | `/skills` | `plugin-skills/listing.ts` |

## Fix

Add `createSlashRegistryView()` in `slash/registry.ts` as the single adapter factory, delegating membership to the registry's alias-aware `has()` (re-adding the leading `/` the colorizer strips). All three call sites now share it instead of re-deriving membership from `list()`. Memo semantics are preserved: `version` stays wired to `registryVersion`, and each surface still constructs the view once (stable object identity for the colorizer's per-keystroke memo).

## Tests

New `src/cli/slash/registry.test.ts` (7 tests):
- canonical / alias / unknown membership through the factory;
- a test documenting *why* the old `list()`-based predicate missed aliases (`list()` excludes the alias);
- `version()` wiring to `registryVersion` (the colorizer's memo-invalidation token);
- an end-to-end `colorizeInputBuffer('/quit', view)` assertion that it equals `palette.brand('/quit')` and is **not** `palette.meta('/quit')` — the exact user-visible symptom.

Verified locally: full suite **698 files / 12974 tests passed**, 0 failed; `tsc --noEmit` clean.
