### PR TITLE
fix(compaction): support history compaction on the openai-compatible responses wire (#653)

### DIFF
--- a/src/agent/providers/openai-compatible/oneshot.test.ts
+++ b/src/agent/providers/openai-compatible/oneshot.test.ts
@@ -20,7 +20,12 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type OpenAI from 'openai';
-import { oneShotChatCompletion, oneShotResponses, __setOpenAIOneShotClientFactory } from './oneshot.js';
+import {
+  oneShotChatCompletion,
+  oneShotResponses,
+  ResponsesSummaryIncompleteError,
+  __setOpenAIOneShotClientFactory,
+} from './oneshot.js';
 import type { OpenAIAuthResolution } from './auth.js';
 import type { ResponsesStreamEvent } from './responses-translate.js';
 
@@ -358,6 +363,25 @@ function streamOf(...events: ResponsesStreamEvent[]): AsyncIterable<ResponsesStr
   })();
 }
 
+/** The terminal event that licenses `oneShotResponses` to return its text. */
+const COMPLETED_EVENT: ResponsesStreamEvent = {
+  type: 'response.completed',
+  response: { usage: { input_tokens: 1, output_tokens: 2, total_tokens: 3 } },
+};
+
+/**
+ * Text deltas followed by `response.completed` — the only shape that yields a
+ * summary. Fixtures that stop short of a terminal event now reject by design
+ * (a never-completed stream is a truncated summary), so request-shape tests
+ * must still complete their stream.
+ */
+function completedStreamOf(...deltas: string[]): ResponsesStreamEvent[] {
+  return [
+    ...deltas.map((delta): ResponsesStreamEvent => ({ type: 'response.output_text.delta', delta })),
+    COMPLETED_EVENT,
+  ];
+}
+
 describe('oneShotResponses', () => {
   it('accumulates output_text.delta events and returns the trimmed text', async () => {
     const result = await oneShotResponses({
@@ -379,9 +403,7 @@ describe('oneShotResponses', () => {
 
   it('awaits a promise-returning create (SDK APIPromise) and drains it', async () => {
     const result = await oneShotResponses({
-      client: makeResponsesClient(async () =>
-        streamOf({ type: 'response.output_text.delta', delta: 'ok' }),
-      ),
+      client: makeResponsesClient(async () => streamOf(...completedStreamOf('ok'))),
       model: 'gpt-5.5',
       system: 'sys',
       user: 'transcript',
@@ -395,7 +417,7 @@ describe('oneShotResponses', () => {
     await oneShotResponses({
       client: makeResponsesClient((params) => {
         captured = params;
-        return streamOf({ type: 'response.output_text.delta', delta: 'x' });
+        return streamOf(...completedStreamOf('x'));
       }),
       model: 'gpt-4o',
       system: 'COMPACT-SYS',
@@ -417,7 +439,7 @@ describe('oneShotResponses', () => {
     await oneShotResponses({
       client: makeResponsesClient((params) => {
         captured = params;
-        return streamOf({ type: 'response.output_text.delta', delta: 'x' });
+        return streamOf(...completedStreamOf('x'));
       }),
       model: 'gpt-5.5',
       system: 'COMPACT-SYS',
@@ -436,7 +458,7 @@ describe('oneShotResponses', () => {
     await oneShotResponses({
       client: makeResponsesClient((_params, options) => {
         capturedSignal = options?.signal;
-        return streamOf({ type: 'response.output_text.delta', delta: 'x' });
+        return streamOf(...completedStreamOf('x'));
       }),
       model: 'gpt-5.5',
       system: 'sys',
@@ -472,5 +494,83 @@ describe('oneShotResponses', () => {
         isChatGptBackend: true,
       }),
     ).rejects.toThrow(/backend rejected/);
+  });
+
+  // ── truncation guards (review findings on PR #700) ───────────────────────────
+  //
+  // Both assert the same invariant from opposite directions: this function must
+  // never RESOLVE with a partial summary, because the compaction core splices a
+  // resolved summary over real history and reports success.
+
+  it('REJECTS when an abort lands mid-stream instead of resolving with partial text', async () => {
+    const controller = new AbortController();
+    // Emits one delta, aborts, then keeps yielding — mimicking openai@6, whose
+    // SSE iterator SWALLOWS an abort and ends cleanly. Without abortableStream
+    // the drain would exit normally and resolve with just 'partial'.
+    const stream = (async function* (): AsyncIterable<ResponsesStreamEvent> {
+      yield { type: 'response.output_text.delta', delta: 'partial' };
+      controller.abort();
+      yield { type: 'response.output_text.delta', delta: ' more' };
+      yield COMPLETED_EVENT;
+    })();
+
+    await expect(
+      oneShotResponses({
+        client: makeResponsesClient(() => stream),
+        model: 'gpt-5.5',
+        system: 'sys',
+        user: 'msg',
+        isChatGptBackend: true,
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('REJECTS on response.failed after text deltas (partial summary, not a success)', async () => {
+    await expect(
+      oneShotResponses({
+        client: makeResponsesClient(() =>
+          streamOf(
+            { type: 'response.output_text.delta', delta: 'half a summ' },
+            { type: 'response.failed', response: {} },
+          ),
+        ),
+        model: 'gpt-5.5',
+        system: 'sys',
+        user: 'msg',
+        isChatGptBackend: true,
+      }),
+    ).rejects.toThrow(ResponsesSummaryIncompleteError);
+  });
+
+  it('REJECTS on response.incomplete, naming the terminal status', async () => {
+    await expect(
+      oneShotResponses({
+        client: makeResponsesClient(() =>
+          streamOf(
+            { type: 'response.output_text.delta', delta: 'cut short' },
+            { type: 'response.incomplete', response: { incomplete_details: { reason: 'max_output_tokens' } } },
+          ),
+        ),
+        model: 'gpt-5.5',
+        system: 'sys',
+        user: 'msg',
+        isChatGptBackend: true,
+      }),
+    ).rejects.toThrow(/max_output_tokens/);
+  });
+
+  it('REJECTS when the stream ends with no terminal event at all', async () => {
+    await expect(
+      oneShotResponses({
+        client: makeResponsesClient(() =>
+          streamOf({ type: 'response.output_text.delta', delta: 'truncated' }),
+        ),
+        model: 'gpt-5.5',
+        system: 'sys',
+        user: 'msg',
+        isChatGptBackend: true,
+      }),
+    ).rejects.toThrow(ResponsesSummaryIncompleteError);
   });
 });

--- a/src/agent/providers/openai-compatible/oneshot.test.ts
+++ b/src/agent/providers/openai-compatible/oneshot.test.ts
@@ -20,8 +20,9 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type OpenAI from 'openai';
-import { oneShotChatCompletion, __setOpenAIOneShotClientFactory } from './oneshot.js';
+import { oneShotChatCompletion, oneShotResponses, __setOpenAIOneShotClientFactory } from './oneshot.js';
 import type { OpenAIAuthResolution } from './auth.js';
+import type { ResponsesStreamEvent } from './responses-translate.js';
 
 // ── Auth mock ───────────────────────────────────────────────────────────────
 // `oneShotChatCompletion` calls `resolveOpenAIAuth(apiKey)` without deps, so we
@@ -326,5 +327,150 @@ describe('oneShotChatCompletion', () => {
       user: 'msg',
     });
     expect(result).toBe('from-hook');
+  });
+});
+
+// ── oneShotResponses (Responses wire — issue #653) ────────────────────────────
+
+interface ResponsesCreateParams {
+  model: string;
+  input: unknown;
+  stream?: boolean;
+  instructions?: string;
+  store?: boolean;
+  max_output_tokens?: number;
+  tools?: unknown[];
+}
+type ResponsesCreateFn = (
+  params: ResponsesCreateParams,
+  options?: { signal?: AbortSignal },
+) => Promise<AsyncIterable<ResponsesStreamEvent>> | AsyncIterable<ResponsesStreamEvent>;
+
+/** A client exposing only `responses.create` — oneShotResponses uses it verbatim. */
+function makeResponsesClient(createFn: ResponsesCreateFn): OpenAI {
+  return { responses: { create: createFn } } as unknown as OpenAI;
+}
+
+/** Async generator over a fixed list of Responses stream events. */
+function streamOf(...events: ResponsesStreamEvent[]): AsyncIterable<ResponsesStreamEvent> {
+  return (async function* () {
+    for (const e of events) yield e;
+  })();
+}
+
+describe('oneShotResponses', () => {
+  it('accumulates output_text.delta events and returns the trimmed text', async () => {
+    const result = await oneShotResponses({
+      client: makeResponsesClient(() =>
+        streamOf(
+          { type: 'response.output_text.delta', delta: '  first ' },
+          { type: 'response.output_text.delta', delta: 'second  ' },
+          { type: 'response.completed', response: { usage: { input_tokens: 1, output_tokens: 2, total_tokens: 3 } } },
+        ),
+      ),
+      model: 'gpt-5.5',
+      system: 'sys',
+      user: 'transcript',
+      isChatGptBackend: false,
+    });
+    // Deltas concatenated verbatim, then trimmed at the ends only.
+    expect(result).toBe('first second');
+  });
+
+  it('awaits a promise-returning create (SDK APIPromise) and drains it', async () => {
+    const result = await oneShotResponses({
+      client: makeResponsesClient(async () =>
+        streamOf({ type: 'response.output_text.delta', delta: 'ok' }),
+      ),
+      model: 'gpt-5.5',
+      system: 'sys',
+      user: 'transcript',
+      isChatGptBackend: false,
+    });
+    expect(result).toBe('ok');
+  });
+
+  it('sends stream:true, the model, no tools, and the system prompt as instructions', async () => {
+    let captured: ResponsesCreateParams | undefined;
+    await oneShotResponses({
+      client: makeResponsesClient((params) => {
+        captured = params;
+        return streamOf({ type: 'response.output_text.delta', delta: 'x' });
+      }),
+      model: 'gpt-4o',
+      system: 'COMPACT-SYS',
+      user: 'the transcript',
+      isChatGptBackend: false,
+    });
+    expect(captured?.model).toBe('gpt-4o');
+    expect(captured?.stream).toBe(true);
+    expect(captured?.instructions).toBe('COMPACT-SYS');
+    // A summarize advertises no tools.
+    expect(captured?.tools).toBeUndefined();
+    // Public API-key path carries the output cap.
+    expect(captured?.max_output_tokens).toBeDefined();
+    expect(captured?.store).toBeUndefined();
+  });
+
+  it('on the ChatGPT backend: omits max_output_tokens and sets store:false', async () => {
+    let captured: ResponsesCreateParams | undefined;
+    await oneShotResponses({
+      client: makeResponsesClient((params) => {
+        captured = params;
+        return streamOf({ type: 'response.output_text.delta', delta: 'x' });
+      }),
+      model: 'gpt-5.5',
+      system: 'COMPACT-SYS',
+      user: 'the transcript',
+      isChatGptBackend: true,
+    });
+    // The ChatGPT/Codex backend 400s on any output-cap param, and needs store:false.
+    expect(captured && 'max_output_tokens' in captured).toBe(false);
+    expect(captured?.store).toBe(false);
+    expect(captured?.instructions).toBe('COMPACT-SYS');
+  });
+
+  it('forwards the abort signal to responses.create', async () => {
+    const controller = new AbortController();
+    let capturedSignal: AbortSignal | undefined;
+    await oneShotResponses({
+      client: makeResponsesClient((_params, options) => {
+        capturedSignal = options?.signal;
+        return streamOf({ type: 'response.output_text.delta', delta: 'x' });
+      }),
+      model: 'gpt-5.5',
+      system: 'sys',
+      user: 'msg',
+      isChatGptBackend: true,
+      signal: controller.signal,
+    });
+    expect(capturedSignal).toBe(controller.signal);
+  });
+
+  it('returns empty string when the stream carries no text', async () => {
+    const result = await oneShotResponses({
+      client: makeResponsesClient(() =>
+        streamOf({ type: 'response.completed', response: { usage: { input_tokens: 1, output_tokens: 0, total_tokens: 1 } } }),
+      ),
+      model: 'gpt-5.5',
+      system: 'sys',
+      user: 'msg',
+      isChatGptBackend: true,
+    });
+    expect(result).toBe('');
+  });
+
+  it('propagates a create() error (caller/compaction core treats it as a safe no-op)', async () => {
+    await expect(
+      oneShotResponses({
+        client: makeResponsesClient(() => {
+          throw new Error('backend rejected');
+        }),
+        model: 'gpt-5.5',
+        system: 'sys',
+        user: 'msg',
+        isChatGptBackend: true,
+      }),
+    ).rejects.toThrow(/backend rejected/);
   });
 });

--- a/src/agent/providers/openai-compatible/oneshot.ts
+++ b/src/agent/providers/openai-compatible/oneshot.ts
@@ -19,6 +19,10 @@
 import OpenAI from 'openai';
 import { resolveOpenAIAuth } from './auth.js';
 import { isReasoningModel } from '../../model-capabilities.js';
+import type { OpenAIMessage } from './messages.js';
+import { buildResponsesRequestBody } from './query/request-body.js';
+import { createStreamState } from './translate.js';
+import { translateResponsesEvent, type ResponsesStreamEvent } from './responses-translate.js';
 
 /** Test injection hook — supplants the real `OpenAI` constructor. */
 export type OneShotOpenAIClientFactory = (opts: { apiKey: string; baseURL?: string }) => OpenAI;
@@ -129,4 +133,101 @@ export async function oneShotChatCompletion(input: OpenAIOneShotInput): Promise<
 
   const content = response.choices?.[0]?.message?.content;
   return typeof content === 'string' ? content.trim() : '';
+}
+
+export interface OpenAIResponsesOneShotInput {
+  /**
+   * Pre-built client, used verbatim (its baseURL, credentials, ChatGPT-OAuth
+   * headers, and account-id). REQUIRED — unlike {@link oneShotChatCompletion}
+   * there is no auth-resolution fallback: a Responses-wire summarize is only
+   * meaningful reusing a live session's client, which is where the Responses
+   * wire (and the private ChatGPT/Codex backend) is configured.
+   */
+  client: OpenAI;
+  /** Model id, passed straight through to the API (no alias expansion). */
+  model: string;
+  /** System prompt. Becomes the Responses `instructions` field. */
+  system: string;
+  /** User message content. Becomes the single Responses `input` item. */
+  user: string;
+  /**
+   * True on the private ChatGPT/Codex subscription backend. Scopes the
+   * request-body quirks that {@link buildResponsesRequestBody} applies: omit
+   * every output-cap param (the backend 400s on them), force `store: false`,
+   * and require a non-empty `instructions`. Mirror the caller's own
+   * `auth.source === 'chatgpt-oauth'` check.
+   */
+  isChatGptBackend: boolean;
+  /**
+   * Soft output cap, applied ONLY on the public API-key path. Default 1024 —
+   * summary-sized. Omitted entirely when `isChatGptBackend` (that backend
+   * rejects `max_output_tokens`).
+   */
+  maxTokens?: number;
+  /** Caller-controlled cancellation. Aborts the in-flight request. */
+  signal?: AbortSignal;
+}
+
+/**
+ * Single one-shot summarization over the OpenAI **Responses** wire. The
+ * Responses-wire sibling of {@link oneShotChatCompletion}; it exists so history
+ * compaction works on responses-mode sessions (ChatGPT-OAuth and the
+ * `AFK_OPENAI_USE_RESPONSES` opt-in), where `chat.completions.create` is
+ * rejected by the backend — issue #653.
+ *
+ * Design:
+ *   - Reuses {@link buildResponsesRequestBody} (so every ChatGPT-backend quirk
+ *     stays in one place) and {@link translateResponsesEvent} (the single
+ *     source of truth for which stream event carries assistant text), so the
+ *     summarize path can never drift from the turn path.
+ *   - Streams (`stream: true`, set by the body builder) rather than issuing a
+ *     non-streaming call. Deliberate: the ChatGPT/Codex backend is only ever
+ *     streamed to, so a throwaway summarize rides the one proven wire.
+ *   - Drains the stream in ISOLATION — its own {@link createStreamState}, the
+ *     yielded `ProviderEvent`s discarded — so it never touches session state
+ *     (`lastUsage`, `priorTurns`), emits no trace, and dispatches no tools.
+ *   - Has no retry opinion (like `oneShotChatCompletion`): it throws on SDK
+ *     error, and the compaction core treats that as a safe no-op (history
+ *     untouched).
+ *
+ * Returns the accumulated assistant text, trimmed.
+ */
+export async function oneShotResponses(input: OpenAIResponsesOneShotInput): Promise<string> {
+  const { client, model, system, user, isChatGptBackend, maxTokens = 1024, signal } = input;
+
+  const messages: OpenAIMessage[] = [
+    { role: 'system', content: system },
+    { role: 'user', content: user },
+  ];
+  const requestBody = buildResponsesRequestBody({
+    model,
+    messages,
+    // A summarize advertises no tools — with none, the model must answer in text.
+    activeTools: undefined,
+    // Public path: bound the summary length. On the ChatGPT backend the builder
+    // omits the cap entirely (it 400s there), so this value is simply ignored.
+    maxOutputTokens: maxTokens,
+    // No reasoning on a summarize — cheaper/faster, and a compaction summary
+    // needs none. resolveReasoningEffort(undefined, ...) yields no reasoning key.
+    effort: undefined,
+    isChatGptBackend,
+  });
+
+  const stream = (await client.responses.create(
+    requestBody as never,
+    signal ? { signal } : undefined,
+  )) as unknown as AsyncIterable<ResponsesStreamEvent>;
+
+  // Drain into a private StreamState. `translateResponsesEvent` mutates only the
+  // state we pass (accumulating `response.output_text.delta` into
+  // `assistantText`); the ProviderEvents it yields have no consumer here, so we
+  // exhaust the generator purely for its state mutation.
+  const state = createStreamState();
+  for await (const event of stream) {
+    const events = translateResponsesEvent(event, state, 'compact-oneshot');
+    while (!events.next().done) {
+      // Discard — assistant text is accumulated into `state`, not emitted.
+    }
+  }
+  return state.assistantText.trim();
 }

--- a/src/agent/providers/openai-compatible/oneshot.ts
+++ b/src/agent/providers/openai-compatible/oneshot.ts
@@ -23,6 +23,25 @@ import type { OpenAIMessage } from './messages.js';
 import { buildResponsesRequestBody } from './query/request-body.js';
 import { createStreamState } from './translate.js';
 import { translateResponsesEvent, type ResponsesStreamEvent } from './responses-translate.js';
+import { abortableStream } from '../shared/abortable-stream.js';
+
+/**
+ * Thrown by {@link oneShotResponses} when the summarize stream ends WITHOUT a
+ * `response.completed` — i.e. `response.failed`, `response.incomplete`, or no
+ * terminal event at all. Distinct error type on purpose: a non-completed
+ * response means "this summary is partial", NOT "this backend rejects the
+ * request shape", so the caller must not latch the Responses wire as
+ * unsupported on it (see `query.ts` `summarizeViaResponses`). `finishReason`
+ * carries whatever terminal status the translator recorded, or `null`.
+ */
+export class ResponsesSummaryIncompleteError extends Error {
+  constructor(public readonly finishReason: string | null) {
+    super(
+      `responses summarize did not complete (terminal status: ${finishReason ?? 'none'})`,
+    );
+    this.name = 'ResponsesSummaryIncompleteError';
+  }
+}
 
 /** Test injection hook — supplants the real `OpenAI` constructor. */
 export type OneShotOpenAIClientFactory = (opts: { apiKey: string; baseURL?: string }) => OpenAI;
@@ -190,7 +209,12 @@ export interface OpenAIResponsesOneShotInput {
  *     error, and the compaction core treats that as a safe no-op (history
  *     untouched).
  *
- * Returns the accumulated assistant text, trimmed.
+ * Returns the accumulated assistant text, trimmed — but ONLY for a response the
+ * backend marked complete. Throws an AbortError if `signal` fires mid-stream
+ * (the wrapper defeats openai@6's abort-swallowing iterator) and
+ * {@link ResponsesSummaryIncompleteError} when the stream ends on
+ * `response.failed` / `response.incomplete` / no terminal event. Both keep the
+ * compaction core on its safe no-op path instead of splicing a partial summary.
  */
 export async function oneShotResponses(input: OpenAIResponsesOneShotInput): Promise<string> {
   const { client, model, system, user, isChatGptBackend, maxTokens = 1024, signal } = input;
@@ -218,16 +242,37 @@ export async function oneShotResponses(input: OpenAIResponsesOneShotInput): Prom
     signal ? { signal } : undefined,
   )) as unknown as AsyncIterable<ResponsesStreamEvent>;
 
-  // Drain into a private StreamState. `translateResponsesEvent` mutates only the
-  // state we pass (accumulating `response.output_text.delta` into
-  // `assistantText`); the ProviderEvents it yields have no consumer here, so we
-  // exhaust the generator purely for its state mutation.
+  // Invariant: this function may return text ONLY when the backend marked the
+  // response COMPLETE and no abort landed mid-drain. Anything else must throw,
+  // because the compaction core splices a returned summary over real history and
+  // reports success — so a truncated summary is silent, irreversible data loss.
+  // Two distinct ways a naive drain leaks a partial summary:
+  //   1. openai@6 SWALLOWS a mid-stream abort: `core/streaming.js` RETURNS from
+  //      its iterator on an AbortError, and a `return` in an async generator
+  //      yields `done:true` — so a bare `for await` ends CLEANLY and we would
+  //      resolve with truncated text. `abortableStream` races each pull against
+  //      the signal and THROWS instead, so the core's existing catch/isAborted()
+  //      path maps it to the `aborted` no-op. Same wrapper the turn path uses
+  //      (`query/stream-drive.ts`); see `shared/abortable-stream.ts`.
+  //   2. `response.failed` / `response.incomplete` can arrive AFTER text deltas,
+  //      so accumulated text exists but is not a whole summary. Only
+  //      `response.completed` licenses the return; every other terminal state —
+  //      and a stream that ends carrying none — throws.
+  //
+  // `translateResponsesEvent` mutates only the state we pass (accumulating
+  // `response.output_text.delta` into `assistantText`); the ProviderEvents it
+  // yields have no consumer here, so we exhaust the generator purely for its
+  // state mutation.
+  const source = signal ? abortableStream(stream, signal) : stream;
   const state = createStreamState();
-  for await (const event of stream) {
+  let completed = false;
+  for await (const event of source) {
+    if (event.type === 'response.completed') completed = true;
     const events = translateResponsesEvent(event, state, 'compact-oneshot');
     while (!events.next().done) {
       // Discard — assistant text is accumulated into `state`, not emitted.
     }
   }
+  if (!completed) throw new ResponsesSummaryIncompleteError(state.finishReason);
   return state.assistantText.trim();
 }

--- a/src/agent/providers/openai-compatible/query.test.ts
+++ b/src/agent/providers/openai-compatible/query.test.ts
@@ -22,6 +22,7 @@ import {
 } from './query.js';
 import { OpenAICompatibleProvider } from './index.js';
 import type { OpenAIChunk } from './translate.js';
+import { COMPACT_SYSTEM_PROMPT } from '../shared/compaction.js';
 import { SessionToolDispatcher } from '../../tools/dispatcher.js';
 import { createHookRegistry, type HookRegistry } from '../../hooks.js';
 import { createPlanModeGate } from '../../plan-mode-gate.js';
@@ -1336,7 +1337,7 @@ describe('OpenAICompatibleQuery — ProviderQuery surface', () => {
     q.close();
   });
 
-  it('compact bails `unsupported-wire-mode` on a responses-mode (ChatGPT-OAuth) session', async () => {
+  it('compact now ATTEMPTS on a responses-mode session (no-ops history-too-short when empty) (#653)', async () => {
     const q = new OpenAICompatibleQuery({
       auth: { apiKey: 'k', source: 'chatgpt-oauth', last4: 'kkkk' },
       model: 'gpt-4o-mini',
@@ -1344,13 +1345,110 @@ describe('OpenAICompatibleQuery — ProviderQuery surface', () => {
       promptStream: singleInput('x'),
       config: baseConfig(),
     });
-    // A ChatGPT-OAuth session is forced to the responses wire, whose backend
-    // would reject the Chat Completions summarize call — so compact() must bail
-    // early with an actionable reason rather than issue a doomed request.
+    // Responses-mode compaction is now wired (#653): the old 'unsupported-wire-mode'
+    // early bail is gone. With no turns run there is nothing older than the keep
+    // window, so the shared core no-ops 'history-too-short' BEFORE any summarize
+    // is issued — identical to the Chat-Completions empty-session case above, and
+    // proving compaction is no longer structurally refused on the responses wire.
     const result = await q.compact();
     expect(result.compacted).toBe(false);
-    expect(result.reason).toBe('unsupported-wire-mode');
+    expect(result.reason).toBe('history-too-short');
     q.close();
+  });
+
+  it('auto-compacts on the responses wire via responses.create, never chat.completions (#653)', async () => {
+    // The responses-mode compaction fix: the summarize must ride the Responses
+    // wire (the ChatGPT/Codex backend rejects chat.completions). Both the
+    // streaming turns AND the throwaway summarize go through responses.create;
+    // the summarize is the call whose `instructions` is COMPACT_SYSTEM_PROMPT.
+    const summarizeCalls: Array<Record<string, unknown>> = [];
+    __setOpenAIClientFactory(
+      () =>
+        ({
+          chat: {
+            completions: {
+              create: async () => {
+                throw new Error('chat.completions.create must not run on the responses wire');
+              },
+            },
+          },
+          responses: {
+            create: async (args: Record<string, unknown>) => {
+              if (args['instructions'] === COMPACT_SYSTEM_PROMPT) summarizeCalls.push(args);
+              return (async function* () {
+                yield { type: 'response.output_text.delta', delta: 'AUTO-SUMMARY' };
+                yield {
+                  type: 'response.completed',
+                  response: { usage: { input_tokens: 200_000, output_tokens: 10, total_tokens: 200_010 } },
+                };
+              })();
+            },
+          },
+        }) as unknown as OpenAI,
+    );
+    const q = buildQueryFromConfig(
+      baseConfig({ model: 'gpt-4o-mini', autoCompact: true }),
+      multiInput('u1', 'u2', 'u3'),
+      { useResponsesApi: true },
+    );
+    await collect(q);
+    // Each turn reports ~200k tokens — far over gpt-4o-mini's 128k window — so the
+    // turn-boundary trigger fires compaction, and the summarize rode responses.create
+    // (a chat.completions.create would have thrown above and failed the run).
+    expect(summarizeCalls.length).toBeGreaterThanOrEqual(1);
+    // Public API-key path (source 'config', not chatgpt-oauth) DOES carry the cap.
+    expect(summarizeCalls[0]?.['max_output_tokens']).toBeDefined();
+    installMockClient();
+  });
+
+  it('latches after a responses summarize failure and stops re-issuing the doomed call (#653)', async () => {
+    // If the responses-wire summarize throws (e.g. the backend rejects the
+    // throwaway summarize turn), the session latches so later boundaries no-op
+    // cheaply instead of hammering the backend every turn.
+    let summarizeAttempts = 0;
+    __setOpenAIClientFactory(
+      () =>
+        ({
+          chat: {
+            completions: {
+              create: async () => {
+                throw new Error('chat.completions.create must not run on the responses wire');
+              },
+            },
+          },
+          responses: {
+            create: async (args: Record<string, unknown>) => {
+              if (args['instructions'] === COMPACT_SYSTEM_PROMPT) {
+                summarizeAttempts++;
+                throw new Error('backend rejected summarize');
+              }
+              return (async function* () {
+                yield { type: 'response.output_text.delta', delta: 'ok' };
+                yield {
+                  type: 'response.completed',
+                  response: { usage: { input_tokens: 200_000, output_tokens: 10, total_tokens: 200_010 } },
+                };
+              })();
+            },
+          },
+        }) as unknown as OpenAI,
+    );
+    const q = buildQueryFromConfig(
+      baseConfig({ model: 'gpt-4o-mini', autoCompact: true }),
+      multiInput('u1', 'u2', 'u3'),
+      { useResponsesApi: true },
+    );
+    await collect(q);
+    // The first summarize attempt throws and latches the flag; every later
+    // boundary short-circuits, so the backend is asked to summarize exactly once.
+    expect(summarizeAttempts).toBe(1);
+    // A subsequent manual compact() confirms the latch: no-op without re-calling.
+    const manual = await q.compact();
+    expect(manual.compacted).toBe(false);
+    expect(manual.reason).toBe('responses-compaction-unavailable');
+    expect(summarizeAttempts).toBe(1);
+    q.close();
+    installMockClient();
   });
 
   it("compact bails 'no-usable-auth' when no client was constructed (null auth)", async () => {

--- a/src/agent/providers/openai-compatible/query.test.ts
+++ b/src/agent/providers/openai-compatible/query.test.ts
@@ -1401,11 +1401,15 @@ describe('OpenAICompatibleQuery — ProviderQuery surface', () => {
     installMockClient();
   });
 
-  it('latches after a responses summarize failure and stops re-issuing the doomed call (#653)', async () => {
-    // If the responses-wire summarize throws (e.g. the backend rejects the
-    // throwaway summarize turn), the session latches so later boundaries no-op
-    // cheaply instead of hammering the backend every turn.
-    let summarizeAttempts = 0;
+  /**
+   * Responses-wire client whose summarize call (the one carrying
+   * COMPACT_SYSTEM_PROMPT as `instructions`) fails with `summarizeError`, while
+   * ordinary turns stream a ~200k-token reply so every turn boundary trips the
+   * auto-compaction threshold. `attempts` counts summarize calls reaching the
+   * backend — the observable that proves whether the latch engaged.
+   */
+  function installResponsesClientFailingSummarize(summarizeError: unknown): { attempts: () => number } {
+    let attempts = 0;
     __setOpenAIClientFactory(
       () =>
         ({
@@ -1419,11 +1423,121 @@ describe('OpenAICompatibleQuery — ProviderQuery surface', () => {
           responses: {
             create: async (args: Record<string, unknown>) => {
               if (args['instructions'] === COMPACT_SYSTEM_PROMPT) {
-                summarizeAttempts++;
-                throw new Error('backend rejected summarize');
+                attempts++;
+                throw summarizeError;
               }
               return (async function* () {
                 yield { type: 'response.output_text.delta', delta: 'ok' };
+                yield {
+                  type: 'response.completed',
+                  response: { usage: { input_tokens: 200_000, output_tokens: 10, total_tokens: 200_010 } },
+                };
+              })();
+            },
+          },
+        }) as unknown as OpenAI,
+    );
+    return { attempts: () => attempts };
+  }
+
+  /** An error carrying an explicit HTTP status, as the OpenAI SDK's APIError does. */
+  function statusError(status: number, message: string): Error {
+    return Object.assign(new Error(message), { status });
+  }
+
+  it('latches after the backend REFUSES the summarize (400) and stops re-issuing it (#653)', async () => {
+    // A 400 proves the backend rejects this request shape (e.g. the ChatGPT/Codex
+    // backend refusing the throwaway summarize turn), so the session stops
+    // hammering it every turn boundary.
+    const client = installResponsesClientFailingSummarize(
+      statusError(400, 'unsupported request for this backend'),
+    );
+    const q = buildQueryFromConfig(
+      baseConfig({ model: 'gpt-4o-mini', autoCompact: true }),
+      multiInput('u1', 'u2', 'u3'),
+      { useResponsesApi: true },
+    );
+    await collect(q);
+    // The first attempt is refused and latches the flag; every later boundary
+    // short-circuits, so the backend is asked to summarize exactly once.
+    expect(client.attempts()).toBe(1);
+    // A subsequent manual compact() confirms the latch: no-op without re-calling.
+    const manual = await q.compact();
+    expect(manual.compacted).toBe(false);
+    expect(manual.reason).toBe('responses-compaction-unavailable');
+    expect(client.attempts()).toBe(1);
+    q.close();
+    installMockClient();
+  });
+
+  it('does NOT latch on a transient summarize failure (429) — later boundaries retry (#700 review)', async () => {
+    // Regression guard for the review finding: latching on ANY non-abort error
+    // meant one 429/5xx/network blip permanently disabled compaction for the
+    // session, letting context grow until normal calls overflow the window —
+    // re-creating the exact bug #653 fixed. A transient status must stay
+    // retryable, so the backend is asked again on later boundaries.
+    const client = installResponsesClientFailingSummarize(statusError(429, 'rate limited'));
+    const q = buildQueryFromConfig(
+      baseConfig({ model: 'gpt-4o-mini', autoCompact: true }),
+      multiInput('u1', 'u2', 'u3'),
+      { useResponsesApi: true },
+    );
+    await collect(q);
+    expect(client.attempts()).toBeGreaterThan(1);
+    // And a manual compact() still ATTEMPTS rather than reporting the latch.
+    const before = client.attempts();
+    const manual = await q.compact();
+    expect(manual.reason).not.toBe('responses-compaction-unavailable');
+    expect(client.attempts()).toBeGreaterThan(before);
+    q.close();
+    installMockClient();
+  });
+
+  it('does NOT latch when a status-less error (network blip) fails the summarize (#700 review)', async () => {
+    // A throw with no HTTP status is a network drop / DNS failure / bad baseURL —
+    // never proof that the backend refuses this request shape.
+    const client = installResponsesClientFailingSummarize(new Error('socket hang up'));
+    const q = buildQueryFromConfig(
+      baseConfig({ model: 'gpt-4o-mini', autoCompact: true }),
+      multiInput('u1', 'u2', 'u3'),
+      { useResponsesApi: true },
+    );
+    await collect(q);
+    expect(client.attempts()).toBeGreaterThan(1);
+    const manual = await q.compact();
+    expect(manual.reason).not.toBe('responses-compaction-unavailable');
+    q.close();
+    installMockClient();
+  });
+
+  it('an abort mid-summarize leaves history UNCHANGED and does not latch (#700 review)', async () => {
+    // The high-severity review finding: openai@6 swallows a mid-stream abort, so
+    // before the abortableStream wrapper the drain resolved with TRUNCATED text
+    // and the core spliced that partial summary over real history, reporting
+    // success. Now the abort throws: history is untouched, and because an
+    // interrupt is transient it must NOT disable compaction for the session.
+    let summarizeAttempts = 0;
+    let queryRef: OpenAICompatibleQuery | undefined;
+    __setOpenAIClientFactory(
+      () =>
+        ({
+          chat: {
+            completions: {
+              create: async () => {
+                throw new Error('chat.completions.create must not run on the responses wire');
+              },
+            },
+          },
+          responses: {
+            create: async (args: Record<string, unknown>) => {
+              const isSummarize = args['instructions'] === COMPACT_SYSTEM_PROMPT;
+              if (isSummarize) summarizeAttempts++;
+              return (async function* () {
+                yield { type: 'response.output_text.delta', delta: isSummarize ? 'PARTIAL' : 'ok' };
+                // Interrupt lands mid-summarize, exactly as an ESC keypress would
+                // (interrupt() aborts the same coordinator slot compaction uses).
+                if (isSummarize) await queryRef?.interrupt();
+                yield { type: 'response.output_text.delta', delta: ' MORE' };
                 yield {
                   type: 'response.completed',
                   response: { usage: { input_tokens: 200_000, output_tokens: 10, total_tokens: 200_010 } },
@@ -1438,15 +1552,111 @@ describe('OpenAICompatibleQuery — ProviderQuery surface', () => {
       multiInput('u1', 'u2', 'u3'),
       { useResponsesApi: true },
     );
+    queryRef = q;
     await collect(q);
-    // The first summarize attempt throws and latches the flag; every later
-    // boundary short-circuits, so the backend is asked to summarize exactly once.
-    expect(summarizeAttempts).toBe(1);
-    // A subsequent manual compact() confirms the latch: no-op without re-calling.
+    expect(summarizeAttempts).toBeGreaterThanOrEqual(1);
+    // The aborted summarize never latched, so compaction is still available: a
+    // manual compact() reports any reason EXCEPT the permanent-disable one.
     const manual = await q.compact();
-    expect(manual.compacted).toBe(false);
-    expect(manual.reason).toBe('responses-compaction-unavailable');
-    expect(summarizeAttempts).toBe(1);
+    expect(manual.reason).not.toBe('responses-compaction-unavailable');
+    // And no partial summary was spliced in: the summary preamble the core writes
+    // on success (COMPACT_SUMMARY_HEADER) is absent, so history is unchanged.
+    expect(manual.compacted === true && manual.messagesAfter > manual.messagesBefore).toBe(false);
+    q.close();
+    installMockClient();
+  });
+
+  it('on the latched path, deterministic microcompaction still reclaims tool results (#700 review)', async () => {
+    // Review finding 3: the latch returned BEFORE compactOpenAIHistory, which
+    // also skipped microcompaction — a no-LLM, no-network pass that works even
+    // when the backend refuses everything. Skipping it left the session unable to
+    // reclaim context by ANY mechanism. A big tool_result must still be cleared.
+    // Microcompaction protects the newest `keepLast` (4) tool results, so the
+    // session needs MORE than four before any are eligible — hence six turns,
+    // each producing one oversized tool result.
+    const bigResult = 'x'.repeat(50_000);
+    const hookRegistry = createHookRegistry();
+    const dispatcher = new SessionToolDispatcher({
+      handlers: new Map<string, ToolHandler>([['fetch_big', async () => ({ content: bigResult })]]),
+      schemas: [{ name: 'fetch_big', description: 'Big', input_schema: { type: 'object' } }],
+      hookRegistry,
+    });
+    let turnCalls = 0;
+    __setOpenAIClientFactory(
+      () =>
+        ({
+          chat: {
+            completions: {
+              create: async () => {
+                throw new Error('chat.completions.create must not run on the responses wire');
+              },
+            },
+          },
+          responses: {
+            create: async (args: Record<string, unknown>) => {
+              // Summarize is REFUSED (400) so the latch engages.
+              if (args['instructions'] === COMPACT_SYSTEM_PROMPT) {
+                throw statusError(400, 'unsupported request for this backend');
+              }
+              // Each turn is exactly two calls: the odd one requests the tool, the
+              // even one answers with text. Counting calls (rather than sniffing
+              // the input for the tool name) keeps turns 2..N from mistaking an
+              // EARLIER turn's tool call in history for their own.
+              turnCalls++;
+              if (turnCalls % 2 === 1) {
+                return (async function* () {
+                  yield {
+                    type: 'response.output_item.added',
+                    output_index: 0,
+                    item: { type: 'function_call', call_id: `call_${turnCalls}`, name: 'fetch_big' },
+                  };
+                  yield { type: 'response.function_call_arguments.delta', output_index: 0, delta: '{}' };
+                  yield {
+                    type: 'response.completed',
+                    response: { usage: { input_tokens: 200_000, output_tokens: 10, total_tokens: 200_010 } },
+                  };
+                })();
+              }
+              return (async function* () {
+                yield { type: 'response.output_text.delta', delta: 'done' };
+                yield {
+                  type: 'response.completed',
+                  response: { usage: { input_tokens: 200_000, output_tokens: 10, total_tokens: 200_010 } },
+                };
+              })();
+            },
+          },
+        }) as unknown as OpenAI,
+    );
+    // autoCompact OFF so the boundaries are driven explicitly below — an auto pass
+    // would microcompact mid-run and make the assertions order-dependent.
+    const q = buildQueryFromConfig(
+      baseConfig({ model: 'gpt-4o-mini', autoCompact: false }),
+      multiInput('u1', 'u2', 'u3', 'u4', 'u5', 'u6'),
+      { useResponsesApi: true, toolDispatcher: dispatcher },
+    );
+    await collect(q);
+
+    // 1st compact: not yet latched, so it attempts the summarize and is refused.
+    // The core reports a safe no-op and the latch engages. (The core's own
+    // microcompaction fallback does NOT run on a summarization failure, so every
+    // oversized tool result is still present for the next call.)
+    const first = await q.compact();
+    expect(first.compacted).toBe(false);
+    expect(first.reason).not.toBe('microcompacted');
+
+    // 2nd compact: takes the latched path — which must still microcompact rather
+    // than short-circuiting on the latch alone.
+    const second = await q.compact();
+    expect(second.compacted).toBe(false);
+    expect(second.reason).toBe('microcompacted');
+    expect(second.microcompaction?.blocksCleared).toBeGreaterThan(0);
+    expect(second.microcompaction?.bytesReclaimed).toBeGreaterThan(0);
+
+    // 3rd compact: every remaining result is inside the protected window, so
+    // there is nothing left to reclaim and the latch reason surfaces.
+    const third = await q.compact();
+    expect(third.reason).toBe('responses-compaction-unavailable');
     q.close();
     installMockClient();
   });

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -91,7 +91,7 @@ import {
 import { HookBlockedError, DenialCircuitBreakerError } from '../../../utils/errors.js';
 import { COMPACT_SYSTEM_PROMPT, wrapTranscriptForSummary } from '../shared/compaction.js';
 import { compactOpenAIHistory, readShrinkFraction } from './compact.js';
-import { oneShotChatCompletion } from './oneshot.js';
+import { oneShotChatCompletion, oneShotResponses } from './oneshot.js';
 import { PLAN_MODE_ADDENDUM_TEXT } from '../shared/plan-mode-addendum.js';
 import { AFK_MODE_ADDENDUM_TEXT } from '../shared/afk-mode-addendum.js';
 import { EXIT_PLAN_MODE_TOOL_NAME } from '../../tools/handlers/exit-plan-mode.js';
@@ -192,6 +192,16 @@ export class OpenAICompatibleQuery implements ProviderQuery {
 
   private currentModel: string;
   private currentPermissionMode: string;
+
+  /**
+   * Latched `true` when a Responses-wire summarize (history compaction) fails
+   * for a non-abort reason — e.g. the ChatGPT/Codex backend rejects the
+   * throwaway summarize turn. Once set, further compaction attempts no-op
+   * immediately (see `compactHistory`) instead of re-issuing a doomed request
+   * every turn boundary. Per-session; never reset. Aborts/timeouts do NOT set
+   * it (those are transient, not a backend incompatibility). Issue #653.
+   */
+  private responsesCompactionUnavailable = false;
 
   private abortController: AbortController | null = null;
   private pendingAbortReason: 'interrupted' | 'closed' | null = null;
@@ -885,11 +895,15 @@ export class OpenAICompatibleQuery implements ProviderQuery {
    * is intentionally NOT wired here: a mismatched id simply fails the summarize
    * call, which the core treats as a safe no-op, leaving history untouched.
    *
-   * Only Chat Completions sessions are supported. The summarizer runs through
-   * `oneShotChatCompletion` (Chat Completions wire), so a responses-mode session
-   * (ChatGPT-OAuth, or the `AFK_OPENAI_USE_RESPONSES` opt-in) bails early with
-   * `unsupported-wire-mode` rather than issuing a chat.completions call its
-   * backend would reject.
+   * Both wires are supported. Chat Completions sessions summarize through
+   * `oneShotChatCompletion`; responses-mode sessions (ChatGPT-OAuth, or the
+   * `AFK_OPENAI_USE_RESPONSES` opt-in) summarize through `oneShotResponses`,
+   * which streams over the Responses wire the backend actually accepts —
+   * issue #653. The splice machinery is wire-agnostic; only the summarize
+   * transport differs. If a responses-wire summarize fails for a non-abort
+   * reason (e.g. the backend rejects the throwaway summarize turn), the session
+   * latches `responsesCompactionUnavailable` so subsequent boundaries no-op
+   * cheaply instead of re-issuing a doomed request.
    */
   async compact(): Promise<ProviderCompactResult> {
     // Manual entrypoint (REPL /compact, Telegram, router). Auto-compaction
@@ -908,14 +922,14 @@ export class OpenAICompatibleQuery implements ProviderQuery {
       // than reusing 'session-closed'.
       return { compacted: false, reason: 'no-usable-auth', messagesBefore, messagesAfter: messagesBefore };
     }
-    if (this.wireMode === 'responses') {
-      // oneShotChatCompletion speaks only Chat Completions; a responses-mode
-      // backend (ChatGPT-OAuth / AFK_OPENAI_USE_RESPONSES) would reject that
-      // call. Surface an explicit, honest no-op instead of a generic
-      // summarization failure so the reason is actionable.
+    if (this.wireMode === 'responses' && this.responsesCompactionUnavailable) {
+      // A prior responses-wire summarize failed for a non-abort reason (e.g. the
+      // ChatGPT/Codex backend rejected the throwaway summarize turn). Don't
+      // re-issue a doomed request every turn boundary — no-op with an actionable
+      // reason. Latched by `summarizeViaResponses` below; never reset this session.
       return {
         compacted: false,
-        reason: 'unsupported-wire-mode',
+        reason: 'responses-compaction-unavailable',
         messagesBefore,
         messagesAfter: messagesBefore,
       };
@@ -934,14 +948,16 @@ export class OpenAICompatibleQuery implements ProviderQuery {
       usedFraction,
       shrinkAtFraction: readShrinkFraction(),
       summarize: (transcript, signal) =>
-        oneShotChatCompletion({
-          client: this.client,
-          model: compactModel,
-          system: COMPACT_SYSTEM_PROMPT,
-          user: wrapTranscriptForSummary(transcript),
-          maxTokens: 1024,
-          signal,
-        }),
+        this.wireMode === 'responses'
+          ? this.summarizeViaResponses(transcript, signal, compactModel)
+          : oneShotChatCompletion({
+              client: this.client,
+              model: compactModel,
+              system: COMPACT_SYSTEM_PROMPT,
+              user: wrapTranscriptForSummary(transcript),
+              maxTokens: 1024,
+              signal,
+            }),
       isClosed: this.closed,
       isIdle: this.abortController === null,
       beginAbort: () => {
@@ -955,6 +971,39 @@ export class OpenAICompatibleQuery implements ProviderQuery {
       trigger,
       traceWriter: this.traceWriter,
     });
+  }
+
+  /**
+   * Responses-wire summarize for {@link compactHistory}. Delegates to
+   * {@link oneShotResponses} (streams over the Responses wire the backend
+   * accepts), reusing THIS session's `client` so the call inherits the same
+   * endpoint, credentials, and ChatGPT-OAuth headers as the conversation.
+   *
+   * On a NON-abort failure it latches `responsesCompactionUnavailable` so the
+   * next boundary no-ops cheaply instead of re-issuing a doomed request, then
+   * re-throws so the compaction core records a safe no-op (history untouched).
+   * Aborts/timeouts (`signal.aborted`) are transient — they do NOT latch, so a
+   * user interrupt never permanently disables compaction for the session.
+   */
+  private async summarizeViaResponses(
+    transcript: string,
+    signal: AbortSignal,
+    model: string,
+  ): Promise<string> {
+    try {
+      return await oneShotResponses({
+        client: this.client,
+        model,
+        system: COMPACT_SYSTEM_PROMPT,
+        user: wrapTranscriptForSummary(transcript),
+        isChatGptBackend: this.opts.auth.source === 'chatgpt-oauth',
+        maxTokens: 1024,
+        signal,
+      });
+    } catch (err) {
+      if (!signal.aborted) this.responsesCompactionUnavailable = true;
+      throw err;
+    }
   }
 
   async setModel(model?: string): Promise<void> {

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -92,9 +92,22 @@ import {
 } from '../shared/auto-compact.js';
 import { AbortCoordinator, CLOSED_SENTINEL } from '../shared/abort-coordinator.js';
 import { HookBlockedError, DenialCircuitBreakerError } from '../../../utils/errors.js';
-import { COMPACT_SYSTEM_PROMPT, wrapTranscriptForSummary } from '../shared/compaction.js';
-import { compactOpenAIHistory, readShrinkFraction } from './compact.js';
-import { oneShotChatCompletion, oneShotResponses } from './oneshot.js';
+import {
+  COMPACT_SYSTEM_PROMPT,
+  wrapTranscriptForSummary,
+  resolveMicrocompactOptions,
+} from '../shared/compaction.js';
+import { compactOpenAIHistory, readShrinkFraction, microcompactToolResults } from './compact.js';
+import {
+  oneShotChatCompletion,
+  oneShotResponses,
+  ResponsesSummaryIncompleteError,
+} from './oneshot.js';
+import {
+  getErrorStatus,
+  isRetryableConnectionError,
+  isRetryableStreamError,
+} from './query/retry.js';
 import { PLAN_MODE_ADDENDUM_TEXT } from '../shared/plan-mode-addendum.js';
 import { AFK_MODE_ADDENDUM_TEXT } from '../shared/afk-mode-addendum.js';
 import { EXIT_PLAN_MODE_TOOL_NAME } from '../../tools/handlers/exit-plan-mode.js';
@@ -176,6 +189,36 @@ export interface OpenAICompatibleQueryOptions {
   traceWriter?: TraceWriter;
 }
 
+/**
+ * Statuses that prove the endpoint refused the REQUEST ITSELF (its shape, route,
+ * or media type) rather than transiently failing to serve it. 429 and 5xx are
+ * deliberately absent (transient — see `isRetryableConnectionError`), as are
+ * 401/403 (a credential can be hot-swapped mid-session, so an auth lapse must
+ * not permanently disable compaction).
+ */
+const UNSUPPORTED_REQUEST_STATUSES = new Set([400, 404, 405, 415, 422, 501]);
+
+/**
+ * Contract: does `err` PROVE this endpoint cannot serve a Responses-wire
+ * summarize at all — as opposed to having transiently failed one?
+ *
+ * Only an explicit, deterministic client-side refusal counts. The distinction
+ * matters because the latch it guards is PERMANENT for the session, so a false
+ * positive disables compaction until the session ends — re-creating the very
+ * context-window exhaustion issue #653 fixed. Deliberately NOT proof:
+ *   - 429 / 5xx and friends — transient, already classified by the retry preds;
+ *   - status-less throws (network drop, DNS, bad baseURL) — a blip or a
+ *     misconfiguration, neither of which is the backend refusing this shape;
+ *   - {@link ResponsesSummaryIncompleteError} — the backend DID accept and serve
+ *     the request, then streamed a failed/partial response. The wire works.
+ */
+function provesResponsesCompactionUnsupported(err: unknown): boolean {
+  if (err instanceof ResponsesSummaryIncompleteError) return false;
+  if (isRetryableConnectionError(err) || isRetryableStreamError(err)) return false;
+  const status = getErrorStatus(err);
+  return status !== undefined && UNSUPPORTED_REQUEST_STATUSES.has(status);
+}
+
 /** Internal record used to drive the per-turn iteration loop. */
 export class OpenAICompatibleQuery implements ProviderQuery {
   private readonly client: OpenAI;
@@ -197,12 +240,15 @@ export class OpenAICompatibleQuery implements ProviderQuery {
   private currentPermissionMode: string;
 
   /**
-   * Latched `true` when a Responses-wire summarize (history compaction) fails
-   * for a non-abort reason — e.g. the ChatGPT/Codex backend rejects the
-   * throwaway summarize turn. Once set, further compaction attempts no-op
-   * immediately (see `compactHistory`) instead of re-issuing a doomed request
-   * every turn boundary. Per-session; never reset. Aborts/timeouts do NOT set
-   * it (those are transient, not a backend incompatibility). Issue #653.
+   * Latched `true` when a Responses-wire summarize (history compaction) fails in
+   * a way that PROVES the backend refuses the request — e.g. the ChatGPT/Codex
+   * backend rejecting the throwaway summarize turn with a 400. Once set, further
+   * compaction skips the summarize transport (see `compactHistory`, which still
+   * runs deterministic microcompaction) instead of re-issuing a doomed request
+   * every turn boundary. Per-session; never reset — which is exactly why the
+   * latch predicate is narrow: only {@link provesResponsesCompactionUnsupported}
+   * errors set it. Aborts, timeouts, 429/5xx, network blips, and partial/failed
+   * responses are all transient and do NOT latch. Issue #653.
    */
   private responsesCompactionUnavailable = false;
 
@@ -908,10 +954,12 @@ export class OpenAICompatibleQuery implements ProviderQuery {
    * `AFK_OPENAI_USE_RESPONSES` opt-in) summarize through `oneShotResponses`,
    * which streams over the Responses wire the backend actually accepts —
    * issue #653. The splice machinery is wire-agnostic; only the summarize
-   * transport differs. If a responses-wire summarize fails for a non-abort
-   * reason (e.g. the backend rejects the throwaway summarize turn), the session
-   * latches `responsesCompactionUnavailable` so subsequent boundaries no-op
-   * cheaply instead of re-issuing a doomed request.
+   * transport differs. If a responses-wire summarize fails in a way that proves
+   * the backend refuses the request (see
+   * {@link provesResponsesCompactionUnsupported}), the session latches
+   * `responsesCompactionUnavailable` so subsequent boundaries skip the doomed
+   * request — falling back to deterministic microcompaction, which needs no
+   * model call. Transient failures never latch.
    */
   async compact(): Promise<ProviderCompactResult> {
     // Manual entrypoint (REPL /compact, Telegram, router). Auto-compaction
@@ -931,10 +979,30 @@ export class OpenAICompatibleQuery implements ProviderQuery {
       return { compacted: false, reason: 'no-usable-auth', messagesBefore, messagesAfter: messagesBefore };
     }
     if (this.wireMode === 'responses' && this.responsesCompactionUnavailable) {
-      // A prior responses-wire summarize failed for a non-abort reason (e.g. the
-      // ChatGPT/Codex backend rejected the throwaway summarize turn). Don't
-      // re-issue a doomed request every turn boundary — no-op with an actionable
-      // reason. Latched by `summarizeViaResponses` below; never reset this session.
+      // Invariant: the latch disables the SUMMARIZE TRANSPORT only — never the
+      // deterministic fallback. A prior responses-wire summarize proved the
+      // backend refuses the throwaway summarize turn, so re-issuing a doomed
+      // request every turn boundary is pure waste. But microcompaction is
+      // no-LLM and no-network: it clears large/old tool_result CONTENT in place,
+      // so it still works when the backend refuses everything. Skipping it here
+      // would leave the session unable to reclaim context by ANY mechanism,
+      // which overshoots "no-op cheaply" into "guarantee an eventual overflow".
+      // Mirrors the fallback `compactOpenAIHistory` runs on its own no-op
+      // reasons (compact.ts) — same options source, same result shape.
+      const microOpts = resolveMicrocompactOptions(
+        env.AFK_MICROCOMPACT_TOOL_RESULT_BYTES,
+        env.AFK_MICROCOMPACT_KEEP_LAST,
+      );
+      const { blocksCleared, bytesReclaimed } = microcompactToolResults(this.priorTurns, microOpts);
+      if (blocksCleared > 0) {
+        return {
+          compacted: false,
+          reason: 'microcompacted',
+          messagesBefore,
+          messagesAfter: this.priorTurns.length,
+          microcompaction: { blocksCleared, bytesReclaimed },
+        };
+      }
       return {
         compacted: false,
         reason: 'responses-compaction-unavailable',
@@ -989,11 +1057,15 @@ export class OpenAICompatibleQuery implements ProviderQuery {
    * accepts), reusing THIS session's `client` so the call inherits the same
    * endpoint, credentials, and ChatGPT-OAuth headers as the conversation.
    *
-   * On a NON-abort failure it latches `responsesCompactionUnavailable` so the
-   * next boundary no-ops cheaply instead of re-issuing a doomed request, then
-   * re-throws so the compaction core records a safe no-op (history untouched).
-   * Aborts/timeouts (`signal.aborted`) are transient — they do NOT latch, so a
-   * user interrupt never permanently disables compaction for the session.
+   * On a failure that PROVES the backend refuses this request shape (see
+   * {@link provesResponsesCompactionUnsupported}) it latches
+   * `responsesCompactionUnavailable` — and emits a `compaction_disabled` trace
+   * event, since the auto path discards the result and would otherwise hide the
+   * disable — then re-throws so the compaction core records a safe no-op
+   * (history untouched). Aborts/timeouts (`signal.aborted`), 429/5xx, network
+   * blips, and partial/failed responses are all transient: they do NOT latch, so
+   * neither a user interrupt nor a passing outage permanently disables
+   * compaction for the session.
    */
   private async summarizeViaResponses(
     transcript: string,
@@ -1011,7 +1083,22 @@ export class OpenAICompatibleQuery implements ProviderQuery {
         signal,
       });
     } catch (err) {
-      if (!signal.aborted) this.responsesCompactionUnavailable = true;
+      if (!signal.aborted && provesResponsesCompactionUnsupported(err)) {
+        this.responsesCompactionUnavailable = true;
+        // Fire-and-forget: a permanent per-session disable is otherwise
+        // invisible — the auto path discards compactHistory()'s result, so
+        // without this the reason surfaces only if a human runs /compact.
+        const status = getErrorStatus(err);
+        void emitSessionPhase(this.traceWriter, {
+          phase: 'compaction_disabled',
+          metadata: {
+            wire: 'responses',
+            reason: 'responses-compaction-unavailable',
+            error: err instanceof Error ? err.message : String(err),
+            ...(status !== undefined ? { status } : {}),
+          },
+        });
+      }
       throw err;
     }
   }

--- a/src/agent/providers/openai-compatible/query/retry.ts
+++ b/src/agent/providers/openai-compatible/query/retry.ts
@@ -103,7 +103,7 @@ export function retryAfterDelayMs(err: unknown): number | undefined {
  * network errors and generic throws have no status and are treated as
  * retryable (transient network blip) only when they carry no explicit code.
  */
-function getErrorStatus(err: unknown): number | undefined {
+export function getErrorStatus(err: unknown): number | undefined {
   if (err === null || typeof err !== 'object') return undefined;
   const e = err as { status?: unknown };
   return typeof e.status === 'number' ? e.status : undefined;

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -404,6 +404,9 @@ export const SessionPhaseNameSchema = z.enum([
   'usage_limit_resume',
   'idle_watchdog_fired',
   'suspected_loop',
+  // Per-session compaction disable (single event, at most once). See
+  // SessionPhaseName JSDoc in types.ts — metadata names the wire and cause.
+  'compaction_disabled',
 ]);
 
 export const SessionPhasePayloadSchema = z.object({

--- a/src/agent/trace/session-phase.test.ts
+++ b/src/agent/trace/session-phase.test.ts
@@ -261,6 +261,7 @@ describe('SessionPhaseName union ↔ SessionPhaseNameSchema parity', () => {
     usage_limit_resume: true,
     idle_watchdog_fired: true,
     suspected_loop: true,
+    compaction_disabled: true,
   };
 
   it('the Zod enum contains exactly the union members (no drift either way)', () => {

--- a/src/agent/trace/types.ts
+++ b/src/agent/trace/types.ts
@@ -688,7 +688,16 @@ export type SessionPhaseName =
   // measure whether real busy-loops occur before deciding if an enforcing
   // detector is ever warranted. Distinct from `idle_watchdog_fired` (a stall
   // with NO output) — this marks the opposite: a fork actively repeating work.
-  | 'suspected_loop';
+  | 'suspected_loop'
+  // History compaction was DISABLED for the remainder of the session because the
+  // backend proved it cannot serve the summarize request (e.g. the ChatGPT/Codex
+  // Responses backend refusing the throwaway summarize turn — issue #653). A
+  // single event (no paired start), emitted AT MOST ONCE per session, carrying
+  // `wire`, `reason`, `error`, and (when present) `status` in `metadata`. High
+  // signal: the auto-compaction caller discards its result, so without this the
+  // disable is invisible until a human runs /compact — and an undisclosed
+  // disable ends in a context-window overflow the operator cannot explain.
+  | 'compaction_disabled';
 
 export interface SessionPhasePayload {
   /** Which lifecycle milestone this record marks. */

--- a/src/cli/commands/trace.test.ts
+++ b/src/cli/commands/trace.test.ts
@@ -312,6 +312,26 @@ describe('formatTrace — usage-limit pause/resume is high-signal (shown by defa
   });
 });
 
+describe('formatTrace — compaction_disabled is high-signal (shown by default)', () => {
+  // A per-session compaction disable explains an otherwise-invisible FUTURE
+  // failure: the session can no longer shed context, so it will eventually
+  // overflow the window. The auto-compaction caller discards its result, so this
+  // event is the only place the disable and its cause are recorded.
+  const events: EventObj[] = [
+    { ts: '2026-06-05T12:30:00.000Z', seq: 0, kind: 'session_phase', payload: { phase: 'compaction_disabled', metadata: { wire: 'responses', reason: 'responses-compaction-unavailable', error: 'unsupported request for this backend', status: 400 } } },
+    { ts: '2026-06-05T12:35:00.000Z', seq: 1, kind: 'session_sealed', payload: { status: 'succeeded', finalCostUsd: 0.01, finalTurnCount: 1, closedAt: '2026-06-05T12:35:00.000Z' } },
+  ];
+  const out = formatTrace('s', '/p', parseTrace(toJsonl(events)));
+
+  it('renders the disable in the DEFAULT view with wire, status, and cause', () => {
+    expect(out).toContain('compact');
+    expect(out).toContain('DISABLED for session');
+    expect(out).toContain('responses wire');
+    expect(out).toContain('400');
+    expect(out).toContain('unsupported request for this backend');
+  });
+});
+
 describe('formatTrace — closure stop_reason rendering', () => {
   const seal: EventObj = {
     ts: '2026-06-05T12:35:00.500Z',

--- a/src/cli/commands/trace.ts
+++ b/src/cli/commands/trace.ts
@@ -472,6 +472,20 @@ function renderEvent(event: TraceEvent, ctx: RenderContext): string | null {
         const hotSwap = md['hotSwapped'] === true ? '  (hot-swap)' : '';
         return line('resumed', `usage-limit${parked}${hotSwap}`);
       }
+      // A per-session compaction disable is high-signal for the same reason as
+      // the stalls above: it explains an otherwise-invisible future failure (the
+      // session can no longer shed context, so it will eventually overflow the
+      // window). Rendered in the DEFAULT view, before the showAll gate.
+      if (p.phase === 'compaction_disabled') {
+        const md = p.metadata ?? {};
+        const wire = md['wire'];
+        const status = md['status'];
+        const errMsg = md['error'];
+        const wireBit = wire !== undefined ? ` (${wire} wire)` : '';
+        const statusBit = status !== undefined ? `  ${status}` : '';
+        const causeBit = errMsg !== undefined ? `  ${errMsg}` : '';
+        return line('compact', `DISABLED for session${wireBit}${statusBit}${causeBit}`);
+      }
       if (!ctx.showAll) return null; // latency waterfall — low signal by default
       const dur = p.durationMs !== undefined ? `  ${fmtDuration(p.durationMs)}` : '';
       // Prefer the operator alias (session_init_start); fall back to the

--- a/src/cli/slash/commands/core.ts
+++ b/src/cli/slash/commands/core.ts
@@ -95,6 +95,13 @@ const compactCmd: SlashCommand = {
           ctx.out.info('Nothing to compact — all history is within the keep window.');
         } else if (reason === 'not-supported') {
           ctx.out.warn('Compaction is not supported for this model or provider — use a Claude model to enable /compact.');
+        } else if (reason === 'responses-compaction-unavailable') {
+          // This backend refused the summarize request earlier in the session, so
+          // the transport stays disabled until restart. Name the recovery path —
+          // the raw token alone tells an operator nothing actionable.
+          ctx.out.warn(
+            'Summarization is unavailable on this backend — it refused the compaction request earlier this session. Start a new session, or set AFK_COMPACT_MODEL to a model this endpoint can serve.',
+          );
         } else {
           ctx.out.info(`Nothing to compact (${reason}).`);
         }

--- a/src/telegram/formatter.test.ts
+++ b/src/telegram/formatter.test.ts
@@ -618,6 +618,15 @@ describe('formatCompactNoop — new reasons', () => {
     expect(result).toContain('⚠️');
     expect(result.toLowerCase()).toContain('failed');
   });
+
+  test('"responses-compaction-unavailable" → prose naming the recovery path, not the raw token', () => {
+    const result = formatCompactNoop('responses-compaction-unavailable');
+    // The raw kebab-case reason must not leak into the user-facing message.
+    expect(result).not.toContain('responses-compaction-unavailable');
+    expect(result.toLowerCase()).toContain('unavailable');
+    // Actionable: names at least one way out of the latched state.
+    expect(result).toMatch(/new session|AFK_COMPACT_MODEL/);
+  });
 });
 
 describe('markdownToTelegramHtml — mis-nested emphasis safety net', () => {

--- a/src/telegram/formatter.ts
+++ b/src/telegram/formatter.ts
@@ -463,6 +463,9 @@ export function formatCompactNoop(reason: string): string {
   if (reason === 'aborted') return '📦 Compaction cancelled.';
   if (reason === 'history-too-short') return '📦 Not enough history to compact yet.';
   if (reason === 'not-supported') return "📦 Compaction isn't available for the current model.";
+  if (reason === 'responses-compaction-unavailable') {
+    return '⚠️ Summarization is unavailable on this backend — it refused the compaction request earlier this session. Start a new session, or set AFK_COMPACT_MODEL to a model this endpoint can serve.';
+  }
   if (reason.startsWith('summarization-failed')) {
     return `⚠️ Compaction failed: ${reason}. History unchanged.`;
   }


### PR DESCRIPTION
## What & why

Closes #653.

History compaction previously **no-oped** on the openai-compatible **Responses** wire (the ChatGPT-OAuth backend and the `AFK_OPENAI_USE_RESPONSES` opt-in). `compactHistory()` bailed early with `unsupported-wire-mode` because the only summarizer — `oneShotChatCompletion` — speaks Chat Completions, a call the Responses backend rejects. So long/iterative skill subagents (`mint`, `refactor`) running on the ChatGPT backend could not shed context and risked hitting the context-window limit. Chat Completions mode was unaffected.

## Root cause

The compaction split is already three layers (see `providers/shared/compaction.ts`):

1. provider-agnostic orchestration `runCompactionCore` (boundary → render → splice),
2. representation via `CompactionOps<M>` (generic over message type),
3. the model call, injected per-provider as a `summarize(transcript, signal) => Promise<string>` closure.

`priorTurns` is a single canonical `OpenAIMessage[]` for **both** wire modes; the Responses translation happens at request-build time, not in storage. So the splice machinery was already wire-agnostic — **only the summarize transport** was Chat-Completions-bound. The fix supplies the missing transport rather than touching the core.

## Change

- **`oneShotResponses` (`oneshot.ts`)** — a Responses-wire sibling of `oneShotChatCompletion`. It:
  - reuses `buildResponsesRequestBody`, so every ChatGPT-backend quirk (omit `max_output_tokens`, `store: false`, non-empty `instructions`, gpt-5.x-only) stays in one place;
  - reuses `translateResponsesEvent` — the single source of truth for which stream event carries assistant text — so the summarize path can't drift from the turn path;
  - **streams** (`stream: true`) rather than issuing a non-streaming call: the ChatGPT/Codex backend is only ever streamed to in the codebase, so a throwaway summarize rides the one proven wire;
  - **drains in isolation** — its own `StreamState`, yielded `ProviderEvent`s discarded — so it never mutates session state (`lastUsage`, `priorTurns`), emits no trace, and dispatches no tools;
  - has no retry opinion (like the Chat-Completions sibling): it throws on error and the compaction core treats that as a safe no-op.
- **`compactHistory` (`query.ts`)** — the `wireMode === 'responses'` branch now selects the summarizer instead of bailing. A **non-abort** summarize failure latches a per-session `responsesCompactionUnavailable` flag so subsequent turn boundaries no-op cheaply (`responses-compaction-unavailable`) instead of re-issuing a doomed request every turn. Aborts/timeouts do **not** latch (transient, not a backend incompatibility). Failures remain safe no-ops — history is never corrupted.

## Why not a shared cross-provider summarizer?

Considered and rejected (via a `/devils-advocate` pass): the orchestration that *should* be shared already is. The transport can't be centralized because each summarize must reuse **that session's own `this.client`** (baseURL, credentials, OAuth headers, account-id) — a central service can't re-resolve it — and the mechanisms genuinely differ (anthropic streaming messages vs. OpenAI chat-completions vs. OpenAI responses). The right seam is per-provider transport, which is what this PR fills.

## Tests

- `oneshot.test.ts` — `oneShotResponses`: delta accumulation + trim, promise/`APIPromise` create, request shape (`stream:true`, model, no tools, `instructions`), ChatGPT-backend path (omits `max_output_tokens`, sets `store:false`) vs. public path (carries the cap), abort-signal forwarding, empty-stream → `''`, error propagation.
- `query.test.ts` — responses-wire auto-compaction goes through `responses.create` and **never** `chat.completions`; the latch causes the backend to be asked to summarize exactly once after a failure, then a manual `compact()` no-ops with `responses-compaction-unavailable`. Repurposed the stale `unsupported-wire-mode` test (an empty responses session now no-ops `history-too-short`, proving compaction is no longer structurally refused).

## Gates

- `pnpm lint` (tsc --noEmit strict) — clean
- `pnpm test` — 698 files, **13077 passed**, 0 failed
- `pnpm audit:sdk:check` — OK (no new `@anthropic-ai/sdk` imports; this touches the `openai` SDK)
- `pnpm scan:env:check` — in sync (no env changes)

## Known limitation / follow-up

The ChatGPT-OAuth backend is only ever *streamed* to in the codebase; a throwaway summarize turn has **not** been confirmed against it live (no local creds in CI). The design degrades safely — on rejection the per-session latch reverts to today's behavior (no compaction) rather than erroring — so this is safe to land flag-guarded. Worth a one-off live confirmation on a real ChatGPT-OAuth session.
