### PR TITLE
fix(telegram): bound and latency-gate ◦ tool-progress lines

### DIFF
--- a/src/telegram/streaming.test.ts
+++ b/src/telegram/streaming.test.ts
@@ -1108,3 +1108,82 @@ describe('bounded ◦ progress region', () => {
     expect(renderActivityReceipt(2, 200)).toBe('\n\n⏱️ 2 steps · 1s');
   });
 });
+
+describe('◦ progress region — PR #702 review follow-ups', () => {
+  const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+  function progressEvent(description: string): OutputEvent {
+    return {
+      type: 'progress',
+      progress: { taskId: 't', description, totalTokens: 0, toolUses: 1, durationMs: 1 },
+    } as OutputEvent;
+  }
+
+  it('bounds progress across INTERLEAVED content, not just within one consecutive run (Codex P1)', async () => {
+    // Regression: the region used to be spliced into `accumulated` at an offset,
+    // so any content chunk froze it in place and the next progress event started a
+    // NEW region. An alternating stream — what the anthropic-direct and
+    // openai-compatible loops actually emit — therefore kept all 9 lines. As a
+    // single footer the MAX_PROGRESS_LINES bound holds globally.
+    const { ctx, edits } = makeCtx();
+    const session = makeSession(async function* () {
+      for (let i = 1; i <= 9; i++) {
+        yield progressEvent(`round-${i}`);
+        yield { type: 'chunk' as const, chunk: { type: 'content' as const, content: `c${i} ` } };
+      }
+      yield { type: 'done' as const, metadata: undefined };
+    });
+
+    await streamResponse(ctx, session, 'go', undefined, { progressDelayMs: 0 });
+
+    const final = edits[edits.length - 1] ?? '';
+    // Window of 6 over NINE rounds that each had content in between.
+    expect(final).toContain('round-9');
+    expect(final).toContain('round-4');
+    expect(final).not.toContain('round-3');
+    expect(final).not.toContain('round-1');
+    // Answer content is untouched by the bounded region.
+    expect(final).toContain('c1 ');
+    expect(final).toContain('c9 ');
+  });
+
+  it('opens the gate on a timer when no further progress event arrives (Codex P2)', async () => {
+    // Regression: the gate was re-checked ONLY when another `progress` event
+    // arrived, so a single tool running silently past the delay left the user on
+    // `Thinking…` for its whole duration. cleanFinal delivers only `answerText`
+    // (no ◦), so the progress line can reach the user ONLY via a live edit —
+    // which means the timer fired.
+    const { ctx, replies, edits } = makeCtx();
+    const session = makeSession(async function* () {
+      yield progressEvent('slow tool running');
+      await sleep(90); // silent stretch longer than progressDelayMs
+      yield { type: 'chunk' as const, chunk: { type: 'content' as const, content: 'Answer.' } };
+      yield { type: 'done' as const, metadata: undefined };
+    });
+
+    await streamResponse(ctx, session, 'go', undefined, { cleanFinal: true, progressDelayMs: 25 });
+
+    expect(edits.some((e) => e.includes('slow tool running'))).toBe(true);
+    // The clean final answer is still free of ◦ noise.
+    expect(replies.some((r) => r.includes('◦'))).toBe(false);
+    expect(replies.some((r) => r.includes('Answer.'))).toBe(true);
+  });
+
+  it('delivers a gated progress-only turn that ends WITHOUT a done event (review: medium)', async () => {
+    // Regression introduced by the first commit of this PR: the withheld-region
+    // flush was added to the `done` branch only. A provider stream that ends by
+    // graceful iterator close (no done/error) hit the post-loop branch, where
+    // bare `accumulated` is empty under a closed gate — so nothing was delivered
+    // and the user was stranded on `Thinking…`. Uses the DEFAULT gate so every
+    // line really is withheld.
+    const { ctx, replies, edits } = makeCtx();
+    const session = makeSession(async function* () {
+      yield progressEvent('did work then the stream closed');
+      // no `done` — the generator simply returns
+    });
+
+    await streamResponse(ctx, session, 'go', undefined, { cleanFinal: true });
+
+    expect([...replies, ...edits].some((t) => t.includes('did work then the stream closed'))).toBe(true);
+    expect([...replies, ...edits].every((t) => t !== 'Thinking…') || replies.length > 0).toBe(true);
+  });
+});

--- a/src/telegram/streaming.test.ts
+++ b/src/telegram/streaming.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { streamResponse, StreamTimeoutError, renderSubagentFooter, replyWithFloodRetry } from './streaming.js';
+import { streamResponse, StreamTimeoutError, renderSubagentFooter, renderProgressRegion, renderActivityReceipt, replyWithFloodRetry } from './streaming.js';
 import { TelegramError } from 'telegraf';
 import type { Context } from 'telegraf';
 import type { IAgentSession, OutputEvent } from '../agent/types.js';
@@ -105,7 +105,10 @@ describe('streamResponse', () => {
       );
     });
 
-    await streamResponse(ctx, session, 'go');
+    // progressDelayMs: 0 opts out of the latency gate (PROGRESS_START_DELAY_MS)
+    // so this test asserts the RENDERING contract deterministically. The gate
+    // itself is covered by the 'latency gate' tests below.
+    await streamResponse(ctx, session, 'go', undefined, { progressDelayMs: 0 });
     const joined = [...replies, ...edits].join('\n');
     expect(joined).toContain('◦ Researching codebase');
     expect(joined).toContain('(Grep)');
@@ -375,7 +378,9 @@ describe('streamResponse', () => {
   it('default (no cleanFinal): force-flushes the in-place preview (noise included) and never deletes', async () => {
     const { ctx, edits, deletes } = makeCtx();
 
-    await streamResponse(ctx, answerWithProgress(), 'go');
+    // progressDelayMs: 0 opts out of the latency gate so the ◦ line is rendered
+    // into `accumulated` and this test still exercises the legacy flush path.
+    await streamResponse(ctx, answerWithProgress(), 'go', undefined, { progressDelayMs: 0 });
 
     // Legacy force-flushes `accumulated` on done, which mixes the ◦ progress
     // noise into the final in-place edit — the behavior cleanFinal improves on.
@@ -931,5 +936,175 @@ describe('replyWithFloodRetry (flood-control 429 backoff)', () => {
       replyWithFloodRetry(reply, 'hi', { parse_mode: 'HTML' }, { sleep: async () => {} }),
     ).rejects.toBe(err);
     expect(reply).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('bounded ◦ progress region', () => {
+  function progressEvent(description: string): OutputEvent {
+    return {
+      type: 'progress',
+      progress: { taskId: 't', description, totalTokens: 0, toolUses: 1, durationMs: 1 },
+    } as OutputEvent;
+  }
+
+  it('latency gate: a fast turn renders NO ◦ progress lines at all', async () => {
+    // The user-visible point of the gate: most turns finish well under
+    // PROGRESS_START_DELAY_MS, and those turns should go straight from the
+    // `Thinking…` placeholder to the answer with zero `◦` churn. No
+    // progressDelayMs override here — this asserts the production default.
+    const { ctx, replies, edits } = makeCtx();
+    const session = makeSession(async function* () {
+      yield* yieldEvents(
+        progressEvent('Running tool'),
+        progressEvent('Running another tool'),
+        { type: 'chunk', chunk: { type: 'content', content: 'Done thinking.' } },
+        { type: 'done', metadata: undefined },
+      );
+    });
+
+    await streamResponse(ctx, session, 'go', undefined, { cleanFinal: true });
+
+    expect([...replies, ...edits].some((t) => t.includes('◦'))).toBe(false);
+    expect(replies.some((r) => r.includes('Done thinking.'))).toBe(true);
+  });
+
+  it('rolling window: only the most recent MAX_PROGRESS_LINES survive', async () => {
+    // Regression: progress lines used to append to `accumulated` without bound,
+    // so a tool-heavy turn grew the preview one line per round forever.
+    const { ctx, edits } = makeCtx();
+    const session = makeSession(async function* () {
+      for (let i = 1; i <= 9; i++) yield progressEvent(`round-${i}`);
+      yield { type: 'done', metadata: undefined };
+    });
+
+    await streamResponse(ctx, session, 'go', undefined, { progressDelayMs: 0 });
+
+    // `done` force-flushes the full accumulated buffer into the preview.
+    const final = edits[edits.length - 1] ?? '';
+    expect(final).toContain('round-9');
+    expect(final).toContain('round-4'); // 9 rounds, window of 6 → 4..9 kept
+    expect(final).not.toContain('round-3');
+    expect(final).not.toContain('round-1');
+  });
+
+  it('REGRESSION: a gated-off progress round still sets the stream_retry boundary, so a retry does not eat earlier answer text', async () => {
+    // This is the trap a shadow-verify wave caught. The `progress` handler's
+    // `inContentRun = false` is NOT cosmetic — it is the stream_retry round
+    // boundary. Suppressing progress RENDERING must not skip it: if it were
+    // skipped, contentRunStartAnswer would still point at offset 0 when the
+    // second content run began, and the stream_retry below would slice
+    // answerText back to '' — silently destroying 'AAA', text the model had
+    // already streamed. Runs with the DEFAULT latency gate (progress renders
+    // nothing here) precisely to prove render-suppression keeps the boundary.
+    const { ctx, replies } = makeCtx();
+    const session = makeSession(async function* () {
+      yield { type: 'chunk', chunk: { type: 'content', content: 'AAA' } };
+      yield progressEvent('tool round between two content runs');
+      yield { type: 'chunk', chunk: { type: 'content', content: 'BBB' } };
+      yield { type: 'stream_retry' } as OutputEvent;
+      yield { type: 'chunk', chunk: { type: 'content', content: 'CCC' } };
+      yield { type: 'done', metadata: undefined };
+    });
+
+    let recorded: string | undefined;
+    await streamResponse(ctx, session, 'go', undefined, {
+      cleanFinal: true,
+      onComplete: (text) => { recorded = text; },
+    });
+
+    // 'AAA' survived the retry; only the retried round ('BBB') was discarded.
+    expect(recorded).toBe('AAACCC');
+    expect(replies.some((r) => r.includes('AAACCC'))).toBe(true);
+  });
+
+  it('dead-turn guard: a fast progress-only turn still delivers, never stranding the user on `Thinking…`', async () => {
+    // With the latency gate active and no answer text (e.g. an abort mid
+    // tool-loop yields turn.completed with no assistant message), `accumulated`
+    // is empty — so without an explicit flush the user's entire reply would be
+    // the bare `Thinking…` placeholder: a silent dead turn.
+    const { ctx, replies, edits } = makeCtx();
+    const session = makeSession(async function* () {
+      yield* yieldEvents(
+        progressEvent('searched the codebase'),
+        { type: 'done', metadata: undefined },
+      );
+    });
+
+    await streamResponse(ctx, session, 'go', undefined, { cleanFinal: true });
+
+    const all = [...replies, ...edits];
+    expect(all.some((t) => t.includes('searched the codebase'))).toBe(true);
+    // The placeholder is not the last thing the user sees.
+    expect(all[all.length - 1]).not.toBe('Thinking…');
+  });
+
+  it('activity receipt: summarizes tool rounds on the clean final but never enters recorded history', async () => {
+    const { ctx, replies } = makeCtx();
+    const session = makeSession(async function* () {
+      yield* yieldEvents(
+        progressEvent('step one'),
+        progressEvent('step two'),
+        { type: 'chunk', chunk: { type: 'content', content: 'The answer.' } },
+        { type: 'done', metadata: undefined },
+      );
+    });
+
+    let recorded: string | undefined;
+    await streamResponse(ctx, session, 'go', undefined, {
+      cleanFinal: true,
+      onComplete: (text) => { recorded = text; },
+    });
+
+    const finalReply = replies[replies.length - 1] ?? '';
+    expect(finalReply).toContain('The answer.');
+    expect(finalReply).toContain('2 steps');
+    // The receipt is presentation only: recorded turn history stays clean so a
+    // CLI `--resume` does not replay UI chrome as assistant text.
+    expect(recorded).toBe('The answer.');
+    expect(recorded).not.toContain('⏱️');
+  });
+
+  it('activity receipt: absent on a turn with no tool rounds', async () => {
+    const { ctx, replies } = makeCtx();
+    const session = makeSession(async function* () {
+      yield* yieldChunks('Just an answer.');
+    });
+
+    await streamResponse(ctx, session, 'go', undefined, { cleanFinal: true });
+
+    expect(replies[replies.length - 1]).toBe('Just an answer.');
+  });
+
+  it('suggestion dedupe compares against the ANSWER, not the progress-polluted buffer', async () => {
+    // Regression: the gate used to compare the suggestion against `accumulated`,
+    // which also carries the `◦` region. On a tool-heavy turn that made the
+    // comparison spuriously unequal, so a suggestion identical to the answer was
+    // appended anyway — a duplicate 💡 echo on exactly the turns with progress.
+    const { ctx, replies } = makeCtx();
+    const session = makeSession(async function* () {
+      yield* yieldEvents(
+        progressEvent('did some work'),
+        { type: 'chunk', chunk: { type: 'content', content: 'Hi! What can I help with?' } },
+        { type: 'suggestion', suggestion: 'Hi! What can I help with?' },
+        { type: 'done', metadata: undefined },
+      );
+    });
+
+    await streamResponse(ctx, session, 'go', undefined, { cleanFinal: true, progressDelayMs: 0 });
+
+    expect(replies.some((r) => r.includes('💡'))).toBe(false);
+  });
+
+  it('renderProgressRegion/renderActivityReceipt are pure and bounded', () => {
+    expect(renderProgressRegion([])).toBe('');
+    expect(renderProgressRegion(['a', 'b'])).toBe('\na\nb');
+    // Window of 6: a 9-entry input keeps the tail only.
+    const nine = Array.from({ length: 9 }, (_, i) => `l${i + 1}`);
+    expect(renderProgressRegion(nine)).toBe('\nl4\nl5\nl6\nl7\nl8\nl9');
+    expect(renderActivityReceipt(0, 5_000)).toBe('');
+    expect(renderActivityReceipt(1, 4_000)).toBe('\n\n⏱️ 1 step · 4s');
+    expect(renderActivityReceipt(3, 12_400)).toBe('\n\n⏱️ 3 steps · 12s');
+    // Sub-second turns floor to 1s rather than showing '0s'.
+    expect(renderActivityReceipt(2, 200)).toBe('\n\n⏱️ 2 steps · 1s');
   });
 });

--- a/src/telegram/streaming.ts
+++ b/src/telegram/streaming.ts
@@ -287,23 +287,33 @@ export async function streamResponse(
   let subagentSteps = 0;
   const recentSubagentSteps: string[] = [];
 
-  // Invariant: the `◦` tool-progress region is a BOUNDED, REWRITABLE tail of
-  // `accumulated`, not an append-only log. `progressRunStart` is the offset in
-  // `accumulated` where the current consecutive progress run begins; each new
-  // progress event rewrites `accumulated` from that offset with the last
-  // MAX_PROGRESS_LINES entries. That offset is only valid while nothing else
-  // appends to `accumulated`, so EVERY other writer (content chunk, assistant
-  // message, suggestion, stream_retry rollback) must call `endProgressRun()`
-  // first — otherwise the rewrite would truncate their text.
+  // Invariant: the `◦` tool-progress region is ONE bounded footer of the live
+  // preview, never spliced into `accumulated`. Keeping it out of the content
+  // buffer is what makes the MAX_PROGRESS_LINES bound hold GLOBALLY: an earlier
+  // design rewrote a region inside `accumulated` at an offset, which bounded
+  // only a run of CONSECUTIVE progress events — a stream that alternates content
+  // with tool rounds (what the anthropic-direct and openai-compatible loops
+  // actually emit) froze each run in place and grew without limit anyway. As a
+  // footer the region is inherently single and replaceable, so no writer of
+  // `accumulated` has to coordinate with it. Same treatment the sub-agent lane
+  // already uses (renderSubagentFooter).
   const progressDelayMs = options.progressDelayMs ?? PROGRESS_START_DELAY_MS;
   const turnStartedAt = Date.now();
   let progressLines: string[] = [];
-  let progressRunStart = -1;
   // Total tool rounds seen this turn (never trimmed) — drives the activity receipt.
   let progressRounds = 0;
-  const endProgressRun = (): void => {
-    progressRunStart = -1;
-    progressLines = [];
+  // Latency gate: closed until the turn has run progressDelayMs, so short turns
+  // render no `◦` churn at all. Withheld lines stay in `progressLines`.
+  let progressGateOpen = progressDelayMs <= 0;
+  let progressTimer: ReturnType<typeof setTimeout> | null = null;
+  // Set once a terminal event or the finally-block runs, so a timer callback
+  // that loses the race can't edit a finished turn's message.
+  let turnEnded = false;
+  const clearProgressTimer = (): void => {
+    if (progressTimer !== null) {
+      clearTimeout(progressTimer);
+      progressTimer = null;
+    }
   };
 
   const sendOrEdit = async (text: string, force = false): Promise<void> => {
@@ -407,11 +417,22 @@ export async function streamResponse(
     return delivered;
   };
 
-  // Live preview = answer/content buffer + bounded sub-agent footer. Used for
-  // every in-turn edit so sub-agent progress stays visible without the buffer
-  // growing one line per child tool call.
+  // Content + the bounded `◦` progress region, as it should appear in a FINAL
+  // delivery. Invariant: the latency gate throttles LIVE churn only — once the
+  // turn is over there is nothing left to churn, so a finished turn always
+  // surfaces the progress it recorded instead of silently dropping lines the
+  // gate happened to withhold. Every terminal/fallback delivery path uses this;
+  // `accumulated` alone would be empty on a gated progress-only turn and would
+  // strand the user on the bare `Thinking…` placeholder.
+  const finalBody = (): string => accumulated + renderProgressRegion(progressLines);
+
+  // Live preview = content + GATED progress region + bounded sub-agent footer.
+  // Used for every in-turn edit so progress and sub-agent activity stay visible
+  // without either region growing one line per tool call.
   const livePreview = (): string =>
-    accumulated + renderSubagentFooter(subagentSteps, recentSubagentSteps);
+    accumulated
+    + (progressGateOpen ? renderProgressRegion(progressLines) : '')
+    + renderSubagentFooter(subagentSteps, recentSubagentSteps);
 
   try {
     const stream =
@@ -564,9 +585,6 @@ export async function streamResponse(
         }
 
         if (event.type === 'chunk' && event.chunk.type === 'content') {
-          // Answer text follows the progress region, so the region is now frozen
-          // history — stop rewriting it (see the progressRunStart invariant).
-          endProgressRun();
           if (!inContentRun) {
             contentRunStartAccumulated = accumulated.length;
             contentRunStartAnswer = answerText.length;
@@ -584,9 +602,8 @@ export async function streamResponse(
           accumulated = accumulated.slice(0, contentRunStartAccumulated);
           answerText = answerText.slice(0, contentRunStartAnswer);
           inContentRun = false;
-          // The rollback moved the end of `accumulated`, invalidating any live
-          // progress-region offset into it.
-          endProgressRun();
+          // The `◦` region is a separate footer, so a content rollback leaves it
+          // untouched: those tool rounds really did happen and stay on screen.
           await sendOrEdit(livePreview(), true);
         }
         if (event.type === 'chunk' && event.chunk.type === 'tool_diff') {
@@ -596,9 +613,6 @@ export async function streamResponse(
           accumulated = event.message.content;
           answerText = event.message.content;
           inContentRun = false;
-          // `accumulated` was replaced wholesale — any progress-region offset
-          // into the old buffer is stale.
-          endProgressRun();
           await sendOrEdit(livePreview());
         }
         // Lane D — progress summaries appear in the response as dim lines
@@ -628,18 +642,37 @@ export async function streamResponse(
             ? `◦ ${safeDescription} (${safeToolName})`
             : `◦ ${safeDescription}`;
           // Record first, render second: a line withheld by the latency gate is
-          // still retained, so when the gate opens the bounded region shows the
-          // most recent rounds rather than starting from empty.
-          if (progressRunStart < 0) progressRunStart = accumulated.length;
+          // still retained, so when the gate opens — by a later event OR by the
+          // timer armed below — the bounded region shows the most recent rounds.
+          // The list is global and capped, so the bound holds across a stream
+          // that interleaves content with tool rounds, not just within one run.
           progressLines.push(safeSummary ? `${line}\n  ${safeSummary}` : line);
           if (progressLines.length > MAX_PROGRESS_LINES) {
             progressLines = progressLines.slice(-MAX_PROGRESS_LINES);
           }
-          if (Date.now() - turnStartedAt >= progressDelayMs) {
-            // Rewrite the region in place (bounded) instead of appending, so the
-            // preview keeps a fixed height across a long tool-heavy turn.
-            accumulated = accumulated.slice(0, progressRunStart) + renderProgressRegion(progressLines);
+          if (!progressGateOpen && Date.now() - turnStartedAt >= progressDelayMs) {
+            progressGateOpen = true;
+          }
+          if (progressGateOpen) {
+            clearProgressTimer();
             await sendOrEdit(livePreview());
+          } else if (progressTimer === null) {
+            // Invariant: the gate must be able to open with NO further stream
+            // event. Checking it only on the next `progress` event means one tool
+            // that runs silently past the delay leaves the user on `Thinking…`
+            // for its entire duration. Arm a one-shot timer for the remaining
+            // wait; it is cleared on every terminal path and in the finally.
+            progressTimer = setTimeout(() => {
+              progressTimer = null;
+              if (turnEnded) return;
+              progressGateOpen = true;
+              // A render already in flight computed its text before the gate
+              // opened; skip rather than racing it — the next event or the final
+              // delivery (finalBody, ungated) still surfaces the region.
+              if (editInFlight) return;
+              editInFlight = true;
+              void sendOrEdit(livePreview(), true).finally(() => { editInFlight = false; });
+            }, Math.max(0, progressDelayMs - (Date.now() - turnStartedAt)));
           }
         }
         // Lane D — post-turn prompt suggestion appended to the message.
@@ -656,7 +689,6 @@ export async function streamResponse(
         // comparison spuriously unequal and append a duplicate 💡 line to the
         // answer on exactly the tool-heavy turns that produce progress.
         if (event.type === 'suggestion' && event.suggestion.trim() !== answerText.trim()) {
-          endProgressRun();
           accumulated += `\n\n💡 ${event.suggestion}`;
           answerText += `\n\n💡 ${event.suggestion}`;
           await sendOrEdit(livePreview());
@@ -721,6 +753,8 @@ export async function streamResponse(
 
         if (event.type === 'done') {
           sawTerminalEvent = true;
+          turnEnded = true;
+          clearProgressTimer();
           if (countdownInterval !== null) {
             clearInterval(countdownInterval);
             countdownInterval = null;
@@ -744,19 +778,13 @@ export async function streamResponse(
               // otherwise re-send the noisy `accumulated` buffer) is skipped.
               sentMessage = null;
             }
-          } else if (accumulated.trim()) {
-            await sendOrEdit(accumulated, true);
-          } else if (progressLines.length > 0) {
+          } else if (finalBody().trim()) {
             // Invariant: a turn must never end on the bare `Thinking…` placeholder.
-            // Reachable when the latency gate withheld EVERY progress line and no
-            // answer text arrived — e.g. an abort mid tool-loop, which yields
-            // turn.completed with no assistant text (a progress-only turn). Before
-            // the gate existed `accumulated` always held the progress lines, so the
-            // branch above covered this; now the withheld region must be flushed
-            // explicitly. Assigning `accumulated` (not just editing) also keeps the
-            // post-loop overflow branch able to send chunks[1..] of a long region.
-            accumulated = renderProgressRegion(progressLines).trimStart();
-            await sendOrEdit(accumulated, true);
+            // finalBody() is `accumulated` PLUS the ungated progress region, so a
+            // progress-only turn whose lines the gate withheld still delivers them
+            // (`accumulated` alone is empty there). Covers the plain non-cleanFinal
+            // path and the cleanFinal-with-no-answer path in one branch.
+            await sendOrEdit(finalBody(), true);
           }
           // Record the completed turn into the shared session store (Telegram
           // → CLI resume). answerText is the noise-free assistant answer.
@@ -773,6 +801,8 @@ export async function streamResponse(
           // The provider already emitted a terminal error and parked itself, so
           // no interrupt() is needed (and would wrongly abort the NEXT turn).
           sawTerminalEvent = true;
+          turnEnded = true;
+          clearProgressTimer();
           if (countdownInterval !== null) {
             clearInterval(countdownInterval);
             countdownInterval = null;
@@ -806,7 +836,10 @@ export async function streamResponse(
       // `const` keeps the narrowing across the awaits below.
       const preview = sentMessage as Message.TextMessage | null;
       if (preview && !sawTerminalEvent) {
-        const full = cleanFinal && answerText.trim() ? answerText : accumulated;
+        // finalBody() (not bare `accumulated`) so a gated progress-only turn that
+        // ends by graceful iterator close — no done/error event — still delivers
+        // its recorded `◦` region instead of stranding the user on `Thinking…`.
+        const full = cleanFinal && answerText.trim() ? answerText : finalBody();
         if (full.trim()) {
           // Only delete the preview if delivery actually produced content — a
           // failed first chunk must leave the frozen preview in place rather
@@ -817,7 +850,7 @@ export async function streamResponse(
             sentMessage = null;
           }
         }
-      } else if (!(cleanFinal && answerText.trim()) && accumulated && preview) {
+      } else if (!(cleanFinal && answerText.trim()) && finalBody() && preview) {
         // Overflow send: `done` fired (`sawTerminalEvent` true, so the branch above is
         // skipped) and the `done` handler used `sendOrEdit`, which only ever renders
         // chunk[0] into the preview — send the remaining chunks[1..] here.
@@ -835,7 +868,10 @@ export async function streamResponse(
         // regardless of delivery outcome, so `!(...)` is false and this branch is skipped —
         // preserving the original #623 fix (no contradictory resend after the truncation
         // notice `deliverClean` already posted).
-        const chunks = splitLongMessage(markdownToTelegramHtml(accumulated));
+        // Must split the SAME text the `done` handler flushed (finalBody, which
+        // includes the progress region) or chunks[1..] would not line up with the
+        // chunk[0] already rendered into the preview.
+        const chunks = splitLongMessage(markdownToTelegramHtml(finalBody()));
         if (chunks.length > 1) {
           const reply = (t: string, extra?: { parse_mode?: 'HTML' }): Promise<unknown> => ctx.reply(t, extra);
           try {
@@ -882,6 +918,10 @@ export async function streamResponse(
         clearInterval(countdownInterval);
         countdownInterval = null;
       }
+      // Ordering: set turnEnded BEFORE clearing, so a timer callback already
+      // queued on the event loop sees the flag and declines to edit a dead turn.
+      turnEnded = true;
+      clearProgressTimer();
       editInFlight = false;
       // Always close the async generator — on both the happy path and the error
       // path — so the session's currentState resets to 'idle' only after all

--- a/src/telegram/streaming.ts
+++ b/src/telegram/streaming.ts
@@ -46,6 +46,27 @@ const TOOL_INFLIGHT_RECHECK_MS = 15_000;
 /** Max sub-agent progress lines retained in the bounded live-preview footer. */
 const MAX_SUBAGENT_PREVIEW_LINES = 4;
 
+/**
+ * Tool-progress (`◦`) lines stay HIDDEN until the turn has been working this
+ * long. Most turns finish faster than this and now render no progress noise at
+ * all — the live preview goes straight from `Thinking…` to the answer.
+ *
+ * Withheld lines are still recorded (see `progressLines`); when the gate opens
+ * the rolling region renders the most recent ones, so nothing is lost — it is a
+ * render delay, not a drop. Overridable per call via `options.progressDelayMs`
+ * (tests pass 0 to assert rendering deterministically).
+ */
+const PROGRESS_START_DELAY_MS = 5_000;
+
+/**
+ * Max `◦` tool-progress lines kept in the rolling live-preview region. Older
+ * lines are trimmed rather than accumulated, so a long tool-heavy turn no longer
+ * grows the preview without bound (which also meant one Telegram edit per round
+ * against an ever-longer message). Same bounded-region treatment
+ * `renderSubagentFooter` already applies to sub-agent steps.
+ */
+const MAX_PROGRESS_LINES = 6;
+
 // StreamTimeoutError lives in its own module so the message handler's
 // `instanceof` check survives `vi.mock('./streaming.js')` in tests (see
 // stream-timeout-error.ts). Imported above for local use (the watchdog throws
@@ -134,6 +155,38 @@ export function renderSubagentFooter(steps: number, recent: readonly string[]): 
   return shown.length > 0 ? `\n${head}\n  ${shown.join('\n  ')}` : `\n${head}`;
 }
 
+/**
+ * Render the BOUNDED `◦` tool-progress region for the live preview. Returns ''
+ * for no lines. Only the last MAX_PROGRESS_LINES are shown regardless of how
+ * many are passed, so a tool-heavy turn keeps a fixed-height status region
+ * instead of an ever-growing log. Pure + exported for unit tests.
+ */
+export function renderProgressRegion(lines: readonly string[]): string {
+  const shown = lines.slice(-MAX_PROGRESS_LINES);
+  return shown.length > 0 ? shown.map((l) => `\n${l}`).join('') : '';
+}
+
+/**
+ * One-line activity receipt appended to the CLEAN final message, replacing the
+ * `◦` progress log that cleanFinal deletes: the turn's cost stays visible
+ * without the per-round noise. Empty when no tool work happened, so plain
+ * question/answer turns are unchanged.
+ *
+ * Plain text on purpose — `markdownToTelegramHtml` escapes `<`/`>` before
+ * injecting its own fixed tag set (formatter.ts), so any HTML written here
+ * would reach the user as literal visible markup.
+ *
+ * Invariant: must NOT use the `◦` prefix. In this module `◦` marks live
+ * progress/status noise that cleanFinal exists to strip, and tests assert the
+ * delivered answer contains no `◦` at all. The receipt is a distinct concept
+ * (a kept summary, not stripped noise) and carries its own marker.
+ */
+export function renderActivityReceipt(toolRounds: number, elapsedMs: number): string {
+  if (toolRounds <= 0) return '';
+  const secs = Math.max(1, Math.round(elapsedMs / 1_000));
+  return `\n\n⏱️ ${toolRounds} ${toolRounds === 1 ? 'step' : 'steps'} · ${secs}s`;
+}
+
 /** Countdown update granularity during a usage-limit pause: every 5 minutes. */
 const PAUSE_COUNTDOWN_INTERVAL_MS = 5 * 60 * 1_000;
 /** Extra slack (ms) added to the timeout deadline while paused. */
@@ -165,6 +218,12 @@ export async function streamResponse(
      * the callback are caught and logged — they never disrupt delivery.
      */
     onComplete?: (assistantText: string, metadata?: ResponseMetadata) => void | Promise<void>;
+    /**
+     * How long the turn must run before `◦` tool-progress lines start rendering.
+     * Defaults to PROGRESS_START_DELAY_MS. Pass 0 to render immediately (tests
+     * assert progress output without depending on wall-clock timing).
+     */
+    progressDelayMs?: number;
   } = {}
 ): Promise<void> {
   if (!ctx.chat?.id) {
@@ -227,6 +286,25 @@ export async function streamResponse(
   // counter + the last few lines, instead of an unbounded per-tool-call append.
   let subagentSteps = 0;
   const recentSubagentSteps: string[] = [];
+
+  // Invariant: the `◦` tool-progress region is a BOUNDED, REWRITABLE tail of
+  // `accumulated`, not an append-only log. `progressRunStart` is the offset in
+  // `accumulated` where the current consecutive progress run begins; each new
+  // progress event rewrites `accumulated` from that offset with the last
+  // MAX_PROGRESS_LINES entries. That offset is only valid while nothing else
+  // appends to `accumulated`, so EVERY other writer (content chunk, assistant
+  // message, suggestion, stream_retry rollback) must call `endProgressRun()`
+  // first — otherwise the rewrite would truncate their text.
+  const progressDelayMs = options.progressDelayMs ?? PROGRESS_START_DELAY_MS;
+  const turnStartedAt = Date.now();
+  let progressLines: string[] = [];
+  let progressRunStart = -1;
+  // Total tool rounds seen this turn (never trimmed) — drives the activity receipt.
+  let progressRounds = 0;
+  const endProgressRun = (): void => {
+    progressRunStart = -1;
+    progressLines = [];
+  };
 
   const sendOrEdit = async (text: string, force = false): Promise<void> => {
     // markdownToTelegramHtml runs 8 serial regex passes over the full accumulated
@@ -486,6 +564,9 @@ export async function streamResponse(
         }
 
         if (event.type === 'chunk' && event.chunk.type === 'content') {
+          // Answer text follows the progress region, so the region is now frozen
+          // history — stop rewriting it (see the progressRunStart invariant).
+          endProgressRun();
           if (!inContentRun) {
             contentRunStartAccumulated = accumulated.length;
             contentRunStartAnswer = answerText.length;
@@ -503,6 +584,9 @@ export async function streamResponse(
           accumulated = accumulated.slice(0, contentRunStartAccumulated);
           answerText = answerText.slice(0, contentRunStartAnswer);
           inContentRun = false;
+          // The rollback moved the end of `accumulated`, invalidating any live
+          // progress-region offset into it.
+          endProgressRun();
           await sendOrEdit(livePreview(), true);
         }
         if (event.type === 'chunk' && event.chunk.type === 'tool_diff') {
@@ -512,6 +596,9 @@ export async function streamResponse(
           accumulated = event.message.content;
           answerText = event.message.content;
           inContentRun = false;
+          // `accumulated` was replaced wholesale — any progress-region offset
+          // into the old buffer is stale.
+          endProgressRun();
           await sendOrEdit(livePreview());
         }
         // Lane D — progress summaries appear in the response as dim lines
@@ -519,9 +606,16 @@ export async function streamResponse(
         // above since they go through sendOrEdit on the same accumulated
         // buffer, so rapid progress bursts won't spam the Telegram API.
         if (event.type === 'progress') {
-          // Round boundary: a new content run after this starts a fresh
-          // snapshot, so a later stream_retry rolls back only the new round.
+          // Invariant: this assignment is NOT cosmetic and must stay
+          // unconditional — it is the stream_retry round boundary. A new content
+          // run after this point re-snapshots contentRunStart*, so a later
+          // retry rolls back only the new round. Skipping it (e.g. by early
+          // -returning when progress rendering is gated off below) leaves the
+          // snapshot at an older offset and a later stream_retry truncates MORE
+          // of `answerText` than the retry produced — silently deleting
+          // already-delivered answer text. Gate the RENDER, never this line.
           inContentRun = false;
+          progressRounds++;
           const { description, summary, lastToolName } = event.progress;
           // These fields are model-controlled (path/command/URL text from
           // summarizeToolInput) and markdownToTelegramHtml does not strip
@@ -531,11 +625,22 @@ export async function streamResponse(
           const safeToolName = lastToolName ? sanitizeLabel(lastToolName) : lastToolName;
           const safeSummary = summary ? sanitizeLabel(summary) : summary;
           const line = safeToolName
-            ? `\n◦ ${safeDescription} (${safeToolName})`
-            : `\n◦ ${safeDescription}`;
-          accumulated += line;
-          if (safeSummary) accumulated += `\n  ${safeSummary}`;
-          await sendOrEdit(livePreview());
+            ? `◦ ${safeDescription} (${safeToolName})`
+            : `◦ ${safeDescription}`;
+          // Record first, render second: a line withheld by the latency gate is
+          // still retained, so when the gate opens the bounded region shows the
+          // most recent rounds rather than starting from empty.
+          if (progressRunStart < 0) progressRunStart = accumulated.length;
+          progressLines.push(safeSummary ? `${line}\n  ${safeSummary}` : line);
+          if (progressLines.length > MAX_PROGRESS_LINES) {
+            progressLines = progressLines.slice(-MAX_PROGRESS_LINES);
+          }
+          if (Date.now() - turnStartedAt >= progressDelayMs) {
+            // Rewrite the region in place (bounded) instead of appending, so the
+            // preview keeps a fixed height across a long tool-heavy turn.
+            accumulated = accumulated.slice(0, progressRunStart) + renderProgressRegion(progressLines);
+            await sendOrEdit(livePreview());
+          }
         }
         // Lane D — post-turn prompt suggestion appended to the message.
         // Skip when the suggestion duplicates the already-rendered response:
@@ -545,7 +650,13 @@ export async function streamResponse(
         // text via chunk/message events, so appending `\n\n💡 <same text>`
         // would produce a visible duplicate prefixed with 💡. Only append
         // true follow-up hints whose payload differs from the response.
-        if (event.type === 'suggestion' && event.suggestion.trim() !== accumulated.trim()) {
+        // Compare against `answerText`, not `accumulated`: the gate's purpose is
+        // "don't echo text already rendered as the ANSWER", and `accumulated`
+        // also carries the `◦` progress region — whose presence would make the
+        // comparison spuriously unequal and append a duplicate 💡 line to the
+        // answer on exactly the tool-heavy turns that produce progress.
+        if (event.type === 'suggestion' && event.suggestion.trim() !== answerText.trim()) {
+          endProgressRun();
           accumulated += `\n\n💡 ${event.suggestion}`;
           answerText += `\n\n💡 ${event.suggestion}`;
           await sendOrEdit(livePreview());
@@ -620,7 +731,13 @@ export async function streamResponse(
             // delete the preview if something actually landed — if the very first
             // chunk failed, `delivered` is false and the frozen preview must
             // survive so the user is never left with zero visible content.
-            const delivered = await deliverClean(answerText);
+            // The receipt is appended at DELIVERY only, never to `answerText`
+            // itself: `answerText` is what onComplete records into the resumable
+            // session store below, and a UI receipt there would corrupt the
+            // stored transcript (and be replayed by `afk --resume`).
+            const delivered = await deliverClean(
+              answerText + renderActivityReceipt(progressRounds, Date.now() - turnStartedAt),
+            );
             if (delivered && sentMessage) {
               await ctx.telegram.deleteMessage?.(chatId, sentMessage.message_id).catch(() => {});
               // Null the preview ref so the post-loop overflow block (which would
@@ -628,6 +745,17 @@ export async function streamResponse(
               sentMessage = null;
             }
           } else if (accumulated.trim()) {
+            await sendOrEdit(accumulated, true);
+          } else if (progressLines.length > 0) {
+            // Invariant: a turn must never end on the bare `Thinking…` placeholder.
+            // Reachable when the latency gate withheld EVERY progress line and no
+            // answer text arrived — e.g. an abort mid tool-loop, which yields
+            // turn.completed with no assistant text (a progress-only turn). Before
+            // the gate existed `accumulated` always held the progress lines, so the
+            // branch above covered this; now the withheld region must be flushed
+            // explicitly. Assigning `accumulated` (not just editing) also keeps the
+            // post-loop overflow branch able to send chunks[1..] of a long region.
+            accumulated = renderProgressRegion(progressLines).trimStart();
             await sendOrEdit(accumulated, true);
           }
           // Record the completed turn into the shared session store (Telegram


### PR DESCRIPTION
## Summary

The Telegram live preview appended one `◦` progress line per tool round to `accumulated` with **no bound and no delay**. Every turn — including fast ones — churned the message, and a tool-heavy turn grew it without limit. `cleanFinal` already deletes the noisy preview at the end, so *scrollback* was clean; the problem was purely the live experience, and there was no knob to tune it.

Prior art check: OpenClaw (the closest analogue — self-hosted agent over Telegram) uses the same send-and-edit transport we do, and solves this with a bounded rolling window (`maxLines` default 8) plus a 5s start delay. This lands the same shape. Notably it does **not** need Telegram's newer `sendMessageDraft` (Bot API 9.3+), which our `telegraf@4.16.3` (Bot API 7.1) couldn't call anyway.

Four changes, all inside `streamResponse`:

| # | Change | Effect |
|---|---|---|
| 1 | **Latency gate** (`PROGRESS_START_DELAY_MS` = 5s) | Fast turns render **zero** `◦` lines — straight from `Thinking…` to the answer. Withheld lines are still recorded, so the gate opening shows recent rounds: a render delay, not a drop. |
| 2 | **Rolling window** (`MAX_PROGRESS_LINES` = 6) | The region is a bounded, rewritable tail of `accumulated` instead of an append-only log — the same treatment `renderSubagentFooter` already applies to sub-agent steps. |
| 3 | **Suggestion dedupe** compares `answerText`, not `accumulated` | Fixes a latent bug: the gate means "don't echo text already rendered as the answer", but `accumulated` also carries the `◦` region, making the comparison spuriously unequal and appending a duplicate 💡 on exactly the tool-heavy turns that produce progress. |
| 4 | **Activity receipt** (`⏱️ N steps · Ns`) | The turn's cost survives the preview deletion. Appended at **delivery only** — never to `answerText`, which `onComplete` records into resumable session history. |

## Two couplings worth reviewer attention

Both were found by adversarial re-derivation before implementation, and each now has a regression test that **fails if the coupling is broken** (verified by deliberately reintroducing the bug):

1. **`inContentRun = false` in the progress handler is not cosmetic — it is the `stream_retry` round boundary.** Gating it off (the obvious way to implement "hide progress") leaves `contentRunStart*` at an older offset, so a later `stream_retry` truncates **more** of `answerText` than the retry produced — silently destroying already-streamed answer text. The *render* is gated; that assignment stays unconditional. Guard: `REGRESSION: a gated-off progress round still sets the stream_retry boundary…` (asserts `AAACCC`, not `CCC`).
2. **Progress-only turns.** With progress withheld and no answer text (reachable via an abort mid tool-loop, which yields `turn.completed` with no assistant message), `accumulated` was empty and the user was stranded on the bare `Thinking…` placeholder. The `done` branch now flushes the withheld region explicitly. Guard: `dead-turn guard: a fast progress-only turn still delivers…`.

The `progressRunStart` offset is only valid while nothing else appends to `accumulated`, so every other writer (content chunk, assistant message, suggestion, `stream_retry` rollback) calls `endProgressRun()` first. That invariant is documented at the declaration.

## Deliberately out of scope

- **Operator-facing config** for the delay/window. `progressDelayMs` is exposed on the options object as a test seam only; a `telegram.progress` config key would pull in `ENV_REGISTRY` + `docs/env-registry.*` sync and is better as a follow-up.
- **`<blockquote expandable>`** for collapsed detail. Investigated and rejected for now: `markdownToTelegramHtml` escapes `<`/`>` unconditionally before injecting its own fixed tag set (`formatter.ts:90-93`), so an injected tag renders as literal text. Would need the tag emitted inside the formatter plus tag-aware `splitLongMessage`.
- **Pre-existing bug, untouched:** on a progress-only turn `onComplete` fires with `answerText === ''` and persists `{assistant: ''}` into resumable history with no non-empty check (`streaming.ts` → `session-stats.ts`). Not caused by this change and not fixed here; worth its own issue.

## Behavior change for reviewers to weigh

Fast tool-using turns now show **no** intermediate progress. That is the intent, but it is a default-behavior change: someone who liked watching each round will see less. The receipt (#4) is the compensating signal.

## How was this tested?

- `pnpm lint` — clean.
- `pnpm test` — **699 files, 13091 passed**, 14 skipped.
- `pnpm audit:env:check`, `pnpm scan:env:check`, `pnpm audit:sdk:check` — all pass.
- `pnpm build` — clean.
- 8 new cases in `streaming.test.ts`: latency gate (asserts the production default, no override), rolling window, retry-boundary regression, dead-turn guard, receipt present / absent / not-recorded, suggestion dedupe, and pure-helper unit tests.
- Two existing tests now pass `progressDelayMs: 0` because they assert progress *rendering* rather than gating; the assertions themselves are unchanged. No assertion was weakened — when the receipt initially tripped the `not.toContain('◦')` invariant, the receipt's marker was changed to `⏱️` rather than relaxing the test.

Not tested: live Telegram delivery (no integration harness); the 5s gate is exercised via the injectable override plus the default-path test.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] No secrets, tokens, or private paths in the diff