### PR TITLE
fix(telegram): humanize live activity

### DIFF
--- a/src/telegram/streaming.test.ts
+++ b/src/telegram/streaming.test.ts
@@ -3,11 +3,12 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { streamResponse, StreamTimeoutError, renderSubagentFooter, renderProgressRegion, renderActivityReceipt, replyWithFloodRetry } from './streaming.js';
+import { streamResponse, StreamTimeoutError, renderSubagentFooter, renderProgressRegion, renderActivityReceipt, formatTelegramActivity, formatTelegramAgentLabel, replyWithFloodRetry } from './streaming.js';
 import { TelegramError } from 'telegraf';
 import type { Context } from 'telegraf';
 import type { IAgentSession, OutputEvent } from '../agent/types.js';
 import type { ContentBlockParam } from '@anthropic-ai/sdk/resources';
+import { getCurrentSink } from '../agent/_lib/skill-sink-channel.js';
 
 async function* yieldChunks(...chunks: string[]) {
   for (const c of chunks) {
@@ -111,8 +112,8 @@ describe('streamResponse', () => {
     await streamResponse(ctx, session, 'go', undefined, { progressDelayMs: 0 });
     const joined = [...replies, ...edits].join('\n');
     expect(joined).toContain('◦ Researching codebase');
-    expect(joined).toContain('(Grep)');
-    expect(joined).toContain('12 matches in 4 files');
+    expect(joined).not.toContain('(Grep)');
+    expect(joined).not.toContain('12 matches in 4 files');
   });
 
   it('sanitizes control/ANSI sequences in model-controlled progress fields before sending to Telegram', async () => {
@@ -150,6 +151,33 @@ describe('streamResponse', () => {
     // Raw escape/control bytes must not reach the Telegram message.
     expect(joined).not.toContain('\x1b');
     expect(joined).not.toContain('\x9b');
+  });
+
+  it('shows friendly sub-agent activity without exposing tool arguments or paths', async () => {
+    const { ctx, replies, edits } = makeCtx();
+    const session = makeSession(async function* () {
+      getCurrentSink()?.(
+        {
+          type: 'chunk',
+          chunk: {
+            type: 'tool_use_detail',
+            toolUseId: 'tool-1',
+            toolName: 'Grep',
+            toolInput: '/Users/example/private-project --hidden secret-pattern',
+          },
+        },
+        { subagentId: 'sub-1', agentType: 'research-agent' },
+      );
+      await Promise.resolve();
+      yield { type: 'done', metadata: undefined };
+    });
+
+    await streamResponse(ctx, session, 'go');
+
+    const joined = [...replies, ...edits].join('\n');
+    expect(joined).toContain('Research agent — Searching');
+    expect(joined).not.toContain('/Users/example/private-project');
+    expect(joined).not.toContain('secret-pattern');
   });
 
   it('appends prompt_suggestion as a final 💡 line', async () => {
@@ -760,6 +788,19 @@ describe('renderSubagentFooter (bounded sub-agent progress)', () => {
   });
 });
 
+describe('Telegram-friendly activity formatting', () => {
+  it('humanizes generic tool activity and keeps meaningful descriptions', () => {
+    expect(formatTelegramActivity('Working', 'memory_search')).toBe('Searching');
+    expect(formatTelegramActivity('Processing', 'Bash')).toBe('Running a command');
+    expect(formatTelegramActivity('Researching release notes', 'WebSearch')).toBe('Researching release notes');
+  });
+
+  it('humanizes agent labels and hides opaque UUIDs', () => {
+    expect(formatTelegramAgentLabel('research-agent')).toBe('Research agent');
+    expect(formatTelegramAgentLabel('c204d56f-bd57-4380-8a5f-123456789abc')).toBe('Sub-agent');
+  });
+});
+
 describe('provider-turn interrupt on incomplete exit (stale-buffer guard)', () => {
   it('throws StreamTimeoutError and interrupts the still-running turn on total silence', async () => {
     vi.useFakeTimers();
@@ -1036,6 +1077,19 @@ describe('bounded ◦ progress region', () => {
     expect(all.some((t) => t.includes('searched the codebase'))).toBe(true);
     // The placeholder is not the last thing the user sees.
     expect(all[all.length - 1]).not.toBe('Thinking…');
+  });
+
+  it('graceful-exit guard: withheld progress survives a stream close without done/error', async () => {
+    const { ctx, replies, deletes } = makeCtx();
+    const session = makeSession(async function* () {
+      yield progressEvent('searched the codebase');
+      // Graceful iterator exhaustion without a terminal OutputEvent.
+    });
+
+    await streamResponse(ctx, session, 'go', undefined, { cleanFinal: true });
+
+    expect(replies.some((text) => text.includes('searched the codebase'))).toBe(true);
+    expect(deletes).toHaveLength(1);
   });
 
   it('activity receipt: summarizes tool rounds on the clean final but never enters recorded history', async () => {

--- a/src/telegram/streaming.test.ts
+++ b/src/telegram/streaming.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { streamResponse, StreamTimeoutError, renderSubagentFooter, replyWithFloodRetry } from './streaming.js';
+import { streamResponse, StreamTimeoutError, renderSubagentFooter, renderProgressRegion, renderActivityReceipt, replyWithFloodRetry } from './streaming.js';
 import { TelegramError } from 'telegraf';
 import type { Context } from 'telegraf';
 import type { IAgentSession, OutputEvent } from '../agent/types.js';
@@ -105,7 +105,10 @@ describe('streamResponse', () => {
       );
     });
 
-    await streamResponse(ctx, session, 'go');
+    // progressDelayMs: 0 opts out of the latency gate (PROGRESS_START_DELAY_MS)
+    // so this test asserts the RENDERING contract deterministically. The gate
+    // itself is covered by the 'latency gate' tests below.
+    await streamResponse(ctx, session, 'go', undefined, { progressDelayMs: 0 });
     const joined = [...replies, ...edits].join('\n');
     expect(joined).toContain('◦ Researching codebase');
     expect(joined).toContain('(Grep)');
@@ -375,7 +378,9 @@ describe('streamResponse', () => {
   it('default (no cleanFinal): force-flushes the in-place preview (noise included) and never deletes', async () => {
     const { ctx, edits, deletes } = makeCtx();
 
-    await streamResponse(ctx, answerWithProgress(), 'go');
+    // progressDelayMs: 0 opts out of the latency gate so the ◦ line is rendered
+    // into `accumulated` and this test still exercises the legacy flush path.
+    await streamResponse(ctx, answerWithProgress(), 'go', undefined, { progressDelayMs: 0 });
 
     // Legacy force-flushes `accumulated` on done, which mixes the ◦ progress
     // noise into the final in-place edit — the behavior cleanFinal improves on.
@@ -931,5 +936,175 @@ describe('replyWithFloodRetry (flood-control 429 backoff)', () => {
       replyWithFloodRetry(reply, 'hi', { parse_mode: 'HTML' }, { sleep: async () => {} }),
     ).rejects.toBe(err);
     expect(reply).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('bounded ◦ progress region', () => {
+  function progressEvent(description: string): OutputEvent {
+    return {
+      type: 'progress',
+      progress: { taskId: 't', description, totalTokens: 0, toolUses: 1, durationMs: 1 },
+    } as OutputEvent;
+  }
+
+  it('latency gate: a fast turn renders NO ◦ progress lines at all', async () => {
+    // The user-visible point of the gate: most turns finish well under
+    // PROGRESS_START_DELAY_MS, and those turns should go straight from the
+    // `Thinking…` placeholder to the answer with zero `◦` churn. No
+    // progressDelayMs override here — this asserts the production default.
+    const { ctx, replies, edits } = makeCtx();
+    const session = makeSession(async function* () {
+      yield* yieldEvents(
+        progressEvent('Running tool'),
+        progressEvent('Running another tool'),
+        { type: 'chunk', chunk: { type: 'content', content: 'Done thinking.' } },
+        { type: 'done', metadata: undefined },
+      );
+    });
+
+    await streamResponse(ctx, session, 'go', undefined, { cleanFinal: true });
+
+    expect([...replies, ...edits].some((t) => t.includes('◦'))).toBe(false);
+    expect(replies.some((r) => r.includes('Done thinking.'))).toBe(true);
+  });
+
+  it('rolling window: only the most recent MAX_PROGRESS_LINES survive', async () => {
+    // Regression: progress lines used to append to `accumulated` without bound,
+    // so a tool-heavy turn grew the preview one line per round forever.
+    const { ctx, edits } = makeCtx();
+    const session = makeSession(async function* () {
+      for (let i = 1; i <= 9; i++) yield progressEvent(`round-${i}`);
+      yield { type: 'done', metadata: undefined };
+    });
+
+    await streamResponse(ctx, session, 'go', undefined, { progressDelayMs: 0 });
+
+    // `done` force-flushes the full accumulated buffer into the preview.
+    const final = edits[edits.length - 1] ?? '';
+    expect(final).toContain('round-9');
+    expect(final).toContain('round-4'); // 9 rounds, window of 6 → 4..9 kept
+    expect(final).not.toContain('round-3');
+    expect(final).not.toContain('round-1');
+  });
+
+  it('REGRESSION: a gated-off progress round still sets the stream_retry boundary, so a retry does not eat earlier answer text', async () => {
+    // This is the trap a shadow-verify wave caught. The `progress` handler's
+    // `inContentRun = false` is NOT cosmetic — it is the stream_retry round
+    // boundary. Suppressing progress RENDERING must not skip it: if it were
+    // skipped, contentRunStartAnswer would still point at offset 0 when the
+    // second content run began, and the stream_retry below would slice
+    // answerText back to '' — silently destroying 'AAA', text the model had
+    // already streamed. Runs with the DEFAULT latency gate (progress renders
+    // nothing here) precisely to prove render-suppression keeps the boundary.
+    const { ctx, replies } = makeCtx();
+    const session = makeSession(async function* () {
+      yield { type: 'chunk', chunk: { type: 'content', content: 'AAA' } };
+      yield progressEvent('tool round between two content runs');
+      yield { type: 'chunk', chunk: { type: 'content', content: 'BBB' } };
+      yield { type: 'stream_retry' } as OutputEvent;
+      yield { type: 'chunk', chunk: { type: 'content', content: 'CCC' } };
+      yield { type: 'done', metadata: undefined };
+    });
+
+    let recorded: string | undefined;
+    await streamResponse(ctx, session, 'go', undefined, {
+      cleanFinal: true,
+      onComplete: (text) => { recorded = text; },
+    });
+
+    // 'AAA' survived the retry; only the retried round ('BBB') was discarded.
+    expect(recorded).toBe('AAACCC');
+    expect(replies.some((r) => r.includes('AAACCC'))).toBe(true);
+  });
+
+  it('dead-turn guard: a fast progress-only turn still delivers, never stranding the user on `Thinking…`', async () => {
+    // With the latency gate active and no answer text (e.g. an abort mid
+    // tool-loop yields turn.completed with no assistant message), `accumulated`
+    // is empty — so without an explicit flush the user's entire reply would be
+    // the bare `Thinking…` placeholder: a silent dead turn.
+    const { ctx, replies, edits } = makeCtx();
+    const session = makeSession(async function* () {
+      yield* yieldEvents(
+        progressEvent('searched the codebase'),
+        { type: 'done', metadata: undefined },
+      );
+    });
+
+    await streamResponse(ctx, session, 'go', undefined, { cleanFinal: true });
+
+    const all = [...replies, ...edits];
+    expect(all.some((t) => t.includes('searched the codebase'))).toBe(true);
+    // The placeholder is not the last thing the user sees.
+    expect(all[all.length - 1]).not.toBe('Thinking…');
+  });
+
+  it('activity receipt: summarizes tool rounds on the clean final but never enters recorded history', async () => {
+    const { ctx, replies } = makeCtx();
+    const session = makeSession(async function* () {
+      yield* yieldEvents(
+        progressEvent('step one'),
+        progressEvent('step two'),
+        { type: 'chunk', chunk: { type: 'content', content: 'The answer.' } },
+        { type: 'done', metadata: undefined },
+      );
+    });
+
+    let recorded: string | undefined;
+    await streamResponse(ctx, session, 'go', undefined, {
+      cleanFinal: true,
+      onComplete: (text) => { recorded = text; },
+    });
+
+    const finalReply = replies[replies.length - 1] ?? '';
+    expect(finalReply).toContain('The answer.');
+    expect(finalReply).toContain('2 steps');
+    // The receipt is presentation only: recorded turn history stays clean so a
+    // CLI `--resume` does not replay UI chrome as assistant text.
+    expect(recorded).toBe('The answer.');
+    expect(recorded).not.toContain('⏱️');
+  });
+
+  it('activity receipt: absent on a turn with no tool rounds', async () => {
+    const { ctx, replies } = makeCtx();
+    const session = makeSession(async function* () {
+      yield* yieldChunks('Just an answer.');
+    });
+
+    await streamResponse(ctx, session, 'go', undefined, { cleanFinal: true });
+
+    expect(replies[replies.length - 1]).toBe('Just an answer.');
+  });
+
+  it('suggestion dedupe compares against the ANSWER, not the progress-polluted buffer', async () => {
+    // Regression: the gate used to compare the suggestion against `accumulated`,
+    // which also carries the `◦` region. On a tool-heavy turn that made the
+    // comparison spuriously unequal, so a suggestion identical to the answer was
+    // appended anyway — a duplicate 💡 echo on exactly the turns with progress.
+    const { ctx, replies } = makeCtx();
+    const session = makeSession(async function* () {
+      yield* yieldEvents(
+        progressEvent('did some work'),
+        { type: 'chunk', chunk: { type: 'content', content: 'Hi! What can I help with?' } },
+        { type: 'suggestion', suggestion: 'Hi! What can I help with?' },
+        { type: 'done', metadata: undefined },
+      );
+    });
+
+    await streamResponse(ctx, session, 'go', undefined, { cleanFinal: true, progressDelayMs: 0 });
+
+    expect(replies.some((r) => r.includes('💡'))).toBe(false);
+  });
+
+  it('renderProgressRegion/renderActivityReceipt are pure and bounded', () => {
+    expect(renderProgressRegion([])).toBe('');
+    expect(renderProgressRegion(['a', 'b'])).toBe('\na\nb');
+    // Window of 6: a 9-entry input keeps the tail only.
+    const nine = Array.from({ length: 9 }, (_, i) => `l${i + 1}`);
+    expect(renderProgressRegion(nine)).toBe('\nl4\nl5\nl6\nl7\nl8\nl9');
+    expect(renderActivityReceipt(0, 5_000)).toBe('');
+    expect(renderActivityReceipt(1, 4_000)).toBe('\n\n⏱️ 1 step · 4s');
+    expect(renderActivityReceipt(3, 12_400)).toBe('\n\n⏱️ 3 steps · 12s');
+    // Sub-second turns floor to 1s rather than showing '0s'.
+    expect(renderActivityReceipt(2, 200)).toBe('\n\n⏱️ 2 steps · 1s');
   });
 });

--- a/src/telegram/streaming.test.ts
+++ b/src/telegram/streaming.test.ts
@@ -795,6 +795,23 @@ describe('Telegram-friendly activity formatting', () => {
     expect(formatTelegramActivity('Researching release notes', 'WebSearch')).toBe('Researching release notes');
   });
 
+  it('categorizes by whole token, so a domain outranks a colliding verb', () => {
+    // `browser_open` is browser navigation, not a file read: the `browser`
+    // domain token wins over the `open` verb token.
+    expect(formatTelegramActivity('Working', 'browser_open')).toBe('Researching');
+    expect(formatTelegramActivity('Working', 'web_scrape')).toBe('Researching');
+    expect(formatTelegramActivity('Working', 'read_file')).toBe('Reading files');
+    expect(formatTelegramActivity('Working', 'write_file')).toBe('Editing files');
+    expect(formatTelegramActivity('Working', 'Grep')).toBe('Searching');
+  });
+
+  it('falls back to a readable label rather than a confidently wrong category', () => {
+    // `memory` alone is not a search, and a `terminal_font_size` setting is not
+    // a shell command — a substring match previously claimed both.
+    expect(formatTelegramActivity('Working', 'memory_update')).toBe('Using memory update');
+    expect(formatTelegramActivity('Working', 'terminal_font_size')).toBe('Using terminal font size');
+  });
+
   it('humanizes agent labels and hides opaque UUIDs', () => {
     expect(formatTelegramAgentLabel('research-agent')).toBe('Research agent');
     expect(formatTelegramAgentLabel('c204d56f-bd57-4380-8a5f-123456789abc')).toBe('Sub-agent');

--- a/src/telegram/streaming.ts
+++ b/src/telegram/streaming.ts
@@ -138,6 +138,49 @@ export async function replyWithFloodRetry(
   }
 }
 
+function humanizeToolActivity(toolName: string): string {
+  const safeName = sanitizeLabel(toolName);
+  const normalized = safeName.toLowerCase().replace(/[^a-z0-9]/g, '');
+  if (/memory|search|grep|glob|find/.test(normalized)) return 'Searching';
+  if (/read|open|view|inspect/.test(normalized)) return 'Reading files';
+  if (/edit|write|patch|replace/.test(normalized)) return 'Editing files';
+  if (/test|vitest|jest/.test(normalized)) return 'Running tests';
+  if (/browser|web|fetch/.test(normalized)) return 'Researching';
+  if (/bash|shell|exec|command|terminal/.test(normalized)) return 'Running a command';
+
+  const readable = safeName
+    .replace(/[_-]+/g, ' ')
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return readable ? `Using ${readable}` : 'Working';
+}
+
+/**
+ * Convert model/provider progress into short Telegram-facing activity copy.
+ * Generic descriptions use the tool category; meaningful descriptions remain
+ * available when no better structured signal exists. Tool summaries and input
+ * are deliberately excluded because they commonly contain commands and paths.
+ */
+export function formatTelegramActivity(description?: string, toolName?: string): string {
+  const safeDescription = sanitizeLabel(description ?? '').replace(/\s+/g, ' ').trim();
+  const genericDescription =
+    /^(working|processing|in progress|running)(?:\s*\([^)]*\))?$/i.test(safeDescription);
+  if (toolName && (!safeDescription || genericDescription)) {
+    return humanizeToolActivity(toolName);
+  }
+  return safeDescription || (toolName ? humanizeToolActivity(toolName) : 'Working');
+}
+
+/** Make internal sub-agent identifiers readable without exposing opaque UUIDs. */
+export function formatTelegramAgentLabel(label: string): string {
+  if (/^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i.test(label)) return 'Sub-agent';
+  const readable = sanitizeLabel(label).replace(/[_-]+/g, ' ').replace(/\s+/g, ' ').trim();
+  return readable
+    ? readable.charAt(0).toUpperCase() + readable.slice(1)
+    : 'Sub-agent';
+}
+
 /**
  * Render a compact, BOUNDED footer summarizing sub-agent tool activity for the
  * live preview. Returns '' when there is no activity. Pure + exported for unit
@@ -151,7 +194,7 @@ export async function replyWithFloodRetry(
 export function renderSubagentFooter(steps: number, recent: readonly string[]): string {
   if (steps <= 0) return '';
   const shown = recent.slice(-MAX_SUBAGENT_PREVIEW_LINES);
-  const head = `◦ sub-agents working — ${steps} ${steps === 1 ? 'step' : 'steps'}`;
+  const head = `🤖 Sub-agents · ${steps} ${steps === 1 ? 'step' : 'steps'}`;
   return shown.length > 0 ? `\n${head}\n  ${shown.join('\n  ')}` : `\n${head}`;
 }
 
@@ -510,20 +553,17 @@ export async function streamResponse(
     // visible annotations on the accumulated message. Without this,
     // subagent events are silently dropped because no ambient sink is set.
     const subagentSink = (event: OutputEvent, meta: SubagentProgressMeta): void => {
-      const label = meta.agentType ?? meta.subagentId;
+      const label = formatTelegramAgentLabel(meta.agentType ?? meta.subagentId);
       // Sub-agent activity keeps the turn alive: bump the watchdog so deep
       // fan-out (silent on the parent stream) does not trip a false timeout.
       lastActivityAt = Date.now();
       if (event.type === 'chunk' && event.chunk.type === 'tool_use_detail') {
-        // toolInput is redacted at its source (summarizeToolInput) before it
-        // reaches this network-egress sink, so no secret-scrub is needed here.
-        const toolArgs = event.chunk.toolInput.length > 60
-          ? event.chunk.toolInput.slice(0, 57) + '...'
-          : event.chunk.toolInput;
         // Bounded: count every step but retain only the most recent few lines,
         // rendered as a compact footer rather than one appended line per call.
+        // Never include toolInput: even summarized input commonly contains raw
+        // commands and private filesystem paths that are poor mobile UI.
         subagentSteps++;
-        recentSubagentSteps.push(`${label}: ${event.chunk.toolName} ${toolArgs}`);
+        recentSubagentSteps.push(`${label} — ${humanizeToolActivity(event.chunk.toolName)}`);
         if (recentSubagentSteps.length > MAX_SUBAGENT_PREVIEW_LINES) recentSubagentSteps.shift();
         void sendOrEdit(livePreview());
       } else if (event.type === 'done') {
@@ -581,24 +621,20 @@ export async function streamResponse(
           // text (re-streamed from scratch after the backoff). The final
           // `message` event overwrites `accumulated` anyway — this just stops
           // the live preview from showing the text twice during the retry.
+          endProgressRun();
           accumulated = accumulated.slice(0, contentRunStartAccumulated);
           answerText = answerText.slice(0, contentRunStartAnswer);
           inContentRun = false;
-          // The rollback moved the end of `accumulated`, invalidating any live
-          // progress-region offset into it.
-          endProgressRun();
           await sendOrEdit(livePreview(), true);
         }
         if (event.type === 'chunk' && event.chunk.type === 'tool_diff') {
           // intentional no-op: diff is CLI-only; Telegram has no terminal palette
         }
         if (event.type === 'message' && event.message.role === 'assistant') {
+          endProgressRun();
           accumulated = event.message.content;
           answerText = event.message.content;
           inContentRun = false;
-          // `accumulated` was replaced wholesale — any progress-region offset
-          // into the old buffer is stale.
-          endProgressRun();
           await sendOrEdit(livePreview());
         }
         // Lane D — progress summaries appear in the response as dim lines
@@ -616,22 +652,18 @@ export async function streamResponse(
           // already-delivered answer text. Gate the RENDER, never this line.
           inContentRun = false;
           progressRounds++;
-          const { description, summary, lastToolName } = event.progress;
-          // These fields are model-controlled (path/command/URL text from
-          // summarizeToolInput) and markdownToTelegramHtml does not strip
-          // ANSI/C1/control bytes, so scrub them here to match the CLI
-          // banner's field-scoped hardening (tool-lane-format-sanitize.ts).
-          const safeDescription = sanitizeLabel(description);
-          const safeToolName = lastToolName ? sanitizeLabel(lastToolName) : lastToolName;
-          const safeSummary = summary ? sanitizeLabel(summary) : summary;
-          const line = safeToolName
-            ? `◦ ${safeDescription} (${safeToolName})`
-            : `◦ ${safeDescription}`;
+          const { description, lastToolName } = event.progress;
+          // Telegram is a compact chat surface, not a terminal. Prefer a short
+          // activity category for generic progress and intentionally omit the
+          // summary, which routinely contains commands, URLs, and local paths.
+          const line = `◦ ${formatTelegramActivity(description, lastToolName)}`;
           // Record first, render second: a line withheld by the latency gate is
           // still retained, so when the gate opens the bounded region shows the
           // most recent rounds rather than starting from empty.
           if (progressRunStart < 0) progressRunStart = accumulated.length;
-          progressLines.push(safeSummary ? `${line}\n  ${safeSummary}` : line);
+          // Repeated tool categories add no information to a rolling mobile
+          // preview. Count every round for the receipt, but render duplicates once.
+          if (progressLines[progressLines.length - 1] !== line) progressLines.push(line);
           if (progressLines.length > MAX_PROGRESS_LINES) {
             progressLines = progressLines.slice(-MAX_PROGRESS_LINES);
           }
@@ -806,7 +838,14 @@ export async function streamResponse(
       // `const` keeps the narrowing across the awaits below.
       const preview = sentMessage as Message.TextMessage | null;
       if (preview && !sawTerminalEvent) {
-        const full = cleanFinal && answerText.trim() ? answerText : accumulated;
+        // A gracefully exhausted provider can omit done/error. If the latency
+        // gate withheld a progress-only turn, accumulated is still empty; flush
+        // the retained activity instead of leaving the user on `Thinking…`.
+        const full = cleanFinal && answerText.trim()
+          ? answerText
+          : accumulated.trim()
+            ? accumulated
+            : renderProgressRegion(progressLines).trimStart();
         if (full.trim()) {
           // Only delete the preview if delivery actually produced content — a
           // failed first chunk must leave the frozen preview in place rather

--- a/src/telegram/streaming.ts
+++ b/src/telegram/streaming.ts
@@ -138,15 +138,45 @@ export async function replyWithFloodRetry(
   }
 }
 
+// Invariant: categorize a tool name by WHOLE TOKEN, and test DOMAIN tokens
+// (what the tool acts on) before VERB tokens (what it does to it). Both halves
+// are load-bearing, because the category vocabulary is not partitioned: `open`
+// belongs to file reads AND to browser navigation, `memory` to a search AND to
+// a write. Flattening the name into one string made every keyword a substring
+// match across segment boundaries, and first-match-wins let a generic verb
+// preempt the specific domain — so real registered tools were labeled with
+// confident, wrong copy: `browser_open` → "Reading files" (verb `open` beat
+// domain `browser`), `memory_update` → "Searching" (domain `memory` matched
+// without its `search` verb), `terminal_font_size` → "Running a command"
+// (an editor setting matched the shell keyword `terminal`).
+// A name whose tokens carry no known keyword deliberately falls through to the
+// readable `Using …` form: a generic label is honest, a wrong category is not.
+const ACTIVITY_DOMAIN_TOKENS: readonly (readonly [readonly string[], string])[] = [
+  [['browser', 'web', 'fetch', 'scrape'], 'Researching'],
+  [['test', 'vitest', 'jest'], 'Running tests'],
+  [['bash', 'shell', 'exec', 'command'], 'Running a command'],
+];
+
+const ACTIVITY_VERB_TOKENS: readonly (readonly [readonly string[], string])[] = [
+  [['search', 'grep', 'glob', 'find'], 'Searching'],
+  [['read', 'open', 'view', 'inspect'], 'Reading files'],
+  [['edit', 'write', 'patch', 'replace'], 'Editing files'],
+];
+
 function humanizeToolActivity(toolName: string): string {
   const safeName = sanitizeLabel(toolName);
-  const normalized = safeName.toLowerCase().replace(/[^a-z0-9]/g, '');
-  if (/memory|search|grep|glob|find/.test(normalized)) return 'Searching';
-  if (/read|open|view|inspect/.test(normalized)) return 'Reading files';
-  if (/edit|write|patch|replace/.test(normalized)) return 'Editing files';
-  if (/test|vitest|jest/.test(normalized)) return 'Running tests';
-  if (/browser|web|fetch/.test(normalized)) return 'Researching';
-  if (/bash|shell|exec|command|terminal/.test(normalized)) return 'Running a command';
+  // Split on separators AND camelCase boundaries so `WebSearch`, `web_search`,
+  // and `mcp__chrome-devtools__take_screenshot` all yield comparable tokens.
+  const tokens = new Set(
+    safeName
+      .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter(Boolean),
+  );
+  for (const [keywords, label] of [...ACTIVITY_DOMAIN_TOKENS, ...ACTIVITY_VERB_TOKENS]) {
+    if (keywords.some((keyword) => tokens.has(keyword))) return label;
+  }
 
   const readable = safeName
     .replace(/[_-]+/g, ' ')

--- a/src/telegram/streaming.ts
+++ b/src/telegram/streaming.ts
@@ -46,6 +46,27 @@ const TOOL_INFLIGHT_RECHECK_MS = 15_000;
 /** Max sub-agent progress lines retained in the bounded live-preview footer. */
 const MAX_SUBAGENT_PREVIEW_LINES = 4;
 
+/**
+ * Tool-progress (`◦`) lines stay HIDDEN until the turn has been working this
+ * long. Most turns finish faster than this and now render no progress noise at
+ * all — the live preview goes straight from `Thinking…` to the answer.
+ *
+ * Withheld lines are still recorded (see `progressLines`); when the gate opens
+ * the rolling region renders the most recent ones, so nothing is lost — it is a
+ * render delay, not a drop. Overridable per call via `options.progressDelayMs`
+ * (tests pass 0 to assert rendering deterministically).
+ */
+const PROGRESS_START_DELAY_MS = 5_000;
+
+/**
+ * Max `◦` tool-progress lines kept in the rolling live-preview region. Older
+ * lines are trimmed rather than accumulated, so a long tool-heavy turn no longer
+ * grows the preview without bound (which also meant one Telegram edit per round
+ * against an ever-longer message). Same bounded-region treatment
+ * `renderSubagentFooter` already applies to sub-agent steps.
+ */
+const MAX_PROGRESS_LINES = 6;
+
 // StreamTimeoutError lives in its own module so the message handler's
 // `instanceof` check survives `vi.mock('./streaming.js')` in tests (see
 // stream-timeout-error.ts). Imported above for local use (the watchdog throws
@@ -134,6 +155,38 @@ export function renderSubagentFooter(steps: number, recent: readonly string[]): 
   return shown.length > 0 ? `\n${head}\n  ${shown.join('\n  ')}` : `\n${head}`;
 }
 
+/**
+ * Render the BOUNDED `◦` tool-progress region for the live preview. Returns ''
+ * for no lines. Only the last MAX_PROGRESS_LINES are shown regardless of how
+ * many are passed, so a tool-heavy turn keeps a fixed-height status region
+ * instead of an ever-growing log. Pure + exported for unit tests.
+ */
+export function renderProgressRegion(lines: readonly string[]): string {
+  const shown = lines.slice(-MAX_PROGRESS_LINES);
+  return shown.length > 0 ? shown.map((l) => `\n${l}`).join('') : '';
+}
+
+/**
+ * One-line activity receipt appended to the CLEAN final message, replacing the
+ * `◦` progress log that cleanFinal deletes: the turn's cost stays visible
+ * without the per-round noise. Empty when no tool work happened, so plain
+ * question/answer turns are unchanged.
+ *
+ * Plain text on purpose — `markdownToTelegramHtml` escapes `<`/`>` before
+ * injecting its own fixed tag set (formatter.ts), so any HTML written here
+ * would reach the user as literal visible markup.
+ *
+ * Invariant: must NOT use the `◦` prefix. In this module `◦` marks live
+ * progress/status noise that cleanFinal exists to strip, and tests assert the
+ * delivered answer contains no `◦` at all. The receipt is a distinct concept
+ * (a kept summary, not stripped noise) and carries its own marker.
+ */
+export function renderActivityReceipt(toolRounds: number, elapsedMs: number): string {
+  if (toolRounds <= 0) return '';
+  const secs = Math.max(1, Math.round(elapsedMs / 1_000));
+  return `\n\n⏱️ ${toolRounds} ${toolRounds === 1 ? 'step' : 'steps'} · ${secs}s`;
+}
+
 /** Countdown update granularity during a usage-limit pause: every 5 minutes. */
 const PAUSE_COUNTDOWN_INTERVAL_MS = 5 * 60 * 1_000;
 /** Extra slack (ms) added to the timeout deadline while paused. */
@@ -165,6 +218,12 @@ export async function streamResponse(
      * the callback are caught and logged — they never disrupt delivery.
      */
     onComplete?: (assistantText: string, metadata?: ResponseMetadata) => void | Promise<void>;
+    /**
+     * How long the turn must run before `◦` tool-progress lines start rendering.
+     * Defaults to PROGRESS_START_DELAY_MS. Pass 0 to render immediately (tests
+     * assert progress output without depending on wall-clock timing).
+     */
+    progressDelayMs?: number;
   } = {}
 ): Promise<void> {
   if (!ctx.chat?.id) {
@@ -227,6 +286,25 @@ export async function streamResponse(
   // counter + the last few lines, instead of an unbounded per-tool-call append.
   let subagentSteps = 0;
   const recentSubagentSteps: string[] = [];
+
+  // Invariant: the `◦` tool-progress region is a BOUNDED, REWRITABLE tail of
+  // `accumulated`, not an append-only log. `progressRunStart` is the offset in
+  // `accumulated` where the current consecutive progress run begins; each new
+  // progress event rewrites `accumulated` from that offset with the last
+  // MAX_PROGRESS_LINES entries. That offset is only valid while nothing else
+  // appends to `accumulated`, so EVERY other writer (content chunk, assistant
+  // message, suggestion, stream_retry rollback) must call `endProgressRun()`
+  // first — otherwise the rewrite would truncate their text.
+  const progressDelayMs = options.progressDelayMs ?? PROGRESS_START_DELAY_MS;
+  const turnStartedAt = Date.now();
+  let progressLines: string[] = [];
+  let progressRunStart = -1;
+  // Total tool rounds seen this turn (never trimmed) — drives the activity receipt.
+  let progressRounds = 0;
+  const endProgressRun = (): void => {
+    progressRunStart = -1;
+    progressLines = [];
+  };
 
   const sendOrEdit = async (text: string, force = false): Promise<void> => {
     // markdownToTelegramHtml runs 8 serial regex passes over the full accumulated
@@ -486,6 +564,9 @@ export async function streamResponse(
         }
 
         if (event.type === 'chunk' && event.chunk.type === 'content') {
+          // Answer text follows the progress region, so the region is now frozen
+          // history — stop rewriting it (see the progressRunStart invariant).
+          endProgressRun();
           if (!inContentRun) {
             contentRunStartAccumulated = accumulated.length;
             contentRunStartAnswer = answerText.length;
@@ -503,6 +584,9 @@ export async function streamResponse(
           accumulated = accumulated.slice(0, contentRunStartAccumulated);
           answerText = answerText.slice(0, contentRunStartAnswer);
           inContentRun = false;
+          // The rollback moved the end of `accumulated`, invalidating any live
+          // progress-region offset into it.
+          endProgressRun();
           await sendOrEdit(livePreview(), true);
         }
         if (event.type === 'chunk' && event.chunk.type === 'tool_diff') {
@@ -512,6 +596,9 @@ export async function streamResponse(
           accumulated = event.message.content;
           answerText = event.message.content;
           inContentRun = false;
+          // `accumulated` was replaced wholesale — any progress-region offset
+          // into the old buffer is stale.
+          endProgressRun();
           await sendOrEdit(livePreview());
         }
         // Lane D — progress summaries appear in the response as dim lines
@@ -519,9 +606,16 @@ export async function streamResponse(
         // above since they go through sendOrEdit on the same accumulated
         // buffer, so rapid progress bursts won't spam the Telegram API.
         if (event.type === 'progress') {
-          // Round boundary: a new content run after this starts a fresh
-          // snapshot, so a later stream_retry rolls back only the new round.
+          // Invariant: this assignment is NOT cosmetic and must stay
+          // unconditional — it is the stream_retry round boundary. A new content
+          // run after this point re-snapshots contentRunStart*, so a later
+          // retry rolls back only the new round. Skipping it (e.g. by early
+          // -returning when progress rendering is gated off below) leaves the
+          // snapshot at an older offset and a later stream_retry truncates MORE
+          // of `answerText` than the retry produced — silently deleting
+          // already-delivered answer text. Gate the RENDER, never this line.
           inContentRun = false;
+          progressRounds++;
           const { description, summary, lastToolName } = event.progress;
           // These fields are model-controlled (path/command/URL text from
           // summarizeToolInput) and markdownToTelegramHtml does not strip
@@ -531,11 +625,22 @@ export async function streamResponse(
           const safeToolName = lastToolName ? sanitizeLabel(lastToolName) : lastToolName;
           const safeSummary = summary ? sanitizeLabel(summary) : summary;
           const line = safeToolName
-            ? `\n◦ ${safeDescription} (${safeToolName})`
-            : `\n◦ ${safeDescription}`;
-          accumulated += line;
-          if (safeSummary) accumulated += `\n  ${safeSummary}`;
-          await sendOrEdit(livePreview());
+            ? `◦ ${safeDescription} (${safeToolName})`
+            : `◦ ${safeDescription}`;
+          // Record first, render second: a line withheld by the latency gate is
+          // still retained, so when the gate opens the bounded region shows the
+          // most recent rounds rather than starting from empty.
+          if (progressRunStart < 0) progressRunStart = accumulated.length;
+          progressLines.push(safeSummary ? `${line}\n  ${safeSummary}` : line);
+          if (progressLines.length > MAX_PROGRESS_LINES) {
+            progressLines = progressLines.slice(-MAX_PROGRESS_LINES);
+          }
+          if (Date.now() - turnStartedAt >= progressDelayMs) {
+            // Rewrite the region in place (bounded) instead of appending, so the
+            // preview keeps a fixed height across a long tool-heavy turn.
+            accumulated = accumulated.slice(0, progressRunStart) + renderProgressRegion(progressLines);
+            await sendOrEdit(livePreview());
+          }
         }
         // Lane D — post-turn prompt suggestion appended to the message.
         // Skip when the suggestion duplicates the already-rendered response:
@@ -545,7 +650,13 @@ export async function streamResponse(
         // text via chunk/message events, so appending `\n\n💡 <same text>`
         // would produce a visible duplicate prefixed with 💡. Only append
         // true follow-up hints whose payload differs from the response.
-        if (event.type === 'suggestion' && event.suggestion.trim() !== accumulated.trim()) {
+        // Compare against `answerText`, not `accumulated`: the gate's purpose is
+        // "don't echo text already rendered as the ANSWER", and `accumulated`
+        // also carries the `◦` progress region — whose presence would make the
+        // comparison spuriously unequal and append a duplicate 💡 line to the
+        // answer on exactly the tool-heavy turns that produce progress.
+        if (event.type === 'suggestion' && event.suggestion.trim() !== answerText.trim()) {
+          endProgressRun();
           accumulated += `\n\n💡 ${event.suggestion}`;
           answerText += `\n\n💡 ${event.suggestion}`;
           await sendOrEdit(livePreview());
@@ -620,7 +731,13 @@ export async function streamResponse(
             // delete the preview if something actually landed — if the very first
             // chunk failed, `delivered` is false and the frozen preview must
             // survive so the user is never left with zero visible content.
-            const delivered = await deliverClean(answerText);
+            // The receipt is appended at DELIVERY only, never to `answerText`
+            // itself: `answerText` is what onComplete records into the resumable
+            // session store below, and a UI receipt there would corrupt the
+            // stored transcript (and be replayed by `afk --resume`).
+            const delivered = await deliverClean(
+              answerText + renderActivityReceipt(progressRounds, Date.now() - turnStartedAt),
+            );
             if (delivered && sentMessage) {
               await ctx.telegram.deleteMessage?.(chatId, sentMessage.message_id).catch(() => {});
               // Null the preview ref so the post-loop overflow block (which would
@@ -628,6 +745,17 @@ export async function streamResponse(
               sentMessage = null;
             }
           } else if (accumulated.trim()) {
+            await sendOrEdit(accumulated, true);
+          } else if (progressLines.length > 0) {
+            // Invariant: a turn must never end on the bare `Thinking…` placeholder.
+            // Reachable when the latency gate withheld EVERY progress line and no
+            // answer text arrived — e.g. an abort mid tool-loop, which yields
+            // turn.completed with no assistant text (a progress-only turn). Before
+            // the gate existed `accumulated` always held the progress lines, so the
+            // branch above covered this; now the withheld region must be flushed
+            // explicitly. Assigning `accumulated` (not just editing) also keeps the
+            // post-loop overflow branch able to send chunks[1..] of a long region.
+            accumulated = renderProgressRegion(progressLines).trimStart();
             await sendOrEdit(accumulated, true);
           }
           // Record the completed turn into the shared session store (Telegram


### PR DESCRIPTION
## Stack

- Base: #702 (`fix/telegram-progress-line-noise`)
- This PR intentionally contains only the complementary UX/privacy layer and follow-up correctness fix.

## Summary

- translate generic Telegram tool progress into short user-facing activity labels such as `Searching`, `Reading files`, `Running tests`, and `Running a command`
- omit progress summaries and sub-agent tool inputs from the live preview because they commonly contain raw commands, URLs, and private filesystem paths
- humanize sub-agent names, hide opaque UUID labels, and render a clearer bounded sub-agent header
- deduplicate adjacent activity categories while preserving the true tool-round count used by #702's final activity receipt
- flush withheld progress when the provider iterator closes gracefully without a terminal `done`/`error` event
- align `endProgressRun()` call order with its documented invariant

## Why

#702 fixes the unbounded transcript with a five-second latency gate and rolling window. Once that gate opens, however, Telegram can still show terminal-oriented summaries and sub-agent arguments like the original mobile screenshot. This stacked change keeps #702's transport and accounting behavior while making the visible activity suitable for a small chat surface.

It also resolves the medium correctness finding from #702's automated review: a progress-only stream that closes without a terminal event no longer leaves the user on the bare `Thinking…` placeholder.

## User impact

A long-running turn now shows compact status such as:

```text
◦ Running a command

🤖 Sub-agents · 3 steps
  Research agent — Searching
```

Raw commands, tool arguments, summaries, and private paths are not sent to the Telegram progress UI. The clean final answer and #702's `⏱️ N steps · Ns` receipt remain unchanged.

## Validation

- `pnpm tsc --noEmit`
- `pnpm vitest run src/telegram/streaming.test.ts` — 45 passed
- `pnpm test` — 699 files passed; 13,095 tests passed; 14 skipped
- `git diff --check`

Signed-off commit included for DCO.