### PR TITLE
ci: scope the advisory windows leg to push/label/dispatch instead of every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   push:
     branches: [main]
+  # Manual runs from the Actions tab. Primary use: firing the advisory
+  # `test-windows` leg on demand while grinding Windows compat (issue #703).
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -80,17 +83,18 @@ jobs:
   test:
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    # Cross-platform matrix (Windows-compat effort, see .afk/plans/windows-compat-roadmap
-    # or the tracking issue). ubuntu-latest is the REQUIRED gate; windows-latest and
-    # macos-latest run for SIGNAL but do not block merges yet — `continue-on-error`
-    # keeps them advisory while the compat grind is in progress. `fail-fast: false`
-    # so one OS failing never cancels the others. Public repos get unlimited free
-    # GitHub-hosted minutes on all three runners. Flip windows/macos to required
-    # (delete the continue-on-error line) once the suite is green there.
+    # Cross-platform matrix (see issue #703 for the Windows-compat effort).
+    # ubuntu-latest is the REQUIRED gate; macos-latest runs for SIGNAL but does not
+    # block merges yet — `continue-on-error` keeps it advisory. It has been green
+    # since the matrix landed, so promoting it to required is a live follow-up.
+    # `fail-fast: false` so one OS failing never cancels the other. Public repos get
+    # unlimited free GitHub-hosted minutes on both runners.
+    # windows-latest is NOT in this matrix — it runs in `test-windows` below, which
+    # is trigger-scoped because it is uniformly red today. See that job's comment.
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
     continue-on-error: ${{ matrix.os != 'ubuntu-latest' }}
     timeout-minutes: 15
     steps:
@@ -119,10 +123,65 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          # Per-OS name — a matrix can't upload three artifacts under one name (v4 immutable).
+          # Per-OS name — a matrix can't upload multiple artifacts under one name (v4 immutable).
           name: coverage-report-${{ matrix.os }}
           path: coverage/
           retention-days: 14
+
+  # Windows compat leg (issue #703). Trigger-scoped, NOT part of the `test` matrix.
+  #
+  # Why: Windows is not a supported platform yet — 85 of 699 test files fail, ~90% of
+  # them because tests hardcode POSIX `/tmp` rather than because product code is broken.
+  # A uniformly-red advisory check on every PR carries zero marginal information: you
+  # cannot distinguish a newly-introduced POSIX-ism from the known-red baseline, so the
+  # red X on unrelated PRs (dependabot bumps, feature work) trains reviewers to ignore
+  # CI. Scoping the trigger keeps the signal where it is actionable and drops it where
+  # it is noise:
+  #   - push to main      → the authoritative post-merge scoreboard #703 tracks
+  #   - `windows-compat`  → opt in per-PR while grinding a compat fix, to get the
+  #     PR label            per-PR falsifier back on exactly the PR that needs it
+  #   - workflow_dispatch → on-demand run from the Actions tab (see `on:` above)
+  # On every other PR the job is SKIPPED (grey), not failed (red).
+  #
+  # Runs `pnpm test` rather than `pnpm test:coverage`: the coverage floors
+  # (stmts 74 / branch 79) can red this leg on coverage alone once win32-skipped
+  # branches go uncovered, which would mask the assertion signal this job exists to
+  # collect. The required ubuntu leg still enforces the coverage gate.
+  #
+  # Closing condition (issue #703): once the suite is green here, DELETE this job and
+  # add `windows-latest` back to the `test` matrix above — that restores both the
+  # coverage gate and required-gate status in one move.
+  test-windows:
+    name: Test (windows-latest)
+    if: >-
+      github.event_name == 'push'
+      || github.event_name == 'workflow_dispatch'
+      || contains(github.event.pull_request.labels.*.name, 'windows-compat')
+    runs-on: windows-latest
+    # Advisory until the compat grind lands — never blocks a merge.
+    continue-on-error: true
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          dest: ${{ runner.temp }}/setup-pnpm
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Test (no coverage gate — see job comment)
+        run: pnpm test
 
   # Real-PTY scrollback harness (issue #541). Isolated from the main `test` job
   # because it depends on the native `node-pty` module (compiled from source on

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, labeled]
   push:
     branches: [main]
   # Manual runs from the Actions tab. Primary use: firing the advisory


### PR DESCRIPTION
## Problem

`Test (windows-latest)` has failed **every completed run since it was added** on 2026-07-24 — `30204038057`, `30137517004`, `30128726777`, `30127658645`. Latest: **85 of 699 test files failed** (557s).

It was never blocking anything. `continue-on-error` at `ci.yml:94` keeps the run conclusion `success` (verified: run `30204038057` = windows job `failure`, run conclusion `success`), and `main` has no branch protection, so there are no required checks at all. The cost is purely informational — and that cost is real:

**A uniformly-red advisory check carries zero marginal information.** With 85 files red you cannot distinguish a newly-introduced POSIX-ism from the known baseline, so the red X on unrelated PRs (dependabot bumps, feature work) only trains reviewers to ignore CI.

## Why it is red

From the job log (`89798904067`), signature counts:

| count | signature | class |
|---:|---|---|
| 197 | `ENOENT: mkdtemp '/tmp/…'` | test-harness POSIX hardcoding |
| 42 | `expected 'D:\repo' to be '/repo'` | test-harness POSIX literals |
| 40 | `kill ESRCH` | **real product bug** |
| 9 | `EPERM` (chmod `0o600`) | test-harness |

80 test files hardcode `/tmp` — essentially the whole 85. So ~90% of the redness is test-harness portability, tracked as Phase 2 grind in #703. This PR does not touch any of it.

## Change

Move `windows-latest` out of the `test` matrix into a trigger-scoped `test-windows` job:

- **push to main** → the authoritative post-merge scoreboard #703 tracks
- **`workflow_dispatch`** → on-demand from the Actions tab (new trigger on this workflow)
- **PR labelled `windows-compat`** → opt back into the per-PR falsifier on exactly the PR that is grinding a compat fix (label created)

Every other PR **skips** the job (grey) instead of failing it (red).

Two smaller things in the same diff:

- The leg runs `pnpm test` rather than `pnpm test:coverage`. The coverage floors (stmts 74 / branch 79) can red this leg on coverage alone once win32-skipped branches go uncovered — the meta-risk already flagged in the roadmap — which would mask the assertion signal the job exists to collect. The required ubuntu leg still enforces the coverage gate.
- `ci.yml:83` referenced `.afk/plans/windows-compat-roadmap`, which is gitignored and was never committed — a dangling pointer for any public reader. Now points at #703.

## What is deliberately unchanged

- **The leg stays advisory.** #703's closing condition is unchanged: once the suite is green here, delete `test-windows` and add `windows-latest` back to the `test` matrix — one move restores both the coverage gate and required-gate status. The job comment says exactly this.
- **The compat trajectory is untouched.** No product code, no test files. The 4 real runtime gaps (cmd.exe `bash` tool, `kill(-pid)` ESRCH incl. the uncaught-in-`setTimeout` path, separator-broken credential denylists, `@`-file injection) remain #703's Phase 1.
- **macOS stays advisory.** It has been green in every run since the matrix landed, so promoting it to required is a live follow-up — but flipping it here would start blocking merges on runner flake, which is out of scope for a noise fix.

## Verification

- `.github/workflows/ci.yml` parses; job graph, matrix, `if:` expression, and step list asserted via `yaml.safe_load` — `test` matrix is now `[ubuntu-latest, macos-latest]`, `test-windows` is `continue-on-error: true`, `timeout-minutes: 20`.
- No `needs:`/`workflow_run:` in any workflow depends on the windows leg; nothing under `src/`, `tests/`, or `scripts/` references `windows-latest`, `macos-latest`, or the `coverage-report-*` artifact names.
- YAML-only diff — no TypeScript touched, so `lint`/`test` behaviour on the required legs is unchanged.
- This PR is itself the first check: `test-windows` should show **skipped**, and the remaining legs green.

Refs #703