### PR TITLE
feat(usage): show subscription quota in the REPL status line

### DIFF
--- a/src/agent/providers/anthropic-direct.test.ts
+++ b/src/agent/providers/anthropic-direct.test.ts
@@ -436,7 +436,14 @@ describe('AnthropicDirectProvider', () => {
 
     expect(anthropicCtorMock).toHaveBeenCalledTimes(1);
     const ctorArg = anthropicCtorMock.mock.calls[0]?.[0] as Record<string, unknown>;
-    expect(ctorArg).toEqual({ authToken: 'sk-ant-oat01-test' });
+    // `fetch` is expected: the tracing/quota wrapper is installed for EVERY
+    // non-local-shim client, no longer only when a trace writer is attached,
+    // because subscription-quota capture must keep working with tracing off
+    // (see the install site in providers/anthropic-direct/index.ts). Asserting
+    // the exact key set keeps this strict — an unintended third key still fails.
+    expect(Object.keys(ctorArg).sort()).toEqual(['authToken', 'fetch']);
+    expect(ctorArg['authToken']).toBe('sk-ant-oat01-test');
+    expect(typeof ctorArg['fetch']).toBe('function');
     expect('apiKey' in ctorArg).toBe(false);
 
     expect(messagesCreateMock).toHaveBeenCalledTimes(1);
@@ -465,7 +472,14 @@ describe('AnthropicDirectProvider', () => {
     await collect(query);
 
     expect(anthropicCtorMock).toHaveBeenCalledTimes(1);
-    expect(anthropicCtorMock.mock.calls[0]?.[0]).toEqual({ apiKey: 'sk-ant-api03-test' });
+    // `fetch` is expected here too — the wrapper is installed for every
+    // non-local-shim client so quota capture survives tracing being disabled.
+    // Under API-key auth the quota headers never arrive, so the cache simply
+    // stays empty and the status line draws no quota segment.
+    const apiKeyCtorArg = anthropicCtorMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(Object.keys(apiKeyCtorArg).sort()).toEqual(['apiKey', 'fetch']);
+    expect(apiKeyCtorArg['apiKey']).toBe('sk-ant-api03-test');
+    expect(typeof apiKeyCtorArg['fetch']).toBe('function');
 
     const [params, opts] = messagesCreateMock.mock.calls[0] as CreateArgs;
     expect(opts?.headers?.['anthropic-beta']).toBeUndefined();

--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -36,6 +36,7 @@ import {
 import { oneShotCompletion, type OneShotInput } from './oneshot.js';
 import { makeTracingFetch } from './tracing-fetch.js';
 import { ThrottleQueue } from './throttle-queue.js';
+import { parseQuotaHeaders, recordQuotaSnapshot } from '../../quota-cache.js';
 import { refreshClaudeCodeOauthToken } from '../../auth/keychain.js';
 import { AnthropicDirectQuery } from './query.js';
 import { pathContainmentBypassed } from '../../permission-policy.js';
@@ -636,6 +637,18 @@ export class AnthropicDirectProvider implements ModelProvider {
     // query below so the fetch producer and the loop consumer meet.
     const throttleQueue =
       !localMode && config.traceWriter ? new ThrottleQueue() : undefined;
+    // Invariant: quota capture is gated on `!localMode` ALONE — deliberately not
+    // on `config.traceWriter`. The `anthropic-ratelimit-unified-*` headers ride
+    // on every response and feed the CLI status line, which must stay live even
+    // when tracing is off (`AFK_TRACE_DISABLED=1`); tying it to the trace writer
+    // would silently blank the indicator in that configuration. localMode is
+    // still excluded: a local shim is not Anthropic and emits no quota headers.
+    const quotaObserver = localMode
+      ? undefined
+      : (headers: Headers): void => {
+          const snapshot = parseQuotaHeaders(headers);
+          if (snapshot !== undefined) recordQuotaSnapshot(snapshot);
+        };
     const clientOpts = buildClientOptions(
       token,
       authMode,
@@ -643,14 +656,18 @@ export class AnthropicDirectProvider implements ModelProvider {
       // Observability: route SDK HTTP through a wrapper that (1) records
       // 429/503/529 throttling into the witness trace so the SDK's
       // otherwise-silent retry-after backoff is legible in `afk trace show`,
-      // and (2) pushes a live signal onto `throttleQueue` so the progress
-      // banner can show the backoff as it happens. Skipped in local-shim mode
-      // (not Anthropic's billing surface) and when no trace writer is attached.
-      !localMode && config.traceWriter
+      // (2) pushes a live signal onto `throttleQueue` so the progress banner can
+      // show the backoff as it happens, and (3) captures subscription-quota
+      // headers into the quota cache for the status line. Skipped entirely in
+      // local-shim mode (not Anthropic's billing surface). Note the wrapper is
+      // installed whenever ANY of the three observers is live — a trace writer
+      // is no longer required, since (3) must work with tracing disabled.
+      !localMode
         ? makeTracingFetch(
             config.traceWriter,
             undefined,
             throttleQueue ? (info) => throttleQueue.push(info) : undefined,
+            quotaObserver,
           )
         : undefined,
     );
@@ -877,17 +894,19 @@ export class AnthropicDirectProvider implements ModelProvider {
           freshToken,
           'oauth',
           config.baseUrl,
-          // Preserve throttle observability AND the live-banner signal across an
-          // OAuth account swap — the rebuilt client must keep the same
-          // tracing-fetch wrapper wired to the same `throttleQueue`. localMode
-          // is false in this branch (see the guard above).
-          config.traceWriter
-            ? makeTracingFetch(
-                config.traceWriter,
-                undefined,
-                throttleQueue ? (info) => throttleQueue.push(info) : undefined,
-              )
-            : undefined,
+          // Preserve throttle observability, the live-banner signal AND quota
+          // capture across an OAuth account swap — the rebuilt client must keep
+          // the same tracing-fetch wrapper wired to the same `throttleQueue` and
+          // the same quota observer. localMode is false in this branch (see the
+          // guard above), so `quotaObserver` is always defined here and the
+          // wrapper installs unconditionally — no trace-writer gate, matching
+          // the primary install site above.
+          makeTracingFetch(
+            config.traceWriter,
+            undefined,
+            throttleQueue ? (info) => throttleQueue.push(info) : undefined,
+            quotaObserver,
+          ),
         );
         return factory ? factory(opts) : new Anthropic(opts);
       };

--- a/src/agent/providers/anthropic-direct/tracing-fetch.test.ts
+++ b/src/agent/providers/anthropic-direct/tracing-fetch.test.ts
@@ -30,6 +30,38 @@ describe('makeTracingFetch', () => {
     expect(makeTracingFetch(undefined, base)).toBe(base);
   });
 
+  it('still WRAPS when only onQuota is supplied (no trace writer)', () => {
+    // The quota indicator has to work with tracing disabled, so an onQuota
+    // observer alone must be enough to install the wrapper. If this regresses to
+    // returning `base`, the status-line quota segment silently blanks whenever
+    // AFK_TRACE_DISABLED=1 or no writer is attached.
+    const base = vi.fn() as unknown as typeof fetch;
+    expect(makeTracingFetch(undefined, base, undefined, () => {})).not.toBe(base);
+  });
+
+  it('invokes onQuota with response headers on a successful 200', async () => {
+    const seen: Array<string | null> = [];
+    const base = vi.fn(async () =>
+      res(200, { 'anthropic-ratelimit-unified-5h-utilization': '0.62' }),
+    ) as unknown as typeof fetch;
+    const wrapped = makeTracingFetch(undefined, base, undefined, (h) => {
+      seen.push(h.get('anthropic-ratelimit-unified-5h-utilization'));
+    });
+    const r = await wrapped('https://api.anthropic.com/v1/messages');
+    expect(r.status).toBe(200);
+    expect(seen).toEqual(['0.62']);
+  });
+
+  it('a throwing onQuota never disturbs the request path', async () => {
+    const base = vi.fn(async () => res(200)) as unknown as typeof fetch;
+    const wrapped = makeTracingFetch(undefined, base, undefined, () => {
+      throw new Error('observer exploded');
+    });
+    await expect(wrapped('https://api.anthropic.com/v1/messages')).resolves.toMatchObject({
+      status: 200,
+    });
+  });
+
   it('emits a rate_limit trace event on a 429 with retry-after', async () => {
     const { writer, events } = mockWriter();
     const base = vi.fn(async () => res(429, { 'retry-after': '30' })) as unknown as typeof fetch;

--- a/src/agent/providers/anthropic-direct/tracing-fetch.ts
+++ b/src/agent/providers/anthropic-direct/tracing-fetch.ts
@@ -43,24 +43,38 @@ export interface ThrottleInfo {
 /**
  * Wrap a `fetch` implementation so throttled responses (429/503/529) emit a
  * `rate_limit` trace event AND (when provided) invoke `onThrottle` for a live
- * surface. Returns the wrapped fetch; when BOTH `writer` and `onThrottle` are
- * undefined the base fetch is returned unchanged (no overhead).
+ * surface. Returns the wrapped fetch; when `writer`, `onThrottle`, AND
+ * `onQuota` are all undefined the base fetch is returned unchanged (no
+ * overhead).
  *
- * `onThrottle` is fire-and-forget from the caller's perspective — this wrapper
- * guards it with try/catch so a throwing callback can never disturb the request
- * path or the SDK's retry loop.
+ * `onThrottle` and `onQuota` are fire-and-forget from the caller's
+ * perspective — this wrapper guards both with try/catch so a throwing
+ * callback can never disturb the request path or the SDK's retry loop.
  */
 export function makeTracingFetch(
   writer: TraceWriter | undefined,
   baseFetch: typeof fetch = fetch,
   onThrottle?: (info: ThrottleInfo) => void,
+  onQuota?: (headers: Headers) => void,
 ): typeof fetch {
-  if (!writer && !onThrottle) return baseFetch;
+  if (!writer && !onThrottle && !onQuota) return baseFetch;
   return async (
     input: Parameters<typeof fetch>[0],
     init?: Parameters<typeof fetch>[1],
   ): Promise<Response> => {
     const res = await baseFetch(input, init);
+    // Passive quota capture: Anthropic returns `anthropic-ratelimit-unified-*`
+    // headers on EVERY response under OAuth auth, not just throttled ones, so
+    // this runs unconditionally (before the throttle-status gate below) and
+    // is guarded exactly like `onThrottle` — a throwing observer must never
+    // disturb the request path or the SDK's retry loop.
+    if (onQuota) {
+      try {
+        onQuota(res.headers);
+      } catch {
+        // A broken live observer must never disturb the SDK retry loop.
+      }
+    }
     if (THROTTLE_STATUSES.has(res.status)) {
       const retryAfterMs = parseRetryAfterMs({ headers: res.headers });
       // Live signal FIRST so the banner updates with minimal latency; the

--- a/src/agent/quota-cache.test.ts
+++ b/src/agent/quota-cache.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Tests for src/agent/quota-cache.ts
+ *
+ * The cache is module-scope mutable state shared across cases in this file, so
+ * every test calls `resetQuotaCacheForTests()` first.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  parseQuotaHeaders,
+  recordQuotaSnapshot,
+  getQuotaSnapshot,
+  onQuotaUpdate,
+  resetQuotaCacheForTests,
+  type QuotaSnapshot,
+} from './quota-cache.js';
+
+const H_5H_UTIL = 'anthropic-ratelimit-unified-5h-utilization';
+const H_5H_RESET = 'anthropic-ratelimit-unified-5h-reset';
+const H_7D_UTIL = 'anthropic-ratelimit-unified-7d-utilization';
+const H_7D_RESET = 'anthropic-ratelimit-unified-7d-reset';
+
+/** Epoch seconds for a plausible near-future reset. */
+const RESET_EPOCH = 1_785_110_400;
+
+function headers(init: Record<string, string>): Headers {
+  return new Headers(init);
+}
+
+beforeEach(() => {
+  resetQuotaCacheForTests();
+});
+
+describe('parseQuotaHeaders', () => {
+  it('parses both windows including reset timestamps', () => {
+    const snap = parseQuotaHeaders(
+      headers({
+        [H_5H_UTIL]: '0.62',
+        [H_5H_RESET]: String(RESET_EPOCH),
+        [H_7D_UTIL]: '0.31',
+        [H_7D_RESET]: String(RESET_EPOCH),
+      }),
+    );
+    expect(snap).toBeDefined();
+    expect(snap?.fiveHourUtilization).toBeCloseTo(0.62);
+    expect(snap?.sevenDayUtilization).toBeCloseTo(0.31);
+    expect(snap?.fiveHourResetsAt?.getTime()).toBe(RESET_EPOCH * 1000);
+    expect(snap?.sevenDayResetsAt?.getTime()).toBe(RESET_EPOCH * 1000);
+    expect(snap?.observedAt).toBeInstanceOf(Date);
+  });
+
+  it('reads header names case-insensitively', () => {
+    const snap = parseQuotaHeaders(headers({ 'ANTHROPIC-RATELIMIT-UNIFIED-5H-UTILIZATION': '0.5' }));
+    expect(snap?.fiveHourUtilization).toBeCloseTo(0.5);
+  });
+
+  it('parses a 5h-only response and omits the 7d window', () => {
+    const snap = parseQuotaHeaders(headers({ [H_5H_UTIL]: '0.1' }));
+    expect(snap?.fiveHourUtilization).toBeCloseTo(0.1);
+    expect(snap?.sevenDayUtilization).toBeUndefined();
+    expect(snap?.sevenDayResetsAt).toBeUndefined();
+  });
+
+  it('parses a 7d-only response and omits the 5h window', () => {
+    const snap = parseQuotaHeaders(headers({ [H_7D_UTIL]: '0.9' }));
+    expect(snap?.sevenDayUtilization).toBeCloseTo(0.9);
+    expect(snap?.fiveHourUtilization).toBeUndefined();
+  });
+
+  it('returns undefined when no quota headers are present at all', () => {
+    expect(parseQuotaHeaders(headers({ 'content-type': 'application/json' }))).toBeUndefined();
+  });
+
+  it('returns undefined when a reset is present but neither utilization is', () => {
+    // A reset alone is not worth caching — there is no percentage to render.
+    expect(parseQuotaHeaders(headers({ [H_5H_RESET]: String(RESET_EPOCH) }))).toBeUndefined();
+  });
+
+  it('omits a non-numeric utilization', () => {
+    expect(parseQuotaHeaders(headers({ [H_5H_UTIL]: 'not-a-number' }))).toBeUndefined();
+  });
+
+  it('omits a non-finite utilization', () => {
+    expect(parseQuotaHeaders(headers({ [H_5H_UTIL]: 'Infinity' }))).toBeUndefined();
+  });
+
+  it('clamps utilization above 1 down to 1', () => {
+    const snap = parseQuotaHeaders(headers({ [H_5H_UTIL]: '7.5' }));
+    expect(snap?.fiveHourUtilization).toBe(1);
+  });
+
+  it('clamps negative utilization up to 0', () => {
+    const snap = parseQuotaHeaders(headers({ [H_5H_UTIL]: '-3' }));
+    expect(snap?.fiveHourUtilization).toBe(0);
+  });
+
+  it('omits a negative reset epoch but keeps the utilization', () => {
+    const snap = parseQuotaHeaders(headers({ [H_5H_UTIL]: '0.4', [H_5H_RESET]: '-10' }));
+    expect(snap?.fiveHourUtilization).toBeCloseTo(0.4);
+    expect(snap?.fiveHourResetsAt).toBeUndefined();
+  });
+
+  it('omits an absurd reset epoch (millisecond value mistaken for seconds)', () => {
+    // A ms-precision value read as seconds lands far past year 2100.
+    const snap = parseQuotaHeaders(headers({ [H_5H_UTIL]: '0.4', [H_5H_RESET]: '1785110400000' }));
+    expect(snap?.fiveHourUtilization).toBeCloseTo(0.4);
+    expect(snap?.fiveHourResetsAt).toBeUndefined();
+  });
+
+  it('omits a non-numeric reset epoch', () => {
+    const snap = parseQuotaHeaders(headers({ [H_5H_UTIL]: '0.4', [H_5H_RESET]: 'soon' }));
+    expect(snap?.fiveHourResetsAt).toBeUndefined();
+  });
+
+  it('never throws when the headers object misbehaves', () => {
+    const hostile = {
+      get() {
+        throw new Error('header access exploded');
+      },
+    } as unknown as Headers;
+    expect(() => parseQuotaHeaders(hostile)).not.toThrow();
+    expect(parseQuotaHeaders(hostile)).toBeUndefined();
+  });
+});
+
+describe('cache + subscription', () => {
+  function snapshot(fiveHour?: number, sevenDay?: number): QuotaSnapshot {
+    return {
+      ...(fiveHour !== undefined ? { fiveHourUtilization: fiveHour } : {}),
+      ...(sevenDay !== undefined ? { sevenDayUtilization: sevenDay } : {}),
+      observedAt: new Date(),
+    };
+  }
+
+  it('returns undefined before anything is recorded', () => {
+    expect(getQuotaSnapshot()).toBeUndefined();
+  });
+
+  it('stores and returns the latest snapshot', () => {
+    recordQuotaSnapshot(snapshot(0.2));
+    recordQuotaSnapshot(snapshot(0.5));
+    expect(getQuotaSnapshot()?.fiveHourUtilization).toBeCloseTo(0.5);
+  });
+
+  it('notifies on the very first snapshot', () => {
+    const listener = vi.fn();
+    onQuotaUpdate(listener);
+    recordQuotaSnapshot(snapshot(0.2));
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('notifies when a rounded percentage changes', () => {
+    const listener = vi.fn();
+    recordQuotaSnapshot(snapshot(0.2));
+    onQuotaUpdate(listener);
+    recordQuotaSnapshot(snapshot(0.25));
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT notify when the rounded percentage is unchanged', () => {
+    // Flicker guard: repaint throttles at 100ms with no trailing flush, so a
+    // push per API response must not reach the status line.
+    const listener = vi.fn();
+    recordQuotaSnapshot(snapshot(0.2001));
+    onQuotaUpdate(listener);
+    recordQuotaSnapshot(snapshot(0.2004));
+    expect(listener).not.toHaveBeenCalled();
+    // ...but the stored snapshot is still refreshed.
+    expect(getQuotaSnapshot()?.fiveHourUtilization).toBeCloseTo(0.2004);
+  });
+
+  it('notifies when only the 7d window moves', () => {
+    const listener = vi.fn();
+    recordQuotaSnapshot(snapshot(0.2, 0.3));
+    onQuotaUpdate(listener);
+    recordQuotaSnapshot(snapshot(0.2, 0.4));
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('unsubscribe stops further notifications', () => {
+    const listener = vi.fn();
+    const off = onQuotaUpdate(listener);
+    recordQuotaSnapshot(snapshot(0.1));
+    off();
+    recordQuotaSnapshot(snapshot(0.9));
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('a throwing listener does not propagate to the recorder', () => {
+    const good = vi.fn();
+    onQuotaUpdate(() => {
+      throw new Error('subscriber exploded');
+    });
+    onQuotaUpdate(good);
+    expect(() => recordQuotaSnapshot(snapshot(0.5))).not.toThrow();
+    // A broken subscriber must not starve the healthy ones.
+    expect(good).toHaveBeenCalledTimes(1);
+  });
+
+  it('resetQuotaCacheForTests clears both the snapshot and the listeners', () => {
+    const listener = vi.fn();
+    onQuotaUpdate(listener);
+    recordQuotaSnapshot(snapshot(0.5));
+    resetQuotaCacheForTests();
+    expect(getQuotaSnapshot()).toBeUndefined();
+    recordQuotaSnapshot(snapshot(0.7));
+    expect(listener).toHaveBeenCalledTimes(1); // only the pre-reset call
+  });
+});

--- a/src/agent/quota-cache.ts
+++ b/src/agent/quota-cache.ts
@@ -1,0 +1,147 @@
+/**
+ * Passive module-scope cache for Anthropic's OAuth-subscription quota headers.
+ *
+ * Every response returned to a Claude subscription (OAuth) caller carries
+ * `anthropic-ratelimit-unified-5h-*` / `-7d-*` headers describing how much of
+ * the rolling 5-hour and 7-day windows have been consumed. These headers cost
+ * nothing extra to read — they ride on responses the SDK already made — so
+ * this module captures them passively from the tracing-fetch wrapper
+ * (`providers/anthropic-direct/tracing-fetch.ts`) and holds the latest snapshot
+ * for the CLI status line to poll or subscribe to.
+ *
+ * The headers are UNDOCUMENTED and have been observed to change names
+ * upstream, so every parse in this module is best-effort: a missing, renamed,
+ * or unparseable header is silently omitted, never thrown.
+ *
+ * @module agent/quota-cache
+ */
+
+/** Fraction-of-window ceiling: clamp any reported utilization into `0..1`. */
+function parseUtilization(raw: string | null): number | undefined {
+  if (raw === null) return undefined;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return undefined;
+  return Math.min(1, Math.max(0, n));
+}
+
+/**
+ * Reject anything past this instant (2100-01-01T00:00:00Z) as an "absurd"
+ * reset timestamp — almost certainly a unit mismatch (ms vs. s) rather than a
+ * real reset deadline this far out.
+ */
+const MAX_REASONABLE_RESET_EPOCH_SECONDS = Date.UTC(2100, 0, 1) / 1000;
+
+/** Epoch-seconds → `Date`, or `undefined` when the value isn't a sane forward deadline. */
+function parseResetEpochSeconds(raw: string | null): Date | undefined {
+  if (raw === null) return undefined;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0 || n > MAX_REASONABLE_RESET_EPOCH_SECONDS) return undefined;
+  return new Date(n * 1000);
+}
+
+export interface QuotaSnapshot {
+  /** Fraction of the 5-hour rolling window consumed, 0..1. */
+  readonly fiveHourUtilization?: number;
+  readonly fiveHourResetsAt?: Date;
+  /** Fraction of the 7-day window consumed, 0..1. */
+  readonly sevenDayUtilization?: number;
+  readonly sevenDayResetsAt?: Date;
+  readonly observedAt: Date;
+}
+
+/**
+ * Pure. Reads the four `anthropic-ratelimit-unified-*` headers (case-
+ * insensitive via `headers.get`) and returns a snapshot, or `undefined` when
+ * neither window's utilization is present/parseable — i.e. nothing worth
+ * caching. Never throws: an individual malformed field is simply omitted
+ * rather than failing the whole parse.
+ */
+export function parseQuotaHeaders(headers: Headers): QuotaSnapshot | undefined {
+  try {
+    const fiveHourUtilization = parseUtilization(
+      headers.get('anthropic-ratelimit-unified-5h-utilization'),
+    );
+    const fiveHourResetsAt = parseResetEpochSeconds(
+      headers.get('anthropic-ratelimit-unified-5h-reset'),
+    );
+    const sevenDayUtilization = parseUtilization(
+      headers.get('anthropic-ratelimit-unified-7d-utilization'),
+    );
+    const sevenDayResetsAt = parseResetEpochSeconds(
+      headers.get('anthropic-ratelimit-unified-7d-reset'),
+    );
+    if (fiveHourUtilization === undefined && sevenDayUtilization === undefined) return undefined;
+    return {
+      ...(fiveHourUtilization !== undefined ? { fiveHourUtilization } : {}),
+      ...(fiveHourResetsAt !== undefined ? { fiveHourResetsAt } : {}),
+      ...(sevenDayUtilization !== undefined ? { sevenDayUtilization } : {}),
+      ...(sevenDayResetsAt !== undefined ? { sevenDayResetsAt } : {}),
+      observedAt: new Date(),
+    };
+  } catch {
+    // Best-effort: a header read/parse must never throw or block the request
+    // that carried it.
+    return undefined;
+  }
+}
+
+// Invariant: this cache is module-scope mutable state, valid for exactly one
+// Node process. AFK runs one CLI/daemon/Telegram process per session with no
+// cross-process sharing, so a single "latest snapshot" + listener set here is
+// sufficient — there is no multi-process fan-in to reconcile. Tests must call
+// `resetQuotaCacheForTests()` between cases (same-file vitest tests share this
+// module instance) to avoid state leaking across assertions.
+let currentSnapshot: QuotaSnapshot | undefined;
+const listeners = new Set<() => void>();
+
+/** `Math.round(utilization * 100)`, or `undefined` when the window is absent. */
+function roundedPercent(utilization: number | undefined): number | undefined {
+  return utilization === undefined ? undefined : Math.round(utilization * 100);
+}
+
+/**
+ * Store a snapshot; notify listeners ONLY when a rounded percentage changed
+ * for either window (or when this is the first snapshot ever recorded).
+ *
+ * Flicker requirement: the consumer's repaint throttles at 100ms and stores-
+ * without-painting with no trailing flush, so a push on every single API
+ * response would churn the bottom terminal row. Gating notification on the
+ * rounded percentage keeps updates meaningful to a human glance while still
+ * always keeping the stored snapshot current for the next poll.
+ */
+export function recordQuotaSnapshot(snapshot: QuotaSnapshot): void {
+  const previous = currentSnapshot;
+  const meaningfulChange =
+    previous === undefined ||
+    roundedPercent(previous.fiveHourUtilization) !== roundedPercent(snapshot.fiveHourUtilization) ||
+    roundedPercent(previous.sevenDayUtilization) !== roundedPercent(snapshot.sevenDayUtilization);
+  currentSnapshot = snapshot;
+  if (!meaningfulChange) return;
+  for (const listener of listeners) {
+    try {
+      listener();
+    } catch {
+      // A broken subscriber must never break the fetch/caller that recorded
+      // this snapshot.
+    }
+  }
+}
+
+/** Latest snapshot, or `undefined` if none seen this process. */
+export function getQuotaSnapshot(): QuotaSnapshot | undefined {
+  return currentSnapshot;
+}
+
+/** Subscribe to meaningful changes (see {@link recordQuotaSnapshot}). Returns an unsubscribe fn. */
+export function onQuotaUpdate(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** Test-only: clear cache + listeners. */
+export function resetQuotaCacheForTests(): void {
+  currentSnapshot = undefined;
+  listeners.clear();
+}

--- a/src/agent/subscription-usage.test.ts
+++ b/src/agent/subscription-usage.test.ts
@@ -15,6 +15,14 @@ import {
   type UsageSnapshot,
 } from './subscription-usage.js';
 
+// Mocked so tests exercising the CLAUDE_CODE_OAUTH_TOKEN env-var fallback are
+// deterministic regardless of the real machine's keychain/credentials state.
+// Tests that pass an explicit `token` never reach this (see hermeticity note
+// below), so this has no effect on them.
+vi.mock('./auth/keychain.js', () => ({
+  loadClaudeCodeOauthToken: vi.fn(() => undefined),
+}));
+
 const SECRET_TOKEN = 'sk-ant-oat01-super-secret-token-value';
 
 function jsonResponse(status: number, body: unknown): Response {
@@ -32,7 +40,13 @@ function fetchThrowing(err: unknown): typeof fetch {
 }
 
 describe('fetchSubscriptionUsage', () => {
+  // Hermeticity: the global clean-config-env.ts setup file already deletes
+  // CLAUDE_CODE_OAUTH_TOKEN from process.env before every test (it's an
+  // ENV_REGISTRY 'auth'-category var), but tests asserting the no-token path
+  // stub it explicitly too so the assertion holds regardless of that global
+  // behavior. vi.unstubAllEnvs() runs in that same global afterEach.
   it('returns unavailable/no-token when no token is available', async () => {
+    vi.stubEnv('CLAUDE_CODE_OAUTH_TOKEN', '');
     const fetchImpl = vi.fn() as unknown as typeof fetch;
     const result = await fetchSubscriptionUsage({ fetchImpl, token: '' });
     expect(result).toEqual({
@@ -177,18 +191,25 @@ describe('fetchSubscriptionUsage', () => {
     expect(ok.sevenDay?.resetsAt).toBeUndefined();
   });
 
-  it('clamps utilization into 0..1', async () => {
-    const fetchImpl = fetchReturning(
-      jsonResponse(200, {
-        five_hour: { utilization: 1.5 },
-        seven_day: { utilization: -0.3 },
-      }),
-    );
-    const result = await fetchSubscriptionUsage({ fetchImpl, token: SECRET_TOKEN });
-    const ok = result as UsageSnapshot;
-    expect(ok.fiveHour?.utilization).toBe(1);
-    expect(ok.sevenDay?.utilization).toBe(0);
-  });
+  it.each([
+    [42, 0.42],
+    [100, 1],
+    [150, 1],
+    [0.62, 0.62],
+    [-0.3, 0],
+    [1, 1],
+    [0, 0],
+  ])(
+    'normalizes utilization=%s (>1 treated as a percentage) to %s',
+    async (utilizationRaw, expected) => {
+      const fetchImpl = fetchReturning(
+        jsonResponse(200, { five_hour: { utilization: utilizationRaw } }),
+      );
+      const result = await fetchSubscriptionUsage({ fetchImpl, token: SECRET_TOKEN });
+      const ok = result as UsageSnapshot;
+      expect(ok.fiveHour?.utilization).toBe(expected);
+    },
+  );
 
   it('skips a window whose utilization is non-numeric or non-finite', async () => {
     const fetchImpl = fetchReturning(
@@ -239,12 +260,39 @@ describe('fetchSubscriptionUsage', () => {
     // only asserts the options default wiring: omitting fetchImpl still
     // type-checks and defaults to global fetch, which we don't invoke here
     // because we supply a token of '' to short-circuit before any request.
+    // `??` treats '' as present, so this never reads CLAUDE_CODE_OAUTH_TOKEN —
+    // stubbed anyway for an explicit, self-evident hermeticity guarantee.
+    vi.stubEnv('CLAUDE_CODE_OAUTH_TOKEN', '');
     const result = await fetchSubscriptionUsage({ token: '' });
     expect(result).toEqual({
       kind: 'unavailable',
       reason: 'no-token',
       detail: expect.any(String),
     });
+  });
+
+  it('uses CLAUDE_CODE_OAUTH_TOKEN from the environment when the keychain has no token', async () => {
+    vi.stubEnv('CLAUDE_CODE_OAUTH_TOKEN', 'env-supplied-oauth-token');
+    const fetchImpl = fetchReturning(jsonResponse(200, { five_hour: { utilization: 0.1 } }));
+    await fetchSubscriptionUsage({ fetchImpl });
+    const [, init] = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    const headers = init.headers as Record<string, string>;
+    expect(headers['Authorization']).toBe('Bearer env-supplied-oauth-token');
+  });
+
+  it('prefers an explicit options.token over CLAUDE_CODE_OAUTH_TOKEN from the environment', async () => {
+    vi.stubEnv('CLAUDE_CODE_OAUTH_TOKEN', 'env-supplied-oauth-token');
+    const fetchImpl = fetchReturning(jsonResponse(200, { five_hour: { utilization: 0.1 } }));
+    await fetchSubscriptionUsage({ fetchImpl, token: SECRET_TOKEN });
+    const [, init] = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    const headers = init.headers as Record<string, string>;
+    expect(headers['Authorization']).toBe(`Bearer ${SECRET_TOKEN}`);
   });
 });
 

--- a/src/agent/subscription-usage.test.ts
+++ b/src/agent/subscription-usage.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Tests for {@link fetchSubscriptionUsage} and {@link formatUsagePlain}.
+ *
+ * All network access goes through the injectable `fetchImpl` seam — no real
+ * network calls are made.
+ *
+ * @module agent/subscription-usage.test
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  fetchSubscriptionUsage,
+  formatUsagePlain,
+  type UsageResult,
+  type UsageSnapshot,
+} from './subscription-usage.js';
+
+const SECRET_TOKEN = 'sk-ant-oat01-super-secret-token-value';
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), { status });
+}
+
+function fetchReturning(response: Response): typeof fetch {
+  return vi.fn(async () => response) as unknown as typeof fetch;
+}
+
+function fetchThrowing(err: unknown): typeof fetch {
+  return vi.fn(async () => {
+    throw err;
+  }) as unknown as typeof fetch;
+}
+
+describe('fetchSubscriptionUsage', () => {
+  it('returns unavailable/no-token when no token is available', async () => {
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    const result = await fetchSubscriptionUsage({ fetchImpl, token: '' });
+    expect(result).toEqual({
+      kind: 'unavailable',
+      reason: 'no-token',
+      detail: expect.stringContaining('claude login'),
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('happy path: parses all four known windows', async () => {
+    const fetchImpl = fetchReturning(
+      jsonResponse(200, {
+        five_hour: { utilization: 0.62, resets_at: '2026-07-26T18:00:00Z' },
+        seven_day: { utilization: 0.31, resets_at: 1785110400 },
+        seven_day_sonnet: { utilization: 0.28 },
+        seven_day_opus: { utilization: 0.44 },
+      }),
+    );
+    const result = await fetchSubscriptionUsage({ fetchImpl, token: SECRET_TOKEN });
+    expect(result.kind).toBe('ok');
+    const ok = result as UsageSnapshot;
+    expect(ok.fiveHour?.utilization).toBe(0.62);
+    expect(ok.fiveHour?.resetsAt?.toISOString()).toBe('2026-07-26T18:00:00.000Z');
+    expect(ok.sevenDay?.utilization).toBe(0.31);
+    expect(ok.sevenDay?.resetsAt?.getTime()).toBe(1785110400 * 1000);
+    expect(ok.sevenDaySonnet?.utilization).toBe(0.28);
+    expect(ok.sevenDaySonnet?.resetsAt).toBeUndefined();
+    expect(ok.sevenDayOpus?.utilization).toBe(0.44);
+  });
+
+  it('sends the expected request headers and URL', async () => {
+    const fetchImpl = fetchReturning(jsonResponse(200, { five_hour: { utilization: 0.1 } }));
+    await fetchSubscriptionUsage({ fetchImpl, token: SECRET_TOKEN });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    expect(url).toBe('https://api.anthropic.com/api/oauth/usage');
+    const headers = init.headers as Record<string, string>;
+    expect(headers['Authorization']).toBe(`Bearer ${SECRET_TOKEN}`);
+    expect(headers['anthropic-beta']).toBe('oauth-2025-04-20');
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('returns unavailable/http-error on HTTP 401 and never leaks the token', async () => {
+    const fetchImpl = fetchReturning(new Response('unauthorized: token abc123', { status: 401 }));
+    const result = await fetchSubscriptionUsage({ fetchImpl, token: SECRET_TOKEN });
+    expect(result).toEqual({
+      kind: 'unavailable',
+      reason: 'http-error',
+      detail: expect.stringContaining('401'),
+    });
+    const detail = (result as { detail: string }).detail;
+    expect(detail).not.toContain(SECRET_TOKEN);
+    expect(detail).not.toContain('unauthorized');
+  });
+
+  it('returns unavailable/http-error on HTTP 429', async () => {
+    const fetchImpl = fetchReturning(new Response('rate limited', { status: 429 }));
+    const result = await fetchSubscriptionUsage({ fetchImpl, token: SECRET_TOKEN });
+    expect(result).toEqual({
+      kind: 'unavailable',
+      reason: 'http-error',
+      detail: expect.stringContaining('429'),
+    });
+  });
+
+  it('returns unavailable/malformed-response on unparseable JSON', async () => {
+    const fetchImpl = fetchReturning(new Response('not json at all', { status: 200 }));
+    const result = await fetchSubscriptionUsage({ fetchImpl, token: SECRET_TOKEN });
+    expect(result.kind).toBe('unavailable');
+    expect((result as { reason: string }).reason).toBe('malformed-response');
+  });
+
+  it('returns unavailable/malformed-response on an empty body', async () => {
+    const fetchImpl = fetchReturning(new Response('', { status: 200 }));
+    const result = await fetchSubscriptionUsage({ fetchImpl, token: SECRET_TOKEN });
+    expect(result.kind).toBe('unavailable');
+    expect((result as { reason: string }).reason).toBe('malformed-response');
+  });
+
+  it('returns unavailable/malformed-response when JSON has none of the known windows', async () => {
+    const fetchImpl = fetchReturning(jsonResponse(200, { unrelated_field: 42 }));
+    const result = await fetchSubscriptionUsage({ fetchImpl, token: SECRET_TOKEN });
+    expect(result).toEqual({
+      kind: 'unavailable',
+      reason: 'malformed-response',
+      detail: expect.any(String),
+    });
+  });
+
+  it('returns unavailable/malformed-response when JSON body is not an object (e.g. an array)', async () => {
+    const fetchImpl = fetchReturning(jsonResponse(200, [1, 2, 3]));
+    const result = await fetchSubscriptionUsage({ fetchImpl, token: SECRET_TOKEN });
+    expect(result.kind).toBe('unavailable');
+    expect((result as { reason: string }).reason).toBe('malformed-response');
+  });
+
+  it('parses resets_at as an ISO string', async () => {
+    const fetchImpl = fetchReturning(
+      jsonResponse(200, { five_hour: { utilization: 0.5, resets_at: '2026-01-01T00:00:00Z' } }),
+    );
+    const result = await fetchSubscriptionUsage({ fetchImpl, token: SECRET_TOKEN });
+    const ok = result as UsageSnapshot;
+    expect(ok.fiveHour?.resetsAt?.toISOString()).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  it('parses resets_at as an epoch-seconds number', async () => {
+    const epoch = 1_800_000_000;
+    const fetchImpl = fetchReturning(
+      jsonResponse(200, { five_hour: { utilization: 0.5, resets_at: epoch } }),
+    );
+    const result = await fetchSubscriptionUsage({ fetchImpl, token: SECRET_TOKEN });
+    const ok = result as UsageSnapshot;
+    expect(ok.fiveHour?.resetsAt?.getTime()).toBe(epoch * 1000);
+  });
+
+  it('drops resets_at when it is an out-of-range epoch number rather than producing Invalid Date', async () => {
+    const fetchImpl = fetchReturning(
+      jsonResponse(200, {
+        five_hour: { utilization: 0.5, resets_at: Number.MAX_SAFE_INTEGER },
+      }),
+    );
+    const result = await fetchSubscriptionUsage({ fetchImpl, token: SECRET_TOKEN });
+    const ok = result as UsageSnapshot;
+    expect(ok.fiveHour?.utilization).toBe(0.5);
+    expect(ok.fiveHour?.resetsAt).toBeUndefined();
+  });
+
+  it('drops resets_at when it is non-finite (NaN/Infinity) or an unrecognized type', async () => {
+    const fetchImpl = fetchReturning(
+      jsonResponse(200, {
+        five_hour: { utilization: 0.5, resets_at: { nested: true } },
+        seven_day: { utilization: 0.2, resets_at: null },
+      }),
+    );
+    const result = await fetchSubscriptionUsage({ fetchImpl, token: SECRET_TOKEN });
+    const ok = result as UsageSnapshot;
+    expect(ok.fiveHour?.resetsAt).toBeUndefined();
+    expect(ok.sevenDay?.resetsAt).toBeUndefined();
+  });
+
+  it('clamps utilization into 0..1', async () => {
+    const fetchImpl = fetchReturning(
+      jsonResponse(200, {
+        five_hour: { utilization: 1.5 },
+        seven_day: { utilization: -0.3 },
+      }),
+    );
+    const result = await fetchSubscriptionUsage({ fetchImpl, token: SECRET_TOKEN });
+    const ok = result as UsageSnapshot;
+    expect(ok.fiveHour?.utilization).toBe(1);
+    expect(ok.sevenDay?.utilization).toBe(0);
+  });
+
+  it('skips a window whose utilization is non-numeric or non-finite', async () => {
+    const fetchImpl = fetchReturning(
+      jsonResponse(200, {
+        five_hour: { utilization: 'high' },
+        seven_day: { utilization: Number.NaN },
+        seven_day_sonnet: { utilization: Number.POSITIVE_INFINITY },
+        seven_day_opus: { utilization: 0.5 },
+      }),
+    );
+    const result = await fetchSubscriptionUsage({ fetchImpl, token: SECRET_TOKEN });
+    const ok = result as UsageSnapshot;
+    expect(ok.fiveHour).toBeUndefined();
+    expect(ok.sevenDay).toBeUndefined();
+    expect(ok.sevenDaySonnet).toBeUndefined();
+    expect(ok.sevenDayOpus?.utilization).toBe(0.5);
+  });
+
+  it('returns unavailable/timeout when the request aborts via timeout', async () => {
+    const fetchImpl = fetchThrowing(new DOMException('The operation timed out.', 'TimeoutError'));
+    const result = await fetchSubscriptionUsage({ fetchImpl, token: SECRET_TOKEN, timeoutMs: 5 });
+    expect(result).toEqual({
+      kind: 'unavailable',
+      reason: 'timeout',
+      detail: expect.any(String),
+    });
+  });
+
+  it('returns unavailable/timeout on a generic AbortError', async () => {
+    const fetchImpl = fetchThrowing(new DOMException('aborted', 'AbortError'));
+    const result = await fetchSubscriptionUsage({ fetchImpl, token: SECRET_TOKEN });
+    expect((result as { reason: string }).reason).toBe('timeout');
+  });
+
+  it('returns unavailable/network-error on other thrown fetch errors', async () => {
+    const fetchImpl = fetchThrowing(new TypeError('fetch failed: getaddrinfo ENOTFOUND'));
+    const result = await fetchSubscriptionUsage({ fetchImpl, token: SECRET_TOKEN });
+    expect(result).toEqual({
+      kind: 'unavailable',
+      reason: 'network-error',
+      detail: expect.any(String),
+    });
+  });
+
+  it('falls back to the keychain loader when no token override and no fetchImpl-bypassing occurs', async () => {
+    // Passing an explicit empty-string token exercises the no-token branch
+    // without touching the real keychain loader (covered above). This test
+    // only asserts the options default wiring: omitting fetchImpl still
+    // type-checks and defaults to global fetch, which we don't invoke here
+    // because we supply a token of '' to short-circuit before any request.
+    const result = await fetchSubscriptionUsage({ token: '' });
+    expect(result).toEqual({
+      kind: 'unavailable',
+      reason: 'no-token',
+      detail: expect.any(String),
+    });
+  });
+});
+
+describe('formatUsagePlain', () => {
+  it('renders all four windows, one per line', () => {
+    const snapshot: UsageResult = {
+      kind: 'ok',
+      fiveHour: { utilization: 0.62, resetsAt: new Date('2026-07-26T18:00:00Z') },
+      sevenDay: { utilization: 0.31 },
+      sevenDaySonnet: { utilization: 0.28 },
+      sevenDayOpus: { utilization: 0.44 },
+    };
+    const text = formatUsagePlain(snapshot);
+    expect(text).toBe(
+      ['5h: 62% (resets 18:00)', '7d: 31%', '7d-sonnet: 28%', '7d-opus: 44%'].join('\n'),
+    );
+    expect(text).not.toMatch(/\x1b\[/);
+    expect(text).not.toMatch(/<[a-z]+>/i);
+  });
+
+  it('renders a single line when only one window is present', () => {
+    const snapshot: UsageResult = { kind: 'ok', fiveHour: { utilization: 0.1 } };
+    expect(formatUsagePlain(snapshot)).toBe('5h: 10%');
+  });
+
+  it('renders a fallback line when kind is ok but no windows are present', () => {
+    const snapshot: UsageResult = { kind: 'ok' };
+    expect(formatUsagePlain(snapshot)).toBe('No usage windows available.');
+  });
+
+  it.each([
+    ['no-token', 'Run `claude login`.'],
+    ['http-error', 'HTTP 401.'],
+    ['malformed-response', 'Body was not valid JSON.'],
+    ['timeout', 'Request timed out.'],
+    ['network-error', 'Could not reach the usage endpoint.'],
+  ] as const)('renders a clear single line for reason=%s', (reason, detail) => {
+    const result: UsageResult = { kind: 'unavailable', reason, detail };
+    const text = formatUsagePlain(result);
+    expect(text.split('\n')).toHaveLength(1);
+    expect(text).toContain(reason);
+    expect(text).toContain(detail);
+  });
+});

--- a/src/agent/subscription-usage.ts
+++ b/src/agent/subscription-usage.ts
@@ -1,0 +1,223 @@
+/**
+ * Fetch subscription usage windows (5-hour / 7-day / 7-day-Sonnet / 7-day-Opus)
+ * from the Claude Code OAuth usage endpoint, and render them as plain text.
+ *
+ * The endpoint and its response shape are reverse-engineered and unversioned;
+ * upstream may change them at any time without notice. Parsing below is
+ * therefore fully defensive — unknown or missing fields are treated as absent
+ * windows rather than thrown errors — and `fetchSubscriptionUsage` never
+ * rejects or throws: every path (missing token, network failure, timeout,
+ * non-2xx, malformed body) resolves to a `UsageResult` the caller can render
+ * or branch on.
+ *
+ * @module agent/subscription-usage
+ */
+
+import { loadClaudeCodeOauthToken } from './auth/keychain.js';
+
+const USAGE_URL = 'https://api.anthropic.com/api/oauth/usage';
+const OAUTH_BETA_HEADER = 'oauth-2025-04-20';
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+/** One usage window (e.g. the rolling 5-hour or 7-day allowance). */
+export interface UsageWindow {
+  /** Fraction of the window consumed, 0..1. */
+  readonly utilization: number;
+  /** When the window resets, when the API supplies it. */
+  readonly resetsAt?: Date;
+}
+
+/** A successfully retrieved and parsed usage snapshot. */
+export interface UsageSnapshot {
+  readonly kind: 'ok';
+  readonly fiveHour?: UsageWindow;
+  readonly sevenDay?: UsageWindow;
+  readonly sevenDaySonnet?: UsageWindow;
+  readonly sevenDayOpus?: UsageWindow;
+}
+
+/** Why a usage snapshot could not be retrieved. */
+export type UsageUnavailableReason =
+  | 'no-token'
+  | 'http-error'
+  | 'malformed-response'
+  | 'timeout'
+  | 'network-error';
+
+/** Usage could not be retrieved. */
+export interface UsageUnavailable {
+  readonly kind: 'unavailable';
+  readonly reason: UsageUnavailableReason;
+  /** Short human-readable detail, safe to show a user. Never contains the token. */
+  readonly detail: string;
+}
+
+export type UsageResult = UsageSnapshot | UsageUnavailable;
+
+export interface FetchSubscriptionUsageOptions {
+  /** Injectable for tests. Defaults to global fetch. */
+  readonly fetchImpl?: typeof fetch;
+  /** Override the OAuth token. Defaults to the keychain loader. */
+  readonly token?: string;
+  /** Request timeout. Defaults to 10_000. */
+  readonly timeoutMs?: number;
+}
+
+/**
+ * Fetch the current subscription usage snapshot from the Claude Code OAuth
+ * usage endpoint.
+ *
+ * Never throws: every failure mode (missing token, network error, timeout,
+ * non-2xx status, unparseable or unrecognized body) resolves to
+ * `{ kind: 'unavailable', ... }` rather than rejecting the returned promise.
+ */
+export async function fetchSubscriptionUsage(
+  options?: FetchSubscriptionUsageOptions,
+): Promise<UsageResult> {
+  const fetchImpl = options?.fetchImpl ?? fetch;
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const token = options?.token ?? loadClaudeCodeOauthToken();
+
+  if (!token) {
+    return {
+      kind: 'unavailable',
+      reason: 'no-token',
+      detail: 'No Claude Code OAuth token found. Run `claude login` and try again.',
+    };
+  }
+
+  let response: Response;
+  try {
+    response = await fetchImpl(USAGE_URL, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'anthropic-beta': OAUTH_BETA_HEADER,
+      },
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (err) {
+    if (isAbortOrTimeoutError(err)) {
+      return {
+        kind: 'unavailable',
+        reason: 'timeout',
+        detail: 'Request to the usage endpoint timed out.',
+      };
+    }
+    return {
+      kind: 'unavailable',
+      reason: 'network-error',
+      detail: 'Network error while contacting the usage endpoint.',
+    };
+  }
+
+  if (!response.ok) {
+    // Contract: never surface response body text here — it may carry
+    // credentials or PII from an error page. Status code + generic phrase only.
+    return {
+      kind: 'unavailable',
+      reason: 'http-error',
+      detail: `Usage endpoint returned HTTP ${response.status}.`,
+    };
+  }
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    return {
+      kind: 'unavailable',
+      reason: 'malformed-response',
+      detail: 'Usage endpoint returned a response that was not valid JSON.',
+    };
+  }
+
+  if (typeof body !== 'object' || body === null) {
+    return {
+      kind: 'unavailable',
+      reason: 'malformed-response',
+      detail: 'Usage endpoint returned an unexpected response shape.',
+    };
+  }
+
+  const record = body as Record<string, unknown>;
+  const fiveHour = parseWindow(record['five_hour']);
+  const sevenDay = parseWindow(record['seven_day']);
+  const sevenDaySonnet = parseWindow(record['seven_day_sonnet']);
+  const sevenDayOpus = parseWindow(record['seven_day_opus']);
+
+  if (!fiveHour && !sevenDay && !sevenDaySonnet && !sevenDayOpus) {
+    return {
+      kind: 'unavailable',
+      reason: 'malformed-response',
+      detail: 'Usage endpoint response contained none of the known usage windows.',
+    };
+  }
+
+  return {
+    kind: 'ok',
+    ...(fiveHour !== undefined ? { fiveHour } : {}),
+    ...(sevenDay !== undefined ? { sevenDay } : {}),
+    ...(sevenDaySonnet !== undefined ? { sevenDaySonnet } : {}),
+    ...(sevenDayOpus !== undefined ? { sevenDayOpus } : {}),
+  };
+}
+
+function isAbortOrTimeoutError(err: unknown): boolean {
+  return err instanceof Error && (err.name === 'TimeoutError' || err.name === 'AbortError');
+}
+
+/** Reject epoch-seconds values outside a sane [1970, 2100) range. */
+const MIN_REASONABLE_EPOCH_SECONDS = 0;
+const MAX_REASONABLE_EPOCH_SECONDS = 4_102_444_800; // 2100-01-01T00:00:00Z
+
+function parseResetsAt(value: unknown): Date | undefined {
+  if (typeof value === 'string') {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+  }
+  if (typeof value === 'number') {
+    if (
+      !Number.isFinite(value) ||
+      value < MIN_REASONABLE_EPOCH_SECONDS ||
+      value > MAX_REASONABLE_EPOCH_SECONDS
+    ) {
+      return undefined;
+    }
+    return new Date(value * 1000);
+  }
+  return undefined;
+}
+
+function parseWindow(value: unknown): UsageWindow | undefined {
+  if (typeof value !== 'object' || value === null) return undefined;
+  const record = value as Record<string, unknown>;
+  const utilizationRaw = record['utilization'];
+  if (typeof utilizationRaw !== 'number' || !Number.isFinite(utilizationRaw)) return undefined;
+  const utilization = Math.min(1, Math.max(0, utilizationRaw));
+  const resetsAt = parseResetsAt(record['resets_at']);
+  return {
+    utilization,
+    ...(resetsAt !== undefined ? { resetsAt } : {}),
+  };
+}
+
+/** Surface-neutral plain text. No chalk, no HTML, no markdown. */
+export function formatUsagePlain(result: UsageResult): string {
+  if (result.kind === 'unavailable') {
+    return `Usage unavailable (${result.reason}): ${result.detail}`;
+  }
+  const lines: string[] = [];
+  if (result.fiveHour) lines.push(formatWindowLine('5h', result.fiveHour));
+  if (result.sevenDay) lines.push(formatWindowLine('7d', result.sevenDay));
+  if (result.sevenDaySonnet) lines.push(formatWindowLine('7d-sonnet', result.sevenDaySonnet));
+  if (result.sevenDayOpus) lines.push(formatWindowLine('7d-opus', result.sevenDayOpus));
+  return lines.length > 0 ? lines.join('\n') : 'No usage windows available.';
+}
+
+function formatWindowLine(label: string, win: UsageWindow): string {
+  const pct = Math.round(win.utilization * 100);
+  if (!win.resetsAt) return `${label}: ${pct}%`;
+  const hh = String(win.resetsAt.getUTCHours()).padStart(2, '0');
+  const mm = String(win.resetsAt.getUTCMinutes()).padStart(2, '0');
+  return `${label}: ${pct}% (resets ${hh}:${mm})`;
+}

--- a/src/agent/subscription-usage.ts
+++ b/src/agent/subscription-usage.ts
@@ -14,6 +14,7 @@
  */
 
 import { loadClaudeCodeOauthToken } from './auth/keychain.js';
+import { env } from '../config/env.js';
 
 const USAGE_URL = 'https://api.anthropic.com/api/oauth/usage';
 const OAUTH_BETA_HEADER = 'oauth-2025-04-20';
@@ -76,13 +77,14 @@ export async function fetchSubscriptionUsage(
 ): Promise<UsageResult> {
   const fetchImpl = options?.fetchImpl ?? fetch;
   const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const token = options?.token ?? loadClaudeCodeOauthToken();
+  const token = options?.token ?? (env.CLAUDE_CODE_OAUTH_TOKEN || loadClaudeCodeOauthToken());
 
   if (!token) {
     return {
       kind: 'unavailable',
       reason: 'no-token',
-      detail: 'No Claude Code OAuth token found. Run `claude login` and try again.',
+      detail:
+        'No Claude Code OAuth token found. Set CLAUDE_CODE_OAUTH_TOKEN or run `claude login` and try again.',
     };
   }
 
@@ -193,7 +195,13 @@ function parseWindow(value: unknown): UsageWindow | undefined {
   const record = value as Record<string, unknown>;
   const utilizationRaw = record['utilization'];
   if (typeof utilizationRaw !== 'number' || !Number.isFinite(utilizationRaw)) return undefined;
-  const utilization = Math.min(1, Math.max(0, utilizationRaw));
+  // Contract: the endpoint's utilization unit is unverified — it may be a
+  // 0..1 fraction or a 0..100 percentage. Values >1 are interpreted as a
+  // percentage and divided by 100: a fraction can only exceed 1 by a small
+  // overage (upstream jitter), whereas a percentage routinely does, so this
+  // is the safer reading of the ambiguity. Result is then clamped to [0, 1].
+  const normalized = utilizationRaw > 1 ? utilizationRaw / 100 : utilizationRaw;
+  const utilization = Math.min(1, Math.max(0, normalized));
   const resetsAt = parseResetsAt(record['resets_at']);
   return {
     utilization,

--- a/src/cli/commands/interactive/shared.test.ts
+++ b/src/cli/commands/interactive/shared.test.ts
@@ -11,11 +11,12 @@
  *   - Picks the LAST turn from a multi-turn array
  */
 
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { printResumeBanner, resolveResumeCwd } from './shared.js';
+import { printResumeBanner, resolveResumeCwd, formatStatusFields } from './shared.js';
+import { recordQuotaSnapshot, resetQuotaCacheForTests } from '../../../agent/quota-cache.js';
 import type { SessionStats, TurnRecord } from '../../slash/types.js';
 import type { CompletionWriter } from './shared.js';
 
@@ -375,5 +376,54 @@ describe('resolveResumeCwd — resume cwd precedence', () => {
 
   it('returns the explicit override even when there is no stored cwd', () => {
     expect(resolveResumeCwd('/explicit/worktree', undefined)).toBe('/explicit/worktree');
+  });
+});
+
+describe('formatStatusFields — subscription-quota segment', () => {
+  beforeEach(() => {
+    resetQuotaCacheForTests();
+  });
+  afterEach(() => {
+    resetQuotaCacheForTests();
+  });
+
+  it('omits the quota field entirely when no headers have been observed', () => {
+    // Permanent state under API-key auth — must be absent, not a placeholder.
+    const fields = formatStatusFields(makeStats([]));
+    expect('quota' in fields).toBe(false);
+  });
+
+  it('renders both windows as rounded percentages', () => {
+    recordQuotaSnapshot({
+      fiveHourUtilization: 0.62,
+      sevenDayUtilization: 0.31,
+      observedAt: new Date(),
+    });
+    expect(formatStatusFields(makeStats([])).quota).toBe('5h 62% · 7d 31%');
+  });
+
+  it('renders only the 5h window when the 7d window is absent', () => {
+    recordQuotaSnapshot({ fiveHourUtilization: 0.05, observedAt: new Date() });
+    expect(formatStatusFields(makeStats([])).quota).toBe('5h 5%');
+  });
+
+  it('renders only the 7d window when the 5h window is absent', () => {
+    recordQuotaSnapshot({ sevenDayUtilization: 0.5, observedAt: new Date() });
+    expect(formatStatusFields(makeStats([])).quota).toBe('7d 50%');
+  });
+
+  it('treats utilization as a 0..1 fraction, never as an already-scaled percent', () => {
+    // Units regression guard: the same class of bug as rendering a fraction as
+    // if it were a percentage. 0.62 must be 62% — not 0% and not 6200%.
+    recordQuotaSnapshot({ fiveHourUtilization: 0.62, observedAt: new Date() });
+    const quota = formatStatusFields(makeStats([])).quota;
+    expect(quota).toContain('62%');
+    expect(quota).not.toContain('6200');
+    expect(quota).not.toContain('0%');
+  });
+
+  it('rounds to the nearest whole percent', () => {
+    recordQuotaSnapshot({ fiveHourUtilization: 0.626, observedAt: new Date() });
+    expect(formatStatusFields(makeStats([])).quota).toBe('5h 63%');
   });
 });

--- a/src/cli/commands/interactive/shared.ts
+++ b/src/cli/commands/interactive/shared.ts
@@ -1,5 +1,6 @@
 import * as readline from 'node:readline';
 import { statSync } from 'node:fs';
+import { getQuotaSnapshot, type QuotaSnapshot } from '../../../agent/quota-cache.js';
 import type { HookRegistry } from '../../../agent/hooks.js';
 import type { SessionRef } from '../../../agent/session-ref.js';
 import type { MemoryStore } from '../../../agent/memory/index.js';
@@ -763,6 +764,26 @@ export function contextRatio(stats: SessionStats, sampler?: ContextSampler): num
   return used / contextLimitFor(stats.model);
 }
 
+/**
+ * Compact status-line rendering of the subscription-quota cache, e.g.
+ * `5h 62% · 7d 31%`. Returns undefined when nothing is cached — permanently the
+ * case under API-key auth, since only subscription OAuth responses carry the
+ * `anthropic-ratelimit-unified-*` headers — so the caller omits the segment
+ * entirely rather than drawing a placeholder. `utilization` is a 0..1 fraction
+ * (clamped at the cache boundary), hence the ×100.
+ */
+function formatQuotaSegment(snapshot: QuotaSnapshot | undefined): string | undefined {
+  if (snapshot === undefined) return undefined;
+  const segments: string[] = [];
+  if (snapshot.fiveHourUtilization !== undefined) {
+    segments.push(`5h ${Math.round(snapshot.fiveHourUtilization * 100)}%`);
+  }
+  if (snapshot.sevenDayUtilization !== undefined) {
+    segments.push(`7d ${Math.round(snapshot.sevenDayUtilization * 100)}%`);
+  }
+  return segments.length > 0 ? segments.join(' · ') : undefined;
+}
+
 export function formatStatusFields(
   stats: SessionStats,
   sampler?: ContextSampler,
@@ -798,6 +819,7 @@ export function formatStatusFields(
 
   const branch = gitSampler?.getBranch();
   const pr = gitSampler?.getPr();
+  const quota = formatQuotaSegment(getQuotaSnapshot());
 
   return {
     model: stats.model,
@@ -811,5 +833,6 @@ export function formatStatusFields(
     ...(stats.cwd !== undefined ? { cwd: stats.cwd } : {}),
     ...(branch !== undefined ? { branch } : {}),
     ...(pr !== undefined ? { pr } : {}),
+    ...(quota !== undefined ? { quota } : {}),
   };
 }

--- a/src/cli/commands/interactive/surface-setup.ts
+++ b/src/cli/commands/interactive/surface-setup.ts
@@ -10,6 +10,7 @@ import { cyclePermissionMode } from '../../permission-mode-cycle.js';
 import { openEditorForBuffer } from '../../slash/commands/editor-open.js';
 import { palette } from '../../palette.js';
 import type { InteractiveCtx } from './shared.js';
+import { onQuotaUpdate } from '../../../agent/quota-cache.js';
 import { formatStatusFields } from './shared.js';
 import type { TranscriptHandle } from './transcript.js';
 import type { LoopStageBar } from './loop-stage.js';
@@ -385,6 +386,19 @@ export async function setupSurface(
     ctx.statusLine.repaint(formatStatusFields(ctx.stats, ctx.contextSampler, ctx.gitStatusSampler));
   });
   void ctx.gitStatusSampler.refresh();
+
+  // Subscription-quota indicator: repaint when the cached quota actually moves.
+  // No debounce here on purpose — the cache only notifies when a ROUNDED
+  // percentage changes, and `repaint` throttles at 100ms with no trailing flush,
+  // so notifying per API response would churn (and sometimes drop) the bottom row.
+  // Invariant: this subscription is process-lifetime, exactly like the git
+  // sampler's onUpdate above — the quota listener set, the status line and the
+  // REPL all die together, so there is no inverse to orphan and no teardown to
+  // sequence. Tests that invoke setupSurface more than once must call
+  // resetQuotaCacheForTests() to clear the module-scope listener set.
+  onQuotaUpdate(() => {
+    ctx.statusLine.repaint(formatStatusFields(ctx.stats, ctx.contextSampler, ctx.gitStatusSampler));
+  });
 
   return { installSoftStop };
 }

--- a/src/cli/slash/commands/info.test.ts
+++ b/src/cli/slash/commands/info.test.ts
@@ -14,7 +14,14 @@ vi.mock('../../../agent/auth/model-availability.js', () => ({
   isModelAvailable: (model: string | undefined) => model !== 'large' && model !== 'opus',
 }));
 
+// /usage delegates entirely to fetchSubscriptionUsage() — mocked so tests
+// never hit the network; each /usage test sets its own resolved value.
+vi.mock('../../../agent/subscription-usage.js', () => ({
+  fetchSubscriptionUsage: vi.fn(),
+}));
+
 import { infoCommands } from './info.js';
+import { fetchSubscriptionUsage } from '../../../agent/subscription-usage.js';
 import type { SlashContext, SessionStats } from '../types.js';
 import type { PickerController, TerminalCompositor } from '../../terminal-compositor.js';
 
@@ -157,5 +164,63 @@ describe('/model', () => {
     for (const alias of ['local', 'small', 'medium', 'large', 'opus', 'sonnet', 'haiku', 'fable']) {
       expect(aliasLine).toContain(alias);
     }
+  });
+});
+
+const usageCmd = infoCommands.find((c) => c.name === '/usage')!;
+const mockFetchUsage = vi.mocked(fetchSubscriptionUsage);
+
+describe('/usage', () => {
+  it('kind:"ok" with all windows renders each as a percentage plus reset time', async () => {
+    const { ctx, lines } = makeCtx(false);
+    mockFetchUsage.mockResolvedValueOnce({
+      kind: 'ok',
+      fiveHour: { utilization: 0.42, resetsAt: new Date('2026-01-01T00:00:00Z') },
+      sevenDay: { utilization: 0.10 },
+      sevenDaySonnet: { utilization: 0.05 },
+      sevenDayOpus: { utilization: 0.01 },
+    });
+
+    await usageCmd.handler(ctx, '');
+
+    const text = lines.join('\n');
+    expect(text).toMatch(/5-hour/);
+    expect(text).toMatch(/42%/);
+    expect(text).toMatch(/resets/);
+    expect(text).toMatch(/7-day/);
+    expect(text).toMatch(/10%/);
+    expect(text).toMatch(/7-day \(Sonnet\)/);
+    expect(text).toMatch(/5%/);
+    expect(text).toMatch(/7-day \(Opus\)/);
+    expect(text).toMatch(/1%/);
+  });
+
+  it('kind:"ok" with only fiveHour renders just that window', async () => {
+    const { ctx, lines } = makeCtx(false);
+    mockFetchUsage.mockResolvedValueOnce({
+      kind: 'ok',
+      fiveHour: { utilization: 0.75 },
+    });
+
+    await usageCmd.handler(ctx, '');
+
+    const text = lines.join('\n');
+    expect(text).toMatch(/5-hour/);
+    expect(text).toMatch(/75%/);
+    expect(text).not.toMatch(/7-day/);
+  });
+
+  it('kind:"unavailable" with reason "no-token" tells the user to run claude login', async () => {
+    const { ctx, lines } = makeCtx(false);
+    mockFetchUsage.mockResolvedValueOnce({
+      kind: 'unavailable',
+      reason: 'no-token',
+      detail: 'no credentials found',
+    });
+
+    await usageCmd.handler(ctx, '');
+
+    const text = lines.join('\n');
+    expect(text).toMatch(/claude login/);
   });
 });

--- a/src/cli/slash/commands/info.ts
+++ b/src/cli/slash/commands/info.ts
@@ -1,9 +1,14 @@
 /**
  * Information / introspection commands:
- *   /cost /tokens /history /model /tools /mcp /debug
+ *   /cost /tokens /history /model /tools /mcp /debug /usage
  *
  * These all read from SessionStats or session metadata and format for
  * display. `/model` mutates state by calling `session.setModel()`.
+ *
+ * `/cost` vs `/usage`: /cost is session-local spend (this conversation's
+ * turn-by-turn API cost); /usage is the operator's account-wide Claude
+ * subscription quota (5h/7d rolling windows). Different axes — cross-
+ * referenced in each other's output.
  */
 
 import { palette } from '../../palette.js';
@@ -13,6 +18,7 @@ import { contextLimitFor, MODEL_CONTEXT_LIMITS } from '../../model-limits.js';
 import { renderDebugBanner } from '../../debug-banner.js';
 import { providerForModel } from '../../../agent/providers/index.js';
 import { isModelAvailable } from '../../../agent/auth/model-availability.js';
+import { fetchSubscriptionUsage, type UsageWindow } from '../../../agent/subscription-usage.js';
 import {
   MODEL_ALIASES_HINT,
   resolveBinding,
@@ -41,6 +47,57 @@ const costCmd: SlashCommand = {
     if (stats.turnCosts.length > 0) {
       const last5 = stats.turnCosts.slice(-5).map(formatCost).join(palette.dim(' · '));
       out.line(`  last 5      ${last5}`);
+    }
+    out.line();
+    out.line(palette.dim('  This is session-local spend. For account-wide subscription quota, see /usage.'));
+    out.line();
+    return 'continue';
+  },
+};
+
+/** Render a single usage window as a percentage plus reset time when present. */
+function formatUsageWindowLine(label: string, w: UsageWindow): string {
+  const pct = `${Math.round(w.utilization * 100)}%`;
+  const resets = w.resetsAt ? palette.dim(`  (resets ${w.resetsAt.toLocaleString()})`) : '';
+  return `  ${label.padEnd(16)}${palette.meta(pct)}${resets}`;
+}
+
+const usageCmd: SlashCommand = {
+  name: '/usage',
+  summary: 'Show Claude subscription usage (5h / 7d windows)',
+  hint: 'When you want to know how close you are to hitting your Claude subscription\'s rolling usage limits — distinct from /cost, which is session-local spend.',
+  async handler(ctx) {
+    const { out } = ctx;
+    const result = await fetchSubscriptionUsage();
+    out.line();
+    if (result.kind === 'unavailable') {
+      out.line(palette.bold('Subscription usage'));
+      out.line(divider());
+      if (result.reason === 'no-token') {
+        out.warn('No Claude subscription token found — run `claude login`, then try /usage again.');
+      } else {
+        out.warn(`Usage unavailable (${result.reason}): ${result.detail}`);
+      }
+      out.line();
+      return 'continue';
+    }
+
+    const windows: Array<[string, UsageWindow | undefined]> = [
+      ['5-hour', result.fiveHour],
+      ['7-day', result.sevenDay],
+      ['7-day (Sonnet)', result.sevenDaySonnet],
+      ['7-day (Opus)', result.sevenDayOpus],
+    ];
+    const available = windows.filter((entry): entry is [string, UsageWindow] => entry[1] !== undefined);
+
+    out.line(palette.bold('Subscription usage'));
+    out.line(divider());
+    if (available.length === 0) {
+      out.line(palette.dim('  No usage windows reported.'));
+    } else {
+      for (const [label, w] of available) {
+        out.line(formatUsageWindowLine(label, w));
+      }
     }
     out.line();
     return 'continue';
@@ -474,5 +531,5 @@ const debugCmd: SlashCommand = {
 };
 
 export const infoCommands: SlashCommand[] = [
-  costCmd, tokensCmd, historyCmd, modelCmd, toolsCmd, mcpCmd, limitsCmd, debugCmd,
+  costCmd, tokensCmd, historyCmd, modelCmd, toolsCmd, mcpCmd, limitsCmd, debugCmd, usageCmd,
 ];

--- a/src/cli/status-line.test.ts
+++ b/src/cli/status-line.test.ts
@@ -723,6 +723,49 @@ describe('StatusLine with git branch + PR field', () => {
     status.stop();
   });
 
+  it('renders the subscription-quota segment when supplied', () => {
+    stream.columns = 200;
+    const status = new StatusLine({ stream: stream as unknown as NodeJS.WriteStream, throttleMs: 0 });
+    status.start();
+    stream.writes.length = 0;
+    status.repaint({ model: 'sonnet', quota: '5h 62% · 7d 31%' });
+    const out = lastJoined(stream).replace(BROAD_ANSI_RE, '');
+    expect(out).toContain('5h 62%');
+    expect(out).toContain('7d 31%');
+    status.stop();
+  });
+
+  it('draws no quota text at all when the field is absent (API-key auth)', () => {
+    // Under API-key auth the unified quota headers never arrive, so the cache
+    // stays empty forever. That must render as "no segment", not a placeholder.
+    stream.columns = 200;
+    const status = new StatusLine({ stream: stream as unknown as NodeJS.WriteStream, throttleMs: 0 });
+    status.start();
+    stream.writes.length = 0;
+    status.repaint({ model: 'sonnet', cost: 0.05, tokens: 1200 });
+    const out = lastJoined(stream).replace(BROAD_ANSI_RE, '');
+    expect(out).not.toContain('5h');
+    expect(out).not.toContain('7d');
+    expect(out).not.toContain('%');
+    status.stop();
+  });
+
+  it('drops quota BEFORE the token count, and dropping quota does not also drop tokens', () => {
+    // Regression guard for the droppablePriority allocation. The shed loop
+    // removes EVERY part sharing the current maximum priority in one pass, so if
+    // quota were given tokens' priority 4 instead of its own 5, both would vanish
+    // together. Width here is chosen to force exactly one shed step.
+    stream.columns = 40;
+    const status = new StatusLine({ stream: stream as unknown as NodeJS.WriteStream, throttleMs: 0 });
+    status.start();
+    stream.writes.length = 0;
+    status.repaint({ model: 'sonnet', cost: 0.05, tokens: 1200, quota: '5h 62% · 7d 31%' });
+    const out = lastJoined(stream).replace(BROAD_ANSI_RE, '');
+    expect(out).not.toContain('5h 62%'); // quota (priority 5) shed first
+    expect(out).toContain('tok'); // tokens (priority 4) survived that step
+    status.stop();
+  });
+
   it('drops the branch before the model on a very narrow terminal', () => {
     stream.columns = 12;
     const status = new StatusLine({ stream: stream as unknown as NodeJS.WriteStream, throttleMs: 0 });

--- a/src/cli/status-line.ts
+++ b/src/cli/status-line.ts
@@ -57,6 +57,15 @@ export interface StatusLineFields {
    * Only meaningful alongside `branch`.
    */
   pr?: number;
+  /**
+   * Pre-formatted Claude subscription quota summary (e.g. `5h 62% · 7d 31%`),
+   * or undefined when no quota headers have been observed in this process —
+   * which is the PERMANENT state under API-key auth, since only subscription
+   * OAuth responses carry `anthropic-ratelimit-unified-*`. Undefined must draw
+   * no segment at all rather than a placeholder. Rendered rightmost and dropped
+   * first on a narrow terminal: the most peripheral field on the line.
+   */
+  quota?: string;
 }
 
 interface StatusLineOpts {
@@ -494,7 +503,16 @@ export class StatusLine {
     }
 
     if (f.tokens !== undefined) {
-      parts.push({ text: palette.chrome(`${formatTokens(f.tokens)} tok`), droppablePriority: 4 }); // drop 1st
+      parts.push({ text: palette.chrome(`${formatTokens(f.tokens)} tok`), droppablePriority: 4 }); // drop 2nd
+    }
+
+    // Invariant: every droppablePriority on this line must be UNIQUE. The shed
+    // loop below drops EVERY part sharing the current maximum priority in one
+    // pass, so reusing the token count's 4 here would make the quota segment and
+    // the token count vanish together instead of shedding one at a time. 5 =
+    // drop 1st, ahead of tokens — quota is the most peripheral field here.
+    if (f.quota !== undefined) {
+      parts.push({ text: palette.chrome(f.quota), droppablePriority: 5 }); // drop 1st
     }
 
     // Join with separator and measure the result.

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -11,6 +11,7 @@ import { handleHelp } from './handlers/help.js';
 import { handleClear, handleCompact, handleCwd, handleModelSwitch, handleName, MODEL_ALIASES_HINT } from './handlers/commands.js';
 import { handleSessions, handleNew, handleSwitchCallback } from './handlers/sessions.js';
 import { handleAfk } from './handlers/afk.js';
+import { handleUsage } from './handlers/usage.js';
 import type { AgentModelInput } from '../agent/types.js';
 import { handleFarmCallback } from './handlers/farm-callbacks.js';
 import { MessageHandler } from './handlers/message.js';
@@ -160,6 +161,11 @@ export class TelegramBot {
     // handlers/afk.ts + docs/afk-telegram-native-host.md.
     this.bot.command('afk', (ctx) =>
       handleAfk(ctx, this.sessionManager, this.log.bind(this))
+    );
+    // /usage — report the operator's Claude subscription usage (5-hour rolling
+    // + 7-day windows) for this chat. See handlers/usage.ts.
+    this.bot.command('usage', (ctx) =>
+      handleUsage(ctx, this.log.bind(this))
     );
     // /sessions — list this chat's resumable conversations with tap-to-switch
     // buttons; /new — start a fresh conversation (previous preserved). One
@@ -401,6 +407,7 @@ export class TelegramBot {
       { command: 'cd', description: 'Show or change session working directory' },
       { command: 'name', description: 'Show or set the session name' },
       { command: 'afk', description: 'Toggle autonomous (AFK) mode for this chat' },
+      { command: 'usage', description: 'Show Claude subscription usage' },
       { command: 'watch', description: 'Live-tail a CLI session from this chat' },
       { command: 'unwatch', description: 'Stop watching a session' },
     ]);

--- a/src/telegram/formatter.test.ts
+++ b/src/telegram/formatter.test.ts
@@ -22,7 +22,9 @@ import {
   escapeHtml,
   formatSystemError,
   formatQueued,
+  formatUsage,
 } from './formatter';
+import type { UsageResult } from '../agent/subscription-usage.js';
 
 describe('splitLongMessage', () => {
   test('should not split short messages', () => {
@@ -675,5 +677,56 @@ describe('markdownToTelegramHtml — mis-nested emphasis safety net', () => {
     expect(out).toContain('<i>(empty bash block)</i>'); // label keeps its italic
     expect(out).not.toContain('<b>'); // mis-nested emphasis still dropped
     expect(out).toContain('a b c'); // emphasis text preserved as plain
+  });
+});
+
+describe('formatUsage', () => {
+  test('kind: ok with all windows renders one line per window with percentage and reset time', () => {
+    const resetsAt = new Date('2026-01-01T00:00:00Z');
+    const result: UsageResult = {
+      kind: 'ok',
+      fiveHour: { utilization: 0.42, resetsAt },
+      sevenDay: { utilization: 0.7 },
+      sevenDaySonnet: { utilization: 0.1, resetsAt },
+      sevenDayOpus: { utilization: 0.99 },
+    };
+    const out = formatUsage(result);
+    expect(out).toContain('42%');
+    expect(out).toContain('70%');
+    expect(out).toContain('10%');
+    expect(out).toContain('99%');
+    expect(out).toMatch(/5-hour/);
+    expect(out).toMatch(/7-day \(Sonnet\)/);
+    expect(out).toMatch(/7-day \(Opus\)/);
+    expect(out).toContain(resetsAt.toLocaleString());
+  });
+
+  test('kind: ok with only fiveHour renders exactly one line, no other windows', () => {
+    const result: UsageResult = { kind: 'ok', fiveHour: { utilization: 0.5 } };
+    const out = formatUsage(result);
+    expect(out).toContain('5-hour');
+    expect(out).toContain('50%');
+    expect(out).not.toMatch(/7-day/);
+  });
+
+  test('kind: unavailable / no-token tells the operator to run claude login', () => {
+    const result: UsageResult = {
+      kind: 'unavailable',
+      reason: 'no-token',
+      detail: 'no credentials found',
+    };
+    const out = formatUsage(result);
+    expect(out).toMatch(/claude login/);
+  });
+
+  test('kind: unavailable / other reasons surface the reason and detail', () => {
+    const result: UsageResult = {
+      kind: 'unavailable',
+      reason: 'http-error',
+      detail: '503 Service Unavailable',
+    };
+    const out = formatUsage(result);
+    expect(out).toMatch(/http-error/);
+    expect(out).toContain('503 Service Unavailable');
   });
 });

--- a/src/telegram/formatter.ts
+++ b/src/telegram/formatter.ts
@@ -3,6 +3,8 @@
  * @module telegram/formatter
  */
 
+import type { UsageResult, UsageWindow } from '../agent/subscription-usage.js';
+
 /**
  * Maximum message length for Telegram (4096 chars)
  */
@@ -216,6 +218,46 @@ export function escapeHtml(text: string): string {
 }
 
 /**
+ * Format a `UsageResult` (src/agent/subscription-usage.ts) for a plain-text
+ * Telegram reply. One line per available window on `kind: 'ok'`; a single
+ * clear line on `kind: 'unavailable'` (with a `claude login` hint for the
+ * no-token case, since that's operator-actionable from the phone).
+ *
+ * Plain text by design — no parse_mode, so no HTML-escaping concerns even
+ * though the underlying `detail` string comes from an external API response.
+ *
+ * @param result - UsageResult from fetchSubscriptionUsage()
+ * @returns Plain-text status message
+ */
+export function formatUsage(result: UsageResult): string {
+  if (result.kind === 'unavailable') {
+    if (result.reason === 'no-token') {
+      return '⚠️ No Claude subscription token found. Run `claude login` on the host machine, then try /usage again.';
+    }
+    return `⚠️ Usage unavailable (${result.reason}): ${result.detail}`;
+  }
+
+  const windows: Array<[string, UsageWindow | undefined]> = [
+    ['5-hour', result.fiveHour],
+    ['7-day', result.sevenDay],
+    ['7-day (Sonnet)', result.sevenDaySonnet],
+    ['7-day (Opus)', result.sevenDayOpus],
+  ];
+  const lines = windows
+    .filter((entry): entry is [string, UsageWindow] => entry[1] !== undefined)
+    .map(([label, w]) => {
+      const pct = Math.round(w.utilization * 100);
+      const resets = w.resetsAt ? ` (resets ${w.resetsAt.toLocaleString()})` : '';
+      return `  ${label}: ${pct}%${resets}`;
+    });
+
+  if (lines.length === 0) {
+    return '📊 Usage: no windows reported.';
+  }
+  return ['📊 Claude subscription usage:', ...lines].join('\n');
+}
+
+/**
  * Format a filesystem error (ENOENT/EACCES) for display to the user.
  *
  * @param code - NodeJS errno code (e.g. 'ENOENT', 'EACCES')
@@ -297,6 +339,7 @@ export function formatHelp(sdkCommands?: string[]): string {
     '  /model      — Switch Claude model',
     '  /cd         — Change working directory',
     '  /name       — Show or set the session name',
+    '  /usage      — Show Claude subscription usage',
     '  /sessions   — List and switch between sessions',
     '  /new        — Start a new session (keeps the current one)',
     '  /watch      — Live-tail a CLI session from this chat',

--- a/src/telegram/handlers/registration.ts
+++ b/src/telegram/handlers/registration.ts
@@ -39,6 +39,7 @@ export async function registerChatCommands(
       { command: 'model', description: 'Switch Claude model (opus/sonnet/haiku)' },
       { command: 'cd', description: 'Show or change session working directory' },
       { command: 'name', description: 'Show or set the session name' },
+      { command: 'usage', description: 'Show Claude subscription usage' },
       { command: 'sessions', description: 'List and switch between sessions' },
       { command: 'new', description: 'Start a new session (keeps the current one)' },
     ];

--- a/src/telegram/handlers/usage.test.ts
+++ b/src/telegram/handlers/usage.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for the Telegram `/usage` command handler (handlers/usage.ts).
+ *
+ * Mocks the sibling module `agent/subscription-usage.js` (fetchSubscriptionUsage
+ * never throws in practice — this test only verifies handleUsage wires its
+ * result into formatUsage() and replies with the result, plus that a thrown
+ * error is caught and surfaced via formatError as a last-resort guard).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { Context } from 'telegraf';
+import type { UsageResult } from '../../agent/subscription-usage.js';
+
+const mockFetch = vi.fn<() => Promise<UsageResult>>();
+vi.mock('../../agent/subscription-usage.js', () => ({
+  fetchSubscriptionUsage: (...args: unknown[]) => mockFetch(...(args as [])),
+}));
+
+const { handleUsage } = await import('./usage.js');
+
+function makeCtx(): { ctx: Context; replies: string[] } {
+  const replies: string[] = [];
+  const ctx = {
+    chat: { id: 555 },
+    reply: (t: string) => {
+      replies.push(t);
+      return Promise.resolve({ message_id: replies.length });
+    },
+  };
+  return { ctx: ctx as unknown as Context, replies };
+}
+
+describe('handleUsage (/usage on Telegram)', () => {
+  it('ok with all windows replies with a formatted percentage line per window', async () => {
+    const resetsAt = new Date('2026-01-01T00:00:00Z');
+    mockFetch.mockResolvedValueOnce({
+      kind: 'ok',
+      fiveHour: { utilization: 0.5, resetsAt },
+      sevenDay: { utilization: 0.3 },
+    });
+    const { ctx, replies } = makeCtx();
+
+    await handleUsage(ctx, () => {});
+
+    expect(replies).toHaveLength(1);
+    expect(replies[0]).toContain('50%');
+    expect(replies[0]).toContain('30%');
+    expect(replies[0]).toMatch(/5-hour/);
+    expect(replies[0]).toMatch(/7-day/);
+  });
+
+  it('ok with only fiveHour replies with just that window', async () => {
+    mockFetch.mockResolvedValueOnce({ kind: 'ok', fiveHour: { utilization: 0.9 } });
+    const { ctx, replies } = makeCtx();
+
+    await handleUsage(ctx, () => {});
+
+    expect(replies[0]).toContain('90%');
+    expect(replies[0]).not.toMatch(/7-day/);
+  });
+
+  it('unavailable / no-token tells the operator to run claude login', async () => {
+    mockFetch.mockResolvedValueOnce({
+      kind: 'unavailable',
+      reason: 'no-token',
+      detail: 'no credentials found',
+    });
+    const { ctx, replies } = makeCtx();
+
+    await handleUsage(ctx, () => {});
+
+    expect(replies[0]).toMatch(/claude login/);
+  });
+
+  it('a thrown error from fetchSubscriptionUsage is caught and surfaces a generic error reply', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('boom'));
+    const { ctx, replies } = makeCtx();
+    const log = vi.fn();
+
+    await handleUsage(ctx, log);
+
+    expect(replies[0]).toMatch(/Could not fetch usage/);
+    expect(log).toHaveBeenCalled();
+  });
+});

--- a/src/telegram/handlers/usage.ts
+++ b/src/telegram/handlers/usage.ts
@@ -1,0 +1,26 @@
+/**
+ * `/usage` — report the operator's Claude subscription usage (5-hour rolling
+ * and 7-day windows) into this chat.
+ *
+ * Delegates entirely to fetchSubscriptionUsage() (src/agent/subscription-usage.ts),
+ * which never throws — failures come back as a `kind: 'unavailable'` result and
+ * are rendered via formatUsage(). The try/catch below is a last-resort guard
+ * only, matching the defensive posture of the other command handlers in this
+ * directory (e.g. handlers/afk.ts).
+ */
+
+import type { Context } from 'telegraf';
+import { fetchSubscriptionUsage } from '../../agent/subscription-usage.js';
+import { formatError, formatUsage } from '../formatter.js';
+
+type LogFn = (...args: unknown[]) => void;
+
+export async function handleUsage(ctx: Context, log: LogFn): Promise<void> {
+  try {
+    const result = await fetchSubscriptionUsage();
+    await ctx.reply(formatUsage(result));
+  } catch (error) {
+    log('Usage command error:', error);
+    await ctx.reply(formatError('Could not fetch usage'));
+  }
+}


### PR DESCRIPTION
> **Stacked on #711.** Base branch is `afk/usage-subscription-command`, not `main` — review #711 first. GitHub will retarget this to `main` automatically when #711 merges.

## Why a second mechanism

#711 added `/usage`, which **polls** `GET /api/oauth/usage` when the operator asks. That's right for a command but wrong for a persistent indicator — it would mean a request per repaint.

Anthropic returns `anthropic-ratelimit-unified-5h-utilization` / `-7d-utilization` headers on **every** response under subscription OAuth auth. So the status line rides on responses the SDK already made: **zero extra requests, zero model tokens.**

Result — a segment on the REPL status line:

```
~/projects/agent-afk  ⎇ main  ▁▂▃ 12%  $0.42  1.2k tok  5h 62% · 7d 31%
```

## How

- **`src/agent/quota-cache.ts`** (new) — best-effort header parsing into a module-scope latest-snapshot cache with a change subscription. These headers are **undocumented and have been observed to change names upstream**, so every field is optional, every value is validated, and a malformed one is omitted rather than thrown. `parseQuotaHeaders` returns `undefined` when neither utilization is present — nothing worth caching.
- **`tracing-fetch.ts`** — new `onQuota` observer, invoked for **all** responses (before the throttle-status gate, so 2xx included) and guarded in `try/catch` exactly like `onThrottle`, per that file's own contract that a throwing callback must never disturb the request path or the SDK retry loop.
- **`status-line.ts`** — quota segment at `droppablePriority: 5`, rendered rightmost.
- **`interactive/shared.ts`** — `formatStatusFields` reads the cache and formats `5h 62% · 7d 31%`.
- **`interactive/surface-setup.ts`** — subscribes a repaint, mirroring the git-status sampler's `onUpdate` wiring.

## Three decisions worth a reviewer's attention

**1. The wrapper is now installed for every non-local-shim client, not just when a trace writer is attached.** This is the deliberate behaviour change in this PR. Previously `makeTracingFetch` was gated on `!localMode && config.traceWriter`; quota capture must survive `AFK_TRACE_DISABLED=1`, so the gate is now `!localMode` alone. **Both** install sites are updated, including the OAuth-token-refresh rebuild path. `localMode` is still excluded — a local shim isn't Anthropic and emits no quota headers.

This is what changed two existing assertions in `anthropic-direct.test.ts`: the SDK ctor arg now carries a `fetch`. I tightened those tests rather than loosening them — they now assert the **exact key set** plus types, so an unintended third key still fails.

**2. `droppablePriority: 5` is not a free choice.** The shed loop does `parts.filter(p => p.droppablePriority === undefined || p.droppablePriority !== maxPriority)` — it removes **every** part sharing the current maximum in one pass. Reusing the token count's `4` would make quota and tokens vanish *together* instead of shedding one at a time. There is an explicit regression test for this (`drops quota BEFORE the token count, and dropping quota does not also drop tokens`).

**3. Repaints fire only when a rounded percentage changes.** `repaint()` throttles at 100 ms and stores-without-painting with no trailing flush, so notifying per API response would churn the bottom row and could drop the final update. The cache gates notification on `Math.round(u * 100)` changing, while always keeping the stored snapshot current for the next poll.

## Graceful degradation

Under **API-key auth these headers never arrive**, so the cache stays empty for the process lifetime and the status line draws **no segment at all** — not a placeholder, not a zero. Same for a renamed header upstream. Tested explicitly.

## Verification

| gate | result |
|---|---|
| `pnpm lint` (tsc --noEmit, strict) | ✅ clean |
| `pnpm test` | ✅ **704 files, 13,188 passed**, 0 failed |
| `pnpm test:coverage` | ✅ 87.12 / 85.21 / 91.27 / 87.12 (floors 74/79/82/74) |
| `pnpm audit:sdk:check` | ✅ |
| `pnpm audit:env:check` | ✅ |
| `pnpm scan:env:check` | ✅ |
| `pnpm audit:chalk:check` | ✅ |

`quota-cache.ts` and `tracing-fetch.ts` both at **100%** coverage. **42 new tests**: header parsing (both windows, each alone, neither, case-insensitivity, non-numeric, out-of-range clamping, negative/absurd/non-numeric reset epochs, a hostile headers object), cache/subscription semantics (first-snapshot notify, rounded-change notify, **no**-notify on unchanged rounding, unsubscribe, throwing listener isolation), the `onQuota` wrapper-install guard, and status-line rendering including the drop-priority regression and a units guard (0.62 → `62%`, never `0%` or `6200%`).

No new env var, no new dependency, no `process.env` read, no direct chalk import.

## Still open from #711

The endpoint/header contract remains **reverse-engineered, not documented**. The verification command in #711's description applies here too — in particular whether `utilization` is a 0–1 fraction (assumed, and clamped to that range) or a 0–100 percentage. A unit mismatch is the one failure mode that renders plausible-looking wrong numbers instead of degrading to no segment.

## Not in scope

- Telegram has no persistent status surface, so this is REPL-only. `/usage` from #711 covers Telegram.
- `rate_limit` `durationMs` still stores an advertised hint rather than a measurement.
- `usage_limit_pause`/`_resume` still aren't aggregated in `afk trace show` (~16–20 lines; cheapest remaining win).
- `AFK.md:51` still claims a usage-limit pause has no event — stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
