### PR TITLE
feat(telemetry): record stop_reason on subagent terminal rows and flag partial results

### DIFF
--- a/src/agent/background-registry.test.ts
+++ b/src/agent/background-registry.test.ts
@@ -801,6 +801,42 @@ describe('BackgroundAgentRegistry', () => {
       expect(meta!.endedAt).toBeDefined();
       expect(meta!.endedAt).toBeGreaterThan(0);
     });
+
+    // PR#713 Wave-A A1(b): markTerminal persists `result.stopReason` into the
+    // closing meta record so the /bgsub:join disk-fallback path (bgsub.ts) can
+    // reconstruct the same partial-result labeling the in-memory replay
+    // applies, even after the job's in-memory entry is TTL-evicted.
+    it('terminal callback persists stopReason into meta.json when the result carries one', async () => {
+      const handle = createStubHandle('sub-disk-5');
+      const job = registry.register({ handle, prompt: 'capped job', model: 'sonnet' });
+
+      handle.__fireTerminal({
+        ...successResult('sub-disk-5', 'partial output'),
+        stopReason: 'tool_use_loop_capped',
+      });
+
+      await new Promise((r) => setTimeout(r, 200));
+
+      const { BgJobLogReader } = await import('./bg-job-log.js');
+      const meta = await BgJobLogReader.readMeta(job.jobId);
+      expect(meta).not.toBeNull();
+      expect(meta!.stopReason).toBe('tool_use_loop_capped');
+    });
+
+    it('terminal callback leaves meta.stopReason ABSENT when the result carries none', async () => {
+      const handle = createStubHandle('sub-disk-6');
+      const job = registry.register({ handle, prompt: 'clean job', model: 'sonnet' });
+
+      // successResult() never sets stopReason.
+      handle.__fireTerminal(successResult('sub-disk-6', 'clean output'));
+
+      await new Promise((r) => setTimeout(r, 200));
+
+      const { BgJobLogReader } = await import('./bg-job-log.js');
+      const meta = await BgJobLogReader.readMeta(job.jobId);
+      expect(meta).not.toBeNull();
+      expect(meta!.stopReason).toBeUndefined();
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -1040,6 +1076,78 @@ describe('BackgroundAgentRegistry', () => {
       expect(failedCalls).toHaveLength(1);
       const entry = failedCalls[0]![0] as Record<string, unknown>;
       expect(entry['stop_reason']).toBe('stream_incomplete');
+    });
+
+    // -------------------------------------------------------------------
+    // A3: stop_reason is bounded before it rides into telemetry. On the
+    // OpenAI-compatible path `stopReason` is provider-controlled free text
+    // (translate.ts / responses-translate.ts), not a bounded enum, so — like
+    // the sibling free-form fields — it must be capped, not emitted uncapped.
+    // -------------------------------------------------------------------
+    it('completed: a >64-char stop_reason is truncated to 64 chars + ellipsis in the emitted row', () => {
+      const longReason = 'x'.repeat(100);
+      const handle = createStubHandle('rt-stopreason-trunc-1');
+      registry.register({ handle, prompt: 'p', model: 'sonnet' });
+      handle.__fireTerminal({
+        ...successResult('rt-stopreason-trunc-1', 'done'),
+        stopReason: longReason,
+      });
+
+      const completedCalls = appendRoutingDecision.mock.calls.filter(
+        (c) => (c[0] as Record<string, unknown>)?.['event'] === 'subagent.completed',
+      );
+      expect(completedCalls).toHaveLength(1);
+      const entry = completedCalls[0]![0] as Record<string, unknown>;
+      // truncate(s, 64): first 64 chars + a single '…' — never the raw
+      // 100-char string, and never silently dropped.
+      expect(entry['stop_reason']).toBe('x'.repeat(64) + '…');
+      expect((entry['stop_reason'] as string).length).toBe(65);
+    });
+
+    it('failure: a >64-char stop_reason is truncated to 64 chars + ellipsis in the emitted row', () => {
+      const longReason = 'y'.repeat(90);
+      const handle = createStubHandle('rt-stopreason-trunc-2');
+      registry.register({ handle, prompt: 'p', model: 'sonnet' });
+      handle.__fireTerminal({
+        ...failureResult('rt-stopreason-trunc-2', 'boom'),
+        stopReason: longReason,
+      });
+
+      const failedCalls = appendRoutingDecision.mock.calls.filter(
+        (c) => (c[0] as Record<string, unknown>)?.['event'] === 'subagent.failed',
+      );
+      expect(failedCalls).toHaveLength(1);
+      const entry = failedCalls[0]![0] as Record<string, unknown>;
+      expect(entry['stop_reason']).toBe('y'.repeat(64) + '…');
+    });
+
+    it('completed: a stop_reason at or under 64 chars is passed through unchanged (no ellipsis)', () => {
+      const shortReason = 'tool_use_loop_capped'; // well under 64 chars
+      const handle = createStubHandle('rt-stopreason-trunc-3');
+      registry.register({ handle, prompt: 'p', model: 'sonnet' });
+      handle.__fireTerminal({
+        ...successResult('rt-stopreason-trunc-3', 'done'),
+        stopReason: shortReason,
+      });
+
+      const completedCalls = appendRoutingDecision.mock.calls.filter(
+        (c) => (c[0] as Record<string, unknown>)?.['event'] === 'subagent.completed',
+      );
+      const entry = completedCalls[0]![0] as Record<string, unknown>;
+      expect(entry['stop_reason']).toBe(shortReason);
+    });
+
+    it('completed: an absent stop_reason stays ABSENT (never truncated to a defined value)', () => {
+      const handle = createStubHandle('rt-stopreason-trunc-4');
+      registry.register({ handle, prompt: 'p', model: 'sonnet' });
+      // successResult() never sets stopReason.
+      handle.__fireTerminal(successResult('rt-stopreason-trunc-4', 'done'));
+
+      const completedCalls = appendRoutingDecision.mock.calls.filter(
+        (c) => (c[0] as Record<string, unknown>)?.['event'] === 'subagent.completed',
+      );
+      const entry = completedCalls[0]![0] as Record<string, unknown>;
+      expect(entry['stop_reason']).toBeUndefined();
     });
   });
 });

--- a/src/agent/background-registry.test.ts
+++ b/src/agent/background-registry.test.ts
@@ -906,5 +906,140 @@ describe('BackgroundAgentRegistry', () => {
       const entry = completedCalls[0]![0] as Record<string, unknown>;
       expect(entry['parent_session_id']).toBeUndefined();
     });
+
+    // -----------------------------------------------------------------------
+    // stop_reason coverage (subagent partial-result observability).
+    //
+    // Telemetry proved `stop_reason` appeared on 0 of 14,152 `subagent.completed`
+    // rows — this predicate closes that blind spot for the background-registry
+    // emit path. `content_chars` must stay computed on the raw, un-annotated
+    // content regardless of stopReason (markTerminal never annotates; see the
+    // class-level note on markTerminal).
+    // -----------------------------------------------------------------------
+    it('completed: stop_reason is present and equals the result stopReason when set', () => {
+      const handle = createStubHandle('rt-stopreason-1');
+      registry.register({ handle, prompt: 'p', model: 'sonnet' });
+      handle.__fireTerminal({
+        ...successResult('rt-stopreason-1', 'partial output'),
+        stopReason: 'tool_use_loop_capped',
+      });
+
+      const completedCalls = appendRoutingDecision.mock.calls.filter(
+        (c) => (c[0] as Record<string, unknown>)?.['event'] === 'subagent.completed',
+      );
+      expect(completedCalls).toHaveLength(1);
+      const entry = completedCalls[0]![0] as Record<string, unknown>;
+      expect(entry['stop_reason']).toBe('tool_use_loop_capped');
+    });
+
+    it('completed: stop_reason is ABSENT (not null/empty) when the result carries none', () => {
+      const handle = createStubHandle('rt-stopreason-2');
+      registry.register({ handle, prompt: 'p', model: 'sonnet' });
+      // successResult() never sets stopReason.
+      handle.__fireTerminal(successResult('rt-stopreason-2', 'clean answer'));
+
+      const completedCalls = appendRoutingDecision.mock.calls.filter(
+        (c) => (c[0] as Record<string, unknown>)?.['event'] === 'subagent.completed',
+      );
+      expect(completedCalls).toHaveLength(1);
+      const entry = completedCalls[0]![0] as Record<string, unknown>;
+      // Key-absence in the PERSISTED row is asserted against the real
+      // buildRoutingDecisionRow in routing-telemetry.test.ts. Here
+      // appendRoutingDecision is mocked, so the pre-strip entry still carries
+      // the key with an undefined value — matching the parent_session_id
+      // precedent above ("not present or undefined is fine").
+      expect(entry['stop_reason']).toBeUndefined();
+    });
+
+    it('completed: content_chars measures raw content, unaffected by a partial stopReason', () => {
+      const handle = createStubHandle('rt-stopreason-3');
+      registry.register({ handle, prompt: 'p', model: 'sonnet' });
+      const rawContent = 'short partial body';
+      handle.__fireTerminal({
+        ...successResult('rt-stopreason-3', rawContent),
+        stopReason: 'stream_incomplete',
+      });
+
+      const completedCalls = appendRoutingDecision.mock.calls.filter(
+        (c) => (c[0] as Record<string, unknown>)?.['event'] === 'subagent.completed',
+      );
+      const entry = completedCalls[0]![0] as Record<string, unknown>;
+      // No `[⚠ PARTIAL RESULT…]` banner counted — markTerminal never annotates.
+      expect(entry['content_chars']).toBe(rawContent.length);
+      expect(entry['stop_reason']).toBe('stream_incomplete');
+    });
+
+    it('failure: stop_reason is present when the failed result carries one', () => {
+      const handle = createStubHandle('rt-stopreason-4');
+      registry.register({ handle, prompt: 'p', model: 'sonnet' });
+      handle.__fireTerminal({
+        ...failureResult('rt-stopreason-4', 'stream died'),
+        stopReason: 'stream_incomplete',
+      });
+
+      const failedCalls = appendRoutingDecision.mock.calls.filter(
+        (c) => (c[0] as Record<string, unknown>)?.['event'] === 'subagent.failed',
+      );
+      expect(failedCalls).toHaveLength(1);
+      const entry = failedCalls[0]![0] as Record<string, unknown>;
+      expect(entry['stop_reason']).toBe('stream_incomplete');
+    });
+
+    it('failure: stop_reason is absent when the failed result carries none', () => {
+      const handle = createStubHandle('rt-stopreason-5');
+      registry.register({ handle, prompt: 'p', model: 'sonnet' });
+      handle.__fireTerminal(failureResult('rt-stopreason-5', 'plain failure'));
+
+      const failedCalls = appendRoutingDecision.mock.calls.filter(
+        (c) => (c[0] as Record<string, unknown>)?.['event'] === 'subagent.failed',
+      );
+      expect(failedCalls).toHaveLength(1);
+      const entry = failedCalls[0]![0] as Record<string, unknown>;
+      // Key-absence in the PERSISTED row is asserted against the real
+      // buildRoutingDecisionRow in routing-telemetry.test.ts. Here
+      // appendRoutingDecision is mocked, so the pre-strip entry still carries
+      // the key with an undefined value — matching the parent_session_id
+      // precedent above ("not present or undefined is fine").
+      expect(entry['stop_reason']).toBeUndefined();
+    });
+
+    it('cancellation: stop_reason is omitted for a bare cancelled result (stub sets none)', async () => {
+      const handle = createStubHandle('rt-stopreason-6');
+      const job = registry.register({ handle, prompt: 'p', model: 'sonnet' });
+
+      await registry.cancelJob(job.jobId);
+
+      const failedCalls = appendRoutingDecision.mock.calls.filter(
+        (c) => (c[0] as Record<string, unknown>)?.['event'] === 'subagent.failed',
+      );
+      expect(failedCalls).toHaveLength(1);
+      const entry = failedCalls[0]![0] as Record<string, unknown>;
+      // Key-absence in the PERSISTED row is asserted against the real
+      // buildRoutingDecisionRow in routing-telemetry.test.ts. Here
+      // appendRoutingDecision is mocked, so the pre-strip entry still carries
+      // the key with an undefined value — matching the parent_session_id
+      // precedent above ("not present or undefined is fine").
+      expect(entry['stop_reason']).toBeUndefined();
+    });
+
+    it('cancellation: stop_reason is present when the terminal result carries one', () => {
+      // Drives the 'cancelled' branch directly (rather than via cancelJob())
+      // so a stopReason can ride the terminal result, mirroring how a
+      // cascade-abort might still preserve a stream-incomplete stopReason.
+      const handle = createStubHandle('rt-stopreason-7');
+      registry.register({ handle, prompt: 'p', model: 'sonnet' });
+      handle.__fireTerminal({
+        id: 'rt-stopreason-7',
+        status: 'cancelled' as SubagentStatus,
+        stopReason: 'stream_incomplete',
+      });
+
+      const failedCalls = appendRoutingDecision.mock.calls.filter(
+        (c) => (c[0] as Record<string, unknown>)?.['event'] === 'subagent.failed',
+      );
+      expect(failedCalls).toHaveLength(1);
+      const entry = failedCalls[0]![0] as Record<string, unknown>;
+      expect(entry['stop_reason']).toBe('stream_incomplete');
+    });
   });
 });

--- a/src/agent/background-registry.ts
+++ b/src/agent/background-registry.ts
@@ -585,6 +585,12 @@ export class BackgroundAgentRegistry extends EventEmitter<BackgroundRegistryEven
     // Map SubagentStatus → BackgroundAgentPayload transition + emit.
     if (job.status === 'completed') {
       const rawContent = result.message?.content;
+      // Invariant: `content` here is the RAW message content, measured BEFORE
+      // any `annotateIfIncomplete` / provenance-header pass runs. This method
+      // is an observation site only (see class-level note on markTerminal) —
+      // it never mutates `result` — so `content_chars` always reflects the
+      // subagent's actual output size, never the parent-visible banner text
+      // a delivery consumer (bg-result-notifier.ts, bgsub.ts) may prepend.
       const content = typeof rawContent === 'string'
         ? rawContent
         : rawContent !== undefined
@@ -604,6 +610,7 @@ export class BackgroundAgentRegistry extends EventEmitter<BackgroundRegistryEven
         status: result.status,
         duration_ms: durationMs,
         content_chars: content.length,
+        stop_reason: result.stopReason,
       });
       this.emit('settled', this.snapshot(job));
     } else if (job.status === 'failed') {
@@ -623,6 +630,7 @@ export class BackgroundAgentRegistry extends EventEmitter<BackgroundRegistryEven
         status: result.status,
         duration_ms: durationMs,
         error_message: err?.message,
+        stop_reason: result.stopReason,
       });
       this.emit('settled', this.snapshot(job));
     } else {
@@ -641,6 +649,7 @@ export class BackgroundAgentRegistry extends EventEmitter<BackgroundRegistryEven
         parent_session_id: job.parentSessionId,
         status: result.status,
         duration_ms: durationMs,
+        stop_reason: result.stopReason,
       });
       this.emit('settled', this.snapshot(job));
     }

--- a/src/agent/background-registry.ts
+++ b/src/agent/background-registry.ts
@@ -59,6 +59,7 @@ import { BgJobLogWriter } from './bg-job-log.js';
 import type { BgJobMeta } from './bg-job-log.js';
 import { getBgJobsRoot, getBgJobDir } from '../paths.js';
 import { appendRoutingDecision } from './routing-telemetry.js';
+import { truncate } from './tools/subagent/failure-payload.js';
 
 export type BackgroundJobStatus = 'running' | 'completed' | 'failed' | 'cancelled';
 
@@ -119,6 +120,18 @@ export const MAX_TRANSCRIPT_TAIL_BYTES = 4096;
  */
 function emitRoutingTelemetry(entry: Parameters<typeof appendRoutingDecision>[0]): void {
   void appendRoutingDecision(entry).catch(() => {});
+}
+
+/**
+ * Cap `stopReason` before it rides into a telemetry row. On the
+ * OpenAI-compatible path `stopReason` is provider-controlled free text
+ * (`providers/openai-compatible/translate.ts`, `responses-translate.ts`),
+ * not a bounded enum, so — like the sibling free-form telemetry fields — it
+ * must not be emitted uncapped. Preserves omit-when-absent: `undefined` stays
+ * `undefined`, never `''`.
+ */
+function boundedStopReason(stopReason: string | undefined): string | undefined {
+  return stopReason !== undefined ? truncate(stopReason, 64) : undefined;
 }
 
 /**
@@ -610,7 +623,7 @@ export class BackgroundAgentRegistry extends EventEmitter<BackgroundRegistryEven
         status: result.status,
         duration_ms: durationMs,
         content_chars: content.length,
-        stop_reason: result.stopReason,
+        stop_reason: boundedStopReason(result.stopReason),
       });
       this.emit('settled', this.snapshot(job));
     } else if (job.status === 'failed') {
@@ -630,7 +643,7 @@ export class BackgroundAgentRegistry extends EventEmitter<BackgroundRegistryEven
         status: result.status,
         duration_ms: durationMs,
         error_message: err?.message,
-        stop_reason: result.stopReason,
+        stop_reason: boundedStopReason(result.stopReason),
       });
       this.emit('settled', this.snapshot(job));
     } else {
@@ -649,7 +662,7 @@ export class BackgroundAgentRegistry extends EventEmitter<BackgroundRegistryEven
         parent_session_id: job.parentSessionId,
         status: result.status,
         duration_ms: durationMs,
-        stop_reason: result.stopReason,
+        stop_reason: boundedStopReason(result.stopReason),
       });
       this.emit('settled', this.snapshot(job));
     }
@@ -665,6 +678,11 @@ export class BackgroundAgentRegistry extends EventEmitter<BackgroundRegistryEven
         ...openMeta,
         status: finalStatus,
         ...(endedAt !== undefined ? { endedAt } : {}),
+        // Persist stopReason so the /bgsub:join disk-fallback path (reached
+        // after this job's in-memory entry is TTL-evicted) can reconstruct
+        // the same partial-result labeling the in-memory replay applies —
+        // see BgJobMeta.stopReason. Omitted (not undefined/null) when absent.
+        ...(result.stopReason !== undefined ? { stopReason: result.stopReason } : {}),
       }).then(() => writer.close());
     }
 

--- a/src/agent/bg-job-log.test.ts
+++ b/src/agent/bg-job-log.test.ts
@@ -198,6 +198,41 @@ describe('BgJobLogReader', () => {
     expect(read!.status).toBe('completed');
   });
 
+  // ---------------------------------------------------------------------
+  // BgJobMeta.stopReason round-trip (A1: persisted for the /bgsub:join
+  // disk-fallback path — see background-registry.ts markTerminal and
+  // bgsub.ts's disk-fallback branch).
+  // ---------------------------------------------------------------------
+  it('readMeta() round-trips a written stopReason', async () => {
+    const jobId = `readmeta-stopreason-${Date.now()}`;
+    const w = new BgJobLogWriter(jobId);
+    const meta = makeMeta(jobId, {
+      status: 'completed',
+      endedAt: Date.now(),
+      stopReason: 'tool_use_loop_capped',
+    });
+    await w.writeMeta(meta);
+    await w.close();
+
+    const read = await BgJobLogReader.readMeta(jobId);
+    expect(read).not.toBeNull();
+    expect(read!.stopReason).toBe('tool_use_loop_capped');
+  });
+
+  it('readMeta() leaves stopReason undefined for legacy meta that never set it', async () => {
+    const jobId = `readmeta-legacy-${Date.now()}`;
+    const w = new BgJobLogWriter(jobId);
+    // No `stopReason` override — mirrors meta.json written before this field
+    // existed.
+    const meta = makeMeta(jobId, { status: 'completed', endedAt: Date.now() });
+    await w.writeMeta(meta);
+    await w.close();
+
+    const read = await BgJobLogReader.readMeta(jobId);
+    expect(read).not.toBeNull();
+    expect(read!.stopReason).toBeUndefined();
+  });
+
   it('readEvents() round-trips a written log', async () => {
     const jobId = `readevents-${Date.now()}`;
     const w = new BgJobLogWriter(jobId);

--- a/src/agent/bg-job-log.ts
+++ b/src/agent/bg-job-log.ts
@@ -45,6 +45,15 @@ export interface BgJobMeta {
   endedAt?: number;
   status: 'running' | 'completed' | 'failed' | 'cancelled';
   parentSessionId?: string;
+  /**
+   * The terminal `SubagentResult.stopReason` (see `agent/subagent/result.ts`),
+   * persisted so the `/bgsub:join` disk-fallback replay path — reached once a
+   * job's in-memory entry is evicted after its TTL — can reconstruct the same
+   * `isIncompleteStopReason` / `annotateIfIncomplete` partial-result labeling
+   * the in-memory replay applies. Optional and additive: old logs written
+   * before this field existed simply lack it (schemaVersion stays 1).
+   */
+  stopReason?: string;
   schemaVersion: 1;
 }
 

--- a/src/agent/hooks.ts
+++ b/src/agent/hooks.ts
@@ -248,6 +248,22 @@ export interface PostToolUseContext {
    * PreToolUse containment check consulted.
    */
   grantManager?: GrantManager;
+  /**
+   * True when `output` is a subagent's capped/stream-cut partial answer
+   * rather than a clean completion. Mirrors `ToolResult.incomplete` (see
+   * `agent/providers/anthropic-direct/types.ts`) — additive channel so a
+   * hook can branch on the same structured fact the trace layer records,
+   * without substring-matching the `[⚠ PARTIAL RESULT…]` banner already
+   * present in `output`. Absent for a clean completion or any non-subagent
+   * tool.
+   */
+  incomplete?: boolean;
+  /**
+   * The subagent's `stopReason` that produced `incomplete: true` (e.g.
+   * `tool_use_loop_capped`, `stream_incomplete`). Present only alongside
+   * `incomplete: true`; absent otherwise.
+   */
+  incompleteReason?: string;
 }
 
 export interface PreCompactContext {

--- a/src/agent/provider.ts
+++ b/src/agent/provider.ts
@@ -167,6 +167,23 @@ export type ProviderEvent =
        */
       batchIndex?: number;
       batchSize?: number;
+      /**
+       * Plumbed from `ToolResult.incomplete` — `true` when this result carries
+       * a subagent's capped/stream-cut partial answer rather than a clean
+       * completion. Distinct from `truncated` (tool-OUTPUT byte-cap slicing):
+       * a subagent result can be `incomplete` with no truncation involved at
+       * all. Lets non-model consumers (subagent traces, hooks) branch on the
+       * same fact `annotateIfIncomplete` banners into `content` without
+       * substring-matching that banner text. Both providers expose this
+       * symmetrically. Absent for a clean completion or any non-subagent tool.
+       */
+      incomplete?: boolean;
+      /**
+       * The subagent's `stopReason` that produced `incomplete: true` (e.g.
+       * `tool_use_loop_capped`, `stream_incomplete`). Present only alongside
+       * `incomplete: true`; absent otherwise.
+       */
+      incompleteReason?: string;
     }
   | {
       /**

--- a/src/agent/providers/anthropic-direct/loop.ts
+++ b/src/agent/providers/anthropic-direct/loop.ts
@@ -1014,6 +1014,8 @@ export async function* runTurn(
         content: result.content,
         ...(result.isError === true ? { isError: true } : {}),
         ...(truncated ? { truncated: true } : {}),
+        ...(result.incomplete === true ? { incomplete: true } : {}),
+        ...(result.incompleteReason ? { incompleteReason: result.incompleteReason } : {}),
         ...(typeof result.batchIndex === 'number' && typeof result.batchSize === 'number'
           ? { batchIndex: result.batchIndex, batchSize: result.batchSize }
           : {}),

--- a/src/agent/providers/anthropic-direct/types.ts
+++ b/src/agent/providers/anthropic-direct/types.ts
@@ -93,6 +93,28 @@ export interface ToolResult {
    * caller code).
    */
   truncated?: boolean;
+  /**
+   * Set to `true` when this result carries a SUBAGENT's partial/incomplete
+   * answer — the child hit its tool-use iteration cap or its stream was cut
+   * off mid-flight (see `isIncompleteStopReason` in `agent/subagent/result.js`).
+   * Deliberately NOT named `truncated`: that field means tool-OUTPUT truncation
+   * (bash/grep/web-scrape byte-cap slicing) and is orthogonal — a subagent
+   * result can be `incomplete` while its content is nowhere near any byte cap,
+   * and a tool's output can be `truncated` with no subagent involved at all.
+   * `incomplete` is the structured counterpart to the `[⚠ PARTIAL RESULT…]`
+   * prose banner `annotateIfIncomplete` prepends to `content`: the banner
+   * stays (existing consumers depend on it as the in-band model-visible
+   * signal); this flag lets non-model consumers (trace readers, hooks,
+   * calling code) branch on the same fact without substring-matching the
+   * banner text. Absent for a clean completion or any non-subagent tool.
+   */
+  incomplete?: boolean;
+  /**
+   * The subagent's `stopReason` that produced `incomplete: true` (e.g.
+   * `tool_use_loop_capped`, `stream_incomplete`). Present only alongside
+   * `incomplete: true`; absent otherwise.
+   */
+  incompleteReason?: string;
   /** True when this result is a synthetic repeat-loop circuit-breaker block,
    *  not a real tool outcome — lets trace consumers exclude it from failure stats. */
   circuitBreaker?: boolean;

--- a/src/agent/providers/openai-compatible/query/dispatch-append.ts
+++ b/src/agent/providers/openai-compatible/query/dispatch-append.ts
@@ -209,6 +209,8 @@ export async function* dispatchAndAppendToolCalls({
         content: result.content,
         ...(result.isError === true ? { isError: true } : {}),
         ...(result.truncated === true ? { truncated: true } : {}),
+        ...(result.incomplete === true ? { incomplete: true } : {}),
+        ...(result.incompleteReason ? { incompleteReason: result.incompleteReason } : {}),
         // Plumb concurrency-batch membership onto the render-facing event, not
         // just the trace event above, so the TUI `∥i/N` badge works here too.
         // Parity with anthropic-direct/loop.ts's tool.output yield — omitting it

--- a/src/agent/providers/shared/tool-call-trace.test.ts
+++ b/src/agent/providers/shared/tool-call-trace.test.ts
@@ -125,6 +125,39 @@ describe('buildToolCallCompletedPayload', () => {
     expect(payload.durationMs).toBe(987);
   });
 
+  it('spreads incomplete/incompleteReason only when result carries them', () => {
+    const withIncomplete = buildToolCallCompletedPayload({
+      toolUseId: 'tu_inc',
+      name: 'agent',
+      result: { content: 'partial', incomplete: true, incompleteReason: 'tool_use_loop_capped' },
+      truncated: false,
+      durationMs: 1,
+    });
+    expect(withIncomplete.incomplete).toBe(true);
+    expect(withIncomplete.incompleteReason).toBe('tool_use_loop_capped');
+
+    // Clean ToolResult: both keys ABSENT (not present-with-falsy), matching
+    // the omit-when-absent idiom used by circuitBreaker/failureClass below.
+    const clean = buildToolCallCompletedPayload({
+      toolUseId: 'tu_clean',
+      name: 'agent',
+      result: baseResult,
+      truncated: false,
+      durationMs: 1,
+    });
+    expect('incomplete' in clean).toBe(false);
+    expect('incompleteReason' in clean).toBe(false);
+
+    const falseIncomplete = buildToolCallCompletedPayload({
+      toolUseId: 'tu_false_inc',
+      name: 'agent',
+      result: { content: 'x', incomplete: false },
+      truncated: false,
+      durationMs: 1,
+    });
+    expect('incomplete' in falseIncomplete).toBe(false);
+  });
+
   it('spreads circuitBreaker only when result.circuitBreaker === true', () => {
     const withBreaker = buildToolCallCompletedPayload({
       toolUseId: 'tu_cb',

--- a/src/agent/providers/shared/tool-call-trace.ts
+++ b/src/agent/providers/shared/tool-call-trace.ts
@@ -84,6 +84,8 @@ export function buildToolCallCompletedPayload(args: {
     isError: result.isError === true,
     truncated,
     durationMs,
+    ...(result.incomplete === true ? { incomplete: true } : {}),
+    ...(result.incompleteReason ? { incompleteReason: result.incompleteReason } : {}),
     ...(result.circuitBreaker === true ? { circuitBreaker: true } : {}),
     ...(result.failureClass ? { failureClass: result.failureClass } : {}),
     ...(typeof result.batchIndex === 'number' && typeof result.batchSize === 'number'

--- a/src/agent/routing-telemetry.test.ts
+++ b/src/agent/routing-telemetry.test.ts
@@ -79,3 +79,23 @@ describe('buildRoutingDecisionRow — resolved_agent_type', () => {
     expect('resolved_agent_type' in row).toBe(false);
   });
 });
+
+describe('buildRoutingDecisionRow — stop_reason', () => {
+  it('carries stop_reason on a terminal row that has one', () => {
+    const row = buildRoutingDecisionRow({
+      event: 'subagent.completed',
+      subagent_id: 'c1',
+      stop_reason: 'stream_incomplete',
+    });
+    expect(row['stop_reason']).toBe('stream_incomplete');
+  });
+
+  it('omits stop_reason when the result carries none (undefined dropped, no null leakage)', () => {
+    const row = buildRoutingDecisionRow({
+      event: 'subagent.completed',
+      subagent_id: 'c2',
+      stop_reason: undefined,
+    });
+    expect('stop_reason' in row).toBe(false);
+  });
+});

--- a/src/agent/routing-telemetry.ts
+++ b/src/agent/routing-telemetry.ts
@@ -53,6 +53,13 @@ export interface RoutingDecisionEntry {
   duration_ms?: number | undefined;
   /** Size of the returned assistant content, in characters. */
   content_chars?: number | undefined;
+  /**
+   * The subagent result's `stopReason` when present (e.g.
+   * `tool_use_loop_capped`, `stream_incomplete`) — the signal distinguishing
+   * a genuinely clean completion from a capped/truncated partial. Omitted
+   * (not `null`/`''`) when the result carried no stopReason.
+   */
+  stop_reason?: string | undefined;
   /** Short error message — no stack traces, no user content. */
   error_message?: string | undefined;
   /** Short schema-validation error message when present. */

--- a/src/agent/subagent/result.test.ts
+++ b/src/agent/subagent/result.test.ts
@@ -14,6 +14,7 @@ import {
   buildResultFromMessage,
   isIncompleteStopReason,
   annotateIfIncomplete,
+  incompleteToolResultFields,
   STREAM_INCOMPLETE,
 } from './result.js';
 import { TOOL_USE_LOOP_CAPPED } from '../providers/shared/tool-loop-cap.js';
@@ -207,5 +208,29 @@ describe('annotateIfIncomplete — parent-visible partial marker', () => {
     expect(out).toContain('PARTIAL RESULT');
     expect(out).toContain('cut off');
     expect(out.endsWith(BODY)).toBe(true);
+  });
+});
+
+describe('incompleteToolResultFields — structured ToolResult counterpart', () => {
+  it('returns {incomplete:true, incompleteReason} for the tool-use loop cap', () => {
+    expect(incompleteToolResultFields(TOOL_USE_LOOP_CAPPED)).toEqual({
+      incomplete: true,
+      incompleteReason: TOOL_USE_LOOP_CAPPED,
+    });
+  });
+
+  it('returns {incomplete:true, incompleteReason} for a stream-truncated run', () => {
+    expect(incompleteToolResultFields(STREAM_INCOMPLETE)).toEqual({
+      incomplete: true,
+      incompleteReason: STREAM_INCOMPLETE,
+    });
+  });
+
+  it('returns {} for a clean terminal stop reason', () => {
+    expect(incompleteToolResultFields('end_turn')).toEqual({});
+  });
+
+  it('returns {} when the stop reason is undefined', () => {
+    expect(incompleteToolResultFields(undefined)).toEqual({});
   });
 });

--- a/src/agent/subagent/result.ts
+++ b/src/agent/subagent/result.ts
@@ -80,6 +80,30 @@ export function annotateIfIncomplete(content: string, stopReason: string | undef
   );
 }
 
+/**
+ * Structured counterpart to {@link annotateIfIncomplete}'s prose banner —
+ * fields to spread onto a `ToolResult` (see `agent/providers/anthropic-direct/
+ * types.js`) so non-model consumers (trace readers, hooks, calling code) can
+ * branch on the same fact without substring-matching the banner text.
+ * Deliberately named `incomplete`, not `truncated` — `ToolResult.truncated`
+ * already means tool-OUTPUT truncation (bash/grep/web-scrape byte caps) and
+ * is orthogonal to a subagent returning a capped/stream-cut partial.
+ *
+ * Derived from {@link isIncompleteStopReason} — the single source of truth
+ * for the partial-vs-clean classification; this helper does not duplicate
+ * that predicate. Returns `{}` (both fields omitted) for a clean completion,
+ * so `{ content, ...incompleteToolResultFields(stopReason) }` never writes an
+ * explicit `false`/`undefined`.
+ */
+export function incompleteToolResultFields(
+  stopReason: string | undefined,
+): { incomplete?: true; incompleteReason?: string } {
+  if (!isIncompleteStopReason(stopReason)) return {};
+  // Safe: isIncompleteStopReason(stopReason) === true implies stopReason is
+  // one of the two string sentinels above, never undefined.
+  return { incomplete: true, incompleteReason: stopReason as string };
+}
+
 export interface SubagentToolCall {
   id: string;
   name: string;

--- a/src/agent/tools/dispatcher.test.ts
+++ b/src/agent/tools/dispatcher.test.ts
@@ -436,6 +436,55 @@ describe('SessionToolDispatcher', () => {
       });
     });
 
+    it('forwards incomplete/incompleteReason to PostToolUse for a partial agent result', async () => {
+      const registry = createHookRegistryImpl();
+      const postSpy = vi.fn(async () => ({}));
+      registry.register('PostToolUse', postSpy);
+      // A capped/stream-cut subagent partial: the structured flags ride the
+      // ToolResult alongside the `[⚠ PARTIAL RESULT…]` banner in `content`,
+      // so a hook can branch without substring-matching that banner.
+      const executor = {
+        execute: vi.fn().mockResolvedValue({
+          content: 'partial output',
+          incomplete: true,
+          incompleteReason: 'stream_incomplete',
+        }),
+      } as any;
+      const dispatcher = makeDispatcher({
+        subagentExecutor: executor,
+        hookRegistry: registry,
+        permissions: { allowedTools: ['echo', 'agent'] },
+      });
+      await dispatcher.execute(makeCall({ name: 'agent', input: { prompt: 'test' } }));
+      expect(postSpy).toHaveBeenCalledOnce();
+      const callArgs = postSpy.mock.calls[0] as unknown[];
+      expect(callArgs[0]).toMatchObject({
+        event: 'PostToolUse',
+        toolName: 'agent',
+        incomplete: true,
+        incompleteReason: 'stream_incomplete',
+      });
+    });
+
+    it('omits incomplete/incompleteReason from PostToolUse for a clean agent result', async () => {
+      const registry = createHookRegistryImpl();
+      const postSpy = vi.fn(async () => ({}));
+      registry.register('PostToolUse', postSpy);
+      const executor = mockExecutor();
+      const dispatcher = makeDispatcher({
+        subagentExecutor: executor,
+        hookRegistry: registry,
+        permissions: { allowedTools: ['echo', 'agent'] },
+      });
+      await dispatcher.execute(makeCall({ name: 'agent', input: { prompt: 'test' } }));
+      expect(postSpy).toHaveBeenCalledOnce();
+      const ctx = (postSpy.mock.calls[0] as unknown[])[0] as Record<string, unknown>;
+      // Absent, not `false`/`undefined` — mirrors how the dispatcher spreads
+      // the fields only when the ToolResult actually carries them.
+      expect('incomplete' in ctx).toBe(false);
+      expect('incompleteReason' in ctx).toBe(false);
+    });
+
     it('catches executor throws and returns isError', async () => {
       const executor = { execute: vi.fn().mockRejectedValue(new Error('executor boom')) } as any;
       const dispatcher = makeDispatcher({

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -1144,7 +1144,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
       if (agentThrew) {
         this.firePostToolUseFailure(call.name, agentErrMsg, call.signal, call.input);
       } else {
-        this.firePostToolUse(call.name, result.content, call.signal, call.input);
+        this.firePostToolUse(call.name, result.content, call.signal, call.input, result);
       }
       return result;
     }
@@ -1170,7 +1170,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
       if (skillThrew) {
         this.firePostToolUseFailure(call.name, skillErrMsg, call.signal, call.input);
       } else {
-        this.firePostToolUse(call.name, result.content, call.signal, call.input);
+        this.firePostToolUse(call.name, result.content, call.signal, call.input, result);
       }
       return result;
     }
@@ -1178,7 +1178,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
     // Compose tool — DAG-based parallel subagent dispatch
     if (call.name === 'compose') {
       const result = await this.executeCompose(call);
-      this.firePostToolUse(call.name, result.content, call.signal, call.input);
+      this.firePostToolUse(call.name, result.content, call.signal, call.input, result);
       return result;
     }
 
@@ -1206,7 +1206,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
     if (handlerThrew) {
       this.firePostToolUseFailure(call.name, handlerErrMsg, call.signal, call.input);
     } else {
-      this.firePostToolUse(call.name, result.content, call.signal, call.input);
+      this.firePostToolUse(call.name, result.content, call.signal, call.input, result);
     }
     return result;
   }
@@ -1231,12 +1231,22 @@ export class SessionToolDispatcher implements ToolDispatcher {
    * compose path where the caller does not need to await the hook's
    * completion. Routes through `dispatchPostToolUse` so the
    * witness-layer `hook_decision` event lands automatically.
+   *
+   * `resultFlags` is an OPTIONAL trailing parameter (additive, back-compat):
+   * callers that omit it get byte-identical behavior to before this field
+   * existed — no new keys land on `postCtx`. Callers that have the full
+   * `ToolResult` in scope (the agent/skill/compose/handler success paths in
+   * `executeCoreInner`) pass it so a PostToolUse hook can read
+   * `incomplete`/`incompleteReason` — the structured counterpart to the
+   * `[⚠ PARTIAL RESULT…]` banner already in `output` — without substring-
+   * matching that banner text.
    */
   private firePostToolUse(
     toolName: string,
     output: string,
     signal: AbortSignal,
     input?: unknown,
+    resultFlags?: Pick<ToolResult, 'incomplete' | 'incompleteReason'>,
   ): void {
     if (!this.hookRegistry) return;
     const postCtx: PostToolUseContext = {
@@ -1250,6 +1260,8 @@ export class SessionToolDispatcher implements ToolDispatcher {
       ...(this.sessionGrantManager !== undefined
         ? { grantManager: this.sessionGrantManager }
         : {}),
+      ...(resultFlags?.incomplete === true ? { incomplete: true } : {}),
+      ...(resultFlags?.incompleteReason ? { incompleteReason: resultFlags.incompleteReason } : {}),
     };
     void dispatchPostToolUse(this.hookRegistry, postCtx, {
       signal,

--- a/src/agent/tools/skill-executor/fork-dispatch.ts
+++ b/src/agent/tools/skill-executor/fork-dispatch.ts
@@ -363,19 +363,32 @@ export async function runForkedSkillToResult(
     }
 
     // Cancelled mid-flight but produced text: surface the partial output with
-    // a clear marker rather than discarding it.
+    // a clear marker rather than discarding it. incompleteToolResultFields
+    // adds the structured incomplete/incompleteReason counterpart for
+    // non-model consumers (no-op when stopReason is absent or clean).
     if (
       result.status === 'cancelled' &&
       typeof result.partialOutput === 'string' &&
       result.partialOutput.length > 0
     ) {
       const marker = '[skill cancelled mid-flight — partial output preserved below]';
-      toolResult = { content: `${marker}\n\n${result.partialOutput}` };
+      toolResult = {
+        content: `${marker}\n\n${result.partialOutput}`,
+        ...incompleteToolResultFields(result.stopReason),
+      };
       return toolResult;
     }
 
+    // incompleteToolResultFields flags the ZERO-OUTPUT stream_incomplete case
+    // (see `subagent/result.ts`) that resolves `status:'failed'` and routes
+    // through this literal — no-op for any other failure or an absent
+    // stopReason.
     const errorMessage = result.error?.message ?? noOutputError;
-    toolResult = { content: errorMessage, isError: true };
+    toolResult = {
+      content: errorMessage,
+      isError: true,
+      ...incompleteToolResultFields(result.stopReason),
+    };
     return toolResult;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/src/agent/tools/skill-executor/fork-dispatch.ts
+++ b/src/agent/tools/skill-executor/fork-dispatch.ts
@@ -14,7 +14,7 @@
 
 import { SubagentManager } from '../../subagent.js';
 import { resolveChildManagerReadRoots } from '../../subagent-read-scope.js';
-import { annotateIfIncomplete } from '../../subagent/result.js';
+import { annotateIfIncomplete, incompleteToolResultFields } from '../../subagent/result.js';
 import { appendInjectContext } from '../subagent/inject-context.js';
 import type { ToolCall, ToolResult } from '../types.js';
 import type { AgentConfig } from '../../types/config-types.js';
@@ -353,8 +353,11 @@ export async function runForkedSkillToResult(
       // A `succeeded` result can still be an incomplete partial (capped or
       // stream-truncated). annotateIfIncomplete prepends a parent-visible
       // marker in that case and is a no-op for clean completions.
+      // incompleteToolResultFields adds the structured counterpart to that
+      // banner, alongside it, for non-model consumers.
       toolResult = {
         content: annotateIfIncomplete(result.message.content, result.stopReason),
+        ...incompleteToolResultFields(result.stopReason),
       };
       return toolResult;
     }

--- a/src/agent/tools/subagent/foreground-promotion.ts
+++ b/src/agent/tools/subagent/foreground-promotion.ts
@@ -261,7 +261,12 @@ export async function runForegroundWithPromotion(args: RunForegroundArgs): Promi
         status: result.status,
         duration_ms: Date.now() - startedAt,
         content_chars: content.length,
-        stop_reason: result.stopReason,
+        // Capped like the sibling free-form telemetry fields (error_message,
+        // schema_error below): on the OpenAI-compatible path stopReason is
+        // provider-controlled free text (translate.ts / responses-translate.ts),
+        // not a bounded enum, so it must not ride into telemetry uncapped.
+        // Omit-when-absent preserved: `undefined` stays `undefined`, never ''.
+        stop_reason: result.stopReason !== undefined ? truncate(result.stopReason, 64) : undefined,
         depth,
         tool_call_count: trace?.toolCalls.length,
         // Preserve `false` ("confirmed absent") distinctly from `undefined`
@@ -306,7 +311,9 @@ export async function runForegroundWithPromotion(args: RunForegroundArgs): Promi
         ? truncate(result.schemaError.message)
         : undefined,
       partial_output_chars: measurePartial(result.partialOutput),
-      stop_reason: result.stopReason,
+      // Capped — see the completed-path comment above for why (provider
+      // free text on the OpenAI-compatible path, not a bounded enum).
+      stop_reason: result.stopReason !== undefined ? truncate(result.stopReason, 64) : undefined,
       depth,
       // Mirror trace fields on the failure path — failed subagents are the
       // highest-value debugging target and benefit most from this signal.
@@ -329,9 +336,16 @@ export async function runForegroundWithPromotion(args: RunForegroundArgs): Promi
     });
     // Assign (don't return) so the finally can append the in-turn
     // SubagentStop injectContext after teardown. See `toolResult` above.
+    // incompleteToolResultFields flags the ZERO-OUTPUT stream_incomplete case
+    // (see `subagent/result.ts` — a pure cut-off-mid-flight run with nothing
+    // to salvage resolves `status:'failed'` and routes through this exact
+    // literal): without it that case's `stopReason` never reaches the
+    // non-model consumers that key off `ToolResult.incomplete`. No-op
+    // (adds nothing) for a clean failure or an absent stopReason.
     toolResult = {
       content: JSON.stringify(payload),
       isError: true,
+      ...incompleteToolResultFields(result.stopReason),
     };
     return toolResult;
   } catch (err) {

--- a/src/agent/tools/subagent/foreground-promotion.ts
+++ b/src/agent/tools/subagent/foreground-promotion.ts
@@ -19,7 +19,7 @@
 
 import type { BackgroundAgentRegistry } from '../../background-registry.js';
 import type { SubagentManager } from '../../subagent.js';
-import { annotateIfIncomplete } from '../../subagent/result.js';
+import { annotateIfIncomplete, incompleteToolResultFields } from '../../subagent/result.js';
 import { debugLog } from '../../../utils/debug.js';
 import type { TraceOrigin, TraceActor } from '../../session/session-identity.js';
 import type { ToolResult } from '../types.js';
@@ -249,6 +249,10 @@ export async function runForegroundWithPromotion(args: RunForegroundArgs): Promi
       // Guard against non-string content (e.g. SDK may return a ContentBlock[])
       const content = typeof rawContent === 'string' ? rawContent : JSON.stringify(rawContent);
       const trace = result.trace;
+      // Invariant: `content`/`content_chars` are measured on the RAW message
+      // content, before `annotateIfIncomplete`/`withProvenanceHeader` run
+      // below. Telemetry must reflect the subagent's actual output size, not
+      // the parent-visible banner/provenance text prepended at delivery time.
       void emitTelemetry({
         ...identity,
         event: 'subagent.completed',
@@ -257,6 +261,7 @@ export async function runForegroundWithPromotion(args: RunForegroundArgs): Promi
         status: result.status,
         duration_ms: Date.now() - startedAt,
         content_chars: content.length,
+        stop_reason: result.stopReason,
         depth,
         tool_call_count: trace?.toolCalls.length,
         // Preserve `false` ("confirmed absent") distinctly from `undefined`
@@ -271,13 +276,16 @@ export async function runForegroundWithPromotion(args: RunForegroundArgs): Promi
       // annotateIfIncomplete marks capped/stream-truncated partials so the
       // parent model doesn't treat them as a final answer (no-op if clean);
       // withProvenanceHeader stamps the producing model on a mixed-model
-      // dispatch (no-op when child == parent).
+      // dispatch (no-op when child == parent). incompleteToolResultFields adds
+      // the structured counterpart to that same banner, alongside it, for
+      // non-model consumers.
       toolResult = {
         content: withProvenanceHeader(
           annotateIfIncomplete(content, result.stopReason),
           model,
           parentModel,
         ),
+        ...incompleteToolResultFields(result.stopReason),
       };
       return toolResult;
     }
@@ -298,6 +306,7 @@ export async function runForegroundWithPromotion(args: RunForegroundArgs): Promi
         ? truncate(result.schemaError.message)
         : undefined,
       partial_output_chars: measurePartial(result.partialOutput),
+      stop_reason: result.stopReason,
       depth,
       // Mirror trace fields on the failure path — failed subagents are the
       // highest-value debugging target and benefit most from this signal.

--- a/src/agent/trace/events.test.ts
+++ b/src/agent/trace/events.test.ts
@@ -113,6 +113,43 @@ describe('tool_call payload', () => {
     }
   });
 
+  it('accepts and PRESERVES incomplete/incompleteReason on the completed phase (round-trip)', () => {
+    // Proves the schema was updated alongside the TS type: a field the type
+    // carries but the schema omits would be silently STRIPPED by zod's
+    // default non-strict `.object()` behavior (0 `.strict()` calls in this
+    // module) rather than rejected — this assertion would go RED if that
+    // regressed.
+    const parsed = ToolCallPayloadSchema.parse({
+      phase: 'completed',
+      toolUseId: 't1',
+      name: 'agent',
+      resultBytes: 64,
+      isError: false,
+      truncated: false,
+      durationMs: 5,
+      incomplete: true,
+      incompleteReason: 'tool_use_loop_capped',
+    });
+    expect(parsed).toMatchObject({
+      incomplete: true,
+      incompleteReason: 'tool_use_loop_capped',
+    });
+  });
+
+  it('omits incomplete/incompleteReason when absent (no default injected)', () => {
+    const parsed = ToolCallPayloadSchema.parse({
+      phase: 'completed',
+      toolUseId: 't1',
+      name: 'bash',
+      resultBytes: 2,
+      isError: false,
+      truncated: false,
+      durationMs: 1,
+    });
+    expect('incomplete' in parsed).toBe(false);
+    expect('incompleteReason' in parsed).toBe(false);
+  });
+
   it('rejects unknown phase', () => {
     expect(() =>
       ToolCallPayloadSchema.parse({

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -44,6 +44,12 @@ export const ToolCallCompletedPayloadSchema = z.object({
   isError: z.boolean(),
   truncated: z.boolean(),
   durationMs: z.number().nonnegative(),
+  /** True when this result carries a subagent's capped/stream-cut partial
+   *  answer. Mirrors `ToolResult.incomplete`. Absent otherwise. */
+  incomplete: z.boolean().optional(),
+  /** The subagent stopReason that produced `incomplete: true`. Present only
+   *  alongside `incomplete: true`; absent otherwise. */
+  incompleteReason: z.string().optional(),
   /** Set when the event was produced by the repeat-loop circuit breaker. */
   circuitBreaker: z.boolean().optional(),
   /** Coarse failure classification when `isError` is true. Absent otherwise. */

--- a/src/agent/trace/types.ts
+++ b/src/agent/trace/types.ts
@@ -112,6 +112,19 @@ export interface ToolCallCompletedPayload {
   truncated: boolean;
   /** Wall-clock duration from `started` → `completed`, in milliseconds. */
   durationMs: number;
+  /**
+   * True when this result carries a subagent's partial/incomplete answer —
+   * the child hit its tool-use iteration cap or its stream was cut off
+   * mid-flight. Mirrors `ToolResult.incomplete` (see `providers/anthropic-direct/
+   * types.ts`); absent for a clean completion or any non-subagent tool.
+   */
+  incomplete?: boolean;
+  /**
+   * The subagent's `stopReason` that produced `incomplete: true` (e.g.
+   * `tool_use_loop_capped`, `stream_incomplete`). Present only alongside
+   * `incomplete: true`; absent otherwise.
+   */
+  incompleteReason?: string;
   /** True when this completed event was produced by the repeat-loop circuit breaker,
    *  not by a real tool dispatch — lets detectors exclude it from failure stats. */
   circuitBreaker?: boolean;

--- a/src/cli/slash/commands/bgsub.test.ts
+++ b/src/cli/slash/commands/bgsub.test.ts
@@ -379,5 +379,120 @@ describe('/bgsub slash commands', () => {
       expect(result).toBe('continue');
       expect(lines.some((l) => l.startsWith('ERROR:No background job'))).toBe(true);
     });
+
+    // -----------------------------------------------------------------------
+    // A1: stopReason persistence + disk-replay annotation. Reviewer (Codex
+    // P2, bgsub.ts:133): the in-memory replay (printJobDetail) annotates a
+    // capped/stream-truncated partial via annotateIfIncomplete, but the disk
+    // fallback did not — so joining the same incomplete job before vs. after
+    // TTL eviction produced different safety labeling. These three cases pin
+    // the fix: banner present for an incomplete job, absent for a clean one,
+    // and absent (no crash) for legacy meta lacking `stopReason` entirely.
+    // -----------------------------------------------------------------------
+    it('disk replay: surfaces the PARTIAL RESULT banner for an incomplete job (stopReason set)', async () => {
+      const { BgJobLogWriter } = await import('../../../agent/bg-job-log.js');
+      const jobId = `evicted-partial-${Date.now()}`;
+      const w = new BgJobLogWriter(jobId);
+      await w.writeMeta({
+        jobId,
+        subagentId: 'sub-evicted-partial',
+        label: 'evicted partial job',
+        promptHash: 'deadbeef',
+        model: 'sonnet',
+        startedAt: Date.now() - 5000,
+        status: 'completed',
+        endedAt: Date.now() - 1000,
+        stopReason: 'tool_use_loop_capped',
+        schemaVersion: 1,
+      });
+      w.write({
+        type: 'chunk',
+        chunk: { type: 'content', content: 'partial output text' } as any,
+      });
+      await w.close();
+
+      const registry = new BackgroundAgentRegistry({});
+      setBgsubRegistry(registry);
+      expect(registry.get(jobId)).toBeUndefined();
+
+      const { ctx, lines } = makeCtx();
+      const result = await bgsubJoinCmd.handler(ctx, jobId);
+      expect(result).toBe('continue');
+
+      const flat = lines.join('\n');
+      expect(flat).toContain('PARTIAL RESULT');
+      expect(flat).toContain('tool-use iteration cap');
+      expect(flat).toContain('partial output text');
+    });
+
+    it('disk replay: no banner for a clean completed job (stopReason set to end_turn)', async () => {
+      const { BgJobLogWriter } = await import('../../../agent/bg-job-log.js');
+      const jobId = `evicted-clean-${Date.now()}`;
+      const w = new BgJobLogWriter(jobId);
+      await w.writeMeta({
+        jobId,
+        subagentId: 'sub-evicted-clean',
+        label: 'evicted clean job',
+        promptHash: 'deadbeef',
+        model: 'sonnet',
+        startedAt: Date.now() - 5000,
+        status: 'completed',
+        endedAt: Date.now() - 1000,
+        stopReason: 'end_turn',
+        schemaVersion: 1,
+      });
+      w.write({
+        type: 'chunk',
+        chunk: { type: 'content', content: 'clean output text' } as any,
+      });
+      await w.close();
+
+      const registry = new BackgroundAgentRegistry({});
+      setBgsubRegistry(registry);
+
+      const { ctx, lines } = makeCtx();
+      const result = await bgsubJoinCmd.handler(ctx, jobId);
+      expect(result).toBe('continue');
+
+      const flat = lines.join('\n');
+      expect(flat).not.toContain('PARTIAL RESULT');
+      expect(flat).toContain('clean output text');
+    });
+
+    it('disk replay: no banner and no crash for legacy meta with no stopReason field at all', async () => {
+      const { BgJobLogWriter } = await import('../../../agent/bg-job-log.js');
+      const jobId = `evicted-legacy-${Date.now()}`;
+      const w = new BgJobLogWriter(jobId);
+      // Deliberately omit `stopReason` — mirrors meta.json written before
+      // this field existed. `schemaVersion` stays 1 (additive, backward
+      // compatible field — see BgJobMeta.stopReason doc comment).
+      await w.writeMeta({
+        jobId,
+        subagentId: 'sub-evicted-legacy',
+        label: 'evicted legacy job',
+        promptHash: 'deadbeef',
+        model: 'sonnet',
+        startedAt: Date.now() - 5000,
+        status: 'completed',
+        endedAt: Date.now() - 1000,
+        schemaVersion: 1,
+      });
+      w.write({
+        type: 'chunk',
+        chunk: { type: 'content', content: 'legacy output text' } as any,
+      });
+      await w.close();
+
+      const registry = new BackgroundAgentRegistry({});
+      setBgsubRegistry(registry);
+
+      const { ctx, lines } = makeCtx();
+      const result = await bgsubJoinCmd.handler(ctx, jobId);
+      expect(result).toBe('continue');
+
+      const flat = lines.join('\n');
+      expect(flat).not.toContain('PARTIAL RESULT');
+      expect(flat).toContain('legacy output text');
+    });
   });
 });

--- a/src/cli/slash/commands/bgsub.ts
+++ b/src/cli/slash/commands/bgsub.ts
@@ -29,6 +29,7 @@ import type { BackgroundAgentRegistry, BackgroundJob } from '../../../agent/back
 import type { BackgroundSummarizer } from '../../../agent/background-summarizer.js';
 import { BgJobLogReader } from '../../../agent/bg-job-log.js';
 import type { OutputEvent } from '../../../agent/types/session-types.js';
+import { annotateIfIncomplete } from '../../../agent/subagent/result.js';
 
 let registryRef: BackgroundAgentRegistry | undefined;
 let summarizerRef: BackgroundSummarizer | undefined;
@@ -121,9 +122,15 @@ function printJobDetail(ctx: Parameters<SlashCommand['handler']>[0], job: Backgr
   const result = job.result;
   if (result?.message?.content) {
     ctx.out.line('');
-    const text = typeof result.message.content === 'string'
+    const rawText = typeof result.message.content === 'string'
       ? result.message.content
       : JSON.stringify(result.message.content);
+    // A `completed` background job can still be a capped/stream-truncated
+    // partial (see `isIncompleteStopReason`); annotate so this replay path —
+    // the one delivery consumer that lacked the marker — matches the
+    // model-injection path (bg-result-notifier.ts) and foreground/skill/DAG
+    // delivery paths. No-op for a clean completion.
+    const text = annotateIfIncomplete(rawText, result.stopReason);
     const lines = text.split('\n').slice(0, 40);
     for (const line of lines) ctx.out.line(`  ${line}`);
     if (text.split('\n').length > 40) {

--- a/src/cli/slash/commands/bgsub.ts
+++ b/src/cli/slash/commands/bgsub.ts
@@ -29,7 +29,7 @@ import type { BackgroundAgentRegistry, BackgroundJob } from '../../../agent/back
 import type { BackgroundSummarizer } from '../../../agent/background-summarizer.js';
 import { BgJobLogReader } from '../../../agent/bg-job-log.js';
 import type { OutputEvent } from '../../../agent/types/session-types.js';
-import { annotateIfIncomplete } from '../../../agent/subagent/result.js';
+import { annotateIfIncomplete, isIncompleteStopReason } from '../../../agent/subagent/result.js';
 
 let registryRef: BackgroundAgentRegistry | undefined;
 let summarizerRef: BackgroundSummarizer | undefined;
@@ -242,6 +242,18 @@ export const bgsubJoinCmd: SlashCommand = {
     const diskMeta = await BgJobLogReader.readMeta(id);
     if (diskMeta) {
       ctx.out.info('Job evicted from memory — replaying from log.');
+      // A job persisted to disk can still be a capped/stream-truncated
+      // partial (see `isIncompleteStopReason`); surface the same
+      // `[⚠ PARTIAL RESULT…]` marker the in-memory replay applies above
+      // (printJobDetail) from the persisted `stopReason`, so joining the
+      // same job before vs. after TTL eviction labels it identically.
+      // `annotateIfIncomplete` is a no-op for a clean completion or an
+      // absent stopReason — the latter covers legacy meta written before
+      // `BgJobMeta.stopReason` existed, so no crash and no spurious banner.
+      if (isIncompleteStopReason(diskMeta.stopReason)) {
+        ctx.out.line(`  ${annotateIfIncomplete('', diskMeta.stopReason).trimEnd()}`);
+        ctx.out.line('');
+      }
       let lineCount = 0;
       for await (const event of BgJobLogReader.readEvents(id)) {
         const text = formatDiskEvent(event);


### PR DESCRIPTION
## Why

Two prior fixes for the "subagent returns a partial result" class — #628 (zero-output streams now fail instead of silently succeeding) and #678 (bounded stream-incomplete retry + handoff contract) — **looked successful for weeks because no discriminating signal was ever recorded.**

Measured against `~/.afk/agent-framework/routing-decisions.jsonl`:

- `stop_reason` appears on **0 of 14,152** `subagent.completed` rows.
- **55 of 119** sub-200-char completions had run **≥10 tool calls** — worst cases 176, 166 and 148 tool calls returning 115–193 chars.
- Rate of that shape rose from a ≤0.49%/week baseline to **1.54%** in 2026-W27.

A short subagent result is currently indistinguishable across three paths:

| Path | `stopReason` | Surfaces as |
|---|---|---|
| stream cut off mid-flight, some text buffered | `stream_incomplete` | `succeeded` |
| tool-loop cap fired → wind-down synthesis | `tool_use_loop_capped` | `succeeded` |
| model genuinely answered briefly | *(none)* | `succeeded` |

`#628`'s guard genuinely holds — zero-char completions are 0/14,152 — but **near-zero was never guarded**, and nothing recorded which of the three paths produced a given short answer. This PR makes them separable.

## What changed

**1. `stop_reason` on terminal telemetry rows.** Added `RoutingDecisionEntry.stop_reason?: string` (snake_case, matching the `duration_ms` / `content_chars` siblings), omitted when absent — never `null`/`''`. Populated at every terminal emit site: `background-registry.ts` `markTerminal` (all three of completed/failed/cancelled) **and** `foreground-promotion.ts` (completed + the in-band failed emit), since the large majority of dispatches flow through the foreground path. The catch-block failed emit has no `SubagentResult` in scope and is left as-is.

**2. Partial banner on the `/bgsub:join` replay path.** `bgsub.ts` `printJobDetail` read `result.message.content` raw, so a manual join replayed a truncated background result with no marker. It was the only delivery consumer lacking one — the auto-injection path (`bg-result-notifier.ts:91`) already annotates.

> `markTerminal` deliberately does **not** annotate: it is an observation site that never mutates `result`, and `bg-result-notifier` already annotates the same `job.result` at injection time. `annotateIfIncomplete` is not idempotent, so annotating in both places would double-prepend the banner.

**3. Structured `incomplete` flag alongside the prose banner.** `ToolResult.incomplete?: boolean` + `incompleteReason?: string`, spread via a new `incompleteToolResultFields()` helper derived from the existing `isIncompleteStopReason` (predicate not duplicated).

- Named `incomplete`, **not** `truncated` — `ToolResult.truncated` already means tool-**output** byte-cap truncation (bash/grep/web-scrape) and is orthogonal; a subagent result can be incomplete while far under any byte cap.
- The `[⚠ PARTIAL RESULT…]` prose banner **stays** — existing consumers depend on it as the in-band model-visible signal. The flag is additive, so non-model consumers (trace readers, hooks, calling code) can branch without substring-matching banner text.
- Applied at both `ToolResult`-bearing delivery sites (`foreground-promotion`, `fork-dispatch`). `dag-subagent` returns a bare string rather than a `ToolResult`, so it correctly keeps the prose banner only.

**4. Tests.** Extended the existing `describe('routing-telemetry events (A1)')` block in `background-registry.test.ts` (stop_reason present/absent across all three terminal branches; `content_chars` unaffected by annotation) and added 2 cases to `routing-telemetry.test.ts` pinning carry + omission against the real `buildRoutingDecisionRow`.

> Key-absence is asserted in `routing-telemetry.test.ts` rather than `background-registry.test.ts` because the latter mocks `appendRoutingDecision` wholesale, so the pre-strip entry still carries the key with an `undefined` value. The real `buildRoutingDecisionRow` strips undefined fields (`if (v !== undefined) row[k] = v`), which is where that invariant belongs.

All changes are additive and backward-compatible; no existing consumer behavior changes.

## Verification

| Gate | Result |
|---|---|
| `pnpm lint` | clean (`tsc --noEmit`) |
| `pnpm test src/agent/routing-telemetry.test.ts` | `Tests  9 passed (9)` |
| `pnpm test src/agent/background-registry.test.ts` | `Tests  53 passed (53)` |
| `pnpm test src/agent/subagent/result.test.ts` | `Tests  19 passed (19)` |
| `pnpm test src/agent/tools/subagent/foreground-promotion.test.ts` | `Tests  5 passed (5)` |
| `pnpm build` | clean (`tsc` + `copy-prompts`) |
| `pnpm test` (full) | **`Test Files 701 passed (701)` / `Tests 13124 passed \| 14 skipped`** |

Local note: the worktree was installed with `--ignore-scripts` (the root `postinstall` kickstarts live launchd services), which leaves `better-sqlite3`'s native binding unbuilt and makes 214 unrelated test files fail at collection with `Could not locate the bindings file`. `pnpm rebuild better-sqlite3` fixes it; the full-suite result above is post-rebuild. CI does a normal install and is unaffected.

## Follow-ups (deliberately not in this PR)

1. **Split the two conflated "no terminal message" error classes.** `translate.ts:317-327` (true stream cutoff, 38 events) and `handle.ts:518` (cascade kill, 132 events / 104 cancelled) share the same wording and land in the same bucket, inflating cutoff counts ~4×. They want distinct failure codes.
2. **Record `streamIncompleteRetries` on the failure row.** The retry branch at `loop.ts:598-618` emits no telemetry, so a run that retried twice and died is indistinguishable from one that never retried — which is precisely why #678's effectiveness was unmeasurable.
3. **Reconsider #678's mitigation target.** `SUBAGENT_HANDOFF_CONTRACT` shrinks the child's *final reply*, but the upstream trigger documented in [anthropic-sdk-typescript#842](https://github.com/anthropics/anthropic-sdk-typescript/issues/842) is large **tool_use argument JSON** — a different payload. Post-#678 cutoff rate did not improve (2.94% → 4.12%).
