### PR TITLE
fix(dispatcher): emit hook_decision for silently-denied tool calls, attribute blocks to forks

### DIFF
--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -344,6 +344,13 @@ export class AnthropicDirectProvider implements ModelProvider {
       sessionId?: string;
       parentSessionId?: string;
       /**
+       * This fork's own subagent id. Stamped onto every `hook_decision` the
+       * dispatcher emits so a policy block is attributable to the child that
+       * provoked it (parity with what `tool_call` already records). Undefined on
+       * a top-level session.
+       */
+      subagentId?: string;
+      /**
        * Explicit "this session is a forked subagent" signal carrying the
        * per-result output-cap budget (#661). Set to MODEL_CAP_BYTES by
        * `SubagentManager.forkSubagent` for EVERY fork; undefined on a top-level
@@ -492,6 +499,7 @@ export class AnthropicDirectProvider implements ModelProvider {
       ...(opts?.env !== undefined ? { env: opts.env } : {}),
       sessionId: opts?.sessionId,
       parentSessionId: opts?.parentSessionId,
+      ...(opts?.subagentId !== undefined ? { subagentId: opts.subagentId } : {}),
       // Central output-cap backstop (#661), FORK-SCOPED. Armed from the
       // explicit `subagentToolOutputCapBytes` signal that
       // `SubagentManager.forkSubagent` stamps (as MODEL_CAP_BYTES = 100KB) on
@@ -748,6 +756,7 @@ export class AnthropicDirectProvider implements ModelProvider {
           ...(config.env !== undefined ? { env: config.env } : {}),
           sessionId: config.sessionId,
           parentSessionId: config.parentSessionId,
+          ...(config.subagentId !== undefined ? { subagentId: config.subagentId } : {}),
           // Fork-scoped central output cap (#661): forwarded from the child
           // config that forkSubagent stamped, arming maxOutputBytes for forks
           // only (top-level leaves it unset).

--- a/src/agent/providers/openai-compatible/index.ts
+++ b/src/agent/providers/openai-compatible/index.ts
@@ -240,6 +240,7 @@ export class OpenAICompatibleProvider implements ModelProvider {
           ...(this._sharedWriteRoots !== undefined ? { writeRoots: this._sharedWriteRoots } : {}),
           ...(config.sessionId !== undefined ? { sessionId: config.sessionId } : {}),
           ...(config.parentSessionId !== undefined ? { parentSessionId: config.parentSessionId } : {}),
+          ...(config.subagentId !== undefined ? { subagentId: config.subagentId } : {}),
           // Fork-scoped central output cap (#661): forwarded from the child
           // config that forkSubagent stamped, arming maxOutputBytes for forks
           // only (top-level leaves it unset). Parity with anthropic-direct.
@@ -359,6 +360,13 @@ export class OpenAICompatibleProvider implements ModelProvider {
       writeRoots?: string[];
       sessionId?: string;
       parentSessionId?: string;
+      /**
+       * This fork's own subagent id — parity with
+       * `anthropic-direct/index.ts:buildDispatcher`. Stamped onto every
+       * `hook_decision` the dispatcher emits so a policy block is attributable
+       * to the child that provoked it. Undefined on a top-level session.
+       */
+      subagentId?: string;
       /**
        * Explicit "this session is a forked subagent" signal carrying the
        * per-result output-cap budget (#661) — parity with
@@ -507,6 +515,7 @@ export class OpenAICompatibleProvider implements ModelProvider {
     if (opts.writeRoots !== undefined) dispatcherOpts.writeRoots = opts.writeRoots;
     if (opts.sessionId !== undefined) dispatcherOpts.sessionId = opts.sessionId;
     if (opts.parentSessionId !== undefined) dispatcherOpts.parentSessionId = opts.parentSessionId;
+    if (opts.subagentId !== undefined) dispatcherOpts.subagentId = opts.subagentId;
     // Central output-cap backstop (#661), FORK-SCOPED — parity with
     // AnthropicDirectProvider.buildDispatcher. Armed from the explicit
     // `subagentToolOutputCapBytes` signal that `SubagentManager.forkSubagent`

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -162,6 +162,13 @@ export interface SessionToolDispatcherOptions {
    */
   parentSessionId?: string;
   /**
+   * This fork's own subagent id, when the dispatcher belongs to a forked child.
+   * Stamped onto every `hook_decision` this dispatcher emits so a block can be
+   * ATTRIBUTED to the child that provoked it, mirroring what `tool_call`
+   * already records. Undefined for top-level sessions.
+   */
+  subagentId?: string;
+  /**
    * The PROVIDER that owns this dispatcher (it implements {@link GrantManager}).
    * The provider's `buildDispatcher` passes `this`; the dispatcher injects it
    * onto every PreToolUse/PostToolUse context as `context.grantManager` so
@@ -244,6 +251,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
   private readonly _env: Record<string, string> | undefined;
   private readonly sessionId: string | undefined;
   private readonly parentSessionId: string | undefined;
+  private readonly subagentId: string | undefined;
   /**
    * Provider that owns this dispatcher (implements GrantManager). Injected onto
    * PreToolUse/PostToolUse contexts so path-scoped hooks read THIS session's
@@ -323,6 +331,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
     this._env = opts.env;
     this.sessionId = opts.sessionId;
     this.parentSessionId = opts.parentSessionId;
+    this.subagentId = opts.subagentId;
     this.sessionGrantManager = opts.sessionGrantManager;
     this.traceWriter = opts.traceWriter;
     this.readOnlyBash = opts.readOnlyBash === true;
@@ -537,7 +546,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
    * as a no-op pass-through (the handler will surface its own validation
    * error), so we never throw here.
    */
-  private checkReadOnlyBash(call: ToolCall): ToolResult | null {
+  private async checkReadOnlyBash(call: ToolCall): Promise<ToolResult | null> {
     if (!this.readOnlyBash || call.name !== 'bash') return null;
     const input = call.input;
     const command =
@@ -547,14 +556,39 @@ export class SessionToolDispatcher implements ToolDispatcher {
     if (typeof command !== 'string') return null;
     const verdict = classifyBashCommand(command);
     if (!verdict.mutating) return null;
-    return {
-      content:
-        `Bash command blocked: read-only skill may not run mutating commands ` +
-        `(${verdict.reason ?? 'mutation detected'}). Allowed: read-only recon ` +
-        `(git status/log/diff, ls, cat, find, grep).`,
-      isError: true,
-      failureClass: 'permission-denied',
-    };
+    // Reason text is shared by the model-visible result and the trace event so
+    // the two can never drift; the command string itself is deliberately NOT
+    // recorded (ADR 0001 §G.4 keeps raw commands out of telemetry).
+    const reason =
+      `Bash command blocked: read-only skill may not run mutating commands ` +
+      `(${verdict.reason ?? 'mutation detected'}). Allowed: read-only recon ` +
+      `(git status/log/diff, ls, cat, find, grep).`;
+    await this.emitPreToolUseBlock(call.name, reason);
+    return { content: reason, isError: true, failureClass: 'permission-denied' };
+  }
+
+  /**
+   * Emit a PreToolUse `hook_decision` block, stamped with this dispatcher's
+   * `subagentId` when it belongs to a fork.
+   *
+   * Invariant: EVERY path that returns an isError {@link ToolResult} to the
+   * model for a POLICY reason must call this. A denial the model can see but the
+   * trace cannot is unattributable after the fact — child tool arguments and
+   * error text are persisted nowhere, so this event is the only durable record
+   * that the denial happened and which child provoked it. Three sites
+   * (read-only bash gate, and the static allowlist check on both the single and
+   * batch paths) previously returned silently; an audit of 12,108 traces
+   * (2026-07-26) consequently misattributed 268 child `bash` denials to path
+   * containment when they came from the read-only gate.
+   */
+  private async emitPreToolUseBlock(blockedTool: string, reason: string): Promise<void> {
+    await emitHookDecision(this.traceWriter, {
+      hookEvent: 'PreToolUse',
+      decision: 'block',
+      blockedTool,
+      reason,
+      ...(this.subagentId !== undefined ? { subagentId: this.subagentId } : {}),
+    });
   }
 
   /**
@@ -713,34 +747,16 @@ export class SessionToolDispatcher implements ToolDispatcher {
     } catch (err) {
       // Fail closed: a throwing policy denies the call rather than crashing the
       // turn. The message names the cause so the denial is never silent.
-      await emitHookDecision(this.traceWriter, {
-        hookEvent: 'PreToolUse',
-        decision: 'block',
-        blockedTool: call.name,
-        reason: `Tool "${call.name}" denied by canUseTool (threw): ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      });
-      return {
-        content: `Tool "${call.name}" denied by canUseTool (threw): ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-        isError: true,
-        failureClass: 'permission-denied',
-      };
+      const reason = `Tool "${call.name}" denied by canUseTool (threw): ${
+        err instanceof Error ? err.message : String(err)
+      }`;
+      await this.emitPreToolUseBlock(call.name, reason);
+      return { content: reason, isError: true, failureClass: 'permission-denied' };
     }
     if (result.behavior === 'deny') {
-      await emitHookDecision(this.traceWriter, {
-        hookEvent: 'PreToolUse',
-        decision: 'block',
-        blockedTool: call.name,
-        reason: result.message || `Tool "${call.name}" denied by permission policy`,
-      });
-      return {
-        content: result.message || `Tool "${call.name}" denied by permission policy`,
-        isError: true,
-        failureClass: 'permission-denied',
-      };
+      const reason = result.message || `Tool "${call.name}" denied by permission policy`;
+      await this.emitPreToolUseBlock(call.name, reason);
+      return { content: reason, isError: true, failureClass: 'permission-denied' };
     }
     // allow — apply an optional input rewrite in place.
     if (result.updatedInput !== undefined) {
@@ -791,11 +807,9 @@ export class SessionToolDispatcher implements ToolDispatcher {
     // 2. Permission check
     const permResult = checkToolPermission(call.name, this.permissions);
     if (!permResult.allowed) {
-      return {
-        content: permResult.reason ?? `Tool "${call.name}" is not permitted`,
-        isError: true,
-        failureClass: 'permission-denied',
-      };
+      const reason = permResult.reason ?? `Tool "${call.name}" is not permitted`;
+      await this.emitPreToolUseBlock(call.name, reason);
+      return { content: reason, isError: true, failureClass: 'permission-denied' };
     }
 
     // 2a. In-process permission callback (canUseTool). Consulted AFTER the
@@ -807,7 +821,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
     // 2b. Read-only-skill bash gate. Runs after the permission check so the
     // allowlist denial (if any) takes precedence; blocks mutating bash while
     // letting read-only recon through.
-    const bashBlock = this.checkReadOnlyBash(call);
+    const bashBlock = await this.checkReadOnlyBash(call);
     if (bashBlock) return bashBlock;
 
     // 2c. Repeat-loop circuit breaker. Short-circuits no-progress loops where
@@ -897,11 +911,9 @@ export class SessionToolDispatcher implements ToolDispatcher {
 
       const permResult = checkToolPermission(call.name, this.permissions);
       if (!permResult.allowed) {
-        results[i] = {
-          content: permResult.reason ?? `Tool "${call.name}" is not permitted`,
-          isError: true,
-          failureClass: 'permission-denied',
-        };
+        const reason = permResult.reason ?? `Tool "${call.name}" is not permitted`;
+        await this.emitPreToolUseBlock(call.name, reason);
+        results[i] = { content: reason, isError: true, failureClass: 'permission-denied' };
         blocked.add(i);
         continue;
       }
@@ -919,7 +931,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
       // Read-only-skill bash gate — mirror the permission-denied branch:
       // set the result and add to `blocked` so this call is excluded from
       // execution in phase 2.
-      const bashBlock = this.checkReadOnlyBash(call);
+      const bashBlock = await this.checkReadOnlyBash(call);
       if (bashBlock) {
         results[i] = bashBlock;
         blocked.add(i);

--- a/src/agent/tools/subagent/child-config.test.ts
+++ b/src/agent/tools/subagent/child-config.test.ts
@@ -30,6 +30,9 @@ import { buildChildConfig, type BuildChildConfigArgs } from './child-config.js';
 import { SUBAGENT_HANDOFF_CONTRACT } from '../../subagent-contract.js';
 import { InMemoryTraceWriter } from '../../trace/writer.js';
 import type { AgentInput } from './input-parse.js';
+import { buildInitialState } from '../../session/session-setup.js';
+import { pathContainmentBypassed } from '../../permission-policy.js';
+import { DEFAULT_CLI_PERMISSION_MODE } from '../../../cli/config/types.js';
 import type { RegisteredAgent } from '../../agents/index.js';
 import type { ModelProvider } from '../../provider.js';
 import type { SubagentExecutor, SubagentExecutorContext } from '../subagent-executor.js';
@@ -569,5 +572,36 @@ describe('buildChildConfig', () => {
       expect(childManager).toBeUndefined();
       expect(childConfig.provider).toBeDefined();
     });
+  });
+});
+
+describe('permission-mode inheritance (ADR-0001 premise — previously pinned by ZERO tests)', () => {
+  // Invariant: a forked child must NOT inherit a bypassed parent's permission
+  // mode. docs/decisions/0001-bash-tool-path-containment.md states the premise
+  // outright ("Forked sub-agents run permissionMode = 'default' — they do not
+  // inherit bypass"), and both that ADR's warn-only reasoning and the
+  // path-approval hook's fork auto-deny depend on it. An audit on 2026-07-26
+  // found the premise relied on by three documents and asserted by no test, so
+  // an accidental flip in EITHER direction — a child silently gaining bypass, or
+  // a top-level surface silently losing it — would have shipped green.
+  it('never sets permissionMode on the child config', () => {
+    const { childConfig } = buildChildConfig(baseArgs());
+    expect(childConfig.permissionMode).toBeUndefined();
+  });
+
+  it('resolves an unset child permissionMode to "default" (containment ON)', () => {
+    const { childConfig } = buildChildConfig(baseArgs());
+    const { metadata } = buildInitialState(childConfig, 'sonnet');
+    expect(metadata.permissionMode).toBe('default');
+  });
+
+  it('leaves the child contained even though every top-level surface defaults to bypass', () => {
+    // Parent side: the CLI default really is a containment-disabling mode.
+    expect(DEFAULT_CLI_PERMISSION_MODE).toBe('bypassPermissions');
+    expect(pathContainmentBypassed(DEFAULT_CLI_PERMISSION_MODE)).toBe(true);
+    // Child side: resolves to 'default', which does NOT disable containment.
+    const { childConfig } = buildChildConfig(baseArgs());
+    const { metadata } = buildInitialState(childConfig, 'sonnet');
+    expect(pathContainmentBypassed(metadata.permissionMode)).toBe(false);
   });
 });

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -86,6 +86,8 @@ export const HookDecisionPayloadSchema = z.object({
   decision: z.union([z.literal('block'), z.literal('approve')]).optional(),
   reason: z.string().optional(),
   blockedTool: z.string().optional(),
+  /** Present when the decision was made inside a fork; absent at top level. */
+  subagentId: z.string().optional(),
   injectedContextBytes: z.number().int().nonnegative().optional(),
   /** Set only by the AFK high-risk approval gate. Wall-clock ms from gate entry to decision. */
   durationMs: z.number().nonnegative().optional(),

--- a/src/agent/trace/types.ts
+++ b/src/agent/trace/types.ts
@@ -182,6 +182,18 @@ export interface HookDecisionPayload {
   reason?: string;
   /** Set only when `hookEvent === 'PreToolUse'` and `decision === 'block'`. */
   blockedTool?: string;
+  /**
+   * Present when the decision was made inside a fork — mirrors
+   * {@link ToolCallStartedPayload.subagentId} so a block can be attributed to
+   * the child that provoked it. Absent on top-level decisions.
+   *
+   * History: without this, a denial could only be counted, never attributed. An
+   * audit of 12,108 traces (2026-07-26) misattributed 268 child `bash` denials
+   * to path containment because the dominant source — the read-only bash gate —
+   * emitted no event at all and nothing tied blocks to a child. See
+   * docs/decisions/0001-bash-tool-path-containment.md for the containment model.
+   */
+  subagentId?: string;
   /** Set only when the hook returned `injectContext`. */
   injectedContextBytes?: number;
   /** Set only by the AFK high-risk approval gate. Wall-clock ms from gate entry to decision. */


### PR DESCRIPTION
## Problem

Three dispatcher paths returned an `isError` `ToolResult` to the model for a **policy** reason without emitting any `hook_decision` trace event:

- `checkReadOnlyBash` — the read-only-skill bash gate
- `checkToolPermission` on the single-dispatch path
- `checkToolPermission` on the batch path

A denial the model could see was invisible in the trace.

Separately, `hook_decision` carried no `subagentId`, so a block could be **counted** but never **attributed** to the child that provoked it — even though `tool_call` has carried `subagentId` since #612.

## Why it matters

Together these made sub-agent failures effectively unattributable after the fact. Child tool arguments and error text are not persisted anywhere, so the trace event is the only durable record that a denial happened.

Concretely: an audit of 12,108 witness traces attributed 268 child `bash permission-denied` events to path containment. Re-attributing them by child `agentType` showed **255 of 268 (95%) came from the read-only bash gate firing on `git-investigator`** — a deliberately read-only agent — at 5.7% of its 4,459 bash calls. That is the gate working as designed, and the agent then complying with its remediation text. The original reading (children evading a path-containment guard) was wrong, and it was wrong *because* the dominant denial source emitted no event and nothing tied blocks to a child.

With these two changes the same question is a single query.

## Changes

- Add `HookDecisionPayload.subagentId` (+ matching zod schema field) and thread it from both providers (`anthropic-direct`, `openai-compatible`) through `SessionToolDispatcher`, mirroring the existing fork-scoped-signal pattern.
- Route **all five** PreToolUse block emissions through one new `emitPreToolUseBlock` helper, so no call site can forget the stamp. The two pre-existing emit sites (canUseTool threw / canUseTool deny) gain `subagentId` as a side effect.
- Share a single `reason` string between the model-visible result and the trace event so the two cannot drift.
- Pin the ADR-0001 fork permission-inheritance premise with tests.

### Privacy

Raw command strings stay out of telemetry, per ADR 0001 section G.4. The emitted `reason` is the same policy explanation already returned to the model; the `bash` command itself is never recorded.

### Behavior

**No behavior change for the model.** Every denial's `content` string is byte-identical to before — the refactor only hoists it into a `reason` const shared with the new trace event.

## Tests

Adds a `permission-mode inheritance (ADR-0001 premise)` block to `child-config.test.ts`. This premise — a forked child never inherits a bypassed parent's `permissionMode` — is stated in `docs/decisions/0001-bash-tool-path-containment.md` and relied on both by that ADR's warn-only reasoning and by the path-approval hook's fork auto-deny, but was asserted by **zero** tests. An accidental flip in either direction (a child silently gaining bypass, or a top-level surface silently losing it) would previously have shipped green.

Three assertions:
1. `buildChildConfig` never sets `permissionMode` on the child config
2. an unset child `permissionMode` resolves to `'default'` (containment ON)
3. `pathContainmentBypassed(DEFAULT_CLI_PERMISSION_MODE)` is `true` while the child's resolved mode is `false`

## Verification

| gate | result |
|---|---|
| `pnpm lint` (`tsc --noEmit`) | clean |
| full suite | 701 files, 13,118 passed, 14 skipped, 0 failed |
| `pnpm audit:env:check` | 0 violations |
| `pnpm scan:env:check` | in sync |
| `pnpm audit:sdk:check` | lock matches |
| coverage | 87.09 stmts / 85.15 branch / 91.25 funcs / 87.09 lines (floors 74 / 79 / 82 / 74) |

## Follow-ups (not in this PR)

- Persisting child tool args / error text is the remaining half of the observability gap, but it carries a telemetry-privacy decision (ADR 0001 section G.4 deliberately excludes raw commands). Suggested shape: error text plus a credential-scrubbed argument head, not raw args.
- Deliberately **not** widening the denial circuit breaker to `bash`. It currently cannot fire on the dominant denial family, but that family is `git-investigator` correctly probing an intentional read-only boundary — a 5-strike breaker would abort legitimate read-only investigations mid-flight.
- `git-investigator` spends ~5.7% of its bash budget rediscovering the read-only boundary; tightening its prompt or pre-filtering its command set would recover that. Agent tuning, not containment.
