### PR TITLE
fix(worktree): reap shipped worktrees and stop deleting branches that hold commits

### DIFF
--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -695,7 +695,18 @@ export const worktreeTool: AnthropicToolDef = {
     'in days. Verdicts empty/dead-owner/orphaned-* are removal candidates on the next sweep.\n' +
     '- `remove` — remove a worktree checkout you no longer need (branch ref is always preserved). ' +
     'Refuses dirty trees, locked trees, and trees with commits ahead of base unless `force: true`. ' +
-    'Never removes the main worktree or paths outside `.afk-worktrees/`.',
+    'Never removes the main worktree or paths outside `.afk-worktrees/`.\n\n' +
+    'Finishing with a worktree: a worktree is scaffolding, not an artifact — once its work has landed ' +
+    'somewhere durable (pushed branch, open PR, merged commit), remove it in the same turn instead of ' +
+    'leaving it for the sweep. Two cases differ:\n' +
+    '- A worktree you created for a subagent, or one an `isolation: "worktree"` child left behind: ' +
+    'after its commits are pushed, the branch ref holds the work, so the checkout is dead weight. If ' +
+    'it was preserved with commits-ahead it is LOCKED, and a locked worktree is never reaped — call ' +
+    '`release` first, then `remove` (remove refuses a locked tree, so the order is mandatory).\n' +
+    '- The worktree you are RUNNING IN (your own cwd): never remove it mid-session. Deleting your own ' +
+    'working directory strands every later tool call on a path that no longer exists. Session-end ' +
+    'cleanup already removes it when the tree is clean — just tell the operator it will be reclaimed ' +
+    'on exit, and name the branch holding the work.',
   input_schema: {
     type: 'object',
     properties: {

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -702,7 +702,10 @@ export const worktreeTool: AnthropicToolDef = {
     '- A worktree you created for a subagent, or one an `isolation: "worktree"` child left behind: ' +
     'after its commits are pushed, the branch ref holds the work, so the checkout is dead weight. If ' +
     'it was preserved with commits-ahead it is LOCKED, and a locked worktree is never reaped — call ' +
-    '`release` first, then `remove` (remove refuses a locked tree, so the order is mandatory).\n' +
+    '`release` first, then `remove` (remove refuses a locked tree, so the order is mandatory). ' +
+    '`remove` also refuses a tree with commits ahead of base unless `force: true`; once the branch is ' +
+    'pushed that force is safe, because remove never deletes the branch ref — the commits stay on the ' +
+    'branch and on the remote, and only the directory goes away.\n' +
     '- The worktree you are RUNNING IN (your own cwd): never remove it mid-session. Deleting your own ' +
     'working directory strands every later tool call on a path that no longer exists. Session-end ' +
     'cleanup already removes it when the tree is clean — just tell the operator it will be reclaimed ' +

--- a/src/agent/worktree-sweep.test.ts
+++ b/src/agent/worktree-sweep.test.ts
@@ -643,6 +643,14 @@ describe('base-sha-fallback', () => {
       if (args.includes('status') && args.includes('--porcelain')) {
         return { stdout: '', stderr: '' }; // clean
       }
+      if (args.includes('rev-list') && args.some((a) => a.includes('@{upstream}'))) {
+        // Model real git: this branch has no configured upstream, so
+        // `rev-list @{upstream}..HEAD` exits non-zero. The sweep must fail
+        // safe here and keep commitsUnpushed === commitsAhead, preserving the
+        // tree. Matched BEFORE the generic rev-list branch below, which would
+        // otherwise answer this query with the base-comparison count.
+        throw new Error("fatal: no upstream configured for branch 'afk/nobase-ahead'");
+      }
       if (args.includes('rev-list') && args.includes('--count')) {
         // The fix counts commits reachable from the worktree HEAD but NOT from
         // main (`--not`). The old self-comparing fallback (base === head) would
@@ -1781,5 +1789,260 @@ describe('stale-clean liveness guard (Codex review, PR #432)', () => {
     expect(
       result.warnings.some((w) => w.includes('stale-clean') && w.includes(worktreePath)),
     ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pushed-commits reaping — a shipped worktree stops being sacred
+// ---------------------------------------------------------------------------
+
+describe('pushed-commits reaping', () => {
+  /** A PID the kernel agrees does not exist, so ownerLiveness resolves 'dead'. */
+  function findDeadPid(): number {
+    for (let pid = 999_999; pid > 90_000; pid -= 1_117) {
+      try {
+        process.kill(pid, 0);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ESRCH') return pid;
+      }
+    }
+    throw new Error('Could not find a dead PID for test setup');
+  }
+
+  /**
+   * Build a sweep fixture for a clean worktree holding `commitsAhead` commits
+   * past its recorded base, of which `unpushed` are not on the remote.
+   * `unpushed: 'no-upstream'` models a branch with no tracking ref, where real
+   * git exits non-zero on `rev-list @{upstream}..HEAD`.
+   */
+  async function fixture(opts: {
+    name: string;
+    ageMs: number;
+    pid?: number;
+    commitsAhead: number;
+    unpushed: number | 'no-upstream';
+  }) {
+    const worktreePath = join(afkWorktreesDir, opts.name);
+    await fs.mkdir(worktreePath, { recursive: true });
+    await fs.writeFile(
+      join(worktreePath, '.afk-worktree-meta.json'),
+      JSON.stringify({
+        owner: 'agent',
+        ...(opts.pid !== undefined ? { pid: opts.pid } : {}),
+        createdAt: new Date(Date.now() - opts.ageMs).toISOString(),
+        baseSha: 'basesha000',
+      }),
+    );
+
+    const porcelainOut =
+      `${worktreeBlock({ path: repoRoot, head: 'mainsha111' })}\n\n` +
+      `${worktreeBlock({
+        path: worktreePath,
+        head: 'wtsha222',
+        branch: `refs/heads/afk/${opts.name}`,
+      })}\n`;
+
+    const mock = makeMock(async ({ args }) => {
+      if (args.includes('list') && args.includes('--porcelain')) {
+        return { stdout: porcelainOut, stderr: '' };
+      }
+      if (args.includes('status') && args.includes('--porcelain')) {
+        return { stdout: '', stderr: '' }; // clean
+      }
+      if (args.includes('rev-list') && args.some((a) => a.includes('@{upstream}'))) {
+        if (opts.unpushed === 'no-upstream') {
+          throw new Error('fatal: no upstream configured for branch');
+        }
+        return { stdout: `${opts.unpushed}\n`, stderr: '' };
+      }
+      if (args.includes('rev-list') && args.includes('--count')) {
+        return { stdout: `${opts.commitsAhead}\n`, stderr: '' };
+      }
+      return { stdout: '', stderr: '' };
+    });
+
+    return { worktreePath, mock };
+  }
+
+  it('reaps a clean worktree whose commits are all pushed (dead owner)', async () => {
+    // The /ship case: work committed, branch pushed, PR opened, session died.
+    // The commits live on the remote and `git worktree remove` preserves the
+    // branch ref, so the checkout is disposable.
+    const { worktreePath, mock } = await fixture({
+      name: 'afk-shipped',
+      ageMs: 5 * 60_000,
+      pid: findDeadPid(),
+      commitsAhead: 3,
+      unpushed: 0,
+    });
+
+    const result = await runSweep({
+      execFile: mock as ExecFileFn,
+      repoRoot,
+      lockPath: lockFile,
+      dryRun: false,
+      telemetryPath: telemetryFile,
+    });
+
+    const verdict = result.candidates.find((c) => c.path === worktreePath)?.verdict;
+    expect(verdict).toBe('dead-owner');
+    expect(result.removed).toContain(worktreePath);
+  });
+
+  it('reaps a clean fully-pushed worktree past the empty age gate (no pid)', async () => {
+    const { worktreePath, mock } = await fixture({
+      name: 'afk-shipped-old',
+      ageMs: 3 * 3_600_000, // 3h — past MIN_EMPTY_AGE_MS
+      commitsAhead: 2,
+      unpushed: 0,
+    });
+
+    const result = await runSweep({
+      execFile: mock as ExecFileFn,
+      repoRoot,
+      lockPath: lockFile,
+      dryRun: false,
+      telemetryPath: telemetryFile,
+    });
+
+    const verdict = result.candidates.find((c) => c.path === worktreePath)?.verdict;
+    expect(verdict).toBe('empty');
+    expect(result.removed).toContain(worktreePath);
+  });
+
+  it('NEVER runs `git branch -d` when reaping a pushed worktree', async () => {
+    // Regression guard for the hole found in review: `git branch -d` deletes a
+    // branch that is merged to its UPSTREAM, which is exactly the state a
+    // pushed worktree is in. Verified against real git: it exits 0 with
+    // "merged to refs/remotes/origin/X, but not yet merged to HEAD". If the
+    // remote branch is later deleted and the tracking ref pruned, those commits
+    // become reachable from nothing. The branch ref is the last copy — keep it.
+    const { worktreePath, mock } = await fixture({
+      name: 'afk-shipped-keepbranch',
+      ageMs: 5 * 60_000,
+      pid: findDeadPid(),
+      commitsAhead: 3,
+      unpushed: 0,
+    });
+
+    const result = await runSweep({
+      execFile: mock as ExecFileFn,
+      repoRoot,
+      lockPath: lockFile,
+      dryRun: false,
+      telemetryPath: telemetryFile,
+    });
+
+    expect(result.removed).toContain(worktreePath);
+    const branchDeletes = mock.calls.filter(
+      (c) => c.args.includes('branch') && c.args.includes('-d'),
+    );
+    expect(branchDeletes).toHaveLength(0);
+    // ...and the operator is told the branch survived, so the reap is legible.
+    expect(
+      result.warnings.some(
+        (w) => w.includes('branch preserved') && w.includes(worktreePath),
+      ),
+    ).toBe(true);
+  });
+
+  it('still deletes the branch when the reaped tree had no commits at all', async () => {
+    // The pre-existing behavior must not regress: a genuinely empty tree's
+    // throwaway branch is still cleaned up.
+    const { worktreePath, mock } = await fixture({
+      name: 'afk-truly-empty',
+      ageMs: 5 * 60_000,
+      pid: findDeadPid(),
+      commitsAhead: 0,
+      unpushed: 0,
+    });
+
+    const result = await runSweep({
+      execFile: mock as ExecFileFn,
+      repoRoot,
+      lockPath: lockFile,
+      dryRun: false,
+      telemetryPath: telemetryFile,
+    });
+
+    expect(result.removed).toContain(worktreePath);
+    const branchDeletes = mock.calls.filter(
+      (c) => c.args.includes('branch') && c.args.includes('-d'),
+    );
+    expect(branchDeletes.length).toBeGreaterThan(0);
+  });
+
+  it('PRESERVES a worktree with unpushed commits (dead owner)', async () => {
+    // The guard that must not regress: one unpushed commit means this checkout
+    // is the only place that work exists.
+    const { worktreePath, mock } = await fixture({
+      name: 'afk-unpushed',
+      ageMs: 5 * 60_000,
+      pid: findDeadPid(),
+      commitsAhead: 3,
+      unpushed: 1,
+    });
+
+    const result = await runSweep({
+      execFile: mock as ExecFileFn,
+      repoRoot,
+      lockPath: lockFile,
+      dryRun: false,
+      telemetryPath: telemetryFile,
+    });
+
+    const verdict = result.candidates.find((c) => c.path === worktreePath)?.verdict;
+    expect(verdict).not.toBe('dead-owner');
+    expect(verdict).not.toBe('empty');
+    expect(result.removed).not.toContain(worktreePath);
+  });
+
+  it('PRESERVES a worktree with no upstream configured (fail-safe)', async () => {
+    // Any failure reading the upstream must leave commitsUnpushed at
+    // commitsAhead, reproducing pre-change behavior exactly.
+    const { worktreePath, mock } = await fixture({
+      name: 'afk-no-upstream',
+      ageMs: 3 * 3_600_000,
+      pid: findDeadPid(),
+      commitsAhead: 4,
+      unpushed: 'no-upstream',
+    });
+
+    const result = await runSweep({
+      execFile: mock as ExecFileFn,
+      repoRoot,
+      lockPath: lockFile,
+      dryRun: false,
+      telemetryPath: telemetryFile,
+    });
+
+    const verdict = result.candidates.find((c) => c.path === worktreePath)?.verdict;
+    expect(verdict).not.toBe('dead-owner');
+    expect(verdict).not.toBe('empty');
+    expect(result.removed).not.toContain(worktreePath);
+  });
+
+  it('never reaps a fully-pushed worktree that a live session is using', async () => {
+    // Liveness beats disposability: a pushed tree in active use stays.
+    const { worktreePath, mock } = await fixture({
+      name: 'afk-shipped-live',
+      ageMs: 3 * 3_600_000,
+      pid: process.pid, // alive
+      commitsAhead: 2,
+      unpushed: 0,
+    });
+
+    const result = await runSweep({
+      execFile: mock as ExecFileFn,
+      repoRoot,
+      lockPath: lockFile,
+      dryRun: false,
+      telemetryPath: telemetryFile,
+    });
+
+    const verdict = result.candidates.find((c) => c.path === worktreePath)?.verdict;
+    expect(verdict).not.toBe('dead-owner');
+    expect(verdict).not.toBe('empty');
+    expect(result.removed).not.toContain(worktreePath);
   });
 });

--- a/src/agent/worktree-sweep.ts
+++ b/src/agent/worktree-sweep.ts
@@ -57,6 +57,17 @@ interface WorktreeCandidate {
   isDirty: boolean;
   commitsAhead: number;
   /**
+   * Commits on this worktree's HEAD that exist NOWHERE but this checkout —
+   * i.e. `@{upstream}..HEAD`. Zero means every local commit has been pushed,
+   * so the remote holds the work and the checkout is disposable.
+   *
+   * Invariant: this is the only field that may relax a `commitsAhead > 0`
+   * preservation gate, and it fails SAFE — no upstream configured, an
+   * unreadable ref, or any git error yields `commitsUnpushed === commitsAhead`
+   * (treat as unreplaceable). It is never derived from `commitsAhead === 0`.
+   */
+  commitsUnpushed: number;
+  /**
    * Tri-state liveness of the owning process recorded in `meta.pid`:
    *   - `'alive'`      — `meta.pid` resolves to a live process.
    *   - `'dead'`       — `meta.pid` is present, the meta is within the
@@ -265,6 +276,20 @@ function parseWorktreeList(stdout: string): ParsedWorktree[] {
 // Section 3 — Verdict classifier
 // ---------------------------------------------------------------------------
 
+/**
+ * True when this checkout is the ONLY place its committed work exists.
+ *
+ * Invariant: `git worktree remove` never deletes the branch ref, so committed
+ * work is destroyed only if it is unreachable from anywhere else. A branch
+ * whose commits are all pushed (`commitsUnpushed === 0`) has them on the
+ * remote, so reaping the checkout costs a directory, not history — which is
+ * why a PR-shipped worktree stops being sacred the moment the push lands.
+ * Unpushed commits stay protected exactly as before.
+ */
+function holdsUnreplaceableCommits(candidate: WorktreeCandidate): boolean {
+  return candidate.commitsAhead > 0 && candidate.commitsUnpushed > 0;
+}
+
 function classifyCandidate(
   candidate: WorktreeCandidate,
   maxAgeDaysClean: number,
@@ -284,7 +309,7 @@ function classifyCandidate(
   if (
     candidate.ownerLiveness === 'dead' &&
     !candidate.isDirty &&
-    candidate.commitsAhead === 0
+    !holdsUnreplaceableCommits(candidate)
   ) {
     return 'dead-owner';
   }
@@ -300,7 +325,7 @@ function classifyCandidate(
   // ahead worktree older than MIN_EMPTY_AGE_MS still got reaped mid-session.
   if (
     candidate.ownerLiveness !== 'alive' &&
-    candidate.commitsAhead === 0 &&
+    !holdsUnreplaceableCommits(candidate) &&
     !candidate.isDirty &&
     candidate.ageMs >= MIN_EMPTY_AGE_MS
   ) {
@@ -610,6 +635,26 @@ export async function runSweep(options: SweepOptions): Promise<SweepResult> {
         } catch { commitsAhead = 0; }
       }
 
+      // Invariant: commitsUnpushed starts EQUAL to commitsAhead (fully
+      // unpushed) and is only ever lowered by a successful upstream read.
+      // Every failure path — no upstream configured, detached HEAD, unreadable
+      // remote-tracking ref, git error — leaves it at commitsAhead, so the
+      // classifier preserves the tree exactly as it did before this field
+      // existed. Never initialise this to 0.
+      let commitsUnpushed = commitsAhead;
+      if (commitsAhead > 0) {
+        try {
+          // @{upstream} resolves the branch's configured remote-tracking ref.
+          // rev-list @{upstream}..HEAD counts commits present here but not on
+          // the remote; 0 means the push landed and the remote holds the work.
+          const unpushedResult = await execFile('git', [
+            '-C', entry.path, 'rev-list', '@{upstream}..HEAD', '--count',
+          ]);
+          const parsed = parseInt(unpushedResult.stdout.trim(), 10);
+          if (Number.isInteger(parsed) && parsed >= 0) commitsUnpushed = parsed;
+        } catch { /* no upstream / unreadable → stay at commitsAhead */ }
+      }
+
       // Constraint: ownerLiveness must only be 'dead'/'alive' when the meta
       // is fresh enough that PID reuse is implausible. Outside the trust
       // window we fall through to 'unknown' and the classifier ignores PID,
@@ -643,6 +688,7 @@ export async function runSweep(options: SweepOptions): Promise<SweepResult> {
         ageMs,
         isDirty,
         commitsAhead,
+        commitsUnpushed,
         ownerLiveness,
       };
 
@@ -651,11 +697,31 @@ export async function runSweep(options: SweepOptions): Promise<SweepResult> {
 
       if (effectiveDryRun) continue;
 
+      // Invariant: the branch ref is the last copy of committed work once the
+      // checkout is gone, so it may be deleted ONLY when the tree held nothing
+      // ahead of base. `git branch -d` deletes a branch that is merged to its
+      // UPSTREAM (git prints "merged to refs/remotes/origin/X, but not yet
+      // merged to HEAD" and exits 0) — precisely the state a pushed worktree is
+      // in. Gating on commitsAhead keeps a reaped-but-pushed tree recoverable
+      // from the local branch even if its remote branch was later deleted and
+      // the tracking ref pruned, which is otherwise unrecoverable-by-gc.
+      const branchSafeToDelete = candidate.commitsAhead === 0;
+      const deleteBranchIfSafe = async (): Promise<void> => {
+        if (!entry.branch || !branchSafeToDelete) return;
+        await execFile('git', [
+          '-C', repoRoot, 'branch', '-d', shortBranchName(entry.branch),
+        ]).catch(() => {});
+      };
+
       try {
         if (verdict === 'empty') {
           await execFile('git', ['-C', repoRoot, 'worktree', 'remove', '--force', entry.path]);
-          if (entry.branch) {
-            await execFile('git', ['-C', repoRoot, 'branch', '-d', shortBranchName(entry.branch)]).catch(() => {});
+          await deleteBranchIfSafe();
+          if (!branchSafeToDelete && entry.branch) {
+            result.warnings.push(
+              `[INFO] reaped worktree with pushed commits; branch preserved ` +
+                `(${shortBranchName(entry.branch)}): ${entry.path}`,
+            );
           }
           result.removed.push(entry.path);
         } else if (verdict === 'dead-owner') {
@@ -663,10 +729,16 @@ export async function runSweep(options: SweepOptions): Promise<SweepResult> {
           // safe to drop wholesale. Also attempt branch deletion since the
           // owning REPL never got to merge or land it. Branch delete is
           // best-effort (it may already be deleted, or be checked out
-          // elsewhere — git refuses, we move on).
+          // elsewhere — git refuses, we move on) AND gated on commitsAhead ===
+          // 0 by deleteBranchIfSafe: a pushed tree loses its checkout but keeps
+          // its branch.
           await execFile('git', ['-C', repoRoot, 'worktree', 'remove', '--force', entry.path]);
-          if (entry.branch) {
-            await execFile('git', ['-C', repoRoot, 'branch', '-d', shortBranchName(entry.branch)]).catch(() => {});
+          await deleteBranchIfSafe();
+          if (!branchSafeToDelete && entry.branch) {
+            result.warnings.push(
+              `[INFO] reaped worktree with pushed commits; branch preserved ` +
+                `(${shortBranchName(entry.branch)}): ${entry.path}`,
+            );
           }
           result.removed.push(entry.path);
         } else if (verdict === 'stale-clean') {

--- a/src/bundled-plugins/awa-bundled/bundled.test.ts
+++ b/src/bundled-plugins/awa-bundled/bundled.test.ts
@@ -136,7 +136,7 @@ const PINNED_HASHES = {
   // file-based form matches the safe convention already used in src/agent/gh.ts.
   // BACK-PORT GAP: the same fix should land in the upstream example-plugin /ship
   // skill (drift test is skipped here — example-plugin not co-located).
-  ship: '712d3796fc4e14d06f897986b2bb9b79d9b9989f6b149ea70c046165d86190f1',
+  ship: '4b082cdcbfe51453a20edd03231b473812775a7cc452b661bb786ff9735f0066',
   // simplify is bundled-only (no upstream example-plugin counterpart).
   simplify:
     'ce720df16e81eff5e6022db38067d376f2177e08a9783fc377e04cf520c7bf3c',

--- a/src/bundled-plugins/awa-bundled/bundled.test.ts
+++ b/src/bundled-plugins/awa-bundled/bundled.test.ts
@@ -136,7 +136,7 @@ const PINNED_HASHES = {
   // file-based form matches the safe convention already used in src/agent/gh.ts.
   // BACK-PORT GAP: the same fix should land in the upstream example-plugin /ship
   // skill (drift test is skipped here — example-plugin not co-located).
-  ship: 'e778f20e30cb24edd04e2fa25b939c21db2b49b95ad0e0076be0e49dae8a34a3',
+  ship: '712d3796fc4e14d06f897986b2bb9b79d9b9989f6b149ea70c046165d86190f1',
   // simplify is bundled-only (no upstream example-plugin counterpart).
   simplify:
     'ce720df16e81eff5e6022db38067d376f2177e08a9783fc377e04cf520c7bf3c',

--- a/src/bundled-plugins/awa-bundled/skills/ship/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/ship/SKILL.md
@@ -130,7 +130,7 @@ A worktree is scaffolding, not an artifact. Once Phase 8 succeeds the branch is 
 
 Two cases, and they behave differently:
 
-- **A worktree you (or a sub-agent) created for this work, that you are NOT currently inside** — reclaim it now. If it is locked, `release` before `remove`: `remove` refuses a locked tree, so that order is mandatory, not stylistic. Use the `worktree` tool, not `git worktree` in bash. The branch ref survives removal, so the PR is unaffected.
+- **A worktree you (or a sub-agent) created for this work, that you are NOT currently inside** — reclaim it now, using the `worktree` tool rather than `git worktree` in bash. Two refusals to expect, in this order: a **locked** tree must be `release`d first (`remove` refuses a locked tree, so the order is mandatory, not stylistic), and a tree with **commits ahead of base** is refused unless you pass `force: true`. After a successful push that `force` is safe and correct: the tool never deletes the branch ref, so the commits remain on the branch *and* on the remote — you are discarding a directory, not history. Do not pass `force` before the push has landed.
 - **The worktree you are running in (your own cwd)** — **do not remove it.** Deleting your own working directory strands every subsequent tool call on a path that no longer exists, and `/ship` still has output to produce. Session-end cleanup already removes a clean worktree on exit. Say so instead, in one line: which branch carries the work, and that the checkout is reclaimed when the session ends.
 
 Never delete the branch as part of this phase — the open PR depends on that ref.

--- a/src/bundled-plugins/awa-bundled/skills/ship/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/ship/SKILL.md
@@ -123,7 +123,19 @@ gh pr create \
 
 PR bodies are markdown: they routinely carry backticks (inline code), `$(...)`, and quotes. **Never** inline the body as `--body "$(cat <<'EOF' … EOF)"` — the shell parses backticks/`$(` inside the command substitution before `gh` ever runs, so the call fails (or worse, opens the PR with a truncated/garbled body and you don't notice). `--body-file` reads the file verbatim: no shell quoting, no escaping. Only `--title` stays inline — keep it a single plain line with no backticks.
 
-Return the PR URL to the user. Done.
+**Phase 9 — Reclaim the worktree.**
+Skip entirely unless the work you just shipped lives under `.afk-worktrees/` (check the invocation cwd from Phase 1 — if the path has no `.afk-worktrees/` segment, there is nothing to reclaim; go straight to the PR URL).
+
+A worktree is scaffolding, not an artifact. Once Phase 8 succeeds the branch is pushed and the PR holds the work, so the checkout has no remaining job. Do not leave it for the background sweep — the sweep never reaps a *locked* tree, and a preserved commits-ahead tree is exactly the kind that gets locked, so "the sweep will get it" is false for the common case.
+
+Two cases, and they behave differently:
+
+- **A worktree you (or a sub-agent) created for this work, that you are NOT currently inside** — reclaim it now. If it is locked, `release` before `remove`: `remove` refuses a locked tree, so that order is mandatory, not stylistic. Use the `worktree` tool, not `git worktree` in bash. The branch ref survives removal, so the PR is unaffected.
+- **The worktree you are running in (your own cwd)** — **do not remove it.** Deleting your own working directory strands every subsequent tool call on a path that no longer exists, and `/ship` still has output to produce. Session-end cleanup already removes a clean worktree on exit. Say so instead, in one line: which branch carries the work, and that the checkout is reclaimed when the session ends.
+
+Never delete the branch as part of this phase — the open PR depends on that ref.
+
+Return the PR URL to the user, plus a one-line worktree disposition (`reclaimed <path>` / `preserved <path> — reclaimed at session end` / omit if not in a worktree). Done.
 
 ---
 
@@ -131,3 +143,4 @@ Return the PR URL to the user. Done.
 - `/ground-state` unavailable → skip Phase 1 with a loud warning; do not proceed silently.
 - `gh` CLI not authenticated → abort Phase 8 with the exact `gh auth login` command.
 - Detached HEAD or shallow clone → abort at Phase 1; these are edge cases `/ship` should not try to auto-recover.
+- Worktree reclaim fails in Phase 9 → the PR is already open and that is the deliverable; report the failure and the path, never retry-loop or walk back the PR.


### PR DESCRIPTION
## Problem

Agent-created worktrees under `.afk-worktrees/` never get reclaimed once their work ships. The sweep's `empty` and `dead-owner` verdicts both gated on `commitsAhead === 0`, so any worktree that had made a commit was preserved forever — including worktrees whose commits were long since pushed and merged. The checkout is pure disk cost at that point: the remote holds the work.

Measured on this machine before the fix: **46 worktrees, 11 GB, and the sweep classified exactly 1 as reapable.**

## Change

Two commits.

**1. `fix(worktree): instruct agents to reclaim a worktree once its work has landed`** — the `worktree` tool schema and the bundled `ship` skill now tell an agent to remove its worktree after the PR is open, instead of leaving it for the sweep to guess about.

**2. `fix(worktree): reap shipped worktrees, and stop deleting branches that hold commits`** — adds `commitsUnpushed` (`git rev-list @{upstream}..HEAD --count`) to the sweep candidate, and relaxes the `empty` / `dead-owner` gates from `commitsAhead === 0` to `!holdsUnreplaceableCommits(candidate)` — i.e. a worktree is disposable when its commits exist somewhere other than this checkout.

Two invariants hold the safety property:

- **`commitsUnpushed` fails safe.** It is initialised to `commitsAhead` (assume fully unpushed) and only ever *lowered* by a successful upstream read. No upstream configured, detached HEAD, unreadable tracking ref, or any git error leaves it at `commitsAhead`, so the classifier preserves the tree exactly as it did before this field existed. It is never derived from `commitsAhead === 0`.
- **Branch deletion is separately gated on `commitsAhead === 0`.** `git branch -d` *succeeds* on a branch merged to its upstream but not to HEAD — precisely the state a pushed worktree is in — so the old code would have deleted those refs. Now a reaped-but-pushed worktree loses its checkout and keeps its branch, and emits an `[INFO] … branch preserved` warning. That keeps the work recoverable from the local branch even if the remote branch is later deleted and the tracking ref pruned, which is otherwise unrecoverable-by-gc.

## Verification against the live backlog

Ran the patched `runSweep` in `dryRun: true` against this machine's 46 real worktrees (lock and telemetry redirected to a tmp path; nothing removed):

| | before | after |
|---|---|---|
| reapable (`dead-owner`) | 1 | **14** |
| preserved (`active`) | 45 | 32 |
| disk reclaimed | — | **4,090 MB** |

The 32 preserved trees each hold genuinely unpushed commits or dirty state — the classifier is discriminating, not merely conservative.

## Deliberate behaviour: an open PR does not protect a checkout

4 of the 14 newly-reapable worktrees back open PRs. That is intended. Their commits are pushed (`@{upstream}..HEAD` = 0), the branch ref survives the `commitsAhead` gate, and `/fix-pr` creates a fresh worktree on demand — so nothing is lost that a `git worktree add` cannot restore. A live session in the tree is still protected by the existing presence guard, which is the check that actually matters for "someone is working here right now".

## Gates

- `pnpm lint` (tsc --noEmit strict) — clean
- `pnpm test:coverage` (full suite + hard coverage thresholds) — green
- `src/agent/worktree-sweep.test.ts` — 40/40, including new cases for the pushed-commits relaxation and the branch-preservation gate
- Rebased onto `main` @ v5.77.0; no file overlap with anything merged since the branch point
