### PR TITLE
feat(presence): pid liveness + heartbeat + schema version on presence records

### DIFF
--- a/src/agent/awareness/index.ts
+++ b/src/agent/awareness/index.ts
@@ -49,6 +49,17 @@ export {
   removePresenceFile,
   removePresenceFileSync,
   readPresenceFiles,
+  readLivePresenceFiles,
+  touchPresenceHeartbeat,
+  PRESENCE_SCHEMA_VERSION,
   type PresenceFileInfo,
   type PresenceRecord,
+  type PresenceLiveness,
+  type ReadLivePresenceOptions,
 } from './presence.js';
+
+export {
+  isProcessAlive,
+  classifyPidLiveness,
+  type ProcessLiveness,
+} from '../process-liveness.js';

--- a/src/agent/awareness/presence.test.ts
+++ b/src/agent/awareness/presence.test.ts
@@ -209,18 +209,35 @@ describe('readPresenceFiles edge cases', () => {
 // ---------------------------------------------------------------------------
 
 /**
- * A pid that is guaranteed not to be running: spawn a process that exits
- * immediately and wait for Node to reap it. Preferred over a large magic number
- * because `pid_max` differs per platform (~99999 on macOS, up to 4194304 on
- * Linux), so no literal is portably unusable.
+ * A pid that is definitively not running, found WITHOUT creating a process.
+ *
+ * Probes downward from implausibly-high values and returns the first one the
+ * kernel reports as `ESRCH` (no such process). `pid_max` differs per platform
+ * (~99999 on macOS, up to 4194304 on Linux), so no single literal is portably
+ * unusable — but probing finds a usable one on any platform.
+ *
+ * Deliberately does NOT spawn-and-reap a real process to obtain a dead pid, for
+ * two reasons:
+ *   1. Churning pids raises the odds of pid REUSE elsewhere in the suite. The
+ *      process-group-kill test in `tools/handlers/bash.test.ts` probes a
+ *      grandchild pid with `kill -0` after a 100ms reap window and fails if
+ *      anything has recycled it — observed failing exactly this way in CI.
+ *   2. A reaped pid can itself be recycled before the assertion runs, which
+ *      would make THIS test flake in the opposite direction.
+ *
+ * Only `ESRCH` is accepted. `EPERM` means the process exists but belongs to
+ * another user, which `isProcessAlive` correctly treats as alive.
  */
-async function deadPid(): Promise<number> {
-  const { spawn } = await import('child_process');
-  const child = spawn(process.execPath, ['-e', '']);
-  const pid = child.pid;
-  if (pid === undefined) throw new Error('failed to spawn helper process');
-  await new Promise<void>((resolve) => { child.on('exit', () => resolve()); });
-  return pid;
+function unusedPid(): number {
+  for (const candidate of [4_194_305, 4_194_304, 999_999, 99_999]) {
+    try {
+      process.kill(candidate, 0);
+      // No throw ⇒ it exists ⇒ not usable as a dead pid. Try the next.
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ESRCH') return candidate;
+    }
+  }
+  throw new Error('could not find an unused pid to test against');
 }
 
 /** Write a presence file directly, bypassing writePresenceFile's stamping. */
@@ -323,9 +340,9 @@ describe('presence liveness annotation', () => {
     expect(record?.liveness).toBe('alive');
   });
 
-  it("classifies a reaped process as 'dead'", async () => {
+  it("classifies a nonexistent pid as 'dead'", async () => {
     const { writePresenceFile, readPresenceFiles } = await getPresenceMod();
-    await writePresenceFile(mkInfo({ pid: await deadPid() }));
+    await writePresenceFile(mkInfo({ pid: unusedPid() }));
 
     const [record] = await readPresenceFiles();
     expect(record?.liveness).toBe('dead');
@@ -357,7 +374,7 @@ describe('presence liveness annotation', () => {
     // delete a live session's worktree. Liveness is an annotation, not a filter.
     const { writePresenceFile, readPresenceFiles } = await getPresenceMod();
     await writePresenceFile(mkInfo({ sessionId: 'alive-1', pid: process.pid }));
-    await writePresenceFile(mkInfo({ sessionId: 'dead-1', pid: await deadPid() }));
+    await writePresenceFile(mkInfo({ sessionId: 'dead-1', pid: unusedPid() }));
 
     const records = await readPresenceFiles();
     expect(records).toHaveLength(2);
@@ -369,7 +386,7 @@ describe('readLivePresenceFiles', () => {
   it("drops records proven 'dead' and keeps 'alive' ones", async () => {
     const { writePresenceFile, readLivePresenceFiles } = await getPresenceMod();
     await writePresenceFile(mkInfo({ sessionId: 'alive-1', pid: process.pid }));
-    await writePresenceFile(mkInfo({ sessionId: 'dead-1', pid: await deadPid() }));
+    await writePresenceFile(mkInfo({ sessionId: 'dead-1', pid: unusedPid() }));
 
     const live = await readLivePresenceFiles();
     expect(live.map((r) => r.sessionId)).toEqual(['alive-1']);

--- a/src/agent/awareness/presence.test.ts
+++ b/src/agent/awareness/presence.test.ts
@@ -197,3 +197,235 @@ describe('readPresenceFiles edge cases', () => {
     expect(records).toHaveLength(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Session-status contract: schema version, heartbeat, pid liveness.
+//
+// The bug these guard: presence cleanup runs only from
+// `process.once('exit'|'SIGINT'|'SIGTERM')`, none of which fire on SIGKILL or an
+// OOM kill, and nothing reaps the presence directory. A crashed session
+// therefore appeared live forever to every consumer (`/watch` auto-subscribe,
+// the Telegram bot, any status UI).
+// ---------------------------------------------------------------------------
+
+/**
+ * A pid that is guaranteed not to be running: spawn a process that exits
+ * immediately and wait for Node to reap it. Preferred over a large magic number
+ * because `pid_max` differs per platform (~99999 on macOS, up to 4194304 on
+ * Linux), so no literal is portably unusable.
+ */
+async function deadPid(): Promise<number> {
+  const { spawn } = await import('child_process');
+  const child = spawn(process.execPath, ['-e', '']);
+  const pid = child.pid;
+  if (pid === undefined) throw new Error('failed to spawn helper process');
+  await new Promise<void>((resolve) => { child.on('exit', () => resolve()); });
+  return pid;
+}
+
+/** Write a presence file directly, bypassing writePresenceFile's stamping. */
+function writeRawPresence(sessionId: string, obj: Record<string, unknown>): void {
+  const presenceDir = path.join(tmpDir, 'state', 'presence');
+  fs.mkdirSync(presenceDir, { recursive: true });
+  fs.writeFileSync(path.join(presenceDir, `${sessionId}.json`), JSON.stringify(obj), 'utf8');
+}
+
+describe('presence schema version', () => {
+  it('writePresenceFile stamps the current schema version', async () => {
+    const { writePresenceFile, readPresenceFiles, PRESENCE_SCHEMA_VERSION } = await getPresenceMod();
+    await writePresenceFile(mkInfo());
+
+    const [record] = await readPresenceFiles();
+    expect(record?.schemaVersion).toBe(PRESENCE_SCHEMA_VERSION);
+  });
+
+  it('lets a caller-supplied schemaVersion win over the default', async () => {
+    const { writePresenceFile, readPresenceFiles } = await getPresenceMod();
+    await writePresenceFile(mkInfo({ schemaVersion: 99 }));
+
+    const [record] = await readPresenceFiles();
+    expect(record?.schemaVersion).toBe(99);
+  });
+
+  it('reads a legacy record with no schemaVersion or heartbeatAt (fails soft)', async () => {
+    const { readPresenceFiles } = await getPresenceMod();
+    // Exactly the shape written before versioning existed.
+    writeRawPresence('legacy-1', {
+      sessionId: 'legacy-1',
+      surface: 'cli',
+      cwd: '/tmp/x',
+      startedAt: new Date().toISOString(),
+      model: { provider: 'p', name: 'm' },
+      workspace: NULL_WS,
+      pid: process.pid,
+    });
+
+    const [record] = await readPresenceFiles();
+    expect(record?.sessionId).toBe('legacy-1');
+    expect(record?.schemaVersion).toBeUndefined();
+    expect(record?.heartbeatAgeMs).toBeNull();
+    // Still classifiable — a missing version must not cost us liveness.
+    expect(record?.liveness).toBe('alive');
+  });
+});
+
+describe('presence heartbeat', () => {
+  it('writePresenceFile stamps an initial heartbeatAt', async () => {
+    const { writePresenceFile, readPresenceFiles } = await getPresenceMod();
+    await writePresenceFile(mkInfo());
+
+    const [record] = await readPresenceFiles();
+    expect(typeof record?.heartbeatAt).toBe('string');
+    expect(record?.heartbeatAgeMs).not.toBeNull();
+    expect(record!.heartbeatAgeMs!).toBeLessThan(60_000);
+  });
+
+  it('touchPresenceHeartbeat refreshes the timestamp, preserving every other field', async () => {
+    const { writePresenceFile, touchPresenceHeartbeat, readPresenceFiles } = await getPresenceMod();
+    await writePresenceFile(mkInfo({ sessionId: 'hb-1', afk: true, surface: 'telegram' }));
+    const before = (await readPresenceFiles())[0]!;
+
+    // Force a measurable gap, then backdate so the refresh is observable
+    // regardless of clock granularity.
+    writeRawPresence('hb-1', {
+      ...before,
+      path: undefined,
+      liveness: undefined,
+      heartbeatAgeMs: undefined,
+      heartbeatAt: new Date(Date.now() - 120_000).toISOString(),
+    });
+    const stale = (await readPresenceFiles())[0]!;
+    expect(stale.heartbeatAgeMs!).toBeGreaterThan(60_000);
+
+    await touchPresenceHeartbeat('hb-1');
+
+    const after = (await readPresenceFiles())[0]!;
+    expect(after.heartbeatAgeMs!).toBeLessThan(60_000);
+    // Other fields survive the read-modify-write.
+    expect(after.afk).toBe(true);
+    expect(after.surface).toBe('telegram');
+    expect(after.sessionId).toBe('hb-1');
+  });
+
+  it('touchPresenceHeartbeat is a no-op when no presence file exists', async () => {
+    const { touchPresenceHeartbeat, readPresenceFiles } = await getPresenceMod();
+    await expect(touchPresenceHeartbeat('nope')).resolves.toBeUndefined();
+    expect(await readPresenceFiles()).toHaveLength(0);
+  });
+});
+
+describe('presence liveness annotation', () => {
+  it("classifies the current process as 'alive'", async () => {
+    const { writePresenceFile, readPresenceFiles } = await getPresenceMod();
+    await writePresenceFile(mkInfo({ pid: process.pid }));
+
+    const [record] = await readPresenceFiles();
+    expect(record?.liveness).toBe('alive');
+  });
+
+  it("classifies a reaped process as 'dead'", async () => {
+    const { writePresenceFile, readPresenceFiles } = await getPresenceMod();
+    await writePresenceFile(mkInfo({ pid: await deadPid() }));
+
+    const [record] = await readPresenceFiles();
+    expect(record?.liveness).toBe('dead');
+  });
+
+  it("classifies an absent or nonsense pid as 'unknown', never 'dead'", async () => {
+    const { readPresenceFiles } = await getPresenceMod();
+    const base = {
+      surface: 'cli',
+      cwd: '/tmp/x',
+      startedAt: new Date().toISOString(),
+      model: { provider: 'p', name: 'm' },
+      workspace: NULL_WS,
+    };
+    writeRawPresence('no-pid', { ...base, sessionId: 'no-pid' });
+    writeRawPresence('bad-pid', { ...base, sessionId: 'bad-pid', pid: 'not-a-number' });
+    writeRawPresence('zero-pid', { ...base, sessionId: 'zero-pid', pid: 0 });
+
+    const records = await readPresenceFiles();
+    expect(records).toHaveLength(3);
+    for (const r of records) {
+      expect(r.liveness).toBe('unknown');
+    }
+  });
+
+  it('DOES NOT filter dead records out of readPresenceFiles', async () => {
+    // Safety invariant. The worktree sweep decides whether a worktree is in use
+    // from these records; a false 'dead' that removed one would let the sweep
+    // delete a live session's worktree. Liveness is an annotation, not a filter.
+    const { writePresenceFile, readPresenceFiles } = await getPresenceMod();
+    await writePresenceFile(mkInfo({ sessionId: 'alive-1', pid: process.pid }));
+    await writePresenceFile(mkInfo({ sessionId: 'dead-1', pid: await deadPid() }));
+
+    const records = await readPresenceFiles();
+    expect(records).toHaveLength(2);
+    expect(records.map((r) => r.sessionId).sort()).toEqual(['alive-1', 'dead-1']);
+  });
+});
+
+describe('readLivePresenceFiles', () => {
+  it("drops records proven 'dead' and keeps 'alive' ones", async () => {
+    const { writePresenceFile, readLivePresenceFiles } = await getPresenceMod();
+    await writePresenceFile(mkInfo({ sessionId: 'alive-1', pid: process.pid }));
+    await writePresenceFile(mkInfo({ sessionId: 'dead-1', pid: await deadPid() }));
+
+    const live = await readLivePresenceFiles();
+    expect(live.map((r) => r.sessionId)).toEqual(['alive-1']);
+  });
+
+  it("RETAINS 'unknown' records — hiding a running session is the worse failure", async () => {
+    const { readLivePresenceFiles } = await getPresenceMod();
+    writeRawPresence('no-pid', {
+      sessionId: 'no-pid',
+      surface: 'cli',
+      cwd: '/tmp/x',
+      startedAt: new Date().toISOString(),
+      model: { provider: 'p', name: 'm' },
+      workspace: NULL_WS,
+    });
+
+    const live = await readLivePresenceFiles();
+    expect(live.map((r) => r.sessionId)).toEqual(['no-pid']);
+  });
+
+  it('drops stale heartbeats when maxHeartbeatAgeMs is set', async () => {
+    const { readLivePresenceFiles } = await getPresenceMod();
+    const base = {
+      surface: 'cli',
+      cwd: '/tmp/x',
+      startedAt: new Date().toISOString(),
+      model: { provider: 'p', name: 'm' },
+      workspace: NULL_WS,
+      pid: process.pid,
+    };
+    writeRawPresence('fresh', {
+      ...base, sessionId: 'fresh', heartbeatAt: new Date().toISOString(),
+    });
+    writeRawPresence('stale', {
+      ...base, sessionId: 'stale', heartbeatAt: new Date(Date.now() - 600_000).toISOString(),
+    });
+
+    const live = await readLivePresenceFiles({ maxHeartbeatAgeMs: 60_000 });
+    expect(live.map((r) => r.sessionId)).toEqual(['fresh']);
+  });
+
+  it('keeps records with no heartbeat even when maxHeartbeatAgeMs is set', async () => {
+    // Absence of a heartbeat is not evidence of death — pre-heartbeat records
+    // must stay visible or upgrading afk would blank the session list.
+    const { readLivePresenceFiles } = await getPresenceMod();
+    writeRawPresence('no-hb', {
+      sessionId: 'no-hb',
+      surface: 'cli',
+      cwd: '/tmp/x',
+      startedAt: new Date().toISOString(),
+      model: { provider: 'p', name: 'm' },
+      workspace: NULL_WS,
+      pid: process.pid,
+    });
+
+    const live = await readLivePresenceFiles({ maxHeartbeatAgeMs: 1 });
+    expect(live.map((r) => r.sessionId)).toEqual(['no-hb']);
+  });
+});

--- a/src/agent/awareness/presence.ts
+++ b/src/agent/awareness/presence.ts
@@ -26,10 +26,28 @@ import { join } from 'path';
 import { getPresenceDir } from '../../paths.js';
 import type { RuntimeWorkspace } from './types.js';
 import type { TraceActor } from '../session/session-identity.js';
+import { classifyPidLiveness, type ProcessLiveness } from '../process-liveness.js';
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
+
+/**
+ * Current presence-file schema version.
+ *
+ * Stamped by {@link writePresenceFile} onto every record it writes. Readers —
+ * including out-of-process ones that are not part of this codebase — can branch
+ * on it instead of inferring shape from which fields happen to be present.
+ *
+ * Absent on records written before versioning existed; treat a missing value as
+ * version 0 and fail SOFT, never throwing. Presence is best-effort telemetry,
+ * not a transaction log: a reader that rejects an unrecognised version makes a
+ * live session invisible, which is strictly worse than reading it partially.
+ *
+ * Bump when a field's MEANING changes or a required field is added. Purely
+ * additive optional fields do not require a bump.
+ */
+export const PRESENCE_SCHEMA_VERSION = 1;
 
 /** Data written to the presence file for a live top-level session. */
 export interface PresenceFileInfo {
@@ -57,11 +75,54 @@ export interface PresenceFileInfo {
    * every non-REPL surface.
    */
   afk?: boolean;
+  /**
+   * Schema version of this record — see {@link PRESENCE_SCHEMA_VERSION}.
+   * Optional: absent on records written before versioning existed.
+   */
+  schemaVersion?: number;
+  /**
+   * ISO 8601 timestamp of the last time the owning session affirmed it is alive,
+   * via {@link touchPresenceHeartbeat}. Stamped at write time and refreshed
+   * thereafter.
+   *
+   * Exists to bound the one hole pid-liveness cannot cover: the OS recycles
+   * pids, so a record whose owner was SIGKILLed can read `'alive'` again once an
+   * unrelated process inherits that pid. A stale heartbeat on a nominally-alive
+   * pid is the signal for that case. Optional/additive: absent on records
+   * written before this field existed, and on any session that never refreshed.
+   */
+  heartbeatAt?: string;
 }
 
-/** A presence record loaded from disk — same as PresenceFileInfo plus the file path. */
+/**
+ * Liveness verdict for a presence record. Re-exported so consumers need not
+ * import from `process-liveness` directly.
+ */
+export type PresenceLiveness = ProcessLiveness;
+
+/**
+ * A presence record loaded from disk — `PresenceFileInfo` plus the file path and
+ * fields COMPUTED at read time.
+ *
+ * `liveness` and `heartbeatAgeMs` are derived on every read and never persisted;
+ * writing them would immediately stale them.
+ */
 export interface PresenceRecord extends PresenceFileInfo {
   path: string;
+  /**
+   * Whether the recorded `pid` is still running, computed at read time.
+   *
+   * `'unknown'` means the pid was absent or unusable — NOT that the session
+   * ended. Consumers must filter on `'dead'` and never treat `'unknown'` as
+   * finished.
+   */
+  liveness: PresenceLiveness;
+  /**
+   * Milliseconds since {@link PresenceFileInfo.heartbeatAt}, or `null` when no
+   * parseable heartbeat is recorded. Lets a consumer require freshness on top of
+   * pid-liveness without reimplementing the date math.
+   */
+  heartbeatAgeMs: number | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -101,9 +162,42 @@ export async function writePresenceFile(info: PresenceFileInfo): Promise<void> {
     const ok = await ensurePresenceDir();
     if (!ok) return;
     const filePath = presenceFilePath(info.sessionId);
-    await writeFile(filePath, JSON.stringify(info, null, 2), 'utf8');
+    // Stamp the schema version and an initial heartbeat HERE rather than at the
+    // call sites: more than one provider writes presence (anthropic-direct and
+    // openai-compatible), so a per-caller stamp would silently miss a writer the
+    // moment a third surface is added. Caller-supplied values win, which keeps
+    // tests able to pin a specific version or heartbeat.
+    const record: PresenceFileInfo = {
+      schemaVersion: PRESENCE_SCHEMA_VERSION,
+      heartbeatAt: new Date().toISOString(),
+      ...info,
+    };
+    await writeFile(filePath, JSON.stringify(record, null, 2), 'utf8');
   } catch {
     // Best-effort — swallow silently.
+  }
+}
+
+/**
+ * Refresh the `heartbeatAt` timestamp on an existing presence file (best-effort,
+ * read-modify-write). Preserves every other field.
+ *
+ * Call this at turn boundaries. A session that is alive but wedged, or whose pid
+ * has been recycled after a SIGKILL, is indistinguishable from a healthy one on
+ * pid-liveness alone — a stale heartbeat is what separates them.
+ *
+ * No-op when the presence file is absent (subagents never have one). Never
+ * throws: presence is non-critical and the session must proceed regardless.
+ */
+export async function touchPresenceHeartbeat(sessionId: string): Promise<void> {
+  try {
+    const filePath = presenceFilePath(sessionId);
+    const raw = await readFile(filePath, 'utf8');
+    const parsed = JSON.parse(raw) as PresenceFileInfo;
+    parsed.heartbeatAt = new Date().toISOString();
+    await writeFile(filePath, JSON.stringify(parsed, null, 2), 'utf8');
+  } catch {
+    // Best-effort — presence is non-critical.
   }
 }
 
@@ -180,8 +274,17 @@ export function removePresenceFileSync(sessionId: string): void {
   }
 }
 
+/** Compute `heartbeatAgeMs` from a possibly-absent, possibly-garbage timestamp. */
+function heartbeatAge(heartbeatAt: unknown, now: number): number | null {
+  if (typeof heartbeatAt !== 'string') return null;
+  const parsed = Date.parse(heartbeatAt);
+  if (Number.isNaN(parsed)) return null;
+  return now - parsed;
+}
+
 /**
- * Scan the presence directory and return all parseable presence records.
+ * Scan the presence directory and return all parseable presence records,
+ * annotated with computed `liveness` and `heartbeatAgeMs`.
  *
  * Silently skips:
  *   - Files that are not valid JSON.
@@ -189,6 +292,13 @@ export function removePresenceFileSync(sessionId: string): void {
  *   - Any file read or directory scan errors.
  *
  * Returns `[]` when the presence directory does not exist.
+ *
+ * DOES NOT FILTER dead sessions. This is deliberate and safety-critical: the
+ * worktree sweep uses these records to decide whether a worktree is still in use
+ * (`isPathWithin(presence.cwd, worktreePath)`), so a false 'dead' verdict here
+ * would let the sweep delete the worktree out from under a running session.
+ * Liveness is surfaced as an annotation and callers opt in — see
+ * {@link readLivePresenceFiles}.
  */
 export async function readPresenceFiles(): Promise<PresenceRecord[]> {
   const dir = getPresenceDir();
@@ -200,6 +310,7 @@ export async function readPresenceFiles(): Promise<PresenceRecord[]> {
     return [];
   }
 
+  const now = Date.now();
   const records: PresenceRecord[] = [];
   for (const entry of entries) {
     if (!entry.endsWith('.json')) continue;
@@ -213,11 +324,64 @@ export async function readPresenceFiles(): Promise<PresenceRecord[]> {
         'sessionId' in parsed &&
         typeof (parsed as Record<string, unknown>)['sessionId'] === 'string'
       ) {
-        records.push({ ...(parsed as PresenceFileInfo), path: filePath });
+        const info = parsed as PresenceFileInfo;
+        const fields = parsed as Record<string, unknown>;
+        records.push({
+          ...info,
+          path: filePath,
+          liveness: classifyPidLiveness(fields['pid']),
+          heartbeatAgeMs: heartbeatAge(fields['heartbeatAt'], now),
+        });
       }
     } catch {
       // Malformed JSON or unreadable file — skip.
     }
   }
   return records;
+}
+
+/** Options for {@link readLivePresenceFiles}. */
+export interface ReadLivePresenceOptions {
+  /**
+   * When set, additionally drop records whose heartbeat is older than this many
+   * milliseconds. Records with no parseable heartbeat are KEPT — absence of a
+   * heartbeat is not evidence of death, and pre-heartbeat records must stay
+   * visible.
+   */
+  maxHeartbeatAgeMs?: number;
+}
+
+/**
+ * Presence records for sessions that are plausibly still running.
+ *
+ * Opt-in counterpart to {@link readPresenceFiles}, for consumers that want a
+ * "currently live sessions" list — a status UI, a session picker, a notifier —
+ * without every existing caller silently changing behaviour.
+ *
+ * Drops only records proven dead (`liveness === 'dead'`). Records classified
+ * `'unknown'` are RETAINED: an unusable pid means we could not determine
+ * liveness, and hiding a running session is a worse failure than showing a stale
+ * one.
+ *
+ * The bug this addresses: presence cleanup runs from
+ * `process.once('exit'|'SIGINT'|'SIGTERM')`, none of which fire on SIGKILL or an
+ * OOM kill, and nothing else reaps the directory. Before this, a crashed session
+ * appeared live forever to every consumer.
+ */
+export async function readLivePresenceFiles(
+  options: ReadLivePresenceOptions = {},
+): Promise<PresenceRecord[]> {
+  const records = await readPresenceFiles();
+  const { maxHeartbeatAgeMs } = options;
+  return records.filter((r) => {
+    if (r.liveness === 'dead') return false;
+    if (
+      maxHeartbeatAgeMs !== undefined &&
+      r.heartbeatAgeMs !== null &&
+      r.heartbeatAgeMs > maxHeartbeatAgeMs
+    ) {
+      return false;
+    }
+    return true;
+  });
 }

--- a/src/agent/process-liveness.ts
+++ b/src/agent/process-liveness.ts
@@ -1,0 +1,66 @@
+/**
+ * Process liveness probing.
+ *
+ * `kill(pid, 0)` sends no signal — it only performs the permission and
+ * existence checks the kernel would do for a real signal. That makes it the
+ * cheapest portable way to ask "is this pid still running?".
+ *
+ * Why this module exists: several on-disk registries record a `pid` and later
+ * need to know whether the owning process is still alive — presence files, the
+ * worktree sweep's owner check, stale-lock detection. Without a liveness probe,
+ * a record left behind by a process that died without running its cleanup
+ * handlers (SIGKILL, OOM kill, power loss) looks live forever.
+ *
+ * NOTE: `src/agent/worktree-sweep.ts` carries its own private copy of this
+ * idiom. It is deliberately left in place for now — that file has unmerged work
+ * in flight on another branch, and consolidating it here would create a
+ * conflict for no functional gain. Fold it in once that lands.
+ *
+ * @module agent/process-liveness
+ */
+
+/** Liveness verdict for a recorded pid. */
+export type ProcessLiveness =
+  /** The pid is running (or exists but belongs to another user). */
+  | 'alive'
+  /** The pid is not running — the owning process is gone. */
+  | 'dead'
+  /** No usable pid was recorded, so liveness cannot be determined. */
+  | 'unknown';
+
+/**
+ * Whether `pid` currently exists.
+ *
+ * `EPERM` (permission denied) means the process exists but is not ours, which
+ * counts as alive. Any other error — notably `ESRCH` (no such process) — means
+ * it is gone.
+ */
+export function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'EPERM') return true;
+    return false;
+  }
+}
+
+/**
+ * Classify a pid value that came off disk, where it may be absent, the wrong
+ * type, or nonsense.
+ *
+ * Returns `'unknown'` rather than `'dead'` for an unusable pid. That asymmetry
+ * is deliberate and load-bearing: consumers filter on `'dead'`, so an
+ * unparseable record must never be mistaken for a finished one.
+ *
+ * Caveat: pids are recycled by the OS. A record whose owner died can read
+ * `'alive'` again if an unrelated process later inherits that pid. Pair this
+ * with a freshness check (e.g. a heartbeat timestamp) when that matters.
+ */
+export function classifyPidLiveness(pid: unknown): ProcessLiveness {
+  if (typeof pid !== 'number' || !Number.isInteger(pid) || pid <= 0) {
+    return 'unknown';
+  }
+  return isProcessAlive(pid) ? 'alive' : 'dead';
+}

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -25,7 +25,7 @@ import {
 import { elicitationRouter } from '../agent/elicitation-router.js';
 import { ensurePluginEntrypointsLoaded } from '../agent/tools/skill-bridge.js';
 import { SessionWatchManager, resolveWatchTarget, listWatchableSessions } from './watch.js';
-import { readPresenceFiles } from '../agent/awareness/presence.js';
+import { readLivePresenceFiles } from '../agent/awareness/presence.js';
 import { readSessionKey, signAbortRequest, freshChannelId } from '../agent/afk-channel.js';
 import { SessionLedgerWriter } from '../agent/session-ledger.js';
 import { splitLongMessage } from './formatter.js';
@@ -530,7 +530,7 @@ export class TelegramBot {
   /**
    * Start the presence auto-subscribe loop.
    *
-   * Polls `readPresenceFiles()` every AUTO_SUBSCRIBE_INTERVAL_MS and calls
+   * Polls `readLivePresenceFiles()` every AUTO_SUBSCRIBE_INTERVAL_MS and calls
    * `watchManager.start()` for any `surface === 'cli' && afk === true` session
    * not already watched. Stops auto-watches whose `afk` flag cleared or whose
    * presence file disappeared.
@@ -575,9 +575,9 @@ export class TelegramBot {
     const chatIds = [...this.options.allowedChatIds];
     if (chatIds.length === 0) return;
 
-    let presence: Awaited<ReturnType<typeof readPresenceFiles>>;
+    let presence: Awaited<ReturnType<typeof readLivePresenceFiles>>;
     try {
-      presence = await readPresenceFiles();
+      presence = await readLivePresenceFiles();
     } catch {
       return; // presence dir unreadable — ignore silently
     }

--- a/src/telegram/watch.ts
+++ b/src/telegram/watch.ts
@@ -22,7 +22,7 @@
 
 import { tailLedger, ledgerExists, SessionLedgerWriter, type LedgerRecord } from '../agent/session-ledger.js';
 import { findSession, listSessions } from '../cli/session-store.js';
-import { readPresenceFiles } from '../agent/awareness/presence.js';
+import { readLivePresenceFiles } from '../agent/awareness/presence.js';
 import { readSessionKey, signElicitationResponse } from '../agent/afk-channel.js';
 import { makeTelegramElicitationHandler } from './elicitation-handler.js';
 import { createTelegramElicitationHandler, composeTelegramElicitation } from './elicitation-telegram.js';
@@ -117,7 +117,7 @@ export async function resolveWatchTarget(input: string): Promise<string | null> 
 export async function listWatchableSessions(): Promise<string> {
   const lines: string[] = [];
 
-  const presence = await readPresenceFiles();
+  const presence = await readLivePresenceFiles();
   const live = presence.filter((p) => p.surface !== 'telegram');
   if (live.length > 0) {
     lines.push('🟢 Live sessions:');


### PR DESCRIPTION
## Problem

A crashed session appears live forever.

Presence cleanup runs only from `process.once('exit'|'SIGINT'|'SIGTERM')` (`presence-lifecycle.ts:60-63`), none of which fire on `SIGKILL` or an OOM kill, and nothing else reaps `~/.afk/state/presence/`. Every consumer — `/watch` auto-subscribe, the Telegram bot, any status UI — trusted file existence alone. There was no TTL, no heartbeat, and no liveness probe outside `worktree-sweep.ts`, where `isProcessAlive` was private and scoped to that module's own reap decision.

There was also no versioning on the record shape, despite it having already grown fields post-launch (`actor?`, `afk?`). An out-of-process reader had to infer shape from which fields happened to be present. Precedent that this bites: `src/telegram/presence-surface.test.ts` exists *because* the `surface` field defaulted to `'cli'` and `/watch` silently mis-classified every Telegram session.

## Changes

All additive and backward-compatible.

- **`src/agent/process-liveness.ts`** (new) — `isProcessAlive(pid)` and `classifyPidLiveness(pid)` → `'alive' | 'dead' | 'unknown'`. An absent or unusable pid yields `'unknown'`, **never** `'dead'`, so an unparseable record is never mistaken for a finished one.
- **`PresenceRecord`** gains computed `liveness` and `heartbeatAgeMs` — derived on every read, never persisted.
- **`PresenceFileInfo`** gains optional `schemaVersion` and `heartbeatAt`, following the existing house pattern (`worktree.ts:80`, `trace/receipt.ts:81`).
- **`touchPresenceHeartbeat(sessionId)`** — refreshes `heartbeatAt`, read-modify-write, best-effort, preserves all other fields.
- **`readLivePresenceFiles(opts?)`** — opt-in filtered view, with optional `maxHeartbeatAgeMs`.

Stamping happens **inside `writePresenceFile`**, not at call sites: two providers write presence today (`anthropic-direct`, `openai-compatible`), so a per-caller stamp would silently miss a future third surface. Caller-supplied values still win, so tests can pin a version or heartbeat.

## Two safety invariants, both pinned by tests

**1. `readPresenceFiles()` annotates liveness but does NOT filter.** The worktree sweep decides whether a worktree is still in use from these records (`isPathWithin(presence.cwd, worktreePath)`) — its own comment warns the sweep can otherwise "reap the worktree out from under the running session." A false `'dead'` verdict here would let it **delete a live session's worktree**. Filtering is opt-in only.

**2. `readLivePresenceFiles()` retains `'unknown'` and heartbeat-less records.** Hiding a running session is a worse failure than showing a stale one, and dropping heartbeat-less records would blank the session list on upgrade.

## Why a heartbeat as well as pid liveness

Pids are recycled. A `SIGKILL`ed session's record can read `'alive'` again once an unrelated process inherits its pid. A stale heartbeat on a nominally-alive pid is what separates those cases.

## Verification

- `npm run lint` (`tsc --noEmit`) — clean
- `npx vitest run` — **704 files, 13215 passed, 14 skipped, 0 failures**
- 13 new tests in `src/agent/awareness/presence.test.ts` (28 total in that file), including a reaped-child-process helper for a portably-guaranteed dead pid, since `pid_max` differs per platform

## Deferred, deliberately

- **`touchPresenceHeartbeat` is not yet wired to turn boundaries**, so `heartbeatAt` is currently stamped only at session start. The primary ghost-session fix (pid liveness) is fully effective regardless; the heartbeat is the secondary pid-recycling guard and needs a caller to earn its keep.
- **`worktree-sweep.ts` keeps its private `kill(pid, 0)` copy.** It has unmerged work in flight on `afk/cleanup-agent-worktree`; consolidating now would conflict for no functional gain. Fold it in once that lands.
- A **blocked-on-human on-disk signal** (so an external observer can detect a session waiting on `ask_question`) is the natural next piece and is not in this PR.
