### PR TITLE
feat(presence): emit a blocked-on-human marker while an elicitation waits

### DIFF
--- a/src/agent/afk-mode-gate.test.ts
+++ b/src/agent/afk-mode-gate.test.ts
@@ -695,3 +695,74 @@ describe('createAfkModeGate — high-risk approval round-trip (v1.5)', () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// blockedSince marker: session-id sourcing
+// ---------------------------------------------------------------------------
+
+describe('createAfkModeGate — blocked-marker session id', () => {
+  const HIGH_RISK = {
+    event: 'PreToolUse',
+    toolName: 'bash',
+    input: { command: 'rm -rf build' },
+  } as const;
+
+  type RouteOpts = { signal: AbortSignal; onActive?: () => void; sessionId?: string };
+  const approve = (seen: { opts?: RouteOpts }) =>
+    vi.fn(async (_req: unknown, opts: RouteOpts): Promise<ElicitationResult> => {
+      seen.opts = opts;
+      return { action: 'accept', content: { choice: 'approve' } };
+    });
+
+  // Contract: the REPL builds ONE swap-stable hook registry BEFORE the provider
+  // (and therefore the session id) exists, so a gate constructed with no
+  // sessionId option is the REPL's real shape. Without the per-call id the
+  // marker is silently never written on the primary interactive surface.
+  it('uses the per-call context sessionId when the gate was built without one', async () => {
+    const seen: { opts?: RouteOpts } = {};
+    const route = approve(seen);
+    const gate = createAfkModeGate(() => 'autonomous' as PermissionMode, undefined, undefined, { route });
+
+    await gate({ ...HIGH_RISK, sessionId: 'per-call-session' });
+
+    expect(route).toHaveBeenCalledTimes(1);
+    expect(seen.opts?.sessionId).toBe('per-call-session');
+  });
+
+  it('falls back to the construction-time sessionId when the context carries none', async () => {
+    const seen: { opts?: RouteOpts } = {};
+    const route = approve(seen);
+    const gate = createAfkModeGate(() => 'autonomous' as PermissionMode, undefined, undefined, {
+      route,
+      sessionId: 'constructed-session',
+    });
+
+    await gate({ ...HIGH_RISK });
+
+    expect(seen.opts?.sessionId).toBe('constructed-session');
+  });
+
+  it('prefers the per-call sessionId over a stale construction-time one', async () => {
+    const seen: { opts?: RouteOpts } = {};
+    const route = approve(seen);
+    const gate = createAfkModeGate(() => 'autonomous' as PermissionMode, undefined, undefined, {
+      route,
+      sessionId: 'stale-session',
+    });
+
+    await gate({ ...HIGH_RISK, sessionId: 'live-session' });
+
+    expect(seen.opts?.sessionId).toBe('live-session');
+  });
+
+  it('omits sessionId entirely when neither source supplies one (never a wrong-session marker)', async () => {
+    const seen: { opts?: RouteOpts } = {};
+    const route = approve(seen);
+    const gate = createAfkModeGate(() => 'autonomous' as PermissionMode, undefined, undefined, { route });
+
+    await gate({ ...HIGH_RISK });
+
+    expect(seen.opts).toBeDefined();
+    expect('sessionId' in seen.opts!).toBe(false);
+  });
+});

--- a/src/agent/afk-mode-gate.ts
+++ b/src/agent/afk-mode-gate.ts
@@ -110,8 +110,16 @@ export interface AfkModeGateOptions {
    */
   route?: (
     request: ElicitationRequest,
-    options: { signal: AbortSignal; onActive?: () => void },
+    options: { signal: AbortSignal; onActive?: () => void; sessionId?: string },
   ) => Promise<ElicitationResult>;
+  /**
+   * Session id of the session this gate guards. Forwarded into
+   * `elicitationRouter.route()` so a pending high-risk-op approval stamps a
+   * `blockedSince` marker on THIS session's presence file, making "your agent is
+   * waiting on you" visible to an out-of-process observer. Optional — absent
+   * means no marker is written (never a marker on the wrong session).
+   */
+  sessionId?: string;
   /**
    * Trace writer for structured audit events. When provided, the gate emits a
    * `hook_decision` event on every approval decision (approve, deny, timeout,
@@ -129,10 +137,13 @@ export function createAfkModeGate(
   const approvalTimeoutMs = opts?.approvalTimeoutMs ?? DEFAULT_APPROVAL_TIMEOUT_MS;
   const promptForApproval = opts?.promptForApproval ?? true;
   const traceWriter = opts?.traceWriter;
+  const sessionId = opts?.sessionId;
   const route =
     opts?.route ??
-    ((request: ElicitationRequest, options: { signal: AbortSignal; onActive?: () => void }) =>
-      elicitationRouter.route(request, options));
+    ((
+      request: ElicitationRequest,
+      options: { signal: AbortSignal; onActive?: () => void; sessionId?: string },
+    ) => elicitationRouter.route(request, options));
 
   async function requestApproval(
     toolName: string,
@@ -201,7 +212,14 @@ export function createAfkModeGate(
       // than relying on the handler to observe the abort) guarantees progress
       // even for a handler that ignores its signal. The timer is armed via
       // onActive so it starts only when the prompt is actually shown.
-      outcome = await Promise.race([route(request, { signal: ac.signal, onActive: armTimer }), timeoutP]);
+      outcome = await Promise.race([
+        route(request, {
+          signal: ac.signal,
+          onActive: armTimer,
+          ...(sessionId !== undefined ? { sessionId } : {}),
+        }),
+        timeoutP,
+      ]);
     } finally {
       if (timer) clearTimeout(timer);
       if (signal) signal.removeEventListener('abort', onParentAbort);

--- a/src/agent/afk-mode-gate.ts
+++ b/src/agent/afk-mode-gate.ts
@@ -116,8 +116,15 @@ export interface AfkModeGateOptions {
    * Session id of the session this gate guards. Forwarded into
    * `elicitationRouter.route()` so a pending high-risk-op approval stamps a
    * `blockedSince` marker on THIS session's presence file, making "your agent is
-   * waiting on you" visible to an out-of-process observer. Optional — absent
-   * means no marker is written (never a marker on the wrong session).
+   * waiting on you" visible to an out-of-process observer.
+   *
+   * FALLBACK ONLY: the per-call `PreToolUseContext.sessionId` takes precedence
+   * (see `requestApproval`). A registry built before its session exists — the
+   * REPL's swap-stable one — cannot supply this, so it is the per-call id that
+   * carries the marker on every dispatcher-backed surface. Set it for surfaces
+   * that know their id up front and do not route through a populated context
+   * (the daemon scheduler). Absent from both means no marker is written (never a
+   * marker on the wrong session).
    */
   sessionId?: string;
   /**
@@ -149,6 +156,7 @@ export function createAfkModeGate(
     toolName: string,
     input: unknown,
     signal?: AbortSignal,
+    callSessionId?: string,
   ): Promise<HookDecision> {
     const start = Date.now();
     const request = buildApprovalRequest(toolName, input);
@@ -212,11 +220,23 @@ export function createAfkModeGate(
       // than relying on the handler to observe the abort) guarantees progress
       // even for a handler that ignores its signal. The timer is armed via
       // onActive so it starts only when the prompt is actually shown.
+      // Contract: the per-call id from the hook context wins over the one
+      // captured at construction. The REPL builds ONE hook registry that is
+      // deliberately stable across session swaps and is constructed before the
+      // provider exists (interactive/bootstrap.ts), so there is no session id to
+      // pass at construction time and the captured value is permanently
+      // undefined there — a high-risk approval would prompt with no marker at
+      // all. The dispatcher populates `PreToolUseContext.sessionId` per call,
+      // which is the same source the path-approval hook already uses
+      // (tools/hooks/path-approval-hook.ts). The construction-time value stays
+      // as the fallback for surfaces that supply it and do not route through a
+      // dispatcher-populated context (the daemon scheduler).
+      const markSessionId = callSessionId ?? sessionId;
       outcome = await Promise.race([
         route(request, {
           signal: ac.signal,
           onActive: armTimer,
-          ...(sessionId !== undefined ? { sessionId } : {}),
+          ...(markSessionId !== undefined ? { sessionId: markSessionId } : {}),
         }),
         timeoutP,
       ]);
@@ -338,7 +358,7 @@ export function createAfkModeGate(
 
     // Main session: ask the operator to approve/deny (deny-on-timeout). Returns
     // a Promise<HookDecision>; the gate is registered `longRunning: true`.
-    return requestApproval(toolName, context.input, signal);
+    return requestApproval(toolName, context.input, signal, context.sessionId);
   };
 }
 

--- a/src/agent/awareness/index.ts
+++ b/src/agent/awareness/index.ts
@@ -51,6 +51,7 @@ export {
   readPresenceFiles,
   readLivePresenceFiles,
   touchPresenceHeartbeat,
+  setPresenceBlocked,
   PRESENCE_SCHEMA_VERSION,
   type PresenceFileInfo,
   type PresenceRecord,

--- a/src/agent/awareness/presence.test.ts
+++ b/src/agent/awareness/presence.test.ts
@@ -446,3 +446,89 @@ describe('readLivePresenceFiles', () => {
     expect(live.map((r) => r.sessionId)).toEqual(['no-hb']);
   });
 });
+
+// ---------------------------------------------------------------------------
+// setPresenceBlocked — the blocked-on-human marker
+// ---------------------------------------------------------------------------
+
+describe('setPresenceBlocked', () => {
+  it('stamps an ISO timestamp on set and removes the key on clear', async () => {
+    const { writePresenceFile, setPresenceBlocked, readPresenceFiles } = await getPresenceMod();
+    await writePresenceFile(mkInfo({ sessionId: 'blocked-1' }));
+
+    const before = Date.now();
+    await setPresenceBlocked('blocked-1', true);
+    const after = Date.now();
+
+    const set = (await readPresenceFiles())[0]!;
+    expect(typeof set.blockedSince).toBe('string');
+    const stamped = Date.parse(set.blockedSince!);
+    expect(Number.isNaN(stamped)).toBe(false);
+    // Within the call window (1s slack for clock granularity).
+    expect(stamped).toBeGreaterThanOrEqual(before - 1000);
+    expect(stamped).toBeLessThanOrEqual(after + 1000);
+
+    await setPresenceBlocked('blocked-1', false);
+    const cleared = (await readPresenceFiles())[0]!;
+    // Absence, not a sentinel — a reader tests presence of the key.
+    expect(cleared.blockedSince).toBeUndefined();
+    expect(Object.hasOwn(cleared, 'blockedSince')).toBe(false);
+  });
+
+  it('preserves every other field, including afk (they are independent)', async () => {
+    const { writePresenceFile, setPresenceAfk, setPresenceBlocked, readPresenceFiles } =
+      await getPresenceMod();
+    await writePresenceFile(mkInfo({ sessionId: 'blocked-2', cwd: '/tmp/keepme' }));
+    await setPresenceAfk('blocked-2', true);
+
+    await setPresenceBlocked('blocked-2', true);
+    const rec = (await readPresenceFiles())[0]!;
+
+    expect(rec.afk).toBe(true);                 // afk survives a blocked write
+    expect(rec.blockedSince).toBeDefined();     // both can be true at once
+    expect(rec.cwd).toBe('/tmp/keepme');
+    expect(rec.pid).toBe(process.pid);
+    expect(rec.surface).toBe('cli');
+    expect(rec.schemaVersion).toBe(1);          // additive field: no version bump
+
+    // Clearing blocked must not disturb the afk posture.
+    await setPresenceBlocked('blocked-2', false);
+    expect((await readPresenceFiles())[0]!.afk).toBe(true);
+  });
+
+  it('is a silent no-op for a session with no presence file (subagents)', async () => {
+    const { setPresenceBlocked, readPresenceFiles } = await getPresenceMod();
+    // Must not throw and must not conjure a file — an elicitation from a
+    // subagent (which never has presence) still routes normally.
+    await expect(setPresenceBlocked('no-such-session', true)).resolves.toBeUndefined();
+    expect(await readPresenceFiles()).toHaveLength(0);
+  });
+
+  it('is idempotent and last-write-wins on a repeated set', async () => {
+    const { writePresenceFile, setPresenceBlocked, readPresenceFiles } = await getPresenceMod();
+    await writePresenceFile(mkInfo({ sessionId: 'blocked-3' }));
+
+    await setPresenceBlocked('blocked-3', true);
+    const first = (await readPresenceFiles())[0]!.blockedSince!;
+    await new Promise((r) => setTimeout(r, 5));
+    await setPresenceBlocked('blocked-3', true);
+    const second = (await readPresenceFiles())[0]!.blockedSince!;
+
+    expect(Date.parse(second)).toBeGreaterThanOrEqual(Date.parse(first));
+    // Two clears in a row must also be safe.
+    await setPresenceBlocked('blocked-3', false);
+    await setPresenceBlocked('blocked-3', false);
+    expect((await readPresenceFiles())[0]!.blockedSince).toBeUndefined();
+  });
+
+  it('leaves a corrupt presence file untouched instead of throwing', async () => {
+    const { setPresenceBlocked } = await getPresenceMod();
+    const presenceDir = path.join(tmpDir, 'state', 'presence');
+    fs.mkdirSync(presenceDir, { recursive: true });
+    const p = path.join(presenceDir, 'corrupt.json');
+    fs.writeFileSync(p, '{not json', 'utf8');
+
+    await expect(setPresenceBlocked('corrupt', true)).resolves.toBeUndefined();
+    expect(fs.readFileSync(p, 'utf8')).toBe('{not json');
+  });
+});

--- a/src/agent/awareness/presence.test.ts
+++ b/src/agent/awareness/presence.test.ts
@@ -532,3 +532,96 @@ describe('setPresenceBlocked', () => {
     expect(fs.readFileSync(p, 'utf8')).toBe('{not json');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Per-session write serialization
+// ---------------------------------------------------------------------------
+
+describe('presence write serialization', () => {
+  // Invariant under test: every presence mutator is a read → modify → write
+  // cycle that awaits between the read and the write. Two overlapping calls for
+  // one session therefore both read the SAME pre-mutation record, and the later
+  // write drops the earlier mutation unless the writes are serialized per
+  // session. These assertions are deliberately cross-FIELD: whichever write
+  // happens to land last, an unserialized implementation can only ever preserve
+  // one of the two mutations, so the test fails 100% of the time rather than
+  // flaking on fs scheduling.
+  it('does not drop a concurrent mutation to a different field (lost update)', async () => {
+    const { writePresenceFile, setPresenceBlocked, setPresenceAfk, readPresenceFiles } =
+      await getPresenceMod();
+    await writePresenceFile(mkInfo({ sessionId: 'race-1' }));
+
+    // Fire both WITHOUT awaiting the first, so the two read-modify-write cycles
+    // overlap exactly as the elicitation router's unawaited set/clear pair does.
+    await Promise.all([setPresenceBlocked('race-1', true), setPresenceAfk('race-1', true)]);
+
+    const rec = (await readPresenceFiles())[0]!;
+    expect(rec.blockedSince).toBeDefined();
+    expect(rec.afk).toBe(true);
+  });
+
+  it('preserves every mutation across three overlapping writers', async () => {
+    const { writePresenceFile, setPresenceBlocked, setPresenceAfk, updatePresenceCwd, readPresenceFiles } =
+      await getPresenceMod();
+    await writePresenceFile(mkInfo({ sessionId: 'race-2', cwd: '/tmp/before' }));
+
+    await Promise.all([
+      setPresenceBlocked('race-2', true),
+      setPresenceAfk('race-2', true),
+      updatePresenceCwd('race-2', '/tmp/after'),
+    ]);
+
+    const rec = (await readPresenceFiles())[0]!;
+    expect(rec.blockedSince).toBeDefined();
+    expect(rec.afk).toBe(true);
+    expect(rec.cwd).toBe('/tmp/after');
+  });
+
+  it('applies an unawaited set then clear in call order, leaving no stale marker', async () => {
+    const { writePresenceFile, setPresenceBlocked, readPresenceFiles } = await getPresenceMod();
+    await writePresenceFile(mkInfo({ sessionId: 'race-3' }));
+
+    // The router's exact shape: set fired and NOT awaited, clear fired while the
+    // set's write is still in flight. Serialized, the clear always lands last.
+    const set = setPresenceBlocked('race-3', true);
+    const clear = setPresenceBlocked('race-3', false);
+    await Promise.all([set, clear]);
+
+    expect((await readPresenceFiles())[0]!.blockedSince).toBeUndefined();
+  });
+
+  it('does not let a concurrent mutator resurrect a removed presence file', async () => {
+    const { writePresenceFile, removePresenceFile, setPresenceBlocked, readPresenceFiles } =
+      await getPresenceMod();
+    await writePresenceFile(mkInfo({ sessionId: 'race-4' }));
+
+    // A session exiting while a blocked-clear is still in flight: an unordered
+    // unlink lets the mutator's writeFile recreate the file for a dead session.
+    await Promise.all([setPresenceBlocked('race-4', true), removePresenceFile('race-4')]);
+
+    expect(await readPresenceFiles()).toHaveLength(0);
+  });
+
+  it('serializes per session, so one session does not swallow another\'s write', async () => {
+    const { writePresenceFile, setPresenceBlocked, readPresenceFiles } = await getPresenceMod();
+    await writePresenceFile(mkInfo({ sessionId: 'race-5a' }));
+    await writePresenceFile(mkInfo({ sessionId: 'race-5b' }));
+
+    await Promise.all([setPresenceBlocked('race-5a', true), setPresenceBlocked('race-5b', true)]);
+
+    const byId = new Map((await readPresenceFiles()).map((r) => [r.sessionId, r]));
+    expect(byId.get('race-5a')!.blockedSince).toBeDefined();
+    expect(byId.get('race-5b')!.blockedSince).toBeDefined();
+  });
+
+  it('keeps working after a tail drains (queue entry is evicted, not leaked)', async () => {
+    const { writePresenceFile, setPresenceBlocked, readPresenceFiles } = await getPresenceMod();
+    await writePresenceFile(mkInfo({ sessionId: 'race-6' }));
+
+    await setPresenceBlocked('race-6', true);
+    await setPresenceBlocked('race-6', false);
+    await setPresenceBlocked('race-6', true);
+
+    expect((await readPresenceFiles())[0]!.blockedSince).toBeDefined();
+  });
+});

--- a/src/agent/awareness/presence.ts
+++ b/src/agent/awareness/presence.ts
@@ -92,6 +92,32 @@ export interface PresenceFileInfo {
    * written before this field existed, and on any session that never refreshed.
    */
   heartbeatAt?: string;
+  /**
+   * ISO 8601 timestamp of the moment this session began waiting on a human. Set
+   * by {@link setPresenceBlocked} when an elicitation is about to prompt the
+   * operator, and cleared the instant it settles (answer, skip, decline, cancel,
+   * or turn abort).
+   *
+   * Present ⇒ the session is blocked on a human RIGHT NOW; absent ⇒ it is not.
+   * This is the on-disk trace of an event that previously had none: the
+   * elicitation router's only outward signal was a best-effort Telegram push, so
+   * an out-of-process observer (a native app polling {@link readPresenceFiles})
+   * could not see that an agent was stuck waiting.
+   *
+   * A timestamp rather than a boolean deliberately: it lets a reader render
+   * "waiting 4m" and age out a marker that a hard-killed session never cleared.
+   * Treat it as advisory and cross-check `liveness` — a `blockedSince` on a dead
+   * pid is a leftover, not a live prompt.
+   *
+   * Distinct from {@link afk}: `afk` is a remote-control posture the operator
+   * sets and unsets, while `blockedSince` is runtime-set and true only for the
+   * duration of one pending prompt. Both may be present at once.
+   *
+   * Optional/additive (no {@link PRESENCE_SCHEMA_VERSION} bump): absent on
+   * records written before this field existed and on any session not currently
+   * waiting.
+   */
+  blockedSince?: string;
 }
 
 /**
@@ -214,6 +240,41 @@ export async function setPresenceAfk(sessionId: string, afk: boolean): Promise<v
     const raw = await readFile(filePath, 'utf8');
     const parsed = JSON.parse(raw) as PresenceFileInfo;
     parsed.afk = afk;
+    await writeFile(filePath, JSON.stringify(parsed, null, 2), 'utf8');
+  } catch {
+    // Best-effort — presence is non-critical.
+  }
+}
+
+/**
+ * Set or clear the {@link PresenceFileInfo.blockedSince} marker on an existing
+ * presence file (best-effort, read-modify-write).
+ *
+ * Called from the elicitation router around a prompt the operator is actually
+ * about to see: `blocked: true` immediately before the handler runs, `false` the
+ * instant it settles. `true` stamps `new Date().toISOString()`; `false` deletes
+ * the key entirely, so "not waiting" is represented by absence rather than by a
+ * sentinel a reader would have to interpret.
+ *
+ * Idempotent, and safe to call for a session that has no presence file —
+ * subagents never have one, and every non-top-level surface routes elicitations
+ * through the same code path. No-op when the file is absent or unreadable.
+ * Preserves every other field.
+ *
+ * Never throws: an elicitation must not fail because presence telemetry could
+ * not be written. A dropped clear is bounded by the caller's `liveness` check
+ * and by presence-file removal at process exit.
+ */
+export async function setPresenceBlocked(sessionId: string, blocked: boolean): Promise<void> {
+  try {
+    const filePath = presenceFilePath(sessionId);
+    const raw = await readFile(filePath, 'utf8');
+    const parsed = JSON.parse(raw) as PresenceFileInfo;
+    if (blocked) {
+      parsed.blockedSince = new Date().toISOString();
+    } else {
+      delete parsed.blockedSince;
+    }
     await writeFile(filePath, JSON.stringify(parsed, null, 2), 'utf8');
   } catch {
     // Best-effort — presence is non-critical.

--- a/src/agent/awareness/presence.ts
+++ b/src/agent/awareness/presence.ts
@@ -172,6 +172,47 @@ async function ensurePresenceDir(): Promise<boolean> {
   }
 }
 
+// Invariant: presence writes for ONE session must land on disk in call order.
+// Every mutator below is a read → modify → write cycle that awaits between the
+// read and the write, so two overlapping calls for the same session both read
+// the pre-mutation record and the later write silently drops the earlier
+// mutation. This is not hypothetical for `blockedSince`: the elicitation router
+// fires its set and its paired clear WITHOUT awaiting either
+// (elicitation-router.ts:199,206) so telemetry can never delay an operator
+// prompt. A prompt that settles before the set's I/O completes therefore raced
+// its own clear — landing the set last strands a permanent "waiting on you"
+// marker, and landing a previous prompt's clear last erases the marker of the
+// next queued prompt. Both are the exact failure the set/clear pairing exists
+// to prevent, and neither is reachable once the writes are ordered.
+//
+// Serializing per session rather than globally keeps unrelated sessions
+// independent: one wedged filesystem write cannot stall another session's
+// heartbeat. Every writer routes through here, so the fix also closes the
+// pre-existing lost-update race between `touchPresenceHeartbeat` and the other
+// mutators. `removePresenceFileSync` is deliberately NOT enrolled — it runs in
+// a process-exit handler where a promise queue cannot be drained.
+const presenceWriteTails = new Map<string, Promise<void>>();
+
+/**
+ * Chain `mutate` onto this session's serialized write tail and resolve once it
+ * has run. Rejection of a predecessor never blocks a successor (`mutate` runs on
+ * both settle paths); every caller's own body swallows its errors, so the tail
+ * itself is not expected to reject.
+ */
+function enqueuePresenceWrite(sessionId: string, mutate: () => Promise<void>): Promise<void> {
+  const previous = presenceWriteTails.get(sessionId) ?? Promise.resolve();
+  const tail = previous.then(mutate, mutate);
+  presenceWriteTails.set(sessionId, tail);
+  // Drop the entry once this call is the last one queued, so a long-lived
+  // process hosting many short sessions does not retain a promise per session
+  // forever. The identity check is what makes eviction safe: a later enqueue has
+  // already replaced the entry, and that newer tail must survive.
+  void tail.catch(() => undefined).then(() => {
+    if (presenceWriteTails.get(sessionId) === tail) presenceWriteTails.delete(sessionId);
+  });
+  return tail;
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -184,24 +225,26 @@ async function ensurePresenceDir(): Promise<boolean> {
  * best-effort. The session starts normally regardless.
  */
 export async function writePresenceFile(info: PresenceFileInfo): Promise<void> {
-  try {
-    const ok = await ensurePresenceDir();
-    if (!ok) return;
-    const filePath = presenceFilePath(info.sessionId);
-    // Stamp the schema version and an initial heartbeat HERE rather than at the
-    // call sites: more than one provider writes presence (anthropic-direct and
-    // openai-compatible), so a per-caller stamp would silently miss a writer the
-    // moment a third surface is added. Caller-supplied values win, which keeps
-    // tests able to pin a specific version or heartbeat.
-    const record: PresenceFileInfo = {
-      schemaVersion: PRESENCE_SCHEMA_VERSION,
-      heartbeatAt: new Date().toISOString(),
-      ...info,
-    };
-    await writeFile(filePath, JSON.stringify(record, null, 2), 'utf8');
-  } catch {
-    // Best-effort — swallow silently.
-  }
+  return enqueuePresenceWrite(info.sessionId, async () => {
+    try {
+      const ok = await ensurePresenceDir();
+      if (!ok) return;
+      const filePath = presenceFilePath(info.sessionId);
+      // Stamp the schema version and an initial heartbeat HERE rather than at the
+      // call sites: more than one provider writes presence (anthropic-direct and
+      // openai-compatible), so a per-caller stamp would silently miss a writer the
+      // moment a third surface is added. Caller-supplied values win, which keeps
+      // tests able to pin a specific version or heartbeat.
+      const record: PresenceFileInfo = {
+        schemaVersion: PRESENCE_SCHEMA_VERSION,
+        heartbeatAt: new Date().toISOString(),
+        ...info,
+      };
+      await writeFile(filePath, JSON.stringify(record, null, 2), 'utf8');
+    } catch {
+      // Best-effort — swallow silently.
+    }
+  });
 }
 
 /**
@@ -216,15 +259,17 @@ export async function writePresenceFile(info: PresenceFileInfo): Promise<void> {
  * throws: presence is non-critical and the session must proceed regardless.
  */
 export async function touchPresenceHeartbeat(sessionId: string): Promise<void> {
-  try {
-    const filePath = presenceFilePath(sessionId);
-    const raw = await readFile(filePath, 'utf8');
-    const parsed = JSON.parse(raw) as PresenceFileInfo;
-    parsed.heartbeatAt = new Date().toISOString();
-    await writeFile(filePath, JSON.stringify(parsed, null, 2), 'utf8');
-  } catch {
-    // Best-effort — presence is non-critical.
-  }
+  return enqueuePresenceWrite(sessionId, async () => {
+    try {
+      const filePath = presenceFilePath(sessionId);
+      const raw = await readFile(filePath, 'utf8');
+      const parsed = JSON.parse(raw) as PresenceFileInfo;
+      parsed.heartbeatAt = new Date().toISOString();
+      await writeFile(filePath, JSON.stringify(parsed, null, 2), 'utf8');
+    } catch {
+      // Best-effort — presence is non-critical.
+    }
+  });
 }
 
 /**
@@ -235,15 +280,17 @@ export async function touchPresenceHeartbeat(sessionId: string): Promise<void> {
  * keyboard elicitation path works regardless). Preserves every other field.
  */
 export async function setPresenceAfk(sessionId: string, afk: boolean): Promise<void> {
-  try {
-    const filePath = presenceFilePath(sessionId);
-    const raw = await readFile(filePath, 'utf8');
-    const parsed = JSON.parse(raw) as PresenceFileInfo;
-    parsed.afk = afk;
-    await writeFile(filePath, JSON.stringify(parsed, null, 2), 'utf8');
-  } catch {
-    // Best-effort — presence is non-critical.
-  }
+  return enqueuePresenceWrite(sessionId, async () => {
+    try {
+      const filePath = presenceFilePath(sessionId);
+      const raw = await readFile(filePath, 'utf8');
+      const parsed = JSON.parse(raw) as PresenceFileInfo;
+      parsed.afk = afk;
+      await writeFile(filePath, JSON.stringify(parsed, null, 2), 'utf8');
+    } catch {
+      // Best-effort — presence is non-critical.
+    }
+  });
 }
 
 /**
@@ -266,19 +313,21 @@ export async function setPresenceAfk(sessionId: string, afk: boolean): Promise<v
  * and by presence-file removal at process exit.
  */
 export async function setPresenceBlocked(sessionId: string, blocked: boolean): Promise<void> {
-  try {
-    const filePath = presenceFilePath(sessionId);
-    const raw = await readFile(filePath, 'utf8');
-    const parsed = JSON.parse(raw) as PresenceFileInfo;
-    if (blocked) {
-      parsed.blockedSince = new Date().toISOString();
-    } else {
-      delete parsed.blockedSince;
+  return enqueuePresenceWrite(sessionId, async () => {
+    try {
+      const filePath = presenceFilePath(sessionId);
+      const raw = await readFile(filePath, 'utf8');
+      const parsed = JSON.parse(raw) as PresenceFileInfo;
+      if (blocked) {
+        parsed.blockedSince = new Date().toISOString();
+      } else {
+        delete parsed.blockedSince;
+      }
+      await writeFile(filePath, JSON.stringify(parsed, null, 2), 'utf8');
+    } catch {
+      // Best-effort — presence is non-critical.
     }
-    await writeFile(filePath, JSON.stringify(parsed, null, 2), 'utf8');
-  } catch {
-    // Best-effort — presence is non-critical.
-  }
+  });
 }
 
 /**
@@ -293,15 +342,17 @@ export async function setPresenceBlocked(sessionId: string, blocked: boolean): P
  * every other field.
  */
 export async function updatePresenceCwd(sessionId: string, cwd: string): Promise<void> {
-  try {
-    const filePath = presenceFilePath(sessionId);
-    const raw = await readFile(filePath, 'utf8');
-    const parsed = JSON.parse(raw) as PresenceFileInfo;
-    parsed.cwd = cwd;
-    await writeFile(filePath, JSON.stringify(parsed, null, 2), 'utf8');
-  } catch {
-    // Best-effort — presence is non-critical.
-  }
+  return enqueuePresenceWrite(sessionId, async () => {
+    try {
+      const filePath = presenceFilePath(sessionId);
+      const raw = await readFile(filePath, 'utf8');
+      const parsed = JSON.parse(raw) as PresenceFileInfo;
+      parsed.cwd = cwd;
+      await writeFile(filePath, JSON.stringify(parsed, null, 2), 'utf8');
+    } catch {
+      // Best-effort — presence is non-critical.
+    }
+  });
 }
 
 /**
@@ -309,13 +360,20 @@ export async function updatePresenceCwd(sessionId: string, cwd: string): Promise
  *
  * Safe to call even if the file does not exist (ENOENT is swallowed).
  * All other errors are also swallowed — presence cleanup is best-effort.
+ *
+ * Enrolled in the same per-session write tail as the mutators: an unordered
+ * delete racing an in-flight read-modify-write lets the mutator's `writeFile`
+ * resurrect the file after the unlink, leaving a presence record for an exited
+ * session that `readPresenceFiles()` then reports with a dead pid.
  */
 export async function removePresenceFile(sessionId: string): Promise<void> {
-  try {
-    await unlink(presenceFilePath(sessionId));
-  } catch {
-    // ENOENT or any other error — swallow.
-  }
+  return enqueuePresenceWrite(sessionId, async () => {
+    try {
+      await unlink(presenceFilePath(sessionId));
+    } catch {
+      // ENOENT or any other error — swallow.
+    }
+  });
 }
 
 /**

--- a/src/agent/default-hook-registry.ts
+++ b/src/agent/default-hook-registry.ts
@@ -162,6 +162,9 @@ export function createDefaultHookRegistry(
         ...(agentOptions?.afkPromptForApproval !== undefined
           ? { promptForApproval: agentOptions.afkPromptForApproval }
           : {}),
+        // Lets a pending approval mark this session's presence file as
+        // blocked-on-human, so an out-of-process observer can see the wait.
+        ...(agentOptions?.sessionId !== undefined ? { sessionId: agentOptions.sessionId } : {}),
       }),
       // Longrunning: on a high-risk op the gate awaits an operator approve/deny
       // via elicitationRouter.route() (deny-on-timeout). Bypass the 30s per-

--- a/src/agent/elicitation-router.test.ts
+++ b/src/agent/elicitation-router.test.ts
@@ -24,8 +24,31 @@ vi.mock('../telegram/push.js', () => ({
   pushIfConfigured: vi.fn().mockResolvedValue(null),
 }));
 
+// Mock the presence writer so the blocked-marker lifecycle can be asserted as
+// an ordered call log without touching the filesystem. Hoisted above the
+// router import below.
+vi.mock('./awareness/presence.js', () => ({
+  setPresenceBlocked: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { elicitationRouter } from './elicitation-router.js';
 import { pushIfConfigured } from '../telegram/push.js';
+import { setPresenceBlocked } from './awareness/presence.js';
+
+/** Ordered [sessionId, blocked] pairs the router asked presence to write. */
+function blockedCalls(): Array<[string, boolean]> {
+  return vi.mocked(setPresenceBlocked).mock.calls.map((c) => [c[0], c[1]] as [string, boolean]);
+}
+
+/**
+ * The marker writes are fire-and-forget (`void ... .catch()`), so a settle can
+ * be observed by the caller before the clear's microtask has run. Flush the
+ * microtask queue before asserting on the call log.
+ */
+async function flush(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
 
 const NO_SIGNAL = new AbortController().signal;
 
@@ -41,6 +64,7 @@ describe('elicitationRouter', () => {
   beforeEach(() => {
     elicitationRouter.uninstall();
     vi.mocked(pushIfConfigured).mockClear();
+    vi.mocked(setPresenceBlocked).mockClear();
   });
 
   afterEach(() => {
@@ -341,5 +365,197 @@ describe('hasHandler', () => {
 
     elicitationRouter.uninstall();
     expect(elicitationRouter.hasHandler()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// blocked-on-human presence marker
+//
+// The marker is a SET/CLEAR pair, not a fire-and-forget event: an unpaired set
+// strands a permanent "your agent is waiting on you" marker on a session that
+// is no longer waiting. These tests pin the pairing on every settle path, and
+// pin that the set happens ONLY where a human is really about to be prompted.
+// ---------------------------------------------------------------------------
+
+describe('blockedSince presence marker', () => {
+  beforeEach(() => {
+    elicitationRouter.uninstall();
+    vi.mocked(setPresenceBlocked).mockClear();
+  });
+
+  afterEach(() => {
+    elicitationRouter.uninstall();
+  });
+
+  it('sets before the handler runs and clears after it answers', async () => {
+    const order: string[] = [];
+    vi.mocked(setPresenceBlocked).mockImplementation(async (_id, blocked) => {
+      order.push(blocked ? 'set' : 'clear');
+    });
+    elicitationRouter.install(async (): Promise<ElicitationResult> => {
+      order.push('handler');
+      return { action: 'accept' };
+    });
+
+    const result = await elicitationRouter.route(URL_REQUEST, {
+      signal: NO_SIGNAL,
+      sessionId: 'sess-A',
+    });
+    await flush();
+
+    expect(result.action).toBe('accept');
+    // Ordering is the contract: a marker written after the handler returns, or
+    // cleared before it runs, would be visible to a poller as the wrong state.
+    expect(order).toEqual(['set', 'handler', 'clear']);
+    expect(blockedCalls()).toEqual([
+      ['sess-A', true],
+      ['sess-A', false],
+    ]);
+  });
+
+  it('clears when the handler REJECTS (decline path)', async () => {
+    elicitationRouter.install(async () => {
+      throw new Error('handler exploded');
+    });
+
+    const result = await elicitationRouter.route(URL_REQUEST, {
+      signal: NO_SIGNAL,
+      sessionId: 'sess-B',
+    });
+    await flush();
+
+    expect(result.action).toBe('decline');
+    expect(blockedCalls()).toEqual([
+      ['sess-B', true],
+      ['sess-B', false],
+    ]);
+  });
+
+  it('clears when the handler throws SYNCHRONOUSLY', async () => {
+    // A non-async handler that throws bubbles past the inner catch; the safety-net
+    // resolve covers the result, and the finally must still clear the marker.
+    elicitationRouter.install((() => {
+      throw new Error('sync boom');
+    }) as unknown as Parameters<typeof elicitationRouter.install>[0]);
+
+    const result = await elicitationRouter.route(URL_REQUEST, {
+      signal: NO_SIGNAL,
+      sessionId: 'sess-C',
+    });
+    await flush();
+
+    expect(result.action).toBe('decline');
+    expect(blockedCalls()).toEqual([
+      ['sess-C', true],
+      ['sess-C', false],
+    ]);
+  });
+
+  it('clears when the turn is ABORTED mid-prompt (handler never settles)', async () => {
+    // The worst stranding case: operator walks away, turn is torn down, and the
+    // handler never resolves. The abort race unblocks the caller — the clear
+    // must ride the same finally.
+    const ac = new AbortController();
+    elicitationRouter.install(() => new Promise<ElicitationResult>(() => { /* never settles */ }));
+
+    const p = elicitationRouter.route(URL_REQUEST, { signal: ac.signal, sessionId: 'sess-D' });
+    await flush();
+    expect(blockedCalls()).toEqual([['sess-D', true]]); // set, still waiting
+
+    ac.abort();
+    const result = await p;
+    await flush();
+
+    expect(result.action).toBe('decline');
+    expect(blockedCalls()).toEqual([
+      ['sess-D', true],
+      ['sess-D', false],
+    ]);
+  });
+
+  it('does NOT set when no handler is installed (nobody is being prompted)', async () => {
+    // Park-and-notify declines immediately: no human is waiting, so an on-disk
+    // "blocked" marker would be a lie. Telegram push is the signal here.
+    const result = await elicitationRouter.route(URL_REQUEST, {
+      signal: NO_SIGNAL,
+      sessionId: 'sess-E',
+    });
+    await flush();
+
+    expect(result.action).toBe('decline');
+    expect(blockedCalls()).toEqual([]);
+  });
+
+  it('does NOT set when the signal is already aborted', async () => {
+    elicitationRouter.install(vi.fn().mockResolvedValue({ action: 'accept' } as ElicitationResult));
+    const ac = new AbortController();
+    ac.abort();
+
+    const result = await elicitationRouter.route(URL_REQUEST, {
+      signal: ac.signal,
+      sessionId: 'sess-F',
+    });
+    await flush();
+
+    expect(result.action).toBe('decline');
+    expect(blockedCalls()).toEqual([]);
+  });
+
+  it('writes no marker at all when no sessionId is supplied', async () => {
+    // Legacy callers and subagent-originated prompts: better to write nothing
+    // than to guess a session id and mark the wrong file.
+    elicitationRouter.install(vi.fn().mockResolvedValue({ action: 'accept' } as ElicitationResult));
+
+    await elicitationRouter.route(URL_REQUEST, { signal: NO_SIGNAL });
+    await flush();
+
+    expect(setPresenceBlocked).not.toHaveBeenCalled();
+  });
+
+  it('marks each session independently when two sessions queue concurrently', async () => {
+    // A process can host several concurrent top-level sessions (the Telegram bot
+    // keeps one per chat), so the id must ride the call, never a global.
+    const gates: Array<() => void> = [];
+    elicitationRouter.install(
+      () =>
+        new Promise<ElicitationResult>((resolve) => {
+          gates.push(() => resolve({ action: 'accept' }));
+        }),
+    );
+
+    const p1 = elicitationRouter.route(URL_REQUEST, { signal: NO_SIGNAL, sessionId: 'chat-1' });
+    const p2 = elicitationRouter.route(URL_REQUEST, { signal: NO_SIGNAL, sessionId: 'chat-2' });
+    await flush();
+
+    // Serial queue: only the first is active, so only it is marked.
+    expect(blockedCalls()).toEqual([['chat-1', true]]);
+
+    gates[0]!();
+    await p1;
+    await flush();
+    gates[0 + 1]!();
+    await p2;
+    await flush();
+
+    expect(blockedCalls()).toEqual([
+      ['chat-1', true],
+      ['chat-1', false],
+      ['chat-2', true],
+      ['chat-2', false],
+    ]);
+  });
+
+  it('a presence-write failure never affects the elicitation result', async () => {
+    // Presence is best-effort telemetry; an elicitation must not fail with it.
+    vi.mocked(setPresenceBlocked).mockRejectedValue(new Error('disk full'));
+    elicitationRouter.install(vi.fn().mockResolvedValue({ action: 'accept' } as ElicitationResult));
+
+    const result = await elicitationRouter.route(URL_REQUEST, {
+      signal: NO_SIGNAL,
+      sessionId: 'sess-G',
+    });
+    await flush();
+
+    expect(result.action).toBe('accept');
   });
 });

--- a/src/agent/elicitation-router.ts
+++ b/src/agent/elicitation-router.ts
@@ -34,6 +34,7 @@
 
 import type { ElicitationRequest, ElicitationResult } from './types/sdk-types.js';
 import { pushIfConfigured } from '../telegram/push.js';
+import { setPresenceBlocked } from './awareness/presence.js';
 
 export type ElicitationHandler = (
   request: ElicitationRequest,
@@ -79,6 +80,32 @@ function notifyUnattendedElicitation(request: ElicitationRequest): void {
   }
 }
 
+/**
+ * Set/clear the presence-file blocked marker for the session that owns this
+ * prompt, so an out-of-process observer can see "this agent is waiting on you".
+ *
+ * Fire-and-forget by construction: presence is best-effort telemetry and an
+ * elicitation must never be delayed — let alone failed — by a file write.
+ * `setPresenceBlocked` already swallows its own errors; the extra `.catch` and
+ * try/catch here guarantee that even a synchronous throw cannot escape into the
+ * router's must-always-resolve path.
+ *
+ * No-op without a session id. The id is optional because `route()` is
+ * module-scope with several callers, and a process can host multiple concurrent
+ * top-level sessions (the Telegram bot keeps one session per chat and runs turns
+ * detached) — so there is no safe process-global "current session" to fall back
+ * on. A caller that cannot supply an id simply gets no marker, never a marker
+ * written onto some other session's file.
+ */
+function markBlocked(sessionId: string | undefined, blocked: boolean): void {
+  if (sessionId === undefined || sessionId === '') return;
+  try {
+    void setPresenceBlocked(sessionId, blocked).catch(() => undefined);
+  } catch {
+    // Never let presence telemetry affect the elicitation path.
+  }
+}
+
 class ElicitationRouter {
   private handler: ElicitationHandler | null = null;
   private queue: Promise<void> = Promise.resolve();
@@ -110,7 +137,7 @@ class ElicitationRouter {
 
   route(
     request: ElicitationRequest,
-    options: { signal: AbortSignal; onActive?: () => void },
+    options: { signal: AbortSignal; onActive?: () => void; sessionId?: string },
   ): Promise<ElicitationResult> {
     // Fast-path: already aborted before entering the queue
     if (options.signal.aborted) return Promise.resolve(DECLINE);
@@ -163,12 +190,20 @@ class ElicitationRouter {
           // DECLINE paths). It is observational only: a throwing callback must
           // never break the queue or the "must always resolve" invariant.
           try { options.onActive?.(); } catch { /* observational only */ }
+          // Same edge as onActive, and deliberately inside the same try/finally:
+          // the on-disk blocked marker is SET only where a human is really about
+          // to be prompted, and the paired CLEAR below runs on every settle path
+          // (answer, skip, decline, handler throw, turn abort). An unpaired set
+          // would strand a stale "waiting on you" marker for the rest of the
+          // session's life, so the two must never be separated.
+          markBlocked(options.sessionId, true);
           const result = await Promise.race([
             capturedHandler(request, options).catch(() => DECLINE),
             abortPromise,
           ]);
           resolveResult(result);
         } finally {
+          markBlocked(options.sessionId, false);
           options.signal.removeEventListener('abort', onAbort);
         }
       } finally {
@@ -197,7 +232,7 @@ export const elicitationRouter = new ElicitationRouter();
  */
 export async function routeElicitation(
   request: ElicitationRequest,
-  options: { signal: AbortSignal; onActive?: () => void },
+  options: { signal: AbortSignal; onActive?: () => void; sessionId?: string },
 ): Promise<ElicitationResult> {
   return elicitationRouter.route(request, options);
 }

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -382,6 +382,9 @@ export class SessionToolDispatcher implements ToolDispatcher {
       writeRoots: this._writeRoots.slice(),
       ...(this._allowAll ? { allowAll: true } : {}),
       ...(this._env !== undefined ? { env: this._env } : {}),
+      // Lets human-blocking handlers tell the elicitation router WHICH session's
+      // presence file to mark as waiting-on-a-human.
+      ...(this.sessionId !== undefined ? { sessionId: this.sessionId } : {}),
     };
   }
 
@@ -777,6 +780,9 @@ export class SessionToolDispatcher implements ToolDispatcher {
         event: 'PreToolUse',
         toolName: call.name,
         input: call.input,
+        // Lets the path-approval prompt mark THIS session's presence file as
+        // blocked-on-human while the operator decides.
+        ...(this.sessionId !== undefined ? { sessionId: this.sessionId } : {}),
         ...(this.resolveBase !== undefined ? { cwd: this.resolveBase } : {}),
         ...(this.parentSessionId !== undefined
           ? { parentSessionId: this.parentSessionId }
@@ -881,6 +887,8 @@ export class SessionToolDispatcher implements ToolDispatcher {
           event: 'PreToolUse',
           toolName: call.name,
           input: call.input,
+          // See execute(): identifies the session for the blocked-on-human marker.
+          ...(this.sessionId !== undefined ? { sessionId: this.sessionId } : {}),
           ...(this.resolveBase !== undefined ? { cwd: this.resolveBase } : {}),
           ...(this.parentSessionId !== undefined
             ? { parentSessionId: this.parentSessionId }

--- a/src/agent/tools/handlers/ask-question.ts
+++ b/src/agent/tools/handlers/ask-question.ts
@@ -13,7 +13,7 @@ import type { ToolHandler } from '../types.js';
 import type { ElicitationRequest } from '../../types/sdk-types.js';
 import { elicitationRouter } from '../../elicitation-router.js';
 
-export const askQuestionHandler: ToolHandler = async (input, signal) => {
+export const askQuestionHandler: ToolHandler = async (input, signal, context) => {
   if (!input || typeof input !== 'object') {
     return { content: 'Invalid input: expected an object', isError: true };
   }
@@ -123,7 +123,12 @@ export const askQuestionHandler: ToolHandler = async (input, signal) => {
     ...(obj['allow_custom'] !== undefined && { allowCustom: Boolean(obj['allow_custom']) }),
   };
 
-  const result = await elicitationRouter.route(request, { signal });
+  const result = await elicitationRouter.route(request, {
+    signal,
+    // Marks this session's presence file as blocked-on-human for the duration of
+    // the prompt (no-op when the dispatcher supplied no id).
+    ...(context?.sessionId !== undefined ? { sessionId: context.sessionId } : {}),
+  });
   // Contract: only `decline` (no handler installed) and `cancel` (user
   // interrupted) are surfaced to the agent as tool errors. `accept` and
   // `skip` are both successful outcomes — `skip` is the deliberate

--- a/src/agent/tools/handlers/exit-plan-mode.ts
+++ b/src/agent/tools/handlers/exit-plan-mode.ts
@@ -143,7 +143,12 @@ export function createExitPlanModeHandler(controls: PlanExitControls): ToolHandl
       choices,
     };
 
-    const result = await elicitationRouter.route(request, { signal });
+    const result = await elicitationRouter.route(request, {
+      signal,
+      // Marks this session's presence file as blocked-on-human while the operator
+      // decides (no-op when the dispatcher supplied no id).
+      ...(context?.sessionId !== undefined ? { sessionId: context.sessionId } : {}),
+    });
 
     // No human reachable (no handler) or the user interrupted → stay in plan
     // mode and let the model keep refining. Not an error: declining to exit is

--- a/src/agent/tools/hooks/path-approval-hook.ts
+++ b/src/agent/tools/hooks/path-approval-hook.ts
@@ -330,6 +330,7 @@ async function preToolUseImpl(
     state,
     surface: opts.surface,
     ...(signal !== undefined ? { signal } : {}),
+    ...(context.sessionId !== undefined ? { sessionId: context.sessionId } : {}),
   });
   state.inFlight.set(key, promptPromise);
   try {
@@ -488,8 +489,15 @@ async function promptForApproval(args: {
   surface: PathApprovalSurface;
   /** Turn/dispatch abort signal — cancels the pending prompt on teardown. */
   signal?: AbortSignal;
+  /**
+   * Session id of the session whose tool call triggered this prompt. Forwarded
+   * into the router so the pending approval marks THIS session's presence file
+   * as blocked-on-human. Optional — absent means no marker is written.
+   */
+  sessionId?: string;
 }): Promise<HookDecision> {
-  const { toolName, resolvedPath, capturedCwd, mode, grantManager, state, surface, signal } = args;
+  const { toolName, resolvedPath, capturedCwd, mode, grantManager, state, surface, signal, sessionId } =
+    args;
 
   // Show the symlink-resolved target when it differs from the displayed path so
   // the consent decision reflects the REAL destination — a workspace symlink
@@ -536,7 +544,10 @@ async function promptForApproval(args: {
     // signal forwarded here. Falling back to a never-aborting signal (no
     // forwarded signal) preserves prior behavior for surfaces/tests that
     // dispatch without one.
-    { signal: signal ?? new AbortController().signal },
+    {
+      signal: signal ?? new AbortController().signal,
+      ...(sessionId !== undefined ? { sessionId } : {}),
+    },
   );
 
   if (result.action !== 'accept') {

--- a/src/agent/tools/types.ts
+++ b/src/agent/tools/types.ts
@@ -91,6 +91,21 @@ export interface ToolHandlerContext {
    * invocations that construct a context without a live dispatch cycle.
    */
   toolUseId?: string;
+  /**
+   * Session id of the session executing this tool call. Forwarded by the
+   * dispatcher from its construction-bound id.
+   *
+   * Consumed by the human-blocking handlers (`ask_question`, `exit_plan_mode`),
+   * which pass it into `elicitationRouter.route()` so the router can stamp a
+   * `blockedSince` marker on THIS session's presence file while the operator is
+   * being prompted. The router is module-scope and a process can host several
+   * concurrent top-level sessions, so the id has to arrive per-call — there is no
+   * safe process-global "current session".
+   *
+   * Optional: absent for inline test invocations and for dispatchers constructed
+   * without a session id, in which case the blocked marker is simply not written.
+   */
+  sessionId?: string;
 }
 
 /**

--- a/src/agent/worktree-sweep.test.ts
+++ b/src/agent/worktree-sweep.test.ts
@@ -1576,6 +1576,89 @@ describe('dead-owner — live-session protection', () => {
     expect(after.candidates.filter((c) => c.verdict === 'dead-owner')).toHaveLength(0);
     expect(after.removed).not.toContain(worktreePath);
   });
+
+  it('end-to-end: a REAL blockedSince write does not perturb the in-use guard', async () => {
+    // The sweep decides whether a worktree is in use by reading presence records
+    // (`readPresenceFiles` → `isPathWithin(presence.cwd, worktreePath)`), so it is
+    // the safety-critical consumer of this file format: a record it fails to parse
+    // is a worktree reaped out from under a live session. `blockedSince` is an
+    // additive optional field, but "additive is safe" is exactly the assumption
+    // that deserves a test rather than trust — presence-surface.test.ts exists
+    // because a format change silently broke /watch.
+    //
+    // Composes the REAL setPresenceBlocked writer with the REAL readPresenceFiles
+    // reader the daemon sweep uses, and asserts the spare verdict is invariant
+    // across set → clear. The creator pid is DEAD, so presence.cwd is the ONLY
+    // thing sparing this worktree: if a blocked write corrupted or dropped the
+    // record, the verdict would flip straight back to 'dead-owner'.
+    const { writePresenceFile, setPresenceBlocked, readPresenceFiles } = await import('./awareness/presence.js');
+
+    const deadOwnerPid = findDeadPid();
+    const worktreePath = join(afkWorktreesDir, 'afk-e2e-blocked-wt');
+    await fs.mkdir(worktreePath, { recursive: true });
+    await fs.writeFile(
+      join(worktreePath, '.afk-worktree-meta.json'),
+      JSON.stringify({
+        owner: 'interactive',
+        pid: deadOwnerPid,
+        createdAt: new Date(Date.now() - 5 * 60_000).toISOString(),
+        baseSha: 'base123',
+        baseBranch: 'main',
+      }),
+    );
+
+    const mainBlock = worktreeBlock({ path: repoRoot, head: 'base123' });
+    const wtBlock = worktreeBlock({
+      path: worktreePath,
+      head: 'base123',
+      branch: 'refs/heads/afk/e2e-blocked-wt',
+    });
+    const porcelainOut = `${mainBlock}\n\n${wtBlock}\n`;
+    const mock = makeMock(async ({ args }) => {
+      if (args.includes('list') && args.includes('--porcelain')) return { stdout: porcelainOut, stderr: '' };
+      if (args.includes('status') && args.includes('--porcelain')) return { stdout: '', stderr: '' };
+      if (args.includes('rev-list') && args.includes('--count')) return { stdout: '0\n', stderr: '' };
+      return { stdout: '', stderr: '' };
+    });
+    const sweepOpts = {
+      execFile: mock as ExecFileFn,
+      repoRoot,
+      lockPath: lockFile,
+      dryRun: true,
+      telemetryPath: telemetryFile,
+      readPresence: readPresenceFiles,
+    };
+
+    const sessionId = 'e2e-presence-blocked';
+    await writePresenceFile({
+      sessionId,
+      surface: 'cli',
+      cwd: worktreePath, // live session working INSIDE the worktree
+      startedAt: new Date().toISOString(),
+      model: { provider: 'anthropic-direct', name: 'test-model' },
+      workspace: { branch: null, headSha: null, dirty: null, dirtyCount: null, remoteUrl: null },
+      pid: process.pid, // alive — this test process
+    });
+
+    // Baseline: live session inside the worktree → spared.
+    const baseline = await runSweep(sweepOpts);
+    expect(baseline.candidates.filter((c) => c.verdict === 'dead-owner')).toHaveLength(0);
+
+    // Session blocks on a human (e.g. a path-approval prompt) → still spared.
+    await setPresenceBlocked(sessionId, true);
+    const blockedRec = (await readPresenceFiles()).find((r) => r.sessionId === sessionId);
+    expect(blockedRec?.blockedSince).toBeDefined();
+    expect(blockedRec?.cwd).toBe(worktreePath); // the guard's input survived the write
+    const whileBlocked = await runSweep(sweepOpts);
+    expect(whileBlocked.candidates.filter((c) => c.verdict === 'dead-owner')).toHaveLength(0);
+    expect(whileBlocked.removed).not.toContain(worktreePath);
+
+    // Operator answers → marker cleared, verdict unchanged.
+    await setPresenceBlocked(sessionId, false);
+    const afterClear = await runSweep(sweepOpts);
+    expect(afterClear.candidates.filter((c) => c.verdict === 'dead-owner')).toHaveLength(0);
+    expect(afterClear.removed).not.toContain(worktreePath);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

An agent that stops to ask its operator a question left **no on-disk trace** of the fact. The elicitation router's only outward signal was a best-effort Telegram push, so an out-of-process observer — e.g. a native app polling `readPresenceFiles()` — could not distinguish a session that was *thinking* from one that had been *waiting on a human for forty minutes*.

This adds `blockedSince?: string` to the presence record, written by a new `setPresenceBlocked` helper.

**Why a timestamp, not a boolean:** it lets a reader render "waiting 4m" and age out a marker that a hard-killed session never cleared. Absence of the key — not a sentinel value — means "not waiting".

**Why no schema bump:** the field is additive and optional, which `presence.ts:43-48` explicitly documents as not requiring a `PRESENCE_SCHEMA_VERSION` bump. Existing readers are untouched.

### Where the signal is emitted

The set/clear pair lives in `elicitationRouter.route()` — the single chokepoint all four blocking call sites already funnel through:

| Call site | Blocks on |
|---|---|
| `tools/handlers/ask-question.ts` | `ask_question` tool |
| `tools/handlers/exit-plan-mode.ts` | plan-mode exit approval |
| `tools/hooks/path-approval-hook.ts` | write/read outside granted roots |
| `afk-mode-gate.ts` | AFK high-risk-op approve/deny |

The **set** rides the same edge as `onActive`: fired only where an operator is really about to be prompted, never on the pre-aborted, aborted-in-queue, or no-handler decline paths. The **clear** sits in the same `finally`, so answer, skip, decline, a synchronously-throwing handler, and a mid-prompt turn abort all clear it.

An unpaired set would strand a permanent "waiting on you" marker, so the two are deliberately inseparable — and that pairing is what the tests bind hardest.

### Why the session id is threaded per call

Rather than a module-scope "current session" register, the id arrives as an option on `route()`. A single process can host **several concurrent top-level sessions**: the Telegram bot keeps one session per chat (`session-manager.ts:107`) and runs turns detached (`bot.ts:289`). A global would be last-write-wins and could mark the wrong session's file. Callers that cannot supply an id get no marker — never a misattributed one.

`ToolHandlerContext.sessionId` (dispatcher-populated) covers the two tool handlers; `PreToolUseContext.sessionId` — which already existed but was never populated — now is, covering path-approval; the AFK gate takes it via `AfkModeGateOptions`.

Presence stays best-effort throughout: writes are fire-and-forget and exception-proof, so telemetry can never delay or fail an elicitation.

## How was this tested?

`pnpm lint` (strict `tsc --noEmit`) and `pnpm test` both pass: **704 files, 13,290 tests, 0 failures**.

New coverage:

- **`presence.test.ts`** — set stamps a valid ISO timestamp in the call window; clear removes the key entirely; every other field survives (including `afk`, which is independent and may be true simultaneously); silent no-op for a session with no presence file (subagents never have one); idempotent on repeated set/clear; a corrupt presence file is left byte-identical rather than throwing.
- **`elicitation-router.test.ts`** — ordering is asserted (`set → handler → clear`, since a marker written after the handler returns would be visible as the wrong state), plus the clear on **all five settle paths**: accept, handler rejection, *synchronous* handler throw, **mid-prompt turn abort with a handler that never settles** (the worst stranding case), and two concurrent sessions marked independently. Also asserts no marker on the no-handler park-and-notify path, no marker on a pre-aborted signal, no marker without a session id, and that a presence-write failure never changes the elicitation result.
- **`worktree-sweep.test.ts`** — end-to-end test composing the **real** writer with the **real** `readPresenceFiles` reader the daemon sweep uses. The sweep's in-use guard is safety-critical (a record it misreads is a worktree reaped out from under a live session), and `presence-surface.test.ts` exists precisely because a presence format change once silently broke `/watch` — so "additive is safe" gets a test rather than trust. The worktree's creator pid is dead, making `presence.cwd` the only thing sparing it: if a blocked write corrupted or dropped the record, the verdict would flip straight to `dead-owner`.

**Verified by mutation** (i.e. the tests bind the behaviour, not just cover it):

- Delete the clear → **exactly** the 5 pairing tests fail, nothing else.
- Move the set onto the no-handler path → **exactly** the 1 test forbidding it fails.

## Follow-ups (deliberately not in this PR)

- **Ledger events.** `session-ledger.ts` already has `elicitation` / `elicitation_response` kinds, so a paired append-only history of *how long operators kept agents waiting* is a natural next step. Left out to keep this diff to the current-status projection a polling app actually reads.
- **Non-atomic presence writes.** Every presence mutator is read→mutate→`writeFile` with no temp+rename and no lock (`presence.ts:192-221`); a blocked-writer racing `touchPresenceHeartbeat` is last-write-wins. Pre-existing pattern — this adds one more writer to it but does not change the shape. Worth fixing globally, not here.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/) — see [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] No secrets, tokens, or private paths in the diff