### PR TITLE
fix(telegram): interleave ◦ progress lines into the live preview chronologically

### DIFF
--- a/src/telegram/streaming.test.ts
+++ b/src/telegram/streaming.test.ts
@@ -1276,7 +1276,9 @@ describe('chronological interleave of the ◦ progress region (live preview)', (
     await streamResponse(ctx, session, 'go', undefined, { progressDelayMs: 0 });
 
     // The label sits between the runs — this is the whole point of the change.
-    expect(edits).toContain(`${A}\n◦ Using list schedules${B}`);
+    // The trailing break after the label is load-bearing: without it the next
+    // round's narration absorbs into the label (`◦ Using list schedulesNow I…`).
+    expect(edits).toContain(`${A}\n◦ Using list schedules\n${B}`);
     // No LIVE preview glues the two runs into the reported wall of text. The final
     // edit is excluded deliberately: that one is finalBody(), whose trailing-footer
     // shape (and therefore its concatenation) is held byte-stable because it is a
@@ -1313,9 +1315,12 @@ describe('chronological interleave of the ◦ progress region (live preview)', (
     const out = renderInterleavedPreview(text, entries);
 
     // Exact shape: a 6-label window (rounds 4..9) placed after their own text,
-    // and a bare line break standing in for each trimmed round (1..3).
+    // and a bare line break standing in for each trimmed round (1..3). Each
+    // label is TERMINATED by a break when narration follows it, so the next
+    // round's text never absorbs into the label; the last label (round-9) sits
+    // at end-of-text and stays bare.
     expect(out).toBe(
-      'c1 \nc2 \nc3 \nc4 \nround-4c5 \nround-5c6 \nround-6c7 \nround-7c8 \nround-8c9 \nround-9',
+      'c1 \nc2 \nc3 \nc4 \nround-4\nc5 \nround-5\nc6 \nround-6\nc7 \nround-7\nc8 \nround-8\nc9 \nround-9',
     );
     // Global cap preserved — the property PR #702 established.
     expect(out).toContain('round-9');
@@ -1336,7 +1341,12 @@ describe('chronological interleave of the ◦ progress region (live preview)', (
   it('renderInterleavedPreview is pure and degenerate-safe', () => {
     expect(renderInterleavedPreview('abc', [])).toBe('abc');
     expect(renderInterleavedPreview('', [{ label: '◦ a', at: 0 }])).toBe('\n◦ a');
-    expect(renderInterleavedPreview('onetwo', [{ label: '◦ a', at: 3 }])).toBe('one\n◦ atwo');
+    // Following narration is separated from the label by a break, never glued.
+    expect(renderInterleavedPreview('onetwo', [{ label: '◦ a', at: 3 }])).toBe('one\n◦ a\ntwo');
+    // ...but text that ALREADY starts with a newline gains no second break.
+    expect(renderInterleavedPreview('one\ntwo', [{ label: '◦ a', at: 3 }])).toBe('one\n◦ a\ntwo');
+    // A label at END of text stays bare — the footer/byte-equivalence contract.
+    expect(renderInterleavedPreview('one', [{ label: '◦ a', at: 3 }])).toBe('one\n◦ a');
     // Consecutive rounds at the SAME offset emit no stray breaks: this is the
     // progress-only turn, and it must stay byte-identical to the footer output.
     const nine = Array.from({ length: 9 }, (_, i) => ({ label: `l${i + 1}`, at: 0 }));
@@ -1374,6 +1384,116 @@ describe('chronological interleave of the ◦ progress region (live preview)', (
         { label: '◦ first', at: 4 },
         { label: '◦ second', at: 1 },
       ]),
-    ).toBe('abcd\n◦ first\n◦ secondef');
+    ).toBe('abcd\n◦ first\n◦ second\nef');
+  });
+
+  it('terminates a label so following narration never absorbs into it (review 1)', () => {
+    // The next iteration appends text.slice(pos, at) — the FOLLOWING round's
+    // narration. Without a delimiter it reads as part of the label.
+    const out = renderInterleavedPreview('firstNow I run the rehearsal', [
+      { label: '◦ Using list schedules', at: 5 },
+    ]);
+    expect(out).toBe('first\n◦ Using list schedules\nNow I run the rehearsal');
+    expect(out).not.toContain('◦ Using list schedulesNow');
+    // Superstring invariant: narration is never dropped or reordered.
+    expect(out.replace(/\n◦ Using list schedules\n/, '')).toBe('firstNow I run the rehearsal');
+  });
+
+  it('defers a splice inside an UNTERMINATED markdown link (review 2)', () => {
+    // A tool boundary splits a link across rounds. formatter.ts step 7 rewrites
+    // [text](url) positionally, so a label spliced into either half is swallowed
+    // into the href — hiding the status and corrupting the target.
+    const openUrl = 'see [docs](https://exa';
+    expect(renderInterleavedPreview(openUrl, [{ label: '◦ x', at: 22 }]))
+      .toBe(`${openUrl}\n◦ x`);
+    // Mid-URL (in range, not end-of-text) must also degrade to the end.
+    const openUrlMore = 'see [docs](https://exa and then more prose';
+    expect(renderInterleavedPreview(openUrlMore, [{ label: '◦ x', at: 22 }]))
+      .toBe(`${openUrlMore}\n◦ x`);
+    // Unclosed label: `[docs` with no `]` yet.
+    const openLabel = 'see [docs plus trailing prose';
+    expect(renderInterleavedPreview(openLabel, [{ label: '◦ x', at: 9 }]))
+      .toBe(`${openLabel}\n◦ x`);
+    // A COMPLETE link is safe to splice after — the guard is not a blanket ban.
+    const closedLink = 'see [docs](https://example.com) then more';
+    expect(renderInterleavedPreview(closedLink, [{ label: '◦ x', at: 31 }]))
+      .toBe('see [docs](https://example.com)\n◦ x\n then more');
+  });
+
+  it('emits no stray blank line when a trimmed round shares an offset (review 4)', () => {
+    // A trimmed entry (i < labelFrom) emits a bare `\n`; when the immediately
+    // following LABELED entry sits at the same offset it emits `\n<label>` too,
+    // which used to yield `\n\n` between narration and its label.
+    const out = renderInterleavedPreview('abcdef', [
+      { label: 'l1', at: 3 },
+      { label: 'l2', at: 3 },
+      { label: 'l3', at: 4 },
+      { label: 'l4', at: 4 },
+      { label: 'l5', at: 5 },
+      { label: 'l6', at: 5 },
+      { label: 'l7', at: 6 },
+    ]);
+    expect(out).not.toContain('\n\n');
+    expect(out).toBe('abc\nl2\nd\nl3\nl4\ne\nl5\nl6\nf\nl7');
+    // The trimmed round is still label-suppressed (global cap intact).
+    expect(out).not.toContain('l1');
+  });
+
+  it('mirrors the formatter fence pattern: a single-line ```word``` is NOT a fence (review 5)', () => {
+    // formatter.ts step 2 requires a newline after the opening fence and anchors
+    // at line start, so it sees NO complete fence here — meaning an offset after
+    // it lands in the inline-code pass. Both parse models must agree, so this
+    // offset is unsafe and degrades to end-of-text.
+    const inlineFence = 'run ```build``` now and more';
+    expect(renderInterleavedPreview(inlineFence, [{ label: '◦ x', at: 20 }]))
+      .toBe(`${inlineFence}\n◦ x`);
+    // Indented (≤3 spaces) real fence still parses as complete, per the
+    // formatter's ^ {0,3} prefix — so splicing right after it stays SAFE.
+    const indented = ' ```sh\nls\n```\ntail text';
+    expect(renderInterleavedPreview(indented, [{ label: '◦ x', at: indented.indexOf('\ntail') }]))
+      .toBe(' ```sh\nls\n```\n◦ x\ntail text');
+  });
+
+  it('WIRING: re-bases retained offsets when the assistant message replaces the buffer (review 3)', async () => {
+    // :782 replaces `accumulated` wholesale with the FINAL round's text only, so
+    // an offset sampled in an earlier round is frequently still IN RANGE of the
+    // replacement — the monotonic clamp never fires and the label splices
+    // mid-word. Replacement here is LONGER than the recorded offset (the case
+    // the clamp cannot cover).
+    const early = 'Short first round. ';
+    const replacement =
+      'A completely different and much longer authoritative final answer that outruns the early offset.';
+    expect(replacement.length).toBeGreaterThan(early.length);
+
+    const { ctx, edits } = makeCtx();
+    const session = makeSession(async function* () {
+      yield content(early);
+      yield progressEvent('Using list schedules');
+      yield {
+        type: 'message',
+        message: { role: 'assistant', content: replacement },
+      } as OutputEvent;
+      yield { type: 'done', metadata: undefined } as OutputEvent;
+    });
+
+    await streamResponse(ctx, session, 'go', undefined, { progressDelayMs: 0 });
+
+    // Filter-independent on purpose: the BUGGY render splits `replacement`
+    // around the label ('A completely differ\n◦ …\nent and much longer…'), so any
+    // filter keyed on `includes(replacement)` would silently exclude the very
+    // edit under test and pass vacuously. Assert over ALL edits instead.
+    const label = '◦ Using list schedules';
+    const labelled = edits.filter((e) => e.includes(label));
+    expect(labelled.length).toBeGreaterThan(0);
+    for (const e of labelled) {
+      // Footer placement: the label terminates the message, never interrupts it.
+      expect(e.endsWith(`\n${label}`)).toBe(true);
+      // The specific reported corruption: a splice mid-word.
+      expect(e).not.toMatch(new RegExp(`\\n${label}\\n\\S`));
+    }
+    // The post-replace preview shows the authoritative text whole, label at end.
+    expect(edits).toContain(`${replacement}\n${label}`);
+    // And no edit renders the buffer torn apart by the stale offset.
+    expect(edits.some((e) => e.includes('differ\n'))).toBe(false);
   });
 });

--- a/src/telegram/streaming.test.ts
+++ b/src/telegram/streaming.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { streamResponse, StreamTimeoutError, renderSubagentFooter, renderProgressRegion, renderActivityReceipt, formatTelegramActivity, formatTelegramAgentLabel, replyWithFloodRetry } from './streaming.js';
+import { streamResponse, StreamTimeoutError, renderSubagentFooter, renderProgressRegion, renderInterleavedPreview, renderActivityReceipt, formatTelegramActivity, formatTelegramAgentLabel, replyWithFloodRetry } from './streaming.js';
 import { TelegramError } from 'telegraf';
 import type { Context } from 'telegraf';
 import type { IAgentSession, OutputEvent } from '../agent/types.js';
@@ -1243,5 +1243,137 @@ describe('◦ progress region — PR #702 review follow-ups', () => {
 
     expect([...replies, ...edits].some((t) => t.includes('did work then the stream closed'))).toBe(true);
     expect([...replies, ...edits].every((t) => t !== 'Thinking…') || replies.length > 0).toBe(true);
+  });
+});
+
+describe('chronological interleave of the ◦ progress region (live preview)', () => {
+  function progressEvent(description: string): OutputEvent {
+    return {
+      type: 'progress',
+      progress: { taskId: 't', description, totalTokens: 0, toolUses: 1, durationMs: 1 },
+    } as OutputEvent;
+  }
+  const content = (c: string): OutputEvent =>
+    ({ type: 'chunk', chunk: { type: 'content', content: c } }) as OutputEvent;
+
+  // Sentences are >100 chars combined with a label so no live edit is dropped by
+  // EDIT_THROTTLE_MS (which only throttles payloads under 100 chars).
+  const A = 'First I check the schedule and confirm that the cron expression is actually right. ';
+  const B = 'Now I run the rehearsal to see whether the 9am fire really works end to end. ';
+
+  it('WIRING: a live-preview edit places the ◦ line BETWEEN the two narration runs', async () => {
+    // The reported bug: every round's preamble was concatenated into one wall
+    // ("…your session.Diagnosis is clear.") with all ◦ lines collected at the
+    // bottom, so no line sat next to the tool round it described.
+    const { ctx, edits } = makeCtx();
+    const session = makeSession(async function* () {
+      yield content(A);
+      yield progressEvent('Using list schedules');
+      yield content(B);
+      yield { type: 'done', metadata: undefined } as OutputEvent;
+    });
+
+    await streamResponse(ctx, session, 'go', undefined, { progressDelayMs: 0 });
+
+    // The label sits between the runs — this is the whole point of the change.
+    expect(edits).toContain(`${A}\n◦ Using list schedules${B}`);
+    // No LIVE preview glues the two runs into the reported wall of text. The final
+    // edit is excluded deliberately: that one is finalBody(), whose trailing-footer
+    // shape (and therefore its concatenation) is held byte-stable because it is a
+    // DELIVERED payload on progress-only / non-terminal-exit turns.
+    const previews = edits.slice(0, -1);
+    expect(previews.some((e) => e.includes('right. Now I run'))).toBe(false);
+  });
+
+  it('DELIVERY: the final body still uses the legacy trailing footer, byte-stable', async () => {
+    // finalBody() is delivered (not merely previewed) when answerText is empty or
+    // the stream ends without a terminal event, so interleaving must not reach it.
+    const { ctx, edits } = makeCtx();
+    const session = makeSession(async function* () {
+      yield content(A);
+      yield progressEvent('Using list schedules');
+      yield content(B);
+      yield { type: 'done', metadata: undefined } as OutputEvent;
+    });
+
+    await streamResponse(ctx, session, 'go', undefined, { progressDelayMs: 0 });
+
+    expect(edits[edits.length - 1]).toBe(`${A}${B}\n◦ Using list schedules`);
+  });
+
+  it('SEMANTICS: bounded to 6 labels, chronological, and breaks trimmed rounds apart', () => {
+    // Nine rounds, each recorded after its own content chunk — the alternating
+    // shape both provider loops actually emit.
+    const text = 'c1 c2 c3 c4 c5 c6 c7 c8 c9 ';
+    const entries = Array.from({ length: 9 }, (_, i) => ({
+      label: `round-${i + 1}`,
+      at: 3 * (i + 1),
+    }));
+
+    const out = renderInterleavedPreview(text, entries);
+
+    // Exact shape: a 6-label window (rounds 4..9) placed after their own text,
+    // and a bare line break standing in for each trimmed round (1..3).
+    expect(out).toBe(
+      'c1 \nc2 \nc3 \nc4 \nround-4c5 \nround-5c6 \nround-6c7 \nround-7c8 \nround-8c9 \nround-9',
+    );
+    // Global cap preserved — the property PR #702 established.
+    expect(out).toContain('round-9');
+    expect(out).toContain('round-4');
+    expect(out).not.toContain('round-3');
+    expect(out).not.toContain('round-1');
+    // Narration is never trimmed.
+    expect(out).toContain('c1 ');
+    expect(out).toContain('c9 ');
+    // Chronology: each label follows its own round's text and precedes the next.
+    expect(out.indexOf('c4 ')).toBeLessThan(out.indexOf('round-4'));
+    expect(out.indexOf('round-4')).toBeLessThan(out.indexOf('c5 '));
+    expect(out.indexOf('round-8')).toBeLessThan(out.indexOf('round-9'));
+    // A trimmed round still separates the narration either side of it.
+    expect(out).not.toContain('c1 c2 ');
+  });
+
+  it('renderInterleavedPreview is pure and degenerate-safe', () => {
+    expect(renderInterleavedPreview('abc', [])).toBe('abc');
+    expect(renderInterleavedPreview('', [{ label: '◦ a', at: 0 }])).toBe('\n◦ a');
+    expect(renderInterleavedPreview('onetwo', [{ label: '◦ a', at: 3 }])).toBe('one\n◦ atwo');
+    // Consecutive rounds at the SAME offset emit no stray breaks: this is the
+    // progress-only turn, and it must stay byte-identical to the footer output.
+    const nine = Array.from({ length: 9 }, (_, i) => ({ label: `l${i + 1}`, at: 0 }));
+    expect(renderInterleavedPreview('', nine)).toBe('\nl4\nl5\nl6\nl7\nl8\nl9');
+    expect(renderInterleavedPreview('', nine)).toBe(renderProgressRegion(nine.map((e) => e.label)));
+  });
+
+  it('never splices inside a code fence or an inline-code span (formatter safety)', () => {
+    // markdownToTelegramHtml extracts fenced blocks and inline spans positionally,
+    // so a label landing inside one is swallowed into <pre>/<code> and can break
+    // backtick parity for the rest of the message. An unsafe offset degrades to
+    // the end of the text — exactly where the legacy footer put it.
+    const openFence = 'intro\n```bash\nnpm run build';
+    expect(renderInterleavedPreview(openFence, [{ label: '◦ x', at: 20 }]))
+      .toBe(`${openFence}\n◦ x`);
+    const openSpan = 'see `pnpm test for more';
+    expect(renderInterleavedPreview(openSpan, [{ label: '◦ x', at: 12 }]))
+      .toBe(`${openSpan}\n◦ x`);
+    // A CLOSED fence is safe to splice after.
+    const closed = 'a\n```sh\nls\n```\nb';
+    expect(renderInterleavedPreview(closed, [{ label: '◦ x', at: closed.length - 2 }]))
+      .toBe('a\n```sh\nls\n```\n◦ x\nb');
+  });
+
+  it('clamps a stale offset to the end instead of splicing mid-sentence', () => {
+    // stream_retry rewinds `accumulated` mid-turn and the authoritative assistant
+    // message replaces it wholesale at turn end, so a recorded offset can outrun
+    // the buffer. It must collapse to the end (footer placement), never throw.
+    expect(renderInterleavedPreview('short', [{ label: '◦ x', at: 999 }]))
+      .toBe('short\n◦ x');
+    // Offsets are forced monotonic: a later entry can never render before an
+    // earlier one even if its recorded offset went backwards.
+    expect(
+      renderInterleavedPreview('abcdef', [
+        { label: '◦ first', at: 4 },
+        { label: '◦ second', at: 1 },
+      ]),
+    ).toBe('abcd\n◦ first\n◦ secondef');
   });
 });

--- a/src/telegram/streaming.ts
+++ b/src/telegram/streaming.ts
@@ -259,21 +259,47 @@ const MAX_PROGRESS_ENTRIES = 32;
  * Contract: return an offset at or after `pos` at which a `◦` line may be
  * inserted without corrupting markdown that `markdownToTelegramHtml` parses
  * POSITIONALLY. That formatter extracts fenced blocks and inline-code spans
- * before its emphasis passes (formatter.ts), so a label spliced inside an
- * unclosed fence, or between the backticks of a span, is swallowed into
- * `<pre>`/`<code>` — and broken backtick parity shifts which later spans
- * code-ify. When `pos` is unsafe this degrades to the END of the text, i.e.
- * exactly where the legacy footer put the line: never worse than before.
+ * before its emphasis passes and rewrites `[text](url)` links after them
+ * (formatter.ts), so a label spliced inside an unclosed fence, between the
+ * backticks of a span, or into a half-written link is swallowed into
+ * `<pre>`/`<code>`/an `href` — and broken backtick parity shifts which later
+ * spans code-ify. When `pos` is unsafe this degrades to the END of the text,
+ * i.e. exactly where the legacy footer put the line: never worse than before.
  */
 function safeSplicePoint(text: string, pos: number): number {
   if (pos <= 0) return 0;
   if (pos >= text.length) return text.length;
   // Drop COMPLETE fenced blocks first; a leftover ``` means the offset sits
   // inside a fence the model has not closed yet (routine mid-stream).
-  const prefix = text.slice(0, pos).replace(/```[\s\S]*?```/g, '');
+  //
+  // External constraint: the pattern MIRRORS the formatter's own fence regex
+  // (formatter.ts step 2 — line-anchored, newline required after the opening
+  // fence). An unanchored /```[\s\S]*?```/ would count a single-line ```word```
+  // as a complete block that the formatter does NOT see as one, report the
+  // offset safe, and let the label fall into the formatter's inline-code pass.
+  // Both parse models must agree or "safe" means nothing.
+  const prefix = text.slice(0, pos).replace(/^ {0,3}```[\w]*\n[\s\S]*?```/gm, '');
   if (prefix.includes('```')) return text.length;
   // Odd backtick count => the offset falls inside an inline-code span.
   if (((prefix.match(/`/g)?.length) ?? 0) % 2 !== 0) return text.length;
+  // A tool boundary routinely splits a link across rounds: `[docs](https://exa`
+  // now, `mple.com)` next round. formatter.ts step 7 rewrites `[text](url)`
+  // positionally, so a label spliced into either half is absorbed into the
+  // generated href — hiding the status AND corrupting the link target. Cheap
+  // prefix scan for the two open states, in the same spirit as the checks
+  // above; deliberately not a markdown parser.
+  const openBracket = prefix.lastIndexOf('[');
+  const closeBracket = prefix.lastIndexOf(']');
+  // `[label` with no `]` written yet.
+  if (openBracket > closeBracket) return text.length;
+  // `](url` with the closing paren still unwritten.
+  if (
+    closeBracket >= 0 &&
+    prefix[closeBracket + 1] === '(' &&
+    !prefix.includes(')', closeBracket + 1)
+  ) {
+    return text.length;
+  }
   return pos;
 }
 
@@ -291,11 +317,14 @@ function safeSplicePoint(text: string, pos: number): number {
  * bounding the region required deleting from the middle of the content buffer,
  * which a following content chunk then froze in place — cannot recur.
  *
- * Offsets are clamped MONOTONICALLY into `text`, so a mid-turn truncation
- * (`stream_retry` rewinding the buffer) or the end-of-turn wholesale replace by
- * the authoritative assistant message leaves stale offsets collapsing to the end
- * — degrading to footer placement rather than splicing at a position that no
- * longer means anything.
+ * Offsets are clamped MONOTONICALLY into `text`, which covers mid-turn
+ * TRUNCATION (`stream_retry` rewinding the buffer): an offset past the shortened
+ * text collapses to the end, i.e. footer placement. It does NOT cover the
+ * end-of-turn wholesale replace by the authoritative assistant message, whose
+ * replacement text is frequently LONGER than an early offset — so the clamp
+ * never fires and the offset is in range but meaningless. That case is handled
+ * at the call site, which re-bases retained offsets to the new buffer length
+ * before rendering (see the assistant-`message` handler in streamResponse).
  */
 export function renderInterleavedPreview(
   text: string,
@@ -313,10 +342,24 @@ export function renderInterleavedPreview(
     const at = safeSplicePoint(text, Math.min(Math.max(entry.at, pos), text.length));
     out += text.slice(pos, at);
     pos = at;
+    // Offsets are forced monotonic and safeSplicePoint is idempotent, so a NEXT
+    // raw offset at or before the current effective one renders at EXACTLY this
+    // position. That entry then supplies the `\n` separator itself, and emitting
+    // another one here would leave a stray blank line between the narration and
+    // its label.
+    const nextRendersHere = (entries[i + 1]?.at ?? Infinity) <= at;
     if (i >= labelFrom) {
       out += `\n${entry.label}`;
       lastEmitAt = at;
-    } else if (at > lastEmitAt) {
+      // Terminate the label: the next iteration appends `text.slice(pos, at)` —
+      // the following round's narration — which absorbs into the label when it
+      // does not start with a break (`◦ Using list schedulesNow I run…`).
+      // Invariant: only when narration actually follows HERE and does not
+      // already begin with `\n`. A label at END of text must stay bare, or a
+      // progress-only turn stops being byte-identical to renderProgressRegion()
+      // and finalBody()'s footer shape parity goes with it.
+      if (!nextRendersHere && at < text.length && text[at] !== '\n') out += '\n';
+    } else if (at > lastEmitAt && !nextRendersHere) {
       out += '\n';
       lastEmitAt = at;
     }
@@ -782,6 +825,20 @@ export async function streamResponse(
           accumulated = event.message.content;
           answerText = event.message.content;
           inContentRun = false;
+          // Ordering constraint: re-base BEFORE rendering. This assignment
+          // replaced the buffer wholesale, so every offset recorded against the
+          // OLD buffer now indexes unrelated text. Both providers emit this
+          // message once per turn carrying only the final round's text, so an
+          // early offset is usually still IN RANGE of the replacement — the
+          // monotonic clamp inside renderInterleavedPreview never fires and the
+          // label splices mid-word. Re-base to the new length so the preview
+          // degrades to footer placement, which is what the interleave contract
+          // promises for an offset that no longer means anything.
+          //
+          // Copy, never mutate: entries are readonly and `finalBody()` maps the
+          // same list for its byte-stable legacy footer, so `label` must survive
+          // untouched — only `at` moves.
+          progressEntries = progressEntries.map((e) => ({ ...e, at: accumulated.length }));
           await sendOrEdit(livePreview());
         }
         // Lane D — progress summaries appear in the response as dim lines

--- a/src/telegram/streaming.ts
+++ b/src/telegram/streaming.ts
@@ -51,7 +51,7 @@ const MAX_SUBAGENT_PREVIEW_LINES = 4;
  * long. Most turns finish faster than this and now render no progress noise at
  * all — the live preview goes straight from `Thinking…` to the answer.
  *
- * Withheld lines are still recorded (see `progressLines`); when the gate opens
+ * Withheld lines are still recorded (see `progressEntries`); when the gate opens
  * the rolling region renders the most recent ones, so nothing is lost — it is a
  * render delay, not a drop. Overridable per call via `options.progressDelayMs`
  * (tests pass 0 to assert rendering deterministically).
@@ -240,6 +240,91 @@ export function renderProgressRegion(lines: readonly string[]): string {
 }
 
 /**
+ * One recorded `◦` tool-progress round: the rendered label plus the offset into
+ * the content buffer at which it occurred, so the LIVE PREVIEW can place it
+ * chronologically instead of piling every label into a trailing footer.
+ */
+export type ProgressEntry = { readonly label: string; readonly at: number };
+
+/**
+ * Max progress entries retained. Only the last MAX_PROGRESS_LINES render a
+ * LABEL (the same global cap the footer enforces); older retained entries render
+ * a bare line break so narration either side of a trimmed round stays separated
+ * instead of running together. Past this the oldest are dropped outright, so the
+ * list cannot grow with turn length.
+ */
+const MAX_PROGRESS_ENTRIES = 32;
+
+/**
+ * Contract: return an offset at or after `pos` at which a `◦` line may be
+ * inserted without corrupting markdown that `markdownToTelegramHtml` parses
+ * POSITIONALLY. That formatter extracts fenced blocks and inline-code spans
+ * before its emphasis passes (formatter.ts), so a label spliced inside an
+ * unclosed fence, or between the backticks of a span, is swallowed into
+ * `<pre>`/`<code>` — and broken backtick parity shifts which later spans
+ * code-ify. When `pos` is unsafe this degrades to the END of the text, i.e.
+ * exactly where the legacy footer put the line: never worse than before.
+ */
+function safeSplicePoint(text: string, pos: number): number {
+  if (pos <= 0) return 0;
+  if (pos >= text.length) return text.length;
+  // Drop COMPLETE fenced blocks first; a leftover ``` means the offset sits
+  // inside a fence the model has not closed yet (routine mid-stream).
+  const prefix = text.slice(0, pos).replace(/```[\s\S]*?```/g, '');
+  if (prefix.includes('```')) return text.length;
+  // Odd backtick count => the offset falls inside an inline-code span.
+  if (((prefix.match(/`/g)?.length) ?? 0) % 2 !== 0) return text.length;
+  return pos;
+}
+
+/**
+ * Render the live preview with `◦` progress lines interleaved chronologically
+ * into `text` at the offsets where they occurred, instead of collected in a
+ * trailing footer. Pure + exported for unit tests.
+ *
+ * Invariant: the GLOBAL cap on rendered labels is preserved — only the last
+ * MAX_PROGRESS_LINES entries emit a `◦` label no matter how many are passed, so a
+ * tool-heavy turn keeps a fixed-height status budget. That is the bound PR #702
+ * established when it replaced an in-buffer splice, and it holds here for a
+ * structural reason: trimming happens over the ENTRY LIST before rendering and
+ * `text` is never mutated, so the failure mode of the reverted design — where
+ * bounding the region required deleting from the middle of the content buffer,
+ * which a following content chunk then froze in place — cannot recur.
+ *
+ * Offsets are clamped MONOTONICALLY into `text`, so a mid-turn truncation
+ * (`stream_retry` rewinding the buffer) or the end-of-turn wholesale replace by
+ * the authoritative assistant message leaves stale offsets collapsing to the end
+ * — degrading to footer placement rather than splicing at a position that no
+ * longer means anything.
+ */
+export function renderInterleavedPreview(
+  text: string,
+  entries: readonly ProgressEntry[],
+): string {
+  if (entries.length === 0) return text;
+  const labelFrom = Math.max(0, entries.length - MAX_PROGRESS_LINES);
+  let out = '';
+  let pos = 0;
+  // Suppresses a leading/duplicate break when consecutive rounds sit at the SAME
+  // offset (a progress-only turn records every entry at offset 0): a bare break
+  // is only meaningful when real narration separated the two rounds.
+  let lastEmitAt = 0;
+  entries.forEach((entry, i) => {
+    const at = safeSplicePoint(text, Math.min(Math.max(entry.at, pos), text.length));
+    out += text.slice(pos, at);
+    pos = at;
+    if (i >= labelFrom) {
+      out += `\n${entry.label}`;
+      lastEmitAt = at;
+    } else if (at > lastEmitAt) {
+      out += '\n';
+      lastEmitAt = at;
+    }
+  });
+  return out + text.slice(pos);
+}
+
+/**
  * One-line activity receipt appended to the CLEAN final message, replacing the
  * `◦` progress log that cleanFinal deletes: the turn's cost stays visible
  * without the per-round noise. Empty when no tool work happened, so plain
@@ -360,23 +445,29 @@ export async function streamResponse(
   let subagentSteps = 0;
   const recentSubagentSteps: string[] = [];
 
-  // Invariant: the `◦` tool-progress region is ONE bounded footer of the live
-  // preview, never spliced into `accumulated`. Keeping it out of the content
-  // buffer is what makes the MAX_PROGRESS_LINES bound hold GLOBALLY: an earlier
-  // design rewrote a region inside `accumulated` at an offset, which bounded
-  // only a run of CONSECUTIVE progress events — a stream that alternates content
-  // with tool rounds (what the anthropic-direct and openai-compatible loops
-  // actually emit) froze each run in place and grew without limit anyway. As a
-  // footer the region is inherently single and replaceable, so no writer of
-  // `accumulated` has to coordinate with it. Same treatment the sub-agent lane
-  // already uses (renderSubagentFooter).
+  // Invariant: `accumulated` is NEVER mutated to carry `◦` progress lines — they
+  // live only in `progressEntries` and are composed in at render time. This is
+  // load-bearing, not stylistic. An earlier design rewrote a region INSIDE
+  // `accumulated` at an offset; because a following content chunk froze that
+  // region in place, every later progress event started a new one, so the
+  // MAX_PROGRESS_LINES bound held only within a run of CONSECUTIVE progress
+  // events and a stream alternating content with tool rounds (what the
+  // anthropic-direct and openai-compatible loops actually emit) grew without
+  // limit anyway. Trimming over the ENTRY LIST keeps the bound global.
+  //
+  // The live preview interleaves those entries chronologically
+  // (renderInterleavedPreview); `finalBody()` deliberately keeps the legacy
+  // trailing footer, because finalBody IS delivered to the user on a
+  // progress-only or non-terminal-exit turn (see the `done` handler and the
+  // post-loop overflow block) and that delivered output is held byte-stable.
+  // Interleaving is therefore a PREVIEW-only concern by construction.
   const progressDelayMs = options.progressDelayMs ?? PROGRESS_START_DELAY_MS;
   const turnStartedAt = Date.now();
-  let progressLines: string[] = [];
+  let progressEntries: ProgressEntry[] = [];
   // Total tool rounds seen this turn (never trimmed) — drives the activity receipt.
   let progressRounds = 0;
   // Latency gate: closed until the turn has run progressDelayMs, so short turns
-  // render no `◦` churn at all. Withheld lines stay in `progressLines`.
+  // render no `◦` churn at all. Withheld lines stay in `progressEntries`.
   let progressGateOpen = progressDelayMs <= 0;
   let progressTimer: ReturnType<typeof setTimeout> | null = null;
   // Set once a terminal event or the finally-block runs, so a timer callback
@@ -497,14 +588,22 @@ export async function streamResponse(
   // gate happened to withhold. Every terminal/fallback delivery path uses this;
   // `accumulated` alone would be empty on a gated progress-only turn and would
   // strand the user on the bare `Thinking…` placeholder.
-  const finalBody = (): string => accumulated + renderProgressRegion(progressLines);
+  // Invariant: keeps the LEGACY trailing-footer shape. finalBody is not
+  // preview-only — it is the text actually delivered when `answerText` is empty
+  // (progress-only turn) or when the stream ends without a terminal event, so its
+  // bytes are held stable and the interleave is confined to `livePreview()`.
+  const finalBody = (): string =>
+    accumulated + renderProgressRegion(progressEntries.map((e) => e.label));
 
-  // Live preview = content + GATED progress region + bounded sub-agent footer.
-  // Used for every in-turn edit so progress and sub-agent activity stay visible
-  // without either region growing one line per tool call.
+  // Live preview = content with the GATED progress lines interleaved at the
+  // offsets where they occurred, plus the bounded sub-agent footer. Used for every
+  // in-turn edit so progress and sub-agent activity stay visible without either
+  // region growing one line per tool call. Interleaving (rather than a trailing
+  // footer) is what keeps each round's narration next to the tool round it
+  // describes, and supplies the line break between consecutive rounds that
+  // `accumulated += content` does not.
   const livePreview = (): string =>
-    accumulated
-    + (progressGateOpen ? renderProgressRegion(progressLines) : '')
+    (progressGateOpen ? renderInterleavedPreview(accumulated, progressEntries) : accumulated)
     + renderSubagentFooter(subagentSteps, recentSubagentSteps);
 
   try {
@@ -717,9 +816,21 @@ export async function streamResponse(
           // that interleaves content with tool rounds, not just within one run.
           // Repeated tool categories add no information to a rolling mobile
           // preview: count every round for the receipt, but render duplicates once.
-          if (progressLines[progressLines.length - 1] !== line) progressLines.push(line);
-          if (progressLines.length > MAX_PROGRESS_LINES) {
-            progressLines = progressLines.slice(-MAX_PROGRESS_LINES);
+          //
+          // Ordering constraint (externally governed by the provider's event
+          // order): `at` must be sampled from `accumulated` BEFORE any later
+          // content chunk of the NEXT round is appended. A `progress` event is
+          // emitted only after a round's text deltas are complete — the
+          // anthropic-direct loop yields it after `turnResult` is resolved, the
+          // openai-compatible loop after `runIteration` returns — so sampling
+          // here lands exactly on the boundary between two rounds of narration.
+          // Deferring the sample would place the line inside the following round's
+          // prose.
+          if (progressEntries[progressEntries.length - 1]?.label !== line) {
+            progressEntries.push({ label: line, at: accumulated.length });
+          }
+          if (progressEntries.length > MAX_PROGRESS_ENTRIES) {
+            progressEntries = progressEntries.slice(-MAX_PROGRESS_ENTRIES);
           }
           if (!progressGateOpen && Date.now() - turnStartedAt >= progressDelayMs) {
             progressGateOpen = true;


### PR DESCRIPTION
## Problem

The Telegram live preview rendered a tool-heavy turn as a wall of text with the tool activity detached at the bottom:

> …Checking what actually happened to your session.Diagnosis is clear. Now the decisive check: will the 9am fire actually work?Rehearsal passes. Now pinning down what actually killed your session.Rehearsal passes. Two things to nail down…
> - Using list schedules
> - Running a command
> - Editing files

Two separate defects produced that:

1. **No round separator.** `accumulated += event.chunk.content` glues round N's tail to round N+1's head, so consecutive preambles read as one run-on sentence (`session.Diagnosis is clear.`).
2. **Footer, not timeline.** `livePreview()` was `accumulated + renderProgressRegion(...)`, so every `◦` line was collected at the end. "Now let me look at the fix" and its `Editing files` line ended up ~1000 chars apart.

## Approach

Record the content-buffer offset alongside each progress label (`ProgressEntry = { label, at }`) and interleave at **render time** in a new pure `renderInterleavedPreview(text, entries)`.

`accumulated` is never mutated. That is the load-bearing property: the global `MAX_PROGRESS_LINES` cap still holds because trimming happens over the **entry list** before rendering. The in-buffer splice design reverted in #702 failed precisely because bounding the region meant deleting from mid-buffer, and a following content chunk froze the region in place so each new round opened a fresh unbounded one. That cannot recur here.

**Scoped to the live preview on purpose.** `finalBody()` keeps the legacy footer shape, because it is *not* preview-only — it is the delivered payload when `answerText` is empty (progress-only turn) or the stream ends without a terminal event (`streaming.ts` `done` handler, post-loop overflow block). Those bytes are held stable, and a test pins them.

## Hazards found by an adversarial verification wave

A `/shadow-verify` wave re-derived the design's premises independently and refuted two of them. Both are now guarded:

- **Formatter is position-sensitive.** `markdownToTelegramHtml` extracts fenced blocks and inline-code spans *before* its emphasis passes. A label spliced inside an unclosed fence or between the backticks of a span is swallowed into `<pre>`/`<code>`, and broken backtick parity shifts which later spans get code-ified. `safeSplicePoint` degrades an unsafe offset to end-of-text — exactly where the footer put it, so never worse than before.
- **The buffer does shrink.** `stream_retry` rewinds `accumulated` mid-turn, and the authoritative assistant message replaces it wholesale at turn end (its text is per-round, so the buffer shrinks). Recorded offsets can outrun the text; they are clamped monotonically and stale ones collapse to the end.

Rounds whose label ages out of the 6-line window still emit a bare line break, so narration either side of a trimmed round is separated rather than glued — that is what fixes defect (1) for early rounds.

## Verification

- `pnpm lint` (tsc --noEmit strict) — clean
- `pnpm test src/telegram/streaming.test.ts` — 55/55, including the pre-existing #702 interleaved-bound guard and the exact-string pin on `renderProgressRegion` (both unchanged)
- `pnpm test` — 704 files / 13281 tests, 0 failures

6 new tests: end-to-end wiring, delivered-body byte-stability, bounded + chronological semantics, purity/degenerate inputs, formatter safety, stale-offset clamping.

## Follow-up found but deliberately not fixed here

`sendOrEdit` renders `chunks[0]` only (`streaming.ts:403`, `:425`). On a preview over Telegram's 4096-char limit, **everything after the first chunk is dropped — so today's trailing footer is silently invisible on long turns.** Interleaving incidentally makes early lines visible again (they now land inside chunk[0]), but the underlying truncation is a separate latent bug and wants its own change.
