### PR TITLE
fix(render): route sub-agent lane and /bgsub width through getTerminalWidth

### DIFF
--- a/src/cli/_lib/stream-renderer-subagent-helpers.ts
+++ b/src/cli/_lib/stream-renderer-subagent-helpers.ts
@@ -124,7 +124,7 @@ export function synthesizeAgentEntry(
   // Without this, the Agent prefix is stored unbounded and re-renders on every
   // overlay refresh — long labels (e.g. 80-char prompt prefixes) wrap on narrow
   // terminals. Compute once and apply on whichever Agent-creation path runs.
-  const cols = process.stdout.columns ?? 100;
+  const cols = getTerminalWidth();
   const maxWidth = Math.max(20, cols - 14); // 14 = indent + glyph/spinner budget
 
   // Merge path: when the parent entry is itself an original agent-dispatch

--- a/src/cli/_lib/stream-renderer-subagent.ts
+++ b/src/cli/_lib/stream-renderer-subagent.ts
@@ -16,6 +16,7 @@ import type { CardSpec } from '../render.js';
 import { card } from '../render.js';
 import { commitBlockAbove } from './commit-block.js';
 import { StreamingMarkdownRenderer } from '../markdown-stream.js';
+import { getTerminalWidth } from '../terminal-size.js';
 import { ThinkingLane } from '../commands/interactive/thinking-lane.js';
 import { syntheticResult, formatDoneSummary } from './stream-renderer-source.js';
 import type { OrchestratorCtx } from './stream-renderer-orchestrator.js';
@@ -166,7 +167,7 @@ export function handleSubagentEvent(
         // progress signal than a stale clause of thought.
         ctx.toolLane.setThinkingTail(parentId, undefined);
 
-        const cols = process.stdout.columns ?? 100;
+        const cols = getTerminalWidth();
         const maxWidth = Math.max(20, cols - 14);  // 14 = indent + glyph/spinner budget
         ctx.toolLane.addStartWithAgentContext(
           chunk.toolUseId,
@@ -223,7 +224,7 @@ export function handleSubagentEvent(
           // which would resolve to `undefined` and clear a freshly-installed
           // thinking-tail before any substantive text has rendered.
           if (chunk.content.trim()) {
-            const cols = process.stdout.columns ?? 100;
+            const cols = getTerminalWidth();
             const maxTail = Math.max(20, cols - 14); // 14 = indent + glyph budget
             const tail = extractLatestThinkingClause(source.contentBuffer, maxTail);
             // Item #6: Throttle setThinkingTail to ≥1500ms per parentId OR a
@@ -287,7 +288,7 @@ export function handleSubagentEvent(
         if (!source.thinkingLane) source.thinkingLane = new ThinkingLane();
         source.thinkingLane.push(chunk.content);
         if (ctx.thinkingMode === 'live' && ctx.isTTY && ctx.orchestratorCtx) {
-          const cols = process.stdout.columns ?? 100;
+          const cols = getTerminalWidth();
           const maxTail = Math.max(20, cols - 14);
           const tail = extractLatestThinkingClause(source.thinkingLane.peek(), maxTail);
           if (tail) ctx.toolLane.setThinkingTail(parentId, tail);

--- a/src/cli/slash/commands/bgsub.ts
+++ b/src/cli/slash/commands/bgsub.ts
@@ -24,6 +24,7 @@
 
 import { palette } from '../../palette.js';
 import { formatDuration } from '../../format-utils.js';
+import { getTerminalWidth } from '../../terminal-size.js';
 import type { SlashCommand } from '../types.js';
 import type { BackgroundAgentRegistry, BackgroundJob } from '../../../agent/background-registry.js';
 import type { BackgroundSummarizer } from '../../../agent/background-summarizer.js';
@@ -100,7 +101,7 @@ function formatJobLine(job: BackgroundJob): string {
   const summary = summarizerRef.getSummary(job.jobId);
   if (!summary) return mainLine;
 
-  const cols = process.stdout.columns ?? 120;
+  const cols = getTerminalWidth();
   const safeText = sanitizeSummaryText(summary.text, Math.max(40, cols - 10));
   const ageS = Math.round((Date.now() - summary.refreshedAt) / 1000);
   const staleSuffix = summary.stale ? ' [stale]' : '';

--- a/src/cli/terminal-size.fallback-guard.test.ts
+++ b/src/cli/terminal-size.fallback-guard.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Guard: a terminal-width read may not invent its own fallback width.
+ *
+ * `getTerminalWidth()` (terminal-size.ts) is the canonical width source and
+ * falls back to 80 columns when `process.stdout.columns` is unusable. Two
+ * modules had drifted past it with hand-rolled fallbacks:
+ *
+ *   - `_lib/stream-renderer-subagent{,-helpers}.ts` — `?? 100`, then
+ *     `Math.max(20, cols - 14)`. When `columns` read undefined, the sub-agent
+ *     lane budgeted its thinking-tail and tool-preview text at exactly
+ *     `100 - 14 = 86` columns, regardless of the real terminal width. The
+ *     helpers file already imported `getTerminalWidth` and used it 37 lines
+ *     earlier, so the divergence was an oversight, not a deliberate choice.
+ *   - `slash/commands/bgsub.ts` — `?? 120`, then `Math.max(40, cols - 10)`.
+ *
+ * Both belong to the same defect class as the stale-width bugs pinned in
+ * `terminal-compositor.resize-stale-width.repro.test.ts`: rendering at a width
+ * that is not the terminal's width. A too-WIDE invented fallback is the harmful
+ * direction — emitted rows overflow the real terminal and get soft-wrapped
+ * mid-word, which is exactly the artifact those regressions exist to prevent.
+ * The canonical 80 is deliberately conservative: it can under-fill, never
+ * overflow.
+ *
+ * This is a test rather than a lint rule because the failure is invisible in
+ * review and only manifests when `columns` reads undefined — piped output, a
+ * detached PTY, or a resize race. If a future surface genuinely needs a
+ * different fallback, change this test deliberately; do not drift past it.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { getTerminalWidth } from './terminal-size.js';
+
+/** The one fallback width the codebase is allowed to hard-code. */
+const CANONICAL_FALLBACK = 80;
+
+/** `src/` — this file lives in `src/cli/`. */
+const SRC_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/** Matches `stdout.columns ?? 120` / `self.stdout.columns || 100` and captures the literal. */
+const COLUMNS_FALLBACK = /stdout\.columns\s*(?:\?\?|\|\|)\s*(\d+)/g;
+
+function sourceFiles(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      sourceFiles(full, acc);
+    } else if (
+      entry.name.endsWith('.ts') &&
+      !entry.name.endsWith('.test.ts') &&
+      // The canonical helper defines the fallback; it cannot violate itself.
+      entry.name !== 'terminal-size.ts'
+    ) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+describe('terminal-width fallback guard', () => {
+  it('no source module pairs a stdout.columns read with a non-canonical fallback', () => {
+    const offenders: string[] = [];
+
+    for (const file of sourceFiles(SRC_ROOT)) {
+      const lines = readFileSync(file, 'utf8').split('\n');
+      lines.forEach((line, i) => {
+        for (const match of line.matchAll(COLUMNS_FALLBACK)) {
+          const width = Number(match[1]);
+          if (width !== CANONICAL_FALLBACK) {
+            offenders.push(
+              `${relative(SRC_ROOT, file)}:${i + 1} falls back to ${width}, not ${CANONICAL_FALLBACK} — use getTerminalWidth()`,
+            );
+          }
+        }
+      });
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('getTerminalWidth() resolves the canonical fallback for every unusable width', () => {
+    const original = Object.getOwnPropertyDescriptor(process.stdout, 'columns');
+    const setColumns = (value: number | undefined): void => {
+      Object.defineProperty(process.stdout, 'columns', {
+        value,
+        configurable: true,
+        writable: true,
+      });
+    };
+
+    try {
+      setColumns(undefined);
+      expect(getTerminalWidth()).toBe(CANONICAL_FALLBACK);
+
+      // 0 is reported by some non-TTY pipes. `?? 100` did NOT catch this —
+      // it only guards null/undefined — so the old sub-agent path computed
+      // `Math.max(20, 0 - 14)` = 20 columns here.
+      setColumns(0);
+      expect(getTerminalWidth()).toBe(CANONICAL_FALLBACK);
+
+      // A real width is passed through untouched (no readability cap).
+      setColumns(250);
+      expect(getTerminalWidth()).toBe(250);
+    } finally {
+      if (original) {
+        Object.defineProperty(process.stdout, 'columns', original);
+      } else {
+        delete (process.stdout as unknown as { columns?: number }).columns;
+      }
+    }
+  });
+});


### PR DESCRIPTION
## What

Five terminal-width reads bypassed the canonical `getTerminalWidth()` helper and hard-coded their own fallback. When `process.stdout.columns` reads undefined, they rendered at a width that is not the terminal's:

| Site | Was | Effective width on fallback |
|---|---|---|
| `_lib/stream-renderer-subagent.ts:169,226,290` | `?? 100` then `Math.max(20, cols - 14)` | **86 columns** |
| `_lib/stream-renderer-subagent-helpers.ts:127` | `?? 100` then `Math.max(20, cols - 14)` | **86 columns** |
| `slash/commands/bgsub.ts:103` | `?? 120` then `Math.max(40, cols - 10)` | **110 columns** |

All five now call `getTerminalWidth()` (fallback 80). **No behavioural change when `columns` reports a real width.**

## Why it matters

A too-wide invented fallback is the harmful direction. Rows emitted wider than the real terminal overflow it and get soft-wrapped mid-word — precisely the artifact `terminal-compositor.resize-stale-width.repro.test.ts` exists to prevent. The canonical 80 can under-fill; it can never overflow.

`getTerminalWidth()` additionally treats a `0`-column read (reported by some non-TTY pipes) as unusable. `??` only guards null/undefined, so the old sub-agent path computed `Math.max(20, 0 - 14)` = 20 columns in that case.

The divergence looks like drift, not intent: `stream-renderer-subagent-helpers.ts` already imported `getTerminalWidth` and used it at `:90`, 37 lines above its own `?? 100` at `:127`. `docs/tui-resize-reflow.md` already lists this exact item as an open follow-up ("stream-renderer-subagent.ts width fallback is `?? 100` vs the canonical helper's `?? 80`").

## Test

New `src/cli/terminal-size.fallback-guard.test.ts`:
1. Scans the source tree for any `stdout.columns` read paired with a non-80 literal. **Verified red-first** — it flags all five pre-fix sites (`git show HEAD~1` content). Test files are excluded, so deliberate `?? 88` scaffolding in `tool-lane.test.ts` is untouched.
2. Pins `getTerminalWidth()`'s contract: `undefined → 80`, `0 → 80`, `250 → 250` (no readability cap on the canonical path).

- `npx vitest run` → **705 files, 13,302 passed, 14 skipped, 0 failures**
- `npm run lint` (`tsc --noEmit`) → clean

## Scope — what this does NOT fix

This does **not** address the visible "wrapping looks wrong after I resize the window" symptom. That is the documented widen-asymmetry in `docs/tui-resize-reflow.md` F1: committed text is hard-wrapped at commit time and the band reflow re-wraps retained *rows* independently (`band-reflow.ts:63-77`, `flatMap` with no join), so narrowing splits correctly while widening keeps the earlier wrap points. Fixing that means making native scrollback authoritative via scroll-region insertion — a separate, much larger change. This PR only removes the one code path that could silently render at 86 columns in a wide terminal.
