### PR TITLE
fix(trace): gate witness seal on a purpose-built fork marker, not the output cap

### DIFF
--- a/AFK.md
+++ b/AFK.md
@@ -48,7 +48,11 @@ afk trace show --json       # raw NDJSON, unchanged — pipe to jq
 afk trace list              # sessions that have a trace, most recent first (-n/--max <N>, default 20)
 ```
 
-Traces live at `~/.afk/state/witness/<session>/trace.jsonl` (`$AFK_HOME/state/witness/<sessionLabel>/trace.jsonl`). Writer + reader: `src/agent/trace/`; CLI: `src/cli/commands/trace.ts`. Known gaps (do not assume the trace answers these): tool **args** live in `~/.afk/state/sessions/<id>/events.jsonl`, not the witness trace; raw tool **output** is not recorded anywhere durable; a usage-limit **pause** has no event (silent gap); subagent-spawning calls may record `started` without a terminal if the write races the session seal.
+Traces live at `~/.afk/state/witness/<session>/trace.jsonl` (`$AFK_HOME/state/witness/<sessionLabel>/trace.jsonl`). Writer + reader: `src/agent/trace/`; CLI: `src/cli/commands/trace.ts`. Known gaps (do not assume the trace answers these): tool **args** live in `~/.afk/state/sessions/<id>/events.jsonl`, not the witness trace — the trace carries only `inputBytes`; raw tool **output** is not recorded anywhere durable (only `resultBytes`).
+
+Two gaps previously listed here are now closed — verified against 12,212 traces on disk 2026-07-27: a usage-limit **pause** does emit events (`usage_limit_pause` / `usage_limit_resume` session phases, #638); and a subagent `started` without a terminal is no longer the norm — sealing is owner-gated (#666, and `isSubagentFork` since), which took the rate of dispatched-children-with-no-recorded-fate from ~60% (through 2026-07-22) to ~3%.
+
+The residual ~3% is real and worth knowing about: a parent that ends while a wave is still in flight seals over its live children, so their terminal rows are silently dropped (`write()` throws on a sealed writer and `emitSubagentLifecycle` swallows it). It concentrates in daemon/cron sessions running parallel waves — stratified, interactive sessions sit near 1% while daemon labels sit near 8%. Symptom to recognise: `started` rows with no terminal in a trace that *does* contain `session_sealed`, where the children have attributed `tool_call` events right up to the seal. Detector: an unmatched `started` in a sealed trace — **not** "a `started` is the file's last line", which misses it because the seal is written afterward.
 
 ## Architecture
 

--- a/src/agent/session/agent-session.ts
+++ b/src/agent/session/agent-session.ts
@@ -1216,19 +1216,22 @@ export class AgentSession implements IAgentSession {
       finalCostUsd: this.sessionRunningCostUsd,
       runningTokens: this.sessionRunningTokens,
     }).catch(() => {});
-    // Invariant: only the TOP-LEVEL session (no fork marker) may seal the writer.
-    // A session tree shares ONE TraceWriter by reference (forkSubagent threads
-    // the parent's writer into every descendant), and seal() is one-shot /
-    // idempotent (NdjsonTraceWriter). If a subagent sealed on its own close(),
-    // the FIRST descendant torn down would seal the whole shared file while the
-    // top-level is still mid-run — stranding every later ancestor event as the
-    // "started without terminal" gap (a nested grandchild's end_turn sealing the
-    // root trace 30+ min before the real session ends). The seal owner gate uses
-    // forkSubagent's explicit fork marker, not parentSessionId: stub-parent skill
-    // forks can have no parent session id while still sharing the root writer.
-    // Subagents still emit their own `closure` record above; if the top-level
-    // never runs close(), the process-exit backstop still seals.
-    if (this.config.subagentToolOutputCapBytes === undefined) {
+    // Invariant: only the TOP-LEVEL session may seal the writer, and that is
+    // now asserted by `isSubagentFork` — a field whose sole meaning is "I am a
+    // fork" — rather than inferred from `subagentToolOutputCapBytes`, an
+    // unrelated tool-output cap that merely happened to be fork-only (a
+    // top-level session legitimately setting an output cap silently stopped
+    // sealing its own trace). A session tree shares ONE TraceWriter by
+    // reference (forkSubagent threads the parent's writer into every
+    // descendant) and seal() is a one-shot hard gate — once it flips, write()
+    // throws and emitSubagentLifecycle swallows the rejection. So if a subagent
+    // sealed on its own close(), the FIRST descendant torn down would silently
+    // truncate the shared file while the top-level is still mid-run, stranding
+    // every later sibling terminal as the "started without terminal" gap.
+    // Subagents still emit their own `closure` record above; only the seal is
+    // gated. If the top-level never runs close(), the process-exit backstop
+    // still seals.
+    if (this.config.isSubagentFork !== true) {
       await sealTraceWriter(this.config.traceWriter, {
         ...signals,
         finalTurnCount: this.turnCount,

--- a/src/agent/session/agent-session.ts
+++ b/src/agent/session/agent-session.ts
@@ -15,6 +15,7 @@ import type { ContentBlockParam } from '@anthropic-ai/sdk/resources';
 import { debugLog } from '../../utils/debug.js';
 import { AbortError } from '../../utils/errors.js';
 import { emitSessionPhase } from '../trace/emit.js';
+import type { TraceWriter } from '../trace/writer.js';
 import type { HookRegistry } from '../hooks.js';
 import { resolveProvider, providerForModel } from '../providers/index.js';
 import { ProviderRouter } from '../providers/router/provider-router.js';
@@ -82,6 +83,10 @@ import {
 
 
 export class AgentSession implements IAgentSession {
+  /** Writers are claimed by the first session constructed with them. Forks
+   * share that writer, so seal ownership does not depend on every SDK caller
+   * knowing about an internal fork marker. */
+  private static readonly claimedTraceWriters = new WeakSet<TraceWriter>();
   private config: AgentConfig;
   /**
    * Plan-mode-exit state machine: the pending implement-turn seed, the captured
@@ -108,6 +113,7 @@ export class AgentSession implements IAgentSession {
   private readonly abortController: AbortController;
   private readonly _hookRegistry: HookRegistry | undefined;
   private sessionEndDispatched = false;
+  private readonly ownsTraceSeal: boolean;
   private stateManager!: SessionStateManager;
   /** Cumulative USD cost across all turns this session. Mirrored from
    *  per-turn `metadata.totalCostUsd` so the trace writer's
@@ -175,6 +181,13 @@ export class AgentSession implements IAgentSession {
   private readonly ledger = new LedgerLifecycle();
 
   constructor(config: AgentConfig) {
+    this.ownsTraceSeal =
+      config.traceWriter !== undefined &&
+      config.isSubagentFork !== true &&
+      !AgentSession.claimedTraceWriters.has(config.traceWriter);
+    if (this.ownsTraceSeal) {
+      AgentSession.claimedTraceWriters.add(config.traceWriter!);
+    }
     // Wire the plan-exit control bridge for top-level sessions only (plan mode
     // is a REPL affordance; subagent/forked sessions carry a parentSessionId).
     // The model-callable `exit_plan_mode` tool uses these callbacks to flip the
@@ -1216,22 +1229,18 @@ export class AgentSession implements IAgentSession {
       finalCostUsd: this.sessionRunningCostUsd,
       runningTokens: this.sessionRunningTokens,
     }).catch(() => {});
-    // Invariant: only the TOP-LEVEL session may seal the writer, and that is
-    // now asserted by `isSubagentFork` — a field whose sole meaning is "I am a
-    // fork" — rather than inferred from `subagentToolOutputCapBytes`, an
-    // unrelated tool-output cap that merely happened to be fork-only (a
-    // top-level session legitimately setting an output cap silently stopped
-    // sealing its own trace). A session tree shares ONE TraceWriter by
-    // reference (forkSubagent threads the parent's writer into every
-    // descendant) and seal() is a one-shot hard gate — once it flips, write()
-    // throws and emitSubagentLifecycle swallows the rejection. So if a subagent
-    // sealed on its own close(), the FIRST descendant torn down would silently
-    // truncate the shared file while the top-level is still mid-run, stranding
-    // every later sibling terminal as the "started without terminal" gap.
+    // Invariant: only the session that first claimed a shared TraceWriter may
+    // seal it. `isSubagentFork` prevents stub-parent forks from claiming an
+    // otherwise unseen writer; writer identity also protects SDK consumers
+    // that directly construct a child from the legacy fork config (which has
+    // `subagentToolOutputCapBytes` but not the newer marker). This avoids
+    // coupling ownership back to that unrelated output cap, so a top-level
+    // session may still set a cap and seal normally. seal() is a one-shot hard
+    // gate: a child sealing first would silently truncate all later records.
     // Subagents still emit their own `closure` record above; only the seal is
     // gated. If the top-level never runs close(), the process-exit backstop
     // still seals.
-    if (this.config.isSubagentFork !== true) {
+    if (this.ownsTraceSeal) {
       await sealTraceWriter(this.config.traceWriter, {
         ...signals,
         finalTurnCount: this.turnCount,

--- a/src/agent/session/subagent-seal-ownership.test.ts
+++ b/src/agent/session/subagent-seal-ownership.test.ts
@@ -125,6 +125,36 @@ describe('witness seal ownership', () => {
     }
   });
 
+  it('directly constructed legacy fork does NOT seal its parent writer', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afk-seal-own-legacy-sub-'));
+    try {
+      const writer = new NdjsonTraceWriter({ traceDir: dir });
+      const parent = new AgentSession({
+        model: 'sonnet',
+        provider: createMockProvider({ sessionId: `seal-legacy-parent-${Date.now()}` }),
+        traceWriter: writer,
+      });
+      // Public SDK consumers historically constructed children directly with
+      // this output-cap fork signal, before isSubagentFork existed.
+      const child = new AgentSession({
+        model: 'sonnet',
+        provider: createMockProvider({ sessionId: `seal-legacy-child-${Date.now()}` }),
+        subagentToolOutputCapBytes: 100_000,
+        traceWriter: writer,
+      });
+
+      await drainTurn(child, 'legacy child work');
+      await child.close();
+      expect(readTrace(dir).map((e) => e.kind)).not.toContain('session_sealed');
+
+      await drainTurn(parent, 'parent work after child close');
+      await parent.close();
+      expect(readTrace(dir).map((e) => e.kind)).toContain('session_sealed');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('top-level session that sets an output cap STILL seals (marker decoupled)', async () => {
     // Regression for the latent bug the old gate carried: seal ownership used
     // to be inferred from `subagentToolOutputCapBytes`, so a top-level session

--- a/src/agent/session/subagent-seal-ownership.test.ts
+++ b/src/agent/session/subagent-seal-ownership.test.ts
@@ -10,10 +10,16 @@
  * thus reported a clean success for a session that hung and was cancelled, and
  * every subsequent ancestor event hit the sealed writer and was swallowed.
  *
- * Fix: `dispatchSessionEndOnce` gates `sealTraceWriter(...)` on the explicit
- * fork marker (`subagentToolOutputCapBytes` absent ⇒ top-level). Subagents still
- * emit their own `closure` record; the process-exit backstop still seals an
- * orphaned top-level trace if close() never runs.
+ * Fix: `dispatchSessionEndOnce` gates `sealTraceWriter(...)` on `isSubagentFork`
+ * — a field whose sole meaning is "I am a fork", stamped unconditionally by
+ * `SubagentManager.forkSubagent`. Subagents still emit their own `closure`
+ * record; the process-exit backstop still seals an orphaned top-level trace if
+ * close() never runs.
+ *
+ * The gate previously probed `subagentToolOutputCapBytes` — a tool-output cap
+ * that merely happened to be fork-only. That coupling was invisible and
+ * load-bearing: a top-level session legitimately setting an output cap would
+ * silently stop sealing its own trace. The last case below pins that fix.
  *
  * Invariant locked here: a subagent's close() emits `closure` but does NOT
  * append `session_sealed`; a top-level's close() appends both.
@@ -75,7 +81,7 @@ describe('witness seal ownership', () => {
         provider,
         depth: 1,
         parentSessionId: 'parent-abc',
-        subagentToolOutputCapBytes: 100_000,
+        isSubagentFork: true,
         traceWriter: writer,
       });
 
@@ -102,9 +108,9 @@ describe('witness seal ownership', () => {
         provider,
         depth: 1,
         // Stub-parent skill forks may not have a real parent session id, but
-        // forkSubagent still stamps the explicit fork marker below. That marker,
-        // not parentSessionId, owns trace-seal gating.
-        subagentToolOutputCapBytes: 100_000,
+        // forkSubagent still stamps `isSubagentFork`. That marker, not
+        // parentSessionId, owns trace-seal gating.
+        isSubagentFork: true,
         traceWriter: writer,
       });
 
@@ -114,6 +120,34 @@ describe('witness seal ownership', () => {
       const kinds = readTrace(dir).map((e) => e.kind);
       expect(kinds).toContain('closure');
       expect(kinds).not.toContain('session_sealed');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('top-level session that sets an output cap STILL seals (marker decoupled)', async () => {
+    // Regression for the latent bug the old gate carried: seal ownership used
+    // to be inferred from `subagentToolOutputCapBytes`, so a top-level session
+    // that legitimately capped tool output silently stopped sealing its own
+    // trace — the trace would read `sealed-crashed` forever. Ownership now
+    // keys off `isSubagentFork`, which this session does not set.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afk-seal-own-cap-'));
+    try {
+      const writer = new NdjsonTraceWriter({ traceDir: dir });
+      const provider = createMockProvider({ sessionId: `seal-cap-${Date.now()}` });
+      const session = new AgentSession({
+        model: 'sonnet',
+        provider,
+        subagentToolOutputCapBytes: 100_000,
+        traceWriter: writer,
+      });
+
+      await drainTurn(session, 'top-level with a cap');
+      await session.close();
+
+      const kinds = readTrace(dir).map((e) => e.kind);
+      expect(kinds).toContain('closure');
+      expect(kinds).toContain('session_sealed');
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/src/agent/subagent-output-cap.test.ts
+++ b/src/agent/subagent-output-cap.test.ts
@@ -138,3 +138,52 @@ describe('forkSubagent — fork-scoped central output-cap signal (#661)', () => 
     expect(childConfig?.subagentToolOutputCapBytes).toBe(MODEL_CAP_BYTES);
   });
 });
+
+/**
+ * Trace seal ownership shares this file's harness (it captures the child config
+ * forkSubagent builds) but is a SEPARATE concern from the output cap — it used
+ * to be inferred from `subagentToolOutputCapBytes` precisely because both are
+ * fork-only, and that accidental coupling is the bug these cases lock out. The
+ * behavioural half (who appends `session_sealed`) lives in
+ * session/subagent-seal-ownership.test.ts.
+ */
+describe('forkSubagent — trace seal ownership marker', () => {
+  it('stamps isSubagentFork on a fork with a STUB parent (no sessionId)', async () => {
+    shared.lastConfig = null;
+    const mgr = new SubagentManager();
+    await mgr.forkSubagent({
+      parent: { sessionId: undefined },
+      config: { model: 'sonnet', apiKey: 'k' },
+    });
+
+    // Stub-parent skill forks carry no parentSessionId, so seal gating cannot
+    // key off it — the explicit marker must be present regardless.
+    expect(shared.lastConfig?.isSubagentFork).toBe(true);
+    expect(shared.lastConfig?.parentSessionId).toBeUndefined();
+  });
+
+  it('stamps isSubagentFork on a fork with a REAL parent too (unconditional)', async () => {
+    shared.lastConfig = null;
+    const mgr = new SubagentManager();
+    await mgr.forkSubagent({
+      parent: { sessionId: 'parent-session-abc' },
+      config: { model: 'sonnet', apiKey: 'k' },
+    });
+
+    expect(shared.lastConfig?.isSubagentFork).toBe(true);
+  });
+
+  it('is independent of the output cap — a fork is marked even when the caller passes a cap', async () => {
+    // Locks the decoupling: the two fork-only signals must no longer stand in
+    // for one another in either direction.
+    shared.lastConfig = null;
+    const mgr = new SubagentManager();
+    await mgr.forkSubagent({
+      parent: { sessionId: undefined },
+      config: { model: 'sonnet', apiKey: 'k', subagentToolOutputCapBytes: 0 },
+    });
+
+    expect(shared.lastConfig?.isSubagentFork).toBe(true);
+    expect(shared.lastConfig?.subagentToolOutputCapBytes).toBe(MODEL_CAP_BYTES);
+  });
+});

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -792,6 +792,19 @@ export class SubagentManager {
 
     const childConfig: AgentConfig = {
       ...options.config,
+      // Invariant (trace seal ownership): mark this session as a fork so it
+      // never seals the SHARED witness trace. The whole tree shares ONE
+      // TraceWriter by reference and seal() is a one-shot hard gate — after it
+      // flips, write() throws and emitSubagentLifecycle swallows the rejection,
+      // so the first descendant to seal silently truncates every later
+      // sibling's terminal row (the "started without terminal" orphan gap).
+      // Stamped here, unconditionally, for the same reason as
+      // subagentToolOutputCapBytes below: this is the single choke point every
+      // fork path converges through, so no fork path can forget it. A caller
+      // override is intentionally NOT honored — being a fork is not optional.
+      // Grandchildren re-stamp it (and would inherit it via the spread
+      // regardless), which is correct: they are forks too.
+      isSubagentFork: true,
       // Effective model after the cross-provider coercion above (#652). Placed
       // AFTER the spread so it overrides options.config.model; a no-op on the
       // common path where nothing was coerced.

--- a/src/agent/types/config-types.ts
+++ b/src/agent/types/config-types.ts
@@ -430,8 +430,9 @@ export interface AgentConfig {
   /**
    * True when this session is a forked subagent rather than the top-level
    * session. Stamped unconditionally by `SubagentManager.forkSubagent` — the
-   * single choke point every fork path converges through — and never set by
-   * an entry point, so `undefined` authoritatively means "top-level".
+   * single choke point every built-in fork path converges through — and never
+   * set by an entry point. Direct SDK consumers that predate this marker are
+   * additionally protected by shared TraceWriter identity.
    *
    * Its one job today is witness-trace seal ownership. A session tree shares
    * ONE TraceWriter by reference and `NdjsonTraceWriter.seal()` is a hard,
@@ -440,7 +441,8 @@ export interface AgentConfig {
    * first silently truncates the record for every other session in the tree —
    * the "started without terminal" orphan gap.
    *
-   * This replaces probing `subagentToolOutputCapBytes` for the same signal.
+   * This replaces probing `subagentToolOutputCapBytes` for the same signal on
+   * built-in forks.
    * That field is a tool-output cap that merely *happened* to be fork-only, so
    * the coupling was invisible and load-bearing: any top-level session
    * legitimately setting an output cap would have silently stopped sealing its

--- a/src/agent/types/config-types.ts
+++ b/src/agent/types/config-types.ts
@@ -420,8 +420,33 @@ export interface AgentConfig {
    *
    * See `docs/philosophy/afk-contract.md` for the contract this
    * writer makes enforceable, and `src/agent/trace/` for shapes.
+   *
+   * Writing is the only capability a session needs here. Ending the shared
+   * file's life is a separate, non-inherited capability — see
+   * {@link AgentConfig.traceSealOwner}.
    */
   traceWriter?: TraceWriter;
+
+  /**
+   * True when this session is a forked subagent rather than the top-level
+   * session. Stamped unconditionally by `SubagentManager.forkSubagent` — the
+   * single choke point every fork path converges through — and never set by
+   * an entry point, so `undefined` authoritatively means "top-level".
+   *
+   * Its one job today is witness-trace seal ownership. A session tree shares
+   * ONE TraceWriter by reference and `NdjsonTraceWriter.seal()` is a hard,
+   * one-shot gate: after it flips, `write()` throws and
+   * `emitSubagentLifecycle` swallows the rejection, so whichever session seals
+   * first silently truncates the record for every other session in the tree —
+   * the "started without terminal" orphan gap.
+   *
+   * This replaces probing `subagentToolOutputCapBytes` for the same signal.
+   * That field is a tool-output cap that merely *happened* to be fork-only, so
+   * the coupling was invisible and load-bearing: any top-level session
+   * legitimately setting an output cap would have silently stopped sealing its
+   * own trace. Seal ownership now has a field that means what it says.
+   */
+  isSubagentFork?: true;
 
   /**
    * Model provider. Defaults to the Anthropic SDK adapter


### PR DESCRIPTION
## Problem

Witness-trace seal ownership was decided by probing an unrelated field:

```ts
if (this.config.subagentToolOutputCapBytes === undefined) {   // "am I top-level?"
  await sealTraceWriter(this.config.traceWriter, { ... });
}
```

`subagentToolOutputCapBytes` is a **tool-output cap**. It merely happens to be
fork-only, so it worked as a proxy for "am I a fork?" — but the coupling was
invisible and load-bearing. Any top-level session that legitimately set an
output cap would have silently stopped sealing its own trace, leaving it
`sealed-crashed` forever with no error anywhere.

Why sealing is dangerous to get wrong: a session tree shares **one**
`TraceWriter` by reference, and `seal()` is a one-shot hard gate —
`writer.ts:187-190` throws on any later `write()`, and `emit.ts` swallows that
rejection. So whichever session seals first *silently truncates* every other
session's records. That is the "`started` without terminal" orphan gap. #666
fixed **who** may seal; this fixes **how that question is answered**.

## Fix

`AgentConfig.isSubagentFork`, stamped unconditionally by
`SubagentManager.forkSubagent` — the single choke point every fork path
converges through (agent-tool, skill, compose, dag) — so `undefined`
authoritatively means "top-level".

Deliberately an **opt-out marker on forks**, not an opt-in seal handle on roots:

- Default stays "root seals", so no entry point can regress into *never*
  sealing by omission. An opt-in handle would have had to be added at ~8 root
  config sites, and missing one fails silently in the worse direction.
- Spread-safe: `forkSubagent` builds the child via `...options.config`, so a
  grandchild inherits the marker — which is correct, grandchildren are forks
  too. It is also re-stamped explicitly, mirroring how the output cap is
  force-set at the same site so no fork path can forget it.

No behaviour change for forks or top-level sessions on current paths. What goes
away is the accidental coupling.

## Verification

- `pnpm lint` (tsc --noEmit strict) — clean
- `pnpm test` — 704 files, 13,304 passed, 0 failures
- `pnpm test:coverage` — passes hard thresholds
- `pnpm scan:env:check`, `pnpm audit:sdk:check` — clean

New tests: fork-marker stamping for a stub parent, a real parent, and
independently of a caller-supplied output cap; plus a regression case pinning
that a top-level session which sets an output cap **still** seals. Existing
seal-ownership cases migrated off the old marker (they had encoded the
accidental coupling by simulating a fork with `subagentToolOutputCapBytes:
100_000`).

## AFK.md

The trace "known gaps" list was stale in two of four entries. Verified against
**12,212 traces on disk**:

- usage-limit pauses **do** emit events (`usage_limit_pause` ×39 /
  `usage_limit_resume` ×17 on disk, #638)
- seal-race orphans are no longer the norm — dispatched children with no
  recorded fate fell from **~60%** (through 2026-07-22) to **~3%**, stepping
  when #666 shipped

The entry now documents the **residual ~3%**, which is real: a parent that ends
while a wave is still in flight seals over its live children. It concentrates in
daemon/cron parallel waves (~8% there vs ~1% interactive). It also records the
correct detector — an unmatched `started` in a trace that *does* contain
`session_sealed` — because the intuitive "a `started` is the file's last line"
check finds **zero** occurrences and would wrongly declare the gap closed (the
seal is written *after* the orphaned rows).

## Follow-up (not in this PR)

Split `TraceWriter` into a write-only `TraceSink` for sessions and an owner-only
handle carrying `seal`/`close`, so the capability is **removed at the type
level** rather than gated at runtime — a session that cannot express `seal()`
cannot get this wrong. That is a ~40-file signature sweep (167 `traceWriter`
references, nearly all pass-through) and belongs in its own pure-refactor PR;
mixing it with this behavioural change would make a regression unbisectable.

Separately, the residual daemon-wave case wants a real fix: cascade-abort the
tree before the owner seals, so children get true `cancelled` rows with a
reason instead of vanishing.
