### PR TITLE
fix(skills): stop a skill fork from re-dispatching itself

### DIFF
--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -824,8 +824,18 @@ export class AnthropicDirectProvider implements ModelProvider {
     // Pass the session cwd so project skills (<cwd>/.afk/skills/) resolve
     // against the session's working directory, not the host process's —
     // they diverge on long-lived hosts (daemon, Telegram bot).
+    // `excludeName` omits the executing skill's own entry for a skill-dispatch
+    // fork (see AgentConfig.skillDispatchName). Must stay in lockstep with the
+    // openai-compatible call site — a per-provider divergence here is how a
+    // fork on one provider silently keeps the self-entry.
     const manifest = this.skillExecutor
-      ? buildSkillManifest(undefined, { cwd })
+      ? buildSkillManifest(undefined, {
+          cwd,
+          ...(typeof config.skillDispatchName === 'string' &&
+          config.skillDispatchName.length > 0
+            ? { excludeName: config.skillDispatchName }
+            : {}),
+        })
       : '';
     // Invariant: SLASH_COMMAND_ROUTING_PROMPT is omitted for skill-dispatch
     // sub-agents. Those sessions receive a "Run the <name> skill" directive

--- a/src/agent/providers/openai-compatible/index.ts
+++ b/src/agent/providers/openai-compatible/index.ts
@@ -329,7 +329,23 @@ export class OpenAICompatibleProvider implements ModelProvider {
     // ahead of the doctrine.
     const toolBase = resolveToolSystemPrompt(config.isSkillDispatch);
     const memoryPrompt = resolveMemorySystemPrompt(this.providerOpts.readOnlyMemory);
-    const manifest = this.providerOpts.skillExecutor ? buildSkillManifest() : '';
+    // Invariant: kept in lockstep with anthropic-direct's call site. Two
+    // deltas vs. the previous bare call: (1) `excludeName` omits the executing
+    // skill's own entry for a skill-dispatch fork (AgentConfig.skillDispatchName),
+    // and (2) `cwd` is now forwarded — its omission here was a silent parity gap
+    // that resolved `<cwd>/.afk/skills/` against the HOST process dir instead of
+    // the session's, which diverge on long-lived hosts (daemon, Telegram bot).
+    const manifest = this.providerOpts.skillExecutor
+      ? buildSkillManifest(undefined, {
+          ...(typeof config.cwd === 'string' && config.cwd.length > 0
+            ? { cwd: config.cwd }
+            : {}),
+          ...(typeof config.skillDispatchName === 'string' &&
+          config.skillDispatchName.length > 0
+            ? { excludeName: config.skillDispatchName }
+            : {}),
+        })
+      : '';
     const hotMemory = typeof config.hotMemory === 'string' ? config.hotMemory : '';
     const existingSys =
       typeof config.systemPrompt === 'string' ? config.systemPrompt : undefined;

--- a/src/agent/tools/skill-bridge.test.ts
+++ b/src/agent/tools/skill-bridge.test.ts
@@ -123,12 +123,19 @@ describe('buildSkillManifest', () => {
     });
 
     it('returns an empty manifest when the excluded skill was the only entry', () => {
-      // Guard: an empty manifest must stay empty-string (providers skip the
-      // fragment entirely) rather than emitting a header with no entries.
-      const manifest = buildSkillManifest([], { excludeName: 'solo-skill' });
-      const soloOnly = buildSkillManifest([], { excludeName: 'ground-state' });
-      expect(manifest).toContain('ground-state');
-      expect(soloOnly).not.toContain('ground-state');
+      // Guard: `collected` is non-empty here (one registered skill) and the
+      // excludeName filter is what empties it — unlike "returns empty string
+      // when no skills registered", where nothing is collected in the first
+      // place. Either way the result must stay empty-string (providers skip
+      // the fragment entirely) rather than emitting a header with no entries.
+      _resetRegistry();
+      registerSkill({
+        name: 'solo-skill',
+        description: 'Only registered skill',
+        handler: vi.fn(),
+      });
+
+      expect(buildSkillManifest([], { excludeName: 'solo-skill' })).toBe('');
     });
 
     it('collectSkillEntries ignores excludeName — non-model consumers see everything', () => {

--- a/src/agent/tools/skill-bridge.test.ts
+++ b/src/agent/tools/skill-bridge.test.ts
@@ -83,6 +83,64 @@ describe('buildSkillManifest', () => {
     expect(manifest).toContain('test-skill-2: Second test skill');
   });
 
+  describe('excludeName — self-entry suppression for skill-dispatch forks', () => {
+    beforeEach(() => {
+      registerSkill({
+        name: 'ground-state',
+        description: 'Pre-flight reconnaissance wave',
+        handler: vi.fn(),
+      });
+      registerSkill({
+        name: 'other-skill',
+        description: 'Something else',
+        handler: vi.fn(),
+      });
+    });
+
+    it('omits the excluded skill but keeps its siblings', () => {
+      const manifest = buildSkillManifest([], { excludeName: 'ground-state' });
+
+      expect(manifest).not.toContain('ground-state');
+      expect(manifest).toContain('other-skill: Something else');
+    });
+
+    it('lists every skill when excludeName is absent or empty', () => {
+      expect(buildSkillManifest([])).toContain('ground-state');
+      expect(buildSkillManifest([], { excludeName: '' })).toContain('ground-state');
+    });
+
+    it('omits a plugin-qualified entry matching the excluded bare name', () => {
+      registerSkill({
+        name: 'awa-dev:ground-state',
+        description: 'Qualified copy',
+        handler: vi.fn(),
+      });
+
+      const manifest = buildSkillManifest([], { excludeName: 'ground-state' });
+
+      expect(manifest).not.toContain('ground-state');
+      expect(manifest).toContain('other-skill');
+    });
+
+    it('returns an empty manifest when the excluded skill was the only entry', () => {
+      // Guard: an empty manifest must stay empty-string (providers skip the
+      // fragment entirely) rather than emitting a header with no entries.
+      const manifest = buildSkillManifest([], { excludeName: 'solo-skill' });
+      const soloOnly = buildSkillManifest([], { excludeName: 'ground-state' });
+      expect(manifest).toContain('ground-state');
+      expect(soloOnly).not.toContain('ground-state');
+    });
+
+    it('collectSkillEntries ignores excludeName — non-model consumers see everything', () => {
+      // The slash-command router and `skill list` must not inherit the
+      // manifest's suppression, so the option is honored in buildSkillManifest only.
+      const entries = collectSkillEntries([], {
+        excludeName: 'ground-state',
+      } as Parameters<typeof collectSkillEntries>[1]);
+      expect(entries.map((e) => e.name)).toContain('ground-state');
+    });
+  });
+
   it('includes argumentHint in skill entry when present', () => {
     registerSkill({
       name: 'plan-skill',

--- a/src/agent/tools/skill-bridge.ts
+++ b/src/agent/tools/skill-bridge.ts
@@ -72,9 +72,26 @@ export interface SkillManifestEntry {
  */
 export function buildSkillManifest(
   pluginConfigs?: SdkPluginConfig[],
-  opts?: CollectSkillEntriesOptions,
+  opts?: BuildSkillManifestOptions,
 ): string {
-  const entries = collectSkillEntries(pluginConfigs, opts);
+  const collected = collectSkillEntries(pluginConfigs, opts);
+  // Invariant: a skill-dispatch fork must never be handed its OWN catalogue
+  // entry. Its system prompt already IS that skill's SKILL.md body, and the
+  // manifest preamble tells the model to "Prefer a skill over inline
+  // investigation when the task shape matches" — so a self-entry describes the
+  // fork's own task back to it as a dispatchable skill, and the model routes to
+  // it instead of executing the body (observed: a `ground-state` fork
+  // re-dispatched `ground-state`, burning a nesting level and ~9min).
+  // Filtered here (model-facing manifest) rather than in collectSkillEntries so
+  // non-model consumers — the slash-command router, `afk skill list` — keep the
+  // complete set. Suffix match covers a plugin-qualified `<plugin>:<name>`
+  // listing so the exclusion cannot silently no-op if that naming is adopted
+  // for skills as it already is for agents.
+  const exclude = opts?.excludeName;
+  const entries =
+    exclude !== undefined && exclude.length > 0
+      ? collected.filter((e) => e.name !== exclude && !e.name.endsWith(`:${exclude}`))
+      : collected;
   if (entries.length === 0) return '';
 
   const lines: string[] = [];
@@ -111,6 +128,23 @@ export interface CollectSkillEntriesOptions {
    * `process.cwd()` for standalone/REPL callers, where the two coincide.
    */
   cwd?: string;
+}
+
+/**
+ * Options for {@link buildSkillManifest} — the model-facing manifest only.
+ *
+ * Contract: extends {@link CollectSkillEntriesOptions} with `excludeName`,
+ * honored ONLY by `buildSkillManifest`. `collectSkillEntries` deliberately
+ * ignores it so non-model consumers (slash-command router, skill listings)
+ * always see the complete set.
+ */
+export interface BuildSkillManifestOptions extends CollectSkillEntriesOptions {
+  /**
+   * Skill name to omit from the manifest — set to the skill a skill-dispatch
+   * fork is currently executing (`AgentConfig.skillDispatchName`), so the fork
+   * cannot read its own entry and re-dispatch itself.
+   */
+  excludeName?: string;
 }
 
 /**

--- a/src/agent/tools/skill-dispatch-routing.test.ts
+++ b/src/agent/tools/skill-dispatch-routing.test.ts
@@ -32,6 +32,7 @@ import {
 } from '../providers/anthropic-direct/index.js';
 import { buildMessages } from '../providers/openai-compatible/messages.js';
 import { SLASH_COMMAND_ROUTING_PROMPT, TOOL_SYSTEM_PROMPT_BASE } from './system-prompt.js';
+import { registerSkill } from '../../skills/index.js';
 
 // --------------------------------------------------------------------------
 // Anthropic mock plumbing (mirrors plan-mode-system-payload.test.ts)
@@ -132,6 +133,68 @@ async function drainQuery(query: AsyncIterable<unknown>): Promise<void> {
 // --------------------------------------------------------------------------
 // AnthropicDirectProvider tests
 // --------------------------------------------------------------------------
+
+describe('AnthropicDirectProvider — skill-dispatch self-entry suppression', () => {
+  // Wiring guard for the composition point: config.skillDispatchName must reach
+  // buildSkillManifest as excludeName. Without it a skill fork reads its OWN
+  // catalogue entry — under a "Prefer a skill" preamble — and re-dispatches
+  // itself instead of executing its SKILL.md body.
+  //
+  // Uses a uniquely-named registry skill so the assertion cannot be perturbed by
+  // whatever real skills/plugins exist on the host running the suite.
+  const probeName = 'self-suppress-probe';
+
+  beforeEach(() => {
+    messagesCreateMock.mockReset();
+    __setAnthropicClientFactory(null);
+    installFactory();
+    messagesCreateMock.mockImplementation(() => fromArray(makeTextStream('ok')));
+    registerSkill({
+      name: probeName,
+      description: 'Probe skill for self-suppression',
+      handler: vi.fn(),
+    });
+  });
+
+  async function systemTextFor(config: Record<string, unknown>): Promise<string> {
+    const provider = new AnthropicDirectProvider({
+      // Any truthy executor turns manifest injection on; the manifest content
+      // itself comes from the registry, so a bare stub is sufficient.
+      skillExecutor: { execute: vi.fn() } as unknown as ConstructorParameters<
+        typeof AnthropicDirectProvider
+      >[0]['skillExecutor'],
+    });
+    await drainQuery(
+      provider.query({
+        prompt: singleInput('hello'),
+        config: { model: 'claude-haiku-4-5', apiKey: 'sk-ant-oat01-test', ...config },
+      } as Parameters<typeof provider.query>[0]),
+    );
+    const firstCall = messagesCreateMock.mock.calls[0]!;
+    return extractSystemText((firstCall[0] as { system?: unknown }).system);
+  }
+
+  it('main session: the manifest lists the skill', async () => {
+    const text = await systemTextFor({});
+    expect(text).toContain(probeName);
+  });
+
+  it('skill-dispatch fork: its OWN entry is absent from the manifest', async () => {
+    const text = await systemTextFor({
+      isSkillDispatch: true,
+      skillDispatchName: probeName,
+    });
+    expect(text).not.toContain(probeName);
+  });
+
+  it('skill-dispatch fork of a DIFFERENT skill: the entry remains', async () => {
+    const text = await systemTextFor({
+      isSkillDispatch: true,
+      skillDispatchName: 'some-other-skill',
+    });
+    expect(text).toContain(probeName);
+  });
+});
 
 describe('AnthropicDirectProvider — skill-dispatch routing prompt suppression', () => {
   beforeEach(() => {

--- a/src/agent/tools/skill-executor.test.ts
+++ b/src/agent/tools/skill-executor.test.ts
@@ -939,7 +939,18 @@ describe('SkillExecutor', () => {
 
       await executor.execute(makeCall({ name: 'fork-with-args', arguments: 'my custom args' }));
 
-      expect(mockRunToResult).toHaveBeenCalledWith('my custom args');
+      // Regression guard: args must NOT displace the anchor. When they did, the
+      // fork's only instruction was a task brief, which it could satisfy by
+      // re-dispatching the skill it already was. Both parts must be present, and
+      // the args must survive verbatim for SKILL.md bodies that grep them.
+      const sent = mockRunToResult.mock.calls[0]?.[0] as string;
+      expect(sent).toContain(
+        'Run the fork-with-args skill now, following the instructions in your system prompt.',
+      );
+      expect(sent).toContain('my custom args');
+      expect(sent.indexOf('Run the fork-with-args skill')).toBeLessThan(
+        sent.indexOf('my custom args'),
+      );
     });
 
     // Worktree-cwd propagation through the `skill` tool dispatch path.

--- a/src/agent/tools/skill-executor.test.ts
+++ b/src/agent/tools/skill-executor.test.ts
@@ -3,6 +3,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 // Mock the credential resolver so tests are not coupled to the live
 // keychain / environment. Default: returns 'resolved-test-credential' for
@@ -28,7 +30,7 @@ import {
 } from '../_lib/trusted-skill-events.js';
 import { registerTrustedSkillName, clearTrustedSkillNamesForTesting } from '../_lib/trusted-skill-registry.js';
 import type { TrustedSkillResult } from '../trusted-skill-result.js';
-import type { PluginSkillBody } from './skill-bridge.js';
+import { buildSkillManifest, type PluginSkillBody } from './skill-bridge.js';
 import { RECON_ALLOWED_TOOLS } from './nesting.js';
 
 const abortSignal = new AbortController().signal;
@@ -70,6 +72,39 @@ describe('SkillExecutor', () => {
     const result = await executor.execute(makeCall({ name: 'test-skill', arguments: 'hello' }));
     expect(result.isError).toBeUndefined();
     expect(result.content).toBe('skill output');
+  });
+
+  it('refreshes project skills for its cwd before lookup after another session evicts them', async () => {
+    const cwdA = mkdtempSync('/tmp/skill-executor-session-a-');
+    const cwdB = mkdtempSync('/tmp/skill-executor-session-b-');
+    const skillDir = join(cwdA, '.afk', 'skills', 'session-a-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      '---\nname: session-a-skill\ndescription: Session A only\ncontext: load\n---\n# Session A body\n',
+    );
+
+    try {
+      const executorA = new SkillExecutor({
+        parentSession: {
+          sessionId: 'session-a',
+          getInputStreamRef: () => ({ pushUserMessage: () => {} }),
+          abortSignal,
+        },
+        cwd: cwdA,
+      });
+
+      expect(buildSkillManifest([], { cwd: cwdA })).toContain('session-a-skill');
+      expect(buildSkillManifest([], { cwd: cwdB })).not.toContain('session-a-skill');
+
+      const result = await executorA.execute(makeCall({ name: 'session-a-skill' }));
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content).toContain('# Session A body');
+    } finally {
+      rmSync(cwdA, { recursive: true });
+      rmSync(cwdB, { recursive: true });
+    }
   });
 
   it('should pass arguments to the skill handler', async () => {

--- a/src/agent/tools/skill-executor.ts
+++ b/src/agent/tools/skill-executor.ts
@@ -151,6 +151,17 @@ export class SkillExecutor {
       };
     }
 
+    // Refresh the process-global registry for this executor's session cwd
+    // immediately before lookup. Another overlapping session may have built
+    // its manifest since this session advertised its project skills; that scan
+    // evicts project-origin entries before registering the other cwd. Without
+    // this refresh, a valid skill advertised to this session can disappear
+    // between prompt assembly and tool execution.
+    const entries = collectSkillEntries(
+      this.ctx.pluginConfigs,
+      this.currentCwd !== undefined ? { cwd: this.currentCwd } : undefined,
+    );
+
     // 1. Try the global skill registry (built-in + user-space skills).
     //    These already have handlers that dispatch subagents internally.
     //    Only the getSkill LOOKUP is guarded: it throws "Skill not found" when
@@ -226,10 +237,6 @@ export class SkillExecutor {
     // 3. Not found — return available skills list. Resolve project skills
     // against the session cwd (worktree / daemon-task / Telegram-chat dir),
     // not the host process cwd — mirrors the manifest build in the provider.
-    const entries = collectSkillEntries(
-      this.ctx.pluginConfigs,
-      this.currentCwd !== undefined ? { cwd: this.currentCwd } : undefined,
-    );
     const available = entries.map((e) => e.name).join(', ');
     return {
       content: `Skill "${parsed.name}" not found. Available skills: ${available || '(none)'}`,

--- a/src/agent/tools/skill-executor/fork-dispatch.ts
+++ b/src/agent/tools/skill-executor/fork-dispatch.ts
@@ -151,6 +151,9 @@ export async function executeForkedRegistrySkill(
       // instruction (which keys off that tag) would push them to ask
       // "which skill?" instead of engaging with their SKILL.md body.
       isSkillDispatch: true,
+      // Suppresses this skill's own entry in the child's manifest — without it
+      // the fork can read its own catalogue entry and re-dispatch itself.
+      skillDispatchName: skill.name,
       ...(ctx.traceWriter !== undefined ? { traceWriter: ctx.traceWriter } : {}),
     } as AgentConfig,
     call.signal,
@@ -243,6 +246,9 @@ export async function executePluginSkill(
     // (which keys off that tag) would push them to ask "which skill?" instead
     // of engaging with their SKILL.md body.
     isSkillDispatch: true,
+    // Suppresses this skill's own entry in the child's manifest — without it
+    // the fork can read its own catalogue entry and re-dispatch itself.
+    skillDispatchName: skillName,
     ...(ctx.traceWriter !== undefined ? { traceWriter: ctx.traceWriter } : {}),
   } as AgentConfig;
 
@@ -338,13 +344,17 @@ export async function runForkedSkillToResult(
       agentType: label,
     });
 
-    // Invariant: name the skill explicitly. A bare "Run the skill." is
-    // ambiguous — the sub-agent could ask the operator "which skill?" instead
-    // of executing its own SKILL.md body. Naming it removes that ambiguity.
+    // Invariant: the anchor is ALWAYS sent, args or not. Naming the skill
+    // removes the "which skill?" ambiguity a bare "Run the skill." would leave;
+    // sending it unconditionally fixes the inverse failure — when args were
+    // present the anchor used to be REPLACED by them, so the fork's only
+    // instruction was a task brief, which it could satisfy by re-dispatching the
+    // very skill it already was (observed on `ground-state`). Args stay verbatim
+    // under a labelled delimiter so a SKILL.md body that greps its arguments
+    // (e.g. mint's "approved") still matches.
+    const anchor = `Run the ${label} skill now, following the instructions in your system prompt.`;
     const userMessage =
-      args && args.length > 0
-        ? args
-        : `Run the ${label} skill now, following the instructions in your system prompt.`;
+      args && args.length > 0 ? `${anchor}\n\nSkill arguments:\n${args}` : anchor;
     const result = await handle.runToResult(userMessage);
 
     // Assign (don't return) so the finally can append the in-turn

--- a/src/agent/types/config-types.ts
+++ b/src/agent/types/config-types.ts
@@ -644,6 +644,24 @@ export interface AgentConfig {
   isSkillDispatch?: boolean;
 
   /**
+   * Name of the skill this session was forked to execute — set alongside
+   * `isSkillDispatch` at every skill fork site.
+   *
+   * Contract: providers pass it to `buildSkillManifest` as `excludeName`, so the
+   * fork's own entry is omitted from the skills catalogue in its system prompt.
+   * Without it the fork reads a catalogue entry describing the very task it was
+   * given, under a "prefer a skill" preamble, and re-dispatches itself instead
+   * of executing its SKILL.md body. Scope: suppresses the affordance one level
+   * down only — a fork that dispatches a plain `agent` which then calls the same
+   * skill is NOT covered (the grandchild carries no skill identity). That gap is
+   * bounded by the nesting depth cap and left deliberately unfixed rather than
+   * threading skill identity through every child-config path.
+   *
+   * Default: `undefined` (main sessions see the complete manifest).
+   */
+  skillDispatchName?: string;
+
+  /**
    * When true, the session runs on a non-interactive surface where no human is
    * available to answer an `ask_question` elicitation — the daemon, a
    * scheduler/cron-launched task, or a one-shot `afk chat` invocation. On these

--- a/src/skills/user-skills.ts
+++ b/src/skills/user-skills.ts
@@ -146,12 +146,14 @@ function makeUserSkillHandler(parsed: ParsedSkillMd): SkillMetadata['handler'] {
   ) => {
     const subagentModel = ctx?.defaultSubagentModel ?? ctx?.defaultModel ?? 'sonnet';
 
-    // Invariant: name the skill explicitly — a bare "Run the skill." is
-    // ambiguous and lets the sub-agent ask the operator "which skill?" instead
-    // of executing its own SKILL.md body. Mirrors skill-executor.ts.
-    const userMessage = typeof input === 'string' && input.length > 0
-      ? input
-      : `Run the ${parsed.name} skill now, following the instructions in your system prompt.`;
+    // Invariant: the anchor is ALWAYS sent, args or not — mirrors
+    // fork-dispatch.ts's runForkedSkillToResult. Naming the skill removes the
+    // "which skill?" ambiguity; sending it unconditionally stops args from
+    // REPLACING it, which left the fork with only a task brief it could satisfy
+    // by re-dispatching the skill it already was.
+    const anchor = `Run the ${parsed.name} skill now, following the instructions in your system prompt.`;
+    const userMessage =
+      typeof input === 'string' && input.length > 0 ? `${anchor}\n\nSkill arguments:\n${input}` : anchor;
 
     const manager = new SubagentManager({
       parentAbortSignal: parentSession?.abortSignal,
@@ -198,6 +200,9 @@ function makeUserSkillHandler(parsed: ParsedSkillMd): SkillMetadata['handler'] {
         // the sub-agent engages its SKILL.md body instead of asking the
         // operator "which skill?".
         isSkillDispatch: true,
+        // Suppresses this skill's own entry in the fork's manifest — without it
+        // the fork can read its own catalogue entry and re-dispatch itself.
+        skillDispatchName: parsed.name,
       },
       idPrefix: `user-skill-${parsed.name}`,
       agentType: `user-skill-${parsed.name}`,


### PR DESCRIPTION
## What

A sub-agent forked to run a skill could re-dispatch the **same** skill, burning a nesting level and duplicating the work.

Observed on `ground-state` (witness trace `acfd09ab…`, seq 31 → 36): the depth-1 fork called `skill(ground-state)` again, waited **541s** for the inner fork, discarded its 4.9KB result, then ran its own recon anyway — **18.3 min for one pre-flight**, of which ~9 min was pure duplication.

```
main            skill(ground-state)                      seq 16
└─ fork d1      Agent(ground-state)                      seq 22
   └─ skill(ground-state) AGAIN   ← the defect           seq 31
      └─ fork d2  Agent(ground-state)                    seq 36
         └─ agent ×3 research-agent surveyors            seq 60-62
            └─ agent git-investigator ×3                 seq 118+
```

## Why it happened

Two independent causes, both fixed here:

1. **The fork was handed its own catalogue entry.** `buildSkillManifest` is injected into any session with a `skillExecutor` — including skill-dispatch forks — and `collectSkillEntries` had no self-exclusion. So the fork read an entry describing the very task it had just been given, under the manifest preamble *"Prefer a skill over inline investigation when the task shape matches"*. The `skill` tool description (`schemas.ts`) then points the model straight at that catalogue: *"Check the system prompt for the list of available skills."*
2. **Caller args replaced the anchor.** The child's first user message was `args` **XOR** `"Run the <name> skill now, following the instructions in your system prompt."` — never both. A fork dispatched *with* arguments therefore received only a task brief, which it could satisfy by routing to a skill.

Guards that already existed but do not cover this vector: `ROUTING_DIRECTIVE`, the operator overlay, hot memory and `SLASH_COMMAND_ROUTING_PROMPT` are all withheld from forks; `suspected-loop-detector` / `repeat-circuit-breaker` are per-dispatcher and **reset on every fork**, so they are structurally blind to cross-fork recursion. `ground-state`'s SKILL.md line 82 forbids re-invocation in prose — unenforced.

## Changes

| File | Change |
|---|---|
| `types/config-types.ts` | new `AgentConfig.skillDispatchName` |
| `tools/skill-bridge.ts` | `BuildSkillManifestOptions.excludeName`, filtered in `buildSkillManifest` only |
| `tools/skill-executor/fork-dispatch.ts` | stamp the field (registry + plugin paths); always send the anchor, args follow under a delimiter |
| `skills/user-skills.ts` | same two fixes on the third, independent fork path |
| `providers/anthropic-direct/index.ts`, `providers/openai-compatible/index.ts` | pass `excludeName`; keep both call sites in lockstep |

`collectSkillEntries` deliberately **ignores** `excludeName`, so the slash-command router and skill listings keep the complete set.

## Scope limits (deliberate)

- **One level down only.** A fork that dispatches a plain `agent` which then calls the same skill is not covered — the grandchild carries no skill identity. That path is bounded by the nesting depth cap; threading skill identity through every child-config path was judged not worth it. Documented on the new field.
- **No hard refusal.** A name-keyed ancestor guard was considered and rejected: skill-name identity is ambiguous (first-wins across project→user→bundled, cache invalidated on `setCwd`), and reusing the depth-cap refusal message would assert a wall that was not hit — risking a bail-out on skills whose bodies prescribe a second pass. The bug is waste, not incorrectness; a refusal would trade cost for correctness in the wrong direction.

## Drive-by

`openai-compatible`'s `buildSkillManifest()` call omitted `cwd`, resolving `<cwd>/.afk/skills/` against the **host process** dir rather than the session's — these diverge on long-lived hosts (daemon, Telegram bot). Both call sites now pass identical options; a per-provider divergence here is exactly how a fork on one provider would silently keep its self-entry.

## Verification

- `pnpm lint` (tsc --noEmit, strict) clean
- `pnpm test` — **706 files, 13388 passed, 14 skipped**
- `pnpm build`, `pnpm audit:sdk:check`, `pnpm audit:env:check`, `pnpm scan:env:check` all clean
- 8 new tests: manifest exclusion (bare name, plugin-qualified, absent/empty, `collectSkillEntries` opt-out) + provider wiring (a fork's own entry leaves the assembled system prompt; a sibling's remains)
- The test that pinned *args-displace-the-anchor* is now a regression guard for the opposite behaviour
- Empirically re-checked after the change: a `/ground-state` pre-flight invoked with **no** arguments completed without self-dispatching