### PR TITLE
fix(presence): advertise presence for fresh sessions so Telegram AFK can discover them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,6 @@ auto-release workflow to deduplicate commits across successive runs.
 
 ## [Unreleased]
 
-### Fixed
-- advertise presence for fresh sessions so Telegram AFK can discover them (#738)
-- stop presence cleanup from pre-empting a surface's graceful shutdown, and from leaking three process listeners per session (#738)
-- rewrite presence when a provider instance's advertised session id changes, so `/resume` in a live REPL no longer leaves the watcher tailing a closed session's ledger (#738)
-- write presence files `0600` and the presence dir `0700` instead of inheriting the umask (#738)
-
-### Changed
-- a fresh `openai-compatible` session now carries a real session id instead of the `openai-pending-` sentinel, narrowing that sentinel's reachability (#738)
-
 ## [5.81.6] - 2026-07-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ auto-release workflow to deduplicate commits across successive runs.
 
 ## [Unreleased]
 
+### Fixed
+- advertise presence for fresh sessions so Telegram AFK can discover them (#738)
+- stop presence cleanup from pre-empting a surface's graceful shutdown, and from leaking three process listeners per session (#738)
+- rewrite presence when a provider instance's advertised session id changes, so `/resume` in a live REPL no longer leaves the watcher tailing a closed session's ledger (#738)
+- write presence files `0600` and the presence dir `0700` instead of inheriting the umask (#738)
+
+### Changed
+- a fresh `openai-compatible` session now carries a real session id instead of the `openai-pending-` sentinel, narrowing that sentinel's reachability (#738)
+
 ## [5.81.6] - 2026-07-28
 
 ### Fixed

--- a/src/agent/awareness/index.ts
+++ b/src/agent/awareness/index.ts
@@ -46,6 +46,7 @@ export { gatherWorkspace } from './workspace-source.js';
 
 export {
   writePresenceFile,
+  writePresenceFileSync,
   removePresenceFile,
   removePresenceFileSync,
   readPresenceFiles,

--- a/src/agent/awareness/presence.ts
+++ b/src/agent/awareness/presence.ts
@@ -21,7 +21,7 @@
  */
 
 import { mkdir, writeFile, unlink, readdir, readFile } from 'fs/promises';
-import { unlinkSync, existsSync } from 'fs';
+import { unlinkSync, existsSync, mkdirSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { getPresenceDir } from '../../paths.js';
 import type { RuntimeWorkspace } from './types.js';
@@ -237,25 +237,70 @@ export async function writePresenceFile(info: PresenceFileInfo): Promise<void> {
     try {
       const ok = await ensurePresenceDir();
       if (!ok) return;
-      const filePath = presenceFilePath(info.sessionId);
-      // Stamp the schema version and an initial heartbeat HERE rather than at the
-      // call sites: more than one provider writes presence (anthropic-direct and
-      // openai-compatible), so a per-caller stamp would silently miss a writer the
-      // moment a third surface is added. Caller-supplied values win, which keeps
-      // tests able to pin a specific version or heartbeat.
-      const record: PresenceFileInfo = {
-        schemaVersion: PRESENCE_SCHEMA_VERSION,
-        heartbeatAt: new Date().toISOString(),
-        ...info,
-      };
       // mode: 0o600 — presence records carry cwd/pid/afk-posture; a default
       // umask would otherwise leave them world-readable (every mutator below
       // matches this mode so a read-modify-write cannot loosen it back up).
-      await writeFile(filePath, JSON.stringify(record, null, 2), { encoding: 'utf8', mode: 0o600 });
+      await writeFile(presenceFilePath(info.sessionId), serializePresenceRecord(info), {
+        encoding: 'utf8',
+        mode: 0o600,
+      });
     } catch {
       // Best-effort — swallow silently.
     }
   });
+}
+
+/**
+ * Stamp the schema version and an initial heartbeat HERE rather than at the call
+ * sites: more than one provider writes presence (anthropic-direct and
+ * openai-compatible), so a per-caller stamp would silently miss a writer the
+ * moment a third surface is added. Caller-supplied values win, which keeps tests
+ * able to pin a specific version or heartbeat.
+ *
+ * Shared by the async and sync writers so the two cannot drift in record shape.
+ */
+function serializePresenceRecord(info: PresenceFileInfo): string {
+  const record: PresenceFileInfo = {
+    schemaVersion: PRESENCE_SCHEMA_VERSION,
+    heartbeatAt: new Date().toISOString(),
+    ...info,
+  };
+  return JSON.stringify(record, null, 2);
+}
+
+/**
+ * Synchronous variant of {@link writePresenceFile}, for the session's INITIAL
+ * advertisement.
+ *
+ * Invariant: this write must be complete before the call that triggered it
+ * returns. It is issued from `registerPresenceLifecycle` inside a provider's
+ * `query()`, and both providers expose a synchronous `close()`, so an async
+ * write has no handle anything can await — it outlives the turn that started it.
+ * Two concrete failures followed from that. (1) A host that points `AFK_HOME` at
+ * a scratch dir and removes it right after a turn races the in-flight write and
+ * gets `ENOTEMPTY` on teardown, because the write recreates `presence/` while
+ * the tree is being walked. (2) `setPresenceAfk` is a read-modify-write that
+ * swallows `ENOENT`, so an `/afk on` issued immediately after session start
+ * could land BEFORE the initial file existed and silently no-op, leaving the
+ * operator's posture unset. Writing synchronously removes both: the file exists
+ * before `query()` proceeds, and every queued mutator necessarily runs after it.
+ *
+ * Deliberately NOT enrolled in the `presenceWriteTails` queue — it is the first
+ * operation for this session id, and completing inline means later async
+ * mutators serialize behind an already-durable file rather than racing it.
+ *
+ * Best-effort and never throws, matching the async writer.
+ */
+export function writePresenceFileSync(info: PresenceFileInfo): void {
+  try {
+    mkdirSync(getPresenceDir(), { recursive: true, mode: 0o700 });
+    writeFileSync(presenceFilePath(info.sessionId), serializePresenceRecord(info), {
+      encoding: 'utf8',
+      mode: 0o600,
+    });
+  } catch {
+    // Best-effort — swallow silently.
+  }
 }
 
 /**

--- a/src/agent/awareness/presence.ts
+++ b/src/agent/awareness/presence.ts
@@ -162,10 +162,18 @@ function presenceFilePath(sessionId: string): string {
 /**
  * Ensure the presence directory exists. Returns `true` on success, `false` on
  * any fs error (caller treats write as best-effort).
+ *
+ * `mode: 0o700` — presence records include `cwd`, `pid`, and (for AFK
+ * sessions) an `afk` posture marker; a default umask would otherwise leave
+ * the directory (and, by extension, every file mkdir creates under it)
+ * world-readable. `recursive: true` no-ops the mode on an already-existing
+ * directory (Node does not chmod on the recursive/no-op path), so this only
+ * takes effect on first creation — existing installs are unaffected until
+ * the dir is recreated.
  */
 async function ensurePresenceDir(): Promise<boolean> {
   try {
-    await mkdir(getPresenceDir(), { recursive: true });
+    await mkdir(getPresenceDir(), { recursive: true, mode: 0o700 });
     return true;
   } catch {
     return false;
@@ -240,7 +248,10 @@ export async function writePresenceFile(info: PresenceFileInfo): Promise<void> {
         heartbeatAt: new Date().toISOString(),
         ...info,
       };
-      await writeFile(filePath, JSON.stringify(record, null, 2), 'utf8');
+      // mode: 0o600 — presence records carry cwd/pid/afk-posture; a default
+      // umask would otherwise leave them world-readable (every mutator below
+      // matches this mode so a read-modify-write cannot loosen it back up).
+      await writeFile(filePath, JSON.stringify(record, null, 2), { encoding: 'utf8', mode: 0o600 });
     } catch {
       // Best-effort — swallow silently.
     }
@@ -265,7 +276,7 @@ export async function touchPresenceHeartbeat(sessionId: string): Promise<void> {
       const raw = await readFile(filePath, 'utf8');
       const parsed = JSON.parse(raw) as PresenceFileInfo;
       parsed.heartbeatAt = new Date().toISOString();
-      await writeFile(filePath, JSON.stringify(parsed, null, 2), 'utf8');
+      await writeFile(filePath, JSON.stringify(parsed, null, 2), { encoding: 'utf8', mode: 0o600 });
     } catch {
       // Best-effort — presence is non-critical.
     }
@@ -286,7 +297,7 @@ export async function setPresenceAfk(sessionId: string, afk: boolean): Promise<v
       const raw = await readFile(filePath, 'utf8');
       const parsed = JSON.parse(raw) as PresenceFileInfo;
       parsed.afk = afk;
-      await writeFile(filePath, JSON.stringify(parsed, null, 2), 'utf8');
+      await writeFile(filePath, JSON.stringify(parsed, null, 2), { encoding: 'utf8', mode: 0o600 });
     } catch {
       // Best-effort — presence is non-critical.
     }
@@ -323,7 +334,7 @@ export async function setPresenceBlocked(sessionId: string, blocked: boolean): P
       } else {
         delete parsed.blockedSince;
       }
-      await writeFile(filePath, JSON.stringify(parsed, null, 2), 'utf8');
+      await writeFile(filePath, JSON.stringify(parsed, null, 2), { encoding: 'utf8', mode: 0o600 });
     } catch {
       // Best-effort — presence is non-critical.
     }
@@ -348,7 +359,7 @@ export async function updatePresenceCwd(sessionId: string, cwd: string): Promise
       const raw = await readFile(filePath, 'utf8');
       const parsed = JSON.parse(raw) as PresenceFileInfo;
       parsed.cwd = cwd;
-      await writeFile(filePath, JSON.stringify(parsed, null, 2), 'utf8');
+      await writeFile(filePath, JSON.stringify(parsed, null, 2), { encoding: 'utf8', mode: 0o600 });
     } catch {
       // Best-effort — presence is non-critical.
     }

--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -82,7 +82,7 @@ import {
   buildRuntimeStateSource,
   type RuntimeStateSource,
 } from '../../awareness/index.js';
-import { registerPresenceLifecycle } from './query/presence-lifecycle.js';
+import { registerPresenceLifecycle, resolveTopLevelSessionId } from './query/presence-lifecycle.js';
 import { createCwdDependentsFactory } from './query/cwd-dependents.js';
 import { assembleSystemPrompt, buildStableSystemPrefix } from './query/system-prompt.js';
 
@@ -254,6 +254,16 @@ export class AnthropicDirectProvider implements ModelProvider {
    * `string` = the sessionId whose presence file was written
    */
   private _presenceSessionId: string | null = null;
+
+  /**
+   * Session id minted for a top-level session that supplied none (no --resume).
+   * Memoized so it stays stable across turns — `query()` runs once per turn, and
+   * a fresh mint each turn would move the ledger directory out from under the
+   * presence file the Telegram watcher is already following.
+   *
+   * `null` = nothing minted yet (either not top-level, or an explicit id won).
+   */
+  private _mintedSessionId: string | null = null;
 
   constructor(opts: AnthropicDirectProviderOptions = {}) {
     const schemas = [...builtinToolSchemas];
@@ -752,10 +762,26 @@ export class AnthropicDirectProvider implements ModelProvider {
           : { active: [], backgroundJobs: [] },
     });
 
+    // Invariant: presence and query construction MUST use the same session id,
+    // because the Telegram watcher resolves a session's ledger path from the id
+    // in its presence file. Resolve once here — BEFORE the presence write — and
+    // reuse the result for `new AnthropicDirectQuery` below, so the presence
+    // file, the `session.init` event, and the ledger directory cannot diverge.
+    // Reading `config.sessionId` alone is what broke this: it is set only under
+    // --resume, so fresh sessions advertised nothing at all.
+    const resolvedSession = resolveTopLevelSessionId({
+      sessionId: config.sessionId,
+      resume: config.resume,
+      depth: config.depth,
+      parentSessionId: config.parentSessionId,
+      memoized: this._mintedSessionId,
+    });
+    this._mintedSessionId = resolvedSession.memoized;
+
     this._presenceSessionId = registerPresenceLifecycle({
       depth: config.depth,
       parentSessionId: config.parentSessionId,
-      sessionId: config.sessionId,
+      sessionId: resolvedSession.id,
       currentPresenceSessionId: this._presenceSessionId,
       runtimeStateSource,
       surface: this.surface,
@@ -921,7 +947,14 @@ export class AnthropicDirectProvider implements ModelProvider {
       };
     }
 
-    const resumedSessionId = config.sessionId ?? config.resume;
+    // Invariant: this MUST be the same id the presence file advertises, so the
+    // Telegram watcher tails the ledger this session actually writes. Sourced
+    // from the single resolution performed above (explicit --resume id wins;
+    // top-level sessions get a memoized mint; forks stay undefined so the query
+    // keeps minting its own id per call). `opts.sessionId` feeds only
+    // `initSessionId` in query.ts — it gates no resume behavior — so supplying
+    // a minted id here is inert apart from making the id known earlier.
+    const resumedSessionId = resolvedSession.id;
     const initialMessages = resumeHistoryToMessages(config.resumeHistory);
 
     const cwdDependentsFactory = this.externalTools

--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -774,6 +774,7 @@ export class AnthropicDirectProvider implements ModelProvider {
       resume: config.resume,
       depth: config.depth,
       parentSessionId: config.parentSessionId,
+      surface: this.surface,
       memoized: this._mintedSessionId,
     });
     this._mintedSessionId = resolvedSession.memoized;

--- a/src/agent/providers/anthropic-direct/query/presence-lifecycle.ts
+++ b/src/agent/providers/anthropic-direct/query/presence-lifecycle.ts
@@ -1,68 +1,20 @@
 /**
- * Presence-file lifecycle for {@link AnthropicDirectProvider.query}.
+ * Re-export shim — the canonical implementation has moved to
+ * `../../shared/presence-lifecycle.ts` so the openai-compatible provider can
+ * share it instead of hand-duplicating the gate (which is how the two copies
+ * drifted apart in the first place).
  *
- * Owns the top-level-session guard, best-effort presence write, and synchronous
- * cleanup handler registration. The caller owns the provider's
- * `_presenceSessionId` slot and threads it through explicitly so provider state
- * is updated exactly once per instance.
+ * This file is kept so existing imports of
+ * `./query/presence-lifecycle.js` continue to resolve without modification.
  *
  * @module agent/providers/anthropic-direct/query/presence-lifecycle
  */
 
-import {
-  writePresenceFile,
-  removePresenceFileSync,
-  type RuntimeStateSource,
-} from '../../../awareness/index.js';
-import { actorFromDepth } from '../../../session/session-identity.js';
-
-export interface PresenceLifecycleArgs {
-  depth: number | undefined;
-  parentSessionId: string | undefined;
-  sessionId: string | undefined;
-  currentPresenceSessionId: string | null;
-  runtimeStateSource: RuntimeStateSource;
-  surface: string;
-  cwd: string | undefined;
-  providerName: string;
-  model: string;
-}
-
-/**
- * Write top-level session presence once per provider and return the updated
- * provider `_presenceSessionId` slot.
- */
-export function registerPresenceLifecycle(args: PresenceLifecycleArgs): string | null {
-  // Phase 2 — Presence file lifecycle (top-level sessions only).
-  // Guard: only write once per provider instance (not once per turn).
-  // Top-level = depth is 0 or undefined (parentSessionId absent).
-  const isTopLevel =
-    (args.depth === undefined || args.depth === 0) &&
-    args.parentSessionId === undefined;
-  if (isTopLevel && args.sessionId !== undefined && args.currentPresenceSessionId === null) {
-    const sessionId = args.sessionId;
-    const workspace = args.runtimeStateSource.getWorkspace();
-    // Fire-and-forget — presence is best-effort.
-    void writePresenceFile({
-      sessionId,
-      surface: args.surface,
-      // Presence is written only under the top-level gate above, so depth is
-      // 0/undefined here ⇒ 'main'. Derived (not hardcoded) to stay correct
-      // if that gate is ever changed.
-      actor: actorFromDepth(args.depth),
-      cwd: args.cwd ?? process.cwd(),
-      startedAt: new Date().toISOString(),
-      model: { provider: args.providerName, name: args.model },
-      workspace,
-      pid: process.pid,
-    });
-    // Sync cleanup on process exit (cannot await in exit handler).
-    process.once('exit', () => { removePresenceFileSync(sessionId); });
-    // Best-effort cleanup on signals — fires before 'exit'.
-    process.once('SIGINT', () => { removePresenceFileSync(sessionId); process.exit(130); });
-    process.once('SIGTERM', () => { removePresenceFileSync(sessionId); process.exit(143); });
-    return sessionId;
-  }
-
-  return args.currentPresenceSessionId;
-}
+export {
+  isTopLevelSession,
+  registerPresenceLifecycle,
+  resolveTopLevelSessionId,
+  type PresenceLifecycleArgs,
+  type SessionIdResolution,
+  type SessionIdResolutionArgs,
+} from '../../shared/presence-lifecycle.js';

--- a/src/agent/providers/openai-compatible/index.ts
+++ b/src/agent/providers/openai-compatible/index.ts
@@ -279,6 +279,7 @@ export class OpenAICompatibleProvider implements ModelProvider {
       resume: config.resume,
       depth: config.depth,
       parentSessionId: config.parentSessionId,
+      surface: this.providerOpts.surface ?? 'cli',
       memoized: this._mintedSessionId,
     });
     this._mintedSessionId = resolvedSession.memoized;

--- a/src/agent/providers/openai-compatible/index.ts
+++ b/src/agent/providers/openai-compatible/index.ts
@@ -54,11 +54,12 @@ import {
   wrapDispatcherWithRuntimeState,
   buildRuntimeStateSource,
   formatEnvironmentFragment,
-  writePresenceFile,
-  removePresenceFileSync,
   type RuntimeStateSource,
 } from '../../awareness/index.js';
-import { actorFromDepth } from '../../session/session-identity.js';
+import {
+  registerPresenceLifecycle,
+  resolveTopLevelSessionId,
+} from '../shared/presence-lifecycle.js';
 
 const PROVIDER_NAME = 'openai-compatible';
 
@@ -147,6 +148,14 @@ export class OpenAICompatibleProvider implements ModelProvider {
    * `AnthropicDirectProvider._presenceSessionId`. `null` = not yet registered.
    */
   private _presenceSessionId: string | null = null;
+
+  /**
+   * Session id minted for a top-level session that supplied none — same
+   * semantics as `AnthropicDirectProvider._mintedSessionId`. Memoized so the id
+   * stays stable across turns and the ledger directory cannot move out from
+   * under the presence file the Telegram watcher is following.
+   */
+  private _mintedSessionId: string | null = null;
 
   constructor(opts: OpenAICompatibleProviderOptions = {}) {
     this.providerOpts = opts;
@@ -255,12 +264,34 @@ export class OpenAICompatibleProvider implements ModelProvider {
           ...(config.planExitControls !== undefined ? { planExitControls: config.planExitControls } : {}),
         });
 
+    // Invariant: resolve the session id BEFORE anything that consumes it —
+    // both `buildOpts.sessionIdOverride` (query construction) and the presence
+    // write below must receive the SAME id. The Telegram watcher resolves a
+    // session's ledger path from the id in its presence file, so a mismatch
+    // makes auto-subscribe tail a ledger that does not exist.
+    //
+    // This provider previously hand-duplicated the anthropic-direct gate,
+    // including its `config.sessionId` bug: that field is set only under
+    // --resume, so a fresh session wrote no presence file at all. Both providers
+    // now call the one shared helper so they cannot drift again.
+    const resolvedSession = resolveTopLevelSessionId({
+      sessionId: config.sessionId,
+      resume: config.resume,
+      depth: config.depth,
+      parentSessionId: config.parentSessionId,
+      memoized: this._mintedSessionId,
+    });
+    this._mintedSessionId = resolvedSession.memoized;
+
     const buildOpts: {
       baseURL?: string;
       toolDispatcher?: ToolDispatcher;
       onPermissionMode?: (mode: string) => void;
       mcpManager?: import('../../mcp/index.js').McpManager;
+      sessionIdOverride?: string;
     } = {};
+    // Undefined for forks — they keep the factory's own per-call mint.
+    if (resolvedSession.id !== undefined) buildOpts.sessionIdOverride = resolvedSession.id;
     // Per-slot / per-session baseURL (`config.openaiBaseUrl`, set by
     // applySlotCredentials) wins over the construction-time global
     // (`providerOpts.baseURL`, from AFK_OPENAI_BASE_URL) so a tier bound to its
@@ -276,30 +307,19 @@ export class OpenAICompatibleProvider implements ModelProvider {
     };
     if (this.providerOpts.mcpManager !== undefined) buildOpts.mcpManager = this.providerOpts.mcpManager;
 
-    // Phase 2 — Presence file lifecycle (top-level sessions only).
-    const isTopLevel =
-      (config.depth === undefined || config.depth === 0) &&
-      config.parentSessionId === undefined;
-    if (isTopLevel && config.sessionId !== undefined && this._presenceSessionId === null) {
-      this._presenceSessionId = config.sessionId;
-      const sessionId = config.sessionId;
-      const workspace = runtimeStateSource.getWorkspace();
-      void writePresenceFile({
-        sessionId,
-        surface: this.providerOpts.surface ?? 'cli',
-        // Top-level gate above ⇒ depth 0/undefined ⇒ 'main'. Derived (not
-        // hardcoded) to stay correct if that gate is ever changed.
-        actor: actorFromDepth(config.depth),
-        cwd: config.cwd ?? process.cwd(),
-        startedAt: new Date().toISOString(),
-        model: { provider: PROVIDER_NAME, name: modelName },
-        workspace,
-        pid: process.pid,
-      });
-      process.once('exit', () => { removePresenceFileSync(sessionId); });
-      process.once('SIGINT', () => { removePresenceFileSync(sessionId); process.exit(130); });
-      process.once('SIGTERM', () => { removePresenceFileSync(sessionId); process.exit(143); });
-    }
+    // Phase 2 — Presence file lifecycle (top-level sessions only), using the id
+    // resolved above so presence and query construction cannot diverge.
+    this._presenceSessionId = registerPresenceLifecycle({
+      depth: config.depth,
+      parentSessionId: config.parentSessionId,
+      sessionId: resolvedSession.id,
+      currentPresenceSessionId: this._presenceSessionId,
+      runtimeStateSource,
+      surface: this.providerOpts.surface ?? 'cli',
+      cwd: config.cwd,
+      providerName: PROVIDER_NAME,
+      model: modelName,
+    });
 
     // Phase 2 — add `# Environment` block to the system prompt.
     const envFragment = formatEnvironmentFragment({

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -1256,11 +1256,22 @@ export function buildQueryFromConfig(
      * (e.g. `~/.codex/auth.json`) from the developer's machine.
      */
     authDeps?: AuthResolverDeps;
+    /**
+     * Session id resolved by the calling provider (see
+     * `shared/presence-lifecycle.ts#resolveTopLevelSessionId`). Highest
+     * precedence so the presence file, `session.init`, and the ledger directory
+     * all carry one id — the Telegram watcher resolves a session's ledger path
+     * from its presence file, so an id mismatch silently tails a nonexistent
+     * ledger. Omitted for forks, which keep the local mint below.
+     */
+    sessionIdOverride?: string;
   } = {},
 ): OpenAICompatibleQuery {
   const auth = resolveOpenAIAuth(config.apiKey, options.authDeps, config.forceChatgptOAuth ?? false);
   const synthesizedSessionId =
-    config.resume ?? `openai-pending-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    options.sessionIdOverride ??
+    config.resume ??
+    `openai-pending-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   // Resolve model-slot aliases (small/medium/large, custom names, and the
   // legacy haiku/sonnet/opus aliases) to their bound concrete id BEFORE the id
   // reaches the request body — mirroring anthropic-direct, which already calls

--- a/src/agent/providers/shared/presence-advertise.test.ts
+++ b/src/agent/providers/shared/presence-advertise.test.ts
@@ -7,17 +7,19 @@
  * shape of a fresh REPL session (see `cli/commands/interactive/bootstrap.ts`,
  * where `sessionId` arrives only via `...deps.resumeConfig`).
  *
- * Harness note: the presence write is fire-and-forget but scheduled
- * *synchronously* inside `provider.query()`, before any streaming — so these
- * tests call `query()` once, never iterate it, and assert on the real presence
- * file under a temp `AFK_HOME`. No SDK mock is needed because the client is
- * built lazily and never used. Same approach as `presence-surface.test.ts`.
+ * Harness note: the presence write happens *synchronously* inside
+ * `provider.query()`, before any streaming — so these tests call `query()` once,
+ * never iterate it, and assert on the real presence file under a temp
+ * `AFK_HOME`. No SDK mock is needed because the client is built lazily and never
+ * used. Same approach as `presence-surface.test.ts`. The polling helper below is
+ * retained only so these cases stay honest if the write ever becomes async
+ * again; `writes the presence file synchronously` pins the current contract.
  *
  * Resolver-level cases live in `presence-lifecycle.test.ts`.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync } from 'fs';
+import { mkdtempSync, rmSync, readdirSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import {
@@ -25,6 +27,7 @@ import {
   OpenAICompatibleProvider,
 } from '../index.js';
 import { readPresenceFiles, type PresenceFileInfo } from '../../awareness/presence.js';
+import { getPresenceDir } from '../../../paths.js';
 import type { ModelProvider, ProviderQuery, ProviderUserTurn } from '../../provider.js';
 import type { AgentConfig } from '../../types/config-types.js';
 
@@ -124,6 +127,18 @@ for (const branch of branches) {
       expect(rec?.sessionId).not.toBe('');
       expect(rec?.surface).toBe('cli');
       expect(rec?.actor).toBe('main');
+    });
+
+    it('writes the presence file synchronously, before query() returns', () => {
+      // Regression guard for an ENOTEMPTY teardown race. Both providers expose a
+      // synchronous close(), so an async presence write has no handle a caller
+      // can await: it outlived the turn and recreated `presence/` while a host
+      // that points AFK_HOME at a scratch dir was rmdir-ing that tree
+      // (grant-manager.test.ts died exactly this way on macOS CI). The same
+      // unawaited write also let an immediate `/afk on` no-op on ENOENT before
+      // the file existed. No await, no polling — the file must already be there.
+      triggerPresence(branch.makeProvider(), branch.freshConfig());
+      expect(readdirSync(getPresenceDir())).toHaveLength(1);
     });
 
     it('does not write a second, differently-identified file on the next turn', async () => {

--- a/src/agent/providers/shared/presence-advertise.test.ts
+++ b/src/agent/providers/shared/presence-advertise.test.ts
@@ -1,0 +1,198 @@
+/**
+ * End-to-end presence ADVERTISEMENT behavior, per provider.
+ *
+ * `presence-surface.test.ts` did not catch the fresh-session gap because every
+ * config it builds passes an explicit `sessionId` — it only ever exercised the
+ * resumed shape. The cases here deliberately omit `sessionId`, which is the real
+ * shape of a fresh REPL session (see `cli/commands/interactive/bootstrap.ts`,
+ * where `sessionId` arrives only via `...deps.resumeConfig`).
+ *
+ * Harness note: the presence write is fire-and-forget but scheduled
+ * *synchronously* inside `provider.query()`, before any streaming — so these
+ * tests call `query()` once, never iterate it, and assert on the real presence
+ * file under a temp `AFK_HOME`. No SDK mock is needed because the client is
+ * built lazily and never used. Same approach as `presence-surface.test.ts`.
+ *
+ * Resolver-level cases live in `presence-lifecycle.test.ts`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  AnthropicDirectProvider,
+  OpenAICompatibleProvider,
+} from '../index.js';
+import { readPresenceFiles, type PresenceFileInfo } from '../../awareness/presence.js';
+import type { ModelProvider, ProviderQuery, ProviderUserTurn } from '../../provider.js';
+import type { AgentConfig } from '../../types/config-types.js';
+
+// ---------------------------------------------------------------------------
+// End-to-end: a fresh session (NO config.sessionId) must advertise presence.
+// ---------------------------------------------------------------------------
+
+let tmpHome: string;
+let savedHome: string | undefined;
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), 'afk-presence-fresh-'));
+  savedHome = process.env['AFK_HOME'];
+  process.env['AFK_HOME'] = tmpHome;
+});
+
+afterEach(() => {
+  if (savedHome === undefined) delete process.env['AFK_HOME'];
+  else process.env['AFK_HOME'] = savedHome;
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
+async function* emptyPrompt(): AsyncIterable<ProviderUserTurn> {
+  // never iterated — the presence write is scheduled synchronously in query()
+}
+
+/** Drive query() far enough to schedule the presence write, then best-effort close. */
+function triggerPresence(provider: ModelProvider, config: AgentConfig): void {
+  let query: ProviderQuery | undefined;
+  try {
+    query = provider.query({ prompt: emptyPrompt(), config });
+  } catch {
+    // A post-write throw (e.g. the OpenAI builder validating creds) is fine —
+    // the presence write is already scheduled.
+  }
+  if (query !== undefined) {
+    void Promise.resolve(query.close()).catch(() => undefined);
+  }
+}
+
+/** Poll until any presence record appears, else undefined. */
+async function waitForAnyPresence(): Promise<PresenceFileInfo | undefined> {
+  for (let i = 0; i < 100; i++) {
+    const records = await readPresenceFiles();
+    if (records[0] !== undefined) return records[0];
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  return undefined;
+}
+
+interface Branch {
+  name: string;
+  makeProvider: () => ModelProvider;
+  /** Same provider, constructed as a non-CLI surface (daemon/telegram host). */
+  makeProviderOnSurface: (surface: string) => ModelProvider;
+  /** A fresh-session config — deliberately NO sessionId, as a new REPL builds. */
+  freshConfig: () => AgentConfig;
+  /** A fork config — must NOT advertise presence. */
+  forkConfig: () => AgentConfig;
+}
+
+const branches: Branch[] = [
+  {
+    name: 'anthropic-direct',
+    makeProvider: () => new AnthropicDirectProvider({}),
+    makeProviderOnSurface: (surface: string) => new AnthropicDirectProvider({ surface }),
+    freshConfig: () => ({ model: 'claude-sonnet-5', apiKey: 'sk-ant-oat01-test' }),
+    forkConfig: () => ({
+      model: 'claude-sonnet-5',
+      apiKey: 'sk-ant-oat01-test',
+      depth: 1,
+      parentSessionId: 'parent-1',
+    }),
+  },
+  {
+    name: 'openai-compatible',
+    makeProvider: () => new OpenAICompatibleProvider({}),
+    makeProviderOnSurface: (surface: string) => new OpenAICompatibleProvider({ surface }),
+    freshConfig: () => ({ model: 'gpt-5.1', apiKey: 'test-openai-key' }),
+    forkConfig: () => ({
+      model: 'gpt-5.1',
+      apiKey: 'test-openai-key',
+      depth: 1,
+      parentSessionId: 'parent-1',
+    }),
+  },
+];
+
+for (const branch of branches) {
+  describe(`fresh-session presence — ${branch.name}`, () => {
+    it('writes a presence file with a defined sessionId when config.sessionId is absent', async () => {
+      triggerPresence(branch.makeProvider(), branch.freshConfig());
+      const rec = await waitForAnyPresence();
+      // THE REPRODUCER: before the fix this was undefined — no file at all.
+      expect(rec).toBeDefined();
+      expect(rec?.sessionId).toBeTypeOf('string');
+      expect(rec?.sessionId).not.toBe('');
+      expect(rec?.surface).toBe('cli');
+      expect(rec?.actor).toBe('main');
+    });
+
+    it('does not write a second, differently-identified file on the next turn', async () => {
+      const provider = branch.makeProvider();
+      triggerPresence(provider, branch.freshConfig());
+      const first = await waitForAnyPresence();
+      expect(first).toBeDefined();
+
+      // query() runs once per turn — a second turn must reuse the same id.
+      triggerPresence(provider, branch.freshConfig());
+      await new Promise((resolve) => setTimeout(resolve, 60));
+
+      const records = await readPresenceFiles();
+      expect(records).toHaveLength(1);
+      expect(records[0]?.sessionId).toBe(first?.sessionId);
+    });
+
+    it('does not advertise presence for a fork', async () => {
+      triggerPresence(branch.makeProvider(), branch.forkConfig());
+      await new Promise((resolve) => setTimeout(resolve, 60));
+      expect(await readPresenceFiles()).toHaveLength(0);
+    });
+
+    it('rewrites presence when the advertised id changes (/resume on a memoized instance)', async () => {
+      // The REPL memoizes provider instances per model family for the life of
+      // the process, so /resume builds a NEW session on an instance that has
+      // already advertised the previous session's id. Before this fix the
+      // once-per-instance guard suppressed the rewrite: the resumed session was
+      // never advertised, and the closed session's file survived — leaving the
+      // Telegram watcher tailing a ledger nothing writes to any more.
+      const provider = branch.makeProvider();
+      triggerPresence(provider, branch.freshConfig());
+      const first = await waitForAnyPresence();
+      expect(first?.sessionId).toBeTypeOf('string');
+
+      triggerPresence(provider, { ...branch.freshConfig(), sessionId: 'resumed-target' });
+      for (let i = 0; i < 100; i++) {
+        const records = await readPresenceFiles();
+        if (records[0]?.sessionId === 'resumed-target') break;
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+
+      const records = await readPresenceFiles();
+      // Exactly one record, and it names the LIVE session — the stale one is
+      // removed first, so a crash mid-rewrite leaves absence, never two.
+      expect(records).toHaveLength(1);
+      expect(records[0]?.sessionId).toBe('resumed-target');
+    });
+
+    it('does not advertise a fresh session on a non-CLI surface', async () => {
+      // Codex P1: buildDaemonSessionFactory builds a fresh top-level provider
+      // per scheduled task, so minting for every surface left one stale
+      // live-looking record (and, before the registry split, 3 listeners) per
+      // task in a long-running daemon.
+      for (const surface of ['daemon', 'telegram']) {
+        triggerPresence(branch.makeProviderOnSurface(surface), branch.freshConfig());
+      }
+      await new Promise((resolve) => setTimeout(resolve, 80));
+      expect(await readPresenceFiles()).toHaveLength(0);
+    });
+
+    it('still advertises a non-CLI surface session that carries an explicit id', async () => {
+      triggerPresence(branch.makeProviderOnSurface('daemon'), {
+        ...branch.freshConfig(),
+        sessionId: 'resumed-daemon-task',
+      });
+      const rec = await waitForAnyPresence();
+      expect(rec?.sessionId).toBe('resumed-daemon-task');
+      expect(rec?.surface).toBe('daemon');
+    });
+  });
+}

--- a/src/agent/providers/shared/presence-lifecycle.test.ts
+++ b/src/agent/providers/shared/presence-lifecycle.test.ts
@@ -1,5 +1,5 @@
 /**
- * Presence session-id resolution contract.
+ * Presence session-id RESOLUTION contract (pure unit level).
  *
  * The bug this guards: presence was gated on `config.sessionId`, which is set
  * ONLY under `--resume`/`--continue`. Every fresh top-level session therefore
@@ -10,34 +10,17 @@
  * work for a non-resumed session. The real id was minted downstream of the
  * gate, inside query construction, from the *different* `config.resume` field.
  *
- * `presence-surface.test.ts` did not catch it because every config it builds
- * passes an explicit `sessionId` — it only ever exercised the resumed shape.
- * The end-to-end cases below deliberately omit `sessionId`, which is the real
- * shape of a fresh REPL session (see `cli/commands/interactive/bootstrap.ts`,
- * where `sessionId` arrives only via `...deps.resumeConfig`).
- *
- * Harness note: the presence write is fire-and-forget but scheduled
- * *synchronously* inside `provider.query()`, before any streaming — so these
- * tests call `query()` once, never iterate it, and assert on the real presence
- * file under a temp `AFK_HOME`. No SDK mock is needed because the client is
- * built lazily and never used. Same approach as `presence-surface.test.ts`.
+ * End-to-end advertisement behavior (real provider, real presence file) lives
+ * in `presence-advertise.test.ts`; this file covers the resolver alone.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync } from 'fs';
-import { tmpdir } from 'os';
-import { join } from 'path';
+import { describe, it, expect } from 'vitest';
 import { resolveTopLevelSessionId, isTopLevelSession } from './presence-lifecycle.js';
-import {
-  AnthropicDirectProvider,
-  OpenAICompatibleProvider,
-} from '../index.js';
-import { readPresenceFiles, type PresenceFileInfo } from '../../awareness/presence.js';
-import type { ModelProvider, ProviderQuery, ProviderUserTurn } from '../../provider.js';
-import type { AgentConfig } from '../../types/config-types.js';
 
 describe('resolveTopLevelSessionId', () => {
-  const topLevel = { depth: undefined, parentSessionId: undefined };
+  // 'cli' is the default surface for both providers (see each ctor's
+  // `opts.surface ?? 'cli'`) and the only surface a presence consumer reads.
+  const topLevel = { depth: undefined, parentSessionId: undefined, surface: 'cli' };
 
   it('mints an id for a fresh top-level session that supplied none (the regression)', () => {
     const out = resolveTopLevelSessionId({
@@ -109,6 +92,7 @@ describe('resolveTopLevelSessionId', () => {
       resume: undefined,
       depth: 1,
       parentSessionId: undefined,
+      surface: 'cli',
       memoized: null,
     });
     // Forks must not inherit or share a minted id — that would collide on the
@@ -123,9 +107,82 @@ describe('resolveTopLevelSessionId', () => {
       resume: undefined,
       depth: undefined,
       parentSessionId: 'parent-1',
+      surface: 'cli',
       memoized: null,
     });
     expect(out.id).toBeUndefined();
+    expect(out.memoized).toBeNull();
+  });
+
+  it('mints only on a surface a presence consumer reads', () => {
+    // A daemon task or Telegram chat session advertising presence is invisible
+    // to both readers (bot.ts filters surface === 'cli'; watch.ts lists live
+    // records) while still costing a file + a cleanup registration — that is how
+    // a long-running daemon accrued one stale live-looking record per task.
+    for (const surface of ['daemon', 'telegram', 'unknown']) {
+      const out = resolveTopLevelSessionId({
+        sessionId: undefined,
+        resume: undefined,
+        depth: 0,
+        parentSessionId: undefined,
+        surface,
+        memoized: null,
+      });
+      expect(out.id, surface).toBeUndefined();
+      expect(out.memoized, surface).toBeNull();
+    }
+  });
+
+  it('still honors an explicit id on a non-minting surface (resume advertises everywhere)', () => {
+    // presence-surface.test.ts pins this contract for cli/daemon/telegram: the
+    // surface gate applies to the MINT, never to an explicitly supplied id.
+    const out = resolveTopLevelSessionId({
+      sessionId: 'resumed-daemon-task',
+      resume: undefined,
+      depth: 0,
+      parentSessionId: undefined,
+      surface: 'daemon',
+      memoized: null,
+    });
+    expect(out.id).toBe('resumed-daemon-task');
+  });
+
+  it('keeps the memoized id across a reset() (/clear) on the same provider instance', () => {
+    const first = resolveTopLevelSessionId({
+      sessionId: undefined,
+      resume: undefined,
+      ...topLevel,
+      memoized: null,
+    });
+    // AgentSession.reset() deletes config.resume AND config.sessionId, then
+    // rebuilds the query on the SAME provider instance. Id stability is load
+    // bearing: the AFK elicitation channel and the remote-abort watcher are
+    // bound to the id captured at `/afk on`, and the `afk` marker lives on that
+    // id's presence file, so a new mint here would silently strand both.
+    const afterClear = resolveTopLevelSessionId({
+      sessionId: undefined,
+      resume: undefined,
+      ...topLevel,
+      memoized: first.memoized,
+    });
+    expect(afterClear.id).toBe(first.id);
+    expect(afterClear.memoized).toBe(first.memoized);
+  });
+
+  it('resolves a fork to its parent id (subagent.ts threads resume) without minting', () => {
+    // subagent.ts sets `resume: options.parent.sessionId` on every child config,
+    // so the explicit branch returns the parent id — which is exactly what fork
+    // query construction already used. Presence stays blocked by the
+    // isTopLevelSession re-gate in registerPresenceLifecycle, asserted e2e below.
+    const out = resolveTopLevelSessionId({
+      sessionId: undefined,
+      resume: 'parent-session-id',
+      depth: 1,
+      parentSessionId: 'parent-session-id',
+      surface: 'cli',
+      memoized: null,
+    });
+    expect(out.id).toBe('parent-session-id');
     expect(out.memoized).toBeNull();
   });
 });
@@ -141,120 +198,3 @@ describe('isTopLevelSession', () => {
     expect(isTopLevelSession(0, 'parent')).toBe(false);
   });
 });
-
-// ---------------------------------------------------------------------------
-// End-to-end: a fresh session (NO config.sessionId) must advertise presence.
-// ---------------------------------------------------------------------------
-
-let tmpHome: string;
-let savedHome: string | undefined;
-
-beforeEach(() => {
-  tmpHome = mkdtempSync(join(tmpdir(), 'afk-presence-fresh-'));
-  savedHome = process.env['AFK_HOME'];
-  process.env['AFK_HOME'] = tmpHome;
-});
-
-afterEach(() => {
-  if (savedHome === undefined) delete process.env['AFK_HOME'];
-  else process.env['AFK_HOME'] = savedHome;
-  rmSync(tmpHome, { recursive: true, force: true });
-});
-
-async function* emptyPrompt(): AsyncIterable<ProviderUserTurn> {
-  // never iterated — the presence write is scheduled synchronously in query()
-}
-
-/** Drive query() far enough to schedule the presence write, then best-effort close. */
-function triggerPresence(provider: ModelProvider, config: AgentConfig): void {
-  let query: ProviderQuery | undefined;
-  try {
-    query = provider.query({ prompt: emptyPrompt(), config });
-  } catch {
-    // A post-write throw (e.g. the OpenAI builder validating creds) is fine —
-    // the presence write is already scheduled.
-  }
-  if (query !== undefined) {
-    void Promise.resolve(query.close()).catch(() => undefined);
-  }
-}
-
-/** Poll until any presence record appears, else undefined. */
-async function waitForAnyPresence(): Promise<PresenceFileInfo | undefined> {
-  for (let i = 0; i < 100; i++) {
-    const records = await readPresenceFiles();
-    if (records[0] !== undefined) return records[0];
-    await new Promise((resolve) => setTimeout(resolve, 10));
-  }
-  return undefined;
-}
-
-interface Branch {
-  name: string;
-  makeProvider: () => ModelProvider;
-  /** A fresh-session config — deliberately NO sessionId, as a new REPL builds. */
-  freshConfig: () => AgentConfig;
-  /** A fork config — must NOT advertise presence. */
-  forkConfig: () => AgentConfig;
-}
-
-const branches: Branch[] = [
-  {
-    name: 'anthropic-direct',
-    makeProvider: () => new AnthropicDirectProvider({}),
-    freshConfig: () => ({ model: 'claude-sonnet-5', apiKey: 'sk-ant-oat01-test' }),
-    forkConfig: () => ({
-      model: 'claude-sonnet-5',
-      apiKey: 'sk-ant-oat01-test',
-      depth: 1,
-      parentSessionId: 'parent-1',
-    }),
-  },
-  {
-    name: 'openai-compatible',
-    makeProvider: () => new OpenAICompatibleProvider({}),
-    freshConfig: () => ({ model: 'gpt-5.1', apiKey: 'test-openai-key' }),
-    forkConfig: () => ({
-      model: 'gpt-5.1',
-      apiKey: 'test-openai-key',
-      depth: 1,
-      parentSessionId: 'parent-1',
-    }),
-  },
-];
-
-for (const branch of branches) {
-  describe(`fresh-session presence — ${branch.name}`, () => {
-    it('writes a presence file with a defined sessionId when config.sessionId is absent', async () => {
-      triggerPresence(branch.makeProvider(), branch.freshConfig());
-      const rec = await waitForAnyPresence();
-      // THE REPRODUCER: before the fix this was undefined — no file at all.
-      expect(rec).toBeDefined();
-      expect(rec?.sessionId).toBeTypeOf('string');
-      expect(rec?.sessionId).not.toBe('');
-      expect(rec?.surface).toBe('cli');
-      expect(rec?.actor).toBe('main');
-    });
-
-    it('does not write a second, differently-identified file on the next turn', async () => {
-      const provider = branch.makeProvider();
-      triggerPresence(provider, branch.freshConfig());
-      const first = await waitForAnyPresence();
-      expect(first).toBeDefined();
-
-      // query() runs once per turn — a second turn must reuse the same id.
-      triggerPresence(provider, branch.freshConfig());
-      await new Promise((resolve) => setTimeout(resolve, 60));
-
-      const records = await readPresenceFiles();
-      expect(records).toHaveLength(1);
-      expect(records[0]?.sessionId).toBe(first?.sessionId);
-    });
-
-    it('does not advertise presence for a fork', async () => {
-      triggerPresence(branch.makeProvider(), branch.forkConfig());
-      await new Promise((resolve) => setTimeout(resolve, 60));
-      expect(await readPresenceFiles()).toHaveLength(0);
-    });
-  });
-}

--- a/src/agent/providers/shared/presence-lifecycle.test.ts
+++ b/src/agent/providers/shared/presence-lifecycle.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Presence session-id resolution contract.
+ *
+ * The bug this guards: presence was gated on `config.sessionId`, which is set
+ * ONLY under `--resume`/`--continue`. Every fresh top-level session therefore
+ * wrote NO presence file, so the Telegram bot's presence-driven auto-subscribe
+ * loop (`telegram/bot.ts`, filters `surface === 'cli' && afk === true`) was
+ * structurally blind to it, and bidirectional AFK — the agent asking a yes/no
+ * question and the operator tapping an inline Telegram button — could never
+ * work for a non-resumed session. The real id was minted downstream of the
+ * gate, inside query construction, from the *different* `config.resume` field.
+ *
+ * `presence-surface.test.ts` did not catch it because every config it builds
+ * passes an explicit `sessionId` — it only ever exercised the resumed shape.
+ * The end-to-end cases below deliberately omit `sessionId`, which is the real
+ * shape of a fresh REPL session (see `cli/commands/interactive/bootstrap.ts`,
+ * where `sessionId` arrives only via `...deps.resumeConfig`).
+ *
+ * Harness note: the presence write is fire-and-forget but scheduled
+ * *synchronously* inside `provider.query()`, before any streaming — so these
+ * tests call `query()` once, never iterate it, and assert on the real presence
+ * file under a temp `AFK_HOME`. No SDK mock is needed because the client is
+ * built lazily and never used. Same approach as `presence-surface.test.ts`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { resolveTopLevelSessionId, isTopLevelSession } from './presence-lifecycle.js';
+import {
+  AnthropicDirectProvider,
+  OpenAICompatibleProvider,
+} from '../index.js';
+import { readPresenceFiles, type PresenceFileInfo } from '../../awareness/presence.js';
+import type { ModelProvider, ProviderQuery, ProviderUserTurn } from '../../provider.js';
+import type { AgentConfig } from '../../types/config-types.js';
+
+describe('resolveTopLevelSessionId', () => {
+  const topLevel = { depth: undefined, parentSessionId: undefined };
+
+  it('mints an id for a fresh top-level session that supplied none (the regression)', () => {
+    const out = resolveTopLevelSessionId({
+      sessionId: undefined,
+      resume: undefined,
+      ...topLevel,
+      memoized: null,
+    });
+    // Before the fix this position held `config.sessionId` — undefined — so the
+    // presence gate no-opped and no file was ever written.
+    expect(out.id).toBeTypeOf('string');
+    expect(out.id).not.toBe('');
+    expect(out.memoized).toBe(out.id);
+  });
+
+  it('is stable across turns once memoized (query() runs once per turn)', () => {
+    const first = resolveTopLevelSessionId({
+      sessionId: undefined,
+      resume: undefined,
+      ...topLevel,
+      memoized: null,
+    });
+    const second = resolveTopLevelSessionId({
+      sessionId: undefined,
+      resume: undefined,
+      ...topLevel,
+      memoized: first.memoized,
+    });
+    // A fresh mint per turn would move the ledger directory out from under the
+    // presence file the Telegram watcher is already following.
+    expect(second.id).toBe(first.id);
+  });
+
+  it('lets an explicit config.sessionId win unchanged (resume semantics)', () => {
+    const out = resolveTopLevelSessionId({
+      sessionId: 'resumed-abc',
+      resume: undefined,
+      ...topLevel,
+      memoized: null,
+    });
+    expect(out.id).toBe('resumed-abc');
+    expect(out.memoized).toBeNull(); // no mint burned
+  });
+
+  it('falls back to config.resume when sessionId is absent', () => {
+    const out = resolveTopLevelSessionId({
+      sessionId: undefined,
+      resume: 'continued-xyz',
+      ...topLevel,
+      memoized: null,
+    });
+    expect(out.id).toBe('continued-xyz');
+    expect(out.memoized).toBeNull();
+  });
+
+  it('prefers sessionId over resume when both are present', () => {
+    const out = resolveTopLevelSessionId({
+      sessionId: 'explicit',
+      resume: 'fallback',
+      ...topLevel,
+      memoized: null,
+    });
+    expect(out.id).toBe('explicit');
+  });
+
+  it('never mints for a fork identified by depth', () => {
+    const out = resolveTopLevelSessionId({
+      sessionId: undefined,
+      resume: undefined,
+      depth: 1,
+      parentSessionId: undefined,
+      memoized: null,
+    });
+    // Forks must not inherit or share a minted id — that would collide on the
+    // ledger directory. undefined ⇒ query keeps its own per-call mint.
+    expect(out.id).toBeUndefined();
+    expect(out.memoized).toBeNull();
+  });
+
+  it('never mints for a fork identified by parentSessionId', () => {
+    const out = resolveTopLevelSessionId({
+      sessionId: undefined,
+      resume: undefined,
+      depth: undefined,
+      parentSessionId: 'parent-1',
+      memoized: null,
+    });
+    expect(out.id).toBeUndefined();
+    expect(out.memoized).toBeNull();
+  });
+});
+
+describe('isTopLevelSession', () => {
+  it('treats depth 0 / undefined with no parent as top-level', () => {
+    expect(isTopLevelSession(undefined, undefined)).toBe(true);
+    expect(isTopLevelSession(0, undefined)).toBe(true);
+  });
+
+  it('treats any depth > 0 or any parent id as a fork', () => {
+    expect(isTopLevelSession(1, undefined)).toBe(false);
+    expect(isTopLevelSession(0, 'parent')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end: a fresh session (NO config.sessionId) must advertise presence.
+// ---------------------------------------------------------------------------
+
+let tmpHome: string;
+let savedHome: string | undefined;
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), 'afk-presence-fresh-'));
+  savedHome = process.env['AFK_HOME'];
+  process.env['AFK_HOME'] = tmpHome;
+});
+
+afterEach(() => {
+  if (savedHome === undefined) delete process.env['AFK_HOME'];
+  else process.env['AFK_HOME'] = savedHome;
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
+async function* emptyPrompt(): AsyncIterable<ProviderUserTurn> {
+  // never iterated — the presence write is scheduled synchronously in query()
+}
+
+/** Drive query() far enough to schedule the presence write, then best-effort close. */
+function triggerPresence(provider: ModelProvider, config: AgentConfig): void {
+  let query: ProviderQuery | undefined;
+  try {
+    query = provider.query({ prompt: emptyPrompt(), config });
+  } catch {
+    // A post-write throw (e.g. the OpenAI builder validating creds) is fine —
+    // the presence write is already scheduled.
+  }
+  if (query !== undefined) {
+    void Promise.resolve(query.close()).catch(() => undefined);
+  }
+}
+
+/** Poll until any presence record appears, else undefined. */
+async function waitForAnyPresence(): Promise<PresenceFileInfo | undefined> {
+  for (let i = 0; i < 100; i++) {
+    const records = await readPresenceFiles();
+    if (records[0] !== undefined) return records[0];
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  return undefined;
+}
+
+interface Branch {
+  name: string;
+  makeProvider: () => ModelProvider;
+  /** A fresh-session config — deliberately NO sessionId, as a new REPL builds. */
+  freshConfig: () => AgentConfig;
+  /** A fork config — must NOT advertise presence. */
+  forkConfig: () => AgentConfig;
+}
+
+const branches: Branch[] = [
+  {
+    name: 'anthropic-direct',
+    makeProvider: () => new AnthropicDirectProvider({}),
+    freshConfig: () => ({ model: 'claude-sonnet-5', apiKey: 'sk-ant-oat01-test' }),
+    forkConfig: () => ({
+      model: 'claude-sonnet-5',
+      apiKey: 'sk-ant-oat01-test',
+      depth: 1,
+      parentSessionId: 'parent-1',
+    }),
+  },
+  {
+    name: 'openai-compatible',
+    makeProvider: () => new OpenAICompatibleProvider({}),
+    freshConfig: () => ({ model: 'gpt-5.1', apiKey: 'test-openai-key' }),
+    forkConfig: () => ({
+      model: 'gpt-5.1',
+      apiKey: 'test-openai-key',
+      depth: 1,
+      parentSessionId: 'parent-1',
+    }),
+  },
+];
+
+for (const branch of branches) {
+  describe(`fresh-session presence — ${branch.name}`, () => {
+    it('writes a presence file with a defined sessionId when config.sessionId is absent', async () => {
+      triggerPresence(branch.makeProvider(), branch.freshConfig());
+      const rec = await waitForAnyPresence();
+      // THE REPRODUCER: before the fix this was undefined — no file at all.
+      expect(rec).toBeDefined();
+      expect(rec?.sessionId).toBeTypeOf('string');
+      expect(rec?.sessionId).not.toBe('');
+      expect(rec?.surface).toBe('cli');
+      expect(rec?.actor).toBe('main');
+    });
+
+    it('does not write a second, differently-identified file on the next turn', async () => {
+      const provider = branch.makeProvider();
+      triggerPresence(provider, branch.freshConfig());
+      const first = await waitForAnyPresence();
+      expect(first).toBeDefined();
+
+      // query() runs once per turn — a second turn must reuse the same id.
+      triggerPresence(provider, branch.freshConfig());
+      await new Promise((resolve) => setTimeout(resolve, 60));
+
+      const records = await readPresenceFiles();
+      expect(records).toHaveLength(1);
+      expect(records[0]?.sessionId).toBe(first?.sessionId);
+    });
+
+    it('does not advertise presence for a fork', async () => {
+      triggerPresence(branch.makeProvider(), branch.forkConfig());
+      await new Promise((resolve) => setTimeout(resolve, 60));
+      expect(await readPresenceFiles()).toHaveLength(0);
+    });
+  });
+}

--- a/src/agent/providers/shared/presence-lifecycle.ts
+++ b/src/agent/providers/shared/presence-lifecycle.ts
@@ -5,8 +5,11 @@
  *   1. the top-level-session guard ({@link isTopLevelSession}),
  *   2. resolving the session id presence must advertise
  *      ({@link resolveTopLevelSessionId}),
- *   3. the best-effort presence write + cleanup-handler registration
+ *   3. the best-effort presence write, keyed on the advertised id
  *      ({@link registerPresenceLifecycle}).
+ *
+ * Exit/signal cleanup deliberately does NOT live here — it is process-scoped,
+ * not session-scoped, and lives in `./presence-signals.ts`.
  *
  * Invariant: the id written into the presence file MUST be the same id used for
  * that session's ledger directory (`~/.afk/state/sessions/<id>/events.jsonl`).
@@ -35,6 +38,11 @@ import {
   type RuntimeStateSource,
 } from '../../awareness/index.js';
 import { actorFromDepth } from '../../session/session-identity.js';
+import { debugLog } from '../../../utils/debug.js';
+import {
+  registerPresenceCleanup,
+  unregisterPresenceCleanup,
+} from './presence-signals.js';
 
 export interface PresenceLifecycleArgs {
   depth: number | undefined;
@@ -68,9 +76,30 @@ export interface SessionIdResolutionArgs {
   resume: string | undefined;
   depth: number | undefined;
   parentSessionId: string | undefined;
+  /**
+   * The provider instance's user-facing surface (`'cli' | 'daemon' |
+   * 'telegram'`). Gates minting only — see {@link PRESENCE_MINT_SURFACES}.
+   */
+  surface: string | undefined;
   /** The provider instance's memoized mint, or `null` if it has not minted. */
   memoized: string | null;
 }
+
+/**
+ * Surfaces whose *fresh* (non-resumed) sessions are worth advertising.
+ *
+ * Contract: only two readers of presence files exist, and both are Telegram —
+ * `bot.ts` auto-subscribe filters `surface === 'cli' && afk === true`, and the
+ * `/watch` no-argument listing in `watch.ts` renders live records. A minted
+ * advertisement on any other surface is invisible to every reader while still
+ * costing a file plus a cleanup registration, which is how a long-running
+ * daemon accrued one stale live-looking record per scheduled task (12 tasks ⇒
+ * 12 records). Gating the MINT — not the write — keeps the pre-existing
+ * contract intact: a session carrying an explicit id (`--resume`) still
+ * advertises on every surface, which `telegram/presence-surface.test.ts` pins
+ * for `cli`, `daemon`, and `telegram` alike.
+ */
+export const PRESENCE_MINT_SURFACES: ReadonlySet<string> = new Set(['cli']);
 
 export interface SessionIdResolution {
   /**
@@ -89,12 +118,29 @@ export interface SessionIdResolution {
  *
  * Precedence: an explicit id (`config.sessionId`, then `config.resume`) always
  * wins, so resume semantics are bit-for-bit unchanged. Only a top-level session
- * with no explicit id gets a mint, and that mint is memoized so it stays stable
- * across turns on the same provider instance.
+ * on a {@link PRESENCE_MINT_SURFACES} surface with no explicit id gets a mint,
+ * and that mint is memoized so it stays stable across turns on the same
+ * provider instance.
  *
- * Contract: never mints for a fork — returns `id: undefined` there, so fork
- * query construction keeps its existing per-call mint and cannot inherit a
- * parent's id (which would collide on the ledger directory).
+ * Invariant: the memoized mint survives `AgentSession.reset()` (`/clear`) on
+ * purpose, so the post-clear session keeps its id. Two mechanisms depend on it.
+ * (1) `LedgerLifecycle.seal()` resets its own latch precisely "so the same
+ * instance is reused cleanly across a reset() cycle" and writes a delimiting
+ * `closed`/`reset` record, so one ledger file legitimately holds both
+ * conversations. (2) The AFK elicitation channel and the remote-abort watcher
+ * are bound to the id captured at `/afk on` (`cli/afk-mode-toggle.ts`), and the
+ * `afk` marker lives on THAT id's presence file — minting a new id here would
+ * leave the operator's phone relay and remote `/abort` bound to an id nothing
+ * writes to any more, silently, which is the exact failure mode this module's
+ * header forbids. A caller that genuinely wants a new identity constructs a new
+ * provider instance rather than resetting one.
+ *
+ * Contract: never *mints* for a fork. An explicit parent id still wins via the
+ * precedence above — `subagent.ts` sets `resume: parent.sessionId` on every
+ * child config, so a fork resolves to its parent's id, which is exactly the id
+ * fork query construction already used before this helper existed. Presence
+ * stays blocked for forks by the independent `isTopLevelSession` re-gate in
+ * {@link registerPresenceLifecycle}, so a fork never advertises.
  */
 export function resolveTopLevelSessionId(
   args: SessionIdResolutionArgs,
@@ -106,49 +152,75 @@ export function resolveTopLevelSessionId(
     return { id: undefined, memoized: args.memoized };
   }
 
+  // Mint only for a surface some presence consumer actually reads. Returning
+  // `undefined` here restores the pre-gate behavior for every other surface:
+  // query construction keeps its own per-call mint and nothing is advertised.
+  if (args.surface === undefined || !PRESENCE_MINT_SURFACES.has(args.surface)) {
+    return { id: undefined, memoized: args.memoized };
+  }
+
   const minted = args.memoized ?? randomUUID();
   return { id: minted, memoized: minted };
 }
 
 /**
- * Write top-level session presence once per provider instance and return the
- * updated `_presenceSessionId` slot.
+ * Write top-level session presence and return the updated `_presenceSessionId`
+ * slot. Writes once per advertised *id* — not once per turn, and not once per
+ * provider instance.
  *
- * Per-instance (not per-process) on purpose: one OS process can legitimately
- * host several concurrent top-level sessions, and each must advertise its own
- * presence file.
+ * Per-instance state (not per-process) on purpose: one OS process can
+ * legitimately host several concurrent top-level sessions, and each must
+ * advertise its own presence file.
+ *
+ * History: the guard here used to be `currentPresenceSessionId === null`, i.e.
+ * once per provider instance for the life of the process. The REPL memoizes
+ * provider instances per model family (`cli/commands/interactive/provider-factory.ts`),
+ * so `/resume` builds a NEW session on an instance that had already advertised
+ * the previous session's id: the resumed session was never advertised, while the
+ * closed session's file — `afk: true` if the operator had toggled it — survived
+ * and kept the Telegram watcher tailing a ledger nothing writes to any more.
+ * Keying on the id instead makes the advertised id follow the live session.
  */
 export function registerPresenceLifecycle(args: PresenceLifecycleArgs): string | null {
-  // Guard: only write once per provider instance (not once per turn).
-  if (
-    isTopLevelSession(args.depth, args.parentSessionId) &&
-    args.sessionId !== undefined &&
-    args.currentPresenceSessionId === null
-  ) {
-    const sessionId = args.sessionId;
-    const workspace = args.runtimeStateSource.getWorkspace();
-    // Fire-and-forget — presence is best-effort and must never throw into the
-    // query path.
-    void writePresenceFile({
-      sessionId,
-      surface: args.surface,
-      // Presence is written only under the top-level gate above, so depth is
-      // 0/undefined here ⇒ 'main'. Derived (not hardcoded) to stay correct
-      // if that gate is ever changed.
-      actor: actorFromDepth(args.depth),
-      cwd: args.cwd ?? process.cwd(),
-      startedAt: new Date().toISOString(),
-      model: { provider: args.providerName, name: args.model },
-      workspace,
-      pid: process.pid,
-    });
-    // Sync cleanup on process exit (cannot await in exit handler).
-    process.once('exit', () => { removePresenceFileSync(sessionId); });
-    // Best-effort cleanup on signals — fires before 'exit'.
-    process.once('SIGINT', () => { removePresenceFileSync(sessionId); process.exit(130); });
-    process.once('SIGTERM', () => { removePresenceFileSync(sessionId); process.exit(143); });
-    return sessionId;
+  const sessionId = args.sessionId;
+  if (!isTopLevelSession(args.depth, args.parentSessionId) || sessionId === undefined) {
+    return args.currentPresenceSessionId;
+  }
+  // Already advertising this exact id — presence is per session, not per turn.
+  if (args.currentPresenceSessionId === sessionId) return sessionId;
+
+  const previous = args.currentPresenceSessionId;
+  if (previous !== null) {
+    // Ordered-operation constraint (governed by this module's header invariant):
+    // drop the stale record BEFORE writing the new one. A crash between the two
+    // steps must leave ZERO presence records — a loud absence the watcher
+    // reports honestly — rather than two live-looking records, one of which
+    // points at a ledger nothing writes to. Silent misdirection is strictly
+    // worse than absence, so absence is the safe intermediate state.
+    debugLog(`⚑ presence: advertised id changed ${previous} → ${sessionId} — rewriting`);
+    unregisterPresenceCleanup(previous);
+    removePresenceFileSync(previous);
   }
 
-  return args.currentPresenceSessionId;
+  const workspace = args.runtimeStateSource.getWorkspace();
+  // Fire-and-forget — presence is best-effort and must never throw into the
+  // query path.
+  void writePresenceFile({
+    sessionId,
+    surface: args.surface,
+    // Presence is written only under the top-level gate above, so depth is
+    // 0/undefined here ⇒ 'main'. Derived (not hardcoded) to stay correct
+    // if that gate is ever changed.
+    actor: actorFromDepth(args.depth),
+    cwd: args.cwd ?? process.cwd(),
+    startedAt: new Date().toISOString(),
+    model: { provider: args.providerName, name: args.model },
+    workspace,
+    pid: process.pid,
+  });
+  // Cleanup on process exit/signal is owned by the process-level registry —
+  // one set of listeners per process, not three per session, and it never
+  // pre-empts a surface's own graceful shutdown. See ./presence-signals.ts.
+  registerPresenceCleanup(sessionId);
+  return sessionId;
 }

--- a/src/agent/providers/shared/presence-lifecycle.ts
+++ b/src/agent/providers/shared/presence-lifecycle.ts
@@ -28,6 +28,20 @@
  * for any non-resumed session. The real id was minted downstream of the gate,
  * inside query construction, from the *different* `config.resume` field.
  *
+ * Known gap (deliberately not closed here): this module keys presence off ONE
+ * provider instance's memo, so it cannot see a second instance. A cross-family
+ * `/model` swap builds a fresh inner provider whose memo starts `null`
+ * (`router/provider-router.ts`), which mints a second id and advertises a
+ * second record, while the swallowed `session.init` leaves the ledger pinned to
+ * the pre-swap id — so the orphan advertises a directory nothing creates.
+ * Bounded, and fails closed on both readers that could act on it: the orphan
+ * carries `afk: false`, and auto-subscribe requires `afk === true`
+ * (`telegram/bot.ts`), while `/watch` selection re-checks `ledgerExists`
+ * (`telegram/watch.ts`). Closing it means threading the live session id into
+ * the router's inner construction so every inner resolves through the
+ * explicit-id branch above; that touches swap/init semantics this module does
+ * not own, so it is tracked separately rather than bundled here.
+ *
  * @module agent/providers/shared/presence-lifecycle
  */
 
@@ -88,16 +102,32 @@ export interface SessionIdResolutionArgs {
 /**
  * Surfaces whose *fresh* (non-resumed) sessions are worth advertising.
  *
- * Contract: only two readers of presence files exist, and both are Telegram —
- * `bot.ts` auto-subscribe filters `surface === 'cli' && afk === true`, and the
- * `/watch` no-argument listing in `watch.ts` renders live records. A minted
- * advertisement on any other surface is invisible to every reader while still
- * costing a file plus a cleanup registration, which is how a long-running
- * daemon accrued one stale live-looking record per scheduled task (12 tasks ⇒
- * 12 records). Gating the MINT — not the write — keeps the pre-existing
- * contract intact: a session carrying an explicit id (`--resume`) still
- * advertises on every surface, which `telegram/presence-surface.test.ts` pins
- * for `cli`, `daemon`, and `telegram` alike.
+ * Contract: three readers of presence files exist. Two are Telegram and both
+ * ignore non-`cli` fresh sessions — `bot.ts` auto-subscribe filters
+ * `surface === 'cli' && afk === true`, and the `/watch` no-argument listing in
+ * `watch.ts` filters `surface !== 'telegram'` (so it would render a `daemon`
+ * record, but selecting one fails closed on `ledgerExists`). The third is
+ * `worktree-sweep.ts`, which reads presence with NO surface filter to protect a
+ * worktree hosting a live session from being reaped.
+ *
+ * That third reader is why this gate is scoped to the MINT rather than the
+ * write, and why it is not a regression: before this module existed, presence
+ * was gated on `config.sessionId`, which only `--resume`/`--continue` populates
+ * and which neither the daemon nor the Telegram surface ever sets. A fresh
+ * daemon session therefore advertised nothing then either, so declining to mint
+ * here restores that exact behavior — it removes no sweep protection that ever
+ * existed, it only refrains from adding some. Widening this set would hand
+ * daemon tasks reap-protection they have never had; that is a deliberate
+ * decision to make on its own merits, not a side effect to inherit from a
+ * Telegram-discoverability fix.
+ *
+ * Minting on a surface no reader consumes would still cost a file plus a
+ * cleanup registration per session, which is how a long-running daemon accrued
+ * one stale live-looking record per scheduled task (12 tasks ⇒ 12 records).
+ * Gating the MINT also keeps the pre-existing contract intact: a session
+ * carrying an explicit id (`--resume`) still advertises on every surface, which
+ * `telegram/presence-surface.test.ts` pins for `cli`, `daemon`, and `telegram`
+ * alike.
  */
 export const PRESENCE_MINT_SURFACES: ReadonlySet<string> = new Set(['cli']);
 

--- a/src/agent/providers/shared/presence-lifecycle.ts
+++ b/src/agent/providers/shared/presence-lifecycle.ts
@@ -1,0 +1,154 @@
+/**
+ * Shared presence-file lifecycle for provider `query()` implementations.
+ *
+ * Owns three concerns, in one place so both providers cannot drift:
+ *   1. the top-level-session guard ({@link isTopLevelSession}),
+ *   2. resolving the session id presence must advertise
+ *      ({@link resolveTopLevelSessionId}),
+ *   3. the best-effort presence write + cleanup-handler registration
+ *      ({@link registerPresenceLifecycle}).
+ *
+ * Invariant: the id written into the presence file MUST be the same id used for
+ * that session's ledger directory (`~/.afk/state/sessions/<id>/events.jsonl`).
+ * The Telegram watcher resolves the ledger path FROM the presence file's
+ * sessionId, so an id mismatch makes auto-subscribe "succeed" while tailing a
+ * ledger that does not exist — a silent failure strictly worse than the loud
+ * absence of a presence file. Callers therefore MUST pass the id returned by
+ * {@link resolveTopLevelSessionId} to BOTH this module and their query
+ * construction, so the two agree by construction rather than by coincidence.
+ *
+ * History: presence was previously gated on `config.sessionId`, which is
+ * populated only under `--resume`/`--continue`. Every fresh top-level CLI
+ * session therefore wrote NO presence file, leaving the Telegram bot's
+ * presence-driven auto-subscribe loop structurally blind to it and making
+ * bidirectional AFK (inline Yes/No buttons on the operator's phone) impossible
+ * for any non-resumed session. The real id was minted downstream of the gate,
+ * inside query construction, from the *different* `config.resume` field.
+ *
+ * @module agent/providers/shared/presence-lifecycle
+ */
+
+import { randomUUID } from 'node:crypto';
+import {
+  writePresenceFile,
+  removePresenceFileSync,
+  type RuntimeStateSource,
+} from '../../awareness/index.js';
+import { actorFromDepth } from '../../session/session-identity.js';
+
+export interface PresenceLifecycleArgs {
+  depth: number | undefined;
+  parentSessionId: string | undefined;
+  sessionId: string | undefined;
+  currentPresenceSessionId: string | null;
+  runtimeStateSource: RuntimeStateSource;
+  surface: string;
+  cwd: string | undefined;
+  providerName: string;
+  model: string;
+}
+
+/**
+ * Top-level = depth is 0 or undefined AND no parent session id. Subagent forks
+ * always receive `depth: parentDepth + 1` (≥ 1) and a `parentSessionId`, so
+ * they are structurally excluded — forks must never advertise presence, and
+ * must never share a parent's minted session id.
+ */
+export function isTopLevelSession(
+  depth: number | undefined,
+  parentSessionId: string | undefined,
+): boolean {
+  return (depth === undefined || depth === 0) && parentSessionId === undefined;
+}
+
+export interface SessionIdResolutionArgs {
+  /** `config.sessionId` — populated only under `--resume`/`--continue`. */
+  sessionId: string | undefined;
+  /** `config.resume` — the id a continuing turn threads back in. */
+  resume: string | undefined;
+  depth: number | undefined;
+  parentSessionId: string | undefined;
+  /** The provider instance's memoized mint, or `null` if it has not minted. */
+  memoized: string | null;
+}
+
+export interface SessionIdResolution {
+  /**
+   * The id to use for BOTH presence and query construction. `undefined` only
+   * for forks with no explicit id — preserving the pre-existing behavior where
+   * the query mints its own id per call.
+   */
+  id: string | undefined;
+  /** The value the caller must store back into its memo slot. */
+  memoized: string | null;
+}
+
+/**
+ * Resolve the session id a top-level session should use, minting one exactly
+ * once per provider instance when the caller supplied none.
+ *
+ * Precedence: an explicit id (`config.sessionId`, then `config.resume`) always
+ * wins, so resume semantics are bit-for-bit unchanged. Only a top-level session
+ * with no explicit id gets a mint, and that mint is memoized so it stays stable
+ * across turns on the same provider instance.
+ *
+ * Contract: never mints for a fork — returns `id: undefined` there, so fork
+ * query construction keeps its existing per-call mint and cannot inherit a
+ * parent's id (which would collide on the ledger directory).
+ */
+export function resolveTopLevelSessionId(
+  args: SessionIdResolutionArgs,
+): SessionIdResolution {
+  const explicit = args.sessionId ?? args.resume;
+  if (explicit !== undefined) return { id: explicit, memoized: args.memoized };
+
+  if (!isTopLevelSession(args.depth, args.parentSessionId)) {
+    return { id: undefined, memoized: args.memoized };
+  }
+
+  const minted = args.memoized ?? randomUUID();
+  return { id: minted, memoized: minted };
+}
+
+/**
+ * Write top-level session presence once per provider instance and return the
+ * updated `_presenceSessionId` slot.
+ *
+ * Per-instance (not per-process) on purpose: one OS process can legitimately
+ * host several concurrent top-level sessions, and each must advertise its own
+ * presence file.
+ */
+export function registerPresenceLifecycle(args: PresenceLifecycleArgs): string | null {
+  // Guard: only write once per provider instance (not once per turn).
+  if (
+    isTopLevelSession(args.depth, args.parentSessionId) &&
+    args.sessionId !== undefined &&
+    args.currentPresenceSessionId === null
+  ) {
+    const sessionId = args.sessionId;
+    const workspace = args.runtimeStateSource.getWorkspace();
+    // Fire-and-forget — presence is best-effort and must never throw into the
+    // query path.
+    void writePresenceFile({
+      sessionId,
+      surface: args.surface,
+      // Presence is written only under the top-level gate above, so depth is
+      // 0/undefined here ⇒ 'main'. Derived (not hardcoded) to stay correct
+      // if that gate is ever changed.
+      actor: actorFromDepth(args.depth),
+      cwd: args.cwd ?? process.cwd(),
+      startedAt: new Date().toISOString(),
+      model: { provider: args.providerName, name: args.model },
+      workspace,
+      pid: process.pid,
+    });
+    // Sync cleanup on process exit (cannot await in exit handler).
+    process.once('exit', () => { removePresenceFileSync(sessionId); });
+    // Best-effort cleanup on signals — fires before 'exit'.
+    process.once('SIGINT', () => { removePresenceFileSync(sessionId); process.exit(130); });
+    process.once('SIGTERM', () => { removePresenceFileSync(sessionId); process.exit(143); });
+    return sessionId;
+  }
+
+  return args.currentPresenceSessionId;
+}

--- a/src/agent/providers/shared/presence-lifecycle.ts
+++ b/src/agent/providers/shared/presence-lifecycle.ts
@@ -47,7 +47,7 @@
 
 import { randomUUID } from 'node:crypto';
 import {
-  writePresenceFile,
+  writePresenceFileSync,
   removePresenceFileSync,
   type RuntimeStateSource,
 } from '../../awareness/index.js';
@@ -233,9 +233,14 @@ export function registerPresenceLifecycle(args: PresenceLifecycleArgs): string |
   }
 
   const workspace = args.runtimeStateSource.getWorkspace();
-  // Fire-and-forget — presence is best-effort and must never throw into the
-  // query path.
-  void writePresenceFile({
+  // Ordered-operation constraint: this write must be durable before `query()`
+  // continues. Both providers expose a synchronous `close()`, so an async write
+  // issued here has no handle any caller can await and outlives the turn that
+  // started it — which raced host teardown of a scratch `AFK_HOME` (ENOTEMPTY,
+  // the write recreating `presence/` mid-rmdir) and let an immediate `/afk on`
+  // no-op on ENOENT before the file existed. Sync is cheap here: one ~300-byte
+  // write, once per advertised id, never once per turn. Never throws.
+  writePresenceFileSync({
     sessionId,
     surface: args.surface,
     // Presence is written only under the top-level gate above, so depth is

--- a/src/agent/providers/shared/presence-signals.test.ts
+++ b/src/agent/providers/shared/presence-signals.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Process-level presence cleanup registry contract.
+ *
+ * Two defects this guards, both introduced when presence started being written
+ * for every fresh session rather than only resumed ones:
+ *
+ *   (a) the cleanup handlers called `process.exit()` unconditionally. Every
+ *       surface that owns a graceful shutdown installs its OWN signal listener
+ *       at startup — before any session reaches its first `query()` — so the
+ *       presence handler ran second, in the same signal-delivery tick, and
+ *       exited the process while the surface's async shutdown was suspended at
+ *       its first `await` (Telegraf drain / `handle.stop()` /
+ *       `runCleanupFunctions()`), also changing the exit code 0 → 130/143.
+ *   (b) handlers were registered per presence write, so a process hosting N
+ *       top-level sessions leaked 3N listeners (12 daemon tasks ⇒ 36 listeners
+ *       plus `MaxListenersExceededWarning`).
+ *
+ * Harness note: these tests never `process.emit` a signal — that would run the
+ * test runner's own listeners too. They invoke the listener this module
+ * installed (always the last one attached for that event) directly, and spy on
+ * `process.exit` so a test can never take the vitest worker down with it.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  registerPresenceCleanup,
+  unregisterPresenceCleanup,
+  _resetPresenceSignalsForTest,
+} from './presence-signals.js';
+import { writePresenceFile, readPresenceFiles } from '../../awareness/presence.js';
+
+let tmpHome: string;
+let savedHome: string | undefined;
+
+function record(sessionId: string): Parameters<typeof writePresenceFile>[0] {
+  return {
+    sessionId,
+    surface: 'cli',
+    actor: 'main',
+    cwd: '/tmp',
+    startedAt: new Date().toISOString(),
+    model: { provider: 'anthropic-direct', name: 'claude-sonnet-5' },
+    workspace: { branch: null, headSha: null, dirty: false, dirtyCount: 0, remoteUrl: null },
+    pid: process.pid,
+  };
+}
+
+/** The listener this module installed for `event` — always the most recent. */
+function lastListener(event: 'exit' | 'SIGINT' | 'SIGTERM'): () => void {
+  const listeners = process.listeners(event);
+  const last = listeners[listeners.length - 1];
+  expect(last).toBeDefined();
+  return last as () => void;
+}
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), 'afk-presence-signals-'));
+  savedHome = process.env['AFK_HOME'];
+  process.env['AFK_HOME'] = tmpHome;
+  _resetPresenceSignalsForTest();
+});
+
+afterEach(() => {
+  _resetPresenceSignalsForTest();
+  if (savedHome === undefined) delete process.env['AFK_HOME'];
+  else process.env['AFK_HOME'] = savedHome;
+  rmSync(tmpHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe('presence cleanup registry — listener accounting', () => {
+  it('installs exactly one listener per event no matter how many sessions register', () => {
+    const before = {
+      exit: process.listenerCount('exit'),
+      sigint: process.listenerCount('SIGINT'),
+      sigterm: process.listenerCount('SIGTERM'),
+    };
+
+    for (const id of ['s1', 's2', 's3', 's4', 's5', 's6', 's7', 's8', 's9', 's10', 's11', 's12']) {
+      registerPresenceCleanup(id);
+    }
+
+    // Defect (b): this was 12 per event before the registry existed — 36 total,
+    // which tripped Node's default max-listeners warning in a daemon.
+    expect(process.listenerCount('exit') - before.exit).toBe(1);
+    expect(process.listenerCount('SIGINT') - before.sigint).toBe(1);
+    expect(process.listenerCount('SIGTERM') - before.sigterm).toBe(1);
+  });
+});
+
+describe('presence cleanup registry — file cleanup', () => {
+  it('removes every tracked presence file on exit', async () => {
+    await writePresenceFile(record('alpha'));
+    await writePresenceFile(record('beta'));
+    expect(await readPresenceFiles()).toHaveLength(2);
+
+    registerPresenceCleanup('alpha');
+    registerPresenceCleanup('beta');
+    lastListener('exit')();
+
+    expect(await readPresenceFiles()).toHaveLength(0);
+  });
+
+  it('leaves an unregistered session\'s file alone', async () => {
+    await writePresenceFile(record('kept'));
+    await writePresenceFile(record('dropped'));
+
+    registerPresenceCleanup('kept');
+    registerPresenceCleanup('dropped');
+    // Mirrors the rewrite path: the old id is unregistered as the new id takes
+    // over, and its file is removed explicitly by the caller instead.
+    unregisterPresenceCleanup('dropped');
+    lastListener('exit')();
+
+    const remaining = await readPresenceFiles();
+    expect(remaining.map((r) => r.sessionId)).toEqual(['dropped']);
+  });
+});
+
+describe('presence cleanup registry — signal ownership', () => {
+  it('does NOT exit when another listener already owned the signal', () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+    const surfaceHandler = (): void => { /* stands in for bot.ts / daemon.ts */ };
+    process.on('SIGTERM', surfaceHandler);
+    try {
+      registerPresenceCleanup('owned-elsewhere');
+      lastListener('SIGTERM')();
+
+      // Defect (a): exiting here truncates the surface's async shutdown, which
+      // is suspended at its first await when this handler runs.
+      expect(exitSpy).not.toHaveBeenCalled();
+    } finally {
+      process.removeListener('SIGTERM', surfaceHandler);
+    }
+  });
+
+  it('DOES exit when nothing else owns the signal (afk chat has no handler)', () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+    // Node suppresses its default terminate-on-signal once ANY listener is
+    // attached, so a surface with no handler of its own would hang on Ctrl+C if
+    // this module returned unconditionally. Simulate that surface by clearing
+    // pre-existing listeners for the duration of the install.
+    const saved = process.listeners('SIGINT');
+    process.removeAllListeners('SIGINT');
+    try {
+      registerPresenceCleanup('sole-owner');
+      lastListener('SIGINT')();
+      expect(exitSpy).toHaveBeenCalledWith(130);
+    } finally {
+      process.removeAllListeners('SIGINT');
+      for (const listener of saved) process.on('SIGINT', listener as () => void);
+    }
+  });
+
+  it('exits 143 on SIGTERM when it owns the signal', () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+    const saved = process.listeners('SIGTERM');
+    process.removeAllListeners('SIGTERM');
+    try {
+      registerPresenceCleanup('sole-owner-term');
+      lastListener('SIGTERM')();
+      expect(exitSpy).toHaveBeenCalledWith(143);
+    } finally {
+      process.removeAllListeners('SIGTERM');
+      for (const listener of saved) process.on('SIGTERM', listener as () => void);
+    }
+  });
+});

--- a/src/agent/providers/shared/presence-signals.ts
+++ b/src/agent/providers/shared/presence-signals.ts
@@ -1,0 +1,125 @@
+/**
+ * Process-level cleanup registry for presence-file lifecycle.
+ *
+ * `presence-lifecycle.ts` previously registered its OWN `process.once('exit'|
+ * 'SIGINT'|'SIGTERM')` handlers on every presence write, which is wrong on two
+ * independent axes:
+ *
+ *   (a) Every surface that owns a graceful shutdown (`telegram/bot.ts`,
+ *       `cli/commands/daemon.ts`, `cli/commands/interactive.ts`) installs its
+ *       OWN SIGINT/SIGTERM listener at startup — before a session ever reaches
+ *       its first `query()` call, so before presence's handler existed. Node
+ *       invokes same-event listeners in registration order, so the surface's
+ *       handler ran first, kicked off its (async) shutdown, and returned
+ *       control at its first `await` — at which point presence's
+ *       later-registered handler ran SYNCHRONOUSLY, in the same signal-
+ *       delivery tick, and called `process.exit()` before the surface's
+ *       Telegraf drain / `handle.stop()` / `runCleanupFunctions()` ever got a
+ *       turn on the event loop. That both abandoned the graceful shutdown and
+ *       changed the exit code (0 → 130/143) under a supervisor.
+ *   (b) One process can legitimately host N top-level sessions (daemon tasks,
+ *       parallel farm workers), and registering 3 listeners per session leaks
+ *       3N listeners — observed as 36 listeners + `MaxListenersExceededWarning`
+ *       for 12 daemon tasks.
+ *
+ * This module fixes both: a single module-level id set, and exactly ONE
+ * `process.on(...)` install per process (idempotent — later calls are no-ops).
+ *
+ * @module agent/providers/shared/presence-signals
+ */
+
+import { removePresenceFileSync } from '../../awareness/index.js';
+
+/** Live presence session ids awaiting cleanup on process exit/signal. */
+const liveSessionIds = new Set<string>();
+
+/** Whether the process-level listeners have been installed (idempotent gate). */
+let installed = false;
+
+// Handler references, retained so `_resetPresenceSignalsForTest` can remove
+// exactly the listeners this module attached (never a caller's own).
+let onExit: (() => void) | null = null;
+let onSigint: (() => void) | null = null;
+let onSigterm: (() => void) | null = null;
+
+function removeAllTracked(): void {
+  for (const id of liveSessionIds) removePresenceFileSync(id);
+}
+
+/**
+ * Lazily install the process-level `exit`/`SIGINT`/`SIGTERM` listeners.
+ * Idempotent — a no-op after the first call, regardless of how many sessions
+ * register (fixes defect (b) above).
+ *
+ * Invariant: Node suppresses its default terminate-on-signal action the
+ * moment ANY listener is attached to `SIGINT`/`SIGTERM` — there is no way to
+ * "not handle" the signal once `.on()` has been called once by anyone in the
+ * process. So this handler's own `process.exit(code)` call must be
+ * conditional: fire it only when NO OTHER listener owned the signal at
+ * install time (captured via `process.listenerCount(sig) === 0` BEFORE this
+ * module attaches its own listener). A surface with no handler of its own
+ * (`afk chat`, one-shot) would otherwise hang forever on Ctrl+C — nothing else
+ * would ever call `process.exit`. A surface that DOES install its own handler
+ * (telegram/bot.ts, daemon.ts, interactive.ts — all registered at startup,
+ * i.e. before this lazy install ever runs) owns the exit call at the END of
+ * its own async shutdown; this module exiting unconditionally would truncate
+ * that shutdown (defect (a) above). Removing the presence file(s) is safe
+ * either way and always runs first — it is synchronous and idempotent.
+ */
+function ensureInstalled(): void {
+  if (installed) return;
+  installed = true;
+
+  onExit = () => removeAllTracked();
+  process.on('exit', onExit);
+
+  const sigintOwnedElsewhere = process.listenerCount('SIGINT') > 0;
+  onSigint = () => {
+    removeAllTracked();
+    if (!sigintOwnedElsewhere) process.exit(130);
+  };
+  process.on('SIGINT', onSigint);
+
+  const sigtermOwnedElsewhere = process.listenerCount('SIGTERM') > 0;
+  onSigterm = () => {
+    removeAllTracked();
+    if (!sigtermOwnedElsewhere) process.exit(143);
+  };
+  process.on('SIGTERM', onSigterm);
+}
+
+/**
+ * Register a session id for presence-file cleanup on process exit/signal.
+ * Installs the process-level listeners on first call (see {@link ensureInstalled}).
+ */
+export function registerPresenceCleanup(sessionId: string): void {
+  ensureInstalled();
+  liveSessionIds.add(sessionId);
+}
+
+/**
+ * Stop tracking a session id — its presence file is no longer removed on
+ * process exit/signal. Used when a session's advertised id changes (a new
+ * cleanup registration for the new id normally accompanies this) or when a
+ * session ends and its presence file has already been removed explicitly.
+ */
+export function unregisterPresenceCleanup(sessionId: string): void {
+  liveSessionIds.delete(sessionId);
+}
+
+/**
+ * Test-only reset: removes this module's own listeners and clears all
+ * tracked state, so the next `registerPresenceCleanup` call reinstalls fresh
+ * listeners instead of silently no-oping against a previous test's state.
+ * Never call from production code.
+ */
+export function _resetPresenceSignalsForTest(): void {
+  if (onExit) process.removeListener('exit', onExit);
+  if (onSigint) process.removeListener('SIGINT', onSigint);
+  if (onSigterm) process.removeListener('SIGTERM', onSigterm);
+  onExit = null;
+  onSigint = null;
+  onSigterm = null;
+  installed = false;
+  liveSessionIds.clear();
+}


### PR DESCRIPTION
## Summary

Bidirectional AFK — the agent asking a question and the operator tapping an inline **Yes/No** button in Telegram — has never worked for a fresh session. This fixes the cause.

Presence was gated on `config.sessionId`, which AgentConfig receives **only** under `--resume`/`--continue` (it arrives via `...deps.resumeConfig` in `cli/commands/interactive/bootstrap.ts`). Every fresh top-level session therefore wrote **no presence file at all**.

That single gap breaks the whole chain: `telegram/bot.ts` `runAutoSubscribeTick` reads presence files and *nothing else*, so a fresh session is structurally undiscoverable — no watcher ever starts, and `ask_question` with `type: "confirm"` only ever paints the local terminal overlay. `/afk on` cannot rescue it either: `setPresenceAfk` is read-modify-write and silently no-ops on ENOENT, so it can flip the flag on an existing file but never create one.

The id we want existed the whole time, but downstream of the gate and in a **different field** — both providers mint it during query construction from `config.resume`.

**Not a regression.** The gate has been this way since the initial release (`0a23cff`), extracted byte-faithfully in `1c16f81` (#452).

## Fix

Resolve the session id **once** per provider instance, *before* the presence write, and thread that same id into query construction:

- explicit ids win (`config.sessionId`, then `config.resume`) — resume semantics are bit-for-bit unchanged;
- a top-level session with no id gets a mint, memoized so it stays stable across turns (`query()` runs once per turn, and a fresh mint each turn would move the ledger directory out from under the presence file the watcher is following);
- forks resolve to `undefined` and keep their own per-call mint, so they neither advertise presence nor collide on a parent's ledger directory.

### Invariant this protects

The presence id **must** equal the id of the session's ledger directory, because the Telegram watcher resolves the ledger path *from* the presence file. An id mismatch would make auto-subscribe "succeed" while tailing a ledger that does not exist — a silent failure strictly worse than the loud absence being fixed here. Both consumers now read one resolution, so they agree by construction rather than by coincidence.

### Deduplication

`openai-compatible/index.ts` had hand-duplicated the entire gate inline — bug included — and never called the shared helper. Fixing only `anthropic-direct` would have left every OpenAI-compatible-backed CLI session broken. The gate now lives in `shared/presence-lifecycle.ts` and both providers call it; `anthropic-direct/query/presence-lifecycle.ts` becomes a re-export shim, matching the existing precedent in `anthropic-direct/afk-mode-addendum.ts`.

## Ordering trap worth knowing about

Presence registration runs ~190 lines *before* query construction mints the UUID, so you cannot simply pass the query's id at the existing call site. The resolution is therefore hoisted above both consumers in each provider.

## Verification

The new reproducer is load-bearing, so it was checked in both directions:

- **Against pre-fix code** (call sites reverted, helper + test retained): **4 of 15 fail**, both providers, with `AssertionError: expected undefined to be defined` — i.e. no presence file written for a fresh session.
- **After the fix**: 15/15 pass.
- **Full suite**: 707 files, 13,395 passed, 14 skipped, 0 failures.
- **`pnpm lint`** (`tsc --noEmit`, maximally strict): clean.

Coverage added for both providers: fresh top-level session (no `config.sessionId`) writes presence with a defined id; second turn does not create a second/differently-identified file; forks write nothing. Plus unit coverage of the resolver's precedence and fork behavior.

### Why existing tests missed it

`telegram/presence-surface.test.ts` passes an explicit `sessionId` in every config it builds, so only the **resumed** shape was ever exercised. The new tests deliberately omit it, which is the real shape of a fresh REPL session.

## Notes for the reviewer

- `opts.sessionId` (anthropic) feeds only `initSessionId` and gates no resume behavior, so supplying a minted id is inert apart from making the id known earlier. Verified by grep: `resumedSessionId` had exactly two occurrences — its declaration and the query option.
- `buildQueryFromConfig` gains an optional `sessionIdOverride` (highest precedence, above `config.resume`) — additive and backward-compatible, deliberately avoiding semantic overload of `resume`.
- **Not verified end-to-end:** these tests prove a correctly-sourced, stable presence file is written; they cannot prove a live Telegram round-trip. That needs one manual run — fresh session, `/afk on`, then a `confirm` question — to confirm buttons render on the phone.
- **Latent gap, deliberately not fixed here:** `touchPresenceHeartbeat` has no caller anywhere in `src/`. Harmless today because `bot.ts` calls `readLivePresenceFiles()` with no options, leaving the heartbeat-age filter inert (only a dead pid excludes a record) — but any future caller passing `maxHeartbeatAgeMs` would start dropping live sessions.
- Both provider `index.ts` files were already far over the 350-LOC guideline before this change (1038 and 642) and this adds ~33/~20 lines net after removing the duplicate. Splitting them is out of scope here but worth a follow-up.