### PR TITLE
fix(browser): latch launch failures so browser_* stops retrying a cold chromium launch (#722)

### DIFF
--- a/src/agent/tools/handlers/playwright-hints.test.ts
+++ b/src/agent/tools/handlers/playwright-hints.test.ts
@@ -66,6 +66,53 @@ describe('playwrightMissingHint', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Latch reset advice (issue #722 review follow-up)
+//
+// Naming the install command without naming the reset is an incomplete
+// remediation: a caller that installs chromium and retries `browser_open`
+// fast-fails on the identical latched error forever. The advice is opt-in
+// because non-latching callers exist (`afk browser login` launches chromium
+// directly, and the `browser_close` handler would be told to call itself).
+// ---------------------------------------------------------------------------
+
+describe('playwrightMissingHint — latch reset advice', () => {
+  const EXEC_MISSING = "Executable doesn't exist at /ms-playwright/chromium/chrome";
+
+  it('names the browser_close reset when the caller latched the failure', () => {
+    const hint = playwrightMissingHint(EXEC_MISSING, { headless: false, latched: true });
+    expect(hint).toMatch(/install chromium/);
+    expect(hint).toMatch(/call browser_close once to retry/);
+  });
+
+  it('OMITS the reset advice by default, so non-latching callers are not misled', () => {
+    // `afk browser login` and the per-operation handler catches reach this hint
+    // with no latch in play; telling them to call browser_close would be wrong.
+    expect(playwrightMissingHint(EXEC_MISSING, { headless: false })).not.toMatch(/browser_close/);
+    expect(playwrightMissingHint(EXEC_MISSING)).not.toMatch(/browser_close/);
+    expect(playwrightMissingHint(EXEC_MISSING, { headless: false, latched: false })).not.toMatch(
+      /browser_close/,
+    );
+  });
+
+  it('also names the reset on the package-missing branch, which latches too', () => {
+    const hint = playwrightMissingHint('Cannot find package playwright', { latched: true });
+    expect(hint).toMatch(/pnpm add playwright/);
+    expect(hint).toMatch(/call browser_close once to retry/);
+  });
+
+  it('decoratePlaywrightLaunchError defaults to NOT latched', () => {
+    const err = decoratePlaywrightLaunchError(new Error(EXEC_MISSING), false);
+    expect((err as Error).message).toMatch(/install chromium/);
+    expect((err as Error).message).not.toMatch(/browser_close/);
+  });
+
+  it('decoratePlaywrightLaunchError adds the reset when told the caller latches', () => {
+    const err = decoratePlaywrightLaunchError(new Error(EXEC_MISSING), false, true);
+    expect((err as Error).message).toMatch(/call browser_close once to retry/);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Install-command resolution (issue #721)
 // ---------------------------------------------------------------------------
 

--- a/src/browser/playwright-missing.ts
+++ b/src/browser/playwright-missing.ts
@@ -163,7 +163,26 @@ export interface PlaywrightHintOptions {
    * satisfies one does NOT satisfy the other.
    */
   headless?: boolean;
+  /**
+   * Set by callers that LATCH this failure (currently only `BrowserLauncher`).
+   * When true the hint also names the reset the latch requires, because
+   * installing the binary alone does not recover the session — see
+   * `LATCH_RESET_NOTE`. Left false by non-latching callers (`afk browser
+   * login`, the per-operation handler catches) where the advice would be wrong.
+   */
+  latched?: boolean;
 }
+
+/**
+ * Contract: appended only when `opts.latched` is true. Naming the install
+ * command without naming the reset is an incomplete remediation — a caller that
+ * follows the hint verbatim (install, then retry `browser_open`) fast-fails on
+ * the identical latched error forever, because retrying never clears the latch.
+ * `browser_close` -> `closeSession()` is the only in-session clear.
+ */
+const LATCH_RESET_NOTE =
+  'This session already latched the failure, so browser tools keep fast-failing ' +
+  'with this same error — after installing, call browser_close once to retry.';
 
 /**
  * Returns the install hint appropriate to which half of the dependency is
@@ -171,6 +190,7 @@ export interface PlaywrightHintOptions {
  */
 export function playwrightMissingHint(err: unknown, opts?: PlaywrightHintOptions): string {
   const text = flattenErrorText(err);
+  const resetNote = opts?.latched === true ? ` ${LATCH_RESET_NOTE}` : '';
 
   if (text.includes("Executable doesn't exist")) {
     // Package is installed; the chromium browser binary was never downloaded.
@@ -185,7 +205,7 @@ export function playwrightMissingHint(err: unknown, opts?: PlaywrightHintOptions
     }
     return (
       'browser tools require the Playwright chromium binary. ' +
-      `Install via: ${playwrightInstallCommand()}.${artifactNote}`
+      `Install via: ${playwrightInstallCommand()}.${artifactNote}${resetNote}`
     );
   }
 
@@ -193,7 +213,7 @@ export function playwrightMissingHint(err: unknown, opts?: PlaywrightHintOptions
   return (
     'browser tools require the optional `playwright` peer dependency. ' +
     `Install via: pnpm add playwright (then ${playwrightInstallCommand()}). ` +
-    'Or pick a different tool.'
+    `Or pick a different tool.${resetNote}`
   );
 }
 
@@ -207,10 +227,23 @@ export function playwrightMissingHint(err: unknown, opts?: PlaywrightHintOptions
  * exceeded") and the witness trace records it verbatim, so decorating
  * unconditionally would corrupt timeout classification and trace payloads.
  * Only a confirmed Playwright-missing error is ever rewritten.
+ *
+ * Contract: `latched` is opt-in and defaults false. Pass true only from a
+ * caller that latches the returned error, so the message can name the reset
+ * (see `LATCH_RESET_NOTE`). The decoration happens HERE, before the latch is
+ * set, which is what lets the latched fast-fail rethrow the stored error
+ * verbatim and still carry the reset advice — no re-messaging at the fast-fail
+ * site, which the identity Invariant above forbids.
  */
-export function decoratePlaywrightLaunchError(err: unknown, headless: boolean): unknown {
+export function decoratePlaywrightLaunchError(
+  err: unknown,
+  headless: boolean,
+  latched = false,
+): unknown {
   if (!isPlaywrightMissing(err)) return err;
 
   const base = err instanceof Error ? err.message : String(err);
-  return new Error(`${base}\n\n${playwrightMissingHint(err, { headless })}`, { cause: err });
+  return new Error(`${base}\n\n${playwrightMissingHint(err, { headless, latched })}`, {
+    cause: err,
+  });
 }

--- a/src/browser/playwright/launcher.test.ts
+++ b/src/browser/playwright/launcher.test.ts
@@ -251,6 +251,155 @@ describe('BrowserLauncher', () => {
   });
 
   // -------------------------------------------------------------------------
+  // ensureBrowser — launch-failure latch (issue #722)
+  //
+  // The decorated-error assertions key on "install chromium", the same
+  // substring `hasPlaywrightInstallHint` uses, so they fail if the latch ever
+  // starts caching the raw Playwright error instead of the decorated one.
+  // -------------------------------------------------------------------------
+
+  describe('ensureBrowser — launch-failure latch', () => {
+    // Matches PLAYWRIGHT_MISSING_HINTS, so decoratePlaywrightLaunchError
+    // appends the install remediation to it.
+    const MISSING_BINARY = "Executable doesn't exist at /path/to/chromium-1234/chrome";
+
+    it('attempts chromium.launch exactly once across two sequential failed calls', async () => {
+      const launcher = new BrowserLauncher(TEST_CONFIG);
+      vi.mocked(chromium.launch).mockRejectedValue(new Error(MISSING_BINARY));
+
+      await expect(launcher.ensureBrowser()).rejects.toThrow(/Executable doesn't exist/);
+      await expect(launcher.ensureBrowser()).rejects.toThrow(/Executable doesn't exist/);
+
+      // The whole point of the latch: the second call never re-launches.
+      expect(chromium.launch).toHaveBeenCalledTimes(1);
+    });
+
+    it('fast-fails with the same decorated install-command message', async () => {
+      const launcher = new BrowserLauncher(TEST_CONFIG);
+      vi.mocked(chromium.launch).mockRejectedValue(new Error(MISSING_BINARY));
+
+      const first = await launcher.ensureBrowser().catch((e: unknown) => e);
+      const second = await launcher.ensureBrowser().catch((e: unknown) => e);
+
+      expect(first).toBeInstanceOf(Error);
+      expect((first as Error).message).toContain('install chromium');
+      // Identity, not just equality — the latch caches the decorated object.
+      expect(second).toBe(first);
+      expect((second as Error).message).toBe((first as Error).message);
+      expect(chromium.launch).toHaveBeenCalledTimes(1);
+    });
+
+    it('preserves the original error as `cause` on the latched error', async () => {
+      const launcher = new BrowserLauncher(TEST_CONFIG);
+      const original = new Error(MISSING_BINARY);
+      vi.mocked(chromium.launch).mockRejectedValue(original);
+
+      await launcher.ensureBrowser().catch(() => undefined);
+      const latched = await launcher.ensureBrowser().catch((e: unknown) => e);
+
+      expect((latched as Error).cause).toBe(original);
+    });
+
+    it('latches non-Playwright failures too, by identity', async () => {
+      const launcher = new BrowserLauncher(TEST_CONFIG);
+      // Not a missing-binary error, so decoration passes it through unchanged.
+      const oom = new Error('spawn ENOMEM');
+      vi.mocked(chromium.launch).mockRejectedValue(oom);
+
+      const first = await launcher.ensureBrowser().catch((e: unknown) => e);
+      const second = await launcher.ensureBrowser().catch((e: unknown) => e);
+
+      expect(first).toBe(oom);
+      expect(second).toBe(oom);
+      expect(chromium.launch).toHaveBeenCalledTimes(1);
+    });
+
+    it('shutdown() clears the latch so a later call retries the launch', async () => {
+      const launcher = new BrowserLauncher(TEST_CONFIG);
+      vi.mocked(chromium.launch).mockRejectedValueOnce(new Error(MISSING_BINARY));
+
+      await expect(launcher.ensureBrowser()).rejects.toThrow(/install chromium/);
+      expect(chromium.launch).toHaveBeenCalledTimes(1);
+
+      // Operator installs chromium, then browser state is torn down.
+      await launcher.shutdown();
+
+      // Recovery: the next call launches for real rather than fast-failing.
+      const browser = await launcher.ensureBrowser();
+      expect(chromium.launch).toHaveBeenCalledTimes(2);
+      expect(browser).toBe(currentStubBrowser);
+    });
+
+    it('closeSession() — the browser_close path — clears the latch', async () => {
+      const launcher = new BrowserLauncher(TEST_CONFIG);
+      vi.mocked(chromium.launch).mockRejectedValueOnce(new Error(MISSING_BINARY));
+
+      await expect(launcher.ensureBrowser()).rejects.toThrow(/install chromium/);
+      expect(chromium.launch).toHaveBeenCalledTimes(1);
+
+      // `browser_close` → provider.close() → closeSession(). A failed launch
+      // never created a SessionEntry, so this must clear the latch even though
+      // the session is unknown.
+      await launcher.closeSession('session-A');
+
+      const browser = await launcher.ensureBrowser();
+      expect(chromium.launch).toHaveBeenCalledTimes(2);
+      expect(browser).toBe(currentStubBrowser);
+    });
+
+    it('leaves no latch after a successful launch', async () => {
+      const launcher = new BrowserLauncher(TEST_CONFIG);
+
+      await launcher.ensureBrowser();
+      expect(chromium.launch).toHaveBeenCalledTimes(1);
+
+      // Simulate a crash so ensureBrowser takes the cold path again. If a
+      // successful launch had left a latch set, this would throw instead of
+      // re-launching.
+      currentStubBrowser.isConnected.mockReturnValue(false);
+      const freshBrowser = makeStubBrowser();
+      vi.mocked(chromium.launch).mockResolvedValueOnce(
+        freshBrowser as unknown as Awaited<ReturnType<typeof chromium.launch>>,
+      );
+
+      await expect(launcher.ensureBrowser()).resolves.toBe(freshBrowser);
+      expect(chromium.launch).toHaveBeenCalledTimes(2);
+    });
+
+    it('recovers to a live browser after a failure, without a stale latch', async () => {
+      const launcher = new BrowserLauncher(TEST_CONFIG);
+      vi.mocked(chromium.launch).mockRejectedValueOnce(new Error(MISSING_BINARY));
+
+      await expect(launcher.ensureBrowser()).rejects.toThrow(/install chromium/);
+      await launcher.closeSession('unknown-session');
+
+      // Successful relaunch, then a third call must reuse it (fast path) —
+      // proving the recovery did not leave a latch that fast-fails instead.
+      const b1 = await launcher.ensureBrowser();
+      const b2 = await launcher.ensureBrowser();
+      expect(b1).toBe(b2);
+      expect(launcher.isBrowserActive()).toBe(true);
+      expect(chromium.launch).toHaveBeenCalledTimes(2);
+    });
+
+    it('still coalesces concurrent callers onto one in-flight launch', async () => {
+      const launcher = new BrowserLauncher(TEST_CONFIG);
+      vi.mocked(chromium.launch).mockRejectedValueOnce(new Error(MISSING_BINARY));
+
+      // Both callers arrive before the rejection settles, so they must share the
+      // single in-flight promise rather than each starting a launch.
+      const [r1, r2] = await Promise.allSettled([
+        launcher.ensureBrowser(),
+        launcher.ensureBrowser(),
+      ]);
+
+      expect(r1.status).toBe('rejected');
+      expect(r2.status).toBe('rejected');
+      expect(chromium.launch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // ensureContext
   // -------------------------------------------------------------------------
 
@@ -932,7 +1081,14 @@ describe('BrowserLauncher — chromium-missing launch decoration', () => {
     vi.mocked(chromium.launch).mockRejectedValueOnce(new Error(EXEC_MISSING));
 
     await expect(launcher.ensureBrowser()).rejects.toThrow(/install chromium/);
-    // Decoration must not strand the latch — the retry uses the default mock.
+
+    // History: this test originally retried immediately and expected a
+    // successful launch. Issue #722 made the retry fast-fail on the latched
+    // error by design, so the retry now runs after a reset. The assertion this
+    // test exists for is unchanged — decoration must not strand the rejected
+    // `launchPromise` — it is just no longer observable without clearing the
+    // latch first.
+    await launcher.closeSession('unused-session');
     await expect(launcher.ensureBrowser()).resolves.toBe(currentStubBrowser);
   });
 });

--- a/src/browser/playwright/launcher.test.ts
+++ b/src/browser/playwright/launcher.test.ts
@@ -1091,4 +1091,27 @@ describe('BrowserLauncher — chromium-missing launch decoration', () => {
     await launcher.closeSession('unused-session');
     await expect(launcher.ensureBrowser()).resolves.toBe(currentStubBrowser);
   });
+
+  it('names the browser_close reset, so the fast-failed message is self-sufficient', async () => {
+    const launcher = new BrowserLauncher({ ...TEST_CONFIG, headless: false });
+    vi.mocked(chromium.launch).mockRejectedValue(new Error(EXEC_MISSING));
+
+    const first = await launcher.ensureBrowser().then(
+      () => undefined,
+      (e: unknown) => e as Error,
+    );
+    // The latched fast-fail rethrows the STORED error verbatim, so the advice has
+    // to be baked in at decoration time — this asserts it survives that path.
+    const fastFailed = await launcher.ensureBrowser().then(
+      () => undefined,
+      (e: unknown) => e as Error,
+    );
+
+    expect(first?.message).toMatch(/install chromium/);
+    expect(first?.message).toMatch(/call browser_close once to retry/);
+    // Identical by design: the fast-fail must not degrade the remediation.
+    expect(fastFailed?.message).toBe(first?.message);
+    // Only one real launch attempt was paid for — the point of issue #722.
+    expect(vi.mocked(chromium.launch)).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/browser/playwright/launcher.ts
+++ b/src/browser/playwright/launcher.ts
@@ -230,7 +230,11 @@ export class BrowserLauncher {
         // Headed and headless need DIFFERENT chromium downloads, and only this
         // frame knows which one was requested — a handler catch sees just a
         // string. Passing it through lets the hint name the missing artifact.
-        const decorated = decoratePlaywrightLaunchError(err, this.config.headless);
+        // `latched: true` — this frame is the only caller that latches, so it is
+        // the only one where the hint may tell the caller to reset via
+        // browser_close. Set at decoration time so the verbatim rethrow at the
+        // fast-fail path carries the advice without re-messaging the error.
+        const decorated = decoratePlaywrightLaunchError(err, this.config.headless, true);
         // Latch the DECORATED error, not `err`: the fast-failed retry must
         // carry the same install remediation as this first failure.
         this.latchLaunchFailure(decorated);

--- a/src/browser/playwright/launcher.ts
+++ b/src/browser/playwright/launcher.ts
@@ -103,11 +103,51 @@ export class BrowserLauncher {
   // second browser process.
   private launchPromise: Promise<Browser> | undefined;
 
+  // Latched launch failure — see the "Launch-failure latch" section below.
+  // Wrapped in an object rather than stored bare so "no latch" is distinct from
+  // "latched an undefined throw"; `unknown` alone conflates the two.
+  private launchFailure: { error: unknown } | undefined;
+
   // Set to true by `shutdown()` so a second call no-ops cleanly.
   private shutdownComplete = false;
 
   constructor(config: BrowserConfig) {
     this.config = config;
+  }
+
+  // -------------------------------------------------------------------------
+  // Launch-failure latch
+  // -------------------------------------------------------------------------
+
+  /*
+   * Invariant: the latch holds the DECORATED launch error — the one carrying
+   * the install command built by `decoratePlaywrightLaunchError` — never the
+   * raw Playwright error. That remediation is the only actionable half of the
+   * message, so fast-failing with the undecorated error would trade a slow
+   * useful failure for a fast useless one and lose the point of issue #721.
+   *
+   * Invariant: the latch is set ONLY on an `ensureBrowser()` rejection, and is
+   * dropped on launch success, on `closeSession()`, and on `shutdown()`. A live
+   * browser and a set latch are therefore mutually exclusive states.
+   *
+   * Invariant (clear-before-set ordering): the reset is defined and invoked
+   * ahead of the setter because the constraint governing this pair is EXTERNAL
+   * to the process — chromium's launchability is a property of the host
+   * filesystem, not of this object. An operator who runs the advertised install
+   * command changes that host state with no signal reaching us, so every
+   * explicit teardown entry point must drop the latch. An orphaned clear does
+   * not degrade gracefully here: it converts one missing binary into a
+   * permanently browser-less session recoverable only by restarting AFK.
+   */
+
+  /** Drop the latched failure so the next `ensureBrowser()` retries for real. */
+  private clearLaunchFailure(): void {
+    this.launchFailure = undefined;
+  }
+
+  /** Latch an already-decorated launch failure so later calls fast-fail. */
+  private latchLaunchFailure(error: unknown): void {
+    this.launchFailure = { error };
   }
 
   // -------------------------------------------------------------------------
@@ -138,11 +178,25 @@ export class BrowserLauncher {
    * ones. Do NOT move this check up into the handlers' catch blocks: provider
    * construction never launches chromium, which is precisely why the hint was
    * unreachable before issue #721.
+   *
+   * Invariant: once a launch has failed, the decorated error is latched and
+   * every later call rethrows it WITHOUT touching `chromium.launch` (issue
+   * #722). A genuinely missing binary otherwise costs one full launch timeout
+   * per `browser_*` tool call. `closeSession()` / `shutdown()` drop the latch,
+   * so installing chromium mid-session recovers without restarting AFK.
    */
   async ensureBrowser(): Promise<Browser> {
     // Fast path: already connected.
     if (this.browser !== undefined && this.browser.isConnected()) {
       return this.browser;
+    }
+
+    // Latched-failure path: a previous launch failed and nothing has reset the
+    // latch since. Rethrow the decorated error instead of paying another cold
+    // launch. Checked BEFORE the launchPromise coalesce because the two are
+    // never both set — the rejection handler clears the promise as it latches.
+    if (this.launchFailure !== undefined) {
+      throw this.launchFailure.error;
     }
 
     // Crash-recovery path: reference exists but the process is gone. Clear it
@@ -164,6 +218,11 @@ export class BrowserLauncher {
       .then((b) => {
         this.browser = b;
         this.launchPromise = undefined;
+        // A success must never leave a latch behind. Nothing can set one while
+        // this launch is in flight (the latch short-circuits before we get
+        // here), but clearing unconditionally keeps "browser live ⇒ no latch"
+        // true by construction rather than by argument.
+        this.clearLaunchFailure();
         return b;
       })
       .catch((err: unknown) => {
@@ -171,7 +230,11 @@ export class BrowserLauncher {
         // Headed and headless need DIFFERENT chromium downloads, and only this
         // frame knows which one was requested — a handler catch sees just a
         // string. Passing it through lets the hint name the missing artifact.
-        throw decoratePlaywrightLaunchError(err, this.config.headless);
+        const decorated = decoratePlaywrightLaunchError(err, this.config.headless);
+        // Latch the DECORATED error, not `err`: the fast-failed retry must
+        // carry the same install remediation as this first failure.
+        this.latchLaunchFailure(decorated);
+        throw decorated;
       });
 
     return this.launchPromise;
@@ -458,8 +521,16 @@ export class BrowserLauncher {
    *
    * Ordered teardown (page close → context close) ensures Playwright
    * finalizes page-level event listeners before freeing the context.
+   *
+   * Invariant: the launch-failure latch is dropped BEFORE the not-found guard
+   * below. This is the path `browser_close` actually reaches — the handler
+   * calls `provider.close()`, which calls this method, NOT `shutdown()` — and a
+   * failed launch never created a SessionEntry, so a reset placed after the
+   * guard would be unreachable in exactly the case it exists for.
    */
   async closeSession(sessionId: string): Promise<void> {
+    this.clearLaunchFailure();
+
     const entry = this.sessions.get(sessionId);
     if (entry === undefined) {
       return;
@@ -492,8 +563,14 @@ export class BrowserLauncher {
    * Invariant: sessions are closed before `browser.close()`. The reverse
    * order would leave dangling context handles and trigger Playwright
    * "context closed" errors inside the close calls.
+   *
+   * Invariant: the launch-failure latch is dropped BEFORE the
+   * already-shutdown guard, so a second `shutdown()` after a failed launch
+   * still resets it rather than no-opping past the reset.
    */
   async shutdown(): Promise<void> {
+    this.clearLaunchFailure();
+
     if (this.shutdownComplete) {
       return;
     }


### PR DESCRIPTION
## Summary

Closes #722.

`BrowserLauncher` kept no failure state, so a genuinely unlaunchable chromium cost a full `chromium.launch()` attempt — plus its timeout — on **every** `browser_*` tool call. The reported incident burned ~13 minutes across ~9 consecutive `browser_open` failures, each re-attempting the launch from scratch.

This latches the failure:

- **Latch on rejection** — `ensureBrowser()` stores the **decorated** error (the one carrying the install command added in #721), not the raw Playwright error. Later calls rethrow it without touching `chromium.launch`, so the fast-failed result keeps the same actionable remediation as the first failure — quick *and* useful.
- **Clear on recovery** — the latch is dropped on launch success, on `closeSession()`, and on `shutdown()`, so an operator who installs the missing binary mid-session recovers without restarting AFK. The latch never makes a session permanently browser-less.

### Where the reset had to go

The reset lands in **`closeSession()`**, not only `shutdown()`, because that is the path `browser_close` actually reaches — `browserCloseHandler` → `provider.close()` → `launcher.closeSession()`, and never `shutdown()` (`src/browser/playwright/index.ts:479-482`). `shutdown()` is only reached via `closeBrowserProvider()` (signals / process teardown).

It is placed **before** that method's not-found guard: a failed launch never created a `SessionEntry`, so a reset placed after the guard would be unreachable in exactly the case it exists for. Same reasoning for placing `shutdown()`'s clear before its already-shutdown guard.

### Invariants preserved

- The in-flight `launchPromise` dedupe is untouched — the latch check sits after the connected fast path and before the coalesce, and the two are never both set (the rejection handler clears the promise as it latches). Covered by a concurrent-callers regression test.
- A successful launch clears the latch unconditionally, so "browser live ⇒ no latch" holds by construction rather than by argument.
- Non-Playwright failures (OOM, timeouts) are latched **by identity**, so downstream timeout classification and witness-trace payloads still see the verbatim error.

Per the repo's ordered-operation convention, the clear/set pair is written clear-first and the governing external constraint (chromium's launchability is host filesystem state that changes with no signal to this process) is recorded as an `// Invariant:` comment at the pair, not just in the commit message.

## How was this tested?

- `pnpm lint` (tsc --noEmit, whole repo) — passes.
- `pnpm test src/browser/playwright/launcher.test.ts` — **66 passed**, including 9 new latch tests in `ensureBrowser — launch-failure latch`:
  - two sequential failed calls invoke `chromium.launch` **exactly once**
  - the fast-failed error is the *same object* and preserves the `install chromium` remediation
  - the original error survives as `cause`
  - non-Playwright failures latch by identity
  - `shutdown()` clears the latch → next call really re-launches
  - `closeSession()` (the `browser_close` path) clears the latch → next call really re-launches
  - a successful launch leaves **no** latch (verified via the crash-recovery cold path)
  - post-failure recovery reaches a live reusable browser with no stale latch
  - concurrent callers still share one in-flight launch
- `pnpm test src/browser/ …browser-open/browser-close/web-scrape` — 351 passed.
- Full `pnpm test` — **706 files / 13434 tests passed, 14 skipped, 0 failures**. No pre-existing failures on this platform, so nothing to separate out.

Reused the existing `vi.mock('playwright')` + `currentStubBrowser` harness rather than adding one.

**One existing test adjusted:** `still clears the in-flight launch promise, so a later launch can succeed` retried immediately after a failure and expected success — the exact behaviour #722 changes by design. Its assertion intent (decoration must not strand the rejected `launchPromise`) is preserved by clearing the latch before the retry; the change is annotated with a `History:` comment.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/) — see [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] No secrets, tokens, or private paths in the diff