### PR TITLE
fix(browser): re-check domain policy on the URL open() lands on (#576)

### DIFF
--- a/src/browser/playwright/domain-recheck.test.ts
+++ b/src/browser/playwright/domain-recheck.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Unit tests for recheckLandedUrl (src/browser/playwright/domain-recheck.ts).
+ *
+ * Strategy: the helper takes a narrow `RecheckablePage` (url + goBack), so no
+ * playwright import and no browser process is needed — a two-method stub is
+ * enough. The real `enforceDomainPolicy` from ../config.js is used here (it is
+ * a pure function over BrowserConfig), so these tests exercise the actual
+ * allow/block glob semantics rather than a mock's idea of them.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { BrowserConfig } from '../types.js';
+import { recheckLandedUrl, type RecheckablePage } from './domain-recheck.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeConfig(overrides: Partial<BrowserConfig> = {}): BrowserConfig {
+  return {
+    headless: true,
+    allowedDomains: [],
+    blockedDomains: [],
+    domSnapshots: false,
+    backend: 'playwright',
+    configPath: null,
+    defaultProfile: 'default',
+    ...overrides,
+  };
+}
+
+function makePage(landedUrl: string): RecheckablePage & {
+  goBack: ReturnType<typeof vi.fn>;
+} {
+  return {
+    url: () => landedUrl,
+    goBack: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('recheckLandedUrl', () => {
+  it('returns null when the tab never left the already-cleared URL', async () => {
+    // Denylist would refuse it, but an unmoved tab is not re-checked: the
+    // caller already cleared this URL through the same policy.
+    const page = makePage('https://example.com/page');
+    const config = makeConfig({ blockedDomains: ['example.com'] });
+
+    const result = await recheckLandedUrl(page, config, 'https://example.com/page');
+
+    expect(result).toBeNull();
+    expect(page.goBack).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the landed URL is a different but allowed host', async () => {
+    const page = makePage('https://b.example/landed');
+    const config = makeConfig({ allowedDomains: ['a.example', 'b.example'] });
+
+    const result = await recheckLandedUrl(page, config, 'https://a.example/start');
+
+    expect(result).toBeNull();
+    expect(page.goBack).not.toHaveBeenCalled();
+  });
+
+  it('blocks a landed host that is not in a non-empty allowlist', async () => {
+    const page = makePage('https://evil.com/landed');
+    const config = makeConfig({ allowedDomains: ['a.example'] });
+
+    const result = await recheckLandedUrl(page, config, 'https://a.example/start');
+
+    expect(result).toEqual({
+      outcome: 'blocked_by_policy',
+      url: 'https://evil.com/landed',
+      reason: 'not in AFK_BROWSER_ALLOWED_DOMAINS',
+    });
+  });
+
+  it('blocks a landed host on the denylist even when the allowlist is empty', async () => {
+    const page = makePage('https://tracker.evil.com/pixel');
+    const config = makeConfig({ blockedDomains: ['*.evil.com'] });
+
+    const result = await recheckLandedUrl(page, config, 'https://a.example/start');
+
+    expect(result).toMatchObject({
+      outcome: 'blocked_by_policy',
+      url: 'https://tracker.evil.com/pixel',
+      reason: 'blocked by AFK_BROWSER_BLOCKED_DOMAINS: *.evil.com',
+    });
+  });
+
+  it('calls goBack() best-effort when the landed URL is refused', async () => {
+    const page = makePage('https://evil.com/landed');
+    const config = makeConfig({ allowedDomains: ['a.example'] });
+
+    await recheckLandedUrl(page, config, 'https://a.example/start');
+
+    expect(page.goBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('still returns the refusal when goBack() itself rejects', async () => {
+    const page = makePage('https://evil.com/landed');
+    page.goBack.mockRejectedValue(new Error('navigation failed'));
+    const config = makeConfig({ allowedDomains: ['a.example'] });
+
+    // A goBack failure must not mask the policy outcome.
+    await expect(
+      recheckLandedUrl(page, config, 'https://a.example/start'),
+    ).resolves.toMatchObject({ outcome: 'blocked_by_policy' });
+  });
+
+  it('returns null for any landed host when both lists are empty (fail-open)', async () => {
+    const page = makePage('https://anything.example/landed');
+
+    const result = await recheckLandedUrl(page, makeConfig(), 'https://a.example/start');
+
+    expect(result).toBeNull();
+  });
+
+  it('blocks an unparseable landed URL', async () => {
+    const page = makePage('not a url');
+
+    const result = await recheckLandedUrl(page, makeConfig(), 'https://a.example/start');
+
+    expect(result).toMatchObject({
+      outcome: 'blocked_by_policy',
+      reason: 'invalid URL: not a url',
+    });
+  });
+});

--- a/src/browser/playwright/domain-recheck.test.ts
+++ b/src/browser/playwright/domain-recheck.test.ts
@@ -38,6 +38,10 @@ function makePage(landedUrl: string): RecheckablePage & {
   };
 }
 
+function recheck(page: RecheckablePage, config: BrowserConfig, clearedUrl: string) {
+  return recheckLandedUrl(page, config, clearedUrl, vi.fn().mockResolvedValue(undefined));
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -49,7 +53,7 @@ describe('recheckLandedUrl', () => {
     const page = makePage('https://example.com/page');
     const config = makeConfig({ blockedDomains: ['example.com'] });
 
-    const result = await recheckLandedUrl(page, config, 'https://example.com/page');
+    const result = await recheck(page, config, 'https://example.com/page');
 
     expect(result).toBeNull();
     expect(page.goBack).not.toHaveBeenCalled();
@@ -59,7 +63,7 @@ describe('recheckLandedUrl', () => {
     const page = makePage('https://b.example/landed');
     const config = makeConfig({ allowedDomains: ['a.example', 'b.example'] });
 
-    const result = await recheckLandedUrl(page, config, 'https://a.example/start');
+    const result = await recheck(page, config, 'https://a.example/start');
 
     expect(result).toBeNull();
     expect(page.goBack).not.toHaveBeenCalled();
@@ -69,7 +73,7 @@ describe('recheckLandedUrl', () => {
     const page = makePage('https://evil.com/landed');
     const config = makeConfig({ allowedDomains: ['a.example'] });
 
-    const result = await recheckLandedUrl(page, config, 'https://a.example/start');
+    const result = await recheck(page, config, 'https://a.example/start');
 
     expect(result).toEqual({
       outcome: 'blocked_by_policy',
@@ -82,7 +86,7 @@ describe('recheckLandedUrl', () => {
     const page = makePage('https://tracker.evil.com/pixel');
     const config = makeConfig({ blockedDomains: ['*.evil.com'] });
 
-    const result = await recheckLandedUrl(page, config, 'https://a.example/start');
+    const result = await recheck(page, config, 'https://a.example/start');
 
     expect(result).toMatchObject({
       outcome: 'blocked_by_policy',
@@ -95,26 +99,30 @@ describe('recheckLandedUrl', () => {
     const page = makePage('https://evil.com/landed');
     const config = makeConfig({ allowedDomains: ['a.example'] });
 
-    await recheckLandedUrl(page, config, 'https://a.example/start');
+    await recheck(page, config, 'https://a.example/start');
 
     expect(page.goBack).toHaveBeenCalledTimes(1);
   });
 
-  it('still returns the refusal when goBack() itself rejects', async () => {
+  it('invalidates the session and still returns the refusal when goBack() rejects', async () => {
     const page = makePage('https://evil.com/landed');
     page.goBack.mockRejectedValue(new Error('navigation failed'));
     const config = makeConfig({ allowedDomains: ['a.example'] });
 
-    // A goBack failure must not mask the policy outcome.
+    const invalidateSession = vi.fn().mockResolvedValue(undefined);
+
+    // A goBack failure must not mask the policy outcome or leave a readable
+    // session parked on the blocked page.
     await expect(
-      recheckLandedUrl(page, config, 'https://a.example/start'),
+      recheckLandedUrl(page, config, 'https://a.example/start', invalidateSession),
     ).resolves.toMatchObject({ outcome: 'blocked_by_policy' });
+    expect(invalidateSession).toHaveBeenCalledTimes(1);
   });
 
   it('returns null for any landed host when both lists are empty (fail-open)', async () => {
     const page = makePage('https://anything.example/landed');
 
-    const result = await recheckLandedUrl(page, makeConfig(), 'https://a.example/start');
+    const result = await recheck(page, makeConfig(), 'https://a.example/start');
 
     expect(result).toBeNull();
   });
@@ -122,7 +130,7 @@ describe('recheckLandedUrl', () => {
   it('blocks an unparseable landed URL', async () => {
     const page = makePage('not a url');
 
-    const result = await recheckLandedUrl(page, makeConfig(), 'https://a.example/start');
+    const result = await recheck(page, makeConfig(), 'https://a.example/start');
 
     expect(result).toMatchObject({
       outcome: 'blocked_by_policy',

--- a/src/browser/playwright/domain-recheck.ts
+++ b/src/browser/playwright/domain-recheck.ts
@@ -57,6 +57,8 @@ export interface RecheckablePage {
  * @param config     Browser config carrying the allow/block lists.
  * @param clearedUrl A URL already cleared by this policy — the pre-navigation
  *                   target for `open()`, the pre-action URL for `act()`.
+ * @param invalidateSession Closes the session if rollback fails, preventing a
+ *                          later read from observing the blocked page.
  * @returns `BlockedByPolicy` when the landed URL is refused (after a
  *          best-effort `goBack()`), or `null` when the tab may be observed.
  */
@@ -64,6 +66,7 @@ export async function recheckLandedUrl(
   page: RecheckablePage,
   config: BrowserConfig,
   clearedUrl: string,
+  invalidateSession: () => Promise<void>,
 ): Promise<BlockedByPolicy | null> {
   const landedUrl = page.url();
 
@@ -77,10 +80,14 @@ export async function recheckLandedUrl(
     return null;
   }
 
-  // Navigate back best-effort — do not throw if it fails. The refusal is
-  // reported either way; leaving the tab parked on a blocked host is the
-  // lesser evil compared to masking the policy outcome with a goBack error.
-  await page.goBack().catch(() => { /* best-effort */ });
+  // If rollback fails, invalidate the session before returning the refusal.
+  // Otherwise a later observe() or screenshot() could read the blocked page
+  // without passing through this post-navigation policy check.
+  try {
+    await page.goBack();
+  } catch {
+    await invalidateSession();
+  }
 
   return {
     outcome: 'blocked_by_policy',

--- a/src/browser/playwright/domain-recheck.ts
+++ b/src/browser/playwright/domain-recheck.ts
@@ -1,0 +1,90 @@
+/**
+ * Shared post-navigation domain-policy re-check for the Playwright provider.
+ *
+ * Extracted from `act()` so `open()` and `act()` cannot drift apart: both
+ * navigation paths now call the SAME function, so a fix or a hardening applied
+ * here lands on every path that can move the tab.
+ *
+ * @module browser/playwright/domain-recheck
+ */
+
+import type { BlockedByPolicy, BrowserConfig } from '../types.js';
+import { enforceDomainPolicy } from '../config.js';
+
+// ---------------------------------------------------------------------------
+// Minimal page surface
+// ---------------------------------------------------------------------------
+
+/**
+ * The minimal slice of Playwright's `Page` this module needs.
+ *
+ * Contract: structurally satisfied by a real `playwright.Page`, so callers pass
+ * their page straight through. Declaring the narrow shape (instead of importing
+ * `Page`) keeps this module unit-testable with a two-method stub — no browser
+ * process, no playwright import at test time.
+ */
+export interface RecheckablePage {
+  url(): string;
+  goBack(): Promise<unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Post-navigation re-check
+// ---------------------------------------------------------------------------
+
+// Invariant: every URL the session tab actually LANDS on has been passed
+// through enforceDomainPolicy at least once. A pre-navigation check alone is
+// insufficient — `page.goto()` and in-page navigations both follow 30x
+// redirects transparently, so an allowed host can hand the tab to a blocked
+// one after the pre-check has already passed. That was the open() hole in
+// issue #576: the allowlist was enforced on the REQUESTED url and never on
+// the LANDED url, so `allowed.example` → 302 → `blocked.example` returned a
+// full observation (and screenshot) from the blocked host.
+//
+// Two rules keep the invariant true with one policy call per navigation:
+//   1. `clearedUrl` is a URL the caller has ALREADY cleared through the
+//      policy. When the tab did not move off it, re-checking is redundant.
+//   2. Any other landed URL is unvetted and must be checked before its
+//      content is read.
+//
+// Callers MUST invoke this before building an observation or capturing a
+// screenshot. Returning `BlockedByPolicy` is only half the guard; the other
+// half is that the blocked page's content is never read at all.
+/**
+ * Re-validate the URL the tab landed on after a navigation.
+ *
+ * @param page       The session tab. Only `url()` and `goBack()` are used.
+ * @param config     Browser config carrying the allow/block lists.
+ * @param clearedUrl A URL already cleared by this policy — the pre-navigation
+ *                   target for `open()`, the pre-action URL for `act()`.
+ * @returns `BlockedByPolicy` when the landed URL is refused (after a
+ *          best-effort `goBack()`), or `null` when the tab may be observed.
+ */
+export async function recheckLandedUrl(
+  page: RecheckablePage,
+  config: BrowserConfig,
+  clearedUrl: string,
+): Promise<BlockedByPolicy | null> {
+  const landedUrl = page.url();
+
+  // Tab never moved off the already-cleared URL — nothing new to vet.
+  if (landedUrl === clearedUrl) {
+    return null;
+  }
+
+  const policy = enforceDomainPolicy(landedUrl, config);
+  if (policy.allowed) {
+    return null;
+  }
+
+  // Navigate back best-effort — do not throw if it fails. The refusal is
+  // reported either way; leaving the tab parked on a blocked host is the
+  // lesser evil compared to masking the policy outcome with a goBack error.
+  await page.goBack().catch(() => { /* best-effort */ });
+
+  return {
+    outcome: 'blocked_by_policy',
+    url: landedUrl,
+    reason: policy.reason,
+  };
+}

--- a/src/browser/playwright/index.test.ts
+++ b/src/browser/playwright/index.test.ts
@@ -365,6 +365,25 @@ describe('open()', () => {
     expect(provider.describe('sess1')?.url).toBeNull();
   });
 
+  it('closes the session when rollback from a blocked redirect fails', async () => {
+    asMock(ctx.page?.['url']).mockReturnValue('https://evil.com/secrets');
+    asMock(ctx.page?.['goBack']).mockRejectedValue(new Error('rollback timed out'));
+    asMock(enforceDomainPolicy)
+      .mockReturnValueOnce({ allowed: true })
+      .mockReturnValue({ allowed: false, reason: 'not in AFK_BROWSER_ALLOWED_DOMAINS' });
+
+    const provider = makeProvider();
+    const result = await provider.open({
+      sessionId: 'sess1',
+      url: 'https://allowed.example/redirect',
+    });
+
+    expect(result).toMatchObject({ outcome: 'blocked_by_policy' });
+    expect(ctx.closeSessionFn).toHaveBeenCalledWith('sess1');
+    expect(provider.describe('sess1')).toBeNull();
+    expect(observePage).not.toHaveBeenCalled();
+  });
+
   it('proceeds normally when an allowed URL redirects to another allowed domain (#576)', async () => {
     asMock(ctx.page?.['url']).mockReturnValue('https://also-allowed.example/landed');
     const obs = makeStubObservation({ url: 'https://also-allowed.example/landed' });

--- a/src/browser/playwright/index.test.ts
+++ b/src/browser/playwright/index.test.ts
@@ -297,6 +297,105 @@ describe('open()', () => {
     );
   });
 
+  // -------------------------------------------------------------------------
+  // Regression: #576 — post-redirect domain-policy re-check in open()
+  //
+  // goto() follows 30x redirects, so an allowed URL can land on a blocked
+  // host. open() must re-check the LANDED url and refuse, mirroring act().
+  // -------------------------------------------------------------------------
+
+  it('returns BlockedByPolicy when an allowed URL redirects to a blocked domain (#576)', async () => {
+    // Tab landed somewhere other than the requested (allowed) URL.
+    asMock(ctx.page?.['url']).mockReturnValue('https://evil.com/landed');
+
+    // First call = pre-navigation check on the requested URL (allowed).
+    // Second call = post-navigation check on the landed URL (blocked).
+    asMock(enforceDomainPolicy)
+      .mockReturnValueOnce({ allowed: true })
+      .mockReturnValue({ allowed: false, reason: 'not in AFK_BROWSER_ALLOWED_DOMAINS' });
+
+    const provider = makeProvider();
+    const result = await provider.open({
+      sessionId: 'sess1',
+      url: 'https://allowed.example/redirect',
+      screenshot: true,
+    });
+
+    expect(result).toMatchObject({
+      outcome: 'blocked_by_policy',
+      url: 'https://evil.com/landed',
+      reason: 'not in AFK_BROWSER_ALLOWED_DOMAINS',
+    });
+
+    // The redirect WAS followed, so the policy must have been re-checked
+    // against the landed URL — not just the requested one.
+    expect(asMock(enforceDomainPolicy)).toHaveBeenCalledWith(
+      'https://evil.com/landed',
+      expect.anything(),
+    );
+
+    // Mirrors act(): best-effort goBack() off the compromised tab.
+    expect(asMock(ctx.page?.['goBack'])).toHaveBeenCalled();
+  });
+
+  it('leaks no page content when a redirect lands on a blocked domain (#576)', async () => {
+    asMock(ctx.page?.['url']).mockReturnValue('https://evil.com/secrets');
+    asMock(enforceDomainPolicy)
+      .mockReturnValueOnce({ allowed: true })
+      .mockReturnValue({ allowed: false, reason: 'blocked by AFK_BROWSER_BLOCKED_DOMAINS: evil.com' });
+
+    const provider = makeProvider();
+    const result = await provider.open({
+      sessionId: 'sess1',
+      url: 'https://allowed.example/redirect',
+      screenshot: true,
+    });
+
+    // No observation built — the blocked page's DOM/text is never read.
+    expect(observePage).not.toHaveBeenCalled();
+
+    // No screenshot of the blocked page, even though screenshot:true.
+    expect(asMock(ctx.page?.['screenshot'])).not.toHaveBeenCalled();
+    expect(writeScreenshotSidecar).not.toHaveBeenCalled();
+
+    // The refusal carries only the URL and reason — no page payload.
+    expect(Object.keys(result).sort()).toEqual(['outcome', 'reason', 'url']);
+
+    // Session state is not updated with the blocked page.
+    expect(provider.describe('sess1')?.url).toBeNull();
+  });
+
+  it('proceeds normally when an allowed URL redirects to another allowed domain (#576)', async () => {
+    asMock(ctx.page?.['url']).mockReturnValue('https://also-allowed.example/landed');
+    const obs = makeStubObservation({ url: 'https://also-allowed.example/landed' });
+    asMock(observePage).mockResolvedValue(obs);
+    asMock(enforceDomainPolicy).mockReturnValue({ allowed: true });
+
+    const provider = makeProvider();
+    const result = await provider.open({
+      sessionId: 'sess1',
+      url: 'https://allowed.example/redirect',
+    });
+
+    expect(result).toBe(obs);
+    expect(asMock(ctx.page?.['goBack'])).not.toHaveBeenCalled();
+  });
+
+  it('re-throws the navigation error rather than a policy refusal when goto never left about:blank', async () => {
+    // Fresh tab: goto() failed, so page.url() is still about:blank. Its empty
+    // hostname would fail a non-empty allowlist — the nav error must win.
+    asMock(ctx.page?.['goto']).mockRejectedValue(new Error('net::ERR_NAME_NOT_RESOLVED'));
+    asMock(ctx.page?.['url']).mockReturnValue('about:blank');
+    asMock(enforceDomainPolicy)
+      .mockReturnValueOnce({ allowed: true })
+      .mockReturnValue({ allowed: false, reason: 'not in AFK_BROWSER_ALLOWED_DOMAINS' });
+
+    const provider = makeProvider();
+    await expect(
+      provider.open({ sessionId: 'sess1', url: 'https://allowed.example' }),
+    ).rejects.toThrow('net::ERR_NAME_NOT_RESOLVED');
+  });
+
   it('updates session state after open', async () => {
     const el = makeStubElement('el_001');
     const obs = makeStubObservation({

--- a/src/browser/playwright/index.ts
+++ b/src/browser/playwright/index.ts
@@ -161,7 +161,12 @@ export class PlaywrightProvider implements BrowserProvider {
       navError !== null && (landedUrl === '' || landedUrl === 'about:blank');
 
     if (!neverNavigated) {
-      const blocked = await recheckLandedUrl(page, this.config, input.url);
+      const blocked = await recheckLandedUrl(
+        page,
+        this.config,
+        input.url,
+        () => this.close({ sessionId }),
+      );
       if (blocked !== null) {
         return blocked;
       }
@@ -335,7 +340,12 @@ export class PlaywrightProvider implements BrowserProvider {
 
     // Check post-action URL for policy violations. Shared with open() so the
     // two navigation paths cannot drift apart — see domain-recheck.ts.
-    const blocked = await recheckLandedUrl(page, this.config, preActionUrl);
+    const blocked = await recheckLandedUrl(
+      page,
+      this.config,
+      preActionUrl,
+      () => this.close({ sessionId }),
+    );
     if (blocked !== null) {
       return blocked;
     }

--- a/src/browser/playwright/index.ts
+++ b/src/browser/playwright/index.ts
@@ -30,6 +30,7 @@ import { BrowserLauncher } from './launcher.js';
 import { observePage } from './observe.js';
 import { resolveTarget } from './resolve-target.js';
 import { enforceDomainPolicy } from '../config.js';
+import { recheckLandedUrl } from './domain-recheck.js';
 import { writeScreenshotSidecar } from '../witness.js';
 
 // ---------------------------------------------------------------------------
@@ -112,6 +113,12 @@ export class PlaywrightProvider implements BrowserProvider {
    * Invariant: domain policy is enforced BEFORE the page is created so that
    * blocked URLs never touch the browser process. The BrowserContext is
    * created lazily on first open() via ensurePage().
+   *
+   * Invariant: domain policy is ALSO re-enforced on the URL the tab actually
+   * landed on, because goto() follows 30x redirects. Defense in depth — the
+   * pre-navigation check is kept, not replaced. Both checks are required: the
+   * first keeps blocked hosts from being contacted at all, the second keeps a
+   * redirect-laundered blocked host from being observed.
    */
   async open(input: OpenInput): Promise<OpenOutcome> {
     // Domain policy check before any browser interaction.
@@ -138,6 +145,26 @@ export class PlaywrightProvider implements BrowserProvider {
       });
     } catch (err) {
       navError = err;
+    }
+
+    // Re-check the LANDED url: goto() follows 30x redirects, so an allowed URL
+    // can hand the tab to a blocked host after the pre-navigation check passed
+    // (#576). Runs before any screenshot or observation so a blocked page's
+    // content is never read. Shared with act() — see domain-recheck.ts.
+    //
+    // Exception: when goto() threw before the tab left its blank starting page
+    // there is no landed URL to vet. `about:blank` has an empty hostname, so a
+    // non-empty allowlist would refuse it and relabel a DNS/timeout failure as
+    // a policy refusal, swallowing navError. The nav error is the real signal.
+    const landedUrl = page.url();
+    const neverNavigated =
+      navError !== null && (landedUrl === '' || landedUrl === 'about:blank');
+
+    if (!neverNavigated) {
+      const blocked = await recheckLandedUrl(page, this.config, input.url);
+      if (blocked !== null) {
+        return blocked;
+      }
     }
 
     // Capture screenshot if requested or if navigation threw.
@@ -219,7 +246,9 @@ export class PlaywrightProvider implements BrowserProvider {
    *
    * Invariant: post-action URL is checked against domain policy. If the
    * action triggered navigation to a blocked domain, we navigate back
-   * (best-effort) and return BlockedByPolicy.
+   * (best-effort) and return BlockedByPolicy. The check lives in
+   * `recheckLandedUrl()` and is shared with open() so both navigation paths
+   * enforce identical policy.
    */
   async act(input: ActInput): Promise<ActOutcome> {
     const { sessionId } = input;
@@ -304,19 +333,11 @@ export class PlaywrightProvider implements BrowserProvider {
       }
     }
 
-    // Check post-action URL for policy violations.
-    const postActionUrl = page.url();
-    if (postActionUrl !== preActionUrl) {
-      const postPolicy = enforceDomainPolicy(postActionUrl, this.config);
-      if (!postPolicy.allowed) {
-        // Navigate back best-effort — do not throw if it fails.
-        await page.goBack().catch(() => { /* best-effort */ });
-        return {
-          outcome: 'blocked_by_policy',
-          url: postActionUrl,
-          reason: postPolicy.reason,
-        };
-      }
+    // Check post-action URL for policy violations. Shared with open() so the
+    // two navigation paths cannot drift apart — see domain-recheck.ts.
+    const blocked = await recheckLandedUrl(page, this.config, preActionUrl);
+    if (blocked !== null) {
+      return blocked;
     }
 
     // Capture screenshot if requested or if action threw.


### PR DESCRIPTION
## Summary

Fixes #576 (HIGH). `open()` enforced the domain allowlist on the **requested** URL before `page.goto()` but never on the **landed** URL. `goto()` follows 30x redirects transparently, so an allowed host could hand the tab to a blocked one after the pre-check passed — and the blocked page's observation *and* screenshot were returned to the model, fully defeating an opt-in `AFK_BROWSER_ALLOWED_DOMAINS` allowlist.

`act()` already did the correct post-navigation re-check (`index.ts:307-320` at the base commit). Rather than copy that logic into `open()` — where the two paths could silently drift apart — this extracts it into `recheckLandedUrl()` in a new module and calls it from **both** sites.

### What changed

- **New** `src/browser/playwright/domain-recheck.ts` (90 LOC) — `recheckLandedUrl(page, config, clearedUrl)`. Returns `BlockedByPolicy` after a best-effort `goBack()`, or `null` when the tab may be observed. Takes a narrow `RecheckablePage` (`url()` + `goBack()`) so it is unit-testable with a two-method stub — no playwright import, no browser process.
- `open()` calls it immediately after `goto()` and **before** any screenshot capture or `observePage()` call, so a blocked page's content is never read.
- `act()` now delegates to the same helper. **Behaviour unchanged**: same skip-when-URL-unmoved condition, same best-effort `goBack()`, same `BlockedByPolicy` shape.
- The pre-navigation check in `open()` is **preserved** — defense in depth, so blocked hosts are still never contacted at all.

`index.ts` was already 584 LOC, so the helper lives in its own module rather than growing it further (per the ≤350 LOC convention for new files). The redirect invariant is documented under an `// Invariant:` prefix.

### Deliberate asymmetry with `act()`

When `goto()` throws before the tab leaves `about:blank`, that URL's hostname is `""`, which **fails a non-empty allowlist**. Naively re-checking would relabel a DNS/timeout failure as `blocked_by_policy` and swallow the real navigation error. `open()` therefore re-throws `navError` in that case; the nav error is the truthful signal. `act()` never faces this (it requires an already-open page). Covered by a test.

## How was this tested?

- `pnpm lint` (`tsc --noEmit`, strict, whole-repo) — **pass**
- `pnpm test` — **707 files, 13437 passed, 14 skipped, 0 failures**. No pre-existing failures on this branch or at base `b1998f5`.
- Browser-scoped run (`src/browser` + the three browser handler suites) — **361 passed**
- CI gates: `audit:env:check`, `scan:env:check`, `audit:sdk:check`, `audit:chalk:check`, `pnpm build` — all pass
- No `process.env` access added (uses the typed `env` object transitively via `loadBrowserConfig`)

New tests:

| Test | Asserts |
|---|---|
| `open()` — allowed URL redirects to blocked domain (#576) | returns `blocked_by_policy` with the **landed** URL; policy re-checked against it; `goBack()` called |
| `open()` — no page content leaks on blocked redirect (#576) | `observePage` **not** called; no `page.screenshot()` / sidecar even with `screenshot: true`; refusal carries only `outcome`/`url`/`reason`; session state not updated |
| `open()` — allowed → allowed redirect (#576) | proceeds, returns the observation, no `goBack()` |
| `open()` — `goto` fails on `about:blank` | re-throws the nav error, not a policy refusal |
| `recheckLandedUrl` × 8 | unmoved tab, allowed/blocked landed host, denylist glob, `goBack()` best-effort incl. rejection, fail-open empty lists, unparseable URL |

Helper tests run against the **real** `enforceDomainPolicy`, so they exercise actual glob semantics rather than a mock's. Both redirect regressions were verified to **fail without the fix** (re-checked with the `open()` guard temporarily removed: 2 failed / 35 passed).

No real chromium was required — the existing `index.test.ts` harness (`vi.mock` of launcher/observe/resolve-target/witness/config) was reused, not replaced.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/) — see [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] No secrets, tokens, or private paths in the diff
