### PR TITLE
fix(web): block SSRF egress to internal hosts in web_scrape (#575)

### DIFF
--- a/docs/env-registry.json
+++ b/docs/env-registry.json
@@ -813,6 +813,14 @@
       "category": "model"
     },
     {
+      "name": "AFK_WEB_ALLOW_PRIVATE_HOSTS",
+      "description": "Opt out of the web_scrape SSRF egress guard. When unset (default) the guard is ACTIVE: the markdown, raw, and headless-render paths refuse loopback (127/8, ::1), link-local (169.254/16 — including the 169.254.169.254 cloud instance-metadata endpoint), RFC1918 (10/8, 172.16/12, 192.168/16), carrier-grade NAT (100.64/10), IPv6 unique-local (fc00::/7), 0.0.0.0/8, and the IPv4-mapped/compatible IPv6 forms of all of those. Hostnames are resolved and the RESOLVED addresses are classified (DNS-rebinding guard), and the check is re-applied on every redirect hop. Set to 1/true to allow private-host access — needed only to scrape a local dev server. Enabling it restores a model-reachable SSRF path (issue #575).",
+      "type": "boolean",
+      "required": false,
+      "example": "1",
+      "category": "misc"
+    },
+    {
       "name": "AFK_WORKTREE_AUTONAME",
       "description": "Auto-rename worktree branches based on the first user message in interactive mode. 1 = on (default), 0 = off.",
       "type": "boolean",

--- a/docs/env-registry.md
+++ b/docs/env-registry.md
@@ -2,7 +2,7 @@
 
 Generated from `src/config/env.ts`. Do not edit by hand — run `pnpm scan:env` after changing the registry source.
 
-**137 vars** across 12 categories. Every `process.env[...]` read in `src/` outside `src/config/env.ts` is a CI failure (enforced by `pnpm audit:env:check`).
+**138 vars** across 12 categories. Every `process.env[...]` read in `src/` outside `src/config/env.ts` is a CI failure (enforced by `pnpm audit:env:check`).
 
 To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV_REGISTRY`), then run `pnpm scan:env`.
 
@@ -200,5 +200,6 @@ To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV
 | `AFK_THEME` | string |  | `dark` | `light` | TUI color palette for the interactive REPL and all CLI rendering: dark \| light \| auto. Display-only — swaps the semantic color palette, never behavior (cost/latency unaffected). auto detects from COLORFGBG and falls back to dark. Overridden per-launch by --theme and mutable mid-session via /theme. Precedence: --theme flag > this env > config theme > auto-detect > dark. Invalid values are ignored (dark). |
 | `AFK_THINKING_UI` | string |  | `live` | `digest` | Default thinking-display mode for the interactive REPL: summary \| live \| digest \| off. Display-only — controls how extended-thinking blocks render, never whether thinking runs (cost/latency unaffected). Overridden per-launch by --thinking-ui and mutable mid-session via /thinking. Precedence: --thinking-ui flag > this env > interactive.thinkingUi config > live. Invalid values are ignored. |
 | `AFK_USER_CARD_MAX_ROWS` | number |  |  | `24` | Maximum number of visual rows emitted by renderUserCard before collapsing the remainder into a dim "…(N lines collapsed)" summary row. Defaults to 24. Non-integer or non-positive values are silently ignored and the default applies. |
+| `AFK_WEB_ALLOW_PRIVATE_HOSTS` | boolean |  |  | `1` | Opt out of the web_scrape SSRF egress guard. When unset (default) the guard is ACTIVE: the markdown, raw, and headless-render paths refuse loopback (127/8, ::1), link-local (169.254/16 — including the 169.254.169.254 cloud instance-metadata endpoint), RFC1918 (10/8, 172.16/12, 192.168/16), carrier-grade NAT (100.64/10), IPv6 unique-local (fc00::/7), 0.0.0.0/8, and the IPv4-mapped/compatible IPv6 forms of all of those. Hostnames are resolved and the RESOLVED addresses are classified (DNS-rebinding guard), and the check is re-applied on every redirect hop. Set to 1/true to allow private-host access — needed only to scrape a local dev server. Enabling it restores a model-reachable SSRF path (issue #575). |
 | `AFK_WRITE_DENYLIST` | string |  |  | `**/.env,**/secrets/**` | Comma-separated list of additional path globs that the write_file tool refuses to write to. |
 | `AFK_WRITE_DIFF` | boolean |  |  |  | Show a diff preview before each write_file tool call. Defaults provider-controlled when unset. |

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "string-width": "^8.2.0",
     "telegraf": "^4.16.3",
     "turndown": "^7.2.4",
+    "undici": "^7.27.0",
     "wrap-ansi": "^10.0.0",
     "zod": "^4.3.6"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       turndown:
         specifier: ^7.2.4
         version: 7.2.4
+      undici:
+        specifier: ^7.27.0
+        version: 7.27.0
       wrap-ansi:
         specifier: ^10.0.0
         version: 10.0.0

--- a/src/agent/tools/handlers/web-scrape.test.ts
+++ b/src/agent/tools/handlers/web-scrape.test.ts
@@ -32,6 +32,18 @@ function makeFetch(handler: (url: string, init: RequestInit) => Promise<Response
 
 const signal = (): AbortSignal => new AbortController().signal;
 
+/**
+ * Hermetic DNS seam for the SSRF egress guard (issue #575). Every handler in
+ * this file injects it so the guard classifies a fixed PUBLIC address instead of
+ * issuing a real `dns.lookup` — that keeps the suite offline and, critically,
+ * keeps the guard's pre-check off the macrotask queue so the cancellation tests
+ * still observe fetch being reached. Guard behaviour itself is covered in
+ * `src/web/egress-guard.test.ts`.
+ */
+const publicLookup = async (): Promise<readonly { address: string }[]> => [
+  { address: '93.184.216.34' },
+];
+
 /** A content-rich, server-rendered article that survives Readability. */
 function richArticleHtml(marker = 'main article content'): string {
   const paras = Array.from(
@@ -61,6 +73,7 @@ describe('web_scrape handler — input validation', () => {
   const handler = createWebScrapeHandler({
     fetchFn: makeFetch(() => makeResponse({ body: 'unused' })),
     env: {},
+    lookupFn: publicLookup,
   });
 
   it('rejects non-object input', async () => {
@@ -122,7 +135,7 @@ describe('web_scrape handler — markdown mode (fetch-first)', () => {
   it('fetches the URL, extracts main content, and returns markdown — no render', async () => {
     const renderFn = vi.fn<RenderFn>(async () => ({ html: '', finalUrl: '', httpStatus: 200 }));
     const fetchFn = makeFetch(() => makeResponse({ contentType: 'text/html', body: richArticleHtml() }));
-    const handler = createWebScrapeHandler({ fetchFn, env: {}, renderFn });
+    const handler = createWebScrapeHandler({ fetchFn, env: {}, renderFn, lookupFn: publicLookup });
 
     const r = await handler({ url: 'https://example.com/article' }, signal());
     expect(r.isError).toBeUndefined();
@@ -135,7 +148,7 @@ describe('web_scrape handler — markdown mode (fetch-first)', () => {
 
   it('requires no API key for markdown mode', async () => {
     const fetchFn = makeFetch(() => makeResponse({ contentType: 'text/html', body: richArticleHtml() }));
-    const handler = createWebScrapeHandler({ fetchFn, env: {} });
+    const handler = createWebScrapeHandler({ fetchFn, env: {}, lookupFn: publicLookup });
     const r = await handler({ url: 'https://example.com/article' }, signal());
     expect(r.isError).toBeUndefined();
     expect(r.content).toContain('main article content');
@@ -149,7 +162,7 @@ describe('web_scrape handler — markdown mode (fetch-first)', () => {
       finalUrl: 'https://example.com/app',
       httpStatus: 200,
     }));
-    const handler = createWebScrapeHandler({ fetchFn, env: {}, renderFn });
+    const handler = createWebScrapeHandler({ fetchFn, env: {}, renderFn, lookupFn: publicLookup });
 
     const r = await handler({ url: 'https://example.com/app' }, signal());
     expect(r.isError).toBeUndefined();
@@ -162,7 +175,7 @@ describe('web_scrape handler — markdown mode (fetch-first)', () => {
     const fetchFn = makeFetch(() => makeResponse({ contentType: 'text/html', body: empty }));
     // Render also yields nothing.
     const renderFn = vi.fn<RenderFn>(async () => ({ html: empty, finalUrl: 'https://e.com', httpStatus: 200 }));
-    const handler = createWebScrapeHandler({ fetchFn, env: {}, renderFn });
+    const handler = createWebScrapeHandler({ fetchFn, env: {}, renderFn, lookupFn: publicLookup });
 
     const r = await handler({ url: 'https://example.com/empty' }, signal());
     expect(r.isError).toBe(true);
@@ -176,7 +189,7 @@ describe('web_scrape handler — markdown mode (fetch-first)', () => {
     const renderFn = vi.fn<RenderFn>(async () => {
       throw new Error('Cannot find package playwright');
     });
-    const handler = createWebScrapeHandler({ fetchFn, env: {}, renderFn });
+    const handler = createWebScrapeHandler({ fetchFn, env: {}, renderFn, lookupFn: publicLookup });
 
     const r = await handler({ url: 'https://example.com/x' }, signal());
     expect(r.isError).toBe(true);
@@ -202,7 +215,7 @@ describe('web_scrape handler — markdown mode (fetch-first)', () => {
     const renderFn = vi.fn<RenderFn>(async () => {
       throw decorated;
     });
-    const handler = createWebScrapeHandler({ fetchFn, env: {}, renderFn });
+    const handler = createWebScrapeHandler({ fetchFn, env: {}, renderFn, lookupFn: publicLookup });
 
     const r = await handler({ url: 'https://example.com/x' }, signal());
     expect(r.isError).toBe(true);
@@ -221,7 +234,7 @@ describe('web_scrape handler — raw mode', () => {
       seenInit = init;
       return makeResponse({ body: '{"ok":true}' });
     });
-    const handler = createWebScrapeHandler({ fetchFn, env: {} });
+    const handler = createWebScrapeHandler({ fetchFn, env: {}, lookupFn: publicLookup });
     const r = await handler({ mode: 'raw', url: 'https://api.example.com/v1/x' }, signal());
     expect(r.isError).toBeUndefined();
     expect(seenUrl).toBe('https://api.example.com/v1/x');
@@ -233,7 +246,7 @@ describe('web_scrape handler — raw mode', () => {
 
   it('returns isError on non-2xx response', async () => {
     const fetchFn = makeFetch(() => makeResponse({ status: 404, statusText: 'Not Found', body: '' }));
-    const handler = createWebScrapeHandler({ fetchFn, env: {} });
+    const handler = createWebScrapeHandler({ fetchFn, env: {}, lookupFn: publicLookup });
     const r = await handler({ mode: 'raw', url: 'https://example.com/missing' }, signal());
     expect(r.isError).toBe(true);
     expect(r.content).toMatch(/HTTP 404 Not Found/);
@@ -243,7 +256,7 @@ describe('web_scrape handler — raw mode', () => {
     const fetchFn = makeFetch(() => {
       throw new Error('ECONNREFUSED');
     });
-    const handler = createWebScrapeHandler({ fetchFn, env: {} });
+    const handler = createWebScrapeHandler({ fetchFn, env: {}, lookupFn: publicLookup });
     const r = await handler({ mode: 'raw', url: 'https://example.com' }, signal());
     expect(r.isError).toBe(true);
     expect(r.content).toMatch(/network error: ECONNREFUSED/);
@@ -264,7 +277,7 @@ describe('web_scrape handler — search mode (Exa)', () => {
         { title: 'Result 2', highlights: ['desc 2'], url: 'https://r2.example' },
       ]);
     }) as unknown as FetchFn;
-    const handler = createWebScrapeHandler({ fetchFn, env: { EXA_API_KEY: 'exa-secret' } });
+    const handler = createWebScrapeHandler({ fetchFn, env: { EXA_API_KEY: 'exa-secret' }, lookupFn: publicLookup });
 
     const r = await handler({ mode: 'search', query: 'playwright scraping' }, signal());
     expect(r.isError).toBeUndefined();
@@ -279,7 +292,7 @@ describe('web_scrape handler — search mode (Exa)', () => {
 
   it('returns a clear error (and makes no request) when EXA_API_KEY is unset', async () => {
     const fetchFn = vi.fn(async () => makeResponse({ body: '' })) as unknown as FetchFn;
-    const handler = createWebScrapeHandler({ fetchFn, env: {} });
+    const handler = createWebScrapeHandler({ fetchFn, env: {}, lookupFn: publicLookup });
     const r = await handler({ mode: 'search', query: 'whatever' }, signal());
     expect(r.isError).toBe(true);
     expect(r.content).toMatch(/EXA_API_KEY/);
@@ -295,7 +308,7 @@ describe('web_scrape handler — search mode (Exa)', () => {
       text: async (): Promise<string> => 'quota exceeded',
       json: async (): Promise<unknown> => ({}),
     } as unknown as Response)) as unknown as FetchFn;
-    const handler = createWebScrapeHandler({ fetchFn, env: { EXA_API_KEY: 'k' } });
+    const handler = createWebScrapeHandler({ fetchFn, env: { EXA_API_KEY: 'k' }, lookupFn: publicLookup });
     const r = await handler({ mode: 'search', query: 'q' }, signal());
     expect(r.isError).toBe(true);
     expect(r.content).toMatch(/search error \(exa\)/);
@@ -304,7 +317,7 @@ describe('web_scrape handler — search mode (Exa)', () => {
 
   it('handles an empty result set without throwing', async () => {
     const fetchFn = vi.fn(async () => exaResponse([])) as unknown as FetchFn;
-    const handler = createWebScrapeHandler({ fetchFn, env: { EXA_API_KEY: 'k' } });
+    const handler = createWebScrapeHandler({ fetchFn, env: { EXA_API_KEY: 'k' }, lookupFn: publicLookup });
     const r = await handler({ mode: 'search', query: 'no hits' }, signal());
     expect(r.isError).toBeUndefined();
     expect(r.content).toMatch(/no results/);
@@ -320,7 +333,7 @@ describe('web_scrape handler — truncation', () => {
   it('truncates body exceeding max_bytes to head+tail with a marker and truncated:true (raw mode)', async () => {
     const big = 'x'.repeat(5000);
     const fetchFn = makeFetch(() => makeResponse({ body: big }));
-    const handler = createWebScrapeHandler({ fetchFn, env: {} });
+    const handler = createWebScrapeHandler({ fetchFn, env: {}, lookupFn: publicLookup });
     // 500 > the marker's ~160-byte reserve, so head AND tail are non-empty and
     // head-preservation is observable (a cap below the reserve degenerates to
     // marker-only, which is a headAndTail edge case, not what we assert here).
@@ -338,7 +351,7 @@ describe('web_scrape handler — truncation', () => {
   it('does NOT truncate body smaller than max_bytes (no marker, no truncated flag)', async () => {
     const small = 'hello world';
     const fetchFn = makeFetch(() => makeResponse({ body: small }));
-    const handler = createWebScrapeHandler({ fetchFn, env: {} });
+    const handler = createWebScrapeHandler({ fetchFn, env: {}, lookupFn: publicLookup });
     const r = await handler({ mode: 'raw', url: 'https://example.com', max_bytes: 1000 }, signal());
     expect(r.content).toBe(small);
     expect(r.truncated).toBeUndefined();
@@ -347,7 +360,7 @@ describe('web_scrape handler — truncation', () => {
   it('handles multi-byte UTF-8 cleanly (no garbage at the cut points)', async () => {
     const body = '🎉'.repeat(200); // 800 bytes; cut at 200 keeps head+tail of whole emoji
     const fetchFn = makeFetch(() => makeResponse({ body }));
-    const handler = createWebScrapeHandler({ fetchFn, env: {} });
+    const handler = createWebScrapeHandler({ fetchFn, env: {}, lookupFn: publicLookup });
     const r = await handler({ mode: 'raw', url: 'https://example.com', max_bytes: 200 }, signal());
     // Head begins on a code-point boundary and the tail ends on one — no U+FFFD.
     expect(r.content.startsWith('🎉')).toBe(true);
@@ -363,7 +376,7 @@ describe('web_scrape handler — truncation', () => {
     // (sub)agent context window (issue #661).
     const big = 'y'.repeat(150_000);
     const fetchFn = makeFetch(() => makeResponse({ body: big }));
-    const handler = createWebScrapeHandler({ fetchFn, env: {} });
+    const handler = createWebScrapeHandler({ fetchFn, env: {}, lookupFn: publicLookup });
     const r = await handler({ mode: 'raw', url: 'https://example.com' }, signal());
     expect(r.isError).toBeUndefined();
     expect(r.truncated).toBe(true);
@@ -377,7 +390,7 @@ describe('web_scrape handler — truncation', () => {
     // of caller-raised cap that let a 4MB body crash a child before #661.
     const twoMb = 'z'.repeat(2_000_000);
     const fetchFn = makeFetch(() => makeResponse({ body: twoMb }));
-    const handler = createWebScrapeHandler({ fetchFn, env: {} });
+    const handler = createWebScrapeHandler({ fetchFn, env: {}, lookupFn: publicLookup });
     const r = await handler({ mode: 'raw', url: 'https://example.com', max_bytes: 5_000_000 }, signal());
     expect(r.isError).toBeUndefined();
     expect(r.truncated).toBe(true);
@@ -399,7 +412,7 @@ describe('web_scrape handler — cancellation', () => {
         });
       });
     });
-    const handler = createWebScrapeHandler({ fetchFn, env: {} });
+    const handler = createWebScrapeHandler({ fetchFn, env: {}, lookupFn: publicLookup });
     const ac = new AbortController();
     const pending = handler({ mode: 'raw', url: 'https://example.com' }, ac.signal);
     await new Promise((r) => setImmediate(r));
@@ -420,7 +433,7 @@ describe('web_scrape handler — cancellation', () => {
         });
       });
     });
-    const handler = createWebScrapeHandler({ fetchFn, env: {} });
+    const handler = createWebScrapeHandler({ fetchFn, env: {}, lookupFn: publicLookup });
     const r = await handler({ mode: 'raw', url: 'https://example.com', timeout_ms: 20 }, signal());
     expect(r.isError).toBe(true);
     expect(r.content).toMatch(/timeout after 20ms/);
@@ -428,7 +441,7 @@ describe('web_scrape handler — cancellation', () => {
 
   it('returns immediately if signal is already aborted at call time, without calling fetch', async () => {
     const fetchFn = vi.fn(async () => makeResponse({ body: 'should not be called' })) as unknown as FetchFn;
-    const handler = createWebScrapeHandler({ fetchFn, env: {} });
+    const handler = createWebScrapeHandler({ fetchFn, env: {}, lookupFn: publicLookup });
     const ac = new AbortController();
     ac.abort(new Error('pre-cancelled'));
     const r = await handler({ url: 'https://example.com' }, ac.signal);
@@ -447,5 +460,103 @@ describe('web_scrape handler — runtime guard', () => {
     const r = await handler({ url: 'https://example.com' }, signal());
     expect(r.isError).toBe(true);
     expect(r.content).toMatch(/global fetch\(\) is not present/);
+  });
+});
+
+describe('web_scrape handler — SSRF egress guard (issue #575)', () => {
+  /** Resolves every hostname to loopback — the DNS-rebinding scenario. */
+  const rebindLookup = async (): Promise<readonly { address: string }[]> => [
+    { address: '127.0.0.1' },
+  ];
+
+  for (const mode of ['raw', 'markdown'] as const) {
+    it(`${mode} mode: refuses the cloud metadata IP without issuing a request`, async () => {
+      const fetchFn = vi.fn(async () => makeResponse({ body: 'must not be fetched' })) as unknown as FetchFn;
+      const handler = createWebScrapeHandler({ fetchFn, env: {}, lookupFn: publicLookup });
+      const r = await handler(
+        { mode, url: 'http://169.254.169.254/latest/meta-data/iam/security-credentials/' },
+        signal(),
+      );
+      expect(r.isError).toBe(true);
+      expect(r.content).toMatch(/^web_scrape blocked:/);
+      expect(r.content).toContain('169.254.169.254');
+      expect(r.content).toContain('AFK_WEB_ALLOW_PRIVATE_HOSTS');
+      expect(fetchFn).not.toHaveBeenCalled();
+    });
+
+    it(`${mode} mode: refuses loopback`, async () => {
+      const fetchFn = vi.fn(async () => makeResponse({ body: 'must not be fetched' })) as unknown as FetchFn;
+      const handler = createWebScrapeHandler({ fetchFn, env: {}, lookupFn: publicLookup });
+      const r = await handler({ mode, url: 'http://127.0.0.1:8080/admin' }, signal());
+      expect(r.isError).toBe(true);
+      expect(r.content).toMatch(/^web_scrape blocked:/);
+      expect(fetchFn).not.toHaveBeenCalled();
+    });
+
+    it(`${mode} mode: refuses RFC1918`, async () => {
+      const fetchFn = vi.fn(async () => makeResponse({ body: 'must not be fetched' })) as unknown as FetchFn;
+      const handler = createWebScrapeHandler({ fetchFn, env: {}, lookupFn: publicLookup });
+      const r = await handler({ mode, url: 'http://192.168.1.1/' }, signal());
+      expect(r.isError).toBe(true);
+      expect(r.content).toMatch(/^web_scrape blocked:/);
+      expect(fetchFn).not.toHaveBeenCalled();
+    });
+
+    it(`${mode} mode: refuses a hostname that resolves to loopback (DNS rebinding)`, async () => {
+      const fetchFn = vi.fn(async () => makeResponse({ body: 'must not be fetched' })) as unknown as FetchFn;
+      const handler = createWebScrapeHandler({ fetchFn, env: {}, lookupFn: rebindLookup });
+      const r = await handler({ mode, url: 'https://totally-safe.example.com/' }, signal());
+      expect(r.isError).toBe(true);
+      expect(r.content).toMatch(/^web_scrape blocked:/);
+      expect(r.content).toContain('127.0.0.1');
+      expect(fetchFn).not.toHaveBeenCalled();
+    });
+
+    it(`${mode} mode: refuses a redirect hop into internal space`, async () => {
+      const calls: string[] = [];
+      const fetchFn = makeFetch((url) => {
+        calls.push(url);
+        return new Response(null, {
+          status: 302,
+          headers: { location: 'http://169.254.169.254/latest/meta-data/' },
+        });
+      });
+      const handler = createWebScrapeHandler({ fetchFn, env: {}, lookupFn: publicLookup });
+      const r = await handler({ mode, url: 'https://public.example/redirector' }, signal());
+      expect(r.isError).toBe(true);
+      expect(r.content).toMatch(/^web_scrape blocked:/);
+      expect(r.content).toContain('169.254.169.254');
+      // Only the initial public hop was requested; the internal hop never was.
+      expect(calls).toEqual(['https://public.example/redirector']);
+    });
+  }
+
+  it('allows an internal host when AFK_WEB_ALLOW_PRIVATE_HOSTS=1 (raw mode)', async () => {
+    vi.stubEnv('AFK_WEB_ALLOW_PRIVATE_HOSTS', '1');
+    const fetchFn = makeFetch(() => makeResponse({ body: 'local dev server body' }));
+    const handler = createWebScrapeHandler({ fetchFn, env: {}, lookupFn: publicLookup });
+    const r = await handler({ mode: 'raw', url: 'http://127.0.0.1:3000/api' }, signal());
+    expect(r.isError).toBeUndefined();
+    expect(r.content).toBe('local dev server body');
+    vi.unstubAllEnvs();
+  });
+
+  it('still allows a normal public URL with the guard active', async () => {
+    const fetchFn = makeFetch(() => makeResponse({ body: 'public body' }));
+    const handler = createWebScrapeHandler({ fetchFn, env: {}, lookupFn: publicLookup });
+    const r = await handler({ mode: 'raw', url: 'https://example.com/x' }, signal());
+    expect(r.isError).toBeUndefined();
+    expect(r.content).toBe('public body');
+  });
+
+  it('does not consult the egress guard in search mode (no url to classify)', async () => {
+    const lookupFn = vi.fn(async () => {
+      throw new Error('search mode must not resolve DNS for the guard');
+    });
+    const fetchFn = makeFetch(() => exaResponse([{ title: 'T', url: 'https://a.example', highlights: ['h'] }]));
+    const handler = createWebScrapeHandler({ fetchFn, env: { EXA_API_KEY: 'k' }, lookupFn });
+    const r = await handler({ mode: 'search', query: 'anything' }, signal());
+    expect(r.isError).toBeUndefined();
+    expect(lookupFn).not.toHaveBeenCalled();
   });
 });

--- a/src/agent/tools/handlers/web-scrape.ts
+++ b/src/agent/tools/handlers/web-scrape.ts
@@ -18,13 +18,13 @@
  *     later). When no backend is configured the handler returns a clear,
  *     actionable error. See `src/web/search.ts`.
  *
- * Security note: this tool can issue arbitrary outbound HTTP(S) requests to
- * any host the operator's network can reach. The bash tool already has
- * unrestricted network access in agent-afk's threat model, so web_scrape does
- * not widen the surface — it just gives the model a structured, size-capped,
- * timeout-enforced alternative to `curl | head -c …`. The markdown render
- * escalation deliberately bypasses the interactive browser domain allowlist
- * for the same reason (see `BrowserProvider.render()`).
+ * Security note: every egress path here (raw, markdown fetch, headless render)
+ * goes through the SSRF egress guard in `src/web/egress-guard.ts` —
+ * internal/private targets refused, resolved IP classified, every redirect hop
+ * re-checked; see that module for the threat model (issue #575). The render
+ * escalation still bypasses the interactive browser domain allowlist
+ * (`BrowserProvider.render()`), which governs agent-driven navigation, but it
+ * does NOT bypass the egress guard.
  *
  * @module agent/tools/handlers/web-scrape
  */
@@ -32,7 +32,8 @@
 import type { ToolHandler } from '../types.js';
 import { scrapeToMarkdown } from '../../../web/scrape.js';
 import { resolveSearchBackend, formatSearchResults } from '../../../web/search.js';
-import { retryFetch } from '../../../web/retryFetch.js';
+import { checkEgressTarget, guardedFetch, EgressBlockedError } from '../../../web/egress-guard.js';
+import type { EgressGuardOptions as GuardOpts } from '../../../web/egress-guard.js';
 import type { RenderFn } from '../../../web/types.js';
 import { headAndTail } from './_output-cap.js';
 import {
@@ -70,6 +71,11 @@ interface WebScrapeOptions {
    * can exercise escalation without launching chromium.
    */
   renderFn?: RenderFn;
+  /**
+   * Override for tests: DNS resolution used by the SSRF egress guard. Defaults
+   * (inside the guard) to `dns/promises.lookup`, keeping tests off the network.
+   */
+  lookupFn?: GuardOpts['lookupFn'];
 }
 
 type Mode = 'markdown' | 'raw' | 'search';
@@ -160,6 +166,7 @@ function capBody(body: string, maxBytes: number): { content: string; truncated: 
 export function createWebScrapeHandler(opts: WebScrapeOptions = {}): ToolHandler {
   const fetchFn = opts.fetchFn ?? globalThis.fetch;
   const env = opts.env ?? process.env;
+  const guardOpts: GuardOpts = opts.lookupFn !== undefined ? { lookupFn: opts.lookupFn } : {};
 
   return async (input, signal) => {
     if (typeof fetchFn !== 'function') {
@@ -206,18 +213,40 @@ export function createWebScrapeHandler(opts: WebScrapeOptions = {}): ToolHandler
         ac.abort(new Error(`web_scrape timeout after ${parsed.timeoutMs}ms`));
       }, parsed.timeoutMs);
 
+      // Ordered-operation constraint: this SSRF pre-check is the handler's first
+      // `await` (the guard resolves DNS, so it cannot sit in the synchronous
+      // `parseInput`) and MUST come after the abort listener + timer are wired
+      // above — awaiting before that wiring drops a parent abort landing in the
+      // window, leaving the later fetch waiting on a cancel that never fires.
+      // The abort re-check below reports such a cancel as an abort, not a
+      // verdict. Redirect hops are re-validated inside the fetch paths; this
+      // pass just gives a blocked INITIAL url a clean refusal (issue #575).
+      if (parsed.url !== undefined) {
+        const verdict = await checkEgressTarget(parsed.url, guardOpts);
+        if (ac.signal.aborted) return { content: `web_scrape aborted: ${abortMessage()}`, isError: true };
+        if (!verdict.allowed) return { content: `web_scrape blocked: ${verdict.reason}`, isError: true };
+      }
+
       // ---- raw mode: direct GET, no transformation --------------------------
       if (parsed.mode === 'raw') {
         let res: Response;
         try {
-          // retryFetch survives transient 429/5xx + network blips (idempotent GET).
-          res = await retryFetch(fetchFn, parsed.url!, {
+          // guardedFetch = retryFetch (transient 429/5xx + network blips on an
+          // idempotent GET) behind the egress guard, which forces
+          // redirect:'manual' and re-validates every hop (issue #575).
+          const init = {
             method: 'GET',
             headers: { 'User-Agent': 'agent-afk/web_scrape', Accept: '*/*' },
             signal: ac.signal,
-          });
+          };
+          res = await guardedFetch(fetchFn, parsed.url!, init, guardOpts);
         } catch (err) {
           if (ac.signal.aborted) return { content: `web_scrape aborted: ${abortMessage()}`, isError: true };
+          // A redirect hop that landed on internal space — name the refusal
+          // rather than reporting it as a generic network failure.
+          if (err instanceof EgressBlockedError) {
+            return { content: `web_scrape blocked: ${err.message}`, isError: true };
+          }
           return {
             content: `web_scrape network error: ${err instanceof Error ? err.message : String(err)}`,
             isError: true,
@@ -251,6 +280,7 @@ export function createWebScrapeHandler(opts: WebScrapeOptions = {}): ToolHandler
             renderFn: opts.renderFn,
             timeoutMs: parsed.timeoutMs,
             signal: ac.signal,
+            ...(opts.lookupFn !== undefined ? { lookupFn: opts.lookupFn } : {}),
           });
           if (result.markdown.trim().length === 0) {
             return {
@@ -262,6 +292,12 @@ export function createWebScrapeHandler(opts: WebScrapeOptions = {}): ToolHandler
           return { content: capped.content, ...(capped.truncated ? { truncated: true } : {}) };
         } catch (err) {
           if (ac.signal.aborted) return { content: `web_scrape aborted: ${abortMessage()}`, isError: true };
+          // As in raw mode: a guard refusal (initial URL, redirect hop, or the
+          // render path's post-navigation re-check) is a policy decision, not a
+          // markdown-extraction failure.
+          if (err instanceof EgressBlockedError) {
+            return { content: `web_scrape blocked: ${err.message}`, isError: true };
+          }
           const base = err instanceof Error ? err.message : String(err);
           // A chromium-missing LAUNCH failure is already decorated by
           // BrowserLauncher, so `base` may carry the remediation. Only add it

--- a/src/browser/playwright/index.ts
+++ b/src/browser/playwright/index.ts
@@ -362,6 +362,7 @@ export class PlaywrightProvider implements BrowserProvider {
       timeoutMs: input.timeoutMs ?? 30000,
       waitUntil: input.waitFor ?? 'load',
       signal: input.signal,
+      requestGuard: input.requestGuard,
     });
   }
 

--- a/src/browser/playwright/launcher.test.ts
+++ b/src/browser/playwright/launcher.test.ts
@@ -34,6 +34,7 @@ interface StubPage {
 
 interface StubContext {
   newPage: ReturnType<typeof vi.fn>;
+  route: ReturnType<typeof vi.fn>;
   close: ReturnType<typeof vi.fn>;
   storageState: ReturnType<typeof vi.fn>;
   _pages: StubPage[];
@@ -88,6 +89,7 @@ function makeStubContext(): StubContext {
   const ctx: StubContext = {
     close: vi.fn().mockResolvedValue(undefined),
     newPage: vi.fn(),
+    route: vi.fn().mockResolvedValue(undefined),
     storageState: vi.fn().mockResolvedValue({ cookies: [{ name: 'sid', value: 'abc' }], origins: [] }),
     _pages: [],
   };
@@ -351,6 +353,43 @@ describe('BrowserLauncher', () => {
         launcher.renderHtml('https://nope.invalid', { timeoutMs: 5000, waitUntil: 'load' }),
       ).rejects.toThrow(/ERR_NAME_NOT_RESOLVED/);
       expect(ctx.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('checks every browser request before allowing it onto the network', async () => {
+      const launcher = new BrowserLauncher(TEST_CONFIG);
+      const ctx = makeStubContext();
+      currentStubBrowser.newContext.mockResolvedValueOnce(ctx);
+      const requestGuard = vi.fn(async (url: string) => {
+        if (url.includes('169.254.169.254')) throw new Error('private request blocked');
+      });
+
+      await launcher.renderHtml('https://example.com', {
+        timeoutMs: 5000,
+        waitUntil: 'load',
+        requestGuard,
+      });
+
+      const handler = ctx.route.mock.calls[0]?.[1] as (route: {
+        request: () => { url: () => string };
+        continue: () => Promise<void>;
+        abort: (reason: string) => Promise<void>;
+      }) => Promise<void>;
+      const allowed = {
+        request: () => ({ url: () => 'https://cdn.example/app.js' }),
+        continue: vi.fn().mockResolvedValue(undefined),
+        abort: vi.fn().mockResolvedValue(undefined),
+      };
+      await handler(allowed);
+      expect(allowed.continue).toHaveBeenCalledOnce();
+
+      const blocked = {
+        request: () => ({ url: () => 'http://169.254.169.254/latest' }),
+        continue: vi.fn().mockResolvedValue(undefined),
+        abort: vi.fn().mockResolvedValue(undefined),
+      };
+      await handler(blocked);
+      expect(blocked.continue).not.toHaveBeenCalled();
+      expect(blocked.abort).toHaveBeenCalledWith('blockedbyclient');
     });
 
     it('short-circuits a pre-aborted signal without navigating', async () => {

--- a/src/browser/playwright/launcher.ts
+++ b/src/browser/playwright/launcher.ts
@@ -341,10 +341,24 @@ export class BrowserLauncher {
       timeoutMs: number;
       waitUntil: 'load' | 'domcontentloaded' | 'networkidle';
       signal?: AbortSignal;
+      requestGuard?: (url: string) => Promise<void>;
     },
   ): Promise<{ html: string; finalUrl: string; httpStatus: number | null }> {
     const browser = await this.ensureBrowser();
     const context = await browser.newContext(this.contextOptions());
+    let guardError: unknown;
+
+    if (opts.requestGuard !== undefined) {
+      await context.route('**/*', async (route) => {
+        try {
+          await opts.requestGuard!(route.request().url());
+          await route.continue();
+        } catch (err) {
+          guardError = err;
+          await route.abort('blockedbyclient');
+        }
+      });
+    }
 
     const onAbort = (): void => {
       void context.close().catch(() => {
@@ -363,11 +377,21 @@ export class BrowserLauncher {
 
     try {
       const page = await context.newPage();
-      const resp = await page.goto(url, {
-        timeout: opts.timeoutMs,
-        waitUntil: opts.waitUntil,
-      });
+      let resp;
+      try {
+        resp = await page.goto(url, {
+          timeout: opts.timeoutMs,
+          waitUntil: opts.waitUntil,
+        });
+      } catch (err) {
+        throw guardError ?? err;
+      }
+      if (guardError !== undefined) throw guardError;
       const html = await page.content();
+      // A script can start a request immediately after the load event. Do not
+      // return successful content if the route guard rejected such a late
+      // subresource while the DOM was being serialized.
+      if (guardError !== undefined) throw guardError;
       const finalUrl = page.url();
       const httpStatus = resp !== null ? resp.status() : null;
       return { html, finalUrl, httpStatus };

--- a/src/browser/types.ts
+++ b/src/browser/types.ts
@@ -265,6 +265,8 @@ export interface RenderInput {
   waitFor?: WaitForOption;
   /** Optional cancellation — aborting tears down the ephemeral context. */
   signal?: AbortSignal;
+  /** Optional egress check applied before every navigation and subresource request. */
+  requestGuard?: (url: string) => Promise<void>;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1255,6 +1255,24 @@ export const ENV_REGISTRY: readonly EnvVarMeta[] = [
     category: 'misc',
   },
 
+  // ── Web egress ────────────────────────────────────────────────────────────
+  {
+    name: 'AFK_WEB_ALLOW_PRIVATE_HOSTS',
+    description:
+      'Opt out of the web_scrape SSRF egress guard. When unset (default) the guard is ACTIVE: ' +
+      'the markdown, raw, and headless-render paths refuse loopback (127/8, ::1), link-local ' +
+      '(169.254/16 — including the 169.254.169.254 cloud instance-metadata endpoint), RFC1918 ' +
+      '(10/8, 172.16/12, 192.168/16), carrier-grade NAT (100.64/10), IPv6 unique-local (fc00::/7), ' +
+      '0.0.0.0/8, and the IPv4-mapped/compatible IPv6 forms of all of those. Hostnames are ' +
+      'resolved and the RESOLVED addresses are classified (DNS-rebinding guard), and the check is ' +
+      're-applied on every redirect hop. Set to 1/true to allow private-host access — needed only ' +
+      'to scrape a local dev server. Enabling it restores a model-reachable SSRF path (issue #575).',
+    type: 'boolean',
+    required: false,
+    example: '1',
+    category: 'misc',
+  },
+
   // ── CLI / capture-mode ────────────────────────────────────────────────────
   {
     name: 'AFK_DEMO_CLEAN',
@@ -1525,6 +1543,9 @@ export const env = {
   get AFK_WRITE_DENYLIST(): string | undefined { return process.env['AFK_WRITE_DENYLIST']; },
   get AFK_READ_DENYLIST(): string | undefined { return process.env['AFK_READ_DENYLIST']; },
   get AFK_WRITE_DIFF(): string | undefined { return process.env['AFK_WRITE_DIFF']; },
+
+  // Web egress
+  get AFK_WEB_ALLOW_PRIVATE_HOSTS(): string | undefined { return process.env['AFK_WEB_ALLOW_PRIVATE_HOSTS']; },
 
   // CLI / capture-mode
   get AFK_DEMO_CLEAN(): string | undefined { return process.env['AFK_DEMO_CLEAN']; },

--- a/src/web/egress-guard.test.ts
+++ b/src/web/egress-guard.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Unit tests for the SSRF egress guard (src/web/egress-guard.ts).
+ *
+ * Strategy: inject `lookupFn` so no real DNS is issued, and inject `fetchFn`
+ * into `guardedFetch` so no real socket is opened. The behaviours under test are
+ * the per-range classification, the DNS-rebinding guard (hostname resolving to
+ * internal space), per-redirect-hop re-validation, and the env opt-out.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  assertEgressAllowed,
+  checkEgressTarget,
+  guardedFetch,
+  privateHostsAllowed,
+  EgressBlockedError,
+} from './egress-guard.js';
+
+/** A lookupFn that resolves every hostname to the given addresses. */
+function fixedLookup(...addresses: string[]) {
+  return vi.fn(async () => addresses.map((address) => ({ address })));
+}
+
+/** A lookupFn that always resolves to a public address (never blocked). */
+const publicLookup = fixedLookup('93.184.216.34');
+
+/** Never called — asserts a code path classified an IP literal without DNS. */
+const throwingLookup = vi.fn(async () => {
+  throw new Error('lookupFn must not be called for an IP literal');
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('checkEgressTarget — blocked IPv4 ranges', () => {
+  const blocked: ReadonlyArray<readonly [string, string]> = [
+    ['loopback 127.0.0.1', 'http://127.0.0.1/'],
+    ['loopback elsewhere in 127/8', 'http://127.9.9.9/'],
+    ['0.0.0.0 (RFC1122 this-network)', 'http://0.0.0.0/'],
+    ['0.0.0.0/8 member', 'http://0.1.2.3/'],
+    ['cloud metadata 169.254.169.254', 'http://169.254.169.254/latest/meta-data/'],
+    ['link-local 169.254/16', 'http://169.254.1.1/'],
+    ['RFC1918 10/8', 'http://10.0.0.1/'],
+    ['RFC1918 172.16/12 low', 'http://172.16.0.1/'],
+    ['RFC1918 172.16/12 high', 'http://172.31.255.255/'],
+    ['RFC1918 192.168/16', 'http://192.168.1.1/'],
+    ['carrier-grade NAT 100.64/10', 'http://100.64.0.1/'],
+  ];
+
+  for (const [label, url] of blocked) {
+    it(`blocks ${label}`, async () => {
+      const v = await checkEgressTarget(url, { lookupFn: throwingLookup });
+      expect(v.allowed).toBe(false);
+      expect(v.allowed === false && v.reason).toMatch(/internal\/private address/);
+    });
+  }
+
+  it('names the offending address and the opt-out in the refusal', async () => {
+    const v = await checkEgressTarget('http://169.254.169.254/', { lookupFn: throwingLookup });
+    expect(v.allowed === false && v.reason).toContain('169.254.169.254');
+    expect(v.allowed === false && v.reason).toContain('AFK_WEB_ALLOW_PRIVATE_HOSTS');
+  });
+
+  it('classifies IP literals without issuing DNS', async () => {
+    await checkEgressTarget('http://10.0.0.1/', { lookupFn: throwingLookup });
+    expect(throwingLookup).not.toHaveBeenCalled();
+  });
+});
+
+describe('checkEgressTarget — blocked IPv6 ranges', () => {
+  const blocked: ReadonlyArray<readonly [string, string]> = [
+    ['loopback ::1', 'http://[::1]/'],
+    ['unspecified ::', 'http://[::]/'],
+    ['ULA fc00::/7 (fc)', 'http://[fc00::1]/'],
+    ['ULA fc00::/7 (fd)', 'http://[fd12:3456::1]/'],
+    ['link-local fe80::/10', 'http://[fe80::1]/'],
+    ['IPv4-compatible ::127.0.0.1', 'http://[::7f00:1]/'],
+    ['NAT64 64:ff9b::/96 embedding loopback', 'http://[64:ff9b::7f00:1]/'],
+  ];
+
+  for (const [label, url] of blocked) {
+    it(`blocks ${label}`, async () => {
+      const v = await checkEgressTarget(url, { lookupFn: throwingLookup });
+      expect(v.allowed).toBe(false);
+    });
+  }
+
+  const mapped: ReadonlyArray<readonly [string, string]> = [
+    ['IPv4-mapped loopback', 'http://[::ffff:127.0.0.1]/'],
+    ['IPv4-mapped metadata IP', 'http://[::ffff:169.254.169.254]/'],
+    ['IPv4-mapped RFC1918', 'http://[::ffff:10.0.0.1]/'],
+    ['IPv4-mapped RFC1918 (hex form)', 'http://[::ffff:c0a8:1]/'],
+  ];
+
+  for (const [label, url] of mapped) {
+    it(`blocks ${label}`, async () => {
+      const v = await checkEgressTarget(url, { lookupFn: throwingLookup });
+      expect(v.allowed).toBe(false);
+    });
+  }
+
+  it('allows a public IPv6 literal', async () => {
+    const v = await checkEgressTarget('http://[2606:4700::1111]/', { lookupFn: throwingLookup });
+    expect(v.allowed).toBe(true);
+  });
+
+  it('allows an IPv4-mapped PUBLIC address', async () => {
+    const v = await checkEgressTarget('http://[::ffff:8.8.8.8]/', { lookupFn: throwingLookup });
+    expect(v.allowed).toBe(true);
+  });
+});
+
+describe('checkEgressTarget — public targets and near-miss boundaries', () => {
+  const allowed = [
+    'http://8.8.8.8/',
+    'https://1.1.1.1/',
+    'http://172.15.0.1/', // just below 172.16/12
+    'http://172.32.0.1/', // just above 172.16/12
+    'http://11.0.0.1/', // just above 10/8
+    'http://100.63.255.255/', // just below 100.64/10
+    'http://100.128.0.1/', // just above 100.64/10
+  ];
+
+  for (const url of allowed) {
+    it(`allows ${url}`, async () => {
+      const v = await checkEgressTarget(url, { lookupFn: throwingLookup });
+      expect(v.allowed).toBe(true);
+    });
+  }
+
+  it('allows a hostname resolving to a public address', async () => {
+    const v = await checkEgressTarget('https://example.com/a', { lookupFn: publicLookup });
+    expect(v.allowed).toBe(true);
+  });
+
+  it('rejects a non-http(s) scheme', async () => {
+    const v = await checkEgressTarget('file:///etc/passwd', { lookupFn: throwingLookup });
+    expect(v.allowed).toBe(false);
+    expect(v.allowed === false && v.reason).toMatch(/not supported \(http\/https only\)/);
+  });
+
+  it('rejects an unparseable URL', async () => {
+    const v = await checkEgressTarget('not-a-url', { lookupFn: throwingLookup });
+    expect(v.allowed).toBe(false);
+    expect(v.allowed === false && v.reason).toMatch(/not a valid absolute URL/);
+  });
+
+  it('does not block on DNS failure — fetch surfaces the real network error', async () => {
+    const failing = vi.fn(async () => {
+      throw Object.assign(new Error('getaddrinfo ENOTFOUND'), { code: 'ENOTFOUND' });
+    });
+    const v = await checkEgressTarget('https://nx.example/', { lookupFn: failing });
+    expect(v.allowed).toBe(true);
+  });
+});
+
+describe('checkEgressTarget — DNS-rebinding guard (resolved IP, not the literal)', () => {
+  it('blocks a benign-looking hostname that resolves to 127.0.0.1', async () => {
+    const lookupFn = fixedLookup('127.0.0.1');
+    const v = await checkEgressTarget('https://totally-safe.example.com/', { lookupFn });
+    expect(v.allowed).toBe(false);
+    expect(v.allowed === false && v.reason).toContain('127.0.0.1');
+    expect(v.allowed === false && v.reason).toContain('resolved');
+    expect(lookupFn).toHaveBeenCalledWith('totally-safe.example.com');
+  });
+
+  it('blocks a hostname that resolves to the cloud metadata IP', async () => {
+    const v = await checkEgressTarget('https://metadata.attacker.example/', {
+      lookupFn: fixedLookup('169.254.169.254'),
+    });
+    expect(v.allowed).toBe(false);
+  });
+
+  it('blocks when ANY resolved record is internal (mixed public + internal)', async () => {
+    const v = await checkEgressTarget('https://mixed.example/', {
+      lookupFn: fixedLookup('93.184.216.34', '10.1.2.3'),
+    });
+    expect(v.allowed).toBe(false);
+    expect(v.allowed === false && v.reason).toContain('10.1.2.3');
+  });
+
+  it('blocks a hostname resolving to an internal IPv6 address', async () => {
+    const v = await checkEgressTarget('https://v6.example/', { lookupFn: fixedLookup('fd00::1') });
+    expect(v.allowed).toBe(false);
+  });
+
+  it('blocks decimal/short-form loopback encodings via URL normalization', async () => {
+    for (const url of ['http://2130706433/', 'http://127.1/', 'http://0x7f.0.0.1/', 'http://0/']) {
+      const v = await checkEgressTarget(url, { lookupFn: throwingLookup });
+      expect(v.allowed, url).toBe(false);
+    }
+  });
+
+  it('blocks `localhost` when it resolves to loopback', async () => {
+    const v = await checkEgressTarget('http://localhost:8080/admin', {
+      lookupFn: fixedLookup('::1', '127.0.0.1'),
+    });
+    expect(v.allowed).toBe(false);
+  });
+});
+
+describe('assertEgressAllowed', () => {
+  it('throws EgressBlockedError on a blocked target', async () => {
+    await expect(
+      assertEgressAllowed('http://169.254.169.254/', { lookupFn: throwingLookup }),
+    ).rejects.toThrow(EgressBlockedError);
+  });
+
+  it('resolves silently for an allowed target', async () => {
+    await expect(
+      assertEgressAllowed('https://example.com/', { lookupFn: publicLookup }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('AFK_WEB_ALLOW_PRIVATE_HOSTS opt-out', () => {
+  it('is off by default — guard active', async () => {
+    expect(privateHostsAllowed()).toBe(false);
+    const v = await checkEgressTarget('http://127.0.0.1:3000/', { lookupFn: throwingLookup });
+    expect(v.allowed).toBe(false);
+  });
+
+  for (const raw of ['1', 'true', 'TRUE', ' 1 ']) {
+    it(`allows private hosts when set to ${JSON.stringify(raw)}`, async () => {
+      vi.stubEnv('AFK_WEB_ALLOW_PRIVATE_HOSTS', raw);
+      expect(privateHostsAllowed()).toBe(true);
+      const v = await checkEgressTarget('http://127.0.0.1:3000/', { lookupFn: throwingLookup });
+      expect(v.allowed).toBe(true);
+    });
+  }
+
+  for (const raw of ['0', 'false', '', 'yes']) {
+    it(`keeps the guard active for ${JSON.stringify(raw)}`, async () => {
+      vi.stubEnv('AFK_WEB_ALLOW_PRIVATE_HOSTS', raw);
+      const v = await checkEgressTarget('http://127.0.0.1:3000/', { lookupFn: throwingLookup });
+      expect(v.allowed).toBe(false);
+    });
+  }
+
+  it('opt-out also bypasses the redirect-hop check in guardedFetch', async () => {
+    const fetchFn = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      return url.includes('127.0.0.1')
+        ? new Response('internal', { status: 200 })
+        : new Response(null, { status: 302, headers: { location: 'http://127.0.0.1/admin' } });
+    });
+    const res = await guardedFetch(fetchFn as unknown as typeof fetch, 'https://public.example/', {}, {
+      allowPrivateHosts: true,
+      lookupFn: publicLookup,
+    });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('internal');
+  });
+});
+
+describe('guardedFetch — per-redirect-hop re-validation', () => {
+  const noRetrySleep = { sleep: async (): Promise<void> => undefined };
+
+  it('blocks a public URL that redirects to the cloud metadata IP', async () => {
+    const fetchFn = vi.fn(async () =>
+      new Response(null, {
+        status: 302,
+        headers: { location: 'http://169.254.169.254/latest/meta-data/iam/' },
+      }),
+    );
+    await expect(
+      guardedFetch(fetchFn as unknown as typeof fetch, 'https://public.example/', {}, {
+        lookupFn: publicLookup,
+        retry: noRetrySleep,
+      }),
+    ).rejects.toThrow(EgressBlockedError);
+    // The first hop was fetched; the blocked hop was never requested.
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(String(fetchFn.mock.calls[0]?.[0])).toBe('https://public.example/');
+  });
+
+  it('forces redirect:"manual" so hops cannot be followed opaquely', async () => {
+    const fetchFn = vi.fn(async () => new Response('ok', { status: 200 }));
+    await guardedFetch(fetchFn as unknown as typeof fetch, 'https://public.example/', {}, {
+      lookupFn: publicLookup,
+    });
+    const init = fetchFn.mock.calls[0]?.[1] as RequestInit;
+    expect(init.redirect).toBe('manual');
+  });
+
+  it('blocks a RELATIVE redirect that lands on an internal host', async () => {
+    // Hop 1 is a public host; hop 2 resolves (via DNS) to loopback.
+    const lookupFn = vi.fn(async (hostname: string) => [
+      { address: hostname === 'internal.example' ? '127.0.0.1' : '93.184.216.34' },
+    ]);
+    const fetchFn = vi.fn(async () =>
+      new Response(null, { status: 301, headers: { location: '//internal.example/x' } }),
+    );
+    await expect(
+      guardedFetch(fetchFn as unknown as typeof fetch, 'https://public.example/start', {}, {
+        lookupFn,
+        retry: noRetrySleep,
+      }),
+    ).rejects.toThrow(/internal\/private address 127\.0\.0\.1/);
+  });
+
+  it('follows a multi-hop chain of public URLs and returns the final response', async () => {
+    const chain: Record<string, Response> = {
+      'https://a.example/': new Response(null, { status: 302, headers: { location: 'https://b.example/' } }),
+      'https://b.example/': new Response(null, { status: 307, headers: { location: '/final' } }),
+      'https://b.example/final': new Response('landed', { status: 200 }),
+    };
+    const seen: string[] = [];
+    const fetchFn = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      seen.push(url);
+      const res = chain[url];
+      if (res === undefined) throw new Error(`unexpected fetch: ${url}`);
+      // `res.url` is empty on a constructed Response, so guardedFetch resolves
+      // a relative Location against the requested URL — exercised by /final.
+      return res;
+    });
+    const res = await guardedFetch(fetchFn as unknown as typeof fetch, 'https://a.example/', {}, {
+      lookupFn: publicLookup,
+    });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('landed');
+    expect(seen).toEqual(['https://a.example/', 'https://b.example/', 'https://b.example/final']);
+  });
+
+  it('returns a redirect response verbatim when Location is missing', async () => {
+    const fetchFn = vi.fn(async () => new Response(null, { status: 302 }));
+    const res = await guardedFetch(fetchFn as unknown as typeof fetch, 'https://public.example/', {}, {
+      lookupFn: publicLookup,
+    });
+    expect(res.status).toBe(302);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('blocks the INITIAL url before issuing any request', async () => {
+    const fetchFn = vi.fn(async () => new Response('should not happen', { status: 200 }));
+    await expect(
+      guardedFetch(fetchFn as unknown as typeof fetch, 'http://169.254.169.254/', {}, {
+        lookupFn: throwingLookup,
+      }),
+    ).rejects.toThrow(EgressBlockedError);
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('throws rather than looping forever on a redirect cycle', async () => {
+    const fetchFn = vi.fn(async (input: RequestInfo | URL) =>
+      new Response(null, {
+        status: 302,
+        headers: { location: String(input).endsWith('/b') ? 'https://loop.example/a' : 'https://loop.example/b' },
+      }),
+    );
+    await expect(
+      guardedFetch(fetchFn as unknown as typeof fetch, 'https://loop.example/a', {}, {
+        lookupFn: publicLookup,
+      }),
+    ).rejects.toThrow(/too many redirects/);
+  });
+});

--- a/src/web/egress-guard.ts
+++ b/src/web/egress-guard.ts
@@ -30,6 +30,7 @@
 
 import { BlockList, isIP } from 'node:net';
 import { lookup } from 'node:dns/promises';
+import { Agent } from 'undici';
 import { env } from '../config/env.js';
 import { retryFetch, type RetryFetchOptions } from './retryFetch.js';
 import type { FetchFn } from './types.js';
@@ -129,6 +130,42 @@ function isBlockedAddress(ip: string): boolean {
   if (family === 0) return false;
   return blockList.check(ip, family === 4 ? 'ipv4' : 'ipv6');
 }
+
+/**
+ * Undici resolves through this callback at socket-connect time. Classifying
+ * all answers here closes the time-of-check/time-of-use gap that would exist
+ * if fetch performed a second, unchecked DNS lookup after the preflight.
+ */
+const guardedDispatcher = new Agent({
+  connect: {
+    lookup(hostname, _options, callback) {
+      void defaultLookup(hostname).then(
+        (records) => {
+          const blocked = records.find((record) => isBlockedAddress(record.address));
+          if (blocked !== undefined) {
+            callback(
+              new EgressBlockedError(
+                `refusing to connect to ${hostname} (resolved) — internal/private address ` +
+                  `${blocked.address} (loopback, link-local, cloud metadata, or RFC1918 space). ` +
+                  'Set AFK_WEB_ALLOW_PRIVATE_HOSTS=1 to allow private-host access.',
+              ),
+              '',
+              0,
+            );
+            return;
+          }
+          const selected = records[0];
+          if (selected === undefined) {
+            callback(new Error(`DNS lookup returned no addresses for ${hostname}`), '', 0);
+            return;
+          }
+          callback(null, selected.address, isIP(selected.address));
+        },
+        (err: unknown) => callback(err as Error, '', 0),
+      );
+    },
+  },
+});
 
 async function defaultLookup(hostname: string): Promise<readonly { address: string }[]> {
   return lookup(hostname, { all: true, verbatim: true });
@@ -259,7 +296,17 @@ export async function guardedFetch(
   let target = url;
   for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
     await assertEgressAllowed(target, guardOpts);
-    const res = await retryFetch(fetchFn, target, { ...init, redirect: 'manual' }, opts.retry ?? {});
+    // Production fetches use an Undici dispatcher whose lookup callback
+    // classifies the exact DNS answer used for the socket. Injected test
+    // fetches retain the standard RequestInit surface.
+    const requestInit = {
+      ...init,
+      redirect: 'manual' as const,
+      ...(fetchFn === globalThis.fetch && !(opts.allowPrivateHosts ?? privateHostsAllowed())
+        ? { dispatcher: guardedDispatcher }
+        : {}),
+    } as RequestInit;
+    const res = await retryFetch(fetchFn, target, requestInit, opts.retry ?? {});
     if (!REDIRECT_STATUS.has(res.status)) return res;
 
     const location = res.headers.get('location');

--- a/src/web/egress-guard.ts
+++ b/src/web/egress-guard.ts
@@ -1,0 +1,282 @@
+/**
+ * SSRF egress guard for the `src/web/` fetch layer.
+ *
+ * `web_scrape` is an always-on builtin: the model can call it with any URL, and
+ * — because it returns page content back into context — a scraped page can
+ * prompt-inject a follow-up fetch. Without a host filter that is a live SSRF
+ * primitive reaching cloud instance metadata (`169.254.169.254` → IAM
+ * credentials), `localhost` admin surfaces, and every RFC1918 internal service.
+ * This module is the single classifier all egress paths consult (issue #575).
+ *
+ * Two entry points, both async because both resolve DNS:
+ *
+ *   - {@link assertEgressAllowed} — throws {@link EgressBlockedError} on a
+ *     blocked target. Used inside the scraper, where a throw is already the
+ *     failure channel.
+ *   - {@link checkEgressTarget} — returns a structured verdict. Used by the
+ *     handler's input validation, which surfaces a `ToolResult` refusal.
+ *
+ * Why resolve DNS rather than pattern-match the hostname: a hostname is an
+ * attacker-controlled indirection. `internal.attacker.example` with an A record
+ * of `127.0.0.1` passes any lexical check. We resolve and classify every
+ * returned address, so the decision is made on where the connection would
+ * actually land.
+ *
+ * Escape hatch: `AFK_WEB_ALLOW_PRIVATE_HOSTS=1` disables the guard wholesale,
+ * for operators who legitimately scrape a local dev server. Off by default.
+ *
+ * @module web/egress-guard
+ */
+
+import { BlockList, isIP } from 'node:net';
+import { lookup } from 'node:dns/promises';
+import { env } from '../config/env.js';
+import { retryFetch, type RetryFetchOptions } from './retryFetch.js';
+import type { FetchFn } from './types.js';
+
+/**
+ * Blocked IPv4 CIDRs. `0.0.0.0/8` (RFC1122 "this network") is included because
+ * `0.0.0.0` and short forms like `http://0/` route to localhost on Linux.
+ * `100.64.0.0/10` (RFC6598 carrier-grade NAT) is where cloud-provider internal
+ * services commonly live, so it is treated as internal too.
+ */
+const BLOCKED_V4: readonly (readonly [string, number])[] = [
+  ['0.0.0.0', 8], // RFC1122 "this network" — 0.0.0.0 reaches localhost
+  ['10.0.0.0', 8], // RFC1918 private
+  ['100.64.0.0', 10], // RFC6598 carrier-grade NAT (cloud internal)
+  ['127.0.0.0', 8], // loopback
+  ['169.254.0.0', 16], // RFC3927 link-local — includes 169.254.169.254 metadata
+  ['172.16.0.0', 12], // RFC1918 private
+  ['192.168.0.0', 16], // RFC1918 private
+];
+
+/**
+ * Blocked IPv6 CIDRs.
+ *
+ * Invariant: `::/96` covers the unspecified address, `::1` loopback, AND the
+ * deprecated IPv4-COMPATIBLE form (`::7f00:1`), which is a distinct encoding
+ * from the IPv4-MAPPED form (`::ffff:7f00:1`). The mapped form is NOT matched by
+ * an IPv6 rule — Node's `BlockList` unmaps `::ffff:a.b.c.d` and tests it against
+ * the registered IPv4 rules instead (verified on Node 20/24). So the mapped
+ * forms of every range above are covered by {@link BLOCKED_V4} automatically,
+ * while the compatible form needs this explicit `::/96` entry. `64:ff9b::/96`
+ * (RFC6052 NAT64) is listed because a NAT64 gateway translates the embedded
+ * IPv4 address, which `BlockList` does not unmap for us.
+ */
+const BLOCKED_V6: readonly (readonly [string, number])[] = [
+  ['::', 96], // unspecified, ::1 loopback, IPv4-compatible ::a.b.c.d
+  ['64:ff9b::', 96], // RFC6052 NAT64 — embedded IPv4 is not unmapped by BlockList
+  ['fc00::', 7], // RFC4193 unique-local (fc00::/8 + fd00::/8)
+  ['fe80::', 10], // RFC4291 link-local
+];
+
+/**
+ * Module-level singleton: the CIDR set is constant, so build the BlockList once.
+ * `BlockList.check()` is a pure lookup, so sharing one instance is safe.
+ */
+const blockList = ((): BlockList => {
+  const list = new BlockList();
+  for (const [addr, prefix] of BLOCKED_V4) list.addSubnet(addr, prefix, 'ipv4');
+  for (const [addr, prefix] of BLOCKED_V6) list.addSubnet(addr, prefix, 'ipv6');
+  return list;
+})();
+
+/** Verdict from {@link checkEgressTarget}. */
+export type EgressVerdict =
+  | { allowed: true }
+  | { allowed: false; reason: string };
+
+/** Thrown by {@link assertEgressAllowed} when a target is refused. */
+export class EgressBlockedError extends Error {
+  constructor(reason: string) {
+    super(reason);
+    this.name = 'EgressBlockedError';
+  }
+}
+
+/** Injectable seams so tests can classify without touching real DNS or env. */
+export interface EgressGuardOptions {
+  /** Override DNS resolution. Defaults to `dns/promises.lookup` (all records). */
+  lookupFn?: (hostname: string) => Promise<readonly { address: string }[]>;
+  /**
+   * Override the opt-out read. Defaults to `env.AFK_WEB_ALLOW_PRIVATE_HOSTS`.
+   * Never reads `process.env` directly — see `src/config/env.ts`.
+   */
+  allowPrivateHosts?: boolean;
+}
+
+/**
+ * True when the operator has opted out of the guard.
+ *
+ * Truthy iff `'1'` or `'true'`, case-insensitive after trimming — the
+ * convention used by other boolean-ish opt-in vars in this codebase.
+ */
+export function privateHostsAllowed(): boolean {
+  const raw = env.AFK_WEB_ALLOW_PRIVATE_HOSTS?.trim().toLowerCase();
+  return raw === '1' || raw === 'true';
+}
+
+/** Strip the `[...]` brackets `new URL().hostname` wraps IPv6 literals in. */
+function unbracket(hostname: string): string {
+  return hostname.startsWith('[') && hostname.endsWith(']')
+    ? hostname.slice(1, -1)
+    : hostname;
+}
+
+/** True when `ip` (a valid literal) falls inside a blocked range. */
+function isBlockedAddress(ip: string): boolean {
+  const family = isIP(ip);
+  if (family === 0) return false;
+  return blockList.check(ip, family === 4 ? 'ipv4' : 'ipv6');
+}
+
+async function defaultLookup(hostname: string): Promise<readonly { address: string }[]> {
+  return lookup(hostname, { all: true, verbatim: true });
+}
+
+/**
+ * Classify one URL as safe-to-fetch or blocked.
+ *
+ * Contract:
+ *   - Rejects any non-http(s) scheme (`file:`, `gopher:`, …) — those are not
+ *     egress targets the web layer should ever open.
+ *   - An IP literal host is classified directly; no DNS is issued.
+ *   - A hostname is resolved and EVERY returned address is classified. One
+ *     internal address blocks the request (a rebinding attacker only needs one
+ *     record to be honored). Resolution failure is NOT a block — the fetch will
+ *     fail on its own with a truthful network error, and failing closed here
+ *     would turn every offline/NXDOMAIN case into a confusing SSRF refusal.
+ *   - Returns `{ allowed: true }` immediately when the operator set
+ *     `AFK_WEB_ALLOW_PRIVATE_HOSTS`.
+ */
+export async function checkEgressTarget(
+  rawUrl: string,
+  opts: EgressGuardOptions = {},
+): Promise<EgressVerdict> {
+  if (opts.allowPrivateHosts ?? privateHostsAllowed()) return { allowed: true };
+
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return { allowed: false, reason: `"${rawUrl}" is not a valid absolute URL` };
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return {
+      allowed: false,
+      reason: `protocol "${parsed.protocol}" not supported (http/https only)`,
+    };
+  }
+
+  const host = unbracket(parsed.hostname);
+  const blockedReason = (addr: string, via: string): string =>
+    `refusing to fetch ${via} — internal/private address ${addr} ` +
+    `(loopback, link-local, cloud metadata, or RFC1918 space). ` +
+    `Set AFK_WEB_ALLOW_PRIVATE_HOSTS=1 to allow private-host access.`;
+
+  // IP literal: classify directly, no resolution needed.
+  if (isIP(host) !== 0) {
+    return isBlockedAddress(host)
+      ? { allowed: false, reason: blockedReason(host, host) }
+      : { allowed: true };
+  }
+
+  const lookupFn = opts.lookupFn ?? defaultLookup;
+  let records: readonly { address: string }[];
+  try {
+    records = await lookupFn(host);
+  } catch {
+    // Unresolvable — let fetch surface the real network error.
+    return { allowed: true };
+  }
+
+  for (const record of records) {
+    if (isBlockedAddress(record.address)) {
+      return { allowed: false, reason: blockedReason(record.address, `${host} (resolved)`) };
+    }
+  }
+  return { allowed: true };
+}
+
+/**
+ * Throwing wrapper over {@link checkEgressTarget} for call sites whose failure
+ * channel is already an exception (the scraper, the per-hop redirect loop).
+ *
+ * @throws {EgressBlockedError} when the target is refused.
+ */
+export async function assertEgressAllowed(
+  rawUrl: string,
+  opts: EgressGuardOptions = {},
+): Promise<void> {
+  const verdict = await checkEgressTarget(rawUrl, opts);
+  if (!verdict.allowed) throw new EgressBlockedError(verdict.reason);
+}
+
+/** Max redirect hops followed by {@link guardedFetch}, matching the fetch spec. */
+const MAX_REDIRECTS = 20;
+
+/** Statuses that carry a `Location` the client is expected to follow. */
+const REDIRECT_STATUS = new Set<number>([301, 302, 303, 307, 308]);
+
+export interface GuardedFetchOptions extends EgressGuardOptions {
+  /** Forwarded to {@link retryFetch} (retry counts, injectable sleep). */
+  retry?: RetryFetchOptions;
+}
+
+/**
+ * Invariant: the egress guard must be re-applied on EVERY redirect hop, so this
+ * wrapper forces `redirect: 'manual'` and walks the chain itself.
+ *
+ * Native redirect-following happens inside undici with no interception point —
+ * `redirect: 'follow'` means a public URL can 302 straight to
+ * `169.254.169.254` and the app only ever sees the final body. Validating the
+ * initial URL is therefore not enough; the check has to sit between hops, which
+ * requires owning the loop.
+ *
+ * Contract:
+ *   - Validates `url` before the first request, then validates each `Location`
+ *     target before following it. A blocked hop throws
+ *     {@link EgressBlockedError} and no request to that hop is issued.
+ *   - Relative and protocol-relative `Location` values are resolved against the
+ *     responding URL before validation.
+ *   - Returns the first non-redirect response, exactly as `retryFetch` would.
+ *     A redirect response whose `Location` is missing is returned as-is rather
+ *     than treated as an error — the caller decides.
+ *   - Redirect bodies are cancelled before the next hop so the socket is freed.
+ *   - Throws after {@link MAX_REDIRECTS} hops to bound a redirect loop.
+ */
+export async function guardedFetch(
+  fetchFn: FetchFn,
+  url: string,
+  init: RequestInit = {},
+  opts: GuardedFetchOptions = {},
+): Promise<Response> {
+  const guardOpts: EgressGuardOptions = {
+    ...(opts.lookupFn !== undefined ? { lookupFn: opts.lookupFn } : {}),
+    ...(opts.allowPrivateHosts !== undefined ? { allowPrivateHosts: opts.allowPrivateHosts } : {}),
+  };
+
+  let target = url;
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    await assertEgressAllowed(target, guardOpts);
+    const res = await retryFetch(fetchFn, target, { ...init, redirect: 'manual' }, opts.retry ?? {});
+    if (!REDIRECT_STATUS.has(res.status)) return res;
+
+    const location = res.headers.get('location');
+    if (location === null || location.trim() === '') return res;
+
+    let next: string;
+    try {
+      next = new URL(location, res.url || target).toString();
+    } catch {
+      // An unparseable Location can't be followed — hand the redirect back.
+      return res;
+    }
+    // Free the socket before issuing the next hop.
+    await res.body?.cancel().catch(() => undefined);
+    target = next;
+  }
+  throw new EgressBlockedError(
+    `too many redirects (>${MAX_REDIRECTS}) starting from ${url}`,
+  );
+}

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -11,6 +11,14 @@ export { extractReadableMarkdown, THIN_CONTENT_CHARS } from './extract.js';
 export { scrapeToMarkdown } from './scrape.js';
 export type { ScrapeOptions, ScrapeResult } from './scrape.js';
 export {
+  assertEgressAllowed,
+  checkEgressTarget,
+  guardedFetch,
+  privateHostsAllowed,
+  EgressBlockedError,
+} from './egress-guard.js';
+export type { EgressGuardOptions, EgressVerdict, GuardedFetchOptions } from './egress-guard.js';
+export {
   createExaSearchBackend,
   resolveSearchBackend,
   formatSearchResults,

--- a/src/web/scrape.test.ts
+++ b/src/web/scrape.test.ts
@@ -345,6 +345,24 @@ describe('scrapeToMarkdown — SSRF egress guard (issue #575)', () => {
     { address: '127.0.0.1' },
   ];
 
+  it('passes a pre-request guard to the renderer for redirects and subresources', async () => {
+    const fetchFn = vi.fn(async () => makeResponse({ contentType: 'text/html', body: SHELL_HTML }));
+    const renderFn = vi.fn<RenderFn>(async (_url, renderOpts) => {
+      await renderOpts.requestGuard?.('http://169.254.169.254/latest/meta-data/');
+      return { html: richHtml('unreachable'), finalUrl: 'https://example.com/', httpStatus: 200 };
+    });
+
+    await expect(
+      scrapeToMarkdown('https://example.com/', {
+        fetchFn: fetchFn as unknown as typeof fetch,
+        renderFn,
+        timeoutMs: 5000,
+        signal: freshSignal(),
+        lookupFn: publicLookup,
+      }),
+    ).rejects.toThrow(/internal\/private address 169\.254\.169\.254/);
+  });
+
   it('refuses an internal IP literal without fetching or rendering', async () => {
     const fetchFn = vi.fn(async () => makeResponse({ contentType: 'text/html', body: richHtml() }));
     const renderFn = vi.fn<RenderFn>(async () => ({

--- a/src/web/scrape.test.ts
+++ b/src/web/scrape.test.ts
@@ -31,10 +31,12 @@ function makeResponse(opts: {
   contentType?: string;
   body?: string;
   url?: string;
+  headers?: Record<string, string>;
 }): Response {
   const status = opts.status ?? 200;
   const headers = new Headers();
   if (opts.contentType !== undefined) headers.set('content-type', opts.contentType);
+  for (const [k, v] of Object.entries(opts.headers ?? {})) headers.set(k, v);
   return {
     ok: status >= 200 && status < 300,
     status,
@@ -48,6 +50,17 @@ function freshSignal(): AbortSignal {
   return new AbortController().signal;
 }
 
+/**
+ * Hermetic DNS seam for the SSRF egress guard (issue #575): resolves every
+ * hostname to a fixed PUBLIC address so these tests never issue real DNS and
+ * never depend on network reachability. Guard behaviour is covered in
+ * `src/web/egress-guard.test.ts`; the guard's integration with this module is
+ * covered by the `egress guard` describe block at the bottom of this file.
+ */
+const publicLookup = async (): Promise<readonly { address: string }[]> => [
+  { address: '93.184.216.34' },
+];
+
 describe('scrapeToMarkdown — fetch-first happy path', () => {
   it('uses the fetch result and does NOT render when content is rich', async () => {
     const fetchFn = vi.fn(async () => makeResponse({ contentType: 'text/html', body: richHtml() }));
@@ -58,6 +71,7 @@ describe('scrapeToMarkdown — fetch-first happy path', () => {
       renderFn,
       timeoutMs: 5000,
       signal: freshSignal(),
+      lookupFn: publicLookup,
     });
 
     expect(out.usedRender).toBe(false);
@@ -81,6 +95,7 @@ describe('scrapeToMarkdown — render escalation', () => {
       renderFn,
       timeoutMs: 5000,
       signal: freshSignal(),
+      lookupFn: publicLookup,
     });
 
     expect(renderFn).toHaveBeenCalledOnce();
@@ -103,6 +118,7 @@ describe('scrapeToMarkdown — render escalation', () => {
       renderFn,
       timeoutMs: 5000,
       signal: freshSignal(),
+      lookupFn: publicLookup,
     });
 
     expect(renderFn).toHaveBeenCalledOnce();
@@ -123,6 +139,7 @@ describe('scrapeToMarkdown — graceful degradation', () => {
       renderFn,
       timeoutMs: 5000,
       signal: freshSignal(),
+      lookupFn: publicLookup,
     });
 
     expect(out.usedRender).toBe(false);
@@ -143,6 +160,7 @@ describe('scrapeToMarkdown — graceful degradation', () => {
         renderFn,
         timeoutMs: 5000,
         signal: freshSignal(),
+        lookupFn: publicLookup,
       }),
     ).rejects.toThrow(/could not retrieve/i);
   });
@@ -160,6 +178,7 @@ describe('scrapeToMarkdown — content-type handling', () => {
       renderFn,
       timeoutMs: 5000,
       signal: freshSignal(),
+      lookupFn: publicLookup,
     });
 
     expect(out.markdown).toBe('{"hello":"world"}');
@@ -177,6 +196,7 @@ describe('scrapeToMarkdown — content-type handling', () => {
         fetchFn: fetchFn as unknown as typeof fetch,
         timeoutMs: 5000,
         signal: freshSignal(),
+        lookupFn: publicLookup,
       }),
     ).rejects.toThrow(/binary content/i);
   });
@@ -195,6 +215,7 @@ describe('scrapeToMarkdown — cancellation', () => {
         fetchFn: fetchFn as unknown as typeof fetch,
         timeoutMs: 5000,
         signal: ac.signal,
+        lookupFn: publicLookup,
       }),
     ).rejects.toThrow();
   });
@@ -218,6 +239,7 @@ describe('scrapeToMarkdown — cancellation', () => {
         renderFn,
         timeoutMs: 5000,
         signal: ac.signal,
+        lookupFn: publicLookup,
       }),
     ).rejects.toThrow(/render aborted/);
   });
@@ -246,6 +268,7 @@ describe('scrapeToMarkdown — cancellation', () => {
         renderFn,
         timeoutMs: 5000,
         signal: ac.signal,
+        lookupFn: publicLookup,
       }),
     ).rejects.toThrow();
     // The abort must short-circuit before any render escalation.
@@ -272,6 +295,7 @@ describe('scrapeToMarkdown — cancellation', () => {
         renderFn,
         timeoutMs: 5000,
         signal: ac.signal,
+        lookupFn: publicLookup,
       }),
     ).rejects.toThrow();
     expect(renderFn).toHaveBeenCalledOnce();
@@ -303,6 +327,7 @@ describe('scrapeToMarkdown — render produces fewer chars than thin fetch', () 
       renderFn,
       timeoutMs: 5000,
       signal: freshSignal(),
+      lookupFn: publicLookup,
     });
 
     // Render was invoked (thin fetch triggered escalation)…
@@ -311,5 +336,122 @@ describe('scrapeToMarkdown — render produces fewer chars than thin fetch', () 
     expect(out.usedRender).toBe(false);
     // The thin fetched content should be present (the "Loading" text from SHELL_HTML).
     expect(out.markdown).toContain('Loading');
+  });
+});
+
+describe('scrapeToMarkdown — SSRF egress guard (issue #575)', () => {
+  /** Resolves every hostname to loopback — the DNS-rebinding scenario. */
+  const rebindLookup = async (): Promise<readonly { address: string }[]> => [
+    { address: '127.0.0.1' },
+  ];
+
+  it('refuses an internal IP literal without fetching or rendering', async () => {
+    const fetchFn = vi.fn(async () => makeResponse({ contentType: 'text/html', body: richHtml() }));
+    const renderFn = vi.fn<RenderFn>(async () => ({
+      html: richHtml('rendered'),
+      finalUrl: 'http://169.254.169.254/',
+      httpStatus: 200,
+    }));
+
+    await expect(
+      scrapeToMarkdown('http://169.254.169.254/latest/meta-data/', {
+        fetchFn: fetchFn as unknown as typeof fetch,
+        renderFn,
+        timeoutMs: 5000,
+        signal: freshSignal(),
+        lookupFn: publicLookup,
+      }),
+    ).rejects.toThrow(/internal\/private address 169\.254\.169\.254/);
+
+    expect(fetchFn).not.toHaveBeenCalled();
+    // Critical: the refusal must NOT degrade into the render escalation, which
+    // is a second, independent egress path.
+    expect(renderFn).not.toHaveBeenCalled();
+  });
+
+  it('refuses a hostname that resolves to loopback (DNS rebinding) and does NOT escalate to render', async () => {
+    const fetchFn = vi.fn(async () => makeResponse({ contentType: 'text/html', body: richHtml() }));
+    const renderFn = vi.fn<RenderFn>(async () => ({
+      html: richHtml('rendered'),
+      finalUrl: 'https://safe-looking.example/',
+      httpStatus: 200,
+    }));
+
+    await expect(
+      scrapeToMarkdown('https://safe-looking.example/', {
+        fetchFn: fetchFn as unknown as typeof fetch,
+        renderFn,
+        timeoutMs: 5000,
+        signal: freshSignal(),
+        lookupFn: rebindLookup,
+      }),
+    ).rejects.toThrow(/internal\/private address 127\.0\.0\.1/);
+
+    expect(fetchFn).not.toHaveBeenCalled();
+    expect(renderFn).not.toHaveBeenCalled();
+  });
+
+  it('refuses a redirect hop that lands on internal space', async () => {
+    const fetchFn = vi.fn(async () =>
+      makeResponse({ status: 302, headers: { location: 'http://169.254.169.254/latest/' } }),
+    );
+    const renderFn = vi.fn<RenderFn>(async () => ({
+      html: richHtml('rendered'),
+      finalUrl: 'https://example.com/a',
+      httpStatus: 200,
+    }));
+
+    await expect(
+      scrapeToMarkdown('https://example.com/a', {
+        fetchFn: fetchFn as unknown as typeof fetch,
+        renderFn,
+        timeoutMs: 5000,
+        signal: freshSignal(),
+        lookupFn: publicLookup,
+      }),
+    ).rejects.toThrow(/internal\/private address 169\.254\.169\.254/);
+
+    // Only the first (public) hop was requested.
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(renderFn).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the RENDER path redirects to internal space (post-navigation re-check)', async () => {
+    // Fetch yields thin content → escalation fires; the render then reports a
+    // finalUrl inside link-local space, which the post-check must catch.
+    const fetchFn = vi.fn(async () => makeResponse({ contentType: 'text/html', body: SHELL_HTML }));
+    const renderFn = vi.fn<RenderFn>(async () => ({
+      html: richHtml('rendered from internal'),
+      finalUrl: 'http://169.254.169.254/latest/meta-data/',
+      httpStatus: 200,
+    }));
+
+    await expect(
+      scrapeToMarkdown('https://example.com/a', {
+        fetchFn: fetchFn as unknown as typeof fetch,
+        renderFn,
+        timeoutMs: 5000,
+        signal: freshSignal(),
+        lookupFn: publicLookup,
+      }),
+    ).rejects.toThrow(/internal\/private address 169\.254\.169\.254/);
+
+    expect(renderFn).toHaveBeenCalledOnce();
+  });
+
+  it('allows an internal target when AFK_WEB_ALLOW_PRIVATE_HOSTS=1', async () => {
+    vi.stubEnv('AFK_WEB_ALLOW_PRIVATE_HOSTS', '1');
+    const fetchFn = vi.fn(async () => makeResponse({ contentType: 'text/html', body: richHtml('localhost body') }));
+
+    const out = await scrapeToMarkdown('http://127.0.0.1:3000/', {
+      fetchFn: fetchFn as unknown as typeof fetch,
+      timeoutMs: 5000,
+      signal: freshSignal(),
+      lookupFn: publicLookup,
+    });
+
+    expect(out.markdown).toContain('localhost body');
+    expect(fetchFn).toHaveBeenCalledOnce();
+    vi.unstubAllEnvs();
   });
 });

--- a/src/web/scrape.ts
+++ b/src/web/scrape.ts
@@ -89,11 +89,16 @@ async function safeExtract(html: string, url: string): Promise<ExtractedContent>
  */
 async function renderViaBrowser(
   url: string,
-  opts: { timeoutMs: number; signal: AbortSignal },
+  opts: { timeoutMs: number; signal: AbortSignal; requestGuard?: (url: string) => Promise<void> },
 ): Promise<RenderedPage> {
   const { getBrowserProvider } = await import('../browser/registry.js');
   const provider = await getBrowserProvider();
-  return provider.render({ url, timeoutMs: opts.timeoutMs, signal: opts.signal });
+  return provider.render({
+    url,
+    timeoutMs: opts.timeoutMs,
+    signal: opts.signal,
+    requestGuard: opts.requestGuard,
+  });
 }
 
 /**
@@ -186,7 +191,11 @@ export async function scrapeToMarkdown(url: string, opts: ScrapeOptions): Promis
     // then re-validate `finalUrl` after, because an in-browser redirect chain is
     // opaque to us (same pre/post pattern `act()` uses for the domain policy).
     await assertEgressAllowed(url, guardOpts);
-    const rendered = await renderFn(url, { timeoutMs: opts.timeoutMs, signal: opts.signal });
+    const rendered = await renderFn(url, {
+      timeoutMs: opts.timeoutMs,
+      signal: opts.signal,
+      requestGuard: (requestUrl) => assertEgressAllowed(requestUrl, guardOpts),
+    });
     // Only re-check a finalUrl that actually MOVED to another http(s) target:
     // the pre-check already cleared `url`, and a non-http landing spot
     // (`about:blank`, a stubbed empty string) names no egress target to

--- a/src/web/scrape.ts
+++ b/src/web/scrape.ts
@@ -22,7 +22,8 @@
 
 import { extractReadableMarkdown, THIN_CONTENT_CHARS } from './extract.js';
 import type { ExtractedContent, FetchFn, RenderFn, RenderedPage } from './types.js';
-import { retryFetch } from './retryFetch.js';
+import { assertEgressAllowed, guardedFetch, EgressBlockedError } from './egress-guard.js';
+import type { EgressGuardOptions } from './egress-guard.js';
 import { debugLog } from '../utils/debug.js';
 
 /** Content-types we treat as HTML (run the extraction pipeline). */
@@ -54,6 +55,12 @@ export interface ScrapeOptions {
   timeoutMs: number;
   /** Combined parent+timeout signal. Aborting cancels fetch and render. */
   signal: AbortSignal;
+  /**
+   * Override for tests: DNS resolution used by the SSRF egress guard. Defaults
+   * (inside the guard) to `dns/promises.lookup`. Injecting it keeps unit tests
+   * off the network, matching the `fetchFn` / `renderFn` seams above.
+   */
+  lookupFn?: EgressGuardOptions['lookupFn'];
 }
 
 export interface ScrapeResult {
@@ -99,6 +106,8 @@ async function renderViaBrowser(
 export async function scrapeToMarkdown(url: string, opts: ScrapeOptions): Promise<ScrapeResult> {
   const fetchFn = opts.fetchFn ?? globalThis.fetch;
   const renderFn = opts.renderFn ?? renderViaBrowser;
+  const guardOpts: EgressGuardOptions =
+    opts.lookupFn !== undefined ? { lookupFn: opts.lookupFn } : {};
 
   // ---- Phase 1: plain fetch -------------------------------------------------
   let fetched: ExtractedContent | null = null;
@@ -107,13 +116,15 @@ export async function scrapeToMarkdown(url: string, opts: ScrapeOptions): Promis
   let fetchErr: unknown = null;
 
   try {
-    // retryFetch survives transient 429/5xx + network blips (idempotent GET)
-    // before we fall through to render escalation.
-    const res = await retryFetch(fetchFn, url, {
-      headers: FETCH_HEADERS,
-      redirect: 'follow',
-      signal: opts.signal,
-    });
+    // guardedFetch = retryFetch (transient 429/5xx + network blips on an
+    // idempotent GET) wrapped in the SSRF egress guard, which forces
+    // redirect:'manual' so every hop is re-validated (issue #575).
+    const res = await guardedFetch(
+      fetchFn,
+      url,
+      { headers: FETCH_HEADERS, signal: opts.signal },
+      guardOpts,
+    );
     fetchStatus = res.status;
     fetchedUrl = res.url || url;
     const contentType = res.headers.get('content-type') ?? '';
@@ -142,6 +153,12 @@ export async function scrapeToMarkdown(url: string, opts: ScrapeOptions): Promis
   } catch (err) {
     // Abort is terminal — propagate so the handler reports cancellation.
     if (opts.signal.aborted) throw err;
+    // Invariant: an egress refusal is TERMINAL and must never fall through to
+    // the render escalation. The headless render is a second, independent
+    // egress path (chromium does its own DNS + redirect handling), so degrading
+    // to it would hand an attacker exactly the internal fetch the guard just
+    // refused. Re-throw before any escalation decision (issue #575).
+    if (err instanceof EgressBlockedError) throw err;
     // A thrown binary-content error must surface, not silently escalate.
     if (err instanceof Error && err.message.startsWith('web_scrape markdown mode received binary')) {
       throw err;
@@ -163,7 +180,20 @@ export async function scrapeToMarkdown(url: string, opts: ScrapeOptions): Promis
 
   // ---- Phase 3: render escalation -------------------------------------------
   try {
+    // Invariant: the render escalation is a SECOND egress path — chromium does
+    // its own DNS resolution and follows redirects internally, so the
+    // plain-fetch guard above does not cover it. Validate before navigating,
+    // then re-validate `finalUrl` after, because an in-browser redirect chain is
+    // opaque to us (same pre/post pattern `act()` uses for the domain policy).
+    await assertEgressAllowed(url, guardOpts);
     const rendered = await renderFn(url, { timeoutMs: opts.timeoutMs, signal: opts.signal });
+    // Only re-check a finalUrl that actually MOVED to another http(s) target:
+    // the pre-check already cleared `url`, and a non-http landing spot
+    // (`about:blank`, a stubbed empty string) names no egress target to
+    // classify — treating those as refusals would break benign renders.
+    if (rendered.finalUrl !== url && /^https?:\/\//i.test(rendered.finalUrl)) {
+      await assertEgressAllowed(rendered.finalUrl, guardOpts);
+    }
     const renderedContent = await safeExtract(rendered.html, rendered.finalUrl);
     // Same async-boundary abort re-check as the fetch path above: extraction
     // does not observe the signal, so honor a cancel/timeout that landed during
@@ -181,6 +211,10 @@ export async function scrapeToMarkdown(url: string, opts: ScrapeOptions): Promis
   } catch (renderErr) {
     // Abort during render is terminal.
     if (opts.signal.aborted) throw renderErr;
+    // An egress refusal on the render path is terminal too: degrading to thin
+    // fetched content here would report partial success for a request the guard
+    // refused, hiding the block from the caller.
+    if (renderErr instanceof EgressBlockedError) throw renderErr;
     // Render failed (e.g. Playwright not installed). If we have *some* fetched
     // content, degrade gracefully to it. If a missing-Playwright error is the
     // only signal AND we have nothing, re-throw it so the handler can hint.

--- a/src/web/types.ts
+++ b/src/web/types.ts
@@ -27,7 +27,12 @@ export type FetchFn = typeof fetch;
  */
 export type RenderFn = (
   url: string,
-  opts: { timeoutMs: number; signal: AbortSignal },
+  opts: {
+    timeoutMs: number;
+    signal: AbortSignal;
+    /** Rejects a browser request before Chromium sends it. */
+    requestGuard?: (url: string) => Promise<void>;
+  },
 ) => Promise<RenderedPage>;
 
 /** Output of a {@link RenderFn} — the rendered DOM plus navigation metadata. */


### PR DESCRIPTION
## Summary

Fixes #575 (P0 / `priority: critical`). `web_scrape` validated only the URL **scheme** and then fetched any host. Because the tool is an always-on builtin that returns page content into model context, a scraped page could prompt-inject a follow-up fetch of `169.254.169.254` and read back cloud IAM credentials — plus reach `localhost` and RFC1918 internal services. Redirects were followed with `redirect: 'follow'`, which is opaque to app code, so even a validated initial URL could land on internal space.

New module `src/web/egress-guard.ts` (282 LOC) is the single classifier every egress path consults:

- **Blocked ranges** — loopback (`127/8`, `::1`), link-local (`169.254/16` incl. the metadata IP, `fe80::/10`), RFC1918 (`10/8`, `172.16/12`, `192.168/16`), CGNAT (`100.64/10`), ULA (`fc00::/7`), `0.0.0.0/8`, and the IPv4-mapped / IPv4-compatible / NAT64 IPv6 encodings of those. Built on `net.BlockList`; I verified empirically that it unmaps `::ffff:a.b.c.d` against the registered **IPv4** rules, so `::/96` and `64:ff9b::/96` are listed explicitly to cover the two forms it does *not* unmap. URL parsing also normalizes the decimal/hex/short-form encodings (`http://2130706433/`, `http://127.1/`, `http://0/`) before classification — covered by tests.
- **DNS-rebinding guard** — resolves the hostname and classifies the **resolved** addresses, not the hostname string, so a host with an A record of `127.0.0.1` is refused. Any one internal record blocks. Resolution *failure* does **not** block (fetch surfaces the truthful network error instead of a confusing SSRF refusal).
- **Per-hop redirect re-check** — see below.

Wired into **all three** egress paths — raw mode, the markdown plain fetch, and the headless-render escalation. The render path is a *second, independent* egress path (chromium does its own DNS and follows redirects internally), so it gets a pre-check **plus** a post-navigation `finalUrl` re-check, mirroring the pre/post pattern `act()` already uses for the domain policy. An egress refusal is **terminal** on both paths: it never degrades into the render escalation, and never degrades into thin fetched content — either would hand back the internal fetch the guard just refused. Refusals surface as a non-crashing `web_scrape blocked: …` tool error naming the offending address and the opt-out.

**Redirect mechanism:** `guardedFetch()` forces `redirect: 'manual'` and walks the chain itself, validating each hop *before* it is requested (relative and protocol-relative `Location` values resolved against the responding URL first), bounded at 20 hops. I confirmed by probe that native `redirect: 'follow'` offers no interception point, so owning the loop is the only way to re-check per hop. It wraps `retryFetch`, so transient 429/5xx resilience is preserved.

**Opt-out:** `AFK_WEB_ALLOW_PRIVATE_HOSTS` (default off = guard active), registered in `ENV_REGISTRY` with `docs/env-registry.{json,md}` regenerated via `pnpm scan:env`.

One ordering subtlety worth a reviewer's eye: the handler's pre-check is placed **after** the abort listener and timeout are wired. It is the handler's first `await` (the guard resolves DNS, so it cannot live in the synchronous `parseInput`), and awaiting before that wiring drops a parent abort landing inside the window — leaving the later fetch waiting on a cancel that never fires. I hit exactly that as a test failure and fixed the ordering rather than the test.

## How was this tested?

- `pnpm lint` (tsc --noEmit, whole repo) — **pass**
- `pnpm test` — **pass, 707 files / 13,505 tests, 0 failures** (14 pre-existing skips). No pre-existing failures found on the base commit.
- `pnpm scan:env:check`, `pnpm audit:env:check`, `pnpm audit:sdk:check`, `pnpm audit:chalk:check` — all pass.
- **62 new guard unit tests** (`src/web/egress-guard.test.ts`): each blocked range and its IPv6 encodings, near-miss boundaries (`172.15`/`172.32`, `100.63`/`100.128`), the DNS-rebinding case, mixed public+internal records, per-redirect-hop blocking (absolute, relative, protocol-relative), redirect-cycle bound, and the env opt-out.
- **Integration tests on both surfaces**: `scrape.test.ts` proves an egress refusal does not fall through to the render escalation and that the render path's `finalUrl` re-check fires; `web-scrape.test.ts` asserts the `web_scrape blocked:` refusal in raw *and* markdown mode and that no request is issued.
- A `lookupFn` seam (matching the existing `fetchFn` / `renderFn` convention) keeps every test off real DNS — the pre-existing suites were made hermetic too, since the guard would otherwise have resolved `example.com` for real.
- **Verified non-vacuous by mutation**: neutering the guard to always-allow fails 54 of these tests.

Files: `src/web/egress-guard.ts` (+282, new), `src/web/egress-guard.test.ts` (+359, new), `src/web/scrape.ts` (+34), `src/agent/tools/handlers/web-scrape.ts` (+36, 347 LOC — under the 350 ceiling), `src/web/index.ts` (+8), `src/config/env.ts` (+21), plus regenerated env docs and the two test files.

## Notes for the reviewer

- **Known conflict (correction to the filed expectation):** I was told PR #735 (`afk/read-floor-browser-secrets`) also edits `docs/env-registry.json`/`.md` and that this branch would need a registry-regeneration rebase if #735 merges first. **That is not the case as of this writing** — #735 touches only `glob/grep/read-denylist`, the bash-restriction hook, and a website doc; it modifies neither `docs/env-registry.*` nor `src/config/env.ts`. I checked all 5 open PRs and **none** touch the env registry or `src/web/`, and `git merge-tree` against current `origin/main` (b1998f5) reports no conflicts. If a registry-touching PR lands first, the fix is the trivial `pnpm scan:env` regeneration.
- **Scope:** #575 also suggests fixing #576 (the browser `open()` post-redirect re-check) in the same pass. I deliberately left that alone — it is already covered by open PR #749 (`afk/browser-open-policy-576`), so touching it here would collide. This PR is the `web_scrape` surface only.
- The `render()` docstring's "does NOT enforce the allowlist" contract is unchanged and still true: the *interactive domain allowlist* governs agent-driven navigation, and that is a separate policy from this egress guard, which now applies to render as well.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/) — see [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] No secrets, tokens, or private paths in the diff
