### PR TITLE
fix(repl): drain bootstrap warnings after the startup screen clear (#745)

### DIFF
--- a/src/cli/commands/interactive.boot-warnings.test.ts
+++ b/src/cli/commands/interactive.boot-warnings.test.ts
@@ -14,6 +14,10 @@
  * name into a write-capable agent. The fix routes such producers into
  * `ctx.bootWarnings` and drains them after the clear.
  *
+ * Two exits out of bootstrap must both surface the buffer: the success path
+ * drains after the clear, and the abort path drains in `interactive.ts`'s catch
+ * before `handleCommandError` exits (see the `bootstrap abort path` block).
+ *
  * These tests assert ORDER — that the warning bytes are written AFTER the clear
  * escape — via `mock.invocationCallOrder`, the same technique
  * `interactive-lifecycle.test.ts` uses for the clearScreen/compositor ordering.
@@ -31,6 +35,12 @@ import { Command } from 'commander';
 
 const mockBootstrapSession = vi.fn();
 const mockRunReplLoop = vi.fn();
+// Stands in for the real `never`-returning handler, which calls process.exit.
+// Throwing instead makes the abort path observable AND preserves the property
+// the drain ordering depends on: nothing after this call runs.
+const mockHandleCommandError = vi.fn((err: unknown): never => {
+  throw err instanceof Error ? err : new Error(String(err));
+});
 
 // ---------------------------------------------------------------------------
 // Mocks — hoisted above imports. Mirrors interactive.resume.test.ts's thin
@@ -91,9 +101,7 @@ vi.mock('../update-checker.js', () => ({
 }));
 
 vi.mock('../errors/index.js', () => ({
-  handleCommandError: vi.fn((err: unknown): never => {
-    throw err instanceof Error ? err : new Error(String(err));
-  }),
+  get handleCommandError() { return mockHandleCommandError; },
 }));
 
 vi.mock('ora', () => ({
@@ -160,7 +168,10 @@ function makeCtx(bootWarnings: string[]): Record<string, unknown> {
  * evaluated across the two together — exactly why `interactive.ts` wraps both
  * when measuring `preArmAnchorRow`.
  */
-async function runAndCapture(bootWarnings: string[]): Promise<string[]> {
+async function runAndCapture(
+  bootWarnings: string[],
+  opts?: { failBootstrap?: Error },
+): Promise<string[]> {
   // `interactive.ts` installs SIGINT/SIGTERM/SIGHUP handlers before the clear
   // and unregisters them only via its cleanup path, which never runs here (we
   // short-circuit at runReplLoop). Snapshot the pre-existing listeners so the
@@ -183,7 +194,22 @@ async function runAndCapture(bootWarnings: string[]): Promise<string[]> {
     writes.push(a.map(String).join(' '));
   });
 
-  mockBootstrapSession.mockResolvedValue(makeCtx(bootWarnings));
+  if (opts?.failBootstrap !== undefined) {
+    // Reproduces the real abort shape: producers push into the CALLER-owned
+    // bucket (`extras.bootWarnings`), and only then does bootstrap throw — e.g.
+    // an MCP config warning collected just before `McpManager.fromConfig`
+    // rejects on an `alwaysLoad` server. No ctx is ever returned, so the
+    // post-clear drain is unreachable by construction.
+    const failure = opts.failBootstrap;
+    mockBootstrapSession.mockImplementation(
+      async (_options: unknown, extras?: { bootWarnings?: string[] }) => {
+        for (const w of bootWarnings) extras?.bootWarnings?.push(w);
+        throw failure;
+      },
+    );
+  } else {
+    mockBootstrapSession.mockResolvedValue(makeCtx(bootWarnings));
+  }
   // Stop the boot chain right after the pre-arm print block.
   mockRunReplLoop.mockRejectedValue(new Error('test-shortcircuit'));
 
@@ -218,6 +244,8 @@ describe('afk interactive — bootstrap warnings survive the startup clear (#745
   beforeEach(() => {
     mockBootstrapSession.mockReset();
     mockRunReplLoop.mockReset();
+    // `mockClear`, not `mockReset` — the throwing implementation must survive.
+    mockHandleCommandError.mockClear();
   });
 
   afterEach(() => {
@@ -276,5 +304,52 @@ describe('afk interactive — bootstrap warnings survive the startup clear (#745
     // interactive.ts empties the array in place after printing; the REPL loop
     // and any later reader must see nothing left to emit.
     expect(bootWarnings).toHaveLength(0);
+  });
+
+  /**
+   * Regression found in review of PR #751: the post-clear drain sits ~360 lines
+   * after the `bootstrapSession` await. When bootstrap THROWS, `ctx` is never
+   * assigned and `handleCommandError` exits the process, so every warning
+   * buffered before the throw was destroyed — silently, with no clear to blame.
+   *
+   * That was a strict regression, not an inherited gap: before #751 these
+   * producers wrote to stderr the moment they fired, and the abort path never
+   * reaches the clear, so the diagnostic stayed on screen next to the failure
+   * it explained. The fix hoists the buffer into `interactive.ts` and drains it
+   * in the catch, which is why these tests exercise the CALLER-owned bucket.
+   */
+  describe('bootstrap abort path', () => {
+    it('emits warnings buffered before a bootstrap failure', async () => {
+      const writes = await runAndCapture(
+        ['[mcp] server "foo": unknown key "cmd"'],
+        { failBootstrap: new Error('mcp server "foo" (alwaysLoad) failed to connect') },
+      );
+
+      // `handleCommandError` is mocked to throw, mirroring the real `never`
+      // return: if these bytes are present at all, they were written BEFORE the
+      // process would have exited. Presence is the ordering proof on this path.
+      expect(writes.some((w) => w.includes('unknown key "cmd"'))).toBe(true);
+      // Proves we actually went down the abort path rather than succeeding.
+      expect(mockHandleCommandError).toHaveBeenCalledTimes(1);
+    });
+
+    it('never reaches the screen clear, so immediate emission is safe', async () => {
+      const writes = await runAndCapture(['[mcp] pre-throw'], {
+        failBootstrap: new Error('boom'),
+      });
+      // `\x1b[3J` is the only reason buffering was needed in the first place.
+      // It does not run here, so nothing erases the drained warning — and no
+      // second drain exists on this path to double-print it.
+      expect(writes.some((w) => w.includes(CLEAR))).toBe(false);
+      expect(writes.filter((w) => w.includes('pre-throw'))).toHaveLength(1);
+    });
+
+    it('prints nothing when bootstrap fails before any producer ran', async () => {
+      const writes = await runAndCapture([], { failBootstrap: new Error('bad --model') });
+      // Absence of noise: the drain must add no header or blank line of its own
+      // to the far more common "bad flag" failure.
+      expect(writes.some((w) => w.includes('[mcp]'))).toBe(false);
+      expect(mockHandleCommandError).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/cli/commands/interactive.boot-warnings.test.ts
+++ b/src/cli/commands/interactive.boot-warnings.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Regression: bootstrap warnings must survive the interactive startup screen
+ * clear (#745).
+ *
+ * The startup clear is `\x1b[3J\x1b[2J\x1b[H`. `\x1b[3J` is Erase Saved Lines
+ * — it wipes the terminal's SCROLLBACK, not just the viewport — so anything
+ * written before it is unrecoverable, even by scrolling up. `bootstrapSession`
+ * is awaited BEFORE that clear in the same `.action()` callback, so any producer
+ * inside bootstrap that printed straight to stdout/stderr was silently erased.
+ *
+ * That erased class included the agent-registry built-in-shadow warning, which
+ * is a safety signal: a `~/.afk/agents/research-agent.md` declaring broader
+ * `tools:` converts the read-only verifier that bundled skills dispatch by bare
+ * name into a write-capable agent. The fix routes such producers into
+ * `ctx.bootWarnings` and drains them after the clear.
+ *
+ * These tests assert ORDER — that the warning bytes are written AFTER the clear
+ * escape — via `mock.invocationCallOrder`, the same technique
+ * `interactive-lifecycle.test.ts` uses for the clearScreen/compositor ordering.
+ * Per `docs/scrollback.md`, mock-stdout tests can prove bytes were WRITTEN and
+ * in what order, but cannot prove they reached a real terminal's scrollback;
+ * the PTY scenario (`tests/pty/scenarios.ts`) covers visibility.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Command } from 'commander';
+
+// ---------------------------------------------------------------------------
+// Mutable mocks controlled per test
+// ---------------------------------------------------------------------------
+
+const mockBootstrapSession = vi.fn();
+const mockRunReplLoop = vi.fn();
+
+// ---------------------------------------------------------------------------
+// Mocks — hoisted above imports. Mirrors interactive.resume.test.ts's thin
+// surface: we need the real `interactive.ts` action to run from bootstrap
+// through the clear and the pre-arm print block, then stop before the REPL.
+// ---------------------------------------------------------------------------
+
+vi.mock('./interactive/bootstrap.js', () => ({
+  get bootstrapSession() { return mockBootstrapSession; },
+}));
+
+vi.mock('./interactive/repl-loop.js', () => ({
+  get runReplLoop() { return mockRunReplLoop; },
+}));
+
+vi.mock('./interactive/boot-prune.js', () => ({
+  bootPruneWorktrees: vi.fn().mockResolvedValue({ ran: false, removedCount: 0 }),
+}));
+
+vi.mock('./interactive/worktree.js', () => ({
+  setupWorktree: vi.fn(),
+}));
+
+vi.mock('./interactive/worktree-autoname.js', () => ({
+  runFirstTurnAutoname: vi.fn(),
+}));
+
+vi.mock('../resume-session.js', () => ({
+  resolveResumeTarget: vi.fn(() => undefined),
+  resumeConfigFor: vi.fn(() => ({})),
+  saveCurrentSession: vi.fn(),
+}));
+
+vi.mock('../shared-helpers.js', () => ({
+  getApiKey: vi.fn(() => 'test-key'),
+  getModel: vi.fn(() => 'sonnet'),
+  getThinking: vi.fn(() => undefined),
+  getEffort: vi.fn(() => undefined),
+  getMaxOutputTokens: vi.fn(() => undefined),
+  getMaxToolUseIterations: vi.fn(() => undefined),
+  loadSystemPrompt: vi.fn(() => undefined),
+  loadConfigSystemPrompt: vi.fn(() => undefined),
+  resolveBaseSystemPrompt: vi.fn(() => ({ prompt: undefined, source: 'none' })),
+  parseThinking: vi.fn(() => undefined),
+  parseEffort: vi.fn(() => undefined),
+  parseMaxOutputTokens: vi.fn(() => undefined),
+  parseProvider: vi.fn(() => undefined),
+  parseThinkingUiMode: vi.fn(() => 'live'),
+  getDefaultSubagentModel: vi.fn(() => 'sonnet'),
+}));
+
+vi.mock('../config.js', () => ({
+  loadConfig: vi.fn(() => ({ interactive: {} })),
+}));
+
+vi.mock('../update-checker.js', () => ({
+  printUpdateBanner: vi.fn(),
+}));
+
+vi.mock('../errors/index.js', () => ({
+  handleCommandError: vi.fn((err: unknown): never => {
+    throw err instanceof Error ? err : new Error(String(err));
+  }),
+}));
+
+vi.mock('ora', () => ({
+  default: vi.fn(() => {
+    const inst = {
+      text: '',
+      start() { return inst; },
+      stop() { return inst; },
+      succeed() { return inst; },
+      fail() { return inst; },
+    };
+    return inst;
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import { registerInteractiveCommand } from './interactive.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const CLEAR = '\x1b[3J\x1b[2J\x1b[H';
+
+/**
+ * Minimal InteractiveCtx stand-in: only the members `interactive.ts` touches
+ * between `bootstrapSession` returning and `runReplLoop` being called.
+ */
+function makeCtx(bootWarnings: string[]): Record<string, unknown> {
+  return {
+    bootWarnings,
+    stats: { model: 'sonnet', totalTurns: 0, permissionMode: 'default' },
+    statusLine: { start: vi.fn(), stop: vi.fn(), repaint: vi.fn() },
+    slashCtx: {
+      ui: { repaintStatusLine: vi.fn() },
+      getCompositor: () => undefined,
+    },
+    completionWriter: { fn: vi.fn(), line: vi.fn() },
+    rl: { on: vi.fn(), close: vi.fn() },
+    // `abort`/`interrupt` are required by the SIGINT/SIGTERM/SIGHUP handlers
+    // `interactive.ts` installs before the clear — without them a stray signal
+    // during teardown throws instead of unwinding.
+    session: {
+      current: {
+        close: vi.fn(async () => undefined),
+        abort: vi.fn(),
+        interrupt: vi.fn(async () => undefined),
+      },
+    },
+    memoryStore: { close: vi.fn() },
+    backgroundRegistry: { list: vi.fn(() => []) },
+    getInFlight: () => false,
+    teardownTrustedSkillEvents: undefined,
+    options: {},
+  };
+}
+
+/**
+ * Run the interactive action, capturing every stdout+stderr write in one
+ * ordered list. Both streams share the terminal cursor, so ordering must be
+ * evaluated across the two together — exactly why `interactive.ts` wraps both
+ * when measuring `preArmAnchorRow`.
+ */
+async function runAndCapture(bootWarnings: string[]): Promise<string[]> {
+  // `interactive.ts` installs SIGINT/SIGTERM/SIGHUP handlers before the clear
+  // and unregisters them only via its cleanup path, which never runs here (we
+  // short-circuit at runReplLoop). Snapshot the pre-existing listeners so the
+  // caller can restore them and each run doesn't leak a handler onto `process`.
+  const signals = ['SIGINT', 'SIGTERM', 'SIGHUP'] as const;
+  const priorListeners = new Map(
+    signals.map((s) => [s, [...process.listeners(s)]] as const),
+  );
+  const writes: string[] = [];
+  const record = (chunk: unknown): boolean => {
+    writes.push(String(chunk));
+    return true;
+  };
+  const outSpy = vi.spyOn(process.stdout, 'write').mockImplementation(record);
+  const errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(record);
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...a: unknown[]) => {
+    writes.push(a.map(String).join(' '));
+  });
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation((...a: unknown[]) => {
+    writes.push(a.map(String).join(' '));
+  });
+
+  mockBootstrapSession.mockResolvedValue(makeCtx(bootWarnings));
+  // Stop the boot chain right after the pre-arm print block.
+  mockRunReplLoop.mockRejectedValue(new Error('test-shortcircuit'));
+
+  try {
+    const program = new Command();
+    program.exitOverride();
+    registerInteractiveCommand(program);
+    await program.parseAsync(['node', 'afk', 'interactive']);
+  } catch {
+    // `runReplLoop` rejection is the intended stop signal.
+  } finally {
+    outSpy.mockRestore();
+    errSpy.mockRestore();
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+    // Drop handlers this run added; restore exactly the prior set.
+    for (const s of signals) {
+      process.removeAllListeners(s);
+      for (const fn of priorListeners.get(s) ?? []) {
+        process.on(s, fn as (...args: unknown[]) => void);
+      }
+    }
+  }
+  return writes;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('afk interactive — bootstrap warnings survive the startup clear (#745)', () => {
+  beforeEach(() => {
+    mockBootstrapSession.mockReset();
+    mockRunReplLoop.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    process.exitCode = undefined;
+  });
+
+  it('emits an agent-registry built-in-shadow warning AFTER the screen clear', async () => {
+    const warning =
+      '[afk] agents: ~/.afk/agents/research-agent.md overrides built-in agent "research-agent"' +
+      ' — the built-in restricts its tools and gates bash to read-only commands;' +
+      ' the override replaces both';
+
+    const writes = await runAndCapture([warning]);
+
+    const clearIdx = writes.findIndex((w) => w.includes(CLEAR));
+    const warnIdx = writes.findIndex((w) => w.includes('overrides built-in agent'));
+
+    expect(clearIdx).toBeGreaterThanOrEqual(0);   // the clear did happen
+    expect(warnIdx).toBeGreaterThanOrEqual(0);    // the warning was emitted at all
+    // The whole bug: written before the clear === destroyed, scrollback included.
+    expect(warnIdx).toBeGreaterThan(clearIdx);
+    // Content must survive intact, not be summarized away — the operator needs
+    // the agent name and the tools-restriction clause to act on it.
+    expect(writes[warnIdx]).toContain('research-agent');
+    expect(writes[warnIdx]).toContain('read-only');
+  });
+
+  it('routes MCP bootstrap warnings through the same post-clear path', async () => {
+    const writes = await runAndCapture(['[mcp] server "foo": unknown key "cmd"']);
+
+    const clearIdx = writes.findIndex((w) => w.includes(CLEAR));
+    const mcpIdx = writes.findIndex((w) => w.includes('[mcp]'));
+
+    expect(mcpIdx).toBeGreaterThanOrEqual(0);
+    expect(mcpIdx).toBeGreaterThan(clearIdx);
+  });
+
+  it('emits each warning exactly once (no double-emission)', async () => {
+    const writes = await runAndCapture(['[mcp] duplicated?']);
+    const hits = writes.filter((w) => w.includes('duplicated?'));
+    expect(hits).toHaveLength(1);
+  });
+
+  it('prints nothing extra when bootstrap produced no warnings', async () => {
+    const writes = await runAndCapture([]);
+    expect(writes.some((w) => w.includes('[mcp]'))).toBe(false);
+    expect(writes.some((w) => w.includes('overrides built-in agent'))).toBe(false);
+    // The clear still runs — this asserts absence of noise, not absence of boot.
+    expect(writes.some((w) => w.includes(CLEAR))).toBe(true);
+  });
+
+  it('drains the buffer so a later re-read cannot reprint stale warnings', async () => {
+    const bootWarnings = ['[mcp] transient'];
+    await runAndCapture(bootWarnings);
+    // interactive.ts empties the array in place after printing; the REPL loop
+    // and any later reader must see nothing left to emit.
+    expect(bootWarnings).toHaveLength(0);
+  });
+});

--- a/src/cli/commands/interactive.ts
+++ b/src/cli/commands/interactive.ts
@@ -14,6 +14,7 @@ import { saveSession } from '../session-store.js';
 import { formatResumeCommand } from '../resume-command.js';
 import { formatCwd } from '../format-cwd.js';
 import { bootstrapSession } from './interactive/bootstrap.js';
+import { drainBootWarnings } from './interactive/boot-warnings.js';
 import { elicitationRouter } from '../../agent/elicitation-router.js';
 import { initTranscript } from './interactive/transcript.js';
 import { runReplLoop, type TurnState } from './interactive/repl-loop.js';
@@ -401,11 +402,29 @@ export function registerInteractiveCommand(program: Command): void {
           ? `Pruned ${bootPrune.removedCount} stale worktree(s). Run /worktree list for details.`
           : undefined;
 
+      // Bootstrap-warning bucket, owned HERE and passed down rather than
+      // created inside `bootstrapSession`, so it is still reachable when
+      // bootstrap throws — a thrown bootstrap returns no ctx to read it from.
+      // `ctx.bootWarnings` is this same array instance, so the success-path
+      // drain below is unaffected by the hoist.
+      const bootWarnings: string[] = [];
       let ctx: InteractiveCtx;
       try {
-        ctx = await bootstrapSession(options, worktreeCwd !== undefined ? { cwd: worktreeCwd } : undefined);
+        ctx = await bootstrapSession(options, {
+          bootWarnings,
+          ...(worktreeCwd !== undefined ? { cwd: worktreeCwd } : {}),
+        });
       } catch (err) {
+        // Constraint: this sequence is externally forced, not stylistic.
+        // `handleCommandError` is typed `never` and calls `process.exit`, so
+        // the drain cannot follow it; and ora owns the terminal line until
+        // `spinner.fail()` stops it, so the drain cannot precede that. Hence
+        // fail → drain → exit. Without the drain, a warning pushed before the
+        // throw (an MCP config warning accompanying an `alwaysLoad` server that
+        // fails to connect) dies with the process — pre-#751 it had already
+        // reached stderr, and the abort path never clears the screen.
         spinner.fail('Invalid options');
+        drainBootWarnings(bootWarnings);
         handleCommandError(err);
       }
 
@@ -768,13 +787,10 @@ export function registerInteractiveCommand(program: Command): void {
         // newlines count into preArmAnchorRow and the compositor arms BELOW
         // them. Printed LAST in the block — a built-in-shadow warning means a
         // read-only verifier agent may now be write-capable, so it sits closest
-        // to the prompt rather than buried above the banner.
-        if (ctx.bootWarnings.length > 0) {
-          for (const w of ctx.bootWarnings) {
-            console.warn(palette.warning(`  ${w}`));
-          }
-          ctx.bootWarnings.length = 0;
-        }
+        // to the prompt rather than buried above the banner. Shares its printer
+        // with the bootstrap-abort drain above; the buffer is emptied in place,
+        // so only whichever path ran first emits.
+        drainBootWarnings(ctx.bootWarnings);
         console.log();
       } finally {
         process.stdout.write = origStdoutWrite;

--- a/src/cli/commands/interactive.ts
+++ b/src/cli/commands/interactive.ts
@@ -759,6 +759,22 @@ export function registerInteractiveCommand(program: Command): void {
         if (ctx.resumeTarget) {
           printResumeBanner(ctx.stats, ctx.completionWriter);
         }
+        // Bootstrap warnings (#745). `bootstrapSession` above ran BEFORE the
+        // screen clear, so any producer that printed directly — the
+        // agent-registry built-in-shadow warning, MCP config warnings — had its
+        // output erased, scrollback included (`\x1b[3J` = Erase Saved Lines).
+        // Those producers now accumulate into ctx.bootWarnings and are emitted
+        // here instead: after the clear, inside the pre-arm block so the
+        // newlines count into preArmAnchorRow and the compositor arms BELOW
+        // them. Printed LAST in the block — a built-in-shadow warning means a
+        // read-only verifier agent may now be write-capable, so it sits closest
+        // to the prompt rather than buried above the banner.
+        if (ctx.bootWarnings.length > 0) {
+          for (const w of ctx.bootWarnings) {
+            console.warn(palette.warning(`  ${w}`));
+          }
+          ctx.bootWarnings.length = 0;
+        }
         console.log();
       } finally {
         process.stdout.write = origStdoutWrite;

--- a/src/cli/commands/interactive/boot-warnings.ts
+++ b/src/cli/commands/interactive/boot-warnings.ts
@@ -1,0 +1,31 @@
+/**
+ * Drain for warnings buffered during `bootstrapSession` (#745).
+ *
+ * Extracted so the REPL's two mutually exclusive exits out of bootstrap — the
+ * post-clear pre-arm block on success, and the `catch` that precedes
+ * `handleCommandError` on abort — print through one code path instead of two
+ * copies that can drift.
+ *
+ * @module cli/commands/interactive/boot-warnings
+ */
+
+import { palette } from '../../palette.js';
+
+/**
+ * Print every buffered bootstrap warning, then empty the buffer in place.
+ *
+ * Contract: emptying is unconditional and MUTATES the caller's array. That is
+ * what makes a second call a no-op rather than a double-print, so neither exit
+ * path needs to know whether the other already ran. A no-op on an empty buffer,
+ * so callers need no length guard.
+ *
+ * Writes via `console.warn` (stderr) deliberately: the success-path caller runs
+ * inside a block that counts newlines on both streams to derive
+ * `preArmAnchorRow`, so these lines must pass through a wrapped stream write.
+ */
+export function drainBootWarnings(warnings: string[]): void {
+  for (const w of warnings) {
+    console.warn(palette.warning(`  ${w}`));
+  }
+  warnings.length = 0;
+}

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -145,7 +145,8 @@ export function buildAgentSession(deps: BuildAgentSessionDeps): AgentSession {
 /**
  * Build the session context from CLI options. Throws with a user-facing
  * message when option parsing fails — caller is responsible for spinner
- * teardown and exit code.
+ * teardown, exit code, and draining any `extras.bootWarnings` it supplied
+ * (warnings pushed before the throw never reach the returned ctx).
  *
  * Side effects: constructs an SDK AgentSession (opens a subprocess),
  * registers slash commands, creates a non-terminal readline interface on
@@ -154,7 +155,7 @@ export function buildAgentSession(deps: BuildAgentSessionDeps): AgentSession {
  */
 export async function bootstrapSession(
   options: CliOptions,
-  extras?: { cwd?: string },
+  extras?: { cwd?: string; bootWarnings?: string[] },
 ): Promise<InteractiveCtx> {
   // Witness layer: capture true bootstrap entry time. The trace writer is
   // created a few lines below, so bootstrap_start (writer-ready marker) and
@@ -323,7 +324,14 @@ export async function bootstrapSession(
   // is destroyed — `\x1b[3J` erases scrollback, not just the viewport — so
   // producers accumulate into this bucket and `interactive.ts` drains it after
   // the clear. See `InteractiveCtx.bootWarnings` (#745).
-  const bootWarnings: string[] = [];
+  //
+  // Adopted from the caller when supplied, because this function can throw
+  // AFTER producers have pushed (`McpManager.fromConfig` below rejects for an
+  // `alwaysLoad` server that fails to connect) and a thrown bootstrap returns
+  // no ctx to drain — the warnings would be silently destroyed. The REPL passes
+  // its own array so its catch block can still print them. Callers that don't
+  // care get a local bucket and the prior behaviour.
+  const bootWarnings: string[] = extras?.bootWarnings ?? [];
 
   // Named-agent registry: session-static scan (builtin + user ~/.afk/agents
   // + project .afk/agents & .claude/agents). Enables `agent_type` dispatch

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -317,12 +317,26 @@ export async function bootstrapSession(
   // depth — root → skill-forked child → skill-forked grandchild. Without
   // this, the dispatch fast-fails with a 163-byte "BackgroundAgentRegistry
   // is not wired" error after ~24ms (no model call).
+
+  // Bootstrap warnings that must outlive the startup screen clear. Everything
+  // written to stdout/stderr from here until `interactive.ts` finishes clearing
+  // is destroyed — `\x1b[3J` erases scrollback, not just the viewport — so
+  // producers accumulate into this bucket and `interactive.ts` drains it after
+  // the clear. See `InteractiveCtx.bootWarnings` (#745).
+  const bootWarnings: string[] = [];
+
   // Named-agent registry: session-static scan (builtin + user ~/.afk/agents
   // + project .afk/agents & .claude/agents). Enables `agent_type` dispatch
   // on the `agent` tool at every depth of this REPL session.
+  //
+  // `warn` is routed into bootWarnings rather than left to default: the
+  // built-in-shadow warning (an agent file replacing a tool-restricted builtin
+  // like `research-agent`) is a safety signal, and the default writer prints
+  // straight to stderr where the clear eats it.
   const agentRegistry = loadAgentRegistry({
     ...(effectiveCwd !== undefined ? { cwd: effectiveCwd } : {}),
     pluginAgents: discoverPluginAgents(),
+    warn: (message: string) => bootWarnings.push(message),
   });
 
   const childSkillExecutorFactory = createChildSkillExecutorFactory(
@@ -492,6 +506,12 @@ export async function bootstrapSession(
       ...(options.mcpConfig !== undefined ? { cliOverride: options.mcpConfig } : {}),
     });
     const enabledCount = Object.values(loaded.mcpServers).filter((s) => !s.disabled).length;
+    // Config-loader warnings ("your mcp.json had X") reach the operator on both
+    // branches — servers enabled or not — via the post-clear drain. Collected
+    // once here so the two paths cannot diverge: previously the enabled path
+    // printed inside McpManager.fromConfig and the disabled path printed here,
+    // and the clear erased both.
+    for (const w of loaded.warnings) bootWarnings.push(`[mcp] ${w}`);
     if (enabledCount > 0) {
       const sourcesLabel = loaded.sources.length === 1
         ? loaded.sources[0]
@@ -507,8 +527,12 @@ export async function bootstrapSession(
         metadata: { serverCount: enabledCount },
       });
       try {
+        // `warnings` is deliberately NOT forwarded: fromConfig would
+        // `console.warn` them (mcp/manager.ts) mid-bootstrap, where the startup
+        // clear erases them. They ride bootWarnings instead and are drained
+        // after the clear. `chat` still forwards them — it never clears — so
+        // this does not change any other surface, and nothing double-prints.
         mcpManager = await McpManager.fromConfig(loaded.mcpServers, {
-          warnings: loaded.warnings,
           ...(trace?.writer !== undefined ? { traceWriter: trace.writer } : {}),
         });
       } finally {
@@ -518,10 +542,10 @@ export async function bootstrapSession(
           metadata: { serverCount: enabledCount },
         });
       }
-    } else if (loaded.warnings.length > 0) {
-      // Surface warnings even when no servers ended up enabled.
-      for (const w of loaded.warnings) console.warn(`[mcp] ${w}`);
     }
+    // No `else` branch for warnings: the no-enabled-servers case used to
+    // console.warn here, and both branches are now covered by the single
+    // bootWarnings collection above.
   }
 
   // Build a fully-wired provider factory that the ProviderRouter calls to
@@ -858,6 +882,10 @@ export async function bootstrapSession(
     options,
     ...(resumeTarget !== undefined ? { resumeTarget } : {}),
     teardownTrustedSkillEvents: undefined,  // wired below
+    // Same array the producers above pushed into — drained post-clear by
+    // interactive.ts. Passed by reference so a late producer (anything between
+    // here and `return ctx`) still lands.
+    bootWarnings,
     backgroundRegistry,
     // Expose the root executor's narrow promotion seam so the turn handler can
     // make Ctrl+B background a running foreground subagent. The executor

--- a/src/cli/commands/interactive/loop-iteration.test.ts
+++ b/src/cli/commands/interactive/loop-iteration.test.ts
@@ -156,6 +156,11 @@ function makeCtx(overrides?: Partial<InteractiveCtx>): InteractiveCtx {
     options: { thinkingUi: undefined },
     inputSurfaceRef: { current: null },
     backgroundRegistry: new BackgroundAgentRegistry({}),
+    // Required on InteractiveCtx (#745). This fixture feeds runReplLoop
+    // directly and never reaches the drain site, so its absence was a
+    // type-fidelity gap rather than a runtime throw — kept in sync anyway so
+    // the cast cannot hide a future required field.
+    bootWarnings: [],
     ...overrides,
   } as unknown as InteractiveCtx;
 }

--- a/src/cli/commands/interactive/repl-loop-wiring.test.ts
+++ b/src/cli/commands/interactive/repl-loop-wiring.test.ts
@@ -153,6 +153,8 @@ function makeMinimalCtx(backgroundRegistry: BackgroundAgentRegistry): Interactiv
     rl: { close: vi.fn() },
     options: { thinkingUi: undefined },
     backgroundRegistry,
+    // Required on InteractiveCtx (#745) — see the note in loop-iteration.test.ts.
+    bootWarnings: [],
   } as unknown as InteractiveCtx;
 }
 

--- a/src/cli/commands/interactive/shared.ts
+++ b/src/cli/commands/interactive/shared.ts
@@ -379,7 +379,10 @@ export interface InteractiveCtx {
    *
    * Producers push here instead of printing; `interactive.ts` drains this
    * AFTER the clear, next to the update-notice re-emit that solves the same
-   * problem for pre-`program.parse()` output. Empty on every other surface —
+   * problem for pre-`program.parse()` output. The REPL owns the array and
+   * passes it INTO `bootstrapSession` (`extras.bootWarnings`) so it survives a
+   * bootstrap that throws — this field is that same instance. Empty on every
+   * other surface —
    * `chat`/`daemon`/`telegram` never clear the screen, so their producers keep
    * printing directly and are unaffected.
    */

--- a/src/cli/commands/interactive/shared.ts
+++ b/src/cli/commands/interactive/shared.ts
@@ -372,6 +372,19 @@ export interface InteractiveCtx {
   resumeTarget?: ResolvedResumeTarget;
   teardownTrustedSkillEvents?: () => void;
   /**
+   * Warnings produced DURING bootstrap that must survive the interactive
+   * startup screen clear (`\x1b[3J\x1b[2J\x1b[H`, interactive.ts). `\x1b[3J`
+   * is Erase Saved Lines — it wipes scrollback too, so anything bootstrap
+   * writes straight to stderr is unrecoverable even by scrolling up (#745).
+   *
+   * Producers push here instead of printing; `interactive.ts` drains this
+   * AFTER the clear, next to the update-notice re-emit that solves the same
+   * problem for pre-`program.parse()` output. Empty on every other surface —
+   * `chat`/`daemon`/`telegram` never clear the screen, so their producers keep
+   * printing directly and are unaffected.
+   */
+  bootWarnings: string[];
+  /**
    * MCP manager — owns connections to every server in `~/.afk/config/mcp.json`.
    * Lifetime is tied to the REPL session: connected at bootstrap, disconnected
    * by the teardown path in `interactive.ts`. Subagents share this reference

--- a/src/cli/interactive-lifecycle.test.ts
+++ b/src/cli/interactive-lifecycle.test.ts
@@ -171,7 +171,88 @@ describe('interactive bootstrap status line hooks', () => {
  * suggest.ts:355 forwards `ctx.baseUrl` as an `openaiBaseUrl` provider hint, so
  * `suggestBaseUrl` MUST carry `openaiBaseUrl`, never `baseUrl`.
  */
-describe('interactive bootstrap — P1: suggestBaseUrl mirrors openaiBaseUrl', () => {
+// Mocks shared with the status-line test above — enough to let
+// bootstrapSession reach the InteractiveCtx construction without a real
+// session/TTY. `loadConfig` is left unmocked here so each caller can override
+// it per-case. Module-scope so more than one describe can drive the REAL
+// bootstrapSession without duplicating the mock wall.
+function applyCommonMocks(): void {
+  const rl = { on: vi.fn(), close: vi.fn() };
+  vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+  vi.doMock('node:readline', () => ({ createInterface: vi.fn(() => rl) }));
+  vi.doMock('../agent/session.js', () => ({
+    AgentSession: class MockAgentSession {
+      close = vi.fn(async () => undefined);
+      interrupt = vi.fn(async () => undefined);
+    },
+  }));
+  vi.doMock('../agent/default-hook-registry.js', () => ({
+    createDefaultHookRegistry: vi.fn(() => ({
+      // register stub: bootstrap now registers the terminal-state gate (#237)
+      // on the 'Stop' event, so the mock registry must expose `.register`.
+      registry: { register: vi.fn() },
+      memoryStore: { close: vi.fn() },
+      // Real factory always returns this ref (default-hook-registry.ts);
+      // bootstrap.ts writes `.current` once the provider exists, so the mock
+      // must include it or the assignment throws "Cannot set properties of
+      // undefined". Mirrors the status-line test mock above.
+      pathApprovalGrantRef: { current: undefined },
+    })),
+  }));
+  vi.doMock('../agent/memory/index.js', () => ({
+    MemoryStore: vi.fn(() => ({ close: vi.fn() })),
+    injectHotMemory: vi.fn((config: unknown) => config),
+    memoryToolSchemas: [],
+    MEMORY_TOOL_NAMES: [],
+    createMemoryHandlers: vi.fn(() => new Map()),
+  }));
+  vi.doMock('./shared-helpers.js', () => ({
+    parseThinking: vi.fn(() => undefined),
+    parseEffort: vi.fn(() => undefined),
+    parseMaxOutputTokens: vi.fn(() => undefined),
+    parseProvider: vi.fn(() => undefined),
+    getApiKey: vi.fn(() => 'test-key'),
+    getApiKeyForModel: vi.fn(() => 'test-key'),
+    getModel: vi.fn(() => 'sonnet'),
+    getThinking: vi.fn(() => undefined),
+    getEffort: vi.fn(() => undefined),
+    getMaxOutputTokens: vi.fn(() => undefined),
+    getMaxToolUseIterations: vi.fn(() => undefined),
+    getDefaultSubagentModel: vi.fn(() => 'sonnet'),
+    findClaudeExecutable: vi.fn(() => '/usr/bin/claude'),
+    loadSystemPrompt: vi.fn(() => undefined),
+    loadConfigSystemPrompt: vi.fn(() => undefined),
+    resolveBaseSystemPrompt: vi.fn(() => ({ prompt: undefined, source: 'none' })),
+    // Required since bootstrap.ts now calls isGrantManager — return false so
+    // these tests don't care about grant wiring.
+    isGrantManager: vi.fn(() => false),
+  }));
+  vi.doMock('./status-line.js', () => ({
+    StatusLine: vi.fn(() => ({ start: vi.fn(), stop: vi.fn(), repaint: vi.fn() })),
+  }));
+  vi.doMock('./slash/index.js', () => ({ registerAll: vi.fn() }));
+  vi.doMock('./slash/writer.js', () => ({
+    createConsoleWriter: vi.fn(() => ({
+      line: vi.fn(), raw: vi.fn(), success: vi.fn(),
+      info: vi.fn(), warn: vi.fn(), error: vi.fn(),
+    })),
+  }));
+}
+
+/**
+ * Regression (PR #751 review): `bootstrapSession` must ADOPT a caller-supplied
+ * `bootWarnings` array rather than allocating its own.
+ *
+ * `interactive.ts` owns the bucket so it can still drain it when bootstrap
+ * throws — a thrown bootstrap returns no ctx, and the post-clear drain is
+ * unreachable. If bootstrap silently allocated a private array instead, the
+ * success path would look identical while the abort path lost every warning
+ * again. Every other test in this area mocks `bootstrapSession` wholesale, so
+ * this identity assertion is the only thing standing between that refactor and
+ * a silent repeat of the bug (`docs/scrollback.md`: two prior fixes in this
+ * domain shipped green while broken).
+ */
+describe('interactive bootstrap — adopts the caller-owned bootWarnings bucket', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.restoreAllMocks();
@@ -181,71 +262,46 @@ describe('interactive bootstrap — P1: suggestBaseUrl mirrors openaiBaseUrl', (
     vi.restoreAllMocks();
   });
 
-  // Mocks shared with the status-line test above — enough to let
-  // bootstrapSession reach the InteractiveCtx construction without a real
-  // session/TTY. `loadConfig` is the subject: it is overridden per-case.
-  function applyCommonMocks(): void {
-    const rl = { on: vi.fn(), close: vi.fn() };
-    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
-    vi.doMock('node:readline', () => ({ createInterface: vi.fn(() => rl) }));
-    vi.doMock('../agent/session.js', () => ({
-      AgentSession: class MockAgentSession {
-        close = vi.fn(async () => undefined);
-        interrupt = vi.fn(async () => undefined);
-      },
-    }));
-    vi.doMock('../agent/default-hook-registry.js', () => ({
-      createDefaultHookRegistry: vi.fn(() => ({
-        // register stub: bootstrap now registers the terminal-state gate (#237)
-        // on the 'Stop' event, so the mock registry must expose `.register`.
-        registry: { register: vi.fn() },
-        memoryStore: { close: vi.fn() },
-        // Real factory always returns this ref (default-hook-registry.ts);
-        // bootstrap.ts writes `.current` once the provider exists, so the mock
-        // must include it or the assignment throws "Cannot set properties of
-        // undefined". Mirrors the status-line test mock above.
-        pathApprovalGrantRef: { current: undefined },
-      })),
-    }));
-    vi.doMock('../agent/memory/index.js', () => ({
-      MemoryStore: vi.fn(() => ({ close: vi.fn() })),
-      injectHotMemory: vi.fn((config: unknown) => config),
-      memoryToolSchemas: [],
-      MEMORY_TOOL_NAMES: [],
-      createMemoryHandlers: vi.fn(() => new Map()),
-    }));
-    vi.doMock('./shared-helpers.js', () => ({
-      parseThinking: vi.fn(() => undefined),
-      parseEffort: vi.fn(() => undefined),
-      parseMaxOutputTokens: vi.fn(() => undefined),
-      parseProvider: vi.fn(() => undefined),
-      getApiKey: vi.fn(() => 'test-key'),
-      getApiKeyForModel: vi.fn(() => 'test-key'),
-      getModel: vi.fn(() => 'sonnet'),
-      getThinking: vi.fn(() => undefined),
-      getEffort: vi.fn(() => undefined),
-      getMaxOutputTokens: vi.fn(() => undefined),
-      getMaxToolUseIterations: vi.fn(() => undefined),
-      getDefaultSubagentModel: vi.fn(() => 'sonnet'),
-      findClaudeExecutable: vi.fn(() => '/usr/bin/claude'),
-      loadSystemPrompt: vi.fn(() => undefined),
-      loadConfigSystemPrompt: vi.fn(() => undefined),
-      resolveBaseSystemPrompt: vi.fn(() => ({ prompt: undefined, source: 'none' })),
-      // Required since bootstrap.ts now calls isGrantManager — return false so
-      // these tests don't care about grant wiring.
-      isGrantManager: vi.fn(() => false),
-    }));
-    vi.doMock('./status-line.js', () => ({
-      StatusLine: vi.fn(() => ({ start: vi.fn(), stop: vi.fn(), repaint: vi.fn() })),
-    }));
-    vi.doMock('./slash/index.js', () => ({ registerAll: vi.fn() }));
-    vi.doMock('./slash/writer.js', () => ({
-      createConsoleWriter: vi.fn(() => ({
-        line: vi.fn(), raw: vi.fn(), success: vi.fn(),
-        info: vi.fn(), warn: vi.fn(), error: vi.fn(),
-      })),
-    }));
-  }
+  it('exposes the caller-supplied array as ctx.bootWarnings (same instance)', async () => {
+    applyCommonMocks();
+    vi.doMock('./config.js', () => ({ loadConfig: vi.fn(() => ({})) }));
+
+    const bootWarnings: string[] = [];
+    const { bootstrapSession } = await import('./commands/interactive/bootstrap.js');
+    const ctx = await bootstrapSession({ model: 'sonnet', maxTurns: '10' }, { bootWarnings });
+
+    // Identity, not deep equality: two empty arrays are `toEqual`-equal, so
+    // only `toBe` can distinguish adoption from a private allocation.
+    expect(ctx.bootWarnings).toBe(bootWarnings);
+
+    // And the sharing is live in the direction that matters — a producer
+    // pushing inside bootstrap is visible to the caller's catch block.
+    ctx.bootWarnings.push('[mcp] pushed by a producer');
+    expect(bootWarnings).toEqual(['[mcp] pushed by a producer']);
+  });
+
+  it('still allocates its own bucket when the caller supplies none', async () => {
+    applyCommonMocks();
+    vi.doMock('./config.js', () => ({ loadConfig: vi.fn(() => ({})) }));
+
+    const { bootstrapSession } = await import('./commands/interactive/bootstrap.js');
+    const ctx = await bootstrapSession({ model: 'sonnet', maxTurns: '10' });
+
+    // Backward compatibility: `extras.bootWarnings` is optional, so non-REPL
+    // callers keep a working (if unrecoverable-on-throw) bucket.
+    expect(ctx.bootWarnings).toEqual([]);
+  });
+});
+
+describe('interactive bootstrap — P1: suggestBaseUrl mirrors openaiBaseUrl', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
   it('uses cliConfig.openaiBaseUrl when only openaiBaseUrl is configured', async () => {
     applyCommonMocks();
@@ -583,7 +639,9 @@ describe('interactive worktree flag', () => {
     // slot). When no env var or config sets it, the slot is undefined.
     expect(setupWorktree).toHaveBeenCalledWith('feat-spec', undefined);
     expect(bootstrapMock).toHaveBeenCalledTimes(1);
-    expect(bootstrapMock.mock.calls[0]![1]).toEqual({ cwd: '/tmp/afk-wt/feat-spec' });
+    // `toMatchObject`, not `toEqual`: `extras` also carries the boot-warning
+    // bucket (#745/#751). What this pins is the worktree cwd threading.
+    expect(bootstrapMock.mock.calls[0]![1]).toMatchObject({ cwd: '/tmp/afk-wt/feat-spec' });
     expect(worktreeCleanup).toHaveBeenCalledTimes(1);
     expect(session.close).toHaveBeenCalledTimes(1);
 
@@ -627,7 +685,11 @@ describe('interactive worktree flag', () => {
     expect(exitSpy).toHaveBeenCalledWith(0);
     expect(setupWorktree).not.toHaveBeenCalled();
     expect(bootstrapMock).toHaveBeenCalledTimes(1);
-    expect(bootstrapMock.mock.calls[0]![1]).toBeUndefined();
+    // `extras` is always passed now (it carries the boot-warning bucket,
+    // #745/#751), so assert the absent-key property that actually matters: no
+    // cwd is threaded in when --worktree was not requested. The conditional
+    // spread must omit the key entirely, not set it to undefined.
+    expect(bootstrapMock.mock.calls[0]![1]).not.toHaveProperty('cwd');
   });
 
   // ── Item #1: worktree branch line persists past spinner.succeed ─────────

--- a/src/cli/interactive-lifecycle.test.ts
+++ b/src/cli/interactive-lifecycle.test.ts
@@ -380,6 +380,9 @@ describe('interactive command exit teardown', () => {
         // Stub registry: the teardown path calls cancelAll() during normal
         // session close. Real registry is exercised by bgsub.test.ts.
         backgroundRegistry: { cancelAll: vi.fn(async () => undefined) },
+        // #745: interactive.ts drains this after the startup screen clear.
+        // Required on InteractiveCtx — a fixture omitting it throws at the drain.
+        bootWarnings: [],
       })),
     }));
     vi.doMock('./commands/interactive/transcript.js', () => ({
@@ -537,6 +540,9 @@ describe('interactive worktree flag', () => {
       rl,
       options,
       backgroundRegistry: { cancelAll: vi.fn(async () => undefined) },
+      // #745: interactive.ts drains this after the startup screen clear.
+      // Required on InteractiveCtx — a fixture omitting it throws at the drain.
+      bootWarnings: [],
     }));
   }
 
@@ -707,6 +713,9 @@ describe('interactive worktree flag', () => {
         rl,
         options: { model: 'claude-opus-4', maxTurns: '10', debug: false, worktree: 'summary-test' },
         backgroundRegistry: { cancelAll: vi.fn(async () => undefined) },
+        // #745: interactive.ts drains this after the startup screen clear.
+        // Required on InteractiveCtx — a fixture omitting it throws at the drain.
+        bootWarnings: [],
       })),
     }));
 
@@ -810,6 +819,9 @@ describe('interactive worktree flag', () => {
         rl,
         options: { model: 'sonnet', maxTurns: '10', debug: false, worktree: 'feat-spec' },
         backgroundRegistry: { cancelAll: vi.fn(async () => undefined) },
+        // #745: interactive.ts drains this after the startup screen clear.
+        // Required on InteractiveCtx — a fixture omitting it throws at the drain.
+        bootWarnings: [],
       })),
     }));
 
@@ -932,6 +944,9 @@ describe('interactive signal-handler wiring (PR #486)', () => {
         rl,
         options: { model: 'sonnet', maxTurns: '10', debug: false },
         backgroundRegistry: { cancelAll: vi.fn(async () => undefined) },
+        // #745: interactive.ts drains this after the startup screen clear.
+        // Required on InteractiveCtx — a fixture omitting it throws at the drain.
+        bootWarnings: [],
       })),
     }));
 

--- a/tests/pty/scenarios.ts
+++ b/tests/pty/scenarios.ts
@@ -547,6 +547,79 @@ export const SCENARIOS: Record<string, PtyScenario> = {
       logicalSpan: { from: 'LOGSTART', to: 'LOGEND', maxNonWrappedRows: 1 },
     },
   },
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // #745 — bootstrap warnings must survive the startup screen clear.
+  //
+  // The headless test (interactive.boot-warnings.test.ts) proves the warning
+  // bytes are WRITTEN after the clear escape. Per docs/scrollback.md:9-13 that
+  // cannot prove they are actually READABLE afterwards: `\x1b[3J` is Erase
+  // Saved Lines, a property of the real terminal's scroll engine, not of our
+  // code. This scenario reproduces the true startup byte sequence in a real pty
+  // and asserts against the emulator buffer that the pre-clear write is GONE
+  // while the post-clear warning is present — the one assertion that would have
+  // caught the two prior fixes docs/scrollback.md:14-15 says shipped green.
+  // ─────────────────────────────────────────────────────────────────────────
+  'boot-warning-survives-clear': {
+    description: 'bootstrap warning emitted after the startup clear is readable; pre-clear write is erased',
+    cols: 80,
+    rows: 24,
+    ref: '#745 · interactive.ts startup clear vs. bootstrap warnings',
+    async drive({ stdout, stdin }): Promise<void> {
+      // Phase 1 — bootstrap: content written BEFORE the clear. This is what the
+      // agent-registry/MCP producers used to do (straight to stderr/stdout).
+      // Enough rows to push into scrollback, so the assertion covers scrollback
+      // erasure and not merely a viewport wipe.
+      for (let i = 0; i < 30; i++) stdout.write(`PRECLEAR_LINE_${i}\n`);
+
+      // Phase 2 — the startup clear, byte-identical to interactive.ts.
+      // `\x1b[3J` erases saved lines (scrollback); `\x1b[2J` the viewport;
+      // `\x1b[H` homes the cursor.
+      stdout.write('\x1b[3J\x1b[2J\x1b[H');
+
+      // Phase 3 — the pre-arm print block, in production order: banner, then
+      // the drained bootstrap warnings, then the trailing blank line.
+      const BANNER_ROWS = 11;
+      for (let i = 0; i < BANNER_ROWS; i++) stdout.write(`POSTCLEAR_BANNER_${i}\n`);
+      stdout.write('  [afk] agents: SHADOWWARN overrides built-in agent "research-agent"\n');
+      stdout.write('  [mcp] MCPWARN unknown key\n');
+      stdout.write('\n');
+
+      // Phase 4 — arm the compositor below the pre-arm content, exactly as
+      // runReplLoop does with `preArmAnchorRow`. The warnings must remain
+      // readable after the live frame installs and repaints, not be overwritten
+      // by a CUP-positioned frame that mis-measured the anchor row.
+      const anchorRow = BANNER_ROWS + 3; // banner + 2 warnings + blank
+      const statusLine = wireProductionFooter(stdout, 'M');
+      const c = new TerminalCompositor({
+        stdout, stdin, onCancel: () => {}, scrollRegion: statusLine, anchorRow,
+      });
+      await c.arm();
+      const ix = c as unknown as Repaintable;
+      c.setOverlay('preflight-line');
+      c.setOverlay('');
+      c.commitAbove('FIRST_TURN_OUTPUT');
+      ix.repaint();
+      await settle();
+    },
+    expect: {
+      // The bug, inverted: pre-clear writes are unrecoverable. If any survives,
+      // the scenario's premise (and the whole issue) is wrong — that would mean
+      // the warnings were never actually lost and this fix is unnecessary.
+      absent: ['PRECLEAR_LINE_0', 'PRECLEAR_LINE_29'],
+      // The fix: both drained warnings are readable in the live buffer after
+      // the clear, and survive the compositor arming + first commit over them.
+      inViewport: ['SHADOWWARN', 'MCPWARN'],
+      // Exactly once — a drain that re-printed on every repaint would spam.
+      exactlyOnce: ['SHADOWWARN', 'MCPWARN', 'FIRST_TURN_OUTPUT'],
+      // Warnings sit above the first turn's output, below the banner.
+      order: [
+        ['POSTCLEAR_BANNER_10', 'SHADOWWARN'],
+        ['SHADOWWARN', 'MCPWARN'],
+        ['MCPWARN', 'FIRST_TURN_OUTPUT'],
+      ],
+    },
+  },
 };
 
 export type ScenarioName = keyof typeof SCENARIOS;


### PR DESCRIPTION
Fixes #745.

## The bug

The REPL's startup clear (`\x1b[3J\x1b[2J\x1b[H`, `interactive.ts:676`) runs after `bootstrapSession` is awaited (`:406`) — same `.action()` callback, no early return, no TTY or flag gate between them (`awk` over that range for `return|throw|process.exit` returns zero hits). `\x1b[3J` is **Erase Saved Lines**, so it wipes scrollback as well as the viewport: anything bootstrap wrote straight to stdout/stderr was destroyed and unrecoverable, even by scrolling up.

That silently erased the built-in-shadow warning shipped in #739. It's a safety signal, not cosmetics — a single `~/.afk/agents/research-agent.md` declaring broader `tools:` converts the read-only verifier that nine bundled skills dispatch by bare name into a write-capable agent, for every project on the machine. #739's stated purpose was that this "stops being invisible"; on the REPL it stayed invisible, and `/agents` offers no recovery path (both providers return `[]` from `supportedAgents()`).

## The fix

Producers accumulate into `ctx.bootWarnings`; `interactive.ts` drains it **after** the clear, inside the pre-arm print block so the newlines count into `preArmAnchorRow` and the compositor arms below them. This reuses the drain timing already documented for the update-notice re-emit (`interactive.ts:35-44`), which solves the same problem for pre-`program.parse()` output. No new module-level singleton: bootstrap returns at `:406` and the clear fires at `:676` in the same function, so `ctx` already crosses the only boundary that matters.

Warnings print last in the block — closest to the prompt — because a shadow warning means a read-only agent may now be write-capable.

### Two things worth flagging for review

**1. I did not use the mechanism the issue suggested.** #745 proposed reusing `getPluginShadowingNoticeLines()`. Its drain site is gated behind `isDebugEnabled()` (`loop-iteration.ts:139` — one line above the citation in the issue), so routing safety warnings through it would have made them **debug-mode-only**: strictly worse than the stderr status quo, while satisfying every acceptance criterion in the issue. It's also timing-mismatched, firing async off `waitForInitialization()` after the loop has already started.

**2. The MCP producer had a divergence the issue didn't name.** `bootstrap.ts:523` — the line the issue cites — is only the *no-enabled-servers* branch. On the common path, warnings print inside `McpManager.fromConfig` (`manager.ts:116-118`) via the `warnings:` option. Capturing only the cited line would have fixed the rare branch and missed the common one. Both now route through the single bucket. `chat`, `daemon`, and `telegram` still forward `warnings` into `fromConfig` and are untouched — they never clear the screen — so nothing double-prints.

## Verification

`docs/scrollback.md:108-113` is explicit that no test verifies real scrollback, and that **two prior fixes in this domain shipped green while broken**. So byte-level tests were treated as necessary but not sufficient:

- **`interactive.boot-warnings.test.ts`** (new, 5 tests) — pins write ORDER via `invocationCallOrder` (warning after the clear escape), single-emission, and buffer drain. **Mutation-tested**: reverting just the drain block fails 4 of the 5, so these tests genuinely pin the fix rather than passing either way.
- **`tests/pty/scenarios.ts` → `boot-warning-survives-clear`** (new) — real-pty scenario, auto-collected by the existing loop. Asserts the warning is readable in the emulator buffer **and** that pre-clear writes are `absent` — so the erasure premise is empirically demonstrated on real hardware, not assumed.
- **Real-terminal ground truth** — drove the built CLI inside a genuine pty with a project-local shadowing fixture, replaying into `@xterm/headless`:
  - **With this fix:** warning renders one row above the prompt, exactly once, `\x1b[3J` confirmed present in the stream.
  - **On unmodified `main`, identical setup:** the warning appears **nowhere** in the buffer — viewport or scrollback.

Gates: `pnpm lint` clean, `pnpm test` 13430 passed / 707 files, `pnpm test:coverage` passes thresholds, `pnpm test:pty` 9 passed. Baseline was confirmed green before starting, so no failures are pre-existing.

## Note on the touched test fixtures

`bootWarnings` is a **required** field on `InteractiveCtx` rather than optional — the contract should be explicit, and there's one production constructor. The 5 `interactive-lifecycle.test.ts` ctx fixtures build partial objects cast past the type checker, so they needed `bootWarnings: []` added; without it they throw at the drain site. I chose that over an optional field with a `?.` fallback, which would have hidden the contract and let a future producer silently skip the drain.

## Deliberately out of scope

The erased class is larger than the two producers #745 names — also reachable during the same awaited bootstrap: `bootstrap.ts:959` (path-approval), `default-hook-registry.ts:207,299`, `config-bridge.ts:81`, `permissions-store.ts:152`, `mcp/manager.ts:136,235`, `plugins/tool-injector.ts:327-336`. `ctx.bootWarnings` is the seam for those, but converting them all here would widen the blast radius well past a P2 fix.

Separately worth its own issue: `discoverPluginAgents` (`skill-bridge.ts:372`) calls `parseAgentMarkdown` with **no** warn callback, so malformed plugin-agent files are silently swallowed and never reach stderr at all — a different bug from this one (never written vs. written-then-erased).
