### PR TITLE
fix(permissions): follow AFK_HOME in the credential floor + reject overly broad subagent cwd/writeRoots

### DIFF
--- a/src/agent/tools/afk-home-warn.ts
+++ b/src/agent/tools/afk-home-warn.ts
@@ -1,0 +1,57 @@
+/**
+ * One-shot operator diagnostic for a malformed `AFK_HOME` / `AFK_STATE_DIR`.
+ *
+ * Every credential-floor derivation site (`read-denylist`, `write-denylist`,
+ * `bash-restriction-hook`) calls `getAfkHome()` / `getAfkStateDir()` inside a
+ * `try` and drops only the derived entry when it throws. That fail-safe
+ * direction is correct — a typo'd env var must never empty the floor, and the
+ * hardcoded `homedir()`-based entries still apply. Its INVISIBILITY was the
+ * defect: an operator who typo'd `AFK_HOME` ran on a silently reduced floor
+ * with no diagnostic anywhere in the process.
+ *
+ * Invariant: the warning is latched to fire at most ONCE per process, not once
+ * per call. These derivations sit on the read/write hot path — `getReadDenylist`
+ * is consulted on every typed read and `getWriteDenylist` on every
+ * `write_file`/`edit_file` — so a per-call warn would emit thousands of
+ * identical lines and become its own denial-of-service on the operator's
+ * terminal. The latch is module-scope state, which is why this lives in its own
+ * module: all four call sites must share ONE latch, and a per-file copy would
+ * warn once per file instead.
+ *
+ * @module agent/tools/afk-home-warn
+ */
+
+let warned = false;
+
+/**
+ * Emit a single warn-level line naming the rejected env value, then latch.
+ *
+ * Contract: never throws (a diagnostic must not become the failure it reports),
+ * never alters control flow, and returns void. The rejected value is carried in
+ * the thrown message from `paths.ts` (`... got: <value>`), so it is surfaced
+ * without this module re-reading the environment.
+ *
+ * @param err The error thrown by `getAfkHome()` / `getAfkStateDir()`.
+ */
+export function warnAfkHomeRejectedOnce(err: unknown): void {
+  if (warned) return;
+  warned = true;
+  const reason = err instanceof Error ? err.message : String(err);
+  console.warn(
+    `[afk-home] Malformed AFK home/state env var ignored while deriving the ` +
+      `credential floor: ${reason}. The relocated tree is NOT protected — the ` +
+      `default ~/.afk entries still apply. Fix the env var to restore coverage.`,
+  );
+}
+
+/**
+ * Test-only: clear the once-latch so a suite can assert the warning fires.
+ *
+ * Contract: production code must never call this. Without it a test asserting
+ * the warn would depend on suite ordering — whichever spec touched a malformed
+ * env var first would consume the single latch and every later assertion would
+ * see silence.
+ */
+export function resetAfkHomeWarnLatchForTests(): void {
+  warned = false;
+}

--- a/src/agent/tools/handlers/read-denylist.test.ts
+++ b/src/agent/tools/handlers/read-denylist.test.ts
@@ -45,6 +45,7 @@ beforeEach(() => {
 
 afterEach(() => {
   delete process.env['AFK_READ_DENYLIST'];
+  delete process.env['AFK_HOME'];
   _resetReadDenylistCacheForTests();
   if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
 });
@@ -285,6 +286,84 @@ describe('read-denylist — AFK_READ_DENYLIST extras', () => {
     // does NOT widen into the real ~/.ssh floor, which stands on its own.
     expect(getReadDenylist().some((p) => p.endsWith('~someone/.ssh'))).toBe(true);
     expect(isReadDenied(join(homedir(), '.ssh', 'id_rsa')).denied).toBe(true);
+  });
+});
+
+describe('read-denylist — AFK_HOME-relocated credential tree (#740)', () => {
+  it('denies afk.env under a relocated AFK_HOME config dir', () => {
+    const relocated = join(tmpDir, 'relocated-home');
+    mkdirSync(relocated, { recursive: true });
+    process.env['AFK_HOME'] = relocated;
+    _resetReadDenylistCacheForTests();
+
+    expect(isReadDenied(join(relocated, 'config', 'afk.env')).denied).toBe(true);
+  });
+
+  it('still denies the real homedir() ~/.afk/config entry when AFK_HOME is relocated', () => {
+    // ADDITIVE, not a replacement: relocating AFK_HOME must not stop covering
+    // the default homedir()-based tree (an operator could have stale files
+    // there, or another process still reads the default location).
+    const relocated = join(tmpDir, 'relocated-home-2');
+    mkdirSync(relocated, { recursive: true });
+    process.env['AFK_HOME'] = relocated;
+    _resetReadDenylistCacheForTests();
+
+    expect(isReadDenied(join(homedir(), '.afk', 'config', 'afk.env')).denied).toBe(true);
+  });
+
+  it('does NOT deny the relocated AFK_HOME state dir (mirrors the default-home divergence)', () => {
+    const relocated = join(tmpDir, 'relocated-home-state');
+    mkdirSync(relocated, { recursive: true });
+    process.env['AFK_HOME'] = relocated;
+    _resetReadDenylistCacheForTests();
+
+    expect(
+      isReadDenied(join(relocated, 'state', 'todos', 'x.json')).denied,
+    ).toBe(false);
+  });
+
+  it('behavior is unchanged and the derived entry does not double up when AFK_HOME is unset', () => {
+    delete process.env['AFK_HOME'];
+    _resetReadDenylistCacheForTests();
+
+    expect(isReadDenied(join(homedir(), '.afk', 'config', 'afk.env')).denied).toBe(true);
+    const configEntryCount = getReadDenylist().filter(
+      (p) => p === safeRealpath(join(homedir(), '.afk', 'config')),
+    ).length;
+    expect(configEntryCount).toBe(1);
+  });
+
+  // Fail-safe: getAfkHome() throws when AFK_HOME is set but not absolute. The
+  // read denylist must not let that throw propagate and empty the floor —
+  // it must skip only the derived entry and keep the homedir()-based ones.
+  it('stays fail-safe when AFK_HOME is a relative path (getAfkHome() throws)', () => {
+    process.env['AFK_HOME'] = 'relative/not-absolute';
+    _resetReadDenylistCacheForTests();
+
+    expect(() => isReadDenied(join(homedir(), '.afk', 'config', 'afk.env'))).not.toThrow();
+    expect(isReadDenied(join(homedir(), '.afk', 'config', 'afk.env')).denied).toBe(true);
+    expect(isReadDenied(join(homedir(), '.ssh', 'id_rsa')).denied).toBe(true);
+  });
+
+  // Cache-invalidation: the memoization key must include AFK_HOME, not just
+  // AFK_READ_DENYLIST, or a runtime AFK_HOME change returns a STALE verdict.
+  // Invariant: deliberately NO `_resetReadDenylistCacheForTests()` call
+  // between the two queries below — that reset is what the memo key itself
+  // is supposed to make unnecessary. Calling it here would make this test
+  // pass even if AFK_HOME were dropped from the key entirely, defeating the
+  // point of the regression guard.
+  it('invalidates the memoized list when AFK_HOME changes, with no manual cache reset (cache-key regression guard)', () => {
+    // `beforeEach` already reset the cache and AFK_HOME is unset at test start.
+    const relocated = join(tmpDir, 'second-home');
+    mkdirSync(relocated, { recursive: true });
+    const target = join(relocated, 'config', 'afk.env');
+
+    // Query once with AFK_HOME unset: the relocated config dir is NOT covered.
+    expect(isReadDenied(target).denied).toBe(false);
+
+    // Change AFK_HOME and query again — WITHOUT resetting the cache by hand.
+    process.env['AFK_HOME'] = relocated;
+    expect(isReadDenied(target).denied).toBe(true);
   });
 });
 

--- a/src/agent/tools/handlers/read-denylist.test.ts
+++ b/src/agent/tools/handlers/read-denylist.test.ts
@@ -396,6 +396,22 @@ describe('read-denylist — AFK_HOME-relocated credential tree (#740)', () => {
     process.env['AFK_HOME'] = relocated;
     expect(isReadDenied(target).denied).toBe(true);
   });
+
+  // paths.ts treats '' as unset (`envVal !== undefined && envVal !== ''`).
+  // That branch was covered on no surface. Pin it: an empty AFK_HOME must
+  // behave exactly like an unset one, never widening or emptying the floor.
+  it('treats an empty AFK_HOME as unset', () => {
+    process.env['AFK_HOME'] = '';
+    _resetReadDenylistCacheForTests();
+
+    expect(isReadDenied(join(homedir(), '.afk', 'config', 'afk.env')).denied).toBe(true);
+    // The mcp.json carve-out still applies under the default home.
+    expect(isReadDenied(join(homedir(), '.afk', 'config', 'mcp.json')).denied).toBe(false);
+    const configEntryCount = getReadDenylist().filter(
+      (p) => p === safeRealpath(join(homedir(), '.afk', 'config')),
+    ).length;
+    expect(configEntryCount).toBe(1);
+  });
 });
 
 describe('parseReadDenylistEntries — the single parser both surfaces share', () => {

--- a/src/agent/tools/handlers/read-denylist.test.ts
+++ b/src/agent/tools/handlers/read-denylist.test.ts
@@ -299,6 +299,37 @@ describe('read-denylist — AFK_HOME-relocated credential tree (#740)', () => {
     expect(isReadDenied(join(relocated, 'config', 'afk.env')).denied).toBe(true);
   });
 
+  // The mcp.json carve-out MUST follow AFK_HOME whenever the denied parent dir
+  // does. Extending only the deny side inverts the carve-out: the registry
+  // becomes unreadable under a relocated home while the default-home spelling
+  // stays readable — invisible to the typed tools AND the bash surface for
+  // exactly the operators who relocated it. Caught by an empirical probe after
+  // the deny-side change looked complete in review.
+  it('keeps the mcp.json carve-out readable under a relocated AFK_HOME', () => {
+    const relocated = join(tmpDir, 'relocated-home-allow');
+    mkdirSync(join(relocated, 'config'), { recursive: true });
+    process.env['AFK_HOME'] = relocated;
+    _resetReadDenylistCacheForTests();
+
+    // The parent dir stays denied …
+    expect(isReadDenied(join(relocated, 'config', 'afk.env')).denied).toBe(true);
+    // … while the registry itself remains readable, exactly as it does at the
+    // default home location.
+    expect(isReadDenied(join(relocated, 'config', 'mcp.json')).denied).toBe(false);
+  });
+
+  it('keeps a relocated mcp.json re-deniable via AFK_READ_DENYLIST (precedence holds)', () => {
+    const relocated = join(tmpDir, 'relocated-home-redeny');
+    mkdirSync(join(relocated, 'config'), { recursive: true });
+    process.env['AFK_HOME'] = relocated;
+    process.env['AFK_READ_DENYLIST'] = join(relocated, 'config', 'mcp.json');
+    _resetReadDenylistCacheForTests();
+
+    // An explicit extra outranks the derived carve-out, same as it outranks the
+    // hardcoded one.
+    expect(isReadDenied(join(relocated, 'config', 'mcp.json')).denied).toBe(true);
+  });
+
   it('still denies the real homedir() ~/.afk/config entry when AFK_HOME is relocated', () => {
     // ADDITIVE, not a replacement: relocating AFK_HOME must not stop covering
     // the default homedir()-based tree (an operator could have stale files

--- a/src/agent/tools/handlers/read-denylist.ts
+++ b/src/agent/tools/handlers/read-denylist.ts
@@ -34,6 +34,7 @@ import { env } from '../../../config/env.js';
 import { basename, dirname, join, resolve } from 'path';
 import { homedir } from 'os';
 import { safeRealpath } from './write-denylist.js';
+import { getAfkHome } from '../../../paths.js';
 
 /**
  * Paths that `read_file` / `grep` / `glob` / `list_directory` must never read —
@@ -174,19 +175,55 @@ export function parseReadDenylistEntries(raw: string | undefined): string[] {
     .map((p) => resolve(p));
 }
 
+/**
+ * Best-effort derived read-denylist entry for the `AFK_HOME`-relocated config
+ * dir (`${getAfkHome()}/config`), ADDITIVE alongside the hardcoded
+ * `${homedir()}/.afk/config` literal in {@link BUILTIN_READ_DENYLIST} (both
+ * spellings are covered; they are equal, and de-duplicated by the caller,
+ * when `AFK_HOME` is unset). Computed HERE — inside {@link resolveLists}, not
+ * at module scope — because a module-level `getAfkHome()` call would
+ * evaluate once at import time and never observe a runtime `AFK_HOME` change
+ * (the test suite mutates env vars; production operators can too via a
+ * process restart with a different env).
+ *
+ * `getAfkHome()` throws when `AFK_HOME` is set but not absolute (or is `/`,
+ * see `paths.ts`). Caught and dropped here — a malformed env var must never
+ * empty the credential floor; the hardcoded `homedir()`-based entries still
+ * apply regardless.
+ */
+function derivedAfkHomeReadEntry(): string[] {
+  try {
+    return [safeRealpath(resolve(join(getAfkHome(), 'config')))];
+  } catch {
+    return [];
+  }
+}
+
 function resolveLists(): {
   builtins: readonly string[];
   extras: readonly string[];
   allow: readonly string[];
 } {
-  const key = env.AFK_READ_DENYLIST ?? '';
+  // Invariant: AFK_HOME is part of the cache key alongside AFK_READ_DENYLIST.
+  // The builtins list now depends on it (derivedAfkHomeReadEntry), so a
+  // runtime AFK_HOME change must invalidate the memo the same way an
+  // AFK_READ_DENYLIST change does — otherwise a stale denylist survives a
+  // relocated AFK_HOME. Joined with U+0000, which cannot occur in either env
+  // value, so the two components can never collide into an ambiguous key.
+  const key = `${env.AFK_READ_DENYLIST ?? ''}\u0000${env.AFK_HOME ?? ''}`;
   if (cached && cached.key === key) return cached;
-  const extras: string[] = parseReadDenylistEntries(key)
+  const extras: string[] = parseReadDenylistEntries(env.AFK_READ_DENYLIST)
     .map((p) => safeRealpath(p))
     .filter(Boolean);
+  const builtins = [
+    ...new Set([
+      ...BUILTIN_READ_DENYLIST.map((p) => safeRealpath(resolve(p))),
+      ...derivedAfkHomeReadEntry(),
+    ]),
+  ];
   cached = {
     key,
-    builtins: BUILTIN_READ_DENYLIST.map((p) => safeRealpath(resolve(p))),
+    builtins,
     extras,
     allow: BUILTIN_READ_ALLOWLIST.map(resolveExceptionEntry),
   };

--- a/src/agent/tools/handlers/read-denylist.ts
+++ b/src/agent/tools/handlers/read-denylist.ts
@@ -35,6 +35,7 @@ import { basename, dirname, join, resolve } from 'path';
 import { homedir } from 'os';
 import { safeRealpath } from './write-denylist.js';
 import { getAfkHome } from '../../../paths.js';
+import { warnAfkHomeRejectedOnce } from '../afk-home-warn.js';
 
 /**
  * Paths that `read_file` / `grep` / `glob` / `list_directory` must never read —
@@ -194,7 +195,8 @@ export function parseReadDenylistEntries(raw: string | undefined): string[] {
 function derivedAfkHomeReadEntry(): string[] {
   try {
     return [safeRealpath(resolve(join(getAfkHome(), 'config')))];
-  } catch {
+  } catch (err) {
+    warnAfkHomeRejectedOnce(err);
     return [];
   }
 }
@@ -226,7 +228,8 @@ function derivedAfkHomeAllowEntries(): string[] {
     return READ_ALLOWLIST_REL.filter((rel) => rel.startsWith(AFK_HOME_REL_PREFIX)).map((rel) =>
       resolveExceptionEntry(join(afkHome, rel.slice(AFK_HOME_REL_PREFIX.length))),
     );
-  } catch {
+  } catch (err) {
+    warnAfkHomeRejectedOnce(err);
     return [];
   }
 }

--- a/src/agent/tools/handlers/read-denylist.ts
+++ b/src/agent/tools/handlers/read-denylist.ts
@@ -199,6 +199,38 @@ function derivedAfkHomeReadEntry(): string[] {
   }
 }
 
+const AFK_HOME_REL_PREFIX = '.afk/';
+
+/**
+ * The `AFK_HOME`-relocated spelling of every {@link READ_ALLOWLIST_REL}
+ * carve-out, derived the same way {@link derivedAfkHomeReadEntry} derives the
+ * denied parent.
+ *
+ * Invariant: the allowlist MUST follow `AFK_HOME` whenever the denylist does.
+ * These two move together or the carve-out silently inverts: extending only the
+ * deny side makes `${getAfkHome()}/config/mcp.json` unreadable under a
+ * relocated home while the default-home spelling stays readable — the registry
+ * becomes invisible to both the typed tools and the bash surface for exactly
+ * the operators who relocated it. An empirical probe caught that asymmetry;
+ * a diff read did not.
+ *
+ * Entries are declared relative to the home dir (`.afk/config/mcp.json`), so
+ * the relocated form is the tail after `.afk/` rejoined under `getAfkHome()`.
+ * A non-`.afk/` entry has no relocated spelling and is skipped. `getAfkHome()`
+ * throws on a malformed `AFK_HOME`; caught and dropped, which fails CLOSED
+ * here (no extra carve-out) rather than open.
+ */
+function derivedAfkHomeAllowEntries(): string[] {
+  try {
+    const afkHome = getAfkHome();
+    return READ_ALLOWLIST_REL.filter((rel) => rel.startsWith(AFK_HOME_REL_PREFIX)).map((rel) =>
+      resolveExceptionEntry(join(afkHome, rel.slice(AFK_HOME_REL_PREFIX.length))),
+    );
+  } catch {
+    return [];
+  }
+}
+
 function resolveLists(): {
   builtins: readonly string[];
   extras: readonly string[];
@@ -225,7 +257,12 @@ function resolveLists(): {
     key,
     builtins,
     extras,
-    allow: BUILTIN_READ_ALLOWLIST.map(resolveExceptionEntry),
+    allow: [
+      ...new Set([
+        ...BUILTIN_READ_ALLOWLIST.map(resolveExceptionEntry),
+        ...derivedAfkHomeAllowEntries(),
+      ]),
+    ],
   };
   return cached;
 }

--- a/src/agent/tools/handlers/write-denylist.test.ts
+++ b/src/agent/tools/handlers/write-denylist.test.ts
@@ -31,6 +31,7 @@ import {
   BUILTIN_WRITE_DENYLIST,
   getWriteDenylist,
 } from './write-denylist.js';
+import { resetAfkHomeWarnLatchForTests } from '../afk-home-warn.js';
 
 const SIG = AbortSignal.timeout(5000);
 
@@ -443,5 +444,88 @@ describe('write-denylist — AFK_HOME-relocated credential tree (#740)', () => {
     vi.stubEnv('AFK_HOME', relocated);
 
     expect(() => assertNotDenylisted(join(tmpDir, 'safe.txt'))).not.toThrow();
+  });
+
+  // AFK_STATE_DIR relocates the ENTIRE state tier INDEPENDENTLY of AFK_HOME
+  // (paths.ts returns it verbatim when set). Deriving the tier from AFK_HOME
+  // alone left an operator running AFK_STATE_DIR=/opt/state with zero write
+  // protection on their real state tier — the same env-relocation class this
+  // module exists to close.
+  it('covers a state tier relocated by AFK_STATE_DIR independently of AFK_HOME', () => {
+    const stateDir = join(tmpDir, 'independent-state');
+    mkdirSync(stateDir, { recursive: true });
+    vi.stubEnv('AFK_STATE_DIR', stateDir);
+
+    expect(() =>
+      assertNotDenylisted(join(stateDir, 'sessions', 's.json'), 'write_file'),
+    ).toThrow(/refusing to write to protected path/);
+  });
+
+  it('covers AFK_STATE_DIR even when AFK_HOME is relocated elsewhere', () => {
+    const relocated = join(tmpDir, 'home-a');
+    const stateDir = join(tmpDir, 'state-b');
+    mkdirSync(relocated, { recursive: true });
+    mkdirSync(stateDir, { recursive: true });
+    vi.stubEnv('AFK_HOME', relocated);
+    vi.stubEnv('AFK_STATE_DIR', stateDir);
+
+    // Both tiers are floored: the AFK_HOME-derived config dir AND the
+    // independently-relocated state dir.
+    expect(() =>
+      assertNotDenylisted(join(relocated, 'config', 'afk.env'), 'write_file'),
+    ).toThrow(/refusing to write to protected path/);
+    expect(() =>
+      assertNotDenylisted(join(stateDir, 'sessions', 's.json'), 'write_file'),
+    ).toThrow(/refusing to write to protected path/);
+  });
+
+  // Invariant: the two derivations live in SEPARATE try blocks, so one
+  // malformed env var must not discard the other's entries.
+  it('keeps the AFK_HOME config entry when AFK_STATE_DIR alone is malformed', () => {
+    const relocated = join(tmpDir, 'home-c');
+    mkdirSync(relocated, { recursive: true });
+    vi.stubEnv('AFK_HOME', relocated);
+    vi.stubEnv('AFK_STATE_DIR', 'relative/not-absolute');
+
+    expect(() => getWriteDenylist()).not.toThrow();
+    expect(() =>
+      assertNotDenylisted(join(relocated, 'config', 'afk.env'), 'write_file'),
+    ).toThrow(/refusing to write to protected path/);
+    // And the hardcoded floor is untouched.
+    expect(() => assertNotDenylisted(sshPath, 'write_file')).toThrow(
+      /refusing to write to protected path/,
+    );
+  });
+
+  it('treats an empty AFK_HOME as unset', () => {
+    vi.stubEnv('AFK_HOME', '');
+
+    expect(() =>
+      assertNotDenylisted(join(homedir(), '.afk', 'config', 'afk.env'), 'write_file'),
+    ).toThrow(/refusing to write to protected path/);
+    expect(() =>
+      assertNotDenylisted(join(homedir(), '.afk', 'state', 'sessions', 's.json'), 'write_file'),
+    ).toThrow(/refusing to write to protected path/);
+  });
+
+  // The fail-safe direction is correct but used to be INVISIBLE: an operator
+  // who typo'd AFK_HOME ran on a silently reduced floor. Pin that it now says so.
+  it('warns once when a malformed AFK_HOME is rejected', () => {
+    resetAfkHomeWarnLatchForTests();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      vi.stubEnv('AFK_HOME', 'relative/not-absolute');
+
+      getWriteDenylist();
+      getWriteDenylist();
+      getWriteDenylist();
+
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0]?.[0]).toContain('[afk-home]');
+      expect(warn.mock.calls[0]?.[0]).toContain('relative/not-absolute');
+    } finally {
+      warn.mockRestore();
+      resetAfkHomeWarnLatchForTests();
+    }
   });
 });

--- a/src/agent/tools/handlers/write-denylist.test.ts
+++ b/src/agent/tools/handlers/write-denylist.test.ts
@@ -25,7 +25,12 @@ import { homedir } from 'os';
 import { tmpdir } from 'os';
 import { writeFileHandler } from './write-file.js';
 import { editFileHandler } from './edit-file.js';
-import { assertNotDenylisted, safeRealpath, BUILTIN_WRITE_DENYLIST } from './write-denylist.js';
+import {
+  assertNotDenylisted,
+  safeRealpath,
+  BUILTIN_WRITE_DENYLIST,
+  getWriteDenylist,
+} from './write-denylist.js';
 
 const SIG = AbortSignal.timeout(5000);
 
@@ -372,5 +377,71 @@ describe('AFK_WRITE_DENYLIST env override', () => {
     expect(() => assertNotDenylisted(sshPath, 'write_file')).toThrow(
       /refusing to write to protected path/,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AFK_HOME-relocated credential tree (#740)
+// ---------------------------------------------------------------------------
+
+describe('write-denylist — AFK_HOME-relocated credential tree (#740)', () => {
+  it('covers both the relocated config dir AND the relocated state dir', () => {
+    const relocated = join(tmpDir, 'relocated-home');
+    mkdirSync(relocated, { recursive: true });
+    vi.stubEnv('AFK_HOME', relocated);
+
+    expect(() =>
+      assertNotDenylisted(join(relocated, 'config', 'afk.env'), 'write_file'),
+    ).toThrow(/refusing to write to protected path/);
+    expect(() =>
+      assertNotDenylisted(join(relocated, 'state', 'sessions', 's.json'), 'write_file'),
+    ).toThrow(/refusing to write to protected path/);
+  });
+
+  it('still covers the real homedir() ~/.afk/config and ~/.afk/state when AFK_HOME is relocated', () => {
+    // ADDITIVE, not a replacement.
+    const relocated = join(tmpDir, 'relocated-home-2');
+    mkdirSync(relocated, { recursive: true });
+    vi.stubEnv('AFK_HOME', relocated);
+
+    expect(() =>
+      assertNotDenylisted(join(homedir(), '.afk', 'config', 'afk.env'), 'write_file'),
+    ).toThrow(/refusing to write to protected path/);
+    expect(() =>
+      assertNotDenylisted(join(homedir(), '.afk', 'state', 'sessions', 's.json'), 'write_file'),
+    ).toThrow(/refusing to write to protected path/);
+  });
+
+  it('behavior is unchanged and the derived entries do not double up when AFK_HOME is unset', () => {
+    expect(() =>
+      assertNotDenylisted(join(homedir(), '.afk', 'config', 'afk.env'), 'write_file'),
+    ).toThrow(/refusing to write to protected path/);
+    const configEntryCount = getWriteDenylist().filter(
+      (p) => p === safeRealpath(join(homedir(), '.afk', 'config')),
+    ).length;
+    expect(configEntryCount).toBe(1);
+  });
+
+  // Fail-safe: getAfkHome() throws when AFK_HOME is set but not absolute. The
+  // write denylist must not let that throw propagate and empty the floor —
+  // it must skip only the derived entries and keep the homedir()-based ones.
+  it('stays fail-safe when AFK_HOME is a relative path (getAfkHome() throws)', () => {
+    vi.stubEnv('AFK_HOME', 'relative/not-absolute');
+
+    expect(() => getWriteDenylist()).not.toThrow();
+    expect(() =>
+      assertNotDenylisted(join(homedir(), '.afk', 'config', 'afk.env'), 'write_file'),
+    ).toThrow(/refusing to write to protected path/);
+    expect(() => assertNotDenylisted(sshPath, 'write_file')).toThrow(
+      /refusing to write to protected path/,
+    );
+  });
+
+  it('allows a normal write once AFK_HOME is relocated (no over-broad denial)', () => {
+    const relocated = join(tmpDir, 'relocated-home-3');
+    mkdirSync(relocated, { recursive: true });
+    vi.stubEnv('AFK_HOME', relocated);
+
+    expect(() => assertNotDenylisted(join(tmpDir, 'safe.txt'))).not.toThrow();
   });
 });

--- a/src/agent/tools/handlers/write-denylist.ts
+++ b/src/agent/tools/handlers/write-denylist.ts
@@ -18,6 +18,7 @@ import { env } from '../../../config/env.js';
 import { realpathSync } from 'fs';
 import { dirname, resolve, join } from 'path';
 import { homedir } from 'os';
+import { getAfkHome } from '../../../paths.js';
 
 /**
  * Paths that write_file / edit_file must never touch — credential stores,
@@ -47,6 +48,38 @@ export const BUILTIN_WRITE_DENYLIST: readonly string[] = [
 ];
 
 /**
+ * Best-effort derived write-denylist entries for the `AFK_HOME`-relocated
+ * config AND state dirs (`${getAfkHome()}/config`, `${getAfkHome()}/state`),
+ * ADDITIVE alongside the hardcoded `${homedir()}/.afk/config` and
+ * `${homedir()}/.afk/state` literals in {@link BUILTIN_WRITE_DENYLIST} (both
+ * spellings are covered; de-duplicated by the caller when `AFK_HOME` is
+ * unset). Mirrors BOTH existing AFK entries in the write denylist — unlike
+ * the read denylist, `state` belongs here too (writes to session/todo/
+ * transcript state are never legitimate for a model to perform directly).
+ *
+ * `getAfkHome()` throws when `AFK_HOME` is set but not absolute (or is `/`,
+ * see `paths.ts`). Caught and dropped here — a malformed env var must never
+ * empty the credential floor; the hardcoded `homedir()`-based entries still
+ * apply regardless.
+ *
+ * Called fresh on every {@link getWriteDenylist} call (this module is
+ * uncached, unlike the read denylist), so no separate cache-key concern
+ * applies here — a runtime `AFK_HOME` change is picked up on the very next
+ * call.
+ */
+function derivedAfkHomeWriteEntries(): string[] {
+  try {
+    const home = getAfkHome();
+    return [
+      safeRealpath(resolve(join(home, 'config'))),
+      safeRealpath(resolve(join(home, 'state'))),
+    ];
+  } catch {
+    return [];
+  }
+}
+
+/**
  * Return the effective denylist (builtin + any user-supplied extras).
  * Entries are returned as real (symlink-resolved) absolute paths.
  *
@@ -59,7 +92,13 @@ export function getWriteDenylist(): readonly string[] {
   const extras: string[] = extra
     ? extra.split(':').map((p) => safeRealpath(resolve(p))).filter(Boolean)
     : [];
-  return [...BUILTIN_WRITE_DENYLIST.map((p) => safeRealpath(resolve(p))), ...extras];
+  const builtins = [
+    ...new Set([
+      ...BUILTIN_WRITE_DENYLIST.map((p) => safeRealpath(resolve(p))),
+      ...derivedAfkHomeWriteEntries(),
+    ]),
+  ];
+  return [...builtins, ...extras];
 }
 
 /**

--- a/src/agent/tools/handlers/write-denylist.ts
+++ b/src/agent/tools/handlers/write-denylist.ts
@@ -18,7 +18,8 @@ import { env } from '../../../config/env.js';
 import { realpathSync } from 'fs';
 import { dirname, resolve, join } from 'path';
 import { homedir } from 'os';
-import { getAfkHome } from '../../../paths.js';
+import { getAfkHome, getAfkStateDir } from '../../../paths.js';
+import { warnAfkHomeRejectedOnce } from '../afk-home-warn.js';
 
 /**
  * Paths that write_file / edit_file must never touch — credential stores,
@@ -57,26 +58,46 @@ export const BUILTIN_WRITE_DENYLIST: readonly string[] = [
  * the read denylist, `state` belongs here too (writes to session/todo/
  * transcript state are never legitimate for a model to perform directly).
  *
- * `getAfkHome()` throws when `AFK_HOME` is set but not absolute (or is `/`,
- * see `paths.ts`). Caught and dropped here — a malformed env var must never
- * empty the credential floor; the hardcoded `homedir()`-based entries still
- * apply regardless.
+ * Invariant: the state tier is derived via `getAfkStateDir()`, NOT
+ * `join(getAfkHome(), 'state')` alone. `AFK_STATE_DIR` relocates the ENTIRE
+ * state tier INDEPENDENTLY of `AFK_HOME` (`paths.ts`: it returns `AFK_STATE_DIR`
+ * verbatim when set and only falls back to `join(getAfkHome(), 'state')`
+ * otherwise). Deriving the tier from `AFK_HOME` alone left an operator running
+ * `AFK_STATE_DIR=/opt/state` with zero write protection on their real state
+ * tier — the same env-relocation gap this module exists to close. Both
+ * spellings are emitted; the caller's `new Set` collapses them when they
+ * coincide.
+ *
+ * Invariant: the two derivations sit in SEPARATE `try` blocks so one malformed
+ * env var cannot drop the other's entries. A single combined block would let a
+ * bad `AFK_STATE_DIR` also discard the `config` entry it never influenced.
+ *
+ * `getAfkHome()` / `getAfkStateDir()` throw when their env var is set but not
+ * absolute (or is `/`, see `paths.ts`). Caught and dropped here — a malformed
+ * env var must never empty the credential floor; the hardcoded
+ * `homedir()`-based entries still apply regardless. The throw is no longer
+ * silent: {@link warnAfkHomeRejectedOnce} surfaces it once per process.
  *
  * Called fresh on every {@link getWriteDenylist} call (this module is
  * uncached, unlike the read denylist), so no separate cache-key concern
- * applies here — a runtime `AFK_HOME` change is picked up on the very next
- * call.
+ * applies here — a runtime `AFK_HOME` / `AFK_STATE_DIR` change is picked up on
+ * the very next call.
  */
 function derivedAfkHomeWriteEntries(): string[] {
+  const entries: string[] = [];
   try {
     const home = getAfkHome();
-    return [
-      safeRealpath(resolve(join(home, 'config'))),
-      safeRealpath(resolve(join(home, 'state'))),
-    ];
-  } catch {
-    return [];
+    entries.push(safeRealpath(resolve(join(home, 'config'))));
+    entries.push(safeRealpath(resolve(join(home, 'state'))));
+  } catch (err) {
+    warnAfkHomeRejectedOnce(err);
   }
+  try {
+    entries.push(safeRealpath(resolve(getAfkStateDir())));
+  } catch (err) {
+    warnAfkHomeRejectedOnce(err);
+  }
+  return entries;
 }
 
 /**

--- a/src/agent/tools/hooks/bash-restriction-hook.test.ts
+++ b/src/agent/tools/hooks/bash-restriction-hook.test.ts
@@ -639,6 +639,70 @@ describe('createBashRestrictionHook — relocated AFK_HOME parity', () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  // Regression: a TRAILING SEPARATOR on AFK_HOME used to fail OPEN here.
+  // `$AFK_HOME` was substituted into the command text verbatim, yielding an
+  // interior `//` (`/relocated//config/afk.env`), while the restricted needle
+  // was built with path.join, which collapses it (`/relocated/config`). The
+  // final match is a literal includes(), so the two spellings never met and
+  // the command opened the very file this hook exists to block. POSIX
+  // collapses interior separators, so the bypass was real, not cosmetic.
+  // Fixed by resolving once at the source in configuredAfkHome().
+  it('blocks a trailing-separator AFK_HOME in both spellings', () => {
+    process.env['AFK_HOME'] = `${relocated}/`;
+
+    expect(hook(ctx('cat "$AFK_HOME/config/afk.env"')).decision).toBe('block');
+    expect(hook(ctx(`cat ${relocated}//config/afk.env`)).decision).toBe('block');
+    expect(hook(ctx(`cat ${relocated}/config/afk.env`)).decision).toBe('block');
+  });
+
+  it('keeps the mcp.json carve-out working under a trailing-separator AFK_HOME', () => {
+    process.env['AFK_HOME'] = `${relocated}/`;
+
+    expect(hook(ctx('cat "$AFK_HOME/config/mcp.json"')).decision).not.toBe('block');
+    expect(hook(ctx(`cat ${relocated}/config/mcp.json`)).decision).not.toBe('block');
+  });
+
+  // Fail-safe: getAfkHome() throws on a non-absolute AFK_HOME. configuredAfkHome()
+  // must swallow it and fall back to the default floor rather than propagating.
+  it('stays fail-safe when AFK_HOME is relative (getAfkHome() throws)', () => {
+    process.env['AFK_HOME'] = 'relative/not-absolute';
+
+    expect(() => hook(ctx('echo hi'))).not.toThrow();
+    expect(hook(ctx('echo hi')).decision).not.toBe('block');
+    // The default-home floor still applies.
+    expect(hook(ctx(`cat ${join(homedir(), '.afk', 'config', 'afk.env')}`)).decision).toBe(
+      'block',
+    );
+  });
+
+  // paths.ts treats '' as unset. Pin that the bash surface agrees, so an empty
+  // AFK_HOME can never widen the floor beyond the default-home coverage.
+  it('treats an empty AFK_HOME as unset', () => {
+    process.env['AFK_HOME'] = '';
+
+    expect(hook(ctx(`cat ${join(homedir(), '.afk', 'config', 'afk.env')}`)).decision).toBe(
+      'block',
+    );
+    expect(hook(ctx(`cat ${join(homedir(), '.afk', 'config', 'mcp.json')}`)).decision).not.toBe(
+      'block',
+    );
+  });
+
+  // The double-separator bypass was never AFK_HOME-specific: with NO AFK_HOME
+  // set at all, `~/.afk//config/afk.env` slipped past the default-home floor,
+  // because the `//` lands inside the span the needle covers. Pinned here so a
+  // future change to normalizeHomeRefs cannot silently reopen the class.
+  it('blocks a double separator against the DEFAULT home floor (no AFK_HOME)', () => {
+    delete process.env['AFK_HOME'];
+    const afkEnv = join(homedir(), '.afk', 'config', 'afk.env');
+
+    expect(hook(ctx(`cat ${afkEnv.replace('/.afk/config/', '/.afk//config/')}`)).decision).toBe(
+      'block',
+    );
+    expect(hook(ctx('cat ~/.afk//config/afk.env')).decision).toBe('block');
+    expect(hook(ctx('cat "$HOME/.afk//config/afk.env"')).decision).toBe('block');
+  });
 });
 
 describe('createBashRestrictionHook — AFK_READ_DENYLIST extras reach the bash surface', () => {

--- a/src/agent/tools/hooks/bash-restriction-hook.test.ts
+++ b/src/agent/tools/hooks/bash-restriction-hook.test.ts
@@ -28,6 +28,7 @@ import type { GrantManager } from '../../../cli/slash/commands/allow-dir.js';
 import type { PreToolUseContext } from '../../hooks.js';
 import { homedir, tmpdir } from 'os';
 import { join } from 'path';
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync } from 'fs';
 
 function mockGrants(): GrantManager {
   return {
@@ -589,6 +590,54 @@ describe('createBashRestrictionHook — mcp.json carve-out parity (#728)', () =>
     expect(
       hook(ctx('python -c "import json; json.load(open(\'~/.afk/config/mcp.json\'))"')).decision,
     ).not.toBe('block');
+  });
+});
+
+describe('createBashRestrictionHook — relocated AFK_HOME parity', () => {
+  const hook = createBashRestrictionHook({ getGrantManager: mockGrants });
+  const relocated = join(tmpdir(), 'agent-afk-relocated-home');
+
+  afterEach(() => {
+    delete process.env['AFK_HOME'];
+    _resetReadDenylistCacheForTests();
+  });
+
+  it('blocks the configured absolute spelling and $AFK_HOME spelling', () => {
+    process.env['AFK_HOME'] = relocated;
+
+    expect(hook(ctx(`cat ${relocated}/config/afk.env`)).decision).toBe('block');
+    expect(hook(ctx('cat "$AFK_HOME/config/afk.env"')).decision).toBe('block');
+  });
+
+  it('keeps relocated mcp.json readable in both spellings', () => {
+    process.env['AFK_HOME'] = relocated;
+
+    expect(hook(ctx(`cat ${relocated}/config/mcp.json`)).decision).not.toBe('block');
+    expect(hook(ctx('cat "$AFK_HOME/config/mcp.json"')).decision).not.toBe('block');
+  });
+
+  it('keeps the relocated carve-out exact-file only', () => {
+    process.env['AFK_HOME'] = relocated;
+
+    expect(hook(ctx(`cat ${relocated}/config/mcp.json.bak`)).decision).toBe('block');
+    expect(hook(ctx('cat "$AFK_HOME/config/mcp.json/child"')).decision).toBe('block');
+  });
+
+  it('blocks the configured spelling when AFK_HOME is a symlink', () => {
+    const root = mkdtempSync(join(tmpdir(), 'afk-home-symlink-'));
+    const target = join(root, 'target');
+    const link = join(root, 'configured');
+    mkdirSync(join(target, 'config'), { recursive: true });
+    symlinkSync(target, link, 'dir');
+    process.env['AFK_HOME'] = link;
+
+    try {
+      expect(hook(ctx(`cat ${link}/config/afk.env`)).decision).toBe('block');
+      expect(hook(ctx('cat "$AFK_HOME/config/afk.env"')).decision).toBe('block');
+      expect(hook(ctx(`cat ${link}/config/mcp.json`)).decision).not.toBe('block');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/agent/tools/hooks/bash-restriction-hook.test.ts
+++ b/src/agent/tools/hooks/bash-restriction-hook.test.ts
@@ -703,6 +703,39 @@ describe('createBashRestrictionHook — relocated AFK_HOME parity', () => {
     expect(hook(ctx('cat ~/.afk//config/afk.env')).decision).toBe('block');
     expect(hook(ctx('cat "$HOME/.afk//config/afk.env"')).decision).toBe('block');
   });
+
+  // The bypass is positional, not character-specific: any lexically-different
+  // but POSIX-equivalent spelling that SPLITS the span a needle covers defeats
+  // the literal includes(). `//`, `/./` and `/../` are the same defect. The
+  // same spellings AFTER the needle were always caught, which is why the class
+  // was easy to under-diagnose from the `//` report alone.
+  it('blocks dot and dot-dot segments that split the needle span', () => {
+    delete process.env['AFK_HOME'];
+
+    expect(hook(ctx('cat ~/.afk/./config/afk.env')).decision).toBe('block');
+    expect(hook(ctx('cat ~/.afk/../.afk/config/afk.env')).decision).toBe('block');
+    expect(hook(ctx('cat "$HOME/.afk/./config/afk.env"')).decision).toBe('block');
+  });
+
+  // Braced ${VAR} is the ordinary spelling a non-adversarial model emits, so it
+  // sits inside this hook's accidental-access threat model — unlike the runtime
+  // variable assembly (`H=$HOME; …$H/…`) the module header rules out and the
+  // "documented bypass" test pins.
+  it('blocks the braced ${AFK_HOME} spelling', () => {
+    process.env['AFK_HOME'] = relocated;
+
+    expect(hook(ctx('cat ${AFK_HOME}/config/afk.env')).decision).toBe('block');
+    expect(hook(ctx('cat "${AFK_HOME}/config/afk.env"')).decision).toBe('block');
+    // Carve-out parity: the braced spelling of mcp.json stays readable.
+    expect(hook(ctx('cat ${AFK_HOME}/config/mcp.json')).decision).not.toBe('block');
+  });
+
+  it('blocks the braced ${HOME} spelling', () => {
+    delete process.env['AFK_HOME'];
+
+    expect(hook(ctx('cat ${HOME}/.afk/config/afk.env')).decision).toBe('block');
+    expect(hook(ctx('cat ${HOME}/.ssh/id_rsa')).decision).toBe('block');
+  });
 });
 
 describe('createBashRestrictionHook — AFK_READ_DENYLIST extras reach the bash surface', () => {

--- a/src/agent/tools/hooks/bash-restriction-hook.ts
+++ b/src/agent/tools/hooks/bash-restriction-hook.ts
@@ -86,6 +86,7 @@ import {
 } from '../handlers/read-denylist.js';
 import { env } from '../../../config/env.js';
 import { getAfkHome } from '../../../paths.js';
+import { warnAfkHomeRejectedOnce } from '../afk-home-warn.js';
 
 /**
  * Interpreter denylist regex. Matches `<interpreter> -<flag>` where flag is
@@ -286,19 +287,53 @@ export function createBashRestrictionHook(opts: BashRestrictionHookOptions) {
  * the substring checks catch the non-adversarial accident case. NOT a parser —
  * variable-assembled paths (`H=$HOME; …$H/…`) are intentionally out of scope
  * (see module-header threat model). Shared by both checks.
+ *
+ * Invariant: duplicate forward slashes are collapsed LAST, after every
+ * substitution, because the substitutions themselves can create them — a
+ * trailing-separator `AFK_HOME` turns `$AFK_HOME/config` into `/relocated//config`.
+ * POSIX collapses interior separators, so `/a//b` and `/a/b` open the same file,
+ * but the restricted needles are built with `path.join`, which emits only the
+ * collapsed form, and the final match is a literal `includes()`. Without this
+ * the two spellings never meet and the guard fails OPEN.
+ *
+ * This is NOT specific to `AFK_HOME`: `~/.afk//config/afk.env` bypassed the
+ * default-home floor the same way, because the `//` lands inside the span the
+ * needle covers. Collapsing here fixes the whole class in one place rather than
+ * one spelling at a time.
+ *
+ * Safe for non-path text: the result is used ONLY for substring matching and is
+ * never executed, so mangling a `https://` URL in this scanned copy cannot
+ * affect what runs, and no sensitive root resembles a mangled scheme.
  */
 function normalizeHomeRefs(command: string, home: string, afkHome: string | undefined): string {
   const normalized = afkHome === undefined ? command : command.replace(/\$AFK_HOME/g, afkHome);
   return normalized
     .replace(/\$HOME/g, home)
-    .replace(/(^|[\s/=:])~(?=$|[/\s])/g, `$1${home}`);
+    .replace(/(^|[\s/=:])~(?=$|[/\s])/g, `$1${home}`)
+    .replace(/\/{2,}/g, '/');
 }
 
-/** Return AFK_HOME's configured absolute spelling, or nothing when malformed. */
+/**
+ * Return AFK_HOME's configured absolute spelling, or nothing when malformed.
+ *
+ * Invariant: `path.resolve` here — NOT the raw `getAfkHome()` string — is what
+ * keeps this spelling and the `path.join`-built needles
+ * ({@link relocatedAfkSensitiveRoots}, {@link allowlistedFileForms}) in the
+ * same normal form. `getAfkHome()` only rejects non-absolute paths and `/`
+ * (`src/paths.ts`); it does NOT collapse a trailing separator. With
+ * `AFK_HOME=/opt/my-afk/`, substituting the raw string into the command text
+ * produced `/opt/my-afk//config/afk.env` (interior `//`), while
+ * `path.join(afkHome, 'config')` collapses to `/opt/my-afk/config` — a literal
+ * `includes()` between the two then misses, and the command that opens the
+ * very file the guard exists to block sails through. Resolving once, here at
+ * the source, means every downstream consumer of this function's return value
+ * shares one spelling and the mismatch cannot recur.
+ */
 function configuredAfkHome(): string | undefined {
   try {
-    return getAfkHome();
-  } catch {
+    return path.resolve(getAfkHome());
+  } catch (err) {
+    warnAfkHomeRejectedOnce(err);
     return undefined;
   }
 }

--- a/src/agent/tools/hooks/bash-restriction-hook.ts
+++ b/src/agent/tools/hooks/bash-restriction-hook.ts
@@ -288,30 +288,49 @@ export function createBashRestrictionHook(opts: BashRestrictionHookOptions) {
  * variable-assembled paths (`H=$HOME; …$H/…`) are intentionally out of scope
  * (see module-header threat model). Shared by both checks.
  *
- * Invariant: duplicate forward slashes are collapsed LAST, after every
- * substitution, because the substitutions themselves can create them — a
- * trailing-separator `AFK_HOME` turns `$AFK_HOME/config` into `/relocated//config`.
- * POSIX collapses interior separators, so `/a//b` and `/a/b` open the same file,
- * but the restricted needles are built with `path.join`, which emits only the
- * collapsed form, and the final match is a literal `includes()`. Without this
- * the two spellings never meet and the guard fails OPEN.
+ * Invariant: every path-like span is lexically normalized LAST, after all
+ * substitutions, because the substitutions themselves create the mismatches —
+ * a trailing-separator `AFK_HOME` turns `$AFK_HOME/config` into
+ * `/relocated//config`. The restricted needles are built with `path.join` /
+ * `resolve`, which emit only the normal form, and the final match is a literal
+ * `includes()`. Any spelling that is POSIX-equivalent but lexically different
+ * therefore fails OPEN unless it is folded to the same normal form here.
  *
- * This is NOT specific to `AFK_HOME`: `~/.afk//config/afk.env` bypassed the
- * default-home floor the same way, because the `//` lands inside the span the
- * needle covers. Collapsing here fixes the whole class in one place rather than
- * one spelling at a time.
+ * `path.posix.normalize` (not a bare `//` collapse) is what makes this a CLASS
+ * fix: `//`, `/./`, and `/../` all reduce. The distinguishing factor is not
+ * which character is used but WHERE it lands — a separator that splits the span
+ * the needle covers breaks the match, while the same characters after the
+ * needle are harmless. `~/.afk/./config/afk.env` and `~/.afk//config/afk.env`
+ * both defeated the default-home floor for exactly this reason; neither is
+ * `AFK_HOME`-specific.
+ *
+ * Braced `${VAR}` is substituted alongside bare `$VAR` because it is the
+ * ordinary spelling a non-adversarial model emits, not an evasion — it sits
+ * inside this hook's accidental-access threat model, unlike the runtime
+ * variable assembly (`H=$HOME; …$H/…`) the module header rules out.
  *
  * Safe for non-path text: the result is used ONLY for substring matching and is
- * never executed, so mangling a `https://` URL in this scanned copy cannot
- * affect what runs, and no sensitive root resembles a mangled scheme.
+ * never executed, so mangling `https://x` to `https:/x` in this scanned copy
+ * cannot affect what runs, and no sensitive root resembles a mangled scheme.
  */
 function normalizeHomeRefs(command: string, home: string, afkHome: string | undefined): string {
-  const normalized = afkHome === undefined ? command : command.replace(/\$AFK_HOME/g, afkHome);
+  const normalized =
+    afkHome === undefined ? command : command.replace(/\$\{AFK_HOME\}|\$AFK_HOME\b/g, afkHome);
   return normalized
-    .replace(/\$HOME/g, home)
+    .replace(/\$\{HOME\}|\$HOME\b/g, home)
     .replace(/(^|[\s/=:])~(?=$|[/\s])/g, `$1${home}`)
-    .replace(/\/{2,}/g, '/');
+    .replace(PATH_LIKE_SPAN, (span) => path.posix.normalize(span));
 }
+
+/**
+ * An absolute-path-like run inside a command string: a `/` followed by
+ * everything up to the next shell metacharacter, quote, or whitespace.
+ *
+ * Contract: deliberately greedy on ordinary path characters and deliberately
+ * stops at `'"`;|&()<>` and whitespace so one span cannot swallow a following
+ * argument and drag unrelated text through `normalize`.
+ */
+const PATH_LIKE_SPAN = /\/[^\s'"`;|&()<>]*/g;
 
 /**
  * Return AFK_HOME's configured absolute spelling, or nothing when malformed.

--- a/src/agent/tools/hooks/bash-restriction-hook.ts
+++ b/src/agent/tools/hooks/bash-restriction-hook.ts
@@ -85,6 +85,7 @@ import {
   parseReadDenylistEntries,
 } from '../handlers/read-denylist.js';
 import { env } from '../../../config/env.js';
+import { getAfkHome } from '../../../paths.js';
 
 /**
  * Interpreter denylist regex. Matches `<interpreter> -<flag>` where flag is
@@ -199,7 +200,8 @@ export function createBashRestrictionHook(opts: BashRestrictionHookOptions) {
     // is wired (headless), so check 2 fails open there and check 1 falls back to
     // the lexical signal.
     const home = homedir();
-    const scanned = scrubAllowlistedRefs(normalizeHomeRefs(command, home), home);
+    const afkHome = configuredAfkHome();
+    const scanned = scrubAllowlistedRefs(normalizeHomeRefs(command, home, afkHome), home, afkHome);
     const restrictedSubstrings = grantManager
       ? deriveRestrictedSubstrings(grantManager.getGrants())
       : [];
@@ -285,10 +287,25 @@ export function createBashRestrictionHook(opts: BashRestrictionHookOptions) {
  * variable-assembled paths (`H=$HOME; …$H/…`) are intentionally out of scope
  * (see module-header threat model). Shared by both checks.
  */
-function normalizeHomeRefs(command: string, home: string): string {
-  return command
+function normalizeHomeRefs(command: string, home: string, afkHome: string | undefined): string {
+  const normalized = afkHome === undefined ? command : command.replace(/\$AFK_HOME/g, afkHome);
+  return normalized
     .replace(/\$HOME/g, home)
     .replace(/(^|[\s/=:])~(?=$|[/\s])/g, `$1${home}`);
+}
+
+/** Return AFK_HOME's configured absolute spelling, or nothing when malformed. */
+function configuredAfkHome(): string | undefined {
+  try {
+    return getAfkHome();
+  } catch {
+    return undefined;
+  }
+}
+
+function relocatedAfkSensitiveRoots(): string[] {
+  const afkHome = configuredAfkHome();
+  return afkHome === undefined ? [] : [path.join(afkHome, 'config')];
 }
 
 /** Placeholder left behind by {@link scrubAllowlistedRefs}. Deliberately free of
@@ -312,11 +329,20 @@ function escapeRegExp(literal: string): string {
  * unreachable while normalization runs first, and is kept as the one spelling
  * that would silently stop being carved out if that order ever changed.
  */
-function allowlistedFileForms(home: string): string[] {
-  return READ_ALLOWLIST_REL.flatMap((rel) => {
+function allowlistedFileForms(home: string, afkHome: string | undefined): string[] {
+  const homeForms = READ_ALLOWLIST_REL.flatMap((rel) => {
     if (isReadDenied(path.join(home, rel)).denied) return [];
     return [path.join(home, rel), `~/${rel}`, `$HOME/${rel}`];
   });
+  if (afkHome === undefined) return homeForms;
+
+  const afkForms = READ_ALLOWLIST_REL.flatMap((rel) => {
+    if (!rel.startsWith('.afk/')) return [];
+    const relocated = path.join(afkHome, rel.slice('.afk/'.length));
+    if (isReadDenied(relocated).denied) return [];
+    return [relocated, `$AFK_HOME/${rel.slice('.afk/'.length)}`];
+  });
+  return [...new Set([...homeForms, ...afkForms])];
 }
 
 /**
@@ -334,9 +360,9 @@ function allowlistedFileForms(home: string): string[] {
  * the only text carrying the denied enclosing root. Dropping this guard
  * entirely would turn one readable file into a readable directory.
  */
-function scrubAllowlistedRefs(text: string, home: string): string {
+function scrubAllowlistedRefs(text: string, home: string, afkHome: string | undefined): string {
   let out = text;
-  for (const form of allowlistedFileForms(home)) {
+  for (const form of allowlistedFileForms(home, afkHome)) {
     const exactRef = new RegExp(`${escapeRegExp(form)}(?![\\w./\\\\*?\\[\\]{}-])`, 'g');
     out = out.replace(exactRef, ALLOWLISTED_PLACEHOLDER);
   }
@@ -468,6 +494,7 @@ export function deriveRestrictedSubstrings(grants: {
       ...builtinBashSensitiveRoots(),
       ...getReadDenylist(),
       ...readDenylistExtrasAsSpelled(),
+      ...relocatedAfkSensitiveRoots(),
     ]),
   ];
 

--- a/src/agent/tools/subagent/input-parse.test.ts
+++ b/src/agent/tools/subagent/input-parse.test.ts
@@ -364,6 +364,34 @@ describe('parseAgentInput', () => {
       const result = parseAgentInput({ prompt: 'p', cwd: '/tmp/wt/..foo/bar..baz' });
       expect(result.cwd).toBe('/tmp/wt/..foo/bar..baz');
     });
+
+    // --- Hardening: breadth rejection (#740) — mirrors the readRoots guard ---
+    it('throws when cwd is the home directory', () => {
+      expect(() => parseAgentInput({ prompt: 'p', cwd: os.homedir() })).toThrow(
+        /must not be a filesystem root, your home directory, or an ancestor/,
+      );
+    });
+
+    it('throws when cwd is an ancestor of the home directory', () => {
+      const parentOfHome = path.dirname(os.homedir());
+      expect(() => parseAgentInput({ prompt: 'p', cwd: parentOfHome })).toThrow(
+        /must not be a filesystem root, your home directory, or an ancestor/,
+      );
+    });
+
+    it('throws when cwd is a filesystem root', () => {
+      const FS_ROOT = path.parse(path.resolve('.')).root || path.sep;
+      expect(() => parseAgentInput({ prompt: 'p', cwd: FS_ROOT })).toThrow(
+        /must not be a filesystem root, your home directory, or an ancestor/,
+      );
+    });
+
+    it('still accepts a normal absolute project subdir (not broad)', () => {
+      // The breadth guard must not over-reject: a genuine project worktree path
+      // stays accepted, same as before this field grew the check.
+      const result = parseAgentInput({ prompt: 'p', cwd: '/tmp/wt/feat-y' });
+      expect(result.cwd).toBe('/tmp/wt/feat-y');
+    });
   });
 
   describe('writeRoots', () => {
@@ -406,6 +434,20 @@ describe('parseAgentInput', () => {
       const result = parseAgentInput({ prompt: 'p', writeRoots: [] });
       expect(result.writeRoots).toBeUndefined();
       expect('writeRoots' in result).toBe(false);
+    });
+
+    // --- Hardening: breadth rejection (#740) — mirrors the readRoots guard ---
+    it('throws when a writeRoots entry is the home directory', () => {
+      expect(() => parseAgentInput({ prompt: 'p', writeRoots: [os.homedir()] })).toThrow(
+        /must not be a filesystem root, your home directory, or an ancestor/,
+      );
+    });
+
+    it('still accepts a normal absolute subdir entry (not broad)', () => {
+      // The breadth guard must not over-reject: an ordinary write root stays
+      // accepted, same as before this field grew the check.
+      const result = parseAgentInput({ prompt: 'p', writeRoots: ['/sibling/repo'] });
+      expect(result.writeRoots).toEqual(['/sibling/repo']);
     });
 
     it('throws when writeRoots and isolation:worktree are both supplied (mutually exclusive)', () => {

--- a/src/agent/tools/subagent/input-parse.test.ts
+++ b/src/agent/tools/subagent/input-parse.test.ts
@@ -11,11 +11,18 @@
  * plain input → output assertions with no mock harness.
  */
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import os from 'node:os';
 import path from 'node:path';
 import fs from 'node:fs';
 import { parseAgentInput, type AgentInput } from './input-parse.js';
+
+// Invariant: the AFK breadth targets are derived from env on EVERY call, so a
+// leaked `stubEnv` would silently change what later cases in this file treat as
+// too-broad. Unstub after each test rather than relying on case ordering.
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 describe('parseAgentInput', () => {
   describe('input shape', () => {
@@ -384,6 +391,54 @@ describe('parseAgentInput', () => {
       expect(() => parseAgentInput({ prompt: 'p', cwd: FS_ROOT })).toThrow(
         /must not be a filesystem root, your home directory, or an ancestor/,
       );
+    });
+
+    // A relocated AFK_HOME is neither the home dir nor an ancestor of it, so
+    // the home-only targets did not catch it — yet granting it as `cwd` empties
+    // that child's AFK-anchored credential floor by exactly the route `$HOME`
+    // empties the home-anchored one (the bash grant filter drops any candidate
+    // whose ancestor was granted, and `${AFK_HOME}/config` is one).
+    it('throws when cwd is a relocated AFK_HOME', () => {
+      vi.stubEnv('AFK_HOME', '/tmp/relocated-afk-home');
+      expect(() => parseAgentInput({ prompt: 'p', cwd: '/tmp/relocated-afk-home' })).toThrow(
+        /must not be a filesystem root, your home directory, or an ancestor/,
+      );
+      // An ancestor of the relocated home is refused too.
+      expect(() => parseAgentInput({ prompt: 'p', cwd: '/tmp' })).toThrow(
+        /must not be a filesystem root, your home directory, or an ancestor/,
+      );
+    });
+
+    it('throws when cwd is a relocated AFK_STATE_DIR', () => {
+      vi.stubEnv('AFK_STATE_DIR', '/tmp/relocated-afk-state');
+      expect(() => parseAgentInput({ prompt: 'p', cwd: '/tmp/relocated-afk-state' })).toThrow(
+        /must not be a filesystem root, your home directory, or an ancestor/,
+      );
+    });
+
+    // Descendants stay legal: a plugin/worktree dir BELOW the AFK home is a
+    // legitimate cwd and must not be swept up by the breadth guard.
+    it('still accepts a subdir BELOW a relocated AFK_HOME', () => {
+      vi.stubEnv('AFK_HOME', '/tmp/relocated-afk-home');
+      const result = parseAgentInput({ prompt: 'p', cwd: '/tmp/relocated-afk-home/plugins/x' });
+      expect(result.cwd).toBe('/tmp/relocated-afk-home/plugins/x');
+    });
+
+    it('throws when a writeRoots entry is a relocated AFK_HOME', () => {
+      vi.stubEnv('AFK_HOME', '/tmp/relocated-afk-home');
+      expect(() =>
+        parseAgentInput({ prompt: 'p', writeRoots: ['/tmp/relocated-afk-home'] }),
+      ).toThrow(/must not be a filesystem root, your home directory, or an ancestor/);
+    });
+
+    // A malformed AFK_HOME must not loosen the guard: the home-anchored
+    // rejections still fire, and parseAgentInput does not throw the env error.
+    it('keeps the home-anchored guard when AFK_HOME is malformed', () => {
+      vi.stubEnv('AFK_HOME', 'relative/not-absolute');
+      expect(() => parseAgentInput({ prompt: 'p', cwd: os.homedir() })).toThrow(
+        /must not be a filesystem root, your home directory, or an ancestor/,
+      );
+      expect(parseAgentInput({ prompt: 'p', cwd: '/tmp/wt/feat-y' }).cwd).toBe('/tmp/wt/feat-y');
     });
 
     it('still accepts a normal absolute project subdir (not broad)', () => {

--- a/src/agent/tools/subagent/input-parse.ts
+++ b/src/agent/tools/subagent/input-parse.ts
@@ -12,6 +12,8 @@ import { isAbsolute, parse as parsePath, resolve as resolvePath, relative as rel
 import { homedir } from 'node:os';
 import { isReadDenied } from '../handlers/read-denylist.js';
 import { realpathSafe } from '../handlers/_cwd-utils.js';
+import { getAfkHome, getAfkStateDir } from '../../../paths.js';
+import { warnAfkHomeRejectedOnce } from '../afk-home-warn.js';
 
 // Home targets for the shared breadth guard below. Computed once at module
 // scope — `homedir()` is stable per process, so there is no need to
@@ -20,6 +22,40 @@ import { realpathSafe } from '../handlers/_cwd-utils.js';
 // a symlink-resolved candidate would otherwise slip past a lexical-only home
 // comparison.
 const HOME_TARGETS: readonly string[] = [...new Set([homedir(), realpathSafe(homedir())])];
+
+/**
+ * The AFK-anchored breadth targets, resolved PER CALL rather than at module
+ * scope.
+ *
+ * Invariant: unlike `homedir()`, these are env-driven (`AFK_HOME`,
+ * `AFK_STATE_DIR`) and therefore NOT stable per process — hoisting them would
+ * snapshot one spelling at import and never observe a runtime relocation. This
+ * is the same trap the read denylist documents: derive inside the call, not at
+ * module scope.
+ *
+ * Why they belong in the breadth guard at all: a granted root that is at-or-
+ * above the AFK home empties that child's AFK-anchored credential floor by
+ * exactly the route `$HOME` emptied the home-anchored one. The bash hook's
+ * grant filter (`deriveRestrictedSubstrings`) drops any candidate an ancestor
+ * of which has been granted, and `${AFK_HOME}/config` is such a candidate. A
+ * relocated `AFK_HOME` (say `/opt/my-afk`) is neither the home dir nor an
+ * ancestor of it, so the home-only targets did not catch it.
+ *
+ * A malformed env var throws; caught and skipped so a bad value can never
+ * loosen the guard, and surfaced once via the shared warn latch.
+ */
+function afkBreadthTargets(): string[] {
+  const targets: string[] = [];
+  for (const derive of [getAfkHome, getAfkStateDir]) {
+    try {
+      const dir = derive();
+      targets.push(dir, realpathSafe(dir));
+    } catch (err) {
+      warnAfkHomeRejectedOnce(err);
+    }
+  }
+  return targets;
+}
 
 /**
  * True when `candidate` is "too broad" to pre-grant as a `cwd`, `writeRoots`,
@@ -37,7 +73,7 @@ const HOME_TARGETS: readonly string[] = [...new Set([homedir(), realpathSafe(hom
  */
 function isTooBroadRoot(candidate: string): boolean {
   if (candidate === parsePath(candidate).root) return true;
-  return HOME_TARGETS.some((h) => {
+  return [...HOME_TARGETS, ...afkBreadthTargets()].some((h) => {
     const rel = relativePath(candidate, h);
     return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
   });

--- a/src/agent/tools/subagent/input-parse.ts
+++ b/src/agent/tools/subagent/input-parse.ts
@@ -13,6 +13,36 @@ import { homedir } from 'node:os';
 import { isReadDenied } from '../handlers/read-denylist.js';
 import { realpathSafe } from '../handlers/_cwd-utils.js';
 
+// Home targets for the shared breadth guard below. Computed once at module
+// scope — `homedir()` is stable per process, so there is no need to
+// re-resolve it on every `parseAgentInput` call. Check against BOTH the
+// lexical home and its realpath: if the home dir is itself behind a symlink,
+// a symlink-resolved candidate would otherwise slip past a lexical-only home
+// comparison.
+const HOME_TARGETS: readonly string[] = [...new Set([homedir(), realpathSafe(homedir())])];
+
+/**
+ * True when `candidate` is "too broad" to pre-grant as a `cwd`, `writeRoots`,
+ * or `readRoots` entry: a filesystem root, the home dir itself, or an
+ * ANCESTOR of home (home lexically inside it → relative(candidate, home)
+ * neither escapes with '..' nor is absolute).
+ *
+ * Shared by all three fields (#740): each one ends up in the child's grant
+ * snapshot and feeds the bash-restriction hook's grant filter
+ * (`deriveRestrictedSubstrings`), where an ancestor-based containment check
+ * drops any credential root beneath a granted path. A too-broad grant on ANY
+ * of the three — not just `readRoots`, which already carried this guard —
+ * silently empties that child's credential floor, so the rejection must be
+ * identical across all three call sites.
+ */
+function isTooBroadRoot(candidate: string): boolean {
+  if (candidate === parsePath(candidate).root) return true;
+  return HOME_TARGETS.some((h) => {
+    const rel = relativePath(candidate, h);
+    return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+  });
+}
+
 export type AgentExecutionMode = 'foreground' | 'background';
 
 export interface AgentInput {
@@ -52,11 +82,19 @@ export interface AgentInput {
    * `AgentConfig.cwd`, which `SubagentManager.forkSubagent` applies in
    * preference to the parent fallback (see `src/agent/subagent.ts:291-297`).
    *
-   * Validation is format-only at parse time (existence/git-worktree status
-   * is not checked) — a non-existent path surfaces as an ENOENT on the
-   * child's first cwd-relative tool call, which the parent sees as a
-   * structured failure. Mirrors the existing AgentConfig.cwd contract
-   * used by `afk interactive -w` and the diagnose/farm orchestrators.
+   * Existence/git-worktree status is not checked at parse time — a
+   * non-existent path surfaces as an ENOENT on the child's first cwd-relative
+   * tool call, which the parent sees as a structured failure. Mirrors the
+   * existing AgentConfig.cwd contract used by `afk interactive -w` and the
+   * diagnose/farm orchestrators.
+   *
+   * Validation is NOT format-only, though (#740): this becomes the
+   * dispatcher's `resolveBase`, which feeds the bash-restriction hook's grant
+   * filter (`deriveRestrictedSubstrings`) — an ancestor-based containment
+   * check that drops any credential root beneath a granted path. A filesystem
+   * root, `os.homedir()`, or an ancestor of home is refused for that reason,
+   * same breadth guard {@link readRoots} carries (checked on both the lexical
+   * and symlink-resolved form).
    *
    * Caveat: this field affects only the dispatched child's cwd. Depth-2+
    * forks (the child itself calling `agent`) inherit through
@@ -72,7 +110,10 @@ export interface AgentInput {
    * writeRoots here lets the PARENT deliberately grant additional write roots.
    * Composed WITH the child's cwd (never replaces it), so the child keeps write
    * access to its own tree. Each entry must be an absolute path with no `..`
-   * segments. Mutually exclusive with `isolation:'worktree'` (isolation's
+   * segments, PLUS the same BREADTH rejection {@link cwd} and {@link readRoots}
+   * carry (#740): a filesystem root, `os.homedir()`, or an ancestor of home is
+   * refused, because an over-broad write root feeds the same bash-restriction
+   * grant filter. Mutually exclusive with `isolation:'worktree'` (isolation's
    * contract is total confinement). Unlike the #416 read grant this is never
    * automatic — writing outside the worktree breaks isolation, so it requires
    * explicit parent intent.
@@ -211,9 +252,9 @@ export function parseAgentInput(input: unknown): AgentInput {
     mode = modeValue;
   }
 
-  // cwd: optional absolute path. Format-only validation here — existence is
-  // not checked because the call site is sync and any ENOENT surfaces
-  // cleanly through the child's first tool call. Rules:
+  // cwd: optional absolute path. Existence is not checked because the call
+  // site is sync and any ENOENT surfaces cleanly through the child's first
+  // tool call. Rules:
   //   1. Must be a non-empty string when present.
   //   2. Must be absolute (`path.isAbsolute`) — relative paths would otherwise
   //      resolve against `process.cwd()` and silently land somewhere
@@ -222,6 +263,18 @@ export function parseAgentInput(input: unknown): AgentInput {
   //      silently collapse them; rejecting forces the caller to write
   //      what they mean. Splits on both `/` and `\\` so the check holds
   //      on Windows too.
+  //   4. BREADTH (#740) — must not be a filesystem root, os.homedir(), or an
+  //      ancestor of homedir. `cwd` becomes the dispatcher's `resolveBase`,
+  //      which seeds the child's implicit read/write root AND is consulted by
+  //      the bash-restriction hook's grant filter (`deriveRestrictedSubstrings`)
+  //      as an ancestor-based containment check: a broad `resolveBase` drops
+  //      every credential root beneath it from that child's bash restriction,
+  //      silently emptying the credential floor for its bash surface. Checked
+  //      on BOTH the lexical path AND its symlink-resolved target, same as
+  //      readRoots — a symlink to `/`/home would otherwise pass a lexical-only
+  //      check (#664 Codex P1). Unlike readRoots, there is no DENYLIST
+  //      (isReadDenied) rejection here — that is a separate, deliberately
+  //      out-of-scope hardening decision; this is breadth-only.
   let cwd: string | undefined;
   const cwdValue = agentInput['cwd'];
   if (cwdValue !== undefined) {
@@ -244,12 +297,29 @@ export function parseAgentInput(input: unknown): AgentInput {
         `Agent tool cwd must not contain '..' segments, got: ${JSON.stringify(cwdValue)}`,
       );
     }
+    const resolvedCwd = resolvePath(cwdValue);
+    const realResolvedCwd = realpathSafe(resolvedCwd);
+    if (isTooBroadRoot(resolvedCwd) || isTooBroadRoot(realResolvedCwd)) {
+      throw new Error(
+        `Agent tool cwd must not be a filesystem root, your home directory, ` +
+          `or an ancestor of it (checked after resolving symlinks) — pass a ` +
+          `specific subdirectory instead, got: ${JSON.stringify(cwdValue)}`,
+      );
+    }
     cwd = cwdValue;
   }
 
   // writeRoots: optional array of absolute paths pre-granted as extra write
-  // roots to the fork (#435). Same per-entry rules as cwd (non-empty, absolute,
-  // no '..' segments). An empty array normalizes to undefined (no-op grant).
+  // roots to the fork (#435). Per-entry format rules: non-empty, absolute, no
+  // '..' segments. PLUS a BREADTH rejection (#740), same as cwd and readRoots:
+  // a filesystem root, os.homedir(), or an ancestor of it is refused (checked
+  // on both the lexical and symlink-resolved form) because a too-broad write
+  // root feeds the same bash-restriction grant filter
+  // (`deriveRestrictedSubstrings`) that reads `cwd`/`readRoots` — an
+  // over-broad grant would silently drop credential roots from that child's
+  // bash restriction. There is deliberately no DENYLIST (isReadDenied)
+  // rejection here — out of scope, see readRoots below. An empty array
+  // normalizes to undefined (no-op grant).
   let writeRoots: string[] | undefined;
   const writeRootsValue = agentInput['writeRoots'];
   if (writeRootsValue !== undefined) {
@@ -275,6 +345,15 @@ export function parseAgentInput(input: unknown): AgentInput {
           `Agent tool writeRoots entries must not contain '..' segments, got: ${JSON.stringify(entry)}`,
         );
       }
+      const resolvedEntry = resolvePath(entry);
+      const realResolvedEntry = realpathSafe(resolvedEntry);
+      if (isTooBroadRoot(resolvedEntry) || isTooBroadRoot(realResolvedEntry)) {
+        throw new Error(
+          `Agent tool writeRoots entries must not be a filesystem root, your home ` +
+            `directory, or an ancestor of it (checked after resolving symlinks) — ` +
+            `grant a specific subdirectory instead, got: ${JSON.stringify(entry)}`,
+        );
+      }
       roots.push(entry);
     }
     if (roots.length > 0) writeRoots = roots;
@@ -289,12 +368,18 @@ export function parseAgentInput(input: unknown): AgentInput {
   //       Checked on BOTH the lexical path AND its symlink-resolved target: the
   //       containment layer realpaths granted roots (realpathRoot, _cwd-utils),
   //       so a symlink to `/`/home would otherwise pass a lexical-only check and
-  //       become a broad real root at read time (#664 Codex P1).
+  //       become a broad real root at read time (#664 Codex P1). Uses the same
+  //       shared `isTooBroadRoot` helper `cwd` and `writeRoots` apply above
+  //       (#740) — this field's BEHAVIOR is unchanged, only the check is
+  //       factored into one module-scope helper instead of a local closure.
   //   (b) DENYLIST — reject any entry that resolves into the read-denylist
   //       (isReadDenied: ~/.ssh, ~/.afk/config, …). isReadDenied is a pure,
   //       string/realpath-based, non-throwing check (safeRealpath swallows fs
   //       errors), so it is safe to call at parse time. Defense-in-depth ON TOP
   //       of the read-time floor in resolveAndContain / the path-approval hook.
+  //       Deliberately NOT applied to `cwd` or `writeRoots` — out of scope
+  //       there (#740 closes the breadth gap only; the denylist question is a
+  //       separate hardening decision).
   // An empty array normalizes to undefined (no-op grant). Deliberately NOT
   // mutually exclusive with isolation:'worktree' (that constraint is write-only).
   let readRoots: string[] | undefined;
@@ -305,21 +390,6 @@ export function parseAgentInput(input: unknown): AgentInput {
         `Agent tool readRoots must be an array of absolute paths, got: ${JSON.stringify(readRootsValue)}`,
       );
     }
-    const home = homedir();
-    // Check against BOTH the lexical home and its realpath: if the home dir is
-    // itself behind a symlink, a symlink-resolved candidate would otherwise slip
-    // past a lexical-only home comparison.
-    const homeTargets = [...new Set([home, realpathSafe(home)])];
-    // A candidate root is "too broad" to pre-grant when it is a filesystem root,
-    // the home dir itself, or an ANCESTOR of home (home lexically inside it →
-    // relative(candidate, home) neither escapes with '..' nor is absolute).
-    const isTooBroad = (candidate: string): boolean => {
-      if (candidate === parsePath(candidate).root) return true;
-      return homeTargets.some((h) => {
-        const rel = relativePath(candidate, h);
-        return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
-      });
-    };
     const roots: string[] = [];
     for (const entry of readRootsValue) {
       if (typeof entry !== 'string' || entry.length === 0) {
@@ -347,7 +417,7 @@ export function parseAgentInput(input: unknown): AgentInput {
       // falls back to the nearest existing ancestor for a not-yet-created path.
       const resolved = resolvePath(entry);
       const realResolved = realpathSafe(resolved);
-      if (isTooBroad(resolved) || isTooBroad(realResolved)) {
+      if (isTooBroadRoot(resolved) || isTooBroadRoot(realResolved)) {
         throw new Error(
           `Agent tool readRoots entries must not be a filesystem root, your home directory, ` +
             `or an ancestor of it (checked after resolving symlinks) — grant a specific ` +


### PR DESCRIPTION
## Summary

Layered fixes to the credential floor, all found while auditing how `AFK_HOME` relocation interacts with the permission denylists.

The headline gap: `BUILTIN_READ_DENYLIST` and `BUILTIN_WRITE_DENYLIST` hardcoded `${homedir()}/.afk/config`, but this project supports relocating its home via `AFK_HOME` (`src/paths.ts` → `getAfkHome()`). An operator running `AFK_HOME=/opt/my-afk` got **no protection at all** on `/opt/my-afk/config/afk.env` (API keys) — not on the typed read tools, not on the write tools, and not on bash. The floor only ever covered the default `~/.afk` location.

## Commits

1. **`fix(subagent): reject overly broad cwd and writeRoots, matching readRoots`** — `cwd`, `writeRoots`, and `readRoots` all land in a forked child's grant snapshot and all three feed the bash-restriction hook's grant filter, where an ancestor-based containment check drops credential roots beneath a granted path. Only `readRoots` carried the breadth rejection, so `cwd: "$HOME"` silently emptied the home-anchored credential floor for that child's bash surface. Hoists the guard into a shared `isTooBroadRoot()` applied to all three fields.

2. **`fix(permissions): cover the AFK_HOME-relocated credential tree on read, write, and bash`** — derives the relocated spelling inside `resolveLists()` (not at module scope, which would evaluate `getAfkHome()` once at import and never observe a runtime change), adds `AFK_HOME` to the memoization cache key, and fails safe when `AFK_HOME` is malformed.

3. **`fix(permissions): make the mcp.json carve-out follow AFK_HOME too`** — commit 2 moved the deny side but left `BUILTIN_READ_ALLOWLIST` anchored to `homedir()`, which *inverted* the carve-out for relocated operators. Derives the relocated spelling of every `READ_ALLOWLIST_REL` entry, failing **closed** on the allow side.

4. **`fix(permissions): normalize relocated AFK_HOME in bash guard`** — the bash surface is lexical, not realpath-resolved, so it needed its own change: `getReadDenylist()` returns only the symlink-*resolved* spelling, and `$AFK_HOME` was never expanded at all.

5. **`fix(permissions): close the double-separator bash bypass and follow AFK_STATE_DIR`** — review response.

6. **`fix(permissions): fold dot-segments and braced ${VAR} into the bash normal form`** — review response; corrects an overstated claim in commit 5.

7. **`fix(subagent): reject a granted root at or above the AFK home`** — review response.

## Review-response commits (5–7)

### The bash bypass is positional, not character-specific

Commit 5 fixed a **trailing-separator `AFK_HOME`** failing OPEN: `$AFK_HOME` was substituted into the scanned command verbatim, producing an interior `//`, while the needle is built with `path.join`, which collapses it — and the final match is a literal `includes()`. The two spellings never met.

**Commit 5 claimed to close this "as a class". That claim was wrong, and commit 6 corrects it.** An adversarial review wave flagged two siblings and an empirical probe against the built hook confirmed both:

| spelling | before c6 |
|---|---|
| `<home>/.afk//config/afk.env` | blocked (fixed in c5) |
| `<home>/.afk/./config/afk.env` | **BYPASS** |
| `<home>/.afk/../.afk/config/afk.env` | **BYPASS** |
| `<home>/.afk/config/./afk.env` | blocked — dot lands *after* the needle |

The distinguishing factor is not which character is used but **where it lands**: a segment that splits the span the needle covers breaks the match; the same characters after the needle are harmless. That is why the `//` report alone under-specified the class. Commit 6 replaces the narrow `//` collapse with `path.posix.normalize` over every path-like span, folding `//`, `/./` and `/../` into the one normal form the needles already use.

Commit 6 also substitutes the **braced** `${AFK_HOME}` / `${HOME}` spellings, which were never expanded — so a braced reference reached a credential file unblocked. The braced form is the ordinary spelling a non-adversarial model emits, placing it inside this hook's accidental-access threat model, unlike the runtime variable assembly (`H=$HOME; …$H/…`) the module header rules out and the "documented bypass" test still pins (unchanged, still green). **This gap was pre-existing and applied to plain `$HOME` too**, not only to the `AFK_HOME` work here.

### `AFK_STATE_DIR` (commit 5)

The derived write floor followed `AFK_HOME` but not `AFK_STATE_DIR`, which relocates the entire state tier *independently* (`paths.ts` returns it verbatim when set). An operator running `AFK_STATE_DIR=/opt/state` had zero write protection on their real state tier. The two derivations now sit in **separate `try` blocks** so one malformed env var cannot drop the other's entries.

### Silent fail-safe (commit 5)

All four `AFK_HOME` derivation sites swallowed their throw silently. The fail-safe *direction* was correct; its **invisibility** was the defect. New `src/agent/tools/afk-home-warn.ts` emits one warn line **per process** (latched — these sit on the read/write hot path, so a per-call warn would be its own denial of service). Control flow unchanged.

### The breadth guard missed the AFK home (commit 7)

The one-hop restatement of commit 1. That commit rejected a too-broad `cwd`/`writeRoots` because such a grant empties the child's **home**-anchored floor. But the targets were home-only, and a relocated AFK home is neither the home dir nor an ancestor of it — so granting it as `cwd` sailed through and emptied the **AFK**-anchored floor by exactly the same route. Fixing the deny side while leaving that open made this PR's headline claim false on the subagent surface. Targets are derived **per call**, because unlike `homedir()` they are env-driven and are precisely what a runtime relocation changes. Descendants stay legal.

## Why `state` is in the write denylist but not the read denylist

A model must never *write* to the state tier, but forked sub-agents legitimately *read* skill-preflight inputs, todos, and transcripts from it (#544 / #547 / #554). The derived entries mirror that asymmetry.

## Behavior change worth calling out in release notes

`parseAgentInput` now **rejects** `cwd` / `writeRoots` values it previously accepted: a filesystem root, the home dir, an ancestor of home, and (as of commit 7) the AFK home / state dir or an ancestor of either. This is the point of commits 1 and 7, but it is a user-visible contract change — a workflow dispatching with the home dir as `cwd` (including a monorepo checkout that *is* the home dir) will now throw.

## Relationship to other work

- **Composes with #735.** That PR fixed *which paths* are floored; this one fixes *path resolution* so the floor follows a relocated home. No overlap.
- **Reduces exposure to #740** but does not settle it. The ancestor containment check in `deriveRestrictedSubstrings` is unchanged; this closes the gap that let a model hand it an unvetted root.
- **Does not address #736** (case-variant spellings on case-insensitive filesystems) — deliberately out of scope.

## Known-remaining / deferred (raised in review, deliberately not in this PR)

All tracked as follow-up issues: #778, #779, #780, #781, #782, #783.

- **#778 — `SENSITIVE_PATH_SIGNAL` does not carry the relocated AFK tree.** Under `AFK_FORCE_BASH_INTERPRETER_GUARD=1` on a headless surface, where the grant-filtered substring list is empty and the lexical signal is the sole input, an interpreter one-liner naming a relocated config path is not matched by the signal regex. Reported, not independently confirmed here.
- **#779 — the relocated `mcp.json` carve-out is emitted unconditionally** on the typed path, unlike the bash twin which gates each form on `isReadDenied`. Reachable only when the AFK home is nested *under* another builtin denied root (e.g. `~/.ssh/afk`).
- **#781 — memoizing `getWriteDenylist()`.** Adding a cache to a credential denylist is the exact invalidation bug class this PR already had to fix on the read side — disproportionate risk for a 2-syscall saving both reviews rated not-required-for-merge.
- **#782 — the 350-LOC extractions** in `input-parse.ts` and `bash-restriction-hook.ts`. Both files were over the ceiling *before* this PR; a structural refactor on an under-review security PR is scope creep. The new warn helper was added as its own module rather than growing either file.
- **#780 — the warn latch names only the first-thrown variable**, so an operator who typos both `AFK_HOME` and `AFK_STATE_DIR` is told about one.

## Verification

- `pnpm lint` (`tsc --noEmit`, strict) — clean.
- `pnpm audit:env:check` — 0 violations.
- `pnpm test` — **706 files, 13453 passed, 14 skipped, 0 failed.**
- The two bypasses fixed in commit 6 were confirmed by an **empirical probe against the built hook** before and after, not by diff reading — the same method that caught the commit-3 regression. Static review had already passed over the dot-segment case.
- Merges cleanly into `main`.

**949 insertions / 44 deletions across 9 files**; 4 of the 9 are test files.

