### PR TITLE
test(tui): pin the grow-eviction width-resize defect the #540 guards cannot see

### DIFF
--- a/docs/dev/real-terminal-matrix.md
+++ b/docs/dev/real-terminal-matrix.md
@@ -90,8 +90,13 @@ guard drove the one already-fixed write site. Verify, do not assume — composit
 phase traces go to **stderr**, so redirect it and leave stdout (the visual output)
 alone:
 
+All guard refusals print on **stdout**, so they stay visible under the `2>` redirect
+below. If the pane goes blank and you get an immediate prompt back, read what the
+script printed — it refused; it did not crash.
+
 Run these as **two separate commands** — the script holds for 45s, and pasting both
-at once can join them into one line:
+at once can join them into one line (which also silently creates a file named
+`grep` in the repo root; delete it if you see one):
 
 ```bash
 AFK_DEBUG_COMPOSITOR=1 pnpm exec tsx scripts/visual-void-repro.ts widen-evict 2>/tmp/comp.log

--- a/docs/dev/real-terminal-matrix.md
+++ b/docs/dev/real-terminal-matrix.md
@@ -14,7 +14,11 @@ refuses a non-TTY (`exit 2`), so it cannot be piped, screen-scraped, or run from
 agent shell. `tmux` is a valid extra row but not a substitute: it reflows only
 *soft*-wrapped lines and never sends SIGWINCH itself.
 
+**Run from the repo root** — `pnpm exec` resolves against the nearest workspace, so
+running from `~` fails with `ERR_PNPM_RECURSIVE_EXEC_NO_PACKAGE`:
+
 ```bash
+cd ~/Projects/open_source/agent-afk
 pnpm exec tsx scripts/visual-void-repro.ts <scenario>
 ```
 
@@ -61,9 +65,10 @@ band-hold archive (already fixed by #665) rather than grow-eviction. Only a
 |---|---|---|
 | Grow-eviction → widen | `visual-void-repro.ts widen-evict` | see below |
 
-Procedure: start the pane **narrow (48–70 cols)**, run it, and during the 45s hold
-**drag the window wider** (or `cmd`-`-` to shrink the font — same effect). Then
-scroll up:
+Procedure: start the pane **narrow (48–70 cols)** — the scenario refuses to run
+above 80 cols and exits 2, because content has to be *committed* narrow for a later
+widen to have anything to rejoin. Then during the 45s hold **drag the window wider**
+(or `cmd`-`-` to shrink the font — same effect). Then scroll up:
 
 - `LONGLINE-MARKER … END-OF-LONGLINE` — **PASS** it rejoined into one soft-wrapped
   paragraph. **FAIL** it is split across rows that break **mid-word**, with
@@ -85,8 +90,16 @@ guard drove the one already-fixed write site. Verify, do not assume — composit
 phase traces go to **stderr**, so redirect it and leave stdout (the visual output)
 alone:
 
+Run these as **two separate commands** — the script holds for 45s, and pasting both
+at once can join them into one line:
+
 ```bash
 AFK_DEBUG_COMPOSITOR=1 pnpm exec tsx scripts/visual-void-repro.ts widen-evict 2>/tmp/comp.log
+```
+
+then, after it exits:
+
+```bash
 grep -E 'commitAbove:phase1|evict:enter' /tmp/comp.log
 ```
 

--- a/docs/dev/real-terminal-matrix.md
+++ b/docs/dev/real-terminal-matrix.md
@@ -1,0 +1,105 @@
+# Real-terminal validation matrix (compositor)
+
+The human-in-the-loop gate #540 requires before any compositor commit-path change
+lands. It exists because **two prior fixes shipped headless-green and were broken
+in reality** (`docs/scrollback.md`), and a third — #665 — shipped with
+`test:pty 8/8` and still fragmented real scrollback the next day (#755).
+
+Run every row. Green tests are not a substitute; that is the whole point of this file.
+
+## Setup
+
+Run in a **real terminal** — iTerm2, Apple Terminal, Ghostty, or xterm. The script
+refuses a non-TTY (`exit 2`), so it cannot be piped, screen-scraped, or run from an
+agent shell. `tmux` is a valid extra row but not a substitute: it reflows only
+*soft*-wrapped lines and never sends SIGWINCH itself.
+
+```bash
+pnpm exec tsx scripts/visual-void-repro.ts <scenario>
+```
+
+Each scenario renders, holds so you can look and scroll up, then restores the
+terminal. A/B every row against the base branch:
+
+```bash
+git checkout main   && pnpm exec tsx scripts/visual-void-repro.ts <scenario>   # BEFORE
+git checkout <fix>  && pnpm exec tsx scripts/visual-void-repro.ts <scenario>   # AFTER
+```
+
+## Axis 1 — void class (contiguity)
+
+| Scenario | Command | PASS |
+|---|---|---|
+| Long report + table | `visual-void-repro.ts long` | one contiguous block hugging the prompt; no blank void; every row exactly once incl. `HEADER-MARKER`; nothing stranded up top |
+| Short report | `visual-void-repro.ts short` | as above, `HEADER-MARKER` + `PROSE-01` + `BODY-TAIL-ROW` all present once |
+| Overlay grow → collapse | `visual-void-repro.ts grow-collapse` | `BODY-TAIL-ROW` committed after the growth is present; no void where the tall overlay was |
+| Width change mid-turn | `visual-void-repro.ts resize` | band reflows, stays gap-free |
+
+**Interactive rows (cannot be scripted — run `afk interactive` for real):**
+
+| Check | PASS |
+|---|---|
+| Dropdown headroom | open the slash-command menu on a *fresh* session — the prompt must NOT jump |
+| Picker | open a picker mid-session — no void, no double-paint |
+
+## Axis 2 — reflow class (fragmentation) — needs your hands
+
+**The `resize` row above does NOT cover this axis.** It fakes the resize:
+
+```js
+(stdout as unknown as { columns: number }).columns = Math.max(40, cols - 20);
+stdout.emit('resize');
+```
+
+The real terminal never resizes, so it never reflows its own scrollback — and
+terminal-owned reflow is the entire mechanism of the fragmentation bug. It also
+only ever *narrows*, and it commits under a tall overlay, so it drives the
+band-hold archive (already fixed by #665) rather than grow-eviction. Only a
+**real OS window resize** exercises this axis.
+
+| Scenario | Command | PASS |
+|---|---|---|
+| Grow-eviction → widen | `visual-void-repro.ts widen-evict` | see below |
+
+Procedure: start the pane **narrow (48–70 cols)**, run it, and during the 45s hold
+**drag the window wider** (or `cmd`-`-` to shrink the font — same effect). Then
+scroll up:
+
+- `LONGLINE-MARKER … END-OF-LONGLINE` — **PASS** it rejoined into one soft-wrapped
+  paragraph. **FAIL** it is split across rows that break **mid-word**, with
+  continuations at column 0.
+- `CARD-BOTTOM` — **must still be present.** The previous attempt at converting
+  eviction to logical archival dropped exactly that closing border on a growth
+  eviction (`terminal-compositor.frame-preserve.ts:10-30`). This is the specific
+  regression to watch, not a nice-to-have.
+- No block appears twice, and no box borders are spliced at two different indents.
+
+Also worth one manual pass in a real session, since it is the reported sequence:
+let a turn finish with a Done card on screen, start another turn so the thinking
+lane grows the frame, then widen the window and scroll up.
+
+## Confirm which write site you actually drove
+
+The failure that produced #755 was **aim**, not capability: every prior width-resize
+guard drove the one already-fixed write site. Verify, do not assume — compositor
+phase traces go to **stderr**, so redirect it and leave stdout (the visual output)
+alone:
+
+```bash
+AFK_DEBUG_COMPOSITOR=1 pnpm exec tsx scripts/visual-void-repro.ts widen-evict 2>/tmp/comp.log
+grep -E 'commitAbove:phase1|evict:enter' /tmp/comp.log
+```
+
+- `commitAbove:phase1` carries `fitsAboveFrame`, `bandOverflow`, `archiveCount`,
+  `rawGenuineOverflow`, `maxBandModel`. **`archiveCount > 0` means you drove the
+  band-hold archive** (the fixed path).
+- `evict:enter { rows }` means you drove **grow-eviction** in `frame-preserve.ts`
+  — the path that still emits physical rows.
+
+A reflow-axis run that never logs `evict:enter` proved nothing about this axis.
+
+## Recording the result
+
+#540 requires the matrix be **documented in the PR**. Paste the table with a
+per-row verdict, name the terminal(s) and the before/after commits, and state
+which write sites the traces showed you hit.

--- a/docs/scrollback.md
+++ b/docs/scrollback.md
@@ -107,10 +107,22 @@ scroll → still nothing in scrollback. The byte-level test verified
 but that's irrelevant to whether the LF triggers a scroll under the
 full-screen DECSTBM that `withFullScrollRegion` installs.
 
-The fix passed CI and shipped because **no test verifies actual scrollback
-contents end-to-end on a real PTY.** The only ground truth is running
+The fix passed CI and shipped because **no test verified actual scrollback
+contents end-to-end on a real PTY.** The only ground truth was running
 agent-afk in iTerm2 / Apple Terminal / xterm and visually scrolling up to
 see what's there.
+
+**Updated 2026-07-29 — that gap is closed for contents, but not for coverage.**
+`tests/pty/` (issue #541, `11fb1eb`) spawns a real pty, replays the byte stream
+through an xterm emulator, and asserts against reconstructed scrollback
+(`inScrollback`, and `logicalSpan` for hard-break/soft-wrap spans). So the
+harness CAN certify scrollback contents. The residual risk moved from
+capability to aim: a scenario only covers the write site its `drive()` happens
+to exercise, and for a long time every width-resize guard drove the band-hold
+archive alone — leaving the grow-eviction site (`terminal-compositor.frame-preserve.ts`)
+unobserved while a comment there asserted it did not matter. It did.
+When adding a scrollback guard, state which of the write sites it drives in its
+`ref` field, and check whether the others are covered by anything.
 
 ### CUP-to-rows: makes the scroll fire, but pushes the WRONG row
 

--- a/scripts/visual-void-repro.ts
+++ b/scripts/visual-void-repro.ts
@@ -13,6 +13,20 @@
  *   short           a 3-line report under a tall overlay, then collapse
  *   grow-collapse   commit, grow the overlay taller, then collapse (re-pin path)
  *   resize          commit under a tall overlay, resize width mid-turn, collapse
+ *   widen-evict     REFLOW axis (#540 axis-2) — commit under a SHORT frame, grow
+ *                   the overlay so grow-eviction pushes those painted rows to
+ *                   scrollback, collapse, then WAIT for you to drag the window
+ *                   WIDER by hand. See the reflow-axis note below.
+ *
+ * Reflow axis vs. void axis — why `widen-evict` needs a human hand: the four
+ * scenarios above check the VOID class (contiguity). `resize` does NOT check
+ * reflow, because it fakes the resize by assigning `stdout.columns` and emitting
+ * a synthetic 'resize' — the real terminal never resizes, so its scrollback is
+ * never reflowed, and terminal-owned reflow is the whole mechanism of the
+ * fragmentation bug. It also only ever narrows, and commits under a tall overlay
+ * so it drives the band-hold archive (already fixed by #665) rather than
+ * grow-eviction. Only a REAL OS window resize makes the emulator reflow its own
+ * scrollback, so `widen-evict` sets the state up and then blocks on you.
  *
  * Interactive scenarios (run afk for real and eyeball — cannot be scripted as
  * pure output): dropdown headroom (open the slash-command menu on a fresh
@@ -34,8 +48,8 @@ import { TerminalCompositor } from '../src/cli/terminal-compositor.js';
 import { StatusLine } from '../src/cli/status-line.js';
 import { renderMarkdownToTerminal } from '../src/cli/formatter.js';
 
-type Scenario = 'long' | 'short' | 'grow-collapse' | 'resize';
-const SCENARIOS: readonly Scenario[] = ['long', 'short', 'grow-collapse', 'resize'];
+type Scenario = 'long' | 'short' | 'grow-collapse' | 'resize' | 'widen-evict';
+const SCENARIOS: readonly Scenario[] = ['long', 'short', 'grow-collapse', 'resize', 'widen-evict'];
 
 function tallOverlay(n: number): string {
   return Array.from({ length: n }, (_, i) => `  thinking ${i} — held overlay keeping the frame tall`).join('\n');
@@ -66,6 +80,29 @@ async function main(): Promise<void> {
     process.exit(2);
   }
   const cols = stdout.columns ?? 100;
+
+  if (arg === 'widen-evict') {
+    // Printed BEFORE arm() on purpose: the compositor stays LIVE through the
+    // resize (that is the real-session case, and the case the PTY guard drives),
+    // so nothing may write raw rows into its geometry once armed. A pre-arm print
+    // is the same shape as the production banner and is safe.
+    stdout.write(
+      [
+        '',
+        '=== widen-evict — REFLOW axis (#540 axis-2) ===',
+        `Start narrow. This pane is ${cols} cols; 48-70 is ideal. Resize it NOW if wider.`,
+        '',
+        'After the render settles you get 45s. During that window:',
+        '  1. DRAG THIS WINDOW WIDER (or press cmd-minus to shrink the font).',
+        '  2. Scroll up to the LONGLINE-MARKER … END-OF-LONGLINE line.',
+        '       FAIL  it is split across rows breaking MID-WORD, continuations at col 0',
+        '       PASS  it rejoined into one soft-wrapped paragraph',
+        '  3. Confirm CARD-BOTTOM is still present — the previous logical-archive',
+        '     attempt dropped exactly that border row on a growth eviction.',
+        '',
+      ].join('\n') + '\n',
+    );
+  }
 
   const statusLine = new StatusLine({ stream: stdout, force: true, throttleMs: 0 });
   statusLine.start();
@@ -107,6 +144,25 @@ async function main(): Promise<void> {
     ix.repaint();
     commit('BODY-TAIL-ROW  committed after the growth\n\n');
     collapse();
+  } else if (arg === 'widen-evict') {
+    // Commit under a SHORT frame (no overlay) so these rows land in the band and
+    // are CUP-painted as hard-wrapped PHYSICAL rows — deliberately NOT routed to
+    // the band-hold archive that #665 converted to logical lines.
+    c.setOverlay('');
+    c.commitAbove(`LONGLINE-MARKER ${'reflow '.repeat(24)}END-OF-LONGLINE\n\n`);
+    // A boxed card whose CLOSING BORDER is the row the previous logical-archive
+    // attempt dropped on a growth eviction (frame-preserve.ts:10-30). Keeping it
+    // in view means that regression cannot pass unnoticed.
+    c.commitAbove(
+      '┌─ CARD-TOP ───────────────┐\n│ card body row            │\n└─ CARD-BOTTOM ────────────┘\n\n',
+    );
+    for (let i = 1; i <= 4; i++) c.commitAbove(`PROSE-${String(i).padStart(2, '0')}  report line\n\n`);
+    ix.repaint();
+    // Grow the frame: preserveRowsBeforeFrameRender evicts the painted rows above
+    // into scrollback as app hard newlines — the site the PTY guards cannot see.
+    c.setOverlay(tallOverlay(30));
+    ix.repaint();
+    collapse();
   } else {
     // `long` and `resize` share the report+table body.
     commit('HEADER-MARKER  Diagnosis summary\n\n');
@@ -121,7 +177,9 @@ async function main(): Promise<void> {
     collapse();
   }
 
-  await new Promise((r) => setTimeout(r, 6000));
+  // widen-evict needs a human to physically resize the OS window mid-hold, so it
+  // holds far longer than the look-and-scroll scenarios.
+  await new Promise((r) => setTimeout(r, arg === 'widen-evict' ? 45000 : 6000));
   c.disarm();
   statusLine.stop();
   stdout.write(`\n[visual-void-repro:${arg} done — scroll up to inspect scrollback]\n`);

--- a/scripts/visual-void-repro.ts
+++ b/scripts/visual-void-repro.ts
@@ -66,18 +66,29 @@ function reportTable(cols: number): string {
   return renderMarkdownToTerminal(TABLE_MD, { maxWidth: cols - 2 }).replace(/\n+$/, '');
 }
 
+/**
+ * Invariant (a refusal must survive the documented `2>` redirect): every guard in
+ * main() reports on STDOUT and never on stderr. docs/dev/real-terminal-matrix.md
+ * runs the instrumented form `… widen-evict 2>/tmp/comp.log` to capture
+ * AFK_DEBUG_COMPOSITOR traces, so a refusal written to stderr lands in the log
+ * file instead of the screen — the operator sees an empty pane and a silent
+ * exit-2 and cannot tell a refusal from a crash. That is exactly what happened
+ * on the first real run of widen-evict (refused at 111 cols, message invisible).
+ * stdout is already this script's visual channel, so it is the correct sink.
+ */
+function refuse(msg: string): never {
+  process.stdout.write(`${msg}\n`);
+  process.exit(2);
+}
+
 async function main(): Promise<void> {
   const stdout = process.stdout;
   if (!stdout.isTTY) {
-    // eslint-disable-next-line no-console
-    console.error('Not a TTY — run this directly in iTerm2 / Terminal / xterm, not through a pipe.');
-    process.exit(2);
+    refuse('Not a TTY — run this directly in iTerm2 / Terminal / xterm, not through a pipe.');
   }
   const arg = (process.argv[2] ?? 'long') as Scenario;
   if (!SCENARIOS.includes(arg)) {
-    // eslint-disable-next-line no-console
-    console.error(`Unknown scenario "${arg}". Pick one of: ${SCENARIOS.join(', ')}`);
-    process.exit(2);
+    refuse(`Unknown scenario "${arg}". Pick one of: ${SCENARIOS.join(', ')}`);
   }
   const cols = stdout.columns ?? 100;
 
@@ -88,13 +99,11 @@ async function main(): Promise<void> {
     // exact failure mode (a test that cannot observe its target) this scenario
     // exists to correct. There is no pause-and-hope here on purpose: the width
     // has to be right BEFORE the first commitAbove, not after a countdown.
-    // eslint-disable-next-line no-console
-    console.error(
+    refuse(
       `widen-evict needs a NARROW pane to commit at — this one is ${cols} cols.\n` +
         'Resize the window to 48-70 cols (or cmd-+ to grow the font) and re-run.\n' +
         'The whole point is to widen AFTERWARDS, so starting wide leaves no room to widen into.',
     );
-    process.exit(2);
   }
 
   if (arg === 'widen-evict') {

--- a/scripts/visual-void-repro.ts
+++ b/scripts/visual-void-repro.ts
@@ -81,6 +81,22 @@ async function main(): Promise<void> {
   }
   const cols = stdout.columns ?? 100;
 
+  if (arg === 'widen-evict' && cols > 80) {
+    // Fail closed instead of asking politely. The band must be COMMITTED at a
+    // narrow width for a later widen to have anything to rejoin; rendering this
+    // scenario in an already-wide pane silently proves nothing, which is the
+    // exact failure mode (a test that cannot observe its target) this scenario
+    // exists to correct. There is no pause-and-hope here on purpose: the width
+    // has to be right BEFORE the first commitAbove, not after a countdown.
+    // eslint-disable-next-line no-console
+    console.error(
+      `widen-evict needs a NARROW pane to commit at — this one is ${cols} cols.\n` +
+        'Resize the window to 48-70 cols (or cmd-+ to grow the font) and re-run.\n' +
+        'The whole point is to widen AFTERWARDS, so starting wide leaves no room to widen into.',
+    );
+    process.exit(2);
+  }
+
   if (arg === 'widen-evict') {
     // Printed BEFORE arm() on purpose: the compositor stays LIVE through the
     // resize (that is the real-session case, and the case the PTY guard drives),
@@ -90,7 +106,7 @@ async function main(): Promise<void> {
       [
         '',
         '=== widen-evict — REFLOW axis (#540 axis-2) ===',
-        `Start narrow. This pane is ${cols} cols; 48-70 is ideal. Resize it NOW if wider.`,
+        `Pane is ${cols} cols — narrow enough to commit at. Do NOT resize until told.`,
         '',
         'After the render settles you get 45s. During that window:',
         '  1. DRAG THIS WINDOW WIDER (or press cmd-minus to shrink the font).',

--- a/src/cli/terminal-compositor.frame-preserve.ts
+++ b/src/cli/terminal-compositor.frame-preserve.ts
@@ -18,10 +18,22 @@
  * coupled to repositionCommittedBand's stateless re-pin and the exact
  * painted/pending accounting — converting them to the top-paint-logical-then-
  * scroll mechanism regressed the verdict-card overflow case (the card's closing
- * border was dropped on a growth eviction). The band-hold archive is the site
- * that actually carries the width-resize content in practice (verified by
- * instrumenting the #540 PTY guards), so retaining physical emission here does
- * NOT reintroduce the fragmentation those guards check. The committedBandMeta
+ * border was dropped on a growth eviction).
+ *
+ * FALSIFIED 2026-07-29 — this note previously claimed "the band-hold archive is
+ * the site that actually carries the width-resize content in practice (verified
+ * by instrumenting the #540 PTY guards), so retaining physical emission here
+ * does NOT reintroduce the fragmentation those guards check". That was an
+ * empirical bet, and it lost: both #540 guards hold a tall overlay across every
+ * commitAbove, so they only ever drive band-hold and could not observe THIS
+ * site. The new PTY guard `width-resize-fragment-evict-growth` drives it
+ * directly (commit under a short frame, then grow) and measures 4 non-wrapped
+ * rows after a widen where a rejoined line shows 1 — i.e. the ordinary
+ * end-of-turn → next-turn sequence DOES carry width-resize content through
+ * here, and it fragments. Reported from a real session: see the analysis in
+ * that guard's header. The physical emission below is therefore a KNOWN DEFECT
+ * retained only because the naive conversion regresses the verdict-card case
+ * above; it is not sound. The committedBandMeta
  * array IS still sliced in lockstep at every eviction below so the 1:1
  * band↔meta invariant (relied on by reflow and the two logical-flush sites)
  * holds. A full turnModel rewrite (docs/proposals/tui-compositor-rewrite.md §5

--- a/tests/pty/scenarios.ts
+++ b/tests/pty/scenarios.ts
@@ -549,6 +549,67 @@ export const SCENARIOS: Record<string, PtyScenario> = {
   },
 
   // ─────────────────────────────────────────────────────────────────────────
+  // width-resize-fragment-evict-growth (#540 axis-2 · the EVICTION site):
+  // frame-preserve.ts:10-30 justifies leaving the growth-eviction paths on
+  // pre-wrapped PHYSICAL rows by asserting "the band-hold archive is the site
+  // that actually carries the width-resize content in practice". The two guards
+  // above only ever drive band-hold (they hold a tall overlay across every
+  // commitAbove), so nothing tests that claim. This scenario drives the OTHER
+  // site: commit with a SHORT frame so the run lands in the band and is painted
+  // (no archive), THEN grow the overlay so preserveRowsBeforeFrameRender's
+  // grow-eviction scrolls those painted rows into scrollback as app hard
+  // newlines — the real end-of-turn → next-turn sequence from the 2026-07-29
+  // report. On a WIDEN the terminal cannot rejoin app hard-newlines, so the
+  // line stays fragmented: measured 4 non-wrapped rows at HEAD (22751af), where
+  // a rejoined line would show 1. RED-guard shape (minNonWrappedRows) — it
+  // asserts the defect so the blind spot cannot silently persist; flip it to
+  // `maxNonWrappedRows: 1` when the A2 unification retires physical eviction.
+  // ─────────────────────────────────────────────────────────────────────────
+  'width-resize-fragment-evict-growth': {
+    description: 'logical line evicted by frame GROWTH stays FRAGMENTED in scrollback on a WIDER resize (RED guard, #540 axis-2)',
+    cols: 48,
+    rows: 24,
+    ref: '#540 axis-2 · frame-preserve.ts grow-eviction (physical rows)',
+    async drive(ctx): Promise<void> {
+      const { stdout, stdin } = ctx;
+      const statusLine = wireProductionFooter(stdout, 'M');
+      const c = new TerminalCompositor({ stdout, stdin, onCancel: () => {}, scrollRegion: statusLine, anchorRow: 1 });
+      await c.arm();
+      const ix = c as unknown as Repaintable;
+      c.setSpinner({ enabled: true });
+      // Phase 1 — commit under a SHORT frame (no overlay). The run fits above
+      // the frame, so decideCommitMode takes neither band-hold nor the archive:
+      // these rows are CUP-painted into the band as hard-wrapped physical rows.
+      // 186 cols → 4 physical rows at 48; committed first so it sits at band[0].
+      const longLine = `LOGSTART_${'x'.repeat(170)}_LOGEND`;
+      c.setOverlay('');
+      c.commitAbove(longLine + '\n');
+      for (let k = 0; k < 10; k++) c.commitAbove(`FILLER_${String(k).padStart(2, '0')}\n`);
+      ix.repaint();
+      await settle();
+      // Phase 2 — GROW the frame. desiredTopRow drops below prevTopRow, so
+      // growOverflow = bandLen - growRoom > 0 and the top band rows (including
+      // all 4 rows of the long line) are evicted to scrollback physically.
+      c.setOverlay(Array.from({ length: 18 }, (_, i) => `thinking ${i} tall`).join('\n'));
+      ix.repaint();
+      await settle();
+      c.setOverlay('');
+      ix.repaint(); ix.repaint();
+      await settle();
+      await requestResize(ctx, 110, 24); // WIDEN 48 → 110
+      ix.repaint(); ix.repaint();
+      await settle();
+    },
+    expect: {
+      inScrollback: ['LOGSTART'], // precondition: the line was evicted off screen
+      // >=2 non-wrapped rows == still fragmented. Deliberately not pinned to the
+      // measured 4: the exact count depends on eviction row math, but ANY value
+      // >1 means the terminal could not rejoin it.
+      logicalSpan: { from: 'LOGSTART', to: 'LOGEND', minNonWrappedRows: 2 },
+    },
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────
   // #745 — bootstrap warnings must survive the startup screen clear.
   //
   // The headless test (interactive.boot-warnings.test.ts) proves the warning


### PR DESCRIPTION
## This PR does not fix the bug. It proves the bug exists where we assumed it didn't.

Read that first, so nothing here is mistaken for a fix. No production behaviour changes: one new PTY guard, one comment correction, one docs correction.

## What happened

A real session showed the reported width-resize symptom again — after widening the terminal, output from a completed turn was still hard-wrapped mid-word in scrollback with its indent lost, and a block appeared twice. The session was running **5.82.1, which already contains #665** (`git tag --contains 71e5450` → v5.81.6 …), verified by tying the session to its PID and reading `ps -o lstart` against the npm install log. So this is not a stale binary and not a regression — it is a site #665 never covered.

## Why our guards were green

`width-resize-fragment-narrow` and `-widen` both hold a tall overlay across every `commitAbove`:

```js
c.setOverlay(overlay); c.commitAbove(longLine + '\n');
```

That routes every commit through the **band-hold archive** — the one write site #665 converted to soft-wrappable logical lines. Both guards carry `ref: '#540 axis-2 · committed-band-commit.ts band-hold archive (logical flush)'`. They test the fixed site. 7 of 9 scenarios set a tall overlay.

Meanwhile `frame-preserve.ts` justified keeping its grow-eviction paths on pre-wrapped physical rows like this:

> The band-hold archive is the site that actually carries the width-resize content in practice (verified by instrumenting the #540 PTY guards), so retaining physical emission here does NOT reintroduce the fragmentation those guards check.

**That claim is false.** The ordinary sequence — a turn commits under a short frame, then the next turn's thinking lane grows the frame — evicts through `preserveRowsBeforeFrameRender`, not band-hold. Terminals reflow only their own soft wraps, so the app hard newlines it emits can never rejoin on widen.

## The guard

`width-resize-fragment-evict-growth` drives the eviction site directly: commit under a short frame (no overlay → lands in the band and is painted, no archive), then grow the overlay so grow-eviction scrolls those painted rows out, then widen 48 → 110.

Result at `22751af`: **4 non-wrapped rows where a rejoined line shows 1.** With the aspirational assertion it fails `expected 4 to be less than or equal to 1`; committed in RED-guard shape (`minNonWrappedRows: 2`) so CI is green while the defect is pinned and cannot silently persist. Not pinned to exactly 4 — any value >1 means the terminal could not rejoin it.

## Why I did not fix it here

`frame-preserve.ts` records that the obvious fix was already tried and regressed:

> converting them to the top-paint-logical-then-scroll mechanism regressed the verdict-card overflow case (the card's closing border was dropped on a growth eviction)

So the real fix is the A2 unification (`docs/proposals/tui-compositor-rewrite.md` §5 / #540 Stage 2), which #540 gates on a human-in-the-loop real-terminal validation matrix. Shipping a plausible-looking conversion here would be the fourth green-but-broken release in this class. Flip this guard to `maxNonWrappedRows: 1` when that lands — it should be the acceptance test.

## Also corrected

`docs/scrollback.md` claimed **"no test verifies actual scrollback contents end-to-end on a real PTY"**. That predates the #541 harness (`11fb1eb`), which does exactly that. The residual risk moved from capability to **aim**: a scenario only covers the write site its `drive()` exercises. Added guidance to name the write site in `ref` and check whether the others are covered.

## Gates

- `pnpm test:pty` 10/10, new guard included
- `pnpm test` 13513 passed / 711 files
- `pnpm lint` clean; `audit:env:check`, `scan:env:check`, `audit:sdk:check`, `audit:chalk:check`, `build` all OK

Refs #540. Follow-up to #665 (#541 harness).
