### PR TITLE
fix(tui): archive eviction paths as logical lines so scrolled-off content reflows (#540)

### DIFF
--- a/src/cli/terminal-compositor.frame-preserve-archive.ts
+++ b/src/cli/terminal-compositor.frame-preserve-archive.ts
@@ -1,0 +1,136 @@
+/**
+ * Logical-line scrollback archival for the frame-compositor eviction paths.
+ *
+ * #540 axis-2. All three of `preserveRowsBeforeFrameRender`'s eviction sites
+ * (the two `!hasBanner` paths and the banner path) previously shared one
+ * mechanism: paint the FULL band top-aligned, then `evictRowsToScrollback(N)`.
+ * That single paint did TWO jobs at once — it put the evicted prefix into rows
+ * the scroll would carry into history, AND it left the survivors shifted up to
+ * hug the new frame top. Elegant, but it forced the prefix into scrollback as
+ * pre-wrapped PHYSICAL rows, which a terminal can only ever reflow per-row: on
+ * a widen the content stayed hard-wrapped mid-word forever (the reported
+ * fragmentation, pinned by the `width-resize-fragment-evict-growth` PTY guard).
+ *
+ * This module splits those two jobs apart so the archive can emit
+ * SOFT-WRAPPABLE logical lines (via `committedBandMeta` + the shared
+ * `scrollbackFlushLines` / `buildScrollbackArchiveEscape` helpers, the same
+ * pair the band-hold archive and `flushPendingCommittedBand` already use) while
+ * the survivors are re-placed by an explicit paint rather than as a side effect
+ * of the scroll. Splitting them is what makes the conversion safe: a naive swap
+ * that only replaced the emission left the survivors unpainted while the
+ * caller's bookkeeping still claimed `committedBandPaintedRows === length`, so
+ * rows existed in the model but on neither the screen nor in scrollback — the
+ * historical symptom was a verdict card's closing border vanishing on a growth
+ * eviction (`verdict-card-overflow.test.ts` guards it).
+ */
+
+import type { FrameHost } from './terminal-compositor.frame.js';
+import {
+  buildScrollbackArchiveEscape,
+  eraseAndPaintRow,
+  scrollbackFlushLines,
+} from './terminal-compositor.types.js';
+import { withAutowrapDisabled } from './terminal-compositor.band-reflow.js';
+
+/**
+ * Archive the oldest `overflow` rows of the committed band to native scrollback
+ * as logical lines, re-place the survivors top-aligned at `floor`, and update
+ * the band bookkeeping to match.
+ *
+ * Contract — on return: `committedBand` / `committedBandMeta` have lost their
+ * oldest `overflow` entries (sliced in lockstep, preserving the 1:1 invariant);
+ * every surviving row is painted on screen at `[floor, floor + survivors - 1]`;
+ * `committedBandPaintedRows === committedBand.length` (no pending rows); and
+ * the archived prefix is in native scrollback. Callers must NOT repeat any of
+ * that. No-op guard: `overflow <= 0` returns without touching the terminal.
+ *
+ * `overflow` is a PHYSICAL row count and is load-bearing geometry — it is
+ * `bandLen - room`, the exact number of rows that must leave the screen for the
+ * survivors to land flush against the incoming frame top. It is therefore NOT
+ * snapped to a logical-line boundary the way the band-hold archive snaps its
+ * own count: snapping down would leave the band too tall to fit, and snapping
+ * up would strand blank rows between the band and the frame (the void class).
+ * A logical line straddling the boundary is handled by `scrollbackFlushLines`,
+ * which emits the in-prefix rows verbatim so the on-screen tail is never
+ * duplicated — that line stays fragmented (today's behaviour), while every
+ * line wholly inside the prefix now rejoins on a widen.
+ */
+export function archiveBandPrefixAndRepaintSurvivors(
+  self: FrameHost,
+  overflow: number,
+  floor: number,
+): void {
+  if (overflow <= 0) return;
+  const bandLen = self.committedBand.length;
+  const rows = Math.max(1, self.stdout.rows ?? 24);
+  const cols = Math.max(1, self.stdout.columns ?? 80);
+  self.debugLog('evict:logical-archive', { overflow, floor, bandLen });
+
+  // External constraint (DECSTBM/DECAWM — these three steps are NOT
+  // reorderable). Step 2's scroll displaces screen rows upward, so painting
+  // the survivors before it would scroll them straight into history; and the
+  // stale band position must be cleared before step 2 paints over it, or
+  // un-erased glyphs to the right of a shorter archived line scroll into
+  // scrollback verbatim. Hence: erase old position -> archive+scroll -> paint
+  // survivors. Write teardown before setup is not an option here because the
+  // terminal, not this process, owns the intervening scroll.
+
+  // (1) Erase the band's previous painted footprint, from the geometric floor
+  // through its tracked bottom.
+  let erase = '';
+  for (let r = floor; r <= self.committedBandBottomRow; r++) erase += eraseAndPaintRow(r);
+
+  // (2) Archive the prefix as logical lines. Autowrap stays ON for this write
+  // (load-bearing, and the exact opposite of the on-screen band paint in step
+  // 3): the terminal must own the intra-line wrap so its continuation rows are
+  // soft-wrap continuations that rejoin when the width changes. The write goes
+  // through the full-screen scroll-region guard for the same reason
+  // `evictRowsToScrollback` does — with a StatusLine the DECSTBM region is a
+  // SUB-region, and a `\n` at its bottom margin scrolls that sub-region, so the
+  // displaced line exits without ever entering scrollback.
+  const archiveLines = scrollbackFlushLines(self.committedBand, self.committedBandMeta, overflow);
+  const archive = buildScrollbackArchiveEscape(archiveLines, floor, rows, cols);
+  const writeArchive = (): void => {
+    try {
+      self.stdout.write(erase + archive);
+    } catch (err) {
+      self.debugLog('evict:error', { msg: (err as Error)?.message ?? String(err) });
+      // Stdout closed mid-render (process exit / terminal hangup); the next
+      // render() fails too and the surface lifecycle tears us down.
+    }
+  };
+  if (self.scrollRegion !== undefined) {
+    self.scrollRegion.withFullScrollRegion(writeArchive);
+  } else {
+    writeArchive();
+  }
+
+  // (3) Re-place the survivors. The scroll in step 2 left their rows holding
+  // displaced content, so they must be painted explicitly — this is the job the
+  // old full-band paint did implicitly, and dropping it is what regressed the
+  // verdict-card border. Autowrap is disabled here (band rows are already
+  // hard-wrapped to the current width by repaint()'s reflowCommittedBandToWidth,
+  // so this defends against a residual ±1-column displayWidth() gap on
+  // ambiguous-width glyphs fabricating a phantom row).
+  const survivors = self.committedBand.slice(overflow);
+  if (survivors.length > 0) {
+    let paint = '';
+    for (let i = 0; i < survivors.length; i++) paint += eraseAndPaintRow(floor + i, survivors[i]);
+    withAutowrapDisabled(self.stdout, () => {
+      try {
+        self.stdout.write(paint);
+      } catch {
+        /* terminal closed mid-render — lifecycle tears us down on next render */
+      }
+    });
+  }
+
+  // (4) Bookkeeping. Honest by construction now: every survivor was painted
+  // above, so none are pending. Meta slices in lockstep to hold the 1:1
+  // band<->meta invariant the reflow and logical-flush sites rely on.
+  self.committedBand = survivors;
+  self.committedBandMeta = self.committedBandMeta.slice(overflow);
+  self.committedBandTopRow = floor;
+  self.committedBandBottomRow = floor + survivors.length - 1;
+  self.committedBandPaintedRows = survivors.length;
+}

--- a/src/cli/terminal-compositor.frame-preserve.ts
+++ b/src/cli/terminal-compositor.frame-preserve.ts
@@ -7,43 +7,31 @@
  * `import type` for FrameHost keeps this a TYPE-ONLY dependency on frame.ts
  * so there is no runtime circular import between the two siblings.
  *
- * #540 axis-2 scope note (logical-line scrollback flush): the two OTHER sites
- * that push committed content into native scrollback — the band-hold archive
- * (committed-band-commit.ts) and disarm's flushPendingCommittedBand
- * (lifecycle.ts) — now emit SOFT-WRAPPABLE logical lines (via committedBandMeta
- * + buildScrollbackArchiveEscape) so scrolled-off content reflows cleanly on a
- * width change. The eviction paths HERE deliberately still emit pre-wrapped
- * PHYSICAL rows: they are the load-bearing height/void-class machinery
- * (#539/#552/#573), and their paint-full-band-then-scroll mechanism is tightly
- * coupled to repositionCommittedBand's stateless re-pin and the exact
- * painted/pending accounting — converting them to the top-paint-logical-then-
- * scroll mechanism regressed the verdict-card overflow case (the card's closing
- * border was dropped on a growth eviction).
+ * #540 axis-2 (logical-line scrollback flush) — RESOLVED. All three sites that
+ * push committed content into native scrollback now emit SOFT-WRAPPABLE logical
+ * lines, so scrolled-off content reflows cleanly when the width changes: the
+ * band-hold archive (committed-band-commit.ts), disarm's
+ * flushPendingCommittedBand (lifecycle.ts), and the three eviction paths in
+ * `preserveRowsBeforeFrameRender` below — which delegate the archive to
+ * `archiveBandPrefixAndRepaintSurvivors`
+ * (terminal-compositor.frame-preserve-archive.ts, where the ordering constraint
+ * and geometry contract are documented).
  *
- * FALSIFIED 2026-07-29 — this note previously claimed "the band-hold archive is
- * the site that actually carries the width-resize content in practice (verified
- * by instrumenting the #540 PTY guards), so retaining physical emission here
- * does NOT reintroduce the fragmentation those guards check". That was an
- * empirical bet, and it lost: both #540 guards hold a tall overlay across every
- * commitAbove, so they only ever drive band-hold and could not observe THIS
- * site. The new PTY guard `width-resize-fragment-evict-growth` drives it
- * directly (commit under a short frame, then grow) and measures 4 non-wrapped
- * rows after a widen where a rejoined line shows 1 — i.e. the ordinary
- * end-of-turn → next-turn sequence DOES carry width-resize content through
- * here, and it fragments. Reported from a real session: see the analysis in
- * that guard's header. The physical emission below is therefore a KNOWN DEFECT
- * retained only because the naive conversion regresses the verdict-card case
- * above; it is not sound. The committedBandMeta
- * array IS still sliced in lockstep at every eviction below so the 1:1
- * band↔meta invariant (relied on by reflow and the two logical-flush sites)
- * holds. A full turnModel rewrite (docs/proposals/tui-compositor-rewrite.md §5
- * A2) would unify all three sites onto one logical archive; that is the
- * documented follow-up, out of scope for this targeted fix.
+ * History: these paths emitted pre-wrapped PHYSICAL rows until 2026-07-29, and
+ * one earlier attempt to convert them regressed the verdict-card border because
+ * the old mechanism's single paint did two jobs at once. Full account in the
+ * header of terminal-compositor.frame-preserve-archive.ts. Guards:
+ * `verdict-card-overflow.test.ts` and the PTY scenario
+ * `width-resize-fragment-evict-growth`.
+ *
+ * The legacy deficit-based eviction at the end of the function still calls
+ * `evictRowsToScrollback` directly and is deliberately unchanged: it scrolls
+ * whatever is already on screen (including pre-arm banner rows) rather than
+ * archiving band content, so it has no logical lines to emit.
  */
 
 import type { FrameHost } from './terminal-compositor.frame.js';
-import { eraseAndPaintRow } from './terminal-compositor.types.js';
-import { withAutowrapDisabled } from './terminal-compositor.band-reflow.js';
+import { archiveBandPrefixAndRepaintSurvivors } from './terminal-compositor.frame-preserve-archive.js';
 
 /**
  * Preserve rows that the next compositor frame is about to cover.
@@ -129,48 +117,17 @@ export function preserveRowsBeforeFrameRender(self: FrameHost, desiredTopRow: nu
       room > 0
     ) {
       const overflow = bandLen - room;
-      let out = '';
-      // Invariant (#540 — erase from the geometric floor, not the tracked band
-      // top): clear the above-frame content region from the anchor floor (row 1
-      // here, `!hasBanner` ⇒ anchorFloor === 1 per the branch invariant above)
-      // down through the band's tracked bottom, rather than reading
-      // `committedBandTopRow` for the loop start. This mirrors the Stage-2-core
-      // repin change (#552, committed-band-repin.ts): the FULL model is repainted
-      // top-aligned at [1, bandLen] on the very next lines of the SAME batched
-      // `out` write, so any rows in [1, committedBandTopRow) the widened erase
-      // touches are re-covered with real band content before stdout sees them —
-      // observable output is unchanged (byte-for-byte where committedBandTopRow
-      // was already ≤ 1; a repainted-over transient otherwise). This retires the
-      // `committedBandTopRow` adjacency-coupling READ; the tracked `bottom` stays
-      // (it is the vacated-tail boundary, not derivable from geometry pre-Stage-3).
-      for (let r = 1; r <= self.committedBandBottomRow; r++) {
-        out += eraseAndPaintRow(r);
-      }
-      // Paint the FULL model top-aligned at [1, bandLen] so the scroll evicts
-      // real rows — including previously-pending ones never on screen before.
-      for (let i = 0; i < bandLen; i++) {
-        out += eraseAndPaintRow(1 + i, self.committedBand[i]);
-      }
-      // Belt-and-braces DECAWM bracket (see withAutowrapDisabled doc): the band
-      // rows painted here were re-wrapped at the current width by repaint()'s
-      // reflowCommittedBandToWidth call before this function ran; disabling
-      // autowrap defends against a residual ±1-column displayWidth()
-      // measurement gap on ambiguous-width glyphs, which can otherwise
-      // fabricate an unaccounted phantom row.
-      withAutowrapDisabled(self.stdout, () => {
-        try {
-          self.stdout.write(out);
-        } catch {
-          /* terminal closed mid-render — next render's lifecycle tears us down */
-        }
-      });
-      evictRowsToScrollback(self, overflow);
-      // Survivors physically shifted to [1, room] by the scroll.
-      self.committedBand = self.committedBand.slice(overflow);
-      self.committedBandMeta = self.committedBandMeta.slice(overflow); // #540: keep 1:1
-      self.committedBandTopRow = 1;
-      self.committedBandBottomRow = room;
-      self.committedBandPaintedRows = self.committedBand.length;
+      // #540 axis-2: archive the pending-overflow prefix to scrollback as
+      // SOFT-WRAPPABLE logical lines, then re-place the survivors at [1, room].
+      // `!hasBanner` ⇒ anchorFloor === 1 per the branch invariant above. The
+      // helper erases from the geometric FLOOR (row 1) rather than reading the
+      // tracked `committedBandTopRow`, retiring that adjacency-coupling read per
+      // the Stage-2-core repin change (#552, committed-band-repin.ts); the
+      // tracked `bottom` stays, being the vacated-tail boundary and not
+      // derivable from geometry pre-Stage-3. The helper owns the
+      // erase → archive → repaint ordering constraint and all band bookkeeping;
+      // see terminal-compositor.frame-preserve-archive.ts.
+      archiveBandPrefixAndRepaintSurvivors(self, overflow, 1);
       return;
     }
 
@@ -179,42 +136,17 @@ export function preserveRowsBeforeFrameRender(self: FrameHost, desiredTopRow: nu
     const growRoom = Math.max(0, desiredTopRow - 1);
     const growOverflow = bandLen - growRoom;
     if (growOverflow <= 0) return; // whole band fits above the new frame — no scroll
-    // Re-paint the full band top-aligned at [1, bandLen], erasing its old
-    // floating position, so the scroll carries the oldest `overflow` lines —
-    // real content, never blank rows — into scrollback. The frame render that
-    // follows repaints its own (lower) footprint; survivors sit above it.
-    let out = '';
-    // #540: erase from the geometric floor (row 1; `!hasBanner` ⇒ anchorFloor
-    // === 1), not the tracked `committedBandTopRow`. The [1, bandLen] repaint
-    // below re-covers the widened prefix on the same `out` write — see the full
-    // invariant on the pending-overflow eviction above.
-    for (let r = 1; r <= self.committedBandBottomRow; r++) {
-      out += eraseAndPaintRow(r);
-    }
-    for (let i = 0; i < bandLen; i++) {
-      out += eraseAndPaintRow(1 + i, self.committedBand[i]);
-    }
-    // Belt-and-braces DECAWM bracket — see the identical comment above.
-    withAutowrapDisabled(self.stdout, () => {
-      try {
-        self.stdout.write(out);
-      } catch {
-        /* terminal closed mid-render — next render's lifecycle tears us down */
-      }
-    });
-    evictRowsToScrollback(self, growOverflow);
-    // Survivors physically shifted to [1, growRoom] by the scroll — already
-    // hugging the new frame top (growRoom === desiredTopRow - 1). Record that so a
-    // later shrink re-pins from the right place.
-    self.committedBand = self.committedBand.slice(growOverflow);
-    self.committedBandMeta = self.committedBandMeta.slice(growOverflow); // #540: keep 1:1
-    self.committedBandTopRow = 1;
-    self.committedBandBottomRow = growRoom;
-    // The full band was re-painted top-aligned above before the scroll, so
-    // every surviving row is materialized on screen (and the evicted prefix is
-    // now in scrollback) — none are pending. Promote any previously-pending
-    // rows that this growth just materialized.
-    self.committedBandPaintedRows = self.committedBand.length;
+    // #540 axis-2: archive the oldest `growOverflow` rows to scrollback as
+    // SOFT-WRAPPABLE logical lines, then re-place the survivors at
+    // [1, growRoom] — already hugging the new frame top (growRoom ===
+    // desiredTopRow - 1), so a later shrink re-pins from the right place.
+    // `!hasBanner` ⇒ anchorFloor === 1. The helper owns the erase → archive →
+    // repaint ordering constraint and all band bookkeeping; see
+    // terminal-compositor.frame-preserve-archive.ts. This is the site the
+    // reported width-resize fragmentation came through (the ordinary
+    // end-of-turn → next-turn growth), pinned by the PTY guard
+    // `width-resize-fragment-evict-growth`.
+    archiveBandPrefixAndRepaintSurvivors(self, growOverflow, 1);
     return;
   }
 
@@ -261,40 +193,15 @@ export function preserveRowsBeforeFrameRender(self: FrameHost, desiredTopRow: nu
     roomBanner > 0
   ) {
     const overflow = bandLenBanner - roomBanner;
-    let out = '';
-    // #540: erase from the geometric floor (`floorBanner` = max(anchorRow, 1)),
-    // not the tracked `committedBandTopRow`. The banner/anchor rows ABOVE
-    // `floorBanner` are still never touched (the loop starts AT floorBanner); the
-    // top-aligned [floorBanner, floorBanner+bandLen-1] repaint below re-covers the
-    // widened prefix on the same `out` write — see the full invariant on the
-    // !hasBanner pending-overflow eviction above. Retires the adjacency-coupling
-    // READ; the tracked `bottom` (vacated-tail boundary) stays.
-    for (let r = floorBanner; r <= self.committedBandBottomRow; r++) {
-      out += eraseAndPaintRow(r);
-    }
-    // Paint the FULL model top-aligned at [floor, floor+bandLen-1] so the
-    // scroll evicts real rows — including previously-pending ones never on
-    // screen before. External constraint (DECSTBM paint-before-scroll): CUP
-    // writes precede the \n scroll so the evicted rows hold real content.
-    for (let i = 0; i < bandLenBanner; i++) {
-      out += eraseAndPaintRow(floorBanner + i, self.committedBand[i]);
-    }
-    // Belt-and-braces DECAWM bracket — see the identical comment earlier in
-    // this file (the !hasBanner pending-overflow eviction).
-    withAutowrapDisabled(self.stdout, () => {
-      try {
-        self.stdout.write(out);
-      } catch {
-        /* terminal closed mid-render — next render's lifecycle tears us down */
-      }
-    });
-    evictRowsToScrollback(self, overflow);
-    // Survivors physically shifted to [floor, floor+room-1] by the scroll.
-    self.committedBand = self.committedBand.slice(overflow);
-    self.committedBandMeta = self.committedBandMeta.slice(overflow); // #540: keep 1:1
-    self.committedBandTopRow = floorBanner;
-    self.committedBandBottomRow = floorBanner + roomBanner - 1;
-    self.committedBandPaintedRows = self.committedBand.length;
+    // #540 axis-2: archive the pending-overflow prefix to scrollback as
+    // SOFT-WRAPPABLE logical lines, then re-place the survivors at
+    // [floorBanner, floorBanner + roomBanner - 1]. The banner/anchor rows ABOVE
+    // `floorBanner` are never touched — the helper's erase starts AT the floor.
+    // It owns the erase → archive → repaint ordering constraint (DECSTBM
+    // paint-before-scroll: CUP writes precede the \n scroll so evicted rows hold
+    // real content) and all band bookkeeping; see
+    // terminal-compositor.frame-preserve-archive.ts.
+    archiveBandPrefixAndRepaintSurvivors(self, overflow, floorBanner);
     return;
   }
 

--- a/tests/pty/scenarios.ts
+++ b/tests/pty/scenarios.ts
@@ -550,26 +550,27 @@ export const SCENARIOS: Record<string, PtyScenario> = {
 
   // ─────────────────────────────────────────────────────────────────────────
   // width-resize-fragment-evict-growth (#540 axis-2 · the EVICTION site):
-  // frame-preserve.ts:10-30 justifies leaving the growth-eviction paths on
-  // pre-wrapped PHYSICAL rows by asserting "the band-hold archive is the site
-  // that actually carries the width-resize content in practice". The two guards
-  // above only ever drive band-hold (they hold a tall overlay across every
-  // commitAbove), so nothing tests that claim. This scenario drives the OTHER
-  // site: commit with a SHORT frame so the run lands in the band and is painted
-  // (no archive), THEN grow the overlay so preserveRowsBeforeFrameRender's
-  // grow-eviction scrolls those painted rows into scrollback as app hard
-  // newlines — the real end-of-turn → next-turn sequence from the 2026-07-29
-  // report. On a WIDEN the terminal cannot rejoin app hard-newlines, so the
-  // line stays fragmented: measured 4 non-wrapped rows at HEAD (22751af), where
-  // a rejoined line would show 1. RED-guard shape (minNonWrappedRows) — it
-  // asserts the defect so the blind spot cannot silently persist; flip it to
-  // `maxNonWrappedRows: 1` when the A2 unification retires physical eviction.
+  // drives the eviction site rather than band-hold. The two guards above hold a
+  // tall overlay across every commitAbove, so they only ever drive band-hold and
+  // structurally could not observe this path. This scenario commits with a SHORT
+  // frame so the run lands in the band and is painted (no archive), THEN grows
+  // the overlay so preserveRowsBeforeFrameRender's grow-eviction archives those
+  // rows — the ordinary end-of-turn → next-turn sequence from the 2026-07-29
+  // report.
+  //
+  // Was RED-first (minNonWrappedRows: 2): physical-row eviction measured 4
+  // non-wrapped rows after a widen at 22751af, and the defect was then confirmed
+  // in a real terminal (4 mid-word rows still ~60 cols wide inside a 120-col
+  // pane, continuations at column 0). Now asserts the FIXED rejoined property
+  // (maxNonWrappedRows: 1): the eviction paths archive logical lines via
+  // archiveBandPrefixAndRepaintSurvivors. A regression that reverts to
+  // physical-row eviction turns this red again.
   // ─────────────────────────────────────────────────────────────────────────
   'width-resize-fragment-evict-growth': {
-    description: 'logical line evicted by frame GROWTH stays FRAGMENTED in scrollback on a WIDER resize (RED guard, #540 axis-2)',
+    description: 'logical line evicted by frame GROWTH REJOINS in scrollback on a WIDER resize (#540 axis-2)',
     cols: 48,
     rows: 24,
-    ref: '#540 axis-2 · frame-preserve.ts grow-eviction (physical rows)',
+    ref: '#540 axis-2 · frame-preserve.ts grow-eviction (logical archive)',
     async drive(ctx): Promise<void> {
       const { stdout, stdin } = ctx;
       const statusLine = wireProductionFooter(stdout, 'M');
@@ -589,7 +590,8 @@ export const SCENARIOS: Record<string, PtyScenario> = {
       await settle();
       // Phase 2 — GROW the frame. desiredTopRow drops below prevTopRow, so
       // growOverflow = bandLen - growRoom > 0 and the top band rows (including
-      // all 4 rows of the long line) are evicted to scrollback physically.
+      // all 4 physical rows of the long line) are archived to scrollback — as
+      // ONE soft-wrappable logical line, which is what lets the widen rejoin it.
       c.setOverlay(Array.from({ length: 18 }, (_, i) => `thinking ${i} tall`).join('\n'));
       ix.repaint();
       await settle();
@@ -602,10 +604,14 @@ export const SCENARIOS: Record<string, PtyScenario> = {
     },
     expect: {
       inScrollback: ['LOGSTART'], // precondition: the line was evicted off screen
-      // >=2 non-wrapped rows == still fragmented. Deliberately not pinned to the
-      // measured 4: the exact count depends on eviction row math, but ANY value
-      // >1 means the terminal could not rejoin it.
-      logicalSpan: { from: 'LOGSTART', to: 'LOGEND', minNonWrappedRows: 2 },
+      // Exactly 1 non-wrapped row == the terminal rejoined the whole logical
+      // line and every other row in the span is a soft-wrap continuation.
+      // Asserted as an upper bound rather than `=== 1` because the span's row
+      // count depends on eviction row math; ANY value >1 means an interior app
+      // hard-newline survived and the content is still fragmented. Verified
+      // falsifiable: reverting step 2's emission to `committedBand.slice(0,
+      // overflow)` (physical rows) makes this measure 4 and fail.
+      logicalSpan: { from: 'LOGSTART', to: 'LOGEND', maxNonWrappedRows: 1 },
     },
   },
 


### PR DESCRIPTION
Finishes #540 axis-2. PR #755 shipped only the RED guard that reproduces this defect and explicitly deferred the fix; this is that fix.

## The defect

All three eviction paths in `preserveRowsBeforeFrameRender` pushed committed content into native scrollback as pre-wrapped **PHYSICAL** rows. A terminal reflows only its *own* soft wraps, so app hard newlines can never rejoin on a width change — content scrolled off by the ordinary end-of-turn → next-turn sequence (commit under a short frame, then the next turn's thinking lane grows the frame) stayed hard-wrapped mid-word forever, indent lost.

The other two scrollback write sites — the band-hold archive (`committed-band-commit.ts`) and disarm's `flushPendingCommittedBand` (`lifecycle.ts`) — were already converted to logical lines. These three were the remaining gap, and #755's guard measured **4** non-wrapped rows after a widen where a rejoined line shows **1**.

## Mechanism of the fix

The old paths shared one mechanism whose single paint did **two** jobs: it put the evicted prefix into rows the scroll would carry into history, *and* left the survivors shifted up to hug the new frame top. That coupling is what forced physical emission — and a naive swap of only the emission is what regressed the verdict card's closing border on an earlier attempt: survivors were left unpainted while bookkeeping still claimed `committedBandPaintedRows === length`, so rows existed in the model but on neither the screen nor in scrollback.

New `archiveBandPrefixAndRepaintSurvivors` (`terminal-compositor.frame-preserve-archive.ts`) splits the two jobs:

1. **erase** the band's previous painted footprint from the geometric floor,
2. **archive** the prefix as logical lines — autowrap stays **ON**, so the terminal owns the intra-line wrap and its continuation rows are soft-wrap continuations that rejoin on resize,
3. **repaint** survivors explicitly — autowrap **OFF** (rows are already hard-wrapped to current width).

That ordering is externally governed by DECSTBM/DECAWM and is **not** reorderable; it is documented as a constraint comment at the site, per the repo's ordered-operation convention. All three paths delegate, so the erase floor, the 1:1 `committedBand` ↔ `committedBandMeta` slice, and the painted-rows accounting exist in exactly one place instead of three near-copies.

`overflow` is deliberately **not** snapped to a logical-line boundary the way band-hold snaps its own count: it is load-bearing geometry (`bandLen - room`), so snapping down leaves the band too tall to fit and snapping up strands blank rows (the void class). A straddling line is emitted verbatim by `scrollbackFlushLines`, so the on-screen tail is never duplicated.

The **legacy deficit-based eviction** at the end of the function is unchanged, and that is correct rather than an oversight: it scrolls whatever is already on screen (including pre-arm banner rows) rather than archiving band content, so it has no logical lines to emit. Verified in code, not just asserted in the header comment.

## Gates

| Gate | Result |
|---|---|
| `pnpm lint` (tsc --noEmit, strict) | **clean**, exit 0 |
| PTY `width-resize-fragment-evict-growth` | **pass** — filter confirmed applied (1 ran, 9 skipped) |
| `vitest run src/cli/verdict-card-overflow.test.ts` | **2/2 pass** — the regression that blocked the earlier attempt |
| full `pnpm test:pty` | **10/10 pass** |
| compositor + scrollback suites | **49 files / 397 tests pass** — no #539/#552/#573 height/void-class regression |

## Guard now asserts the fix, and is falsifiable

`minNonWrappedRows: 2` (RED, asserting the defect) → `maxNonWrappedRows: 1` (asserting the rejoined property).

Per `docs/scrollback.md:108-113` — two prior fixes in this domain shipped green while broken — a passing assertion is not evidence on its own, so the flip was **mutation-verified**: reverting step 2's emission to `committedBand.slice(0, overflow)` makes the guard measure exactly **4** and fail, reproducing the originally reported count. Restored and re-confirmed green afterward.

```
× width-resize-fragment-evict-growth  (physical emission)
  → logical line ["LOGSTART".."LOGEND"] should rejoin to <=1 non-wrapped row(s) but had 4
✓ width-resize-fragment-evict-growth  (logical archive)
```

## Cross-check vs #665 (`afk/tui-axis2-stage3`, verdicted DO-NOT-MERGE)

**Does not reintroduce either concern.**

- **Anchor-decrement invariant (`committed-band-commit.ts:469`)** — that file is not in this diff. The `scrolledRows` → `anchorRow` decrement lives at `committed-band-commit.ts:469`/`539-540` and is untouched. The new helper never reads or writes `anchorRow` (no reference in `frame-preserve-archive.ts`); it takes `floor` as a parameter, computed by the caller exactly as before (`Math.max(self.anchorRow ?? 1, 1)`, `frame-preserve.ts:184`). The only `anchorRow` mutation in `frame-preserve.ts` is the pre-existing legacy-deficit decrement at `:222`, inside the unchanged block.
- **Band-cap snap-to-zero** — not applicable by construction. That concern was about `snapFlushCountToLogicalBoundary` returning 0 for a straddling line (`committed-band-commit.ts:373-376`), silently archiving nothing. This helper deliberately does **not** snap: `overflow` passes through as exact geometry, so it can never round to zero, and the straddle case emits physical rows verbatim instead of dropping them (`frame-preserve-archive.ts:47-56`, `91`).

## Deferred

The full `turnModel` rewrite unifying all three sites onto one archive *model* — `docs/proposals/tui-compositor-rewrite.md` §5 "A2 — Unified retained model" (verified present, §5 exists at line 78/86). This PR shares the *mechanism*, not the model.

## What a reviewer should scrutinize hardest

1. **Step ordering** in `frame-preserve-archive.ts:69-126` — erase and archive share one write; survivors are a second write inside `withAutowrapDisabled`. The autowrap ON/OFF asymmetry between steps 2 and 3 is intentional and load-bearing in opposite directions.
2. **`committedBandBottomRow` when survivors is empty** — set to `floor - 1` at `:134`, which is the correct "empty band" encoding here but is an off-by-one-shaped expression worth a second read.
3. **`withFullScrollRegion` wrapping** covers the erase+archive write but not the survivor repaint (repaint is CUP-addressed and does not scroll) — `:102-106` vs `:119-125`.

Signed-off-by: Griffin Long <griffinwork40@gmail.com>
