### PR TITLE
fix(provider): send the extended-cache-ttl beta in api-key mode so the 1h TTL is honored (#757)

### DIFF
--- a/src/agent/providers/anthropic-direct.test.ts
+++ b/src/agent/providers/anthropic-direct.test.ts
@@ -32,6 +32,7 @@ import {
   OAUTH_BETA_HEADER,
   CLI_USER_AGENT,
   BILLING_HEADER_TEXT,
+  EXTENDED_CACHE_TTL_BETA,
 } from './anthropic-direct/auth.js';
 import type {
   ToolCall,
@@ -482,9 +483,16 @@ describe('AnthropicDirectProvider', () => {
     expect(typeof apiKeyCtorArg['fetch']).toBe('function');
 
     const [params, opts] = messagesCreateMock.mock.calls[0] as CreateArgs;
-    expect(opts?.headers?.['anthropic-beta']).toBeUndefined();
+    // No OAuth identity headers. `anthropic-beta` IS present, but carries only
+    // the extended-cache-ttl beta: the cache policy stamps `ttl: '1h'` in
+    // api-key mode too, and that TTL is silently downgraded to 5m unless the
+    // activating beta rides along. It must not contain the OAuth betas.
+    expect(opts?.headers?.['anthropic-beta']).toBe(EXTENDED_CACHE_TTL_BETA);
+    expect(opts?.headers?.['anthropic-beta']).not.toContain('oauth-2025-04-20');
+    expect(opts?.headers?.['anthropic-beta']).not.toContain('claude-code-20250219');
     expect(opts?.headers?.['x-app']).toBeUndefined();
     expect(opts?.headers?.['User-Agent']).toBeUndefined();
+    expect(opts?.headers?.['X-Claude-Code-Session-Id']).toBeUndefined();
 
     // system is omitted entirely (no userSystem set, no oauth prefix)
     if (params['system'] !== undefined) {

--- a/src/agent/providers/anthropic-direct/auth.ts
+++ b/src/agent/providers/anthropic-direct/auth.ts
@@ -12,6 +12,14 @@ import type { ContentBlockParam } from '@anthropic-ai/sdk/resources';
 import type { AuthMode } from './types.js';
 
 /**
+ * Beta that activates the 1-hour prompt-cache TTL. Required in BOTH auth modes
+ * whenever a `cache_control` breakpoint carries `ttl: '1h'`; without it the
+ * server silently downgrades the breakpoint to the default 5-minute TTL (no
+ * error is returned, so the miss is invisible except as cache-read misses).
+ */
+export const EXTENDED_CACHE_TTL_BETA = 'extended-cache-ttl-2025-04-11';
+
+/**
  * `anthropic-beta` header value for OAuth mode.
  *
  * Includes `interleaved-thinking-2025-05-14` unconditionally — this matches
@@ -26,7 +34,7 @@ import type { AuthMode } from './types.js';
  * takes effect.
  */
 export const OAUTH_BETA_HEADER =
-  'claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,extended-cache-ttl-2025-04-11';
+  `claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,${EXTENDED_CACHE_TTL_BETA}`;
 
 /**
  * Additional `anthropic-beta` entry that gates the `output_config.effort`
@@ -87,23 +95,39 @@ export function buildClientOptions(
  * Build per-request HTTP headers.
  *
  * OAuth adds the cli-mimicry headers (always includes the interleaved-thinking
- * beta so 4.x models return visible reasoning blocks).  API-key mode returns
- * an empty object.
+ * beta so 4.x models return visible reasoning blocks).  API-key mode sends no
+ * cli-mimicry headers, but still negotiates {@link EXTENDED_CACHE_TTL_BETA}
+ * when the caller reports that a 1-hour breakpoint is being stamped — see
+ * `extendedCacheTtl`.
  *
  * @param withEffort - When `true`, appends {@link EFFORT_BETA_HEADER} to the
  *   `anthropic-beta` value.  Pass this flag only when the request body carries
  *   `output_config.effort`; the server rejects the field when the beta is
  *   absent, and sending the beta unnecessarily is a no-op but needlessly
  *   broadens the negotiated feature set.
+ * @param extendedCacheTtl - When `true`, guarantees `anthropic-beta` carries
+ *   {@link EXTENDED_CACHE_TTL_BETA} in BOTH auth modes. Callers derive it from
+ *   `isExtendedCacheTtlActive({ baseUrl })` (cache-policy.ts) — the single
+ *   authority pairing "a `ttl: '1h'` breakpoint is stamped" with "the beta that
+ *   activates it is on the wire". Omitting it leaves api-key mode's headers
+ *   untouched, so local-shim and cache-disabled sessions stay header-free.
  */
 export function buildRequestHeaders(
   mode: AuthMode,
   sessionId: string,
   requestId: string,
   withEffort?: boolean,
+  extendedCacheTtl?: boolean,
 ): Record<string, string> {
   if (mode !== 'oauth') {
-    return {};
+    // Invariant: api-key mode sends the extended-cache-ttl beta and NOTHING
+    // else. The cli-mimicry headers (x-app, CLI User-Agent, session id) are
+    // OAuth-only by design — `local-mode-oauth.test.ts` pins that a shim never
+    // sees them, and local mode reports `extendedCacheTtl: false` because
+    // `isCacheEnabled` force-disables caching whenever a baseUrl is set.
+    return extendedCacheTtl === true
+      ? { 'anthropic-beta': EXTENDED_CACHE_TTL_BETA }
+      : {};
   }
   const betaHeader = withEffort
     ? `${OAUTH_BETA_HEADER},${EFFORT_BETA_HEADER}`

--- a/src/agent/providers/anthropic-direct/cache-policy.ts
+++ b/src/agent/providers/anthropic-direct/cache-policy.ts
@@ -57,6 +57,24 @@ export function getCacheTtl(): '5m' | '1h' {
 }
 
 /**
+ * Contract: true exactly when a request will carry a `ttl: '1h'` breakpoint,
+ * i.e. when the header layer MUST negotiate `extended-cache-ttl-2025-04-11`
+ * for that TTL to be honored. Sole authority for that coupling — header
+ * assembly (`buildRequestHeaders`) asks this rather than re-deriving the
+ * enablement/TTL pair, so "asks for 1h" and "sends the activating beta" can
+ * never diverge.
+ *
+ * Both branches matter:
+ *  - cache disabled (local shim via `baseUrl`, or `AFK_DISABLE_PROMPT_CACHE`)
+ *    → no breakpoint is stamped, so the beta must NOT be sent (keeps the
+ *    local-mode invariant that no `anthropic-beta` reaches a shim).
+ *  - `AFK_PROMPT_CACHE_TTL=5m` → the 5m default needs no beta.
+ */
+export function isExtendedCacheTtlActive(opts?: { baseUrl?: string }): boolean {
+  return isCacheEnabled(opts) && getCacheTtl() === '1h';
+}
+
+/**
  * Return a new array where the last block carries
  * `cache_control: { type: 'ephemeral', ttl }`. Returns the input unchanged
  * when the array is empty or when the tail is a thinking block (the SDK

--- a/src/agent/providers/anthropic-direct/extended-cache-ttl-beta.test.ts
+++ b/src/agent/providers/anthropic-direct/extended-cache-ttl-beta.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Regression tests: a request that stamps `ttl: '1h'` must also negotiate the
+ * `extended-cache-ttl-2025-04-11` beta — in API-KEY mode, not just OAuth.
+ *
+ * Before the fix `buildRequestHeaders` returned `{}` for every non-oauth mode
+ * while `cache-policy.ts` unconditionally stamped `TTL_DEFAULT = '1h'`, so
+ * API-key sessions asked for a 1-hour cache the server silently downgraded to
+ * the 5-minute default. The header and the stamped TTL are now derived from one
+ * predicate (`isExtendedCacheTtlActive`) so they cannot diverge.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type Anthropic from '@anthropic-ai/sdk';
+import type { RawMessageStreamEvent } from '@anthropic-ai/sdk/resources';
+import type { ProviderEvent } from '../../provider.js';
+import {
+  AnthropicDirectProvider,
+  __setAnthropicClientFactory,
+} from './index.js';
+import {
+  buildRequestHeaders,
+  EXTENDED_CACHE_TTL_BETA,
+  OAUTH_BETA_HEADER,
+  CLI_USER_AGENT,
+} from './auth.js';
+import { isExtendedCacheTtlActive, getCacheTtl } from './cache-policy.js';
+
+// --- unit: the header builder ---
+
+describe('buildRequestHeaders — extended-cache-ttl beta in api-key mode', () => {
+  it('sends the beta in api-key mode when a 1h breakpoint is stamped', () => {
+    const headers = buildRequestHeaders('api-key', 'sid', 'rid', false, true);
+    expect(headers['anthropic-beta']).toBe(EXTENDED_CACHE_TTL_BETA);
+  });
+
+  it('sends ONLY the beta in api-key mode — no cli-mimicry headers', () => {
+    const headers = buildRequestHeaders('api-key', 'sid', 'rid', false, true);
+    expect(headers['x-app']).toBeUndefined();
+    expect(headers['User-Agent']).toBeUndefined();
+    expect(headers['X-Claude-Code-Session-Id']).toBeUndefined();
+    expect(Object.keys(headers)).toEqual(['anthropic-beta']);
+  });
+
+  it('omits all headers in api-key mode when no 1h breakpoint is stamped', () => {
+    expect(buildRequestHeaders('api-key', 'sid', 'rid', false, false)).toEqual({});
+    expect(buildRequestHeaders('api-key', 'sid', 'rid')).toEqual({});
+  });
+
+  it('OAuth headers are unchanged and still carry the beta', () => {
+    const headers = buildRequestHeaders('oauth', 'sid', 'rid', false, true);
+    expect(headers['anthropic-beta']).toBe(OAUTH_BETA_HEADER);
+    expect(headers['anthropic-beta']).toContain(EXTENDED_CACHE_TTL_BETA);
+    expect(headers['User-Agent']).toBe(CLI_USER_AGENT);
+  });
+});
+
+// --- unit: the coupling predicate ---
+
+describe('isExtendedCacheTtlActive', () => {
+  const origTtl = process.env['AFK_PROMPT_CACHE_TTL'];
+  const origOff = process.env['AFK_DISABLE_PROMPT_CACHE'];
+  afterEach(() => {
+    if (origTtl === undefined) delete process.env['AFK_PROMPT_CACHE_TTL'];
+    else process.env['AFK_PROMPT_CACHE_TTL'] = origTtl;
+    if (origOff === undefined) delete process.env['AFK_DISABLE_PROMPT_CACHE'];
+    else process.env['AFK_DISABLE_PROMPT_CACHE'] = origOff;
+  });
+
+  it('is true by default (TTL_DEFAULT is 1h and cache is on)', () => {
+    delete process.env['AFK_PROMPT_CACHE_TTL'];
+    delete process.env['AFK_DISABLE_PROMPT_CACHE'];
+    expect(getCacheTtl()).toBe('1h');
+    expect(isExtendedCacheTtlActive()).toBe(true);
+  });
+
+  it('is false when the TTL is explicitly 5m (no beta needed)', () => {
+    process.env['AFK_PROMPT_CACHE_TTL'] = '5m';
+    expect(isExtendedCacheTtlActive()).toBe(false);
+  });
+
+  it('is false when caching is disabled (nothing is stamped)', () => {
+    delete process.env['AFK_PROMPT_CACHE_TTL'];
+    process.env['AFK_DISABLE_PROMPT_CACHE'] = '1';
+    expect(isExtendedCacheTtlActive()).toBe(false);
+  });
+
+  it('is false in local-shim mode, keeping shim requests header-free', () => {
+    delete process.env['AFK_PROMPT_CACHE_TTL'];
+    delete process.env['AFK_DISABLE_PROMPT_CACHE'];
+    expect(isExtendedCacheTtlActive({ baseUrl: 'http://127.0.0.1:11434' })).toBe(false);
+  });
+});
+
+// --- wire-level: an api-key session actually puts the beta on the request ---
+
+const messagesCreateMock = vi.fn();
+
+class MockAnthropic {
+  public messages: { create: typeof messagesCreateMock };
+  constructor(_opts: unknown) {
+    this.messages = { create: messagesCreateMock };
+  }
+}
+
+async function* fromArray<T>(arr: T[]): AsyncIterable<T> {
+  for (const x of arr) yield x;
+}
+
+async function collect(query: AsyncIterable<ProviderEvent>): Promise<ProviderEvent[]> {
+  const out: ProviderEvent[] = [];
+  for await (const ev of query) out.push(ev);
+  return out;
+}
+
+async function* singleInput(content: string): AsyncIterable<{ content: string }> {
+  yield { content };
+}
+
+function makeTextStream(text: string): RawMessageStreamEvent[] {
+  return [
+    {
+      type: 'message_start',
+      message: {
+        id: 'msg_ttl_test',
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model: 'claude-sonnet-4-5',
+        stop_reason: null,
+        stop_sequence: null,
+        usage: {
+          input_tokens: 3,
+          output_tokens: 0,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+          server_tool_use: null,
+          service_tier: null,
+        },
+      },
+    } as unknown as RawMessageStreamEvent,
+    {
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'text', text: '', citations: [] },
+    } as unknown as RawMessageStreamEvent,
+    {
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'text_delta', text },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'content_block_stop', index: 0 } as unknown as RawMessageStreamEvent,
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'end_turn', stop_sequence: null },
+      usage: { output_tokens: 2 },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'message_stop' } as unknown as RawMessageStreamEvent,
+  ];
+}
+
+describe('api-key session — 1h TTL request carries the activating beta', () => {
+  beforeEach(() => {
+    messagesCreateMock.mockReset();
+    __setAnthropicClientFactory(
+      (opts) => new MockAnthropic(opts) as unknown as Anthropic,
+    );
+  });
+
+  afterEach(() => {
+    __setAnthropicClientFactory(null);
+  });
+
+  it('stamps ttl:1h AND sends extended-cache-ttl with a plain sk-ant-api key', async () => {
+    const captured: {
+      headers: Record<string, string> | undefined;
+      params: Record<string, unknown>;
+    }[] = [];
+    messagesCreateMock.mockImplementation(
+      (
+        params: Record<string, unknown>,
+        opts: { headers?: Record<string, string> } | undefined,
+      ) => {
+        captured.push({ headers: opts?.headers, params });
+        return fromArray(makeTextStream('hi'));
+      },
+    );
+
+    const provider = new AnthropicDirectProvider();
+    await collect(
+      provider.query({
+        prompt: singleInput('hello'),
+        config: {
+          model: 'claude-sonnet-4-5',
+          apiKey: 'sk-ant-api03-FAKE-not-an-oauth-token',
+        } as never,
+      }),
+    );
+
+    expect(captured.length).toBeGreaterThan(0);
+    const first = captured[0]!;
+
+    // The request really does ask for a 1-hour cache...
+    const system = first.params['system'] as
+      | { cache_control?: { ttl?: string } }[]
+      | undefined;
+    const stampedTtls = (system ?? [])
+      .map((b) => b.cache_control?.ttl)
+      .filter((t): t is string => typeof t === 'string');
+    expect(stampedTtls).toContain('1h');
+
+    // ...so the beta that activates it must be on the wire. This is the
+    // assertion that failed before the fix (headers were `{}`).
+    expect(first.headers?.['anthropic-beta']).toBeDefined();
+    expect(first.headers?.['anthropic-beta']).toContain(EXTENDED_CACHE_TTL_BETA);
+
+    // api-key mode still sends no OAuth identity headers.
+    expect(first.headers?.['x-app']).toBeUndefined();
+    expect(first.headers?.['User-Agent']).toBeUndefined();
+  });
+});

--- a/src/agent/providers/anthropic-direct/query.ts
+++ b/src/agent/providers/anthropic-direct/query.ts
@@ -52,6 +52,7 @@ import { buildRequestHeaders } from './auth.js';
 import {
   getCacheTtl,
   isCacheEnabled,
+  isExtendedCacheTtlActive,
   withSystemBreakpoint,
 } from './cache-policy.js';
 import { buildPlanModeAddendumBlock } from './plan-mode-addendum.js';
@@ -303,6 +304,7 @@ export class AnthropicDirectQuery implements ProviderQuery {
       client: opts.client,
       authMode: opts.authMode,
       initSessionId: this.initSessionId,
+      ...(opts.baseUrl !== undefined ? { baseUrl: opts.baseUrl } : {}),
       ...(opts.tokenRefresher ? { tokenRefresher: opts.tokenRefresher } : {}),
       autoResumeOnUsageLimit: opts.autoResumeOnUsageLimit ?? true,
     });
@@ -393,6 +395,10 @@ export class AnthropicDirectQuery implements ProviderQuery {
           this.initSessionId,
           randomUUID(),
           this.effort !== undefined,
+          // Pair the stamped TTL with the beta that activates it: composeSystem
+          // and the loop stamp `ttl: getCacheTtl()` under `isCacheEnabled`, so
+          // the header must be negotiated under that same predicate.
+          isExtendedCacheTtlActive({ ...(this.baseUrl !== undefined ? { baseUrl: this.baseUrl } : {}) }),
         );
 
         const runInput: RunTurnInput = {

--- a/src/agent/providers/anthropic-direct/query/retry-layer.ts
+++ b/src/agent/providers/anthropic-direct/query/retry-layer.ts
@@ -38,6 +38,7 @@ import { randomUUID } from 'node:crypto';
 import type { ProviderEvent } from '../../../provider.js';
 import { runTurn } from '../loop.js';
 import { buildRequestHeaders } from '../auth.js';
+import { isExtendedCacheTtlActive } from '../cache-policy.js';
 import { classifyUsageLimitError, waitForReset, waitForHotSwap } from '../usage-limit.js';
 import { loadClaudeCodeOauthToken, parseAccountIdentifier } from '../../../../cli/keychain.js';
 import { sleepWithAbort } from '../../shared/sleep-with-abort.js';
@@ -76,6 +77,12 @@ export interface RetryLayerOptions {
   client: Anthropic;
   authMode: AuthMode;
   initSessionId: string;
+  /**
+   * Session `baseUrl` (local-shim mode), forwarded verbatim to
+   * `isExtendedCacheTtlActive` so replayed turns negotiate the 1h-cache beta
+   * under exactly the same condition as the original send.
+   */
+  baseUrl?: string;
   /** Optional: called on 401 to obtain a fresh SDK client. Retry once per 401. */
   tokenRefresher?: () => Promise<Anthropic | null>;
   /** Whether to auto-wait+resume on 429 usage-limit (default true). */
@@ -91,6 +98,7 @@ export class RetryLayer {
   private _client: Anthropic;
   private readonly _authMode: AuthMode;
   private readonly initSessionId: string;
+  private readonly baseUrl?: string;
   private readonly tokenRefresher?: () => Promise<Anthropic | null>;
   private readonly autoResumeOnUsageLimit: boolean;
 
@@ -101,6 +109,7 @@ export class RetryLayer {
     this._client = opts.client;
     this._authMode = opts.authMode;
     this.initSessionId = opts.initSessionId;
+    this.baseUrl = opts.baseUrl;
     this.tokenRefresher = opts.tokenRefresher;
     this.autoResumeOnUsageLimit = opts.autoResumeOnUsageLimit;
   }
@@ -114,6 +123,21 @@ export class RetryLayer {
   }
 
   /** Auth mode the session was constructed with. Immutable. */
+  /**
+   * Rebuild per-request headers for a replay (fresh request id). Re-evaluates
+   * the 1h-cache beta rather than reusing the original header map, so a replay
+   * never asks for a TTL whose activating beta it dropped.
+   */
+  private rotateHeaders(): Record<string, string> {
+    return buildRequestHeaders(
+      this._authMode,
+      this.initSessionId,
+      randomUUID(),
+      undefined,
+      isExtendedCacheTtlActive({ ...(this.baseUrl !== undefined ? { baseUrl: this.baseUrl } : {}) }),
+    );
+  }
+
   get authMode(): AuthMode {
     return this._authMode;
   }
@@ -296,11 +320,7 @@ export class RetryLayer {
 
       // Rotate the request id before replaying (mirrors the oauth-limit
       // resume paths). Same client, same token — only the headers refresh.
-      runInput.headers = buildRequestHeaders(
-        this._authMode,
-        this.initSessionId,
-        randomUUID(),
-      );
+      runInput.headers = this.rotateHeaders();
       // Loop: replay the turn.
     }
 
@@ -377,11 +397,7 @@ export class RetryLayer {
             resumedAccountId = refreshed.accountId;
           }
         }
-        runInput.headers = buildRequestHeaders(
-          this._authMode,
-          this.initSessionId,
-          randomUUID(),
-        );
+        runInput.headers = this.rotateHeaders();
 
         // Replay the turn. Peek the stream: if the FIRST thing it does is
         // re-hit a usage limit we are still limited — stay paused and wait
@@ -492,11 +508,7 @@ export class RetryLayer {
     }
     // 'timer' resolution: deadline passed, same account, same token — no
     // client rebuild needed. Headers still rotated to refresh the request-id.
-    runInput.headers = buildRequestHeaders(
-      this._authMode,
-      this.initSessionId,
-      randomUUID(),
-    );
+    runInput.headers = this.rotateHeaders();
     yield { type: 'resumed', hotSwapped: result === 'hot-swap', accountId: resumedAccountId };
     void emitSessionPhase(runInput.traceWriter, {
       phase: 'usage_limit_resume',
@@ -537,11 +549,7 @@ export class RetryLayer {
       return;
     }
     runInput.client = this._client as unknown as AnthropicClientLike;
-    runInput.headers = buildRequestHeaders(
-      this._authMode,
-      this.initSessionId,
-      randomUUID(),
-    );
+    runInput.headers = this.rotateHeaders();
 
     yield* runTurn(runInput);
   }


### PR DESCRIPTION
Closes #757.

## The defect

`cache-policy.ts:26` sets `TTL_DEFAULT = '1h'`, so nearly every request stamps `cache_control: { type: 'ephemeral', ttl: '1h' }`. The beta that **activates** that TTL, `extended-cache-ttl-2025-04-11`, was only sent in OAuth mode — `buildRequestHeaders` returned `{}` outright when `mode !== 'oauth'` (`auth.ts:105-107`), no `defaultHeaders` exists anywhere in the provider, and the SDK adds none.

Every api-key session therefore asked for a 1-hour cache and silently got a 5-minute one. The server does not reject it; `auth.ts:24-26` already documents that it "silently downgrades every `cache_control` breakpoint to the default 5-minute TTL". Compare the *effort* beta at `auth.ts:34-36`, which the server **does** reject when absent — the codebase already distinguishes the two failure modes, and this is the invisible one. The only symptom was cache-read misses.

### Cost

Worked against a real 9-turn, ~30-min-per-turn session (`cacheRead: 2023889`, `cacheCreation: 20243`), base input price *P*:

| | tokens | rate | cost |
|---|---|---|---|
| 1h active | 20,243 write / 2,023,889 read | 2.0*P* / 0.1*P* | 242,875*P* |
| degraded to 5m | 2,044,132 write | 1.25*P* | 2,555,165*P* |

**≈10.5x.** Every gap exceeds the 5m window, so reads become writes. The 2x 1h-write premium is repaid after ~1.4 reuses — the `'1h'` default is the right call, it just was not being honored.

## Mechanism

`isExtendedCacheTtlActive()` (cache-policy.ts) is the **sole authority** pairing "a `ttl: '1h'` breakpoint is stamped" with "the beta that activates it is on the wire" — `isCacheEnabled(opts) && getCacheTtl() === '1h'`. Header assembly consults it instead of re-deriving the enablement/TTL pair, so the two cannot drift apart again. `buildRequestHeaders` gains an `extendedCacheTtl` flag; api-key mode sends that beta and **nothing else**, keeping the cli-mimicry headers (`x-app`, CLI `User-Agent`, session id) OAuth-only.

Both false branches are load-bearing, not defensive padding:
- local shim (`baseUrl` set) or `AFK_DISABLE_PROMPT_CACHE` → no breakpoint is stamped, so the beta must **not** be sent. Preserves the invariant `local-mode-oauth.test.ts` pins: a shim never sees an `anthropic-beta` header.
- `AFK_PROMPT_CACHE_TTL=5m` → the 5m default needs no beta.

### Second instance of the same bug class

`query/retry-layer.ts` rebuilt headers on every replay (usage-limit resume, 401 token refresh) with a bare three-arg `buildRequestHeaders` call, so those replays would have dropped the negotiation while still sending a 1h breakpoint. Extracted to one `rotateHeaders()` that re-evaluates the predicate — a replayed turn can never ask for a TTL whose beta it just dropped. The session `baseUrl` is threaded in for that evaluation.

## Verification

`extended-cache-ttl-beta.test.ts` (9 tests) — the four header permutations, the predicate's four branches, and a wire-level case that drives a real `messages.create` with a plain `sk-ant-api03-*` key and asserts, **in one captured request**, that `system[].cache_control.ttl === '1h'` *and* that `anthropic-beta` carries the beta. The two halves of the defect are pinned together rather than separately, so a future change cannot satisfy one and break the other. Verified load-bearing by mutation: reverting the fix fails 3 of 9.

`anthropic-direct.test.ts:485` asserted `anthropic-beta` was `undefined` in api-key mode, using its absence as a proxy for "no OAuth identity headers" — that assertion **encoded the defect**. Narrowed to its real intent: the header is present and equals exactly the cache beta, with explicit negative assertions that it contains neither `oauth-2025-04-20` nor `claude-code-20250219`, and the identity headers still absent.

**Gates** (run locally on this branch, rebased on `30238ae`):
- `pnpm lint` (tsc --noEmit, strict) — clean, exit 0
- 6 affected provider test files — `Test Files 6 passed (6) / Tests 113 passed (113)`, including `local-mode-oauth.test.ts` 4/4 and `loop.retry.test.ts` 21/21
- `audit:sdk:check` OK · `audit:env:check` 0 violations · `scan:env:check` in sync
- 350-LOC ceiling respected (auth.ts 153, cache-policy.ts 159)

## What a reviewer should scrutinise

1. **Degrade-vs-reject is sourced from the in-repo comment and its test, not an observed 400.** If the server rejected instead, the failure would be loud and immediate rather than silent — and this change makes the request well-formed either way. Worth a second opinion from anyone who has seen the API's actual behavior here.
2. **The api-key header set is now non-empty.** Any consumer asserting "api-key mode sends no headers" will need the same narrowing applied at `anthropic-direct.test.ts:485`.
3. `oneshot.ts` deliberately passes no TTL flag — it stamps no cache breakpoint, so it correctly negotiates nothing. Confirm that still holds if oneshot ever gains caching.

## Not the cause of any known incident

The session behind the cost numbers ran under **OAuth** (keychain `Claude Code-credentials` present; `ANTHROPIC_API_KEY` and `CLAUDE_CODE_OAUTH_TOKEN` both unset; its trace carries `usage_limit_pause` events, which are subscription-quota parks). It did send the beta and did get 1h caching, consistent with its ~100:1 cacheRead:cacheCreation ratio. **The defect is real for every api-key user; it is not what broke that session.** Stated explicitly so the fix is not mistaken for an incident postmortem.