### PR TITLE
feat(tui): make the subscription-usage indicator severity-graded and time-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ auto-release workflow to deduplicate commits across successive runs.
 
 ## [Unreleased]
 
+### Added
+- warn in the turn footer once a subscription rolling window passes 80% used, with its reset countdown and the note that AFK pauses and auto-resumes at the cap
+
+### Changed
+- grade the status-line usage indicator by severity — per-window tone plus a block gauge, the binding window's reset countdown, a stale-reading marker, and drop-last priority so a critical reading survives a narrow terminal (9d2b28d)
+
 ## [5.82.5] - 2026-07-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ auto-release workflow to deduplicate commits across successive runs.
 - warn in the turn footer once a subscription rolling window passes 80% used, with its reset countdown and the note that AFK pauses and auto-resumes at the cap
 
 ### Changed
-- grade the status-line usage indicator by severity — per-window tone plus a block gauge, the binding window's reset countdown, a stale-reading marker, and drop-last priority so a critical reading survives a narrow terminal (9d2b28d)
+- grade the status-line usage indicator by severity — per-window tone, the binding window's reset countdown, a stale-reading marker, and drop-last priority so a critical reading survives a narrow terminal (9d2b28d)
 
 ## [5.82.5] - 2026-07-29
 

--- a/src/cli/commands/interactive/shared.test.ts
+++ b/src/cli/commands/interactive/shared.test.ts
@@ -394,9 +394,9 @@ describe('formatStatusFields — subscription-quota segment', () => {
   });
 
   it('forwards both windows as raw 0..1 fractions, not pre-formatted text', () => {
-    // The adapter must NOT format: `quota-indicator.ts` owns tone, gauge glyph,
-    // countdown and staleness so the status line can grade droppability from the
-    // same severity it renders with.
+    // The adapter must NOT format: `quota-indicator.ts` owns tone, countdown and
+    // staleness so the status line can grade droppability from the same severity
+    // it renders with.
     recordQuotaSnapshot({
       fiveHourUtilization: 0.62,
       sevenDayUtilization: 0.31,

--- a/src/cli/commands/interactive/shared.test.ts
+++ b/src/cli/commands/interactive/shared.test.ts
@@ -390,40 +390,54 @@ describe('formatStatusFields — subscription-quota segment', () => {
   it('omits the quota field entirely when no headers have been observed', () => {
     // Permanent state under API-key auth — must be absent, not a placeholder.
     const fields = formatStatusFields(makeStats([]));
-    expect('quota' in fields).toBe(false);
+    expect('quotaWindows' in fields).toBe(false);
   });
 
-  it('renders both windows as rounded percentages', () => {
+  it('forwards both windows as raw 0..1 fractions, not pre-formatted text', () => {
+    // The adapter must NOT format: `quota-indicator.ts` owns tone, gauge glyph,
+    // countdown and staleness so the status line can grade droppability from the
+    // same severity it renders with.
     recordQuotaSnapshot({
       fiveHourUtilization: 0.62,
       sevenDayUtilization: 0.31,
       observedAt: new Date(),
     });
-    expect(formatStatusFields(makeStats([])).quota).toBe('5h 62% · 7d 31%');
+    const windows = formatStatusFields(makeStats([])).quotaWindows;
+    expect(windows?.fiveHour?.utilization).toBe(0.62);
+    expect(windows?.sevenDay?.utilization).toBe(0.31);
   });
 
-  it('renders only the 5h window when the 7d window is absent', () => {
+  it('forwards the reset deadlines and the observation time verbatim', () => {
+    // Regression guard: these three fields were parsed by the cache but read by
+    // nothing for the segment's whole first life. The countdown and the stale
+    // marker both depend on them surviving the hand-off.
+    const fiveHourResetsAt = new Date('2026-07-29T17:00:00Z');
+    const sevenDayResetsAt = new Date('2026-08-02T09:00:00Z');
+    const observedAt = new Date('2026-07-29T12:00:00Z');
+    recordQuotaSnapshot({
+      fiveHourUtilization: 0.62,
+      fiveHourResetsAt,
+      sevenDayUtilization: 0.31,
+      sevenDayResetsAt,
+      observedAt,
+    });
+    const windows = formatStatusFields(makeStats([])).quotaWindows;
+    expect(windows?.fiveHour?.resetsAt).toBe(fiveHourResetsAt);
+    expect(windows?.sevenDay?.resetsAt).toBe(sevenDayResetsAt);
+    expect(windows?.observedAt).toBe(observedAt);
+  });
+
+  it('carries only the 5h window when the 7d window is absent', () => {
     recordQuotaSnapshot({ fiveHourUtilization: 0.05, observedAt: new Date() });
-    expect(formatStatusFields(makeStats([])).quota).toBe('5h 5%');
+    const windows = formatStatusFields(makeStats([])).quotaWindows;
+    expect(windows?.fiveHour?.utilization).toBe(0.05);
+    expect(windows?.sevenDay).toBeUndefined();
   });
 
-  it('renders only the 7d window when the 5h window is absent', () => {
+  it('carries only the 7d window when the 5h window is absent', () => {
     recordQuotaSnapshot({ sevenDayUtilization: 0.5, observedAt: new Date() });
-    expect(formatStatusFields(makeStats([])).quota).toBe('7d 50%');
-  });
-
-  it('treats utilization as a 0..1 fraction, never as an already-scaled percent', () => {
-    // Units regression guard: the same class of bug as rendering a fraction as
-    // if it were a percentage. 0.62 must be 62% — not 0% and not 6200%.
-    recordQuotaSnapshot({ fiveHourUtilization: 0.62, observedAt: new Date() });
-    const quota = formatStatusFields(makeStats([])).quota;
-    expect(quota).toContain('62%');
-    expect(quota).not.toContain('6200');
-    expect(quota).not.toContain('0%');
-  });
-
-  it('rounds to the nearest whole percent', () => {
-    recordQuotaSnapshot({ fiveHourUtilization: 0.626, observedAt: new Date() });
-    expect(formatStatusFields(makeStats([])).quota).toBe('5h 63%');
+    const windows = formatStatusFields(makeStats([])).quotaWindows;
+    expect(windows?.sevenDay?.utilization).toBe(0.5);
+    expect(windows?.fiveHour).toBeUndefined();
   });
 });

--- a/src/cli/commands/interactive/shared.ts
+++ b/src/cli/commands/interactive/shared.ts
@@ -1,6 +1,6 @@
 import * as readline from 'node:readline';
 import { statSync } from 'node:fs';
-import { getQuotaSnapshot, type QuotaSnapshot } from '../../../agent/quota-cache.js';
+import { getQuotaSnapshot } from '../../../agent/quota-cache.js';
 import type { HookRegistry } from '../../../agent/hooks.js';
 import type { SessionRef } from '../../../agent/session-ref.js';
 import type { MemoryStore } from '../../../agent/memory/index.js';
@@ -17,6 +17,7 @@ import { contextLimitFor } from '../../model-limits.js';
 import { ContextSampler } from '../../context-sampler.js';
 import type { GitStatusSampler } from '../../git-status-sampler.js';
 import { formatTurnSparkline } from '../../context-sparkline.js';
+import { quotaWindowsFromSnapshot } from '../../quota-indicator.js';
 import { palette } from '../../palette.js';
 
 /**
@@ -780,26 +781,6 @@ export function contextRatio(stats: SessionStats, sampler?: ContextSampler): num
   return used / contextLimitFor(stats.model);
 }
 
-/**
- * Compact status-line rendering of the subscription-quota cache, e.g.
- * `5h 62% · 7d 31%`. Returns undefined when nothing is cached — permanently the
- * case under API-key auth, since only subscription OAuth responses carry the
- * `anthropic-ratelimit-unified-*` headers — so the caller omits the segment
- * entirely rather than drawing a placeholder. `utilization` is a 0..1 fraction
- * (clamped at the cache boundary), hence the ×100.
- */
-function formatQuotaSegment(snapshot: QuotaSnapshot | undefined): string | undefined {
-  if (snapshot === undefined) return undefined;
-  const segments: string[] = [];
-  if (snapshot.fiveHourUtilization !== undefined) {
-    segments.push(`5h ${Math.round(snapshot.fiveHourUtilization * 100)}%`);
-  }
-  if (snapshot.sevenDayUtilization !== undefined) {
-    segments.push(`7d ${Math.round(snapshot.sevenDayUtilization * 100)}%`);
-  }
-  return segments.length > 0 ? segments.join(' · ') : undefined;
-}
-
 export function formatStatusFields(
   stats: SessionStats,
   sampler?: ContextSampler,
@@ -835,7 +816,7 @@ export function formatStatusFields(
 
   const branch = gitSampler?.getBranch();
   const pr = gitSampler?.getPr();
-  const quota = formatQuotaSegment(getQuotaSnapshot());
+  const quotaWindows = quotaWindowsFromSnapshot(getQuotaSnapshot());
 
   return {
     model: stats.model,
@@ -849,6 +830,6 @@ export function formatStatusFields(
     ...(stats.cwd !== undefined ? { cwd: stats.cwd } : {}),
     ...(branch !== undefined ? { branch } : {}),
     ...(pr !== undefined ? { pr } : {}),
-    ...(quota !== undefined ? { quota } : {}),
+    ...(quotaWindows !== undefined ? { quotaWindows } : {}),
   };
 }

--- a/src/cli/commands/interactive/turn-handler.test.ts
+++ b/src/cli/commands/interactive/turn-handler.test.ts
@@ -14,7 +14,8 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as path from 'node:path';
-import { runTurn, formatContextUsage } from './turn-handler.js';
+import { runTurn, formatContextUsage, printTurnFooter } from './turn-handler.js';
+import { recordQuotaSnapshot, resetQuotaCacheForTests } from '../../../agent/quota-cache.js';
 import { getCurrentSink } from '../../../agent/_lib/skill-sink-channel.js';
 import type { AgentSession } from '../../../agent/session.js';
 import type { OutputEvent } from '../../../agent/types.js';
@@ -2315,5 +2316,56 @@ describe('formatContextUsage — proactive escalating context tiers', () => {
     expect(over.text).toContain('OVER');
     expect(over.text).toContain('silently truncated');
     expect(formatContextUsage(1.05, LIMIT).tier).toBe('over');
+  });
+});
+
+describe('printTurnFooter — subscription-quota line', () => {
+  beforeEach(() => {
+    resetQuotaCacheForTests();
+  });
+  afterEach(() => {
+    resetQuotaCacheForTests();
+  });
+
+  const footerLines = (): string[] => {
+    const written: string[] = [];
+    printTurnFooter({ durationMs: 1200, totalCostUsd: 0.01 }, makeStats(), (line) => written.push(line));
+    return written;
+  };
+
+  it('prints nothing quota-related when no headers have been observed (API-key auth)', () => {
+    expect(footerLines().join('\n')).not.toContain('quota');
+  });
+
+  it('prints nothing quota-related below the 80% caution bar', () => {
+    recordQuotaSnapshot({ fiveHourUtilization: 0.62, observedAt: new Date() });
+    expect(footerLines().join('\n')).not.toContain('quota');
+  });
+
+  it('prints the quota line with its deadline once the binding window is hot', () => {
+    recordQuotaSnapshot({
+      fiveHourUtilization: 0.94,
+      fiveHourResetsAt: new Date(Date.now() + 12 * 60_000),
+      sevenDayUtilization: 0.24,
+      observedAt: new Date(),
+    });
+    const out = footerLines().join('\n');
+    expect(out).toContain('5h quota 94% used');
+    expect(out).toContain('resets in 12m');
+  });
+
+  it('orders the quota line AFTER the context line — nearest deadline reads first', () => {
+    // Context constrains THIS turn; quota constrains the next hour.
+    const stats = makeStats();
+    // `sonnet` reports a 1M context window, so this lands at ~90% — the context
+    // line's caution tier — rather than the quiet tier.
+    stats.turnTokens.push({ input: 900_000, output: 2_000, cache: 0 });
+    recordQuotaSnapshot({ fiveHourUtilization: 0.94, observedAt: new Date() });
+    const written: string[] = [];
+    printTurnFooter({ durationMs: 1200 }, stats, (line) => written.push(line));
+    const contextIdx = written.findIndex((l) => l.includes('context'));
+    const quotaIdx = written.findIndex((l) => l.includes('quota'));
+    expect(contextIdx).toBeGreaterThanOrEqual(0);
+    expect(quotaIdx).toBeGreaterThan(contextIdx);
   });
 });

--- a/src/cli/commands/interactive/turn-handler.ts
+++ b/src/cli/commands/interactive/turn-handler.ts
@@ -13,6 +13,9 @@ import { usageLimitBox } from '../../render.js';
 import { runPicker } from '../../render/picker.js';
 import { classifyError, presentError } from '../../errors/index.js';
 import { contextLimitFor } from '../../model-limits.js';
+import { getQuotaSnapshot } from '../../../agent/quota-cache.js';
+import { quotaWindowsFromSnapshot } from '../../quota-indicator.js';
+import { formatQuotaUsage } from '../../quota-footer.js';
 import {
   contextRatio,
   type CompletionWriter,
@@ -937,6 +940,21 @@ export function printTurnFooter(
           ? palette.warning
           : palette.dim;
     write(colorFn(usage.text));
+  }
+  // Subscription quota, same cadence and tone mapping as the context line above.
+  // Ordered AFTER it deliberately: context is the constraint on THIS turn, quota
+  // is the constraint on the next hour — nearest deadline reads first. Silent
+  // below 80% (the status-line indicator covers that range ambiently) and silent
+  // forever under API-key auth, where the quota headers never arrive.
+  const quota = formatQuotaUsage(quotaWindowsFromSnapshot(getQuotaSnapshot()));
+  if (quota.text !== null) {
+    const quotaColorFn =
+      quota.tier === 'over' || quota.tier === 'near'
+        ? palette.error
+        : quota.tier === 'caution'
+          ? palette.warning
+          : palette.dim;
+    write(quotaColorFn(quota.text));
   }
   write('');
 }

--- a/src/cli/quota-footer.test.ts
+++ b/src/cli/quota-footer.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for src/cli/quota-footer.ts
+ *
+ * The footer line is pure and colour-free — the caller maps `tier` → palette
+ * role — so every assertion here is on plain text and tier, no ANSI involved.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { formatQuotaUsage } from './quota-footer.js';
+
+const NOW = new Date('2026-07-29T12:00:00Z');
+const inMinutes = (m: number): Date => new Date(NOW.getTime() + m * 60_000);
+
+describe('formatQuotaUsage — silence', () => {
+  it('says nothing when no windows are known (API-key auth)', () => {
+    expect(formatQuotaUsage(undefined, NOW)).toEqual({ tier: 'quiet', text: null });
+    expect(formatQuotaUsage({ observedAt: NOW }, NOW)).toEqual({ tier: 'quiet', text: null });
+  });
+
+  it('stays silent through the whole range the ambient indicator already covers', () => {
+    // The status-line indicator goes amber at 50%. A printed footer line costs
+    // attention every turn, so it must not speak until the cap is a live risk.
+    for (const utilization of [0, 0.24, 0.5, 0.62, 0.79]) {
+      const r = formatQuotaUsage({ fiveHour: { utilization }, observedAt: NOW }, NOW);
+      expect(r).toEqual({ tier: 'quiet', text: null });
+    }
+  });
+});
+
+describe('formatQuotaUsage — tiers', () => {
+  const tierAt = (utilization: number) =>
+    formatQuotaUsage({ fiveHour: { utilization }, observedAt: NOW }, NOW).tier;
+
+  it('mirrors the context line ladder: 80% caution, 95% near, 100% over', () => {
+    expect(tierAt(0.799)).toBe('quiet');
+    expect(tierAt(0.8)).toBe('caution');
+    expect(tierAt(0.94)).toBe('caution');
+    expect(tierAt(0.95)).toBe('near');
+    expect(tierAt(0.99)).toBe('near');
+    expect(tierAt(1)).toBe('over');
+  });
+
+  it('names the window, the percentage, and the deadline at caution', () => {
+    const r = formatQuotaUsage(
+      { fiveHour: { utilization: 0.84, resetsAt: inMinutes(80) }, observedAt: NOW },
+      NOW,
+    );
+    expect(r.tier).toBe('caution');
+    expect(r.text).toBe('  5h quota 84% used — resets in 1h20m');
+  });
+
+  it('adds the park-and-resume reassurance once a cap is imminent', () => {
+    // The runtime really does park and resume on a usage-limit 429, so the line
+    // should say so — an alarming number with no next step is worse than useless.
+    const near = formatQuotaUsage(
+      { fiveHour: { utilization: 0.96, resetsAt: inMinutes(12) }, observedAt: NOW },
+      NOW,
+    );
+    expect(near.tier).toBe('near');
+    expect(near.text).toBe('  5h quota 96% used — resets in 12m — AFK pauses and auto-resumes at the cap');
+  });
+
+  it('reports exhaustion without a percentage — 100% needs no number', () => {
+    const over = formatQuotaUsage(
+      { fiveHour: { utilization: 1, resetsAt: inMinutes(12) }, observedAt: NOW },
+      NOW,
+    );
+    expect(over.tier).toBe('over');
+    expect(over.text).toBe('  5h quota exhausted — resets in 12m — AFK pauses and auto-resumes at the cap');
+  });
+});
+
+describe('formatQuotaUsage — window selection', () => {
+  it('reports the binding window, not the first one', () => {
+    const r = formatQuotaUsage(
+      {
+        fiveHour: { utilization: 0.4, resetsAt: inMinutes(200) },
+        sevenDay: { utilization: 0.88, resetsAt: inMinutes(3300) },
+        observedAt: NOW,
+      },
+      NOW,
+    );
+    expect(r.text).toBe('  7d quota 88% used — resets in 2d7h');
+  });
+
+  it('appends the other window only when it is ALSO hot', () => {
+    // Otherwise a hot 5h line would imply the 7d budget is fine when it is at 99%.
+    const bothHot = formatQuotaUsage(
+      {
+        fiveHour: { utilization: 0.97, resetsAt: inMinutes(12) },
+        sevenDay: { utilization: 0.86, resetsAt: inMinutes(3300) },
+        observedAt: NOW,
+      },
+      NOW,
+    );
+    expect(bothHot.text).toContain('(also 7d 86%)');
+
+    const oneHot = formatQuotaUsage(
+      {
+        fiveHour: { utilization: 0.97, resetsAt: inMinutes(12) },
+        sevenDay: { utilization: 0.24, resetsAt: inMinutes(3300) },
+        observedAt: NOW,
+      },
+      NOW,
+    );
+    expect(oneHot.text).not.toContain('also');
+  });
+});
+
+describe('formatQuotaUsage — deadline handling', () => {
+  it('omits the reset clause when the header carried no deadline', () => {
+    const r = formatQuotaUsage({ fiveHour: { utilization: 0.84 }, observedAt: NOW }, NOW);
+    expect(r.text).toBe('  5h quota 84% used');
+    expect(r.text).not.toContain('resets');
+  });
+
+  it('omits an already-elapsed deadline rather than asserting a passed reset', () => {
+    const r = formatQuotaUsage(
+      { fiveHour: { utilization: 0.84, resetsAt: inMinutes(-5) }, observedAt: NOW },
+      NOW,
+    );
+    expect(r.text).toBe('  5h quota 84% used');
+  });
+
+  it('still reassures at the cap when no deadline is known', () => {
+    const r = formatQuotaUsage({ fiveHour: { utilization: 1 }, observedAt: NOW }, NOW);
+    expect(r.text).toBe('  5h quota exhausted — AFK pauses and auto-resumes at the cap');
+  });
+});
+
+describe('formatQuotaUsage — shape', () => {
+  it('indents by two spaces like every other footer line', () => {
+    const r = formatQuotaUsage({ fiveHour: { utilization: 0.84 }, observedAt: NOW }, NOW);
+    expect(r.text?.startsWith('  ')).toBe(true);
+    expect(r.text?.startsWith('   ')).toBe(false);
+  });
+
+  it('emits no ANSI — the caller owns the tone', () => {
+    const r = formatQuotaUsage({ fiveHour: { utilization: 1 }, observedAt: NOW }, NOW);
+    // eslint-disable-next-line no-control-regex
+    expect(r.text).not.toMatch(/\u001b\[/);
+  });
+});

--- a/src/cli/quota-footer.ts
+++ b/src/cli/quota-footer.ts
@@ -1,0 +1,131 @@
+/**
+ * Turn-footer line for the subscription quota.
+ *
+ * The status-line indicator (`quota-indicator.ts`) is AMBIENT — it lives in
+ * peripheral vision on a row the eye skips. That is correct for a number you
+ * want available but not intrusive, and wrong for the moment a rolling window is
+ * about to cap the session: nobody reads the bottom row before firing off
+ * another turn. This module owns the intrusive half of the same signal, printed
+ * into the turn footer beside the context-usage line it deliberately mirrors
+ * (`formatContextUsage`, turn-handler.ts).
+ *
+ * Two different threshold sets on purpose, and they are not a mistake:
+ *
+ *   - The indicator's tone escalates at 50% / 80%. Tone is free — it costs the
+ *     reader nothing to have already gone amber by the time they look.
+ *   - This footer line starts at 80%. A printed line costs attention every
+ *     single turn, so it stays silent through the whole range where the ambient
+ *     tone is sufficient, and speaks only once the cap is a live risk.
+ *
+ * Deliberately stateless, matching the context-usage line's documented cadence:
+ * the footer already renders once per turn, so escalation is carried by
+ * severity/colour rather than by cross-turn suppression. No tier memory means no
+ * module-scope mutable state, no test-reset hazard, and no way to silently miss
+ * a crossing.
+ *
+ * Pure and colour-free (the caller maps `tier` → palette role) so it is
+ * unit-testable without a palette or a terminal.
+ *
+ * @module cli/quota-footer
+ */
+
+import { formatResetCountdown, type QuotaWindowState, type QuotaWindows } from './quota-indicator.js';
+
+/**
+ * Mirrors `ContextTier` minus its `normal` band — the quota footer has no
+ * chatty middle tier, so the caller's tone mapping is the same expression:
+ * `over`/`near` → error, `caution` → warning.
+ */
+export type QuotaUsageTier = 'quiet' | 'caution' | 'near' | 'over';
+
+/**
+ * Utilization at which each tier begins. Aligned with `formatContextUsage`'s
+ * 80% / 95% / 100% ladder rather than the indicator's 50% / 80% tone ladder, so
+ * the two FOOTER lines escalate in step with each other; see the module note.
+ */
+const CAUTION_AT = 0.8;
+const NEAR_AT = 0.95;
+const OVER_AT = 1.0;
+
+function tierFor(utilization: number): QuotaUsageTier {
+  if (utilization >= OVER_AT) return 'over';
+  if (utilization >= NEAR_AT) return 'near';
+  if (utilization >= CAUTION_AT) return 'caution';
+  return 'quiet';
+}
+
+interface LabelledWindow {
+  readonly label: string;
+  readonly state: QuotaWindowState;
+}
+
+function labelledWindows(windows: QuotaWindows): LabelledWindow[] {
+  const out: LabelledWindow[] = [];
+  if (windows.fiveHour !== undefined) out.push({ label: '5h', state: windows.fiveHour });
+  if (windows.sevenDay !== undefined) out.push({ label: '7d', state: windows.sevenDay });
+  return out;
+}
+
+/** `resets in 1h20m`, or undefined when no usable deadline is known. */
+function resetClause(state: QuotaWindowState, now: Date): string | undefined {
+  if (state.resetsAt === undefined) return undefined;
+  const msLeft = state.resetsAt.getTime() - now.getTime();
+  // A non-positive deadline means the window already rolled over, so the
+  // utilization beside it is stale too — say nothing rather than assert a
+  // deadline that has passed.
+  if (msLeft <= 0) return undefined;
+  return `resets in ${formatResetCountdown(msLeft)}`;
+}
+
+/**
+ * Map the quota windows to an escalating footer line + tier, so the REPL warns
+ * *proactively* as a rolling window approaches its cap rather than only once a
+ * 429 has already paused the turn.
+ *
+ * `text` is null below 80% (the ambient indicator covers that range on its own)
+ * and whenever no window is known — the permanent state under API-key auth,
+ * where the quota headers never arrive at all.
+ *
+ * Reports the BINDING (highest-utilization) window, and appends the other only
+ * when it has also cleared the caution bar — otherwise a hot 5h window would
+ * imply the 7d budget is fine when it might be at 99%.
+ */
+export function formatQuotaUsage(
+  windows: QuotaWindows | undefined,
+  now: Date = new Date(),
+): { tier: QuotaUsageTier; text: string | null } {
+  if (windows === undefined) return { tier: 'quiet', text: null };
+  const all = labelledWindows(windows);
+  const binding = all.reduce<LabelledWindow | undefined>(
+    (worst, w) => (worst === undefined || w.state.utilization > worst.state.utilization ? w : worst),
+    undefined,
+  );
+  if (binding === undefined) return { tier: 'quiet', text: null };
+
+  const tier = tierFor(binding.state.utilization);
+  if (tier === 'quiet') return { tier, text: null };
+
+  const percent = Math.round(binding.state.utilization * 100);
+  const reset = resetClause(binding.state, now);
+  const alsoHot = all
+    .filter((w) => w !== binding && tierFor(w.state.utilization) !== 'quiet')
+    .map((w) => `${w.label} ${Math.round(w.state.utilization * 100)}%`);
+
+  const suffix = alsoHot.length > 0 ? ` (also ${alsoHot.join(', ')})` : '';
+  // Grounded in the runtime's actual behaviour: a usage-limit 429 parks the turn
+  // and resumes it after the reset (see usage-limit.ts), emitting
+  // usage_limit_pause / usage_limit_resume phases. Saying so turns an alarming
+  // line into an actionable one — the session is parked, not lost.
+  const parkNote = 'AFK pauses and auto-resumes at the cap';
+
+  if (tier === 'over') {
+    const head = `  ${binding.label} quota exhausted`;
+    return { tier, text: `${head}${reset === undefined ? '' : ` — ${reset}`} — ${parkNote}${suffix}` };
+  }
+  if (tier === 'near') {
+    const head = `  ${binding.label} quota ${percent}% used`;
+    return { tier, text: `${head}${reset === undefined ? '' : ` — ${reset}`} — ${parkNote}${suffix}` };
+  }
+  const head = `  ${binding.label} quota ${percent}% used`;
+  return { tier, text: `${head}${reset === undefined ? '' : ` — ${reset}`}${suffix}` };
+}

--- a/src/cli/quota-indicator.test.ts
+++ b/src/cli/quota-indicator.test.ts
@@ -39,9 +39,9 @@ describe('formatQuotaIndicator — presence', () => {
 
   it('renders a single window when only one is known', () => {
     const only5h = formatQuotaIndicator({ fiveHour: { utilization: 0.05 }, observedAt: NOW }, NOW);
-    expect(stripAnsi(only5h!.text)).toBe('5h ▁5%');
+    expect(stripAnsi(only5h!.text)).toBe('5h 5%');
     const only7d = formatQuotaIndicator({ sevenDay: { utilization: 0.5 }, observedAt: NOW }, NOW);
-    expect(stripAnsi(only7d!.text)).toBe('7d ▅50%');
+    expect(stripAnsi(only7d!.text)).toBe('7d 50%');
   });
 
   it('treats utilization as a 0..1 fraction and rounds to a whole percent', () => {
@@ -77,41 +77,52 @@ describe('formatQuotaIndicator — severity', () => {
       { fiveHour: { utilization: 0.94 }, sevenDay: { utilization: 0.24 }, observedAt: NOW },
       NOW,
     );
-    expect(r!.text).toContain(palette.error('█94%'));
-    expect(r!.text).toContain(palette.chrome('▂24%'));
+    expect(r!.text).toContain(palette.error('94%'));
+    expect(r!.text).toContain(palette.chrome('24%'));
   });
 
   it('uses the caution tone in the middle band', () => {
     const r = formatQuotaIndicator({ fiveHour: { utilization: 0.62 }, observedAt: NOW }, NOW);
-    expect(r!.text).toContain(palette.warning('▅62%'));
+    expect(r!.text).toContain(palette.warning('62%'));
   });
 
   it('keeps a calm window in chrome, not the near-invisible meta tone', () => {
     // Guard against re-making the context bar's original mistake: a fully
     // recessive readout reads as broken rather than reassuring.
     const r = formatQuotaIndicator({ fiveHour: { utilization: 0.06 }, observedAt: NOW }, NOW);
-    expect(r!.text).toContain(palette.chrome('▁6%'));
-    expect(r!.text).not.toContain(palette.meta('▁6%'));
+    expect(r!.text).toContain(palette.chrome('6%'));
+    expect(r!.text).not.toContain(palette.meta('6%'));
   });
 });
 
-describe('formatQuotaIndicator — gauge glyph (non-colour encoding)', () => {
-  it('scales the block cell with utilization and never renders an empty cell', () => {
-    const cellAt = (u: number) =>
-      stripAnsi(formatQuotaIndicator({ fiveHour: { utilization: u }, observedAt: NOW }, NOW)!.text).slice(3, 4);
-    expect(cellAt(0)).toBe('▁'); // floor cell, so the field is never blank
-    expect(cellAt(0.24)).toBe('▂');
-    expect(cellAt(0.62)).toBe('▅');
-    expect(cellAt(0.94)).toBe('█');
-    expect(cellAt(1)).toBe('█'); // top cell, not an out-of-range read
+describe('formatQuotaIndicator — non-colour encoding', () => {
+  it('never prefixes the percentage with a block-gauge glyph', () => {
+    // Regression guard: a one-cell gauge (`▁`..`█`) shipped here once and read as
+    // a rendering artifact — a solid block of colour abutting the digits at the
+    // top of the ramp, an underscore stub (`▁9%` as `_9%`) at the bottom. One
+    // cell cannot encode magnitude, and the number beside it already does.
+    for (const u of [0, 0.09, 0.24, 0.62, 0.94, 1]) {
+      const text = stripAnsi(formatQuotaIndicator({ fiveHour: { utilization: u }, observedAt: NOW }, NOW)!.text);
+      expect(text).toMatch(/^5h \d{1,3}%$/);
+      expect(text).not.toMatch(/[▁▂▃▄▅▆▇█]/u);
+    }
   });
 
-  it('survives colour stripping — the glyph carries the signal under NO_COLOR', () => {
-    const hot = stripAnsi(formatQuotaIndicator({ fiveHour: { utilization: 0.94 }, observedAt: NOW }, NOW)!.text);
-    const cold = stripAnsi(formatQuotaIndicator({ fiveHour: { utilization: 0.06 }, observedAt: NOW }, NOW)!.text);
-    expect(hot).not.toBe(cold);
-    expect(hot).toContain('█');
-    expect(cold).toContain('▁');
+  it('survives colour stripping — the countdown carries the escalation under NO_COLOR', () => {
+    // With every palette role collapsed to bare text the ladder still reads: the
+    // countdown is absent while calm and present from caution up. Past 80% the
+    // turn footer (quota-footer.ts) prints the escalation as a sentence, which is
+    // what separates caution from critical without colour.
+    const at = (u: number) =>
+      stripAnsi(
+        formatQuotaIndicator(
+          { fiveHour: { utilization: u, resetsAt: inMinutes(12) }, observedAt: NOW },
+          NOW,
+        )!.text,
+      );
+    expect(at(0.06)).toBe('5h 6%');
+    expect(at(0.69)).toBe('5h 69% ⟳12m');
+    expect(at(0.94)).toBe('5h 94% ⟳12m');
   });
 });
 
@@ -121,7 +132,7 @@ describe('formatQuotaIndicator — reset countdown', () => {
       { fiveHour: { utilization: 0.1, resetsAt: inMinutes(30) }, observedAt: NOW },
       NOW,
     );
-    expect(stripAnsi(r!.text)).toBe('5h ▁10%');
+    expect(stripAnsi(r!.text)).toBe('5h 10%');
   });
 
   it('attaches to the BINDING window only, never both', () => {
@@ -133,7 +144,7 @@ describe('formatQuotaIndicator — reset countdown', () => {
       },
       NOW,
     );
-    expect(stripAnsi(r!.text)).toBe('5h █94% ⟳12m · 7d ▂24%');
+    expect(stripAnsi(r!.text)).toBe('5h 94% ⟳12m · 7d 24%');
   });
 
   it('follows the binding window when 7d is the hotter one', () => {
@@ -145,7 +156,7 @@ describe('formatQuotaIndicator — reset countdown', () => {
       },
       NOW,
     );
-    expect(stripAnsi(r!.text)).toBe('5h ▄40% · 7d █88% ⟳2d7h');
+    expect(stripAnsi(r!.text)).toBe('5h 40% · 7d 88% ⟳2d7h');
   });
 
   it('separates two identical percentages by their deadlines', () => {
@@ -166,7 +177,7 @@ describe('formatQuotaIndicator — reset countdown', () => {
 
   it('omits the countdown when the header carried no deadline', () => {
     const r = formatQuotaIndicator({ fiveHour: { utilization: 0.94 }, observedAt: NOW }, NOW);
-    expect(stripAnsi(r!.text)).toBe('5h █94%');
+    expect(stripAnsi(r!.text)).toBe('5h 94%');
   });
 
   it('omits an already-elapsed deadline rather than asserting a passed reset', () => {
@@ -174,7 +185,7 @@ describe('formatQuotaIndicator — reset countdown', () => {
       { fiveHour: { utilization: 0.94, resetsAt: inMinutes(-5) }, observedAt: NOW },
       NOW,
     );
-    expect(stripAnsi(r!.text)).toBe('5h █94%');
+    expect(stripAnsi(r!.text)).toBe('5h 94%');
     expect(stripAnsi(r!.text)).not.toContain('⟳');
   });
 
@@ -205,7 +216,7 @@ describe('formatQuotaIndicator — staleness', () => {
       },
       NOW,
     );
-    expect(stripAnsi(r!.text)).toBe('~5h █94% ⟳12m');
+    expect(stripAnsi(r!.text)).toBe('~5h 94% ⟳12m');
     expect(r!.severity).toBe('critical'); // tone is unchanged: stale-high is pessimistic, not wrong
   });
 
@@ -215,9 +226,10 @@ describe('formatQuotaIndicator — staleness', () => {
 });
 
 describe('formatQuotaIndicator — width budget', () => {
-  it('costs at most a few cells more than the bare-percentage form it replaced', () => {
-    // The row already sheds fields on narrow terminals, so the hot form must not
-    // balloon: `5h 94% · 7d 24%` (16 cells) → at most 8 more with a countdown.
+  it('costs nothing while calm and only the countdown when hot', () => {
+    // The row already sheds fields on narrow terminals. Calm must be EXACTLY the
+    // width of the bare-percentage form it replaced (no glyph, no countdown), and
+    // hot may add only the binding window's deadline.
     const hot = formatQuotaIndicator(
       {
         fiveHour: { utilization: 0.94, resetsAt: inMinutes(12) },
@@ -226,13 +238,14 @@ describe('formatQuotaIndicator — width budget', () => {
       },
       NOW,
     );
-    expect(displayWidth(stripAnsi(hot!.text))).toBeLessThanOrEqual(24);
+    expect(displayWidth(stripAnsi(hot!.text))).toBeLessThanOrEqual(22);
 
     const calm = formatQuotaIndicator(
       { fiveHour: { utilization: 0.06 }, sevenDay: { utilization: 0.12 }, observedAt: NOW },
       NOW,
     );
-    expect(displayWidth(stripAnsi(calm!.text))).toBeLessThanOrEqual(18);
+    expect(stripAnsi(calm!.text)).toBe('5h 6% · 7d 12%');
+    expect(displayWidth(stripAnsi(calm!.text))).toBe(14);
   });
 });
 

--- a/src/cli/quota-indicator.test.ts
+++ b/src/cli/quota-indicator.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Tests for src/cli/quota-indicator.ts
+ *
+ * Assertions run against ANSI-stripped text for layout and against
+ * `palette.<role>`-wrapped substrings for tone, so a palette retune breaks
+ * nothing while a tone REGRESSION (e.g. a critical window rendering in the calm
+ * chrome tone) still fails.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import chalk from 'chalk';
+import { formatQuotaIndicator, formatResetCountdown, STALE_AFTER_MS } from './quota-indicator.js';
+import { palette } from './palette.js';
+import { displayWidth, stripAnsi } from './display.js';
+
+// Invariant: vitest runs non-TTY, so `color-config.ts` pins `chalk.level = 0`
+// and EVERY palette role collapses to bare text — which makes a tone assertion
+// vacuously true and its negation vacuously false. Force truecolor for this file
+// so the tone tests below actually discriminate `error` from `chrome`. Safe to
+// mutate globally: palette builders read `chalk.level` at call time (see the
+// theming invariant in palette.ts).
+let priorChalkLevel: typeof chalk.level;
+beforeAll(() => {
+  priorChalkLevel = chalk.level;
+  chalk.level = 3;
+});
+afterAll(() => {
+  chalk.level = priorChalkLevel;
+});
+
+const NOW = new Date('2026-07-29T12:00:00Z');
+const inMinutes = (m: number): Date => new Date(NOW.getTime() + m * 60_000);
+
+describe('formatQuotaIndicator — presence', () => {
+  it('returns undefined when neither window is known (API-key auth)', () => {
+    expect(formatQuotaIndicator({}, NOW)).toBeUndefined();
+    expect(formatQuotaIndicator({ observedAt: NOW }, NOW)).toBeUndefined();
+  });
+
+  it('renders a single window when only one is known', () => {
+    const only5h = formatQuotaIndicator({ fiveHour: { utilization: 0.05 }, observedAt: NOW }, NOW);
+    expect(stripAnsi(only5h!.text)).toBe('5h ▁5%');
+    const only7d = formatQuotaIndicator({ sevenDay: { utilization: 0.5 }, observedAt: NOW }, NOW);
+    expect(stripAnsi(only7d!.text)).toBe('7d ▅50%');
+  });
+
+  it('treats utilization as a 0..1 fraction and rounds to a whole percent', () => {
+    // Units regression guard: 0.626 must be 63% — not 0%, not 6200%.
+    const r = formatQuotaIndicator({ fiveHour: { utilization: 0.626 }, observedAt: NOW }, NOW);
+    const text = stripAnsi(r!.text);
+    expect(text).toContain('63%');
+    expect(text).not.toContain('6200');
+  });
+});
+
+describe('formatQuotaIndicator — severity', () => {
+  it('is calm at or below 50%, caution above 50%, critical above 80%', () => {
+    const at = (u: number) => formatQuotaIndicator({ fiveHour: { utilization: u }, observedAt: NOW }, NOW)!.severity;
+    expect(at(0)).toBe('calm');
+    expect(at(0.5)).toBe('calm'); // boundary is exclusive, matching context-bar
+    expect(at(0.51)).toBe('caution');
+    expect(at(0.8)).toBe('caution');
+    expect(at(0.81)).toBe('critical');
+    expect(at(1)).toBe('critical');
+  });
+
+  it('reports the WORST window, so a hot 7d escalates a calm 5h row', () => {
+    const r = formatQuotaIndicator(
+      { fiveHour: { utilization: 0.1 }, sevenDay: { utilization: 0.88 }, observedAt: NOW },
+      NOW,
+    );
+    expect(r!.severity).toBe('critical');
+  });
+
+  it('tones each window independently — a red 5h must not drag 7d red with it', () => {
+    const r = formatQuotaIndicator(
+      { fiveHour: { utilization: 0.94 }, sevenDay: { utilization: 0.24 }, observedAt: NOW },
+      NOW,
+    );
+    expect(r!.text).toContain(palette.error('█94%'));
+    expect(r!.text).toContain(palette.chrome('▂24%'));
+  });
+
+  it('uses the caution tone in the middle band', () => {
+    const r = formatQuotaIndicator({ fiveHour: { utilization: 0.62 }, observedAt: NOW }, NOW);
+    expect(r!.text).toContain(palette.warning('▅62%'));
+  });
+
+  it('keeps a calm window in chrome, not the near-invisible meta tone', () => {
+    // Guard against re-making the context bar's original mistake: a fully
+    // recessive readout reads as broken rather than reassuring.
+    const r = formatQuotaIndicator({ fiveHour: { utilization: 0.06 }, observedAt: NOW }, NOW);
+    expect(r!.text).toContain(palette.chrome('▁6%'));
+    expect(r!.text).not.toContain(palette.meta('▁6%'));
+  });
+});
+
+describe('formatQuotaIndicator — gauge glyph (non-colour encoding)', () => {
+  it('scales the block cell with utilization and never renders an empty cell', () => {
+    const cellAt = (u: number) =>
+      stripAnsi(formatQuotaIndicator({ fiveHour: { utilization: u }, observedAt: NOW }, NOW)!.text).slice(3, 4);
+    expect(cellAt(0)).toBe('▁'); // floor cell, so the field is never blank
+    expect(cellAt(0.24)).toBe('▂');
+    expect(cellAt(0.62)).toBe('▅');
+    expect(cellAt(0.94)).toBe('█');
+    expect(cellAt(1)).toBe('█'); // top cell, not an out-of-range read
+  });
+
+  it('survives colour stripping — the glyph carries the signal under NO_COLOR', () => {
+    const hot = stripAnsi(formatQuotaIndicator({ fiveHour: { utilization: 0.94 }, observedAt: NOW }, NOW)!.text);
+    const cold = stripAnsi(formatQuotaIndicator({ fiveHour: { utilization: 0.06 }, observedAt: NOW }, NOW)!.text);
+    expect(hot).not.toBe(cold);
+    expect(hot).toContain('█');
+    expect(cold).toContain('▁');
+  });
+});
+
+describe('formatQuotaIndicator — reset countdown', () => {
+  it('is omitted entirely while the row is calm', () => {
+    const r = formatQuotaIndicator(
+      { fiveHour: { utilization: 0.1, resetsAt: inMinutes(30) }, observedAt: NOW },
+      NOW,
+    );
+    expect(stripAnsi(r!.text)).toBe('5h ▁10%');
+  });
+
+  it('attaches to the BINDING window only, never both', () => {
+    const r = formatQuotaIndicator(
+      {
+        fiveHour: { utilization: 0.94, resetsAt: inMinutes(12) },
+        sevenDay: { utilization: 0.24, resetsAt: inMinutes(5000) },
+        observedAt: NOW,
+      },
+      NOW,
+    );
+    expect(stripAnsi(r!.text)).toBe('5h █94% ⟳12m · 7d ▂24%');
+  });
+
+  it('follows the binding window when 7d is the hotter one', () => {
+    const r = formatQuotaIndicator(
+      {
+        fiveHour: { utilization: 0.4, resetsAt: inMinutes(200) },
+        sevenDay: { utilization: 0.88, resetsAt: inMinutes(3300) },
+        observedAt: NOW,
+      },
+      NOW,
+    );
+    expect(stripAnsi(r!.text)).toBe('5h ▄40% · 7d █88% ⟳2d7h');
+  });
+
+  it('separates two identical percentages by their deadlines', () => {
+    // The whole point of the countdown: 94% with 12m left and 94% with 4h left
+    // are opposite situations that the bare-percentage segment rendered alike.
+    const soon = formatQuotaIndicator(
+      { fiveHour: { utilization: 0.94, resetsAt: inMinutes(12) }, observedAt: NOW },
+      NOW,
+    );
+    const later = formatQuotaIndicator(
+      { fiveHour: { utilization: 0.94, resetsAt: inMinutes(247) }, observedAt: NOW },
+      NOW,
+    );
+    expect(stripAnsi(soon!.text)).not.toBe(stripAnsi(later!.text));
+    expect(stripAnsi(soon!.text)).toContain('⟳12m');
+    expect(stripAnsi(later!.text)).toContain('⟳4h7m');
+  });
+
+  it('omits the countdown when the header carried no deadline', () => {
+    const r = formatQuotaIndicator({ fiveHour: { utilization: 0.94 }, observedAt: NOW }, NOW);
+    expect(stripAnsi(r!.text)).toBe('5h █94%');
+  });
+
+  it('omits an already-elapsed deadline rather than asserting a passed reset', () => {
+    const r = formatQuotaIndicator(
+      { fiveHour: { utilization: 0.94, resetsAt: inMinutes(-5) }, observedAt: NOW },
+      NOW,
+    );
+    expect(stripAnsi(r!.text)).toBe('5h █94%');
+    expect(stripAnsi(r!.text)).not.toContain('⟳');
+  });
+
+  it('keeps the countdown recessive so the percentage stays the focal point', () => {
+    const r = formatQuotaIndicator(
+      { fiveHour: { utilization: 0.94, resetsAt: inMinutes(12) }, observedAt: NOW },
+      NOW,
+    );
+    expect(r!.text).toContain(palette.meta('⟳12m'));
+  });
+});
+
+describe('formatQuotaIndicator — staleness', () => {
+  it('is fresh at the threshold and stale past it', () => {
+    const windows = (ageMs: number) => ({
+      fiveHour: { utilization: 0.94 },
+      observedAt: new Date(NOW.getTime() - ageMs),
+    });
+    expect(formatQuotaIndicator(windows(STALE_AFTER_MS), NOW)!.stale).toBe(false);
+    expect(formatQuotaIndicator(windows(STALE_AFTER_MS + 1), NOW)!.stale).toBe(true);
+  });
+
+  it('marks a stale reading with a leading ~ but still shows the number', () => {
+    const r = formatQuotaIndicator(
+      {
+        fiveHour: { utilization: 0.94, resetsAt: inMinutes(12) },
+        observedAt: new Date(NOW.getTime() - 40 * 60_000),
+      },
+      NOW,
+    );
+    expect(stripAnsi(r!.text)).toBe('~5h █94% ⟳12m');
+    expect(r!.severity).toBe('critical'); // tone is unchanged: stale-high is pessimistic, not wrong
+  });
+
+  it('is never stale when the cache reported no observation time', () => {
+    expect(formatQuotaIndicator({ fiveHour: { utilization: 0.94 } }, NOW)!.stale).toBe(false);
+  });
+});
+
+describe('formatQuotaIndicator — width budget', () => {
+  it('costs at most a few cells more than the bare-percentage form it replaced', () => {
+    // The row already sheds fields on narrow terminals, so the hot form must not
+    // balloon: `5h 94% · 7d 24%` (16 cells) → at most 8 more with a countdown.
+    const hot = formatQuotaIndicator(
+      {
+        fiveHour: { utilization: 0.94, resetsAt: inMinutes(12) },
+        sevenDay: { utilization: 0.24, resetsAt: inMinutes(5000) },
+        observedAt: NOW,
+      },
+      NOW,
+    );
+    expect(displayWidth(stripAnsi(hot!.text))).toBeLessThanOrEqual(24);
+
+    const calm = formatQuotaIndicator(
+      { fiveHour: { utilization: 0.06 }, sevenDay: { utilization: 0.12 }, observedAt: NOW },
+      NOW,
+    );
+    expect(displayWidth(stripAnsi(calm!.text))).toBeLessThanOrEqual(18);
+  });
+});
+
+describe('formatResetCountdown', () => {
+  it('never exceeds six columns across the full range', () => {
+    // Widest possible form is `23h59m`; the 7d window can reach `6d23h`.
+    for (const ms of [0, 30_000, 59_999, 60_000, 3_599_000, 3_600_000, 86_399_000, 86_400_000, 7 * 86_400_000]) {
+      expect(displayWidth(formatResetCountdown(ms))).toBeLessThanOrEqual(6);
+    }
+  });
+
+  it('formats sub-minute, minutes, hours+minutes, and days+hours', () => {
+    expect(formatResetCountdown(30_000)).toBe('<1m');
+    expect(formatResetCountdown(12 * 60_000)).toBe('12m');
+    expect(formatResetCountdown((2 * 60 + 10) * 60_000)).toBe('2h10m');
+    expect(formatResetCountdown((3 * 24 * 60 + 4 * 60) * 60_000)).toBe('3d4h');
+  });
+
+  it('drops the space the shared formatDuration would emit', () => {
+    // Deliberate divergence from format-utils.ts's `2h 10m`: every cell counts on
+    // a row that already sheds fields.
+    expect(formatResetCountdown((2 * 60 + 10) * 60_000)).not.toContain(' ');
+  });
+});

--- a/src/cli/quota-indicator.ts
+++ b/src/cli/quota-indicator.ts
@@ -1,0 +1,248 @@
+/**
+ * Subscription-quota indicator for the status line.
+ *
+ * Renders the Anthropic OAuth rolling-window utilization (`5h` / `7d`) as a
+ * severity-graded, self-explaining segment instead of two flat percentages.
+ *
+ * Design rationale — a bare percentage is not actionable. `5h 94%` reads
+ * identically to `5h 24%` in flat `chrome`, so the single most consequential
+ * number on the row ("am I about to get rate-limited?") had the same salience
+ * as the token counter, and was the FIRST field shed on a narrow terminal.
+ * Three mechanics fix that, all width-cheap:
+ *
+ *   1. Per-window severity tone + a one-cell block gauge (`▁`..`█`). Tone tiers
+ *      mirror the context bar exactly (`> 0.8` error, `> 0.5` warning, else
+ *      chrome) so the two usage readouts on the row grade alike. The gauge is
+ *      the redundant non-color encoding, so the signal survives NO_COLOR and
+ *      color-vision deficiency — same reason `syntaxString` carries italic.
+ *   2. A reset countdown (`⟳12m`) on the BINDING window once it crosses caution.
+ *      `94% resets in 12m` and `94% resets in 4h` are opposite situations that
+ *      the old segment rendered identically. Only the binding window gets one,
+ *      capping the width growth at a few cells.
+ *   3. A `stale` flag (see {@link STALE_AFTER_MS}) so the caller can decline to
+ *      promote an old reading, and a `~` marker so a long idle session doesn't
+ *      show a stale number as live.
+ *
+ * Pure and clock-injectable: takes plain numbers/Dates rather than the
+ * `QuotaSnapshot` type, keeping the render layer decoupled from
+ * `agent/quota-cache` exactly as `formatContextBar` is decoupled from the
+ * session stats.
+ *
+ * @module cli/quota-indicator
+ */
+
+import { palette } from './palette.js';
+import type { QuotaSnapshot } from '../agent/quota-cache.js';
+
+/** One rolling window's state, as observed from the response headers. */
+export interface QuotaWindowState {
+  /** Fraction of the window consumed, `0..1` (already clamped by the cache). */
+  readonly utilization: number;
+  /** When the window rolls over, if the header carried a parseable deadline. */
+  readonly resetsAt?: Date;
+}
+
+/** Both rolling windows plus the observation timestamp, for staleness. */
+export interface QuotaWindows {
+  readonly fiveHour?: QuotaWindowState;
+  readonly sevenDay?: QuotaWindowState;
+  /** When these values were read off a response. Drives {@link QuotaIndicator.stale}. */
+  readonly observedAt?: Date;
+}
+
+/**
+ * Re-shape a cached {@link QuotaSnapshot} into render input, or `undefined` when
+ * neither window is known — the permanent state under API-key auth, where the
+ * caller must draw no segment at all rather than a placeholder.
+ *
+ * Contract: a pure field re-shape, NOT a formatter. `resetsAt`/`observedAt` are
+ * forwarded verbatim and every clock comparison stays inside
+ * {@link formatQuotaIndicator}, so the status line renders and grades
+ * droppability from one severity computed in one place.
+ */
+export function quotaWindowsFromSnapshot(snapshot: QuotaSnapshot | undefined): QuotaWindows | undefined {
+  if (snapshot === undefined) return undefined;
+  if (snapshot.fiveHourUtilization === undefined && snapshot.sevenDayUtilization === undefined) {
+    return undefined;
+  }
+  return {
+    ...(snapshot.fiveHourUtilization !== undefined
+      ? {
+          fiveHour: {
+            utilization: snapshot.fiveHourUtilization,
+            ...(snapshot.fiveHourResetsAt !== undefined ? { resetsAt: snapshot.fiveHourResetsAt } : {}),
+          },
+        }
+      : {}),
+    ...(snapshot.sevenDayUtilization !== undefined
+      ? {
+          sevenDay: {
+            utilization: snapshot.sevenDayUtilization,
+            ...(snapshot.sevenDayResetsAt !== undefined ? { resetsAt: snapshot.sevenDayResetsAt } : {}),
+          },
+        }
+      : {}),
+    observedAt: snapshot.observedAt,
+  };
+}
+
+/**
+ * Worst-window severity. `calm` recedes, `caution` warns, `critical` demands
+ * attention — and earns drop-last treatment from the status line.
+ */
+export type QuotaSeverity = 'calm' | 'caution' | 'critical';
+
+export interface QuotaIndicator {
+  /** ANSI-colored segment text, e.g. `5h █94% ⟳12m · 7d ▂24%`. */
+  readonly text: string;
+  /** Max severity across the present windows. */
+  readonly severity: QuotaSeverity;
+  /** True when the underlying observation is older than {@link STALE_AFTER_MS}. */
+  readonly stale: boolean;
+}
+
+/**
+ * Utilization above which a window is `caution`, and above which it is
+ * `critical`. Deliberately identical to the context bar's tone thresholds
+ * (`context-bar.ts`) so both usage readouts on the status row escalate in step;
+ * change them together or the row stops reading as one instrument.
+ */
+const CAUTION_ABOVE = 0.5;
+const CRITICAL_ABOVE = 0.8;
+
+/**
+ * A quota reading older than this is marked `~` and reported `stale`.
+ *
+ * The headers only refresh when a turn hits the API, so an idle session holds
+ * its last reading indefinitely. Staleness is never *dangerous* here — a
+ * rolling window only decays while idle, so an old reading over-reports rather
+ * than under-reports — but an hour-old `94%` that has actually drained to 40%
+ * would keep the row alarmed for no reason, so it is marked rather than
+ * silently trusted.
+ */
+export const STALE_AFTER_MS = 10 * 60 * 1000;
+
+/**
+ * Block-height gauge cells, low → high. Same glyph family as the context
+ * sparkline (`context-sparkline.ts`), so the row keeps one visual vocabulary.
+ */
+const GAUGE_CELLS = ['▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'] as const;
+
+/** Prefixes the reset countdown. Recessive tone: it is context for the number, not the signal. */
+const RESET_GLYPH = '⟳';
+
+function severityOf(utilization: number): QuotaSeverity {
+  if (utilization > CRITICAL_ABOVE) return 'critical';
+  if (utilization > CAUTION_ABOVE) return 'caution';
+  return 'calm';
+}
+
+function toneFor(severity: QuotaSeverity) {
+  if (severity === 'critical') return palette.error;
+  if (severity === 'caution') return palette.warning;
+  // Calm stays `chrome`, not `meta`: a fully recessive readout reads as broken
+  // rather than reassuring — the same mistake the context bar's single-tone
+  // wrap made before it split fill from track.
+  return palette.chrome;
+}
+
+/** Utilization → one gauge cell. `0` still shows a floor cell so the field never looks empty. */
+function gaugeCell(utilization: number): string {
+  const index = Math.min(GAUGE_CELLS.length - 1, Math.max(0, Math.floor(utilization * GAUGE_CELLS.length)));
+  return GAUGE_CELLS[index] ?? '█';
+}
+
+/**
+ * Compact "time remaining" for a status row: `<1m`, `12m`, `2h10m`, `3d4h`.
+ *
+ * Deliberately NOT `format-utils.ts`'s `formatDuration`, which spaces its units
+ * (`2h 10m`) — every cell counts on a row that already sheds fields, and this
+ * form never exceeds six columns (widest: `23h59m`).
+ */
+export function formatResetCountdown(msRemaining: number): string {
+  const totalMinutes = Math.floor(msRemaining / 60_000);
+  if (totalMinutes < 1) return '<1m';
+  const days = Math.floor(totalMinutes / 1440);
+  const hours = Math.floor((totalMinutes % 1440) / 60);
+  const minutes = totalMinutes % 60;
+  if (days > 0) return `${days}d${hours}h`;
+  if (hours > 0) return `${hours}h${minutes}m`;
+  return `${minutes}m`;
+}
+
+interface RenderedWindow {
+  readonly label: string;
+  readonly state: QuotaWindowState;
+  readonly severity: QuotaSeverity;
+}
+
+function collectWindows(windows: QuotaWindows): RenderedWindow[] {
+  const collected: RenderedWindow[] = [];
+  if (windows.fiveHour !== undefined) {
+    collected.push({
+      label: '5h',
+      state: windows.fiveHour,
+      severity: severityOf(windows.fiveHour.utilization),
+    });
+  }
+  if (windows.sevenDay !== undefined) {
+    collected.push({
+      label: '7d',
+      state: windows.sevenDay,
+      severity: severityOf(windows.sevenDay.utilization),
+    });
+  }
+  return collected;
+}
+
+/** Highest-utilization window — the one that will actually cut the session off first. */
+function bindingWindow(collected: RenderedWindow[]): RenderedWindow | undefined {
+  return collected.reduce<RenderedWindow | undefined>(
+    (worst, w) => (worst === undefined || w.state.utilization > worst.state.utilization ? w : worst),
+    undefined,
+  );
+}
+
+function maxSeverity(collected: RenderedWindow[]): QuotaSeverity {
+  if (collected.some((w) => w.severity === 'critical')) return 'critical';
+  if (collected.some((w) => w.severity === 'caution')) return 'caution';
+  return 'calm';
+}
+
+/**
+ * Render the quota segment, or `undefined` when neither window is known — the
+ * permanent state under API-key auth, where the caller must draw no segment at
+ * all rather than a placeholder.
+ *
+ * `now` is injectable for tests; production callers omit it.
+ */
+export function formatQuotaIndicator(windows: QuotaWindows, now: Date = new Date()): QuotaIndicator | undefined {
+  const collected = collectWindows(windows);
+  if (collected.length === 0) return undefined;
+
+  const severity = maxSeverity(collected);
+  const stale =
+    windows.observedAt !== undefined && now.getTime() - windows.observedAt.getTime() > STALE_AFTER_MS;
+
+  // Only the binding window earns a countdown, and only once it matters: a calm
+  // row stays at its old width, and a hot row spends its extra cells on the one
+  // deadline that is actually load-bearing.
+  const binding = severity === 'calm' ? undefined : bindingWindow(collected);
+
+  const rendered = collected.map((w) => {
+    const tone = toneFor(w.severity);
+    const percent = `${Math.round(w.state.utilization * 100)}%`;
+    let text = `${palette.meta(w.label)} ${tone(`${gaugeCell(w.state.utilization)}${percent}`)}`;
+    if (w === binding && w.state.resetsAt !== undefined) {
+      const msLeft = w.state.resetsAt.getTime() - now.getTime();
+      // A non-positive countdown means the window already rolled over, so the
+      // utilization beside it is stale too — showing `⟳0m` would assert a
+      // deadline that has passed. Omit rather than mislead.
+      if (msLeft > 0) text += ` ${palette.meta(`${RESET_GLYPH}${formatResetCountdown(msLeft)}`)}`;
+    }
+    return text;
+  });
+
+  const prefix = stale ? palette.meta('~') : '';
+  return { text: prefix + rendered.join(palette.dim(' · ')), severity, stale };
+}

--- a/src/cli/quota-indicator.ts
+++ b/src/cli/quota-indicator.ts
@@ -10,11 +10,9 @@
  * as the token counter, and was the FIRST field shed on a narrow terminal.
  * Three mechanics fix that, all width-cheap:
  *
- *   1. Per-window severity tone + a one-cell block gauge (`▁`..`█`). Tone tiers
- *      mirror the context bar exactly (`> 0.8` error, `> 0.5` warning, else
- *      chrome) so the two usage readouts on the row grade alike. The gauge is
- *      the redundant non-color encoding, so the signal survives NO_COLOR and
- *      color-vision deficiency — same reason `syntaxString` carries italic.
+ *   1. Per-window severity tone. Tiers mirror the context bar exactly
+ *      (`> 0.8` error, `> 0.5` warning, else chrome) so the two usage readouts
+ *      on the row grade alike.
  *   2. A reset countdown (`⟳12m`) on the BINDING window once it crosses caution.
  *      `94% resets in 12m` and `94% resets in 4h` are opposite situations that
  *      the old segment rendered identically. Only the binding window gets one,
@@ -22,6 +20,19 @@
  *   3. A `stale` flag (see {@link STALE_AFTER_MS}) so the caller can decline to
  *      promote an old reading, and a `~` marker so a long idle session doesn't
  *      show a stale number as live.
+ *
+ * Invariant: the ladder must stay legible with color stripped, and mechanic 2 is
+ * what carries it — the countdown is absent while calm and present from caution
+ * up, so `5h 40%` and `5h 69% ⟳2h13m` differ in plain text, and past 80% the
+ * turn footer (`quota-footer.ts`) prints the escalation as a sentence. No glyph
+ * badge is used for this. An earlier revision prefixed each percentage with a
+ * one-cell block gauge (`▁`..`█`) and it looked broken: one cell cannot encode
+ * magnitude (the sparkline those glyphs come from reads as a curve only because
+ * it has many cells to compare against), so the top of the ramp rendered as a
+ * solid block of color abutting the digits — terminal vocabulary for a cursor or
+ * a selection, i.e. an artifact — and the bottom as an underscore stub, `▁9%`
+ * reading as `_9%`. It also restated, less precisely, the exact number one cell
+ * to its right. Severity banding is tone's job; the number is the magnitude.
  *
  * Pure and clock-injectable: takes plain numbers/Dates rather than the
  * `QuotaSnapshot` type, keeping the render layer decoupled from
@@ -93,7 +104,7 @@ export function quotaWindowsFromSnapshot(snapshot: QuotaSnapshot | undefined): Q
 export type QuotaSeverity = 'calm' | 'caution' | 'critical';
 
 export interface QuotaIndicator {
-  /** ANSI-colored segment text, e.g. `5h █94% ⟳12m · 7d ▂24%`. */
+  /** ANSI-colored segment text, e.g. `5h 94% ⟳12m · 7d 24%`. */
   readonly text: string;
   /** Max severity across the present windows. */
   readonly severity: QuotaSeverity;
@@ -122,12 +133,6 @@ const CRITICAL_ABOVE = 0.8;
  */
 export const STALE_AFTER_MS = 10 * 60 * 1000;
 
-/**
- * Block-height gauge cells, low → high. Same glyph family as the context
- * sparkline (`context-sparkline.ts`), so the row keeps one visual vocabulary.
- */
-const GAUGE_CELLS = ['▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'] as const;
-
 /** Prefixes the reset countdown. Recessive tone: it is context for the number, not the signal. */
 const RESET_GLYPH = '⟳';
 
@@ -144,12 +149,6 @@ function toneFor(severity: QuotaSeverity) {
   // rather than reassuring — the same mistake the context bar's single-tone
   // wrap made before it split fill from track.
   return palette.chrome;
-}
-
-/** Utilization → one gauge cell. `0` still shows a floor cell so the field never looks empty. */
-function gaugeCell(utilization: number): string {
-  const index = Math.min(GAUGE_CELLS.length - 1, Math.max(0, Math.floor(utilization * GAUGE_CELLS.length)));
-  return GAUGE_CELLS[index] ?? '█';
 }
 
 /**
@@ -232,7 +231,7 @@ export function formatQuotaIndicator(windows: QuotaWindows, now: Date = new Date
   const rendered = collected.map((w) => {
     const tone = toneFor(w.severity);
     const percent = `${Math.round(w.state.utilization * 100)}%`;
-    let text = `${palette.meta(w.label)} ${tone(`${gaugeCell(w.state.utilization)}${percent}`)}`;
+    let text = `${palette.meta(w.label)} ${tone(percent)}`;
     if (w === binding && w.state.resetsAt !== undefined) {
       const msLeft = w.state.resetsAt.getTime() - now.getTime();
       // A non-positive countdown means the window already rolled over, so the

--- a/src/cli/status-line.test.ts
+++ b/src/cli/status-line.test.ts
@@ -728,10 +728,19 @@ describe('StatusLine with git branch + PR field', () => {
     const status = new StatusLine({ stream: stream as unknown as NodeJS.WriteStream, throttleMs: 0 });
     status.start();
     stream.writes.length = 0;
-    status.repaint({ model: 'sonnet', quota: '5h 62% · 7d 31%' });
+    status.repaint({
+      model: 'sonnet',
+      quotaWindows: {
+        fiveHour: { utilization: 0.62 },
+        sevenDay: { utilization: 0.31 },
+        observedAt: new Date(),
+      },
+    });
     const out = lastJoined(stream).replace(BROAD_ANSI_RE, '');
-    expect(out).toContain('5h 62%');
-    expect(out).toContain('7d 31%');
+    expect(out).toContain('5h');
+    expect(out).toContain('62%');
+    expect(out).toContain('7d');
+    expect(out).toContain('31%');
     status.stop();
   });
 
@@ -750,7 +759,7 @@ describe('StatusLine with git branch + PR field', () => {
     status.stop();
   });
 
-  it('drops quota BEFORE the token count, and dropping quota does not also drop tokens', () => {
+  it('drops a calm quota BEFORE the token count, and dropping it does not also drop tokens', () => {
     // Regression guard for the droppablePriority allocation. The shed loop
     // removes EVERY part sharing the current maximum priority in one pass, so if
     // quota were given tokens' priority 4 instead of its own 5, both would vanish
@@ -759,10 +768,68 @@ describe('StatusLine with git branch + PR field', () => {
     const status = new StatusLine({ stream: stream as unknown as NodeJS.WriteStream, throttleMs: 0 });
     status.start();
     stream.writes.length = 0;
-    status.repaint({ model: 'sonnet', cost: 0.05, tokens: 1200, quota: '5h 62% · 7d 31%' });
+    status.repaint({
+      model: 'sonnet',
+      cost: 0.05,
+      tokens: 1200,
+      quotaWindows: {
+        fiveHour: { utilization: 0.42 },
+        sevenDay: { utilization: 0.31 },
+        observedAt: new Date(),
+      },
+    });
     const out = lastJoined(stream).replace(BROAD_ANSI_RE, '');
-    expect(out).not.toContain('5h 62%'); // quota (priority 5) shed first
+    expect(out).not.toContain('42%'); // calm quota (priority 5) shed first
     expect(out).toContain('tok'); // tokens (priority 4) survived that step
+    status.stop();
+  });
+
+  it('keeps a CRITICAL quota on a narrow terminal, shedding tokens/cost/branch instead', () => {
+    // Severity-inverted droppability: at >80% the quota is the most consequential
+    // field on the row, so it must outlast every other droppable rather than
+    // being shed first as the calm case above is.
+    stream.columns = 40;
+    const status = new StatusLine({ stream: stream as unknown as NodeJS.WriteStream, throttleMs: 0 });
+    status.start();
+    stream.writes.length = 0;
+    status.repaint({
+      model: 'sonnet',
+      branch: 'feat/x',
+      cost: 0.05,
+      tokens: 1200,
+      quotaWindows: {
+        fiveHour: { utilization: 0.94 },
+        sevenDay: { utilization: 0.24 },
+        observedAt: new Date(),
+      },
+    });
+    const out = lastJoined(stream).replace(BROAD_ANSI_RE, '');
+    expect(out).toContain('94%'); // critical quota survives
+    expect(out).not.toContain('tok'); // tokens shed
+    expect(out).toContain('sonnet'); // model still never-drop
+    status.stop();
+  });
+
+  it('does NOT promote a STALE critical quota above the identity fields', () => {
+    // A 40-minute-old 94% may already have drained (rolling window), so it keeps
+    // the peripheral priority instead of out-ranking the branch on an old number.
+    stream.columns = 40;
+    const status = new StatusLine({ stream: stream as unknown as NodeJS.WriteStream, throttleMs: 0 });
+    status.start();
+    stream.writes.length = 0;
+    status.repaint({
+      model: 'sonnet',
+      cost: 0.05,
+      tokens: 1200,
+      quotaWindows: {
+        fiveHour: { utilization: 0.94 },
+        sevenDay: { utilization: 0.24 },
+        observedAt: new Date(Date.now() - 40 * 60 * 1000),
+      },
+    });
+    const out = lastJoined(stream).replace(BROAD_ANSI_RE, '');
+    expect(out).not.toContain('94%'); // stale critical shed first, like a calm one
+    expect(out).toContain('tok');
     status.stop();
   });
 

--- a/src/cli/status-line.ts
+++ b/src/cli/status-line.ts
@@ -18,6 +18,7 @@ import { truncateDisplayWidth, displayWidth } from './display.js';
 import { palette } from './palette.js';
 import { ResizeBus } from './terminal-size.js';
 import { formatContextBar } from './context-bar.js';
+import { formatQuotaIndicator, type QuotaWindows } from './quota-indicator.js';
 import { formatCwd } from './format-cwd.js';
 import { isPlainOutputRequested } from '../config/env.js';
 
@@ -58,14 +59,18 @@ export interface StatusLineFields {
    */
   pr?: number;
   /**
-   * Pre-formatted Claude subscription quota summary (e.g. `5h 62% · 7d 31%`),
-   * or undefined when no quota headers have been observed in this process —
-   * which is the PERMANENT state under API-key auth, since only subscription
-   * OAuth responses carry `anthropic-ratelimit-unified-*`. Undefined must draw
-   * no segment at all rather than a placeholder. Rendered rightmost and dropped
-   * first on a narrow terminal: the most peripheral field on the line.
+   * Claude subscription quota windows (5h / 7d rolling utilization + reset
+   * deadlines), or undefined when no quota headers have been observed in this
+   * process — which is the PERMANENT state under API-key auth, since only
+   * subscription OAuth responses carry `anthropic-ratelimit-unified-*`.
+   * Undefined must draw no segment at all rather than a placeholder.
+   *
+   * Passed RAW (not pre-formatted) so the line can grade the segment's tone AND
+   * its droppability from the same severity — see the render block below.
+   * Mirrors how `contextPct`/`contextLimit` are passed raw for
+   * `formatContextBar`.
    */
-  quota?: string;
+  quotaWindows?: QuotaWindows;
 }
 
 interface StatusLineOpts {
@@ -509,10 +514,25 @@ export class StatusLine {
     // Invariant: every droppablePriority on this line must be UNIQUE. The shed
     // loop below drops EVERY part sharing the current maximum priority in one
     // pass, so reusing the token count's 4 here would make the quota segment and
-    // the token count vanish together instead of shedding one at a time. 5 =
-    // drop 1st, ahead of tokens — quota is the most peripheral field here.
-    if (f.quota !== undefined) {
-      parts.push({ text: palette.chrome(f.quota), droppablePriority: 5 }); // drop 1st
+    // the token count vanish together instead of shedding one at a time.
+    //
+    // Contract: quota droppability is SEVERITY-INVERTED. At calm/caution it is 5
+    // — drop 1st, ahead of tokens, the most peripheral field on the line. At
+    // `critical` (>80% of a rolling window) it becomes 0 — drop LAST, behind even
+    // the branch — because the one moment the quota is the most important field
+    // on the row is exactly the moment a narrow terminal used to shed it first.
+    // Promotion requires a FRESH reading: a stale critical (see STALE_AFTER_MS)
+    // may have already drained, so it keeps the peripheral priority rather than
+    // out-ranking identity fields on the strength of an old number. Still never
+    // `undefined` (never-drop) — the top-of-method invariant reserves that for
+    // model/mode, and stacking another never-drop field would force the final
+    // blind truncation to shear the model off the right edge.
+    if (f.quotaWindows !== undefined) {
+      const quota = formatQuotaIndicator(f.quotaWindows);
+      if (quota !== undefined) {
+        const priority = quota.severity === 'critical' && !quota.stale ? 0 : 5;
+        parts.push({ text: quota.text, droppablePriority: priority });
+      }
     }
 
     // Join with separator and measure the result.


### PR DESCRIPTION
## Summary

The subscription-usage indicator rendered `5h 94%` and `5h 24%` **identically** — flat `palette.chrome`, the same tone as the token counter — and carried `droppablePriority: 5`, so the most consequential number on the row was also the first field shed on a narrow terminal. `quota-cache.ts` had been parsing `fiveHourResetsAt` / `sevenDayResetsAt` / `observedAt` since it was written and nothing ever read them, so `94% with 12m left` and `94% with 4h left` looked the same.

Three commits, all TUI-only. No behaviour change outside rendering; no new dependency, env var, or SDK symbol.

### 1. `9d2b28d` — grade the status-line indicator by severity

New pure helper `src/cli/quota-indicator.ts` (247 LOC): per-window severity tone (mirrors `context-bar.ts`'s `>0.8` error / `>0.5` warning / else chrome so both usage readouts on the row escalate in step), a reset countdown on the binding window once it crosses caution, a `stale` flag + `~` marker so an idle session doesn't show a drained reading as live, and severity-inverted droppability — a fresh `critical` reading takes priority `0` (drop last, behind even the branch) instead of `5`, but only when fresh; a stale critical keeps the peripheral priority since the rolling window may have already drained.

`StatusLineFields.quota: string` → `quotaWindows: QuotaWindows` (raw, like `contextPct`/`contextLimit`). Severity is computed once, inside `formatQuotaIndicator` (`quota-indicator.ts`); `status-line.ts`'s render method consumes that single severity value to decide both tone (via the returned text) and droppability — `critical` + fresh → priority `0` (drop last, behind even the branch), everything else (calm, caution, or a *stale* critical) → priority `5` (drop first, same as before). So there's one decision site for droppability, fed by one severity computation upstream — not two independent severity notions to keep in sync.

### 2. `56efcd3` — warn in the turn footer past 80%

New `src/cli/quota-footer.ts` (131 LOC) adds the intrusive half beside the context-usage line it mirrors:

```
  context 91% used of 1.0M — approaching limit
  5h quota 94% used — resets in 12m
```

Deliberately different thresholds from the indicator (50%/80% tone vs. 80/95/100 footer ladder — a printed line costs attention every turn, so it stays silent until the cap is a live risk), stateless (no cross-turn tier memory), names the binding window + its countdown + that AFK pauses/auto-resumes at the cap, and is ordered after the context line (context constrains this turn, quota constrains the next hour).

### 3. `93bb75a` — drop the one-cell block gauge

The initial cut of `quota-indicator.ts` prefixed each percentage with a one-cell block gauge (`▁`..`█`), e.g. `5h ▅69% ⟳2h13m · 7d ▁9%`. One cell can't encode magnitude — the top of the ramp rendered as a solid block of color abutting the digits (terminal vocabulary for a cursor/selection, i.e. an artifact) and the bottom as an underscore stub (`▁9%` reads as `_9%`), and it restated, less precisely, the number one cell to its right. The glyph is gone; tone now lands on the digits themselves. The non-color ladder is unaffected — it was never really carried by the gauge but by the countdown (absent while calm, present from caution up) and the footer sentence past 80%. Calm now costs exactly the width of the bare-percentage form it replaced (14 cells for `5h 6% · 7d 12%`, pinned by the width-budget test). The gauge test suite is replaced, not deleted: one case asserts no block glyph ever appears across the full 0..1 range; one asserts the plain-text forms still differ across tiers under `NO_COLOR`.

### Deliberately not done

- **A 20-cell bar per window** like the context bar — the row already carries one; two more blow the width budget, and since quota sheds early, "make it stand out" would make it *disappear more often*.
- **Countdown on both windows** — +16 cells for a 7d deadline that is rarely actionable.
- **Burn-rate projection** ("cap in ~40m at this rate") — the cache keeps exactly one snapshot and overwrites it, so there's no history to project from; a naive delta over-predicts exhaustion whenever the session idles. Wants a deliberate design pass, not a rider on a rendering PR.
- **API-key auth is untouched.** The unified quota headers never arrive there, so every path returns `undefined` and no segment or footer line is drawn — asserted in both test files.

## Test results

- `pnpm lint` (`tsc --noEmit`, strict): **passed**, exit 0.
- `pnpm test` (`vitest run`): **714 files passed (714)**, **13,619 tests passed**, 2 skipped (13,621 total).
- Both gates run fresh on the merge commit (`5284600`), after merging `origin/main` (through `v5.82.12`) into this branch — not re-run from a stale pre-merge state.

## Verification

Diff exceeds the 100-changed-line threshold, so an independent read-only verifier re-derived the load-bearing claims from the diff alone (not from this body's reasoning):

- **Block gauge fully removed from executable code** — CONFIRM. `quota-indicator.ts`'s only `▁`/`█` references are doc-comment prose explaining why it was removed; `formatQuotaIndicator` emits no glyph. `quota-indicator.test.ts:99-109` asserts no block-gauge glyph appears across the full `0..1` utilization range.
- **Severity-inverted droppability, one decision site** — REFINE (wording tightened above). Priority logic confirmed verbatim: `status-line.ts:533` — `quota.severity === 'critical' && !quota.stale ? 0 : 5`. The verifier's nuance: severity itself is computed inside `quota-indicator.ts`'s `formatQuotaIndicator`, and `status-line.ts` consumes that value to assign droppability — one *decision* site fed by one *computation* site, not literally one place doing both. Body text above now reflects that.
- **Footer silent below 80%, distinct ladder, ordered after context line** — CONFIRM. `quota-footer.ts:46-48` (`CAUTION_AT=0.8, NEAR_AT=0.95, OVER_AT=1.0`) vs. `quota-indicator.ts`'s `CAUTION_ABOVE=0.5/CRITICAL_ABOVE=0.8` — two distinct ladders as documented. `turn-handler.ts`: context-line `write()` (line 942) textually precedes the quota-line `write()` (line 957).
- No `CONTRADICT` verdicts.
- Test-count claim (714 files / 13,619 passed / 2 skipped) was **not** re-executed by the verifier (out of scope for a read-only pass) — those numbers come from this session's own direct `pnpm test` run (Test results section above), not from the verifier.

## Out of scope

This push carries 12 "hitchhiker" commits absorbed via merging `origin/main` (releases `v5.82.6`–`v5.82.12` plus unrelated `fix(...)` PRs already merged to `main` in the interim) — expected for a merge-based catch-up after the branch fell behind, not new work on this branch. The actual authored diff against `origin/main` is 11 files / +1014 / −63, scoped entirely to the quota indicator, quota footer, turn footer, and status line.
