### PR TITLE
fix(trace): split ttfb_timeout out of the rate_limit phase

### DIFF
--- a/src/agent/providers/anthropic-direct/loop.ts
+++ b/src/agent/providers/anthropic-direct/loop.ts
@@ -189,17 +189,24 @@ async function createWithRetry(
  * Emit the trace + surface events for a single time-to-first-byte-timeout
  * re-drive, then return so the caller can `continue` the round with a fresh
  * `messages.create`. Mirrors the mid-stream overload retry's signalling: a
- * `rate_limit` trace phase (so the re-drive is legible in `afk trace show`)
- * plus a `stream.retry` event so surfaces discard any partial paint. No backoff
- * sleep — the point is to fail-fast off a stalled endpoint, and the single
- * retry is gated by the per-round `ttfbRetried` flag so it cannot stack.
+ * dedicated `ttfb_timeout` trace phase (so the re-drive is legible in
+ * `afk trace show`) plus a `stream.retry` event so surfaces discard any partial
+ * paint. No backoff sleep — the point is to fail-fast off a stalled endpoint,
+ * and the single retry is gated by the per-round `ttfbRetried` flag so it
+ * cannot stack.
+ *
+ * The phase is NOT `rate_limit`: this timer is ours, fires with no server
+ * throttle and no retry-after, and the two are otherwise indistinguishable in a
+ * trace — which made every self-inflicted 180s stall read as provider
+ * throttling. `metadata.reason` stays `'ttfb-timeout'` so analyses written
+ * against the pre-split shape keep matching.
  */
 async function* emitTtfbRetry(
   input: RunTurnInput,
   requestStartedAt: number,
 ): AsyncGenerator<ProviderEvent, void, void> {
   void emitSessionPhase(input.traceWriter, {
-    phase: 'rate_limit',
+    phase: 'ttfb_timeout',
     durationMs: Date.now() - requestStartedAt,
     metadata: { reason: 'ttfb-timeout', source: 'first-byte', resolvedModel: input.model },
   });

--- a/src/agent/providers/anthropic-direct/loop.ttfb.test.ts
+++ b/src/agent/providers/anthropic-direct/loop.ttfb.test.ts
@@ -259,4 +259,53 @@ describe('runTurn TTFB stall timeout (#583)', () => {
     expect(events.find((e) => e.type === 'turn.completed')).toBeDefined();
     expect(events.filter((e) => e.type === 'stream.retry')).toHaveLength(0);
   });
+  // A TTFB re-drive must be legible in the trace as ITS OWN phase. Before the
+  // split it emitted `rate_limit`, making a self-inflicted 180s stall
+  // indistinguishable from provider throttling (the same phase the SDK's real
+  // 429/503 backoff uses) — 5 such stalls in one pre-flight were misread that
+  // way. `metadata.reason` stays 'ttfb-timeout' for pre-split analyses.
+  it('emits a ttfb_timeout session_phase — not rate_limit — on the re-drive', async () => {
+    process.env[KEY] = '180000';
+    const { InMemoryTraceWriter } = await import('../../trace/writer.js');
+    const writer = new InMemoryTraceWriter();
+    let callCount = 0;
+    const client: AnthropicClientLike = {
+      messages: {
+        create: vi.fn((_params: unknown, opts: unknown) => {
+          callCount++;
+          const signal = (opts as { signal: AbortSignal }).signal;
+          return callCount === 1
+            ? postHeaderStallStream(signal)
+            : fromArray(makeTextStream('recovered'));
+        }),
+      },
+    };
+    const resultPromise = collect(
+      runTurn({
+        client, messages: [{ role: 'user', content: 'hi' }], system: null, tools: null,
+        toolDispatcher: makeDispatcher(() => Promise.resolve({ content: 'ok' })),
+        model: 'claude-test', maxTokens: 1024, headers: {},
+        signal: new AbortController().signal, ctx, traceWriter: writer,
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(DEFAULT_MODEL_TTFB_TIMEOUT_MS + 1_000);
+    await resultPromise;
+
+    const phases = writer.events.filter((e) => e.kind === 'session_phase');
+    const ttfbStalls = phases.filter(
+      (e) => (e.payload as { phase: string }).phase === 'ttfb_timeout',
+    );
+    expect(ttfbStalls).toHaveLength(1);
+    const payload = ttfbStalls[0]!.payload as {
+      durationMs?: number;
+      metadata?: Record<string, unknown>;
+    };
+    // The dead wait is recorded, and the legacy reason tag is preserved.
+    expect(payload.durationMs).toBeGreaterThanOrEqual(DEFAULT_MODEL_TTFB_TIMEOUT_MS);
+    expect(payload.metadata?.['reason']).toBe('ttfb-timeout');
+    // The conflated phase is gone: no rate_limit was emitted for OUR watchdog.
+    expect(
+      phases.filter((e) => (e.payload as { phase: string }).phase === 'rate_limit'),
+    ).toHaveLength(0);
+  });
 });

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -408,6 +408,9 @@ export const SessionPhaseNameSchema = z.enum([
   // JSDoc in types.ts — carries the ESC→terminal wall-clock in durationMs.
   'interrupt_halt',
   'rate_limit',
+  // Client-side TTFB watchdog re-drive — distinct from `rate_limit` (no server
+  // throttle, no retry-after). See SessionPhaseName JSDoc in types.ts.
+  'ttfb_timeout',
   'usage_limit_pause',
   'usage_limit_resume',
   'idle_watchdog_fired',

--- a/src/agent/trace/session-phase.test.ts
+++ b/src/agent/trace/session-phase.test.ts
@@ -257,6 +257,7 @@ describe('SessionPhaseName union ↔ SessionPhaseNameSchema parity', () => {
     model_ttfb: true,
     interrupt_halt: true,
     rate_limit: true,
+    ttfb_timeout: true,
     usage_limit_pause: true,
     usage_limit_resume: true,
     idle_watchdog_fired: true,

--- a/src/agent/trace/types.ts
+++ b/src/agent/trace/types.ts
@@ -687,6 +687,15 @@ export type SessionPhaseName =
   // turns and on a session `close()` (only a user/turn interrupt qualifies).
   | 'interrupt_halt'
   | 'rate_limit'
+  // Client-side time-to-first-byte watchdog re-drive: OUR timer fired because no
+  // content token arrived within `AFK_MODEL_TTFB_TIMEOUT_MS` (default 180s), so
+  // the request was aborted and re-driven once. Deliberately NOT `rate_limit`:
+  // nothing throttled us and there is no server retry-after — conflating the two
+  // made a self-inflicted 3-minute stall read as provider throttling in every
+  // trace (5 such stalls in one `/ground-state` pre-flight were misattributed
+  // this way). `durationMs` is the dead wait before the abort; metadata keeps
+  // `reason: 'ttfb-timeout'` so pre-split analyses still match.
+  | 'ttfb_timeout'
   // OAuth subscription usage-limit park/unpark. Unlike `rate_limit` (a short,
   // bounded retry-after backoff), these bracket a potentially multi-HOUR pause
   // while the turn waits for the subscription window to reset (or a keychain

--- a/src/cli/commands/trace.ts
+++ b/src/cli/commands/trace.ts
@@ -457,6 +457,18 @@ function renderEvent(event: TraceEvent, ctx: RenderContext): string | null {
         const head = reason !== undefined ? String(reason) : 'throttled';
         return line('throttle', `${head}${statusBit}${wait}${srcBit}`);
       }
+      // `ttfb_timeout` is HIGH-signal for the same reason as `rate_limit` — it
+      // explains a multi-minute gap — but it is OUR watchdog, not a throttle:
+      // `durationMs` is dead wait we chose to spend, not a server retry-after.
+      // Rendered in the DEFAULT view with its own label so the two stop being
+      // read as one thing.
+      if (p.phase === 'ttfb_timeout') {
+        const src = p.metadata?.['source'];
+        const srcBit = src !== undefined ? `  (${String(src)})` : '';
+        const waited =
+          p.durationMs !== undefined ? ` after ${fmtDuration(p.durationMs)}` : '';
+        return line('ttfb-stall', `no first token${waited} — request re-driven once${srcBit}`);
+      }
       // Usage-limit park/unpark is the highest-signal stall of all — a
       // multi-hour subscription pause, not a per-minute backoff. Render in the
       // DEFAULT view (before the showAll gate) so the trace explains the gap.
@@ -525,6 +537,8 @@ interface TraceSummary {
   blocks: number;
   /** Count of rate_limit events (429/503/529 backoff). */
   throttles: number;
+  /** Count of ttfb_timeout events (our client-side watchdog re-drove a stalled request). */
+  ttfbStalls: number;
   sealStatus: string | null;
   finalCostUsd: number | null;
   /** Operator-typed model for the root session (from session_init_start). */
@@ -540,6 +554,7 @@ function summarize(events: TraceEvent[]): TraceSummary {
   let claims = 0;
   let blocks = 0;
   let throttles = 0;
+  let ttfbStalls = 0;
   let sealStatus: string | null = null;
   let finalCostUsd: number | null = null;
   let model: string | null = null;
@@ -555,6 +570,7 @@ function summarize(events: TraceEvent[]): TraceSummary {
         break;
       case 'session_phase':
         if (e.payload.phase === 'rate_limit') throttles++;
+        if (e.payload.phase === 'ttfb_timeout') ttfbStalls++;
         // Root-session model provenance lives on session_init_start (the
         // earliest, always-emitted phase). First occurrence wins.
         if (e.payload.phase === 'session_init_start') {
@@ -593,6 +609,7 @@ function summarize(events: TraceEvent[]): TraceSummary {
     claims,
     blocks,
     throttles,
+    ttfbStalls,
     sealStatus,
     finalCostUsd,
     model,
@@ -637,6 +654,9 @@ export function formatTrace(
       : 'unsealed (live or crashed)';
   const costPart = summary.finalCostUsd !== null ? ` · ${fmtUsd(summary.finalCostUsd)}` : '';
   const throttlePart = summary.throttles > 0 ? ` · ${summary.throttles} throttled` : '';
+  // Surfaced separately from `throttled`: a ttfb stall is dead wall-clock our own
+  // watchdog spent, and folding it into the throttle count is what hid it.
+  const ttfbPart = summary.ttfbStalls > 0 ? ` · ${summary.ttfbStalls} ttfb-stall` : '';
 
   const out: string[] = [];
   out.push(`Trace  ${sessionId}`);
@@ -651,7 +671,7 @@ export function formatTrace(
   out.push(
     `       ${status} · ${summary.total} events · ${summary.toolCalls} tool calls` +
       ` (${summary.toolErrors} err) · ${summary.subagents} subagents · ${summary.claims} claims` +
-      ` · ${summary.blocks} blocks${throttlePart}${costPart}`,
+      ` · ${summary.blocks} blocks${throttlePart}${ttfbPart}${costPart}`,
   );
   out.push('');
 


### PR DESCRIPTION
## What

A client-side time-to-first-byte re-drive emitted `phase: 'rate_limit'` — **the same trace phase the SDK's real 429/503/529 backoff uses** — so a self-inflicted 180s stall was indistinguishable from provider throttling in every trace.

## Why it matters (measured)

While auditing #737 I reconstructed the `/ground-state` pre-flight it cites (witness `acfd09ab…`). The watchdog fired **5× at ~180,000 ms each** (seq 26, 965, 2081, 2237, 2248). In the worst *post*-#737 pre-flight (20.85 min, `07264e5c…`) **≥5.1 min went to this watchdog with zero duplicated work**.

All of it read as rate limiting. That is why the pre-flight's dominant cost went unattributed while #737 optimised a duplicate dispatch worth 49.4% of the older incident — the trace was actively pointing at the wrong culprit.

## Changes

| File | Change |
|---|---|
| `agent/trace/types.ts` | new `ttfb_timeout` member on the `SessionPhaseName` union, documenting why it is not `rate_limit` |
| `agent/trace/events.ts` | same member on `SessionPhaseNameSchema` (the Zod↔union parity test enforces both sides) |
| `providers/anthropic-direct/loop.ts` | `emitTtfbRetry` emits `ttfb_timeout`; `metadata.reason` stays `'ttfb-timeout'` so pre-split analyses keep matching |
| `cli/commands/trace.ts` | rendered in the DEFAULT view under its own `ttfb-stall` label (dead wait we chose to spend, not a server retry-after) and counted separately from `throttled` in the summary header |

The existing `rate_limit` emissions for genuine throttles (`loop.ts:675,707`, `tracing-fetch.ts`, `retry-layer.ts`, `openai-compatible/query/stream-drive.ts`) are untouched.

## Deliberately NOT changed

`DEFAULT_MODEL_TTFB_TIMEOUT_MS = 180_000`. It is documented as **~2× the measured p99 TTFB (≈85s)** per #583, and lowering it trades dead waits for spurious retries on large-context prefills (the module doc explicitly warns an opus_1m prefill can exceed the bound). With the phase now distinct the cost is measurable per-session, so the default can be retuned from data rather than intuition.

## Verification

- `pnpm lint` (tsc --noEmit, strict) clean
- `pnpm test` — **711 files, 13388→13514 passed, 14 skipped**
- `pnpm build`, `pnpm audit:sdk:check`, `pnpm audit:env:check`, `pnpm scan:env:check` all clean
- New behavioural test pins the emitted phase **and** the absence of a `rate_limit` on the re-drive, plus `durationMs ≥ bound` and the preserved `reason` tag
- The Zod↔union parity test caught the missing union key mid-change — working as designed