### PR TITLE
fix(skills): preserve a failed skill fork's partial output

### DIFF
--- a/src/agent/tools/skill-executor/fork-dispatch.ts
+++ b/src/agent/tools/skill-executor/fork-dispatch.ts
@@ -14,7 +14,6 @@
 
 import { SubagentManager } from '../../subagent.js';
 import { resolveChildManagerReadRoots } from '../../subagent-read-scope.js';
-import { annotateIfIncomplete, incompleteToolResultFields } from '../../subagent/result.js';
 import { appendInjectContext } from '../subagent/inject-context.js';
 import type { ToolCall, ToolResult } from '../types.js';
 import type { AgentConfig } from '../../types/config-types.js';
@@ -25,6 +24,7 @@ import { getCurrentSink } from '../../_lib/skill-sink-channel.js';
 import { loadSkillPrompts } from '../../../skills/_lib/prompt-loader.js';
 import { debugLog } from '../../../utils/debug.js';
 import { buildForkedChildConfig } from './fork-child-config.js';
+import { renderForkOutcome } from './fork-result.js';
 import { substituteSkillArgs } from './load-mode.js';
 import type { SkillExecutorInternals } from './types.js';
 
@@ -358,47 +358,10 @@ export async function runForkedSkillToResult(
     const result = await handle.runToResult(userMessage);
 
     // Assign (don't return) so the finally can append the in-turn
-    // SubagentStop injectContext after teardown.
-    if (result.status === 'succeeded' && result.message) {
-      // A `succeeded` result can still be an incomplete partial (capped or
-      // stream-truncated). annotateIfIncomplete prepends a parent-visible
-      // marker in that case and is a no-op for clean completions.
-      // incompleteToolResultFields adds the structured counterpart to that
-      // banner, alongside it, for non-model consumers.
-      toolResult = {
-        content: annotateIfIncomplete(result.message.content, result.stopReason),
-        ...incompleteToolResultFields(result.stopReason),
-      };
-      return toolResult;
-    }
-
-    // Cancelled mid-flight but produced text: surface the partial output with
-    // a clear marker rather than discarding it. incompleteToolResultFields
-    // adds the structured incomplete/incompleteReason counterpart for
-    // non-model consumers (no-op when stopReason is absent or clean).
-    if (
-      result.status === 'cancelled' &&
-      typeof result.partialOutput === 'string' &&
-      result.partialOutput.length > 0
-    ) {
-      const marker = '[skill cancelled mid-flight — partial output preserved below]';
-      toolResult = {
-        content: `${marker}\n\n${result.partialOutput}`,
-        ...incompleteToolResultFields(result.stopReason),
-      };
-      return toolResult;
-    }
-
-    // incompleteToolResultFields flags the ZERO-OUTPUT stream_incomplete case
-    // (see `subagent/result.ts`) that resolves `status:'failed'` and routes
-    // through this literal — no-op for any other failure or an absent
-    // stopReason.
-    const errorMessage = result.error?.message ?? noOutputError;
-    toolResult = {
-      content: errorMessage,
-      isError: true,
-      ...incompleteToolResultFields(result.stopReason),
-    };
+    // SubagentStop injectContext after teardown. Outcome triage — including
+    // preserving partial output off a non-clean terminal status — lives in
+    // `fork-result.ts` as a pure function.
+    toolResult = renderForkOutcome(result, noOutputError);
     return toolResult;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/src/agent/tools/skill-executor/fork-result.test.ts
+++ b/src/agent/tools/skill-executor/fork-result.test.ts
@@ -1,0 +1,156 @@
+// Outcome triage for a forked skill (`SubagentResult` → `ToolResult`).
+//
+// The load-bearing case is the FAILED-with-partial-output branch: an own-budget
+// wall-clock timeout and an idle-watchdog abort both resolve `status: 'failed'`
+// (NOT 'cancelled'), so before this branch existed a fork killed by its own
+// budget returned a bare "Operation timed out after Nms" and silently discarded
+// every finding it had already streamed. That discard is what made bounding a
+// skill fork's runtime unsafe.
+
+import { describe, it, expect } from 'vitest';
+import type { Message } from '@anthropic-ai/sdk/resources';
+import {
+  renderForkOutcome,
+  failedPartialMarker,
+  CANCELLED_PARTIAL_MARKER,
+} from './fork-result.js';
+import { STREAM_INCOMPLETE, type SubagentResult } from '../../subagent/result.js';
+
+const NO_OUTPUT = 'Forked skill failed with no output';
+
+function makeResult(over: Partial<SubagentResult>): SubagentResult {
+  return { id: 'sub_1', status: 'failed', ...over } as SubagentResult;
+}
+
+/** Minimal succeeded message carrying `content` (the only field read here). */
+function messageWith(content: string): Message {
+  return { content } as unknown as Message;
+}
+
+describe('renderForkOutcome — succeeded', () => {
+  it('returns the child content verbatim on a clean completion', () => {
+    const out = renderForkOutcome(
+      makeResult({ status: 'succeeded', message: messageWith('grounding brief') }),
+      NO_OUTPUT,
+    );
+    expect(out.content).toBe('grounding brief');
+    expect(out.isError).toBeUndefined();
+    expect(out.incomplete).toBeUndefined();
+  });
+
+  it('annotates + flags a succeeded-but-incomplete partial', () => {
+    const out = renderForkOutcome(
+      makeResult({
+        status: 'succeeded',
+        message: messageWith('half a brief'),
+        stopReason: STREAM_INCOMPLETE,
+      }),
+      NO_OUTPUT,
+    );
+    expect(out.content).toContain('half a brief');
+    expect(out.content).not.toBe('half a brief'); // banner prepended
+    expect(out.incomplete).toBe(true);
+    expect(out.incompleteReason).toBe(STREAM_INCOMPLETE);
+  });
+});
+
+describe('renderForkOutcome — cancelled', () => {
+  it('preserves partial output behind the cancelled marker, not as an error', () => {
+    const out = renderForkOutcome(
+      makeResult({ status: 'cancelled', partialOutput: 'found 3 dirty files' }),
+      NO_OUTPUT,
+    );
+    expect(out.content).toBe(`${CANCELLED_PARTIAL_MARKER}\n\nfound 3 dirty files`);
+    // A user interrupt is not a skill error — isError must stay unset.
+    expect(out.isError).toBeUndefined();
+  });
+
+  it('falls through to the error path when cancellation produced nothing', () => {
+    const out = renderForkOutcome(
+      makeResult({ status: 'cancelled', error: new Error('aborted by user') }),
+      NO_OUTPUT,
+    );
+    expect(out.content).toBe('aborted by user');
+    expect(out.isError).toBe(true);
+  });
+});
+
+describe('renderForkOutcome — failed (the R2a fix)', () => {
+  it('preserves partial output on an own-budget timeout instead of discarding it', () => {
+    const timeout = new Error('Operation timed out after 480000ms (skill-fork-ground-state)');
+    const out = renderForkOutcome(
+      makeResult({
+        status: 'failed',
+        error: timeout,
+        partialOutput: 'branch: main @ b673c60, 3 dirty files, upstream in sync',
+      }),
+      NO_OUTPUT,
+    );
+    // The findings survive...
+    expect(out.content).toContain('branch: main @ b673c60, 3 dirty files, upstream in sync');
+    // ...behind a marker that names the failure, so they cannot read as complete...
+    expect(out.content.startsWith(failedPartialMarker(timeout.message))).toBe(true);
+    expect(out.content).toContain('Operation timed out after 480000ms');
+    // ...and the call is still unambiguously a failure.
+    expect(out.isError).toBe(true);
+  });
+
+  it('preserves partial output on an idle-watchdog abort (same failed status)', () => {
+    const out = renderForkOutcome(
+      makeResult({
+        status: 'failed',
+        error: new Error('Subagent idle for 480000ms with no output'),
+        partialOutput: 'partial findings',
+      }),
+      NO_OUTPUT,
+    );
+    expect(out.content).toContain('partial findings');
+    expect(out.isError).toBe(true);
+  });
+
+  it('still returns a bare error when the fork produced no text', () => {
+    const out = renderForkOutcome(
+      makeResult({ status: 'failed', error: new Error('boom') }),
+      NO_OUTPUT,
+    );
+    expect(out.content).toBe('boom');
+    expect(out.isError).toBe(true);
+  });
+
+  it('falls back to the caller-supplied no-output message when error is absent', () => {
+    const out = renderForkOutcome(makeResult({ status: 'failed' }), NO_OUTPUT);
+    expect(out.content).toBe(NO_OUTPUT);
+    expect(out.isError).toBe(true);
+  });
+
+  it('ignores an empty-string partial rather than emitting a bare marker', () => {
+    const out = renderForkOutcome(
+      makeResult({ status: 'failed', error: new Error('boom'), partialOutput: '' }),
+      NO_OUTPUT,
+    );
+    expect(out.content).toBe('boom');
+  });
+
+  it('ignores a non-string partial (schema-typed success-path value)', () => {
+    const out = renderForkOutcome(
+      makeResult({ status: 'failed', error: new Error('boom'), partialOutput: { a: 1 } }),
+      NO_OUTPUT,
+    );
+    expect(out.content).toBe('boom');
+  });
+
+  it('carries the structured incomplete fields through the failed-partial branch', () => {
+    const out = renderForkOutcome(
+      makeResult({
+        status: 'failed',
+        error: new Error('stream ended early'),
+        partialOutput: 'some text',
+        stopReason: STREAM_INCOMPLETE,
+      }),
+      NO_OUTPUT,
+    );
+    expect(out.incomplete).toBe(true);
+    expect(out.incompleteReason).toBe(STREAM_INCOMPLETE);
+    expect(out.isError).toBe(true);
+  });
+});

--- a/src/agent/tools/skill-executor/fork-result.test.ts
+++ b/src/agent/tools/skill-executor/fork-result.test.ts
@@ -15,6 +15,7 @@ import {
   CANCELLED_PARTIAL_MARKER,
 } from './fork-result.js';
 import { STREAM_INCOMPLETE, type SubagentResult } from '../../subagent/result.js';
+import { MODEL_CAP_BYTES } from '../handlers/_output-cap.js';
 
 const NO_OUTPUT = 'Forked skill failed with no output';
 
@@ -106,6 +107,34 @@ describe('renderForkOutcome — failed (the R2a fix)', () => {
     );
     expect(out.content).toContain('partial findings');
     expect(out.isError).toBe(true);
+  });
+
+  it('caps oversized partial output to a marked head-and-tail view', () => {
+    const partial = `HEAD${'x'.repeat(MODEL_CAP_BYTES)}TAIL`;
+    const out = renderForkOutcome(
+      makeResult({ status: 'failed', error: new Error('timed out'), partialOutput: partial }),
+      NO_OUTPUT,
+    );
+
+    expect(out.content.startsWith(failedPartialMarker('timed out'))).toBe(true);
+    expect(out.content).toContain('bytes truncated: showing first');
+    expect(out.content).toContain('TAIL');
+    expect(Buffer.byteLength(out.content, 'utf8')).toBeLessThanOrEqual(MODEL_CAP_BYTES);
+    expect(out.truncated).toBe(true);
+    expect(out.isError).toBe(true);
+  });
+
+  it('caps oversized cancelled partial output too', () => {
+    const partial = `HEAD${'x'.repeat(MODEL_CAP_BYTES)}TAIL`;
+    const out = renderForkOutcome(
+      makeResult({ status: 'cancelled', partialOutput: partial }),
+      NO_OUTPUT,
+    );
+
+    expect(out.content.startsWith(CANCELLED_PARTIAL_MARKER)).toBe(true);
+    expect(out.content).toContain('TAIL');
+    expect(out.truncated).toBe(true);
+    expect(out.isError).toBeUndefined();
   });
 
   it('still returns a bare error when the fork produced no text', () => {

--- a/src/agent/tools/skill-executor/fork-result.ts
+++ b/src/agent/tools/skill-executor/fork-result.ts
@@ -24,6 +24,7 @@
 
 import { annotateIfIncomplete, incompleteToolResultFields } from '../../subagent/result.js';
 import type { SubagentResult } from '../../subagent/result.js';
+import { capForModel } from '../handlers/_output-cap.js';
 import type { ToolResult } from '../types.js';
 
 /** Marker prefix for output preserved off a user/parent cancellation. */
@@ -39,6 +40,15 @@ export function failedPartialMarker(errorMessage: string): string {
 function usablePartial(result: SubagentResult): string | undefined {
   const partial = result.partialOutput;
   return typeof partial === 'string' && partial.length > 0 ? partial : undefined;
+}
+
+/** Preserve partial text without allowing a failed fork to flood the parent context. */
+function renderPartial(marker: string, partial: string): Pick<ToolResult, 'content' | 'truncated'> {
+  const capped = capForModel(`${marker}\n\n${partial}`);
+  return {
+    content: capped.content,
+    ...(capped.truncated ? { truncated: true } : {}),
+  };
 }
 
 /**
@@ -73,7 +83,7 @@ export function renderForkOutcome(result: SubagentResult, noOutputError: string)
 
   if (result.status === 'cancelled' && partial !== undefined) {
     return {
-      content: `${CANCELLED_PARTIAL_MARKER}\n\n${partial}`,
+      ...renderPartial(CANCELLED_PARTIAL_MARKER, partial),
       ...incompleteToolResultFields(result.stopReason),
     };
   }
@@ -82,7 +92,7 @@ export function renderForkOutcome(result: SubagentResult, noOutputError: string)
 
   if (partial !== undefined) {
     return {
-      content: `${failedPartialMarker(errorMessage)}\n\n${partial}`,
+      ...renderPartial(failedPartialMarker(errorMessage), partial),
       isError: true,
       ...incompleteToolResultFields(result.stopReason),
     };

--- a/src/agent/tools/skill-executor/fork-result.ts
+++ b/src/agent/tools/skill-executor/fork-result.ts
@@ -1,0 +1,96 @@
+/**
+ * Outcome rendering for a forked skill: `SubagentResult` → `ToolResult`.
+ *
+ * Extracted from `fork-dispatch.ts`'s `runForkedSkillToResult` so the triage is
+ * a pure function with no fork, teardown, or credential wiring around it —
+ * every branch is directly unit-testable, and the dispatch driver keeps one job
+ * (fork → run → teardown) instead of also owning presentation.
+ *
+ * Contract: the returned `ToolResult` is what the MODEL sees for a `skill` call.
+ * Three outcomes, in priority order:
+ *   1. `succeeded` with a message → the child's content, annotated when the
+ *      result is itself an incomplete partial (turn cap / stream truncation).
+ *   2. produced text but did not finish cleanly → the text, behind a marker
+ *      naming why it is partial. Covers BOTH `cancelled` (user interrupt) and
+ *      `failed` (own-budget timeout, idle-watchdog abort) — see the invariant
+ *      on {@link renderForkOutcome}.
+ *   3. no usable text → the error message, `isError: true`.
+ * `incompleteToolResultFields` rides along on every branch so non-model
+ * consumers get the structured `incomplete`/`incompleteReason` counterpart to
+ * whatever banner the model sees (no-op for a clean stopReason).
+ *
+ * @module agent/tools/skill-executor/fork-result
+ */
+
+import { annotateIfIncomplete, incompleteToolResultFields } from '../../subagent/result.js';
+import type { SubagentResult } from '../../subagent/result.js';
+import type { ToolResult } from '../types.js';
+
+/** Marker prefix for output preserved off a user/parent cancellation. */
+export const CANCELLED_PARTIAL_MARKER =
+  '[skill cancelled mid-flight — partial output preserved below]';
+
+/** Build the marker for output preserved off a failure, naming the failure. */
+export function failedPartialMarker(errorMessage: string): string {
+  return `[skill failed: ${errorMessage} — partial output preserved below]`;
+}
+
+/** Non-empty streamed text from a fork that did not complete, or `undefined`. */
+function usablePartial(result: SubagentResult): string | undefined {
+  const partial = result.partialOutput;
+  return typeof partial === 'string' && partial.length > 0 ? partial : undefined;
+}
+
+/**
+ * Render a finished fork's result into the tool result the model receives.
+ *
+ * Invariant: a fork that produced text must never return that text-free. The
+ * runtime attaches whatever content the child streamed before it died
+ * (`subagent/handle.ts`), and BOTH non-clean terminal statuses can carry it:
+ * `cancelled` for a user/parent interrupt, and `failed` for an own-budget
+ * wall-clock timeout or an idle-watchdog abort. Rendering only the `cancelled`
+ * case — the behaviour before this function existed — meant a fork killed by
+ * its own budget returned a bare "Operation timed out after Nms" with every
+ * finding discarded, which is precisely what makes bounding a skill fork's
+ * runtime unsafe. `isError` stays `true` on the failed path (the skill DID
+ * fail) and the marker names the failure, so preserved output can never be
+ * misread as a complete result. The `agent` tool already surfaces partial
+ * output on failure via `tools/subagent/failure-payload.ts`; this brings the
+ * skill-fork path into line with it.
+ *
+ * @param result          terminal result from `handle.runToResult`
+ * @param noOutputError   fallback message when the child carried no error
+ */
+export function renderForkOutcome(result: SubagentResult, noOutputError: string): ToolResult {
+  if (result.status === 'succeeded' && result.message) {
+    return {
+      content: annotateIfIncomplete(result.message.content, result.stopReason),
+      ...incompleteToolResultFields(result.stopReason),
+    };
+  }
+
+  const partial = usablePartial(result);
+
+  if (result.status === 'cancelled' && partial !== undefined) {
+    return {
+      content: `${CANCELLED_PARTIAL_MARKER}\n\n${partial}`,
+      ...incompleteToolResultFields(result.stopReason),
+    };
+  }
+
+  const errorMessage = result.error?.message ?? noOutputError;
+
+  if (partial !== undefined) {
+    return {
+      content: `${failedPartialMarker(errorMessage)}\n\n${partial}`,
+      isError: true,
+      ...incompleteToolResultFields(result.stopReason),
+    };
+  }
+
+  return {
+    content: errorMessage,
+    isError: true,
+    ...incompleteToolResultFields(result.stopReason),
+  };
+}


### PR DESCRIPTION
## What

A forked skill that died on **its own budget** returned a bare error string to the model and silently discarded every finding it had already streamed.

The work was not lost by the runtime — it was dropped at the presentation boundary. `runToResult` attaches whatever content text the child emitted before it died (`subagent/handle.ts:588-590`), but `runForkedSkillToResult` read `result.partialOutput` **only** in the `status === 'cancelled'` branch. A wall-clock timeout and an idle-watchdog abort both resolve `status: 'failed'` (`IdleWatchdogError extends TimeoutError`, `subagent/idle-watchdog.ts:43-45`), so both fell through to `content: result.error?.message, isError: true`.

Net effect: the model saw `Operation timed out after 480000ms (skill-fork-ground-state)` and nothing else.

## Why it matters

This is the blocker for bounding pre-flight cost. `/ground-state` currently runs **7.6–20.9 min (median 11.6)** and the obvious fix is a tight per-skill `timeoutMs` (`AgentConfig.timeoutMs` already exists and is already honoured at the fork site, `subagent.ts:1023`). That fix is **unsafe while a budget expiry destroys the findings**, because it converts a slow pre-flight into a *failed* one — strictly worse. This PR is the prerequisite that makes budgeting safe; the budget itself is deliberately not in this PR.

The `agent` tool already surfaces partial output on failure via `tools/subagent/failure-payload.ts` (`buildFailurePayload`). The skill-fork path now matches it.

## Changes

| File | Change |
|---|---|
| `skill-executor/fork-result.ts` | **new** — outcome triage as a pure function `renderForkOutcome(result, noOutputError)`; failed-with-partial returns the text behind a marker that names the failure, with `isError` still `true` so it can never be misread as a complete result |
| `skill-executor/fork-dispatch.ts` | triage moved out; driver keeps one job (fork → run → teardown). **443 → 384 LOC** |
| `skill-executor/fork-result.test.ts` | **new** — 11 tests |

Extracted rather than adding a fourth branch to a 443-line dispatch driver: the triage is a pure `SubagentResult → ToolResult` mapping with no fork/teardown/credential wiring around it, so every branch is now unit-testable without forking a subagent. The moved branches are verbatim; the only behavioural delta is the new failed-with-partial case.

## Behaviour matrix

| result | before | after |
|---|---|---|
| `succeeded` | content (annotated if incomplete) | unchanged |
| `cancelled` + text | marker + text, not an error | unchanged |
| **`failed` + text** (timeout / idle abort) | **error message only — text discarded** | **marker naming the failure + text, `isError: true`** |
| `failed`, no text | error message, `isError: true` | unchanged |

Tests also pin the empty-string partial and the non-string (schema-typed `T`) partial, both of which must fall through to the bare-error path, and that `incomplete`/`incompleteReason` still ride along on the new branch.

## Verification

- `pnpm lint` (tsc --noEmit, strict) clean
- `pnpm test` — **712 files, 13525 passed, 14 skipped**
- `pnpm build`, `pnpm audit:sdk:check`, `pnpm audit:env:check`, `pnpm scan:env:check` all clean
- Independent of #766 (zero file overlap); either can merge first