### PR TITLE
fix(bash): classify `git worktree add` and `git clone` as mutating in the read-only guard

### DIFF
--- a/src/agent/tools/readonly-bash.test.ts
+++ b/src/agent/tools/readonly-bash.test.ts
@@ -7,6 +7,8 @@ describe('classifyBashCommand', () => {
       ['git commit -m x', 'git commit'],
       ['git push', 'git push'],
       ['git checkout -b f', 'git checkout'],
+      ['git clone https://example.com/x /tmp/z', 'git clone'],
+      ['git init /tmp/newrepo', 'git init'],
       ['rm -rf x', 'rm -rf'],
       ['mv a b', 'mv'],
       ['echo x > file.txt', 'redirection to file'],
@@ -521,10 +523,13 @@ describe('classifyBashCommand', () => {
   describe('git worktree mutations are blocked', () => {
     const blocked: Array<[string, string]> = [
       ['git worktree remove .afk-worktrees/old', 'git worktree remove'],
+      ['git worktree remove /tmp/x', 'git worktree remove (absolute path)'],
       ['git worktree prune', 'git worktree prune'],
       ['git worktree move .afk-worktrees/a .afk-worktrees/b', 'git worktree move'],
       ['git worktree lock .afk-worktrees/x', 'git worktree lock'],
       ['git worktree unlock .afk-worktrees/x', 'git worktree unlock'],
+      ['git worktree add -b foo /tmp/x HEAD', 'git worktree add'],
+      ['git -C /some/other/repo worktree add -b foo /tmp/y HEAD', 'git -C <dir> then git worktree add'],
     ];
     for (const [cmd, label] of blocked) {
       it(`blocks: ${label} (${cmd})`, () => {

--- a/src/agent/tools/readonly-bash.ts
+++ b/src/agent/tools/readonly-bash.ts
@@ -559,7 +559,7 @@ const GIT_GLOBAL_FLAG_WITH_ARG = new Set([
 ]);
 const GIT_MUTATING_SUBCMDS = new Set([
   'commit', 'push', 'pull', 'merge', 'rebase', 'reset', 'checkout', 'switch', 'restore',
-  'cherry-pick', 'revert', 'am', 'apply', 'clean', 'add', 'rm', 'mv', 'init',
+  'cherry-pick', 'revert', 'am', 'apply', 'clean', 'add', 'rm', 'mv', 'init', 'clone',
 ]);
 
 /** Split git argv (tokens after `git`) into the subcommand + its trailing args, skipping global flags. */
@@ -600,8 +600,8 @@ function gitSegmentReason(argv: readonly string[]): string | null {
     case 'remote':
       return ['add', 'remove', 'rm', 'set-url', 'rename'].includes(next) ? 'git remote mutation' : null;
     case 'worktree':
-      return ['remove', 'prune', 'move', 'lock', 'unlock'].includes(next)
-        ? 'git worktree mutation (remove/prune/move)'
+      return ['add', 'remove', 'prune', 'move', 'lock', 'unlock'].includes(next)
+        ? 'git worktree mutation (add/remove/prune/move)'
         : null;
     case 'stash':
       // `stash list`/`stash show` read; bare `stash` (implicit push) + push/drop/


### PR DESCRIPTION
## What

`classifyBashCommand` treated two git forms as read-only even though both write to disk:

- **`git worktree add`** — the `worktree` arm matched only `remove`/`prune`/`move`/`lock`/`unlock`; `add` was never in the list in any revision of the file.
- **`git clone`** — the verb appeared nowhere in the classifier, so it fell through the read-only `default`.

Both now classify as mutating.

## Change

- Add `'add'` to the `worktree` subcommand list in `gitSegmentReason()` and widen the reason string to match.
- Add `'clone'` to `GIT_MUTATING_SUBCMDS`.

`git worktree list` stays read-only — that behaviour is deliberate and is still pinned by an existing test.

## Tests

`readonly-bash.test.ts` had no cases at all for `worktree add`, `clone`, or `init`. Added:

- `git worktree add -b foo /tmp/x HEAD` → blocked
- `git -C /some/other/repo worktree add -b foo /tmp/y HEAD` → blocked (a `-C` global flag must not defeat classification)
- `git clone https://example.com/x /tmp/z` → mutating
- `git init /tmp/newrepo` → mutating (regression pin; already passing)
- `git worktree remove /tmp/x` → blocked (absolute-path form)

## Verification

- `pnpm test src/agent/tools/readonly-bash.test.ts` → 275 passed
- `pnpm lint` (`tsc --noEmit`) clean
