### PR TITLE
fix(worktree): resolve the default create base at the calling session's anchor (#760)

### DIFF
--- a/src/agent/tools/handlers/worktree-managed.test.ts
+++ b/src/agent/tools/handlers/worktree-managed.test.ts
@@ -124,7 +124,7 @@ describe('removeManagedWorktreeGuarded — guards + argv', () => {
 });
 
 describe('createIsolatedWorktree', () => {
-  it('resolves the repo root and creates an afk/iso-* branch based on HEAD', async () => {
+  it("resolves the repo root and creates an afk/iso-* branch based on the anchor's HEAD", async () => {
     const mock = makeMock((call) => {
       if (call.args.includes('--git-common-dir')) return { stdout: `${repoRoot}/.git\n`, stderr: '' };
       if (call.args.includes('add')) {
@@ -138,10 +138,12 @@ describe('createIsolatedWorktree', () => {
     expect(iso.repoRoot).toBe(repoRoot);
     expect(iso.path).toBe(join(repoRoot, '.afk-worktrees', 'iso-diagnose-1-abc123'));
     expect(iso.branch).toBe('afk/iso-diagnose-1-abc123');
-    expect(iso.baseRef).toBe('HEAD');
+    // #760: the default base is the anchor's RESOLVED HEAD sha, not the literal
+    // ref (which `git -C <repoRoot>` would resolve at the MAIN checkout instead).
+    expect(iso.baseRef).toBe('headsha');
     const addCall = mock.calls.find((c) => c.args.includes('add'));
     expect(addCall?.args).toEqual([
-      '-C', repoRoot, 'worktree', 'add', '-b', 'afk/iso-diagnose-1-abc123', iso.path, 'HEAD',
+      '-C', repoRoot, 'worktree', 'add', '-b', 'afk/iso-diagnose-1-abc123', iso.path, 'headsha',
     ]);
   });
 
@@ -172,7 +174,7 @@ describe('createIsolatedWorktree', () => {
     expect(iso.repoRoot).toBe(repoRoot);
     expect(iso.path).toBe(join(repoRoot, '.afk-worktrees', 'iso-parallel-2-def456'));
     expect(iso.branch).toBe('afk/iso-parallel-2-def456');
-    expect(iso.baseRef).toBe('HEAD');
+    expect(iso.baseRef).toBe('headsha');
     // Retried EXACTLY once → `worktree add` invoked twice, second time won.
     expect(mock.calls.filter((c) => c.args.includes('add'))).toHaveLength(2);
   });

--- a/src/agent/tools/handlers/worktree-managed.ts
+++ b/src/agent/tools/handlers/worktree-managed.ts
@@ -59,6 +59,36 @@ export function sanitizeSlug(name: string): string {
     .slice(0, 80);
 }
 
+/**
+ * Contract: resolve the DEFAULT base ref at `anchor` — the calling session's own
+ * checkout — returning a concrete SHA.
+ *
+ * `git worktree add` must run from the MAIN repo root, so handing it the literal
+ * `HEAD` resolves against the MAIN checkout's HEAD rather than the caller's. A
+ * session working inside worktree A that requests a new tree with no explicit
+ * base therefore silently got a branch based on main's tip (#760), while the
+ * design intent is the opposite: `docs/proposals/first-class-worktree-isolation.md`
+ * line 107 — "Base = HEAD of `this.currentCwd`'s repo".
+ *
+ * Resolving to a SHA here (rather than passing a ref through) is what makes the
+ * base unambiguous at the add site, which runs with a different `-C`.
+ *
+ * Documented fallback: when the anchor has no resolvable HEAD (not a git repo, or
+ * an unborn branch) this returns the literal `'HEAD'` — the pre-#760 behaviour —
+ * so the change can never turn a previously working create into a failure.
+ */
+export async function resolveAnchorBaseRef(
+  execFile: ExecFileFn,
+  anchor: string,
+): Promise<string> {
+  try {
+    const out = await execFile('git', ['-C', anchor, 'rev-parse', 'HEAD']);
+    const sha = out.stdout.trim();
+    if (sha) return sha;
+  } catch { /* fall through to the literal ref */ }
+  return 'HEAD';
+}
+
 export interface CreateManagedWorktreeArgs {
   execFile: ExecFileFn;
   /** MAIN repo root (from {@link resolveRepoContext}). */
@@ -214,7 +244,7 @@ export async function createIsolatedWorktree(args: {
   cwd: string;
   /** Raw slug hint (sanitized here); e.g. `iso-agent-tool-3-a1b2c3`. */
   slugHint: string;
-  /** Base ref for the branch. Default `HEAD`. */
+  /** Base ref for the branch. Default: HEAD of `cwd`'s checkout (#760). */
   baseRef?: string;
 }): Promise<ManagedWorktreeInfo & { repoRoot: string }> {
   const execFile = args.execFile ?? defaultExecFile;
@@ -223,7 +253,8 @@ export async function createIsolatedWorktree(args: {
   const worktreePath = join(ctx.afkWorktreesRoot, slug);
   const prefix = env.AFK_WORKTREE_BRANCH_PREFIX ?? 'afk/';
   const branch = `${prefix}${slug}`;
-  const baseRef = args.baseRef ?? 'HEAD';
+  // Default base is the ANCHOR's HEAD (args.cwd), not the main checkout's (#760).
+  const baseRef = args.baseRef ?? await resolveAnchorBaseRef(execFile, args.cwd);
   // Invariant: isolation:"worktree" fans out SEVERAL parallel dispatches, each
   // running `git worktree add` against the SAME main repo — which serializes on
   // the repo/index lock. A burst can transiently fail with a lock error, so we

--- a/src/agent/tools/handlers/worktree.test.ts
+++ b/src/agent/tools/handlers/worktree.test.ts
@@ -109,7 +109,11 @@ describe('worktree handler — create', () => {
         // (mkdir synchronously inside the responder.)
         return fs.mkdir(wtPath, { recursive: true }).then(() => ({ stdout: '', stderr: '' }));
       }
-      if (call.args.includes('rev-parse') && call.args.includes('HEAD')) {
+      // Two distinct rev-parses now run: `rev-parse HEAD` at the anchor to
+      // resolve the default base (#760), then `rev-parse <base>` for meta's
+      // baseSha. Real git answers both with the same commit — emulate that.
+      // `--git-common-dir` is also a rev-parse, so it must not be shadowed.
+      if (call.args.includes('rev-parse') && !call.args.includes('--git-common-dir')) {
         return { stdout: 'base-sha-123\n', stderr: '' };
       }
       return undefined;
@@ -126,10 +130,12 @@ describe('worktree handler — create', () => {
     expect(parsed.note).toMatch(/not installed/i);
     expect(parsed.note).toContain(wtPath);
 
-    // git worktree add argv shape
+    // git worktree add argv shape. #760: an unspecified base is resolved to the
+    // anchor's HEAD sha before the add, since the add itself runs `-C repoRoot`
+    // where a literal `HEAD` would mean the MAIN checkout's tip.
     const addCall = mock.calls.find((c) => c.args.includes('add'));
     expect(addCall?.args).toEqual([
-      '-C', repoRoot, 'worktree', 'add', '-b', 'afk/my-feature', wtPath, 'HEAD',
+      '-C', repoRoot, 'worktree', 'add', '-b', 'afk/my-feature', wtPath, 'base-sha-123',
     ]);
 
     // Meta written with owner 'agent' + pid
@@ -139,6 +145,53 @@ describe('worktree handler — create', () => {
     expect(meta['pid']).toBe(process.pid);
     expect(meta['baseSha']).toBe('base-sha-123');
     expect(typeof meta['createdAt']).toBe('string');
+  });
+
+  // #760: the calling session is usually INSIDE a worktree whose HEAD differs
+  // from the main checkout's. Because `git worktree add` must run from the main
+  // repo root, a literal `HEAD` base resolved there — silently basing the new
+  // branch on main's tip. The default must follow the anchor instead.
+  it("bases an unspecified create on the ANCHOR's HEAD, not the main checkout's", async () => {
+    const anchor = join(afkRoot, 'calling-session');
+    const wtPath = join(afkRoot, 'derived');
+    const mock = makeMock(standardResponder(block(repoRoot), (call) => {
+      if (call.args.includes('add')) {
+        return fs.mkdir(wtPath, { recursive: true }).then(() => ({ stdout: '', stderr: '' }));
+      }
+      // Distinguish the two checkouts by the `-C <dir>` the caller used.
+      if (call.args.includes('rev-parse') && call.args.includes('HEAD')) {
+        const dir = call.args[call.args.indexOf('-C') + 1];
+        return { stdout: dir === anchor ? 'anchor-sha\n' : 'main-sha\n', stderr: '' };
+      }
+      return undefined;
+    }));
+    const handler = createWorktreeHandler(anchor, { execFile: mock });
+    const result = await handler({ action: 'create', name: 'derived' }, SIGNAL);
+    expect(result.isError).toBeUndefined();
+
+    const addCall = mock.calls.find((c) => c.args.includes('add'));
+    expect(addCall?.args.at(-1)).toBe('anchor-sha');
+    expect(addCall?.args.at(-1)).not.toBe('main-sha');
+    // The add itself still runs from the MAIN repo root — only the base moved.
+    expect(addCall?.args.slice(0, 2)).toEqual(['-C', repoRoot]);
+  });
+
+  it('honours an explicit base ref unchanged (no anchor resolution)', async () => {
+    const wtPath = join(afkRoot, 'pinned');
+    const mock = makeMock(standardResponder(block(repoRoot), (call) => {
+      if (call.args.includes('add')) {
+        return fs.mkdir(wtPath, { recursive: true }).then(() => ({ stdout: '', stderr: '' }));
+      }
+      return undefined;
+    }));
+    const handler = createWorktreeHandler(repoRoot, { execFile: mock });
+    const result = await handler(
+      { action: 'create', name: 'pinned', base: 'origin/main' },
+      SIGNAL,
+    );
+    expect(result.isError).toBeUndefined();
+    const addCall = mock.calls.find((c) => c.args.includes('add'));
+    expect(addCall?.args.at(-1)).toBe('origin/main');
   });
 
   it('refuses when a worktree already exists at the target path', async () => {

--- a/src/agent/tools/handlers/worktree.ts
+++ b/src/agent/tools/handlers/worktree.ts
@@ -37,6 +37,7 @@ import {
   sanitizeSlug,
   createManagedWorktree,
   removeManagedWorktreeGuarded,
+  resolveAnchorBaseRef,
   type RepoContext,
 } from './worktree-managed.js';
 
@@ -71,9 +72,10 @@ async function detectInstallCommand(worktreePath: string): Promise<string> {
   return 'pnpm install';
 }
 
-function resolveCreateBaseRef(base: unknown): string | { error: string } {
+/** Returns undefined when no base was supplied — the caller resolves it (#760). */
+function resolveCreateBaseRef(base: unknown): string | undefined | { error: string } {
   if (base === undefined || base === null || base === '') {
-    return 'HEAD';
+    return undefined;
   }
   if (typeof base !== 'string') {
     return { error: 'Invalid input: base must be a string when provided' };
@@ -208,10 +210,12 @@ export function createWorktreeHandler(
           }
           const prefix = env.AFK_WORKTREE_BRANCH_PREFIX ?? 'afk/';
           const branch = `${prefix}${slug}`;
-          const baseRef = resolveCreateBaseRef(obj['base']);
-          if (typeof baseRef !== 'string') {
-            return { content: baseRef.error, isError: true };
+          const baseInput = resolveCreateBaseRef(obj['base']);
+          if (typeof baseInput === 'object') {
+            return { content: baseInput.error, isError: true };
           }
+          // An unspecified base resolves at the ANCHOR, not at ctx.repoRoot (#760).
+          const baseRef = baseInput ?? await resolveAnchorBaseRef(execFile, anchor);
           const info = await createManagedWorktree({
             execFile,
             repoRoot: ctx.repoRoot,


### PR DESCRIPTION
Fixes #760.

## Problem

`git worktree add` must be invoked from the **main** repo root, so handing it the literal `HEAD` resolves the base against the **main checkout's** tip — not the caller's. A session working inside worktree A that created a new tree with no explicit `base` therefore silently got a branch based on main's HEAD.

Measured on this repo while writing the fix: an audit worktree sat at `b673c60` while main was at `a25984a`, so a default `create` from that session would have based its branch on the wrong commit.

Design intent is the opposite — `docs/proposals/first-class-worktree-isolation.md` line 107 specifies *"Base = HEAD of `this.currentCwd`'s repo"*, and the mismatch is not listed among that document's own MVP limitations.

## Change

- New `resolveAnchorBaseRef()` in `worktree-managed.ts`: resolves `HEAD` at the anchor and returns a **concrete SHA**, which is what makes the base unambiguous at the add site (that call runs with a different `-C`).
- Used for the default in **both** callers:
  - the `worktree` tool's `create` action, and
  - `createIsolatedWorktree()` — the `agent` tool's `isolation: "worktree"` path, which had the identical defect. This one is not mentioned in #760; it turned up while tracing the callers.
- An explicit `base` is passed through completely unchanged.
- The `git worktree add` invocation still runs from the main repo root. Only the base moved.

### Documented fallback

When the anchor has no resolvable HEAD (not a git repo, or an unborn branch) the literal `HEAD` is used — the pre-fix behaviour — so this cannot convert a previously working `create` into a failure.

## Tests

Added:
- an unspecified base follows the **anchor's** HEAD and not the main checkout's (the mock distinguishes the two checkouts by the `-C <dir>` each `rev-parse` used);
- an explicit `base` is honoured with no anchor resolution.

Three existing assertions were updated **deliberately**: the trailing token of `worktree add` is now the resolved sha rather than the literal `HEAD`. `worktree-managed.ts` carries an invariant that its git argv stay byte-identical because tests assert exact argv, so that change needed to be made knowingly rather than absorbed silently.

## Verification

| Gate | Result |
|---|---|
| `pnpm test src/agent/tools/handlers/worktree.test.ts` | 32 passed |
| `pnpm test src/agent/tools/handlers/worktree-managed.test.ts` | 12 passed |
| `pnpm test src/agent/tools/subagent/subagent-executor.isolation.test.ts` | 7 passed |
| `pnpm lint` (`tsc --noEmit`) | clean |

File sizes stay under the repo's 350-line-per-file ceiling: `worktree.ts` 343 (was 339 — the new logic deliberately went into `worktree-managed.ts`, 330, which had headroom).
