### PR TITLE
fix(worktree): stop the sweep reaping live trees and discarding ignored files (#759)

### DIFF
--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -997,84 +997,94 @@ export class SubagentManager {
       stopOccupancyHeartbeat = startWorktreeOccupancyHeartbeat(childConfig.cwd);
     }
 
+    // Ordering constraint: the heartbeat armed above is disarmed by the settle
+    // callback installed on the handle built below, so the guarded span has to
+    // run from construction all the way through `active.set`. A throw anywhere
+    // in between — the parent-stream read, the sink resolve, the handle
+    // constructor — would otherwise return with the interval live and no handle
+    // in existence to ever cancel it, and the tree would never be reaped again.
     let session: AgentSession;
+    let handle: SubagentHandleImpl<T>;
+    let effectiveAgentType: string | undefined;
+    let effectiveResolvedAgentType: string | undefined;
     try {
       session = new AgentSession(childConfig);
+      const parentInputStreamRef = options.parent.getInputStreamRef?.();
+      const parentAbortSignal = options.parent.abortSignal;
+      // Resolve sink: explicit option takes precedence, then ambient from AsyncLocalStorage
+      const sink = this.progressSink ?? getCurrentSink();
+      // Normalize empty-string render hints to undefined so the `??` fallbacks
+      // engage. A caller passing `agentType: ''` or `parentId: ''` would
+      // otherwise produce an empty Agent() label / empty agentContext anchor
+      // rather than the intended fallback (idPrefix / parent.sessionId).
+      effectiveAgentType = options.agentType?.trim() || undefined;
+      effectiveResolvedAgentType = options.resolvedAgentType?.trim() || undefined;
+      const effectiveParentId = options.parentId?.trim() || undefined;
+      handle = new SubagentHandleImpl<T>(
+        id,
+        session,
+        childController,
+        this.abortGraph,
+        options.outputSchema,
+        // Wall-clock budget for the child's turn (see SUBAGENT_DEFAULT_TIMEOUT_MS
+        // above). Explicit caller values win, including `0` for unbounded and the
+        // background SUBAGENT_BACKGROUND_TIMEOUT_MS the SubagentExecutor stamps —
+        // `??` preserves that precedence. The default is env-tunable via
+        // AFK_SUBAGENT_TIMEOUT_MS (resolveSubagentTimeoutMs); an unset/invalid
+        // env value returns SUBAGENT_DEFAULT_TIMEOUT_MS, so behaviour is unchanged
+        // when the var is not set.
+        options.config.timeoutMs ?? resolveSubagentTimeoutMs(),
+        registry,
+        () => {
+          // Runs on every terminal outcome of the child — success, failure,
+          // timeout, and abort — so it is the settle hook the heartbeat's
+          // teardown belongs on.
+          stopOccupancyHeartbeat();
+          this.active.delete(id);
+          this.abortGraph.dispose(id);
+        },
+        parentInputStreamRef,
+        parentAbortSignal,
+        // agentType: explicit override → idPrefix fallback. Lets callers
+        // (e.g. compose) supply a render-only label without altering idPrefix
+        // which is also used for routing telemetry.
+        effectiveAgentType ?? options.idPrefix,
+        sink,
+        // parentId: explicit override → parent session id fallback. Lets
+        // callers (e.g. compose) anchor the renderer's nesting at the compose
+        // tool_use_id rather than at the orchestrator session id.
+        effectiveParentId ?? options.parent.sessionId,
+        // traceWriter: child shares the parent's writer so its SubagentStop
+        // hook decision lands in the same trace file. Contract:
+        // docs/philosophy/afk-contract.md — "a child sub-agent inherits its
+        // parent's witness." Resolved once above (per-fork config →
+        // manager-level writer) so the handle's terminal lifecycle emits
+        // pair with the 'started' emit below even when inheritance came
+        // from the manager rather than the per-fork config.
+        effectiveTraceWriter,
+        // onSubagentSucceeded: propagate completion data to the parent
+        // session's session_sealed rollup accumulators.
+        this.onSubagentSucceededCb,
+        // Progress-aware idle-watchdog window for the child's turn (see
+        // SUBAGENT_DEFAULT_IDLE_TIMEOUT_MS above). Explicit caller values win,
+        // including `0` to disable the watchdog for this fork — `??` preserves that
+        // precedence. The default is env-tunable via AFK_SUBAGENT_IDLE_TIMEOUT_MS
+        // (resolveSubagentIdleTimeoutMs); an unset/invalid env value returns
+        // SUBAGENT_DEFAULT_IDLE_TIMEOUT_MS, so behaviour is unchanged when the var
+        // is not set. Runs concurrently with the wall-clock budget above.
+        options.config.idleTimeoutMs ?? resolveSubagentIdleTimeoutMs(),
+      );
+      this.active.set(id, handle as SubagentHandleImpl<unknown>);
     } catch (err) {
-      // Construction failed (e.g. invalid model, sync init failure).
-      // Release the graph node that was registered above to prevent an orphan
-      // accumulating on repeated retries (e.g. forge/farm retry loops), and
-      // disarm the occupancy heartbeat — there is no child left to protect.
+      // Construction or manager-wiring failed (invalid model, sync init
+      // failure, a throwing parent-stream/sink read). Release the graph node
+      // registered above so an orphan cannot accumulate across retry loops
+      // (forge/farm), and disarm the occupancy heartbeat — there is no child
+      // left to protect, and a live timer here would pin the worktree forever.
       stopOccupancyHeartbeat();
       this.abortGraph.dispose(id);
       throw err;
     }
-    const parentInputStreamRef = options.parent.getInputStreamRef?.();
-    const parentAbortSignal = options.parent.abortSignal;
-    // Resolve sink: explicit option takes precedence, then ambient from AsyncLocalStorage
-    const sink = this.progressSink ?? getCurrentSink();
-    // Normalize empty-string render hints to undefined so the `??` fallbacks
-    // engage. A caller passing `agentType: ''` or `parentId: ''` would
-    // otherwise produce an empty Agent() label / empty agentContext anchor
-    // rather than the intended fallback (idPrefix / parent.sessionId).
-    const effectiveAgentType = options.agentType?.trim() || undefined;
-    const effectiveResolvedAgentType = options.resolvedAgentType?.trim() || undefined;
-    const effectiveParentId = options.parentId?.trim() || undefined;
-    const handle = new SubagentHandleImpl<T>(
-      id,
-      session,
-      childController,
-      this.abortGraph,
-      options.outputSchema,
-      // Wall-clock budget for the child's turn (see SUBAGENT_DEFAULT_TIMEOUT_MS
-      // above). Explicit caller values win, including `0` for unbounded and the
-      // background SUBAGENT_BACKGROUND_TIMEOUT_MS the SubagentExecutor stamps —
-      // `??` preserves that precedence. The default is env-tunable via
-      // AFK_SUBAGENT_TIMEOUT_MS (resolveSubagentTimeoutMs); an unset/invalid
-      // env value returns SUBAGENT_DEFAULT_TIMEOUT_MS, so behaviour is unchanged
-      // when the var is not set.
-      options.config.timeoutMs ?? resolveSubagentTimeoutMs(),
-      registry,
-      () => {
-        // Runs on every terminal outcome of the child — success, failure,
-        // timeout, and abort — so it is the settle hook the heartbeat's
-        // teardown belongs on.
-        stopOccupancyHeartbeat();
-        this.active.delete(id);
-        this.abortGraph.dispose(id);
-      },
-      parentInputStreamRef,
-      parentAbortSignal,
-      // agentType: explicit override → idPrefix fallback. Lets callers
-      // (e.g. compose) supply a render-only label without altering idPrefix
-      // which is also used for routing telemetry.
-      effectiveAgentType ?? options.idPrefix,
-      sink,
-      // parentId: explicit override → parent session id fallback. Lets
-      // callers (e.g. compose) anchor the renderer's nesting at the compose
-      // tool_use_id rather than at the orchestrator session id.
-      effectiveParentId ?? options.parent.sessionId,
-      // traceWriter: child shares the parent's writer so its SubagentStop
-      // hook decision lands in the same trace file. Contract:
-      // docs/philosophy/afk-contract.md — "a child sub-agent inherits its
-      // parent's witness." Resolved once above (per-fork config →
-      // manager-level writer) so the handle's terminal lifecycle emits
-      // pair with the 'started' emit below even when inheritance came
-      // from the manager rather than the per-fork config.
-      effectiveTraceWriter,
-      // onSubagentSucceeded: propagate completion data to the parent
-      // session's session_sealed rollup accumulators.
-      this.onSubagentSucceededCb,
-      // Progress-aware idle-watchdog window for the child's turn (see
-      // SUBAGENT_DEFAULT_IDLE_TIMEOUT_MS above). Explicit caller values win,
-      // including `0` to disable the watchdog for this fork — `??` preserves that
-      // precedence. The default is env-tunable via AFK_SUBAGENT_IDLE_TIMEOUT_MS
-      // (resolveSubagentIdleTimeoutMs); an unset/invalid env value returns
-      // SUBAGENT_DEFAULT_IDLE_TIMEOUT_MS, so behaviour is unchanged when the var
-      // is not set. Runs concurrently with the wall-clock budget above.
-      options.config.idleTimeoutMs ?? resolveSubagentIdleTimeoutMs(),
-    );
-    this.active.set(id, handle as SubagentHandleImpl<unknown>);
 
     // Witness layer: subagent_lifecycle.started fires AFTER the handle is
     // wired into the manager's active map and the abort-graph. Emitting

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -34,7 +34,7 @@ import type { AbortOrigin, TraceWriter } from './trace/index.js';
 import type { Surface } from './awareness/types.js';
 import { appendRoutingDecision } from './routing-telemetry.js';
 import { getCurrentSink } from './_lib/skill-sink-channel.js';
-import { touchWorktreeOccupancy } from './worktree-occupancy.js';
+import { touchWorktreeOccupancy, startWorktreeOccupancyHeartbeat } from './worktree-occupancy.js';
 import { resolveWorktreeMainRoot } from './worktree-read-root.js';
 import { computeInheritedReadRoots, type ReadScopeInputs } from './subagent-read-scope.js';
 import { getAfkStateDir } from '../paths.js';
@@ -982,8 +982,19 @@ export class SubagentManager {
     // for cwds outside `.afk-worktrees/`, so it can never delay or fail the
     // fork. Single wiring point — agent/skill/compose/farm dispatches all
     // converge here, whether cwd came per-call or via manager inheritance.
+    //
+    // Ordering constraint: one touch only protects the tree for the sweep's
+    // MIN_EMPTY_AGE_MS (1h), after which a still-running child ages back into
+    // the `empty` verdict and is force-removed mid-flight (#759). So arm a
+    // heartbeat alongside the initial touch, and capture its stop handle HERE —
+    // before the session is constructed — so every exit path below (settle,
+    // construction throw) already has the inverse in hand and cannot orphan the
+    // timer. The timer is unref()'d, so even a leaked one cannot hold the
+    // process open.
+    let stopOccupancyHeartbeat: () => void = () => {};
     if (childConfig.cwd !== undefined) {
       void touchWorktreeOccupancy(childConfig.cwd);
+      stopOccupancyHeartbeat = startWorktreeOccupancyHeartbeat(childConfig.cwd);
     }
 
     let session: AgentSession;
@@ -992,7 +1003,9 @@ export class SubagentManager {
     } catch (err) {
       // Construction failed (e.g. invalid model, sync init failure).
       // Release the graph node that was registered above to prevent an orphan
-      // accumulating on repeated retries (e.g. forge/farm retry loops).
+      // accumulating on repeated retries (e.g. forge/farm retry loops), and
+      // disarm the occupancy heartbeat — there is no child left to protect.
+      stopOccupancyHeartbeat();
       this.abortGraph.dispose(id);
       throw err;
     }
@@ -1023,6 +1036,10 @@ export class SubagentManager {
       options.config.timeoutMs ?? resolveSubagentTimeoutMs(),
       registry,
       () => {
+        // Runs on every terminal outcome of the child — success, failure,
+        // timeout, and abort — so it is the settle hook the heartbeat's
+        // teardown belongs on.
+        stopOccupancyHeartbeat();
         this.active.delete(id);
         this.abortGraph.dispose(id);
       },

--- a/src/agent/tools/handlers/worktree-managed.test.ts
+++ b/src/agent/tools/handlers/worktree-managed.test.ts
@@ -121,6 +121,52 @@ describe('removeManagedWorktreeGuarded — guards + argv', () => {
     // No status check when forced.
     expect(mock.calls.some((c) => c.args.includes('status'))).toBe(false);
   });
+
+  // #759 (second removal path): bare `status --porcelain` never reports
+  // ignored files, so a tree whose only content is a non-rebuildable ignored
+  // file (`.env`) reads clean and reached `git worktree remove` undefended.
+  it('refuses a tree holding a non-rebuildable ignored file without force (reason: ignored-local-state)', async () => {
+    const wtPath = join(repoRoot, '.afk-worktrees', 'has-dotenv');
+    const mock = makeMock((call) => {
+      if (call.args.includes('--ignored')) return { stdout: '!! .env\n!! node_modules/\n', stderr: '' };
+      if (call.args.includes('status')) return { stdout: '', stderr: '' }; // tracked tree is clean
+      return { stdout: '', stderr: '' };
+    });
+    const outcome = await removeManagedWorktreeGuarded({ execFile: mock, repoRoot, worktreePath: wtPath });
+    expect(outcome).toEqual({ removed: false, reason: 'ignored-local-state' });
+    expect(mock.calls.some((c) => c.args.includes('remove'))).toBe(false);
+  });
+
+  // Counterweight: ignored build output alone must NOT block removal, or
+  // every worktree with node_modules/ would become unreapable.
+  it('still succeeds when the only ignored content is rebuildable output', async () => {
+    const wtPath = join(repoRoot, '.afk-worktrees', 'only-build-output');
+    const mock = makeMock((call) => {
+      if (call.args.includes('--ignored')) return { stdout: '!! node_modules/\n!! dist/\n', stderr: '' };
+      if (call.args.includes('status')) return { stdout: '', stderr: '' };
+      return { stdout: '', stderr: '' };
+    });
+    const outcome = await removeManagedWorktreeGuarded({ execFile: mock, repoRoot, worktreePath: wtPath });
+    expect(outcome.removed).toBe(true);
+    const rm = mock.calls.find((c) => c.args.includes('remove'));
+    expect(rm?.args).toEqual(['-C', repoRoot, 'worktree', 'remove', wtPath]);
+  });
+
+  it('force:true still removes even when non-rebuildable ignored content is present', async () => {
+    const wtPath = join(repoRoot, '.afk-worktrees', 'force-dotenv');
+    const mock = makeMock((call) => {
+      if (call.args.includes('--ignored')) return { stdout: '!! .env\n', stderr: '' };
+      return { stdout: '', stderr: '' };
+    });
+    const outcome = await removeManagedWorktreeGuarded({
+      execFile: mock, repoRoot, worktreePath: wtPath, force: true,
+    });
+    expect(outcome.removed).toBe(true);
+    const rm = mock.calls.find((c) => c.args.includes('remove'));
+    expect(rm?.args).toContain('--force');
+    // Explicit override bypasses the ignored-state probe entirely.
+    expect(mock.calls.some((c) => c.args.includes('--ignored'))).toBe(false);
+  });
 });
 
 describe('createIsolatedWorktree', () => {
@@ -228,5 +274,23 @@ describe('teardownIsolatedWorktree', () => {
     });
     const result = await teardownIsolatedWorktree({ execFile: mock, repoRoot, worktreePath: wtPath });
     expect(result).toEqual({ removed: false, preserved: false });
+  });
+
+  // The tree LOOKS clean to `git status`, so the lock reason is the only
+  // place the operator can learn WHY it was preserved instead of removed.
+  it('preserves + locks a tree holding non-rebuildable ignored files, naming the reason', async () => {
+    const wtPath = join(repoRoot, '.afk-worktrees', 'iso-has-dotenv');
+    const mock = makeMock((call) => {
+      if (call.args.includes('--ignored')) return { stdout: '!! .env\n', stderr: '' };
+      if (call.args.includes('status')) return { stdout: '', stderr: '' };
+      return { stdout: '', stderr: '' };
+    });
+    const result = await teardownIsolatedWorktree({ execFile: mock, repoRoot, worktreePath: wtPath });
+    expect(result).toEqual({ removed: false, preserved: true, reason: 'ignored-local-state' });
+    expect(mock.calls.some((c) => c.args.includes('remove'))).toBe(false);
+    const lock = mock.calls.find((c) => c.args.includes('lock'));
+    expect(lock?.args.join(' ')).toContain('afk: isolated-worktree preserved (ignored-local-state');
+    // Legible without needing to already know the reason code.
+    expect(lock?.args.join(' ')).toMatch(/non-rebuildable ignored files/);
   });
 });

--- a/src/agent/tools/handlers/worktree-managed.ts
+++ b/src/agent/tools/handlers/worktree-managed.ts
@@ -21,6 +21,7 @@ import { promisify } from 'node:util';
 import { promises as fs } from 'node:fs';
 import { join, resolve, isAbsolute, dirname } from 'node:path';
 import type { ExecFileFn } from '../../worktree-sweep.js';
+import { hasNonRebuildableIgnoredFiles } from '../../worktree-ignored-probe.js';
 import { env } from '../../../config/env.js';
 
 /** Default git runner. Exported so callers without their own can reuse it. */
@@ -162,7 +163,8 @@ export async function managedWorktreeCommitsAhead(
 export type GuardedRemoveOutcome =
   | { removed: true; branchPreserved: string | null }
   | { removed: false; reason: 'dirty' }
-  | { removed: false; reason: 'commits-ahead'; commitsAhead: number };
+  | { removed: false; reason: 'commits-ahead'; commitsAhead: number }
+  | { removed: false; reason: 'ignored-local-state' };
 
 export interface RemoveManagedWorktreeArgs {
   execFile: ExecFileFn;
@@ -176,10 +178,21 @@ export interface RemoveManagedWorktreeArgs {
 }
 
 /**
- * Guarded worktree removal. Refuses (returns `removed:false` + reason) a dirty
- * or commits-ahead tree unless `force`. Emits `git worktree remove [--force]
- * <path>` on success. Never removes the branch ref. Caller maps the reason to
- * user-facing text (handler) or preserve-and-lock (executor teardown).
+ * Guarded worktree removal. Refuses (returns `removed:false` + reason) a dirty,
+ * commits-ahead, or ignored-local-state tree unless `force`. Emits `git
+ * worktree remove [--force] <path>` on success. Never removes the branch ref.
+ * Caller maps the reason to user-facing text (handler) or preserve-and-lock
+ * (executor teardown).
+ *
+ * Invariant: `isManagedWorktreeDirty` uses bare `git status --porcelain`,
+ * which never reports IGNORED entries — a worktree whose only content is a
+ * non-rebuildable ignored file (`.env`, a gitignored plan) reads clean here
+ * and would otherwise reach `git worktree remove` and be destroyed (#759,
+ * same defect the sweep engine hardened against in `worktree-sweep.ts`; this
+ * is the second, more frequently executed removal path). The
+ * `hasNonRebuildableIgnoredFiles` probe closes it without changing what
+ * "dirty" means for other callers of `isManagedWorktreeDirty` — it is a
+ * separate guard, not a redefinition.
  */
 export async function removeManagedWorktreeGuarded(
   args: RemoveManagedWorktreeArgs,
@@ -188,6 +201,9 @@ export async function removeManagedWorktreeGuarded(
   if (!force) {
     if (await isManagedWorktreeDirty(execFile, worktreePath)) {
       return { removed: false, reason: 'dirty' };
+    }
+    if (await hasNonRebuildableIgnoredFiles(execFile, worktreePath)) {
+      return { removed: false, reason: 'ignored-local-state' };
     }
     const ahead = await managedWorktreeCommitsAhead(execFile, repoRoot, worktreePath);
     if (ahead > 0) {
@@ -258,17 +274,30 @@ export async function createIsolatedWorktree(args: {
 /** Result of {@link teardownIsolatedWorktree}. */
 export interface IsolatedTeardownResult {
   removed: boolean;
-  /** True when the tree was kept (dirty/ahead) and locked against the sweep. */
+  /** True when the tree was kept (dirty/ahead/ignored) and locked against the sweep. */
   preserved: boolean;
-  reason?: 'dirty' | 'commits-ahead';
+  reason?: 'dirty' | 'commits-ahead' | 'ignored-local-state';
+}
+
+/**
+ * Human-legible label for a preserved tree's lock reason. `dirty` and
+ * `commits-ahead` are self-explanatory; `ignored-local-state` is not — the
+ * tree LOOKS clean to `git status`, so the lock reason is the only place the
+ * operator can learn why it was kept anyway.
+ */
+function describePreserveReason(reason: NonNullable<IsolatedTeardownResult['reason']>): string {
+  if (reason === 'ignored-local-state') {
+    return 'ignored-local-state: non-rebuildable ignored files present (e.g. .env) — git status looked clean';
+  }
+  return reason;
 }
 
 /**
  * Tear down an isolated worktree after its subagent finishes. Removes a
- * clean tree; PRESERVES a dirty / commits-ahead tree (WIP is never destroyed)
- * and `git worktree lock`s it so the sweep engine never reaps it out from
- * under work in progress. Best-effort — never throws (teardown runs in a
- * `finally`).
+ * clean tree; PRESERVES a dirty / commits-ahead / ignored-local-state tree
+ * (WIP and untracked local state are never destroyed) and `git worktree
+ * lock`s it so the sweep engine never reaps it out from under work in
+ * progress. Best-effort — never throws (teardown runs in a `finally`).
  */
 export async function teardownIsolatedWorktree(args: {
   execFile?: ExecFileFn;
@@ -284,11 +313,12 @@ export async function teardownIsolatedWorktree(args: {
       force: false,
     });
     if (outcome.removed) return { removed: true, preserved: false };
-    // Dirty or commits-ahead → preserve WIP; lock so the sweep never reaps it.
+    // Dirty, commits-ahead, or ignored-local-state → preserve WIP/local state;
+    // lock so the sweep never reaps it.
     try {
       await execFile('git', [
         '-C', args.repoRoot, 'worktree', 'lock',
-        '--reason', `afk: isolated-worktree preserved (${outcome.reason})`,
+        '--reason', `afk: isolated-worktree preserved (${describePreserveReason(outcome.reason)})`,
         args.worktreePath,
       ]);
     } catch { /* best-effort */ }

--- a/src/agent/tools/handlers/worktree-managed.ts
+++ b/src/agent/tools/handlers/worktree-managed.ts
@@ -285,7 +285,7 @@ export interface IsolatedTeardownResult {
  * tree LOOKS clean to `git status`, so the lock reason is the only place the
  * operator can learn why it was kept anyway.
  */
-function describePreserveReason(reason: NonNullable<IsolatedTeardownResult['reason']>): string {
+export function describePreserveReason(reason: NonNullable<IsolatedTeardownResult['reason']>): string {
   if (reason === 'ignored-local-state') {
     return 'ignored-local-state: non-rebuildable ignored files present (e.g. .env) — git status looked clean';
   }

--- a/src/agent/tools/handlers/worktree.test.ts
+++ b/src/agent/tools/handlers/worktree.test.ts
@@ -379,6 +379,37 @@ describe('worktree handler — remove guards', () => {
     expect(result.content).toContain('commit(s) ahead');
   });
 
+  // #759 (second removal path): a tree whose only content is a non-rebuildable
+  // ignored file (`.env`) reads clean to bare `status --porcelain` and used to
+  // reach `git worktree remove` undefended.
+  it('refuses a worktree holding a non-rebuildable ignored file without force', async () => {
+    const wtPath = join(afkRoot, 'dotenv-wt');
+    const mock = makeMock(standardResponder(`${block(repoRoot)}\n\n${block(wtPath)}\n`, (call) => {
+      if (call.args.includes('--ignored')) return { stdout: '!! .env\n', stderr: '' };
+      if (call.args.includes('status')) return { stdout: '', stderr: '' };
+      return undefined;
+    }));
+    const handler = createWorktreeHandler(repoRoot, { execFile: mock });
+    const result = await handler({ action: 'remove', path: 'dotenv-wt' }, SIGNAL);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('non-rebuildable ignored files');
+    expect(mock.calls.some((c) => c.args.includes('remove'))).toBe(false);
+  });
+
+  it('force removes a worktree holding a non-rebuildable ignored file with --force', async () => {
+    const wtPath = join(afkRoot, 'dotenv-force-wt');
+    const mock = makeMock(standardResponder(`${block(repoRoot)}\n\n${block(wtPath)}\n`, (call) => {
+      if (call.args.includes('--ignored')) return { stdout: '!! .env\n', stderr: '' };
+      if (call.args.includes('status')) return { stdout: '', stderr: '' };
+      return undefined;
+    }));
+    const handler = createWorktreeHandler(repoRoot, { execFile: mock });
+    const result = await handler({ action: 'remove', path: 'dotenv-force-wt', force: true }, SIGNAL);
+    expect(result.isError).toBeUndefined();
+    const removeCall = mock.calls.find((c) => c.args.includes('remove'));
+    expect(removeCall?.args).toContain('--force');
+  });
+
   it('removes a clean worktree and preserves the branch', async () => {
     const wtPath = join(afkRoot, 'clean-wt');
     const mock = makeMock(

--- a/src/agent/tools/handlers/worktree.ts
+++ b/src/agent/tools/handlers/worktree.ts
@@ -316,6 +316,14 @@ export function createWorktreeHandler(
                 isError: true,
               };
             }
+            if (outcome.reason === 'ignored-local-state') {
+              return {
+                content: `Refused: ${entry.path} holds non-rebuildable ignored files (e.g. .env, a gitignored plan) that ` +
+                  `\`git status\` cannot see, so removal would silently delete them. Move/back up what you need, or ` +
+                  'pass force: true to discard them along with the checkout.',
+                isError: true,
+              };
+            }
             return {
               content: `Refused: ${entry.path} has ${outcome.commitsAhead} commit(s) ahead of its base. The branch ref would survive, but pass force: true to confirm removing the checkout.`,
               isError: true,

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -694,7 +694,9 @@ export const worktreeTool: AnthropicToolDef = {
     '- `release` — unlock a previously kept worktree, returning it to normal sweep lifecycle.\n' +
     '- `list` — dry-run sweep report: every afk-managed worktree with its verdict ' +
     '(active | empty | stale-clean | stale-dirty | locked | dead-owner | orphaned-*), owner, and age ' +
-    'in days. Verdicts empty/dead-owner/orphaned-* are removal candidates on the next sweep.\n' +
+    'in days. `stale-dirty` also covers a tree that `git status` calls clean but which holds ' +
+    'non-rebuildable ignored files (e.g. `.env`). Verdicts empty/dead-owner/orphaned-* are removal ' +
+    'candidates on the next sweep.\n' +
     '- `remove` — remove a worktree checkout you no longer need (branch ref is always preserved). ' +
     'Refuses dirty trees, locked trees, trees with commits ahead of base, and trees holding ' +
     'non-rebuildable ignored files (e.g. `.env`) unless `force: true`. Never removes the main ' +

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -696,8 +696,9 @@ export const worktreeTool: AnthropicToolDef = {
     '(active | empty | stale-clean | stale-dirty | locked | dead-owner | orphaned-*), owner, and age ' +
     'in days. Verdicts empty/dead-owner/orphaned-* are removal candidates on the next sweep.\n' +
     '- `remove` — remove a worktree checkout you no longer need (branch ref is always preserved). ' +
-    'Refuses dirty trees, locked trees, and trees with commits ahead of base unless `force: true`. ' +
-    'Never removes the main worktree or paths outside `.afk-worktrees/`.\n\n' +
+    'Refuses dirty trees, locked trees, trees with commits ahead of base, and trees holding ' +
+    'non-rebuildable ignored files (e.g. `.env`) unless `force: true`. Never removes the main ' +
+    'worktree or paths outside `.afk-worktrees/`.\n\n' +
     'Finishing with a worktree: a worktree is scaffolding, not an artifact — once its work has landed ' +
     'somewhere durable (pushed branch, open PR, merged commit), remove it in the same turn instead of ' +
     'leaving it for the sweep. Two cases differ:\n' +
@@ -706,8 +707,11 @@ export const worktreeTool: AnthropicToolDef = {
     'it was preserved with commits-ahead it is LOCKED, and a locked worktree is never reaped — call ' +
     '`release` first, then `remove` (remove refuses a locked tree, so the order is mandatory). ' +
     '`remove` also refuses a tree with commits ahead of base unless `force: true`; once the branch is ' +
-    'pushed that force is safe, because remove never deletes the branch ref — the commits stay on the ' +
-    'branch and on the remote, and only the directory goes away.\n' +
+    'pushed that force is safe for COMMITS specifically, because remove never deletes the branch ref ' +
+    '— they stay on the branch and on the remote. `force` is NOT safe for local state, though: it also ' +
+    'deletes untracked/ignored files (`.env`, a gitignored plan) that never made it into a commit, so ' +
+    'confirm nothing irreplaceable is sitting there first — removal now refuses such a tree unless ' +
+    'forced.\n' +
     '- The worktree you are RUNNING IN (your own cwd): never remove it mid-session. Deleting your own ' +
     'working directory strands every later tool call on a path that no longer exists. Session-end ' +
     'cleanup already removes it when the tree is clean — just tell the operator it will be reclaimed ' +

--- a/src/agent/tools/subagent/foreground-promotion.ts
+++ b/src/agent/tools/subagent/foreground-promotion.ts
@@ -396,9 +396,10 @@ export async function runForegroundWithPromotion(args: RunForegroundArgs): Promi
       appendInjectContext(toolResult, injectContext);
 
       // isolation:"worktree" teardown — remove the child's worktree now that it
-      // has finished. A dirty / commits-ahead tree is preserved and locked
-      // (WIP is never destroyed); the promoted path skips this (guarded by
-      // !promoted) so a still-running detached job keeps its tree. Best-effort:
+      // has finished. A dirty / commits-ahead / ignored-local-state tree is
+      // preserved and locked (WIP and non-rebuildable ignored files are never
+      // destroyed); the promoted path skips this (guarded by !promoted) so a
+      // still-running detached job keeps its tree. Best-effort:
       // teardownIsolatedWorktree never throws, so it cannot break the finally.
       if (args.isolationTeardown) {
         const { repoRoot, worktreePath } = args.isolationTeardown;

--- a/src/agent/tools/subagent/foreground-promotion.ts
+++ b/src/agent/tools/subagent/foreground-promotion.ts
@@ -26,7 +26,7 @@ import type { ToolResult } from '../types.js';
 import type { PromotedSubagentInfo } from '../subagent-executor.js';
 import { emitTelemetry, truncate, measurePartial, buildFailurePayload } from './failure-payload.js';
 import { appendInjectContext } from './inject-context.js';
-import { teardownIsolatedWorktree } from '../handlers/worktree-managed.js';
+import { teardownIsolatedWorktree, describePreserveReason } from '../handlers/worktree-managed.js';
 
 type ForkedHandle = Awaited<ReturnType<SubagentManager['forkSubagent']>>;
 
@@ -406,7 +406,8 @@ export async function runForegroundWithPromotion(args: RunForegroundArgs): Promi
         const outcome = await teardownIsolatedWorktree({ repoRoot, worktreePath });
         if (outcome.preserved) {
           debugLog(
-            `[isolation] preserved worktree ${worktreePath} (${outcome.reason}) — ` +
+            `[isolation] preserved worktree ${worktreePath} ` +
+              `(${outcome.reason ? describePreserveReason(outcome.reason) : 'unknown'}) — ` +
               `locked so the sweep will not reap it; recover via the worktree tool`,
           );
         }

--- a/src/agent/worktree-ignored-patterns.ts
+++ b/src/agent/worktree-ignored-patterns.ts
@@ -1,0 +1,164 @@
+/**
+ * Classification policy for the worktree ignored-file probe.
+ *
+ * Contract: split out of `worktree-ignored-probe.ts` so that module holds only
+ * IO (git invocation, line parsing, scoped expansion) while the policy — which
+ * ignored paths a rebuild can restore — lives here as data. Pure and
+ * synchronous; nothing here touches the filesystem.
+ *
+ * @module agent/worktree-ignored-patterns
+ */
+
+/** How the probe must treat one ignored entry git reported. */
+export type IgnoredEntryClass =
+  /** Reapable, and cheap enough to trust without looking inside. */
+  | 'opaque'
+  /** Reapable only if a scoped expansion finds nothing sensitive beneath it. */
+  | 'inspectable'
+  /** Never reapable — removing the checkout would destroy it. */
+  | 'protected';
+
+/**
+ * Leaf filenames that are NEVER rebuildable, whatever directory holds them.
+ *
+ * Invariant: this list outranks every rebuildable pattern below, and the
+ * precedence is load-bearing. `git status --ignored` collapses an ignored
+ * directory to a single line, so a secret nested under `dist/` is invisible
+ * until the probe expands that directory; once expanded, the leaf has to
+ * protect the tree even though its parent matched a build-output pattern.
+ * Without this table, `dist/secrets.env` reads "rebuildable" twice over — once
+ * because git never listed it, and again because the directory prefix matches.
+ * Matched case-insensitively against the final path segment only.
+ */
+const SENSITIVE_LEAF_PATTERNS: readonly RegExp[] = [
+  /^\.env$/,
+  /^\.env\./,
+  /\.pem$/,
+  /\.key$/,
+  /\.p12$/,
+  /\.keystore$/,
+  /\.jks$/,
+  /^id_rsa/,
+  /^id_ed25519/,
+  /^\.netrc$/,
+  /credential/,
+  /secret/,
+  /\.sqlite3?$/,
+  /\.db$/,
+];
+
+/**
+ * Dependency trees and caches: machine-owned, never hand-authored, and often
+ * enormous. Reapable without inspection — expanding `node_modules/` to look for
+ * a stray secret would walk tens of thousands of paths on every sweep tick,
+ * which is exactly the cost the collapsed `--ignored` output exists to avoid.
+ */
+const OPAQUE_REBUILDABLE_DIRS: readonly RegExp[] = [
+  /(?:^|\/)node_modules\//,
+  /(?:^|\/)\.pnpm(-store)?\//,
+  /(?:^|\/)\.yarn\//,
+  /(?:^|\/)bower_components\//,
+  /(?:^|\/)vendor\/bundle\//,
+  /(?:^|\/)\.venv\//,
+  /(?:^|\/)venv\//,
+  /(?:^|\/)__pycache__\//,
+  /(?:^|\/)\.turbo\//,
+  /(?:^|\/)\.parcel-cache\//,
+  /(?:^|\/)\.vite\//,
+  /(?:^|\/)\.cache\//,
+  /(?:^|\/)\.gradle\//,
+  /(?:^|\/)\.pytest_cache\//,
+  /(?:^|\/)\.mypy_cache\//,
+  /(?:^|\/)\.ruff_cache\//,
+  /(?:^|\/)\.nyc_output\//,
+  /(?:^|\/)logs\//,
+];
+
+/**
+ * Build output: small enough to enumerate, and plausibly holding something a
+ * human put there by hand (a generated deliverable, a scratch `.env` a script
+ * dropped next to the bundle). Reapable, but only after a scoped expansion
+ * confirms no sensitive leaf hides inside.
+ */
+const INSPECTABLE_REBUILDABLE_DIRS: readonly RegExp[] = [
+  /(?:^|\/)dist\//,
+  /(?:^|\/)build\//,
+  /(?:^|\/)out\//,
+  /(?:^|\/)lib-cov\//,
+  /(?:^|\/)\.next\//,
+  /(?:^|\/)\.nuxt\//,
+  /(?:^|\/)\.svelte-kit\//,
+  /(?:^|\/)\.output\//,
+  /(?:^|\/)target\//,
+  /(?:^|\/)coverage\//,
+];
+
+/**
+ * Individual ignored FILES a rebuild restores.
+ *
+ * The log entries are deliberately an emitter allowlist rather than a bare
+ * `/\.log$/`: that suffix matched every ignored `*.log`, so a captured agent
+ * transcript or a hand-kept `decisions.log` was classified as build noise and
+ * force-deleted along with the checkout.
+ */
+const REBUILDABLE_FILE_PATTERNS: readonly RegExp[] = [
+  // AFK owns and recreates this bookkeeping marker.
+  /^\.afk-worktree-meta\.json$/,
+  /\.tsbuildinfo$/,
+  /^\.eslintcache$/,
+  /^\.stylelintcache$/,
+  /^\.DS_Store$/,
+  /^Thumbs\.db$/,
+  // Known log emitters only.
+  /(?:^|\/)debug\.log$/,
+  /(?:^|\/)npm-debug\.log$/,
+  /(?:^|\/)yarn-error\.log$/,
+  /(?:^|\/)yarn-debug\.log$/,
+  /(?:^|\/)pnpm-debug\.log$/,
+  /(?:^|\/)lerna-debug\.log$/,
+];
+
+/**
+ * Normalize the repo-relative path git reported: backslashes to forward
+ * slashes, no `./` prefix, and no wrapping double quotes. The probe already
+ * passes `-c core.quotePath=false`, so the quote strip is belt-and-braces for
+ * any caller that does not.
+ */
+export function normalizeIgnoredPath(relPath: string): string {
+  const slashed = relPath.replace(/\\/g, '/').replace(/^\.\//, '');
+  if (slashed.length >= 2 && slashed.startsWith('"') && slashed.endsWith('"')) {
+    return slashed.slice(1, -1);
+  }
+  return slashed;
+}
+
+/** Final path segment, with any trailing directory slash removed. */
+export function leafOf(normalizedPath: string): string {
+  const withoutTrailingSlash = normalizedPath.replace(/\/+$/, '');
+  const lastSlash = withoutTrailingSlash.lastIndexOf('/');
+  return lastSlash === -1
+    ? withoutTrailingSlash
+    : withoutTrailingSlash.slice(lastSlash + 1);
+}
+
+/** True when the entry's final segment names something unrecoverable. */
+export function isSensitiveLeaf(relPath: string): boolean {
+  const leaf = leafOf(normalizeIgnoredPath(relPath)).toLowerCase();
+  if (leaf === '') return false;
+  return SENSITIVE_LEAF_PATTERNS.some((re) => re.test(leaf));
+}
+
+/**
+ * Classify one ignored entry. Precedence is deliberate: a sensitive leaf wins
+ * over every rebuildable pattern, and anything unrecognised falls through to
+ * `protected` so the default answer is always "leave it alone".
+ */
+export function classifyIgnoredEntry(relPath: string): IgnoredEntryClass {
+  const normalized = normalizeIgnoredPath(relPath);
+  if (normalized === '') return 'protected';
+  if (isSensitiveLeaf(normalized)) return 'protected';
+  if (REBUILDABLE_FILE_PATTERNS.some((re) => re.test(normalized))) return 'opaque';
+  if (OPAQUE_REBUILDABLE_DIRS.some((re) => re.test(normalized))) return 'opaque';
+  if (INSPECTABLE_REBUILDABLE_DIRS.some((re) => re.test(normalized))) return 'inspectable';
+  return 'protected';
+}

--- a/src/agent/worktree-ignored-patterns.ts
+++ b/src/agent/worktree-ignored-patterns.ts
@@ -31,7 +31,10 @@ export type IgnoredEntryClass =
  * Matched case-insensitively against the final path segment only.
  */
 const SENSITIVE_LEAF_PATTERNS: readonly RegExp[] = [
-  /^\.env$/,
+  // Any `*.env` leaf, not just a dot-prefixed one: `app.env` and `prod.env` are
+  // as unrecoverable as `.env`, and the dot-anchored form let `dist/app.env`
+  // survive expansion and be reaped with the checkout. Subsumes `/^\.env$/`.
+  /\.env$/,
   /^\.env\./,
   /\.pem$/,
   /\.key$/,
@@ -71,14 +74,14 @@ const OPAQUE_REBUILDABLE_DIRS: readonly RegExp[] = [
   /(?:^|\/)\.mypy_cache\//,
   /(?:^|\/)\.ruff_cache\//,
   /(?:^|\/)\.nyc_output\//,
-  /(?:^|\/)logs\//,
 ];
 
 /**
- * Build output: small enough to enumerate, and plausibly holding something a
- * human put there by hand (a generated deliverable, a scratch `.env` a script
- * dropped next to the bundle). Reapable, but only after a scoped expansion
- * confirms no sensitive leaf hides inside.
+ * Build output and log directories: small enough to enumerate, and plausibly
+ * holding something a human put there by hand (a generated deliverable, a
+ * scratch `.env` a script dropped next to the bundle, a captured transcript).
+ * Reapable, but only after a scoped expansion confirms no sensitive leaf hides
+ * inside.
  */
 const INSPECTABLE_REBUILDABLE_DIRS: readonly RegExp[] = [
   /(?:^|\/)dist\//,
@@ -91,6 +94,20 @@ const INSPECTABLE_REBUILDABLE_DIRS: readonly RegExp[] = [
   /(?:^|\/)\.output\//,
   /(?:^|\/)target\//,
   /(?:^|\/)coverage\//,
+  // Invariant: `logs/` must stay in THIS tier, never the opaque one. An opaque
+  // verdict is never expanded, so `SENSITIVE_LEAF_PATTERNS` never runs on the
+  // leaves and a `logs/.env` or `logs/prod.key` is force-deleted with the
+  // checkout, unseen (#759). Here the scoped expansion classifies each leaf, so
+  // a sensitive one protects the tree.
+  //
+  // What this does NOT do: a nested leaf re-matches this same directory regex,
+  // so `logs/decisions.log` classifies `inspectable`, not `protected`, and stays
+  // reapable — the presumption "files under a build-output dir are rebuildable
+  // unless sensitive" is what keeps `dist/` from making every tree immortal, and
+  // it applies here too. So a hand-kept log at the repo ROOT is protected by the
+  // emitter allowlist below while the same filename under `logs/` is not. That
+  // residual asymmetry is deliberate and bounded to non-sensitive names.
+  /(?:^|\/)logs\//,
 ];
 
 /**
@@ -108,7 +125,8 @@ const REBUILDABLE_FILE_PATTERNS: readonly RegExp[] = [
   /^\.eslintcache$/,
   /^\.stylelintcache$/,
   /^\.DS_Store$/,
-  /^Thumbs\.db$/,
+  // No `Thumbs.db` entry: `/\.db$/` above is sensitive and tested first, so it
+  // is already protected and a rebuildable entry here would be unreachable.
   // Known log emitters only.
   /(?:^|\/)debug\.log$/,
   /(?:^|\/)npm-debug\.log$/,

--- a/src/agent/worktree-ignored-probe.test.ts
+++ b/src/agent/worktree-ignored-probe.test.ts
@@ -53,6 +53,35 @@ describe('isRebuildableIgnoredEntry', () => {
   it('does not confuse a file containing a rebuildable directory name with output', () => {
     expect(isRebuildableIgnoredEntry('my-notes/dist-plan.md')).toBe(false);
   });
+
+  // A sensitive leaf outranks its containing directory. Without this, the
+  // build-output prefix patterns classify `dist/secrets.env` as reapable.
+  const sensitiveUnderBuildOutput = [
+    'dist/secrets.env', 'dist/.env', 'build/.env.local', 'out/private.pem',
+    'target/service.key', 'coverage/id_rsa', 'dist/nested/app-credentials.json',
+    'packages/app/dist/.env',
+  ];
+  for (const entry of sensitiveUnderBuildOutput) {
+    it(`treats ${entry} as NON-rebuildable despite its parent directory`, () => {
+      expect(isRebuildableIgnoredEntry(entry)).toBe(false);
+    });
+  }
+
+  // The narrowed log rule: emitters stay reapable, hand-kept logs do not.
+  it('treats a hand-kept log as NON-rebuildable', () => {
+    expect(isRebuildableIgnoredEntry('decisions.log')).toBe(false);
+    expect(isRebuildableIgnoredEntry('transcripts/session.log')).toBe(false);
+  });
+
+  it('keeps known log emitters rebuildable', () => {
+    for (const entry of ['npm-debug.log', 'debug.log', 'pnpm-debug.log', 'logs/run.log']) {
+      expect(isRebuildableIgnoredEntry(entry)).toBe(true);
+    }
+  });
+
+  it('classifies a non-ASCII nested dependency dir as rebuildable', () => {
+    expect(isRebuildableIgnoredEntry('café/node_modules/')).toBe(true);
+  });
 });
 
 describe('hasNonRebuildableIgnoredFiles', () => {
@@ -80,5 +109,65 @@ describe('hasNonRebuildableIgnoredFiles', () => {
 
   it('fails SAFE — an unreadable tree protects rather than reaps', async () => {
     expect(await hasNonRebuildableIgnoredFiles(throwingExec, '/tmp/wt')).toBe(true);
+  });
+});
+
+/**
+ * Traditional `--ignored` collapses an ignored directory to one line, so a
+ * secret nested under `dist/` is invisible to the top-level call. These pin the
+ * scoped second call that closes that blind spot — and pin that it is NOT paid
+ * for dependency trees.
+ */
+describe('hasNonRebuildableIgnoredFiles — collapsed-directory expansion', () => {
+  /** Records every git argv so a test can assert which calls were made. */
+  function recordingExec(
+    responder: (args: readonly string[]) => string,
+  ): { exec: ExecFileFn; calls: string[][] } {
+    const calls: string[][] = [];
+    const exec = (async (_cmd: string, args: string[]) => {
+      calls.push([...args]);
+      return { stdout: responder(args), stderr: '' };
+    }) as unknown as ExecFileFn;
+    return { exec, calls };
+  }
+
+  const isScoped = (args: readonly string[]): boolean => args.includes('--untracked-files=all');
+
+  it('expands a collapsed build dir and protects when it hides a secret', async () => {
+    const { exec, calls } = recordingExec((args) =>
+      isScoped(args) ? '!! dist/cli/index.js\n!! dist/secrets.env\n' : '!! dist/\n',
+    );
+    expect(await hasNonRebuildableIgnoredFiles(exec, '/tmp/wt')).toBe(true);
+    expect(calls.filter(isScoped)).toHaveLength(1);
+  });
+
+  it('expands a collapsed build dir and reaps when it holds only output', async () => {
+    const { exec, calls } = recordingExec((args) =>
+      isScoped(args) ? '!! dist/cli/index.js\n!! dist/assets/app.css\n' : '!! dist/\n',
+    );
+    expect(await hasNonRebuildableIgnoredFiles(exec, '/tmp/wt')).toBe(false);
+    expect(calls.filter(isScoped)).toHaveLength(1);
+  });
+
+  it('never pays for an expansion of an opaque dependency tree', async () => {
+    const { exec, calls } = recordingExec(() => '!! node_modules/\n!! .pnpm/\n');
+    expect(await hasNonRebuildableIgnoredFiles(exec, '/tmp/wt')).toBe(false);
+    expect(calls.filter(isScoped)).toHaveLength(0);
+  });
+
+  it('protects when the scoped expansion itself fails', async () => {
+    const exec = (async (_cmd: string, args: string[]) => {
+      if (args.includes('--untracked-files=all')) throw new Error('fatal: bad pathspec');
+      return { stdout: '!! dist/\n', stderr: '' };
+    }) as unknown as ExecFileFn;
+    expect(await hasNonRebuildableIgnoredFiles(exec, '/tmp/wt')).toBe(true);
+  });
+
+  it('passes core.quotePath=false so non-ASCII paths arrive literal', async () => {
+    const { exec, calls } = recordingExec(() => '!! café/node_modules/\n');
+    expect(await hasNonRebuildableIgnoredFiles(exec, '/tmp/wt')).toBe(false);
+    expect(calls[0]).toEqual(
+      expect.arrayContaining(['-c', 'core.quotePath=false']),
+    );
   });
 });

--- a/src/agent/worktree-ignored-probe.test.ts
+++ b/src/agent/worktree-ignored-probe.test.ts
@@ -28,6 +28,9 @@ describe('isRebuildableIgnoredEntry', () => {
     '.turbo/', '.vite/', '.cache/', 'coverage/', '.nyc_output/',
     'tsconfig.tsbuildinfo', 'app.tsbuildinfo', '.eslintcache',
     '__pycache__/', '.venv/', '.DS_Store', 'debug.log',
+    '.afk-worktree-meta.json',
+    'packages/app/node_modules/', 'packages/app/dist/',
+    'crates/server/target/', 'packages/app/.cache/',
   ];
   for (const entry of rebuildable) {
     it(`treats ${entry} as rebuildable`, () => {
@@ -47,15 +50,16 @@ describe('isRebuildableIgnoredEntry', () => {
     });
   }
 
-  it('does not let a rebuildable name nested under a real dir pass as rebuildable', () => {
-    // Patterns are anchored: only a top-level `dist/` is build output.
+  it('does not confuse a file containing a rebuildable directory name with output', () => {
     expect(isRebuildableIgnoredEntry('my-notes/dist-plan.md')).toBe(false);
   });
 });
 
 describe('hasNonRebuildableIgnoredFiles', () => {
   it('is false when every ignored entry is rebuildable', async () => {
-    const exec = mockExec('!! node_modules/\n!! dist/\n!! .eslintcache\n');
+    const exec = mockExec(
+      '!! .afk-worktree-meta.json\n!! packages/app/node_modules/\n!! packages/app/dist/\n',
+    );
     expect(await hasNonRebuildableIgnoredFiles(exec, '/tmp/wt')).toBe(false);
   });
 

--- a/src/agent/worktree-ignored-probe.test.ts
+++ b/src/agent/worktree-ignored-probe.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect } from 'vitest';
 import {
   isRebuildableIgnoredEntry,
   hasNonRebuildableIgnoredFiles,
+  probeNonRebuildableIgnoredFiles,
 } from './worktree-ignored-probe.js';
 import type { ExecFileFn } from './worktree-sweep.js';
 
@@ -60,6 +61,9 @@ describe('isRebuildableIgnoredEntry', () => {
     'dist/secrets.env', 'dist/.env', 'build/.env.local', 'out/private.pem',
     'target/service.key', 'coverage/id_rsa', 'dist/nested/app-credentials.json',
     'packages/app/dist/.env',
+    // Non-dot-prefixed env leaves. The dot-anchored `/^\.env$/` missed these, so
+    // they survived expansion and were reaped with the checkout.
+    'dist/app.env', 'dist/prod.env', 'out/staging.env',
   ];
   for (const entry of sensitiveUnderBuildOutput) {
     it(`treats ${entry} as NON-rebuildable despite its parent directory`, () => {
@@ -74,9 +78,33 @@ describe('isRebuildableIgnoredEntry', () => {
   });
 
   it('keeps known log emitters rebuildable', () => {
-    for (const entry of ['npm-debug.log', 'debug.log', 'pnpm-debug.log', 'logs/run.log']) {
+    for (const entry of ['npm-debug.log', 'debug.log', 'pnpm-debug.log', 'logs/debug.log']) {
       expect(isRebuildableIgnoredEntry(entry)).toBe(true);
     }
+  });
+
+  // `logs/` is `inspectable`, not `opaque`: an opaque verdict is never expanded,
+  // so the sensitive-leaf table never ran on the leaves and `logs/.env` was
+  // force-deleted with the checkout, unseen.
+  const sensitiveUnderLogs = [
+    'logs/.env', 'logs/app.env', 'logs/prod.key', 'logs/creds.pem',
+    'logs/data.db', 'logs/id_rsa',
+  ];
+  for (const entry of sensitiveUnderLogs) {
+    it(`treats ${entry} as NON-rebuildable despite the logs/ prefix`, () => {
+      expect(isRebuildableIgnoredEntry(entry)).toBe(false);
+    });
+  }
+
+  // Documented residual, pinned so a future reader sees it is a choice and not
+  // an oversight: a nested leaf re-matches the `logs/` directory pattern and so
+  // classifies `inspectable`, which is why a non-sensitive hand-kept log stays
+  // reapable under `logs/` while the same filename at the repo root protects.
+  // Closing this would require presuming nested leaves non-rebuildable, which is
+  // exactly what would make every `dist/`-bearing worktree immortal.
+  it('leaves the non-sensitive nested-log asymmetry in place', () => {
+    expect(isRebuildableIgnoredEntry('decisions.log')).toBe(false);
+    expect(isRebuildableIgnoredEntry('logs/decisions.log')).toBe(true);
   });
 
   it('classifies a non-ASCII nested dependency dir as rebuildable', () => {
@@ -163,11 +191,100 @@ describe('hasNonRebuildableIgnoredFiles — collapsed-directory expansion', () =
     expect(await hasNonRebuildableIgnoredFiles(exec, '/tmp/wt')).toBe(true);
   });
 
+  // Regression guard for the reaper-loss path: while `logs/` sat in the opaque
+  // tier this expansion was never paid, so a `logs/` holding a secret read
+  // "reapable" and the tree was force-removed with it. Asserting the scoped call
+  // happened is the part that fails if `logs/` is ever moved back.
+  it('expands a collapsed logs dir and protects when it hides a secret', async () => {
+    const { exec, calls } = recordingExec((args) =>
+      isScoped(args) ? '!! logs/run.log\n!! logs/.env\n' : '!! logs/\n',
+    );
+    expect(await hasNonRebuildableIgnoredFiles(exec, '/tmp/wt')).toBe(true);
+    expect(calls.filter(isScoped)).toHaveLength(1);
+  });
+
+  it('expands a collapsed logs dir and reaps when it holds only log noise', async () => {
+    const { exec, calls } = recordingExec((args) =>
+      isScoped(args) ? '!! logs/debug.log\n!! logs/run.log\n' : '!! logs/\n',
+    );
+    expect(await hasNonRebuildableIgnoredFiles(exec, '/tmp/wt')).toBe(false);
+    expect(calls.filter(isScoped)).toHaveLength(1);
+  });
+
   it('passes core.quotePath=false so non-ASCII paths arrive literal', async () => {
     const { exec, calls } = recordingExec(() => '!! café/node_modules/\n');
     expect(await hasNonRebuildableIgnoredFiles(exec, '/tmp/wt')).toBe(false);
     expect(calls[0]).toEqual(
       expect.arrayContaining(['-c', 'core.quotePath=false']),
     );
+  });
+});
+
+/**
+ * A protect-on-git-failure and a protect-on-real-find are the same boolean, and
+ * that ambiguity is how a permanently unreapable worktree stays invisible. These
+ * pin that the verdict form distinguishes them, and that the scoped expansion
+ * cannot turn "lots of output" into "git failed" via a 1MB buffer overflow.
+ */
+describe('probeNonRebuildableIgnoredFiles — verdict provenance', () => {
+  it('reports a real find as non-rebuildable-entry', async () => {
+    const exec = mockExec('!! local-notes.md\n');
+    expect(await probeNonRebuildableIgnoredFiles(exec, '/tmp/wt')).toEqual({
+      protect: true,
+      because: 'non-rebuildable-entry',
+    });
+  });
+
+  it('reports a top-level git failure as git-failed, carrying the detail', async () => {
+    const verdict = await probeNonRebuildableIgnoredFiles(throwingExec, '/tmp/wt');
+    expect(verdict.protect).toBe(true);
+    expect(verdict).toMatchObject({ because: 'git-failed' });
+    if (verdict.protect && verdict.because === 'git-failed') {
+      expect(verdict.detail).toContain('not a git repository');
+    }
+  });
+
+  it('names the scoped directory when the EXPANSION is what failed', async () => {
+    const exec = (async (_cmd: string, args: string[]) => {
+      if (args.includes('--untracked-files=all')) throw new Error('stdout maxBuffer length exceeded');
+      return { stdout: '!! dist/\n', stderr: '' };
+    }) as unknown as ExecFileFn;
+    const verdict = await probeNonRebuildableIgnoredFiles(exec, '/tmp/wt');
+    if (verdict.protect && verdict.because === 'git-failed') {
+      expect(verdict.detail).toContain('expanding dist/');
+      expect(verdict.detail).toContain('maxBuffer');
+    } else {
+      throw new Error(`expected a git-failed verdict, got ${JSON.stringify(verdict)}`);
+    }
+  });
+
+  it('reports no protection needed when everything is rebuildable', async () => {
+    const exec = mockExec('!! node_modules/\n!! .afk-worktree-meta.json\n');
+    expect(await probeNonRebuildableIgnoredFiles(exec, '/tmp/wt')).toEqual({ protect: false });
+  });
+
+  // Regression guard: an unbounded execFile REJECTS on overflow rather than
+  // truncating, and every failure path here protects — so a missing maxBuffer
+  // silently makes each large-build worktree immortal.
+  it('raises maxBuffer and bounds the timeout on every git call', async () => {
+    const opts: Array<Record<string, unknown> | undefined> = [];
+    const exec = (async (_cmd: string, args: string[], o?: Record<string, unknown>) => {
+      opts.push(o);
+      return {
+        stdout: args.includes('--untracked-files=all') ? '!! dist/app.js\n' : '!! dist/\n',
+        stderr: '',
+      };
+    }) as unknown as ExecFileFn;
+    await probeNonRebuildableIgnoredFiles(exec, '/tmp/wt');
+    expect(opts).toHaveLength(2); // top-level + one scoped expansion
+    for (const o of opts) {
+      expect(o?.['maxBuffer']).toBe(64 * 1024 * 1024);
+      expect(o?.['timeout']).toBe(10_000);
+    }
+  });
+
+  it('still collapses to a boolean for the legacy surface', async () => {
+    expect(await hasNonRebuildableIgnoredFiles(mockExec('!! local-notes.md\n'), '/tmp/wt')).toBe(true);
+    expect(await hasNonRebuildableIgnoredFiles(mockExec('!! node_modules/\n'), '/tmp/wt')).toBe(false);
   });
 });

--- a/src/agent/worktree-ignored-probe.test.ts
+++ b/src/agent/worktree-ignored-probe.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for the sweep's non-rebuildable ignored-file probe (#759).
+ *
+ * The two directions both matter: missing a `.env` means the sweep force-deletes
+ * unrecoverable local state, while treating `node_modules/` as protective would
+ * make every worktree immortal and stop the sweep reclaiming anything at all.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  isRebuildableIgnoredEntry,
+  hasNonRebuildableIgnoredFiles,
+} from './worktree-ignored-probe.js';
+import type { ExecFileFn } from './worktree-sweep.js';
+
+function mockExec(stdout: string): ExecFileFn {
+  return (async () => ({ stdout, stderr: '' })) as unknown as ExecFileFn;
+}
+
+const throwingExec: ExecFileFn = (async () => {
+  throw new Error('fatal: not a git repository');
+}) as unknown as ExecFileFn;
+
+describe('isRebuildableIgnoredEntry', () => {
+  const rebuildable = [
+    'node_modules/', 'node_modules/foo/index.js', '.pnpm/', '.yarn/',
+    'dist/', 'dist/cli/index.js', 'build/', 'out/', '.next/', 'target/',
+    '.turbo/', '.vite/', '.cache/', 'coverage/', '.nyc_output/',
+    'tsconfig.tsbuildinfo', 'app.tsbuildinfo', '.eslintcache',
+    '__pycache__/', '.venv/', '.DS_Store', 'debug.log',
+  ];
+  for (const entry of rebuildable) {
+    it(`treats ${entry} as rebuildable`, () => {
+      expect(isRebuildableIgnoredEntry(entry)).toBe(true);
+    });
+  }
+
+  const protective = [
+    '.env', '.env.local', '.env.production',
+    'secrets.json', 'local-notes.md', 'scratch/data.csv',
+    '.vscode/launch.json', '.idea/workspace.xml',
+    'fixtures/recorded-response.bin',
+  ];
+  for (const entry of protective) {
+    it(`treats ${entry} as NON-rebuildable`, () => {
+      expect(isRebuildableIgnoredEntry(entry)).toBe(false);
+    });
+  }
+
+  it('does not let a rebuildable name nested under a real dir pass as rebuildable', () => {
+    // Patterns are anchored: only a top-level `dist/` is build output.
+    expect(isRebuildableIgnoredEntry('my-notes/dist-plan.md')).toBe(false);
+  });
+});
+
+describe('hasNonRebuildableIgnoredFiles', () => {
+  it('is false when every ignored entry is rebuildable', async () => {
+    const exec = mockExec('!! node_modules/\n!! dist/\n!! .eslintcache\n');
+    expect(await hasNonRebuildableIgnoredFiles(exec, '/tmp/wt')).toBe(false);
+  });
+
+  it('is true when any ignored entry is not rebuildable', async () => {
+    const exec = mockExec('!! node_modules/\n!! .env\n');
+    expect(await hasNonRebuildableIgnoredFiles(exec, '/tmp/wt')).toBe(true);
+  });
+
+  it('is false for an entirely clean tree', async () => {
+    expect(await hasNonRebuildableIgnoredFiles(mockExec(''), '/tmp/wt')).toBe(false);
+  });
+
+  it('ignores non-`!!` porcelain lines (tracked/untracked entries)', async () => {
+    // ` M src/x.ts` and `?? scratch` are the dirty signal's business, not ours.
+    const exec = mockExec(' M src/x.ts\n?? scratch.txt\n!! dist/\n');
+    expect(await hasNonRebuildableIgnoredFiles(exec, '/tmp/wt')).toBe(false);
+  });
+
+  it('fails SAFE — an unreadable tree protects rather than reaps', async () => {
+    expect(await hasNonRebuildableIgnoredFiles(throwingExec, '/tmp/wt')).toBe(true);
+  });
+});

--- a/src/agent/worktree-ignored-probe.ts
+++ b/src/agent/worktree-ignored-probe.ts
@@ -15,7 +15,8 @@
  * and `dist/` are ignored in every checkout — defeating the sweep entirely and
  * regrowing the very leak it exists to prevent. So the default stays
  * "reapable": only an ignored entry that does NOT match a known-rebuildable
- * pattern protects the tree.
+ * pattern protects the tree. Classification policy lives in
+ * `worktree-ignored-patterns.ts`; this module is the IO around it.
  *
  * Fail-safe direction: anything unrecognised is treated as non-rebuildable
  * (protect), and a git failure also protects — mirroring the sweep's existing
@@ -25,64 +26,77 @@
  */
 
 import type { ExecFileFn } from './worktree-sweep.js';
+import { classifyIgnoredEntry } from './worktree-ignored-patterns.js';
+
+export {
+  classifyIgnoredEntry,
+  isSensitiveLeaf,
+  type IgnoredEntryClass,
+} from './worktree-ignored-patterns.js';
 
 /**
- * Ignored paths that a build can regenerate from committed sources. Matched
- * against the repo-relative path git reports. Directory patterns may occur at
- * any package boundary so monorepo output is treated the same as root output.
- *
- * Deliberately NOT listed (so they protect the tree): `.env*`, `.vscode/`,
- * `.idea/`, and anything else unrecognised — editor and environment files are
- * hand-authored local state, not build output.
+ * Invariant: `core.quotePath=false` is not optional. With git's default, a
+ * non-ASCII ignored path arrives wrapped in double quotes and octal-escaped
+ * (`"caf\303\251/node_modules/"`), which defeats the `(?:^|\/)` anchors in
+ * every rebuildable pattern. The entry then reads "unrecognised", protects the
+ * tree, and the worktree becomes immortal — the leak the sweep exists to stop.
  */
-const REBUILDABLE_IGNORED_PATTERNS: readonly RegExp[] = [
-  // AFK owns and recreates this bookkeeping marker.
-  /^\.afk-worktree-meta\.json$/,
-  // Dependency trees
-  /(?:^|\/)node_modules\//,
-  /(?:^|\/)\.pnpm(-store)?\//,
-  /(?:^|\/)\.yarn\//,
-  /(?:^|\/)bower_components\//,
-  /(?:^|\/)vendor\/bundle\//,
-  // Build output
-  /(?:^|\/)dist\//,
-  /(?:^|\/)build\//,
-  /(?:^|\/)out\//,
-  /(?:^|\/)lib-cov\//,
-  /(?:^|\/)\.next\//,
-  /(?:^|\/)\.nuxt\//,
-  /(?:^|\/)\.svelte-kit\//,
-  /(?:^|\/)\.output\//,
-  /(?:^|\/)target\//,
-  // Caches
-  /(?:^|\/)\.turbo\//,
-  /(?:^|\/)\.parcel-cache\//,
-  /(?:^|\/)\.vite\//,
-  /(?:^|\/)\.cache\//,
-  /(?:^|\/)\.gradle\//,
-  /(?:^|\/)__pycache__\//,
-  /(?:^|\/)\.pytest_cache\//,
-  /(?:^|\/)\.mypy_cache\//,
-  /(?:^|\/)\.ruff_cache\//,
-  /(?:^|\/)\.venv\//,
-  /(?:^|\/)venv\//,
-  // Coverage + incremental-build metadata
-  /(?:^|\/)coverage\//,
-  /(?:^|\/)\.nyc_output\//,
-  /\.tsbuildinfo$/,
-  /^\.eslintcache$/,
-  /^\.stylelintcache$/,
-  // OS + log noise
-  /^\.DS_Store$/,
-  /^Thumbs\.db$/,
-  /\.log$/,
-];
+const GIT_LITERAL_PATHS = ['-c', 'core.quotePath=false'];
 
-/** True when `relPath` is ignored build output or cache a rebuild would restore. */
+/** True when `relPath` is ignored output a rebuild would restore. */
 export function isRebuildableIgnoredEntry(relPath: string): boolean {
-  const normalized = relPath.replace(/\\/g, '/').replace(/^\.\//, '');
-  if (normalized === '') return true;
-  return REBUILDABLE_IGNORED_PATTERNS.some((re) => re.test(normalized));
+  return classifyIgnoredEntry(relPath) !== 'protected';
+}
+
+/**
+ * Ignored entries git reports for the worktree, or `undefined` when git failed.
+ * `scopePath` restricts the walk to one directory and expands it per-file
+ * (`--untracked-files=all`) instead of collapsing it to a single line.
+ */
+async function readIgnoredEntries(
+  execFile: ExecFileFn,
+  worktreePath: string,
+  scopePath?: string,
+): Promise<string[] | undefined> {
+  const args = [
+    ...GIT_LITERAL_PATHS,
+    '-C', worktreePath,
+    'status', '--porcelain', '--ignored',
+  ];
+  if (scopePath !== undefined) args.push('--untracked-files=all', '--', scopePath);
+  try {
+    const { stdout } = await execFile('git', args);
+    return stdout
+      .split('\n')
+      .filter((line) => line.startsWith('!!'))
+      .map((line) => line.slice(2).trim())
+      .filter((entry) => entry !== '');
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Expand ONE build-output directory and report whether it hides local state a
+ * rebuild would not restore.
+ *
+ * Contract: the expansion is deliberately non-recursive — nested results are
+ * classified, never expanded again. That bounds the cost to a single extra git
+ * call per inspectable directory and removes any chance of a cycle when git
+ * echoes the collapsed directory back in the scoped output.
+ */
+async function inspectableDirHidesLocalState(
+  execFile: ExecFileFn,
+  worktreePath: string,
+  dirEntry: string,
+): Promise<boolean> {
+  const nested = await readIgnoredEntries(execFile, worktreePath, dirEntry);
+  if (nested === undefined) return true; // unreadable → protect
+  for (const entry of nested) {
+    if (entry === dirEntry) continue; // git echoed the directory — no new information
+    if (classifyIgnoredEntry(entry) === 'protected') return true;
+  }
+  return false;
 }
 
 /**
@@ -90,28 +104,24 @@ export function isRebuildableIgnoredEntry(relPath: string): boolean {
  * NOT restore — i.e. removing the checkout would destroy something the user
  * cannot get back.
  *
- * Uses `--ignored` in its default (traditional) mode on purpose: it collapses an
- * ignored DIRECTORY into a single `!! node_modules/` line instead of listing
- * every file beneath it, which keeps this cheap on a populated worktree.
+ * The top-level call uses `--ignored` in its default (traditional) mode on
+ * purpose: it collapses an ignored DIRECTORY into a single `!! node_modules/`
+ * line instead of listing every file beneath it, which keeps this cheap on a
+ * populated worktree. Only directories classified `inspectable` — small build
+ * output, not dependency trees — pay for a second, scoped call.
  */
 export async function hasNonRebuildableIgnoredFiles(
   execFile: ExecFileFn,
   worktreePath: string,
 ): Promise<boolean> {
-  let stdout: string;
-  try {
-    const result = await execFile('git', [
-      '-C', worktreePath, 'status', '--porcelain', '--ignored',
-    ]);
-    stdout = result.stdout;
-  } catch {
-    return true; // unreadable → protect, never force-remove on a guess
-  }
-  for (const line of stdout.split('\n')) {
-    if (!line.startsWith('!!')) continue;
-    const entry = line.slice(2).trim();
-    if (entry === '') continue;
-    if (!isRebuildableIgnoredEntry(entry)) return true;
+  const entries = await readIgnoredEntries(execFile, worktreePath);
+  if (entries === undefined) return true; // unreadable → never force-remove on a guess
+  for (const entry of entries) {
+    const verdict = classifyIgnoredEntry(entry);
+    if (verdict === 'protected') return true;
+    if (verdict === 'inspectable' && entry.endsWith('/')) {
+      if (await inspectableDirHidesLocalState(execFile, worktreePath, entry)) return true;
+    }
   }
   return false;
 }

--- a/src/agent/worktree-ignored-probe.ts
+++ b/src/agent/worktree-ignored-probe.ts
@@ -28,44 +28,47 @@ import type { ExecFileFn } from './worktree-sweep.js';
 
 /**
  * Ignored paths that a build can regenerate from committed sources. Matched
- * against the repo-relative path git reports, anchored at the start.
+ * against the repo-relative path git reports. Directory patterns may occur at
+ * any package boundary so monorepo output is treated the same as root output.
  *
  * Deliberately NOT listed (so they protect the tree): `.env*`, `.vscode/`,
  * `.idea/`, and anything else unrecognised — editor and environment files are
  * hand-authored local state, not build output.
  */
 const REBUILDABLE_IGNORED_PATTERNS: readonly RegExp[] = [
+  // AFK owns and recreates this bookkeeping marker.
+  /^\.afk-worktree-meta\.json$/,
   // Dependency trees
-  /^node_modules\//,
-  /^\.pnpm(-store)?\//,
-  /^\.yarn\//,
-  /^bower_components\//,
-  /^vendor\/bundle\//,
+  /(?:^|\/)node_modules\//,
+  /(?:^|\/)\.pnpm(-store)?\//,
+  /(?:^|\/)\.yarn\//,
+  /(?:^|\/)bower_components\//,
+  /(?:^|\/)vendor\/bundle\//,
   // Build output
-  /^dist\//,
-  /^build\//,
-  /^out\//,
-  /^lib-cov\//,
-  /^\.next\//,
-  /^\.nuxt\//,
-  /^\.svelte-kit\//,
-  /^\.output\//,
-  /^target\//,
+  /(?:^|\/)dist\//,
+  /(?:^|\/)build\//,
+  /(?:^|\/)out\//,
+  /(?:^|\/)lib-cov\//,
+  /(?:^|\/)\.next\//,
+  /(?:^|\/)\.nuxt\//,
+  /(?:^|\/)\.svelte-kit\//,
+  /(?:^|\/)\.output\//,
+  /(?:^|\/)target\//,
   // Caches
-  /^\.turbo\//,
-  /^\.parcel-cache\//,
-  /^\.vite\//,
-  /^\.cache\//,
-  /^\.gradle\//,
-  /^__pycache__\//,
-  /^\.pytest_cache\//,
-  /^\.mypy_cache\//,
-  /^\.ruff_cache\//,
-  /^\.venv\//,
-  /^venv\//,
+  /(?:^|\/)\.turbo\//,
+  /(?:^|\/)\.parcel-cache\//,
+  /(?:^|\/)\.vite\//,
+  /(?:^|\/)\.cache\//,
+  /(?:^|\/)\.gradle\//,
+  /(?:^|\/)__pycache__\//,
+  /(?:^|\/)\.pytest_cache\//,
+  /(?:^|\/)\.mypy_cache\//,
+  /(?:^|\/)\.ruff_cache\//,
+  /(?:^|\/)\.venv\//,
+  /(?:^|\/)venv\//,
   // Coverage + incremental-build metadata
-  /^coverage\//,
-  /^\.nyc_output\//,
+  /(?:^|\/)coverage\//,
+  /(?:^|\/)\.nyc_output\//,
   /\.tsbuildinfo$/,
   /^\.eslintcache$/,
   /^\.stylelintcache$/,

--- a/src/agent/worktree-ignored-probe.ts
+++ b/src/agent/worktree-ignored-probe.ts
@@ -43,6 +43,29 @@ export {
  */
 const GIT_LITERAL_PATHS = ['-c', 'core.quotePath=false'];
 
+/**
+ * Invariant: a scoped `--untracked-files=all` expansion of a populated `dist/`
+ * or `target/` can print far more than Node's 1MB default, and an execFile
+ * maxBuffer overflow REJECTS rather than truncating. Without a raised ceiling
+ * the reject lands in the `catch` below, protects the tree, and every
+ * large-build worktree becomes permanently unreapable — the immortality this
+ * module's docblock exists to prevent. The timeout bounds the other direction:
+ * a wedged git must not stall the sweep indefinitely.
+ */
+const PROBE_EXEC_OPTS = { maxBuffer: 64 * 1024 * 1024, timeout: 10_000 } as const;
+
+/** Why the probe says a tree must be preserved. */
+export type IgnoredProbeVerdict =
+  | { protect: false }
+  /** Found an ignored entry a rebuild would not restore. */
+  | { protect: true; because: 'non-rebuildable-entry' }
+  /**
+   * git itself failed, so the answer is unknown and we protect on principle.
+   * Distinguished from a real find so callers can SAY SO: a silent protect here
+   * is indistinguishable from a genuine one and hides a permanent leak.
+   */
+  | { protect: true; because: 'git-failed'; detail: string };
+
 /** True when `relPath` is ignored output a rebuild would restore. */
 export function isRebuildableIgnoredEntry(relPath: string): boolean {
   return classifyIgnoredEntry(relPath) !== 'protected';
@@ -57,7 +80,7 @@ async function readIgnoredEntries(
   execFile: ExecFileFn,
   worktreePath: string,
   scopePath?: string,
-): Promise<string[] | undefined> {
+): Promise<{ entries: string[] } | { failure: string }> {
   const args = [
     ...GIT_LITERAL_PATHS,
     '-C', worktreePath,
@@ -65,14 +88,17 @@ async function readIgnoredEntries(
   ];
   if (scopePath !== undefined) args.push('--untracked-files=all', '--', scopePath);
   try {
-    const { stdout } = await execFile('git', args);
-    return stdout
-      .split('\n')
-      .filter((line) => line.startsWith('!!'))
-      .map((line) => line.slice(2).trim())
-      .filter((entry) => entry !== '');
-  } catch {
-    return undefined;
+    const { stdout } = await execFile('git', args, PROBE_EXEC_OPTS);
+    return {
+      entries: stdout
+        .split('\n')
+        .filter((line) => line.startsWith('!!'))
+        .map((line) => line.slice(2).trim())
+        .filter((entry) => entry !== ''),
+    };
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    return { failure: scopePath === undefined ? detail : `expanding ${scopePath}: ${detail}` };
   }
 }
 
@@ -89,14 +115,18 @@ async function inspectableDirHidesLocalState(
   execFile: ExecFileFn,
   worktreePath: string,
   dirEntry: string,
-): Promise<boolean> {
+): Promise<IgnoredProbeVerdict> {
   const nested = await readIgnoredEntries(execFile, worktreePath, dirEntry);
-  if (nested === undefined) return true; // unreadable → protect
-  for (const entry of nested) {
-    if (entry === dirEntry) continue; // git echoed the directory — no new information
-    if (classifyIgnoredEntry(entry) === 'protected') return true;
+  if ('failure' in nested) {
+    return { protect: true, because: 'git-failed', detail: nested.failure };
   }
-  return false;
+  for (const entry of nested.entries) {
+    if (entry === dirEntry) continue; // git echoed the directory — no new information
+    if (classifyIgnoredEntry(entry) === 'protected') {
+      return { protect: true, because: 'non-rebuildable-entry' };
+    }
+  }
+  return { protect: false };
 }
 
 /**
@@ -110,18 +140,33 @@ async function inspectableDirHidesLocalState(
  * populated worktree. Only directories classified `inspectable` — small build
  * output, not dependency trees — pay for a second, scoped call.
  */
+export async function probeNonRebuildableIgnoredFiles(
+  execFile: ExecFileFn,
+  worktreePath: string,
+): Promise<IgnoredProbeVerdict> {
+  const top = await readIgnoredEntries(execFile, worktreePath);
+  // Unreadable → never force-remove on a guess.
+  if ('failure' in top) return { protect: true, because: 'git-failed', detail: top.failure };
+  for (const entry of top.entries) {
+    const verdict = classifyIgnoredEntry(entry);
+    if (verdict === 'protected') return { protect: true, because: 'non-rebuildable-entry' };
+    if (verdict === 'inspectable' && entry.endsWith('/')) {
+      const nested = await inspectableDirHidesLocalState(execFile, worktreePath, entry);
+      if (nested.protect) return nested;
+    }
+  }
+  return { protect: false };
+}
+
+/**
+ * Boolean form, kept as the default surface: most callers only need "may I
+ * remove this?" and collapsing the verdict keeps their code honest about
+ * failing safe. Use `probeNonRebuildableIgnoredFiles` when the caller can
+ * REPORT why, so a protect-on-failure is not silent.
+ */
 export async function hasNonRebuildableIgnoredFiles(
   execFile: ExecFileFn,
   worktreePath: string,
 ): Promise<boolean> {
-  const entries = await readIgnoredEntries(execFile, worktreePath);
-  if (entries === undefined) return true; // unreadable → never force-remove on a guess
-  for (const entry of entries) {
-    const verdict = classifyIgnoredEntry(entry);
-    if (verdict === 'protected') return true;
-    if (verdict === 'inspectable' && entry.endsWith('/')) {
-      if (await inspectableDirHidesLocalState(execFile, worktreePath, entry)) return true;
-    }
-  }
-  return false;
+  return (await probeNonRebuildableIgnoredFiles(execFile, worktreePath)).protect;
 }

--- a/src/agent/worktree-ignored-probe.ts
+++ b/src/agent/worktree-ignored-probe.ts
@@ -1,0 +1,114 @@
+/**
+ * Non-rebuildable ignored-file probe for the worktree sweep.
+ *
+ * Invariant: `git status --porcelain` — the sweep's only dirty signal — reports
+ * untracked files but NEVER ignored ones. A worktree whose sole contents are
+ * ignored therefore reads CLEAN, becomes eligible for `git worktree remove
+ * --force`, and has those files deleted along with the checkout. Committed work
+ * is never lost that way (branch refs live in the shared `.git`), but a
+ * worktree-local `.env`, a scratch fixture, or an un-ignored-by-habit secrets
+ * file is unrecoverable (#759).
+ *
+ * Contract: this probe distinguishes REBUILDABLE ignored artifacts from
+ * non-rebuildable local state, and it must. Treating *any* ignored entry as
+ * protective would make effectively every worktree immortal — `node_modules/`
+ * and `dist/` are ignored in every checkout — defeating the sweep entirely and
+ * regrowing the very leak it exists to prevent. So the default stays
+ * "reapable": only an ignored entry that does NOT match a known-rebuildable
+ * pattern protects the tree.
+ *
+ * Fail-safe direction: anything unrecognised is treated as non-rebuildable
+ * (protect), and a git failure also protects — mirroring the sweep's existing
+ * `catch { isDirty = true }` posture, where the safe answer is "leave it alone".
+ *
+ * @module agent/worktree-ignored-probe
+ */
+
+import type { ExecFileFn } from './worktree-sweep.js';
+
+/**
+ * Ignored paths that a build can regenerate from committed sources. Matched
+ * against the repo-relative path git reports, anchored at the start.
+ *
+ * Deliberately NOT listed (so they protect the tree): `.env*`, `.vscode/`,
+ * `.idea/`, and anything else unrecognised — editor and environment files are
+ * hand-authored local state, not build output.
+ */
+const REBUILDABLE_IGNORED_PATTERNS: readonly RegExp[] = [
+  // Dependency trees
+  /^node_modules\//,
+  /^\.pnpm(-store)?\//,
+  /^\.yarn\//,
+  /^bower_components\//,
+  /^vendor\/bundle\//,
+  // Build output
+  /^dist\//,
+  /^build\//,
+  /^out\//,
+  /^lib-cov\//,
+  /^\.next\//,
+  /^\.nuxt\//,
+  /^\.svelte-kit\//,
+  /^\.output\//,
+  /^target\//,
+  // Caches
+  /^\.turbo\//,
+  /^\.parcel-cache\//,
+  /^\.vite\//,
+  /^\.cache\//,
+  /^\.gradle\//,
+  /^__pycache__\//,
+  /^\.pytest_cache\//,
+  /^\.mypy_cache\//,
+  /^\.ruff_cache\//,
+  /^\.venv\//,
+  /^venv\//,
+  // Coverage + incremental-build metadata
+  /^coverage\//,
+  /^\.nyc_output\//,
+  /\.tsbuildinfo$/,
+  /^\.eslintcache$/,
+  /^\.stylelintcache$/,
+  // OS + log noise
+  /^\.DS_Store$/,
+  /^Thumbs\.db$/,
+  /\.log$/,
+];
+
+/** True when `relPath` is ignored build output or cache a rebuild would restore. */
+export function isRebuildableIgnoredEntry(relPath: string): boolean {
+  const normalized = relPath.replace(/\\/g, '/').replace(/^\.\//, '');
+  if (normalized === '') return true;
+  return REBUILDABLE_IGNORED_PATTERNS.some((re) => re.test(normalized));
+}
+
+/**
+ * True when the worktree holds at least one ignored entry that a rebuild would
+ * NOT restore — i.e. removing the checkout would destroy something the user
+ * cannot get back.
+ *
+ * Uses `--ignored` in its default (traditional) mode on purpose: it collapses an
+ * ignored DIRECTORY into a single `!! node_modules/` line instead of listing
+ * every file beneath it, which keeps this cheap on a populated worktree.
+ */
+export async function hasNonRebuildableIgnoredFiles(
+  execFile: ExecFileFn,
+  worktreePath: string,
+): Promise<boolean> {
+  let stdout: string;
+  try {
+    const result = await execFile('git', [
+      '-C', worktreePath, 'status', '--porcelain', '--ignored',
+    ]);
+    stdout = result.stdout;
+  } catch {
+    return true; // unreadable → protect, never force-remove on a guess
+  }
+  for (const line of stdout.split('\n')) {
+    if (!line.startsWith('!!')) continue;
+    const entry = line.slice(2).trim();
+    if (entry === '') continue;
+    if (!isRebuildableIgnoredEntry(entry)) return true;
+  }
+  return false;
+}

--- a/src/agent/worktree-occupancy.test.ts
+++ b/src/agent/worktree-occupancy.test.ts
@@ -10,7 +10,9 @@ import {
   touchWorktreeOccupancy,
   worktreeRootFor,
   startWorktreeOccupancyHeartbeat,
+  DEFAULT_HEARTBEAT_INTERVAL_MS,
 } from './worktree-occupancy.js';
+import { MIN_EMPTY_AGE_MS } from './worktree-sweep.js';
 
 let repoRoot: string;
 let worktreePath: string;
@@ -156,5 +158,16 @@ describe('startWorktreeOccupancyHeartbeat', () => {
     await new Promise((r) => setTimeout(r, 40));
     stop();
     await expect(fs.readFile(join(outside, '.afk-worktree-meta.json'), 'utf-8')).rejects.toThrow();
+  });
+});
+
+describe('DEFAULT_HEARTBEAT_INTERVAL_MS vs. MIN_EMPTY_AGE_MS', () => {
+  // #759: the heartbeat only re-arms the sweep's age gate if a tick reliably
+  // lands before the gate re-opens. Before this test the two constants were
+  // private in different files, linked only by a prose comment — raising the
+  // interval above the gate would silently reintroduce the bug with zero test
+  // failures. No timers: plain arithmetic on the exported constants.
+  it('stays comfortably below the sweep age gate (<= 1/4 of it, margin explicit)', () => {
+    expect(DEFAULT_HEARTBEAT_INTERVAL_MS).toBeLessThanOrEqual(MIN_EMPTY_AGE_MS / 4);
   });
 });

--- a/src/agent/worktree-occupancy.test.ts
+++ b/src/agent/worktree-occupancy.test.ts
@@ -6,7 +6,11 @@ import { promises as fs } from 'node:fs';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { join, sep } from 'node:path';
 import { tmpdir } from 'node:os';
-import { touchWorktreeOccupancy, worktreeRootFor } from './worktree-occupancy.js';
+import {
+  touchWorktreeOccupancy,
+  worktreeRootFor,
+  startWorktreeOccupancyHeartbeat,
+} from './worktree-occupancy.js';
 
 let repoRoot: string;
 let worktreePath: string;
@@ -98,5 +102,59 @@ describe('touchWorktreeOccupancy', () => {
     await expect(
       touchWorktreeOccupancy(join(repoRoot, '.afk-worktrees', 'gone', 'src')),
     ).resolves.toBeUndefined();
+  });
+});
+
+describe('startWorktreeOccupancyHeartbeat', () => {
+  it('re-asserts occupancy on an interval so a long child never ages out (#759)', async () => {
+    const metaPath = join(worktreePath, '.afk-worktree-meta.json');
+    // Backdate meta well past the sweep's 1h MIN_EMPTY_AGE_MS: this is the state
+    // a >1h child used to be reaped in.
+    await fs.writeFile(
+      metaPath,
+      JSON.stringify({ owner: 'agent', createdAt: new Date(Date.now() - 7_200_000).toISOString() }),
+    );
+
+    const stop = startWorktreeOccupancyHeartbeat(worktreePath, 10);
+    try {
+      await new Promise((r) => setTimeout(r, 60));
+    } finally {
+      stop();
+    }
+
+    const meta = JSON.parse(await fs.readFile(metaPath, 'utf-8')) as Record<string, unknown>;
+    const ageMs = Date.now() - new Date(String(meta['createdAt'])).getTime();
+    expect(ageMs).toBeLessThan(3_600_000);
+    expect(meta['pid']).toBe(process.pid);
+    expect(meta['owner']).toBe('agent'); // unrelated fields preserved
+  });
+
+  it('stops touching after stop() is called', async () => {
+    const metaPath = join(worktreePath, '.afk-worktree-meta.json');
+    await fs.writeFile(metaPath, JSON.stringify({ owner: 'agent' }));
+
+    const stop = startWorktreeOccupancyHeartbeat(worktreePath, 10);
+    await new Promise((r) => setTimeout(r, 40));
+    stop();
+    const afterStop = JSON.parse(await fs.readFile(metaPath, 'utf-8')) as Record<string, unknown>;
+
+    await new Promise((r) => setTimeout(r, 60));
+    const later = JSON.parse(await fs.readFile(metaPath, 'utf-8')) as Record<string, unknown>;
+    expect(later['createdAt']).toBe(afterStop['createdAt']);
+  });
+
+  it('is idempotent — calling stop() twice is safe', async () => {
+    const stop = startWorktreeOccupancyHeartbeat(worktreePath, 10);
+    stop();
+    expect(() => stop()).not.toThrow();
+  });
+
+  it('returns an inert stop for a cwd outside a managed worktree', async () => {
+    const outside = join(repoRoot, 'not-a-worktree');
+    await fs.mkdir(outside, { recursive: true });
+    const stop = startWorktreeOccupancyHeartbeat(outside, 10);
+    await new Promise((r) => setTimeout(r, 40));
+    stop();
+    await expect(fs.readFile(join(outside, '.afk-worktree-meta.json'), 'utf-8')).rejects.toThrow();
   });
 });

--- a/src/agent/worktree-occupancy.test.ts
+++ b/src/agent/worktree-occupancy.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for the worktree occupancy touch helper.
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { promises as fs } from 'node:fs';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { join, sep } from 'node:path';
@@ -169,5 +169,65 @@ describe('DEFAULT_HEARTBEAT_INTERVAL_MS vs. MIN_EMPTY_AGE_MS', () => {
   // failures. No timers: plain arithmetic on the exported constants.
   it('stays comfortably below the sweep age gate (<= 1/4 of it, margin explicit)', () => {
     expect(DEFAULT_HEARTBEAT_INTERVAL_MS).toBeLessThanOrEqual(MIN_EMPTY_AGE_MS / 4);
+  });
+});
+
+/**
+ * The disarm and the atomic-write temp path both had gaps that only show up
+ * under concurrency: `clearInterval` cannot stop a touch already past its first
+ * await, and a pid-only temp name collides across in-process subagents sharing
+ * one cwd.
+ */
+describe('heartbeat disarm and write isolation', () => {
+  it('honours cancellation mid-flight and leaves the meta byte-identical', async () => {
+    const metaPath = join(worktreePath, '.afk-worktree-meta.json');
+    await fs.writeFile(metaPath, JSON.stringify({ owner: 'agent', createdAt: 'ORIGINAL' }));
+
+    // Cancel before the rename lands: the meta must not be re-stamped.
+    await touchWorktreeOccupancy(worktreePath, () => true);
+
+    const meta = JSON.parse(await fs.readFile(metaPath, 'utf-8')) as Record<string, unknown>;
+    expect(meta['createdAt']).toBe('ORIGINAL');
+    const leftovers = (await fs.readdir(worktreePath)).filter((f) => f.endsWith('.tmp'));
+    expect(leftovers).toEqual([]);
+  });
+
+  it('writes normally when not cancelled', async () => {
+    const metaPath = join(worktreePath, '.afk-worktree-meta.json');
+    await fs.writeFile(metaPath, JSON.stringify({ owner: 'agent', createdAt: 'ORIGINAL' }));
+    await touchWorktreeOccupancy(worktreePath, () => false);
+    const meta = JSON.parse(await fs.readFile(metaPath, 'utf-8')) as Record<string, unknown>;
+    expect(meta['createdAt']).not.toBe('ORIGINAL');
+  });
+
+  // Two heartbeats armed for one root in a single process (a worktree-isolated
+  // parent fanning out subagents) must not share a temp filename.
+  it('survives concurrent touches without leaking a temp file or a torn meta', async () => {
+    const metaPath = join(worktreePath, '.afk-worktree-meta.json');
+    await fs.writeFile(metaPath, JSON.stringify({ owner: 'agent' }));
+
+    await Promise.all(
+      Array.from({ length: 8 }, () => touchWorktreeOccupancy(worktreePath)),
+    );
+
+    const raw = await fs.readFile(metaPath, 'utf-8');
+    expect(() => JSON.parse(raw) as unknown).not.toThrow();
+    expect((JSON.parse(raw) as Record<string, unknown>)['pid']).toBe(process.pid);
+    const leftovers = (await fs.readdir(worktreePath)).filter((f) => f.endsWith('.tmp'));
+    expect(leftovers).toEqual([]);
+  });
+
+  it('unrefs the interval so a pending heartbeat cannot hold the process open', () => {
+    const unref = vi.fn();
+    const spy = vi
+      .spyOn(globalThis, 'setInterval')
+      .mockReturnValue({ unref } as unknown as ReturnType<typeof setInterval>);
+    try {
+      const stop = startWorktreeOccupancyHeartbeat(worktreePath, 10);
+      expect(unref).toHaveBeenCalledTimes(1);
+      stop();
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/src/agent/worktree-occupancy.ts
+++ b/src/agent/worktree-occupancy.ts
@@ -41,8 +41,13 @@ const AFK_WORKTREES_SEGMENT = `${sep}.afk-worktrees${sep}`;
 /**
  * Heartbeat period. Must stay comfortably below the sweep's MIN_EMPTY_AGE_MS
  * (1h, `worktree-sweep.ts`) so a tick always lands before the age gate re-arms.
+ * Exported (alongside `worktree-sweep.ts`'s `MIN_EMPTY_AGE_MS`) so the margin
+ * between the two is a checkable relationship instead of a prose comment
+ * linking two private constants in different files — see
+ * `worktree-occupancy.test.ts`'s "heartbeat interval stays comfortably below
+ * the sweep's age gate" assertion.
  */
-const DEFAULT_HEARTBEAT_INTERVAL_MS = 600_000; // 10 minutes
+export const DEFAULT_HEARTBEAT_INTERVAL_MS = 600_000; // 10 minutes
 
 /**
  * Resolve the worktree root containing `cwd`, when `cwd` sits inside an

--- a/src/agent/worktree-occupancy.ts
+++ b/src/agent/worktree-occupancy.ts
@@ -17,10 +17,22 @@
  *   - `ownerLiveness` resolves to 'alive' while this process runs, which
  *     suppresses the accelerated `dead-owner` path.
  *
- * A single touch only buys MIN_EMPTY_AGE_MS (1h) of protection, so a child that
- * outlives it in a clean tree used to age back across the `empty` threshold and
- * get reaped mid-run (#759). `startWorktreeOccupancyHeartbeat` closes that by
- * re-asserting the occupation for as long as the child runs.
+ * What the heartbeat is actually for. A forked subagent runs IN THIS PROCESS
+ * (`new AgentSession(...)` — `subagent.ts` spawns nothing), so once the touch
+ * above has stamped `pid = process.pid`, `ownerLiveness` resolves to 'alive'
+ * for the child's entire run and the `empty` verdict — which requires
+ * `ownerLiveness !== 'alive'` — is unreachable however long the child runs.
+ * The age gate is therefore NOT the thing that protects a correctly-stamped
+ * tree, and `startWorktreeOccupancyHeartbeat` is defence-in-depth rather than
+ * the primary guard. It covers the states where the stamp is missing or
+ * untrustworthy: a meta file that is absent or unparseable, a torn read of a
+ * concurrent write, or an initial touch that failed transiently. In those
+ * states `ownerLiveness` degrades to 'unknown' and the age gate becomes the
+ * only defence, so re-asserting `createdAt` on a 10-minute cadence is what
+ * keeps the tree out of `empty` until the child finishes.
+ *
+ * Because a torn read is one of the states being defended against, the write
+ * itself must be atomic — see `touchWorktreeOccupancy`.
  *
  * The `worktree` tool's `keep` action (git worktree lock) remains the sanctioned
  * escape hatch for anything that must survive unconditionally, including across
@@ -75,11 +87,22 @@ export function worktreeRootFor(cwd: string): string | undefined {
  *
  * No-op (silently) when `cwd` is not inside an `.afk-worktrees/` tree or on
  * any filesystem error.
+ *
+ * Invariant: the write is atomic (temp file in the same directory, then
+ * `rename`) and must stay that way. A plain `writeFile` truncates before it
+ * fills, so a sweep reading the meta mid-write gets invalid JSON, treats the
+ * tree as having no owner, and drops `ownerLiveness` to 'unknown' — the exact
+ * state in which the tree becomes reapable. The heartbeat rewrites this file
+ * every 10 minutes for the life of every dispatched child, so a non-atomic
+ * write would multiply that window rather than close it. `rename` within one
+ * directory is atomic on POSIX and on NTFS, so a concurrent reader sees either
+ * the old meta or the new one, never a partial one.
  */
 export async function touchWorktreeOccupancy(cwd: string): Promise<void> {
   const root = worktreeRootFor(cwd);
   if (root === undefined) return;
   const metaPath = join(root, META_FILENAME);
+  const tmpPath = `${metaPath}.${process.pid}.tmp`;
   try {
     let meta: Record<string, unknown> = {};
     try {
@@ -89,9 +112,12 @@ export async function touchWorktreeOccupancy(cwd: string): Promise<void> {
     }
     meta['pid'] = process.pid;
     meta['createdAt'] = new Date().toISOString();
-    await fs.writeFile(metaPath, JSON.stringify(meta, null, 2), 'utf-8');
+    await fs.writeFile(tmpPath, JSON.stringify(meta, null, 2), 'utf-8');
+    await fs.rename(tmpPath, metaPath);
   } catch {
-    /* best-effort — never block dispatch */
+    // Best-effort — never block dispatch. Drop the temp file if the rename
+    // never happened, so a failed touch cannot litter the worktree.
+    await fs.rm(tmpPath, { force: true }).catch(() => {});
   }
 }
 
@@ -99,10 +125,15 @@ export async function touchWorktreeOccupancy(cwd: string): Promise<void> {
  * Keep the worktree containing `cwd` marked as occupied for as long as the
  * caller runs, returning the function that stops it.
  *
- * Invariant: the sweep derives `ageMs` from `meta.createdAt`, so ONE touch at
- * dispatch protects a child for only MIN_EMPTY_AGE_MS. A longer-running child
- * ages back into the `empty` verdict and is force-removed mid-flight (#759).
- * Occupation must therefore be re-asserted periodically, not stamped once.
+ * Contract: this is defence-in-depth, not the primary guard. For a tree whose
+ * meta carries this process's pid the `empty` verdict is already unreachable —
+ * it requires `ownerLiveness !== 'alive'`, and an in-process child keeps that
+ * pid alive for its whole run, so `createdAt` never gets consulted. The
+ * heartbeat matters only where the stamp is missing or untrustworthy (absent
+ * or unparseable meta, torn read, transient initial-touch failure); there
+ * `ownerLiveness` is 'unknown' and the MIN_EMPTY_AGE_MS gate is the only thing
+ * standing between a live child and `remove --force`. Re-asserting `createdAt`
+ * every 10 minutes keeps that gate armed for as long as the child runs.
  *
  * Ordering constraint (governed by the Node event loop, not by this module):
  * `stop` is defined and captured BEFORE the interval is armed, so there is no

--- a/src/agent/worktree-occupancy.ts
+++ b/src/agent/worktree-occupancy.ts
@@ -17,10 +17,14 @@
  *   - `ownerLiveness` resolves to 'alive' while this process runs, which
  *     suppresses the accelerated `dead-owner` path.
  *
- * Residual gap (accepted): a subagent running longer than MIN_EMPTY_AGE_MS
- * (1h) in a tree that stays clean can still cross the `empty` threshold.
- * The `worktree` tool's `keep` action (git worktree lock) is the sanctioned
- * escape hatch for anything that must survive unconditionally.
+ * A single touch only buys MIN_EMPTY_AGE_MS (1h) of protection, so a child that
+ * outlives it in a clean tree used to age back across the `empty` threshold and
+ * get reaped mid-run (#759). `startWorktreeOccupancyHeartbeat` closes that by
+ * re-asserting the occupation for as long as the child runs.
+ *
+ * The `worktree` tool's `keep` action (git worktree lock) remains the sanctioned
+ * escape hatch for anything that must survive unconditionally, including across
+ * process exit.
  *
  * Best-effort by contract: every failure is swallowed. A missed touch
  * degrades to today's behavior; it must never block or fail a dispatch.
@@ -33,6 +37,12 @@ import { join, resolve, sep } from 'node:path';
 
 const META_FILENAME = '.afk-worktree-meta.json';
 const AFK_WORKTREES_SEGMENT = `${sep}.afk-worktrees${sep}`;
+
+/**
+ * Heartbeat period. Must stay comfortably below the sweep's MIN_EMPTY_AGE_MS
+ * (1h, `worktree-sweep.ts`) so a tick always lands before the age gate re-arms.
+ */
+const DEFAULT_HEARTBEAT_INTERVAL_MS = 600_000; // 10 minutes
 
 /**
  * Resolve the worktree root containing `cwd`, when `cwd` sits inside an
@@ -78,4 +88,39 @@ export async function touchWorktreeOccupancy(cwd: string): Promise<void> {
   } catch {
     /* best-effort — never block dispatch */
   }
+}
+
+/**
+ * Keep the worktree containing `cwd` marked as occupied for as long as the
+ * caller runs, returning the function that stops it.
+ *
+ * Invariant: the sweep derives `ageMs` from `meta.createdAt`, so ONE touch at
+ * dispatch protects a child for only MIN_EMPTY_AGE_MS. A longer-running child
+ * ages back into the `empty` verdict and is force-removed mid-flight (#759).
+ * Occupation must therefore be re-asserted periodically, not stamped once.
+ *
+ * Ordering constraint (governed by the Node event loop, not by this module):
+ * `stop` is defined and captured BEFORE the interval is armed, so there is no
+ * window in which a timer exists without a handle able to cancel it. The timer
+ * is `unref()`d so a pending heartbeat can never hold the process open past the
+ * work it was protecting.
+ *
+ * Callers MUST call the returned function from a `finally`, so it runs on normal
+ * return, on throw, and on abort alike.
+ */
+export function startWorktreeOccupancyHeartbeat(
+  cwd: string,
+  intervalMs: number = DEFAULT_HEARTBEAT_INTERVAL_MS,
+): () => void {
+  let timer: ReturnType<typeof setInterval> | undefined;
+  const stop = (): void => {
+    if (timer === undefined) return;
+    clearInterval(timer);
+    timer = undefined;
+  };
+  // Nothing to protect outside a managed tree — hand back an inert stop.
+  if (worktreeRootFor(cwd) === undefined) return stop;
+  timer = setInterval(() => { void touchWorktreeOccupancy(cwd); }, intervalMs);
+  timer.unref();
+  return stop;
 }

--- a/src/agent/worktree-occupancy.ts
+++ b/src/agent/worktree-occupancy.ts
@@ -44,6 +44,7 @@
  * @module agent/worktree-occupancy
  */
 
+import { randomUUID } from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import { join, resolve, sep } from 'node:path';
 
@@ -98,11 +99,20 @@ export function worktreeRootFor(cwd: string): string | undefined {
  * directory is atomic on POSIX and on NTFS, so a concurrent reader sees either
  * the old meta or the new one, never a partial one.
  */
-export async function touchWorktreeOccupancy(cwd: string): Promise<void> {
+export async function touchWorktreeOccupancy(
+  cwd: string,
+  isCancelled?: () => boolean,
+): Promise<void> {
   const root = worktreeRootFor(cwd);
   if (root === undefined) return;
+  if (isCancelled?.() === true) return;
   const metaPath = join(root, META_FILENAME);
-  const tmpPath = `${metaPath}.${process.pid}.tmp`;
+  // Invariant: the temp name must be unique per CALL, not per process. Subagents
+  // run in-process and inherit the parent cwd verbatim, so a worktree-isolated
+  // parent fanning out N children arms N heartbeats against the same root — a
+  // pid-only name gives all of them one temp path, and their write/rename pairs
+  // interleave on a single file.
+  const tmpPath = `${metaPath}.${process.pid}.${randomUUID()}.tmp`;
   try {
     let meta: Record<string, unknown> = {};
     try {
@@ -113,6 +123,14 @@ export async function touchWorktreeOccupancy(cwd: string): Promise<void> {
     meta['pid'] = process.pid;
     meta['createdAt'] = new Date().toISOString();
     await fs.writeFile(tmpPath, JSON.stringify(meta, null, 2), 'utf-8');
+    // Ordering constraint (Node event loop): the caller's cancel signal can flip
+    // during either await above, and `rename` is the only irreversible step. Re-check
+    // immediately before it — never between read and write — so a cancelled touch
+    // leaves the meta file byte-identical and takes its temp file with it.
+    if (isCancelled?.() === true) {
+      await fs.rm(tmpPath, { force: true }).catch(() => {});
+      return;
+    }
     await fs.rename(tmpPath, metaPath);
   } catch {
     // Best-effort — never block dispatch. Drop the temp file if the rename
@@ -149,14 +167,24 @@ export function startWorktreeOccupancyHeartbeat(
   intervalMs: number = DEFAULT_HEARTBEAT_INTERVAL_MS,
 ): () => void {
   let timer: ReturnType<typeof setInterval> | undefined;
+  // Invariant: clearing the interval is NOT sufficient for "stops touching".
+  // Each tick fires an un-awaited async touch, so one already past its first
+  // await survives `clearInterval` and lands its rename after the caller
+  // believes the heartbeat is disarmed — re-stamping `createdAt` on a tree the
+  // sweep was about to judge. This flag is what the touch honours to make the
+  // disarm actually observable.
+  let stopped = false;
   const stop = (): void => {
+    stopped = true;
     if (timer === undefined) return;
     clearInterval(timer);
     timer = undefined;
   };
   // Nothing to protect outside a managed tree — hand back an inert stop.
   if (worktreeRootFor(cwd) === undefined) return stop;
-  timer = setInterval(() => { void touchWorktreeOccupancy(cwd); }, intervalMs);
+  timer = setInterval(() => {
+    void touchWorktreeOccupancy(cwd, () => stopped);
+  }, intervalMs);
   timer.unref();
   return stop;
 }

--- a/src/agent/worktree-sweep.test.ts
+++ b/src/agent/worktree-sweep.test.ts
@@ -250,6 +250,11 @@ describe('empty-detection', () => {
 
     expect(result.candidates.some((c) => c.verdict === 'empty')).toBe(true);
     expect(result.removed).toContain(worktreePath);
+    // Discriminates this test from pre-existing clean+0-ahead+old => `empty`
+    // behaviour: without this, hardcoding `hasNonRebuildableIgnoredFiles` to
+    // always return `false` still passes, because nothing here proves the
+    // probe ran at all. Assert the `--ignored` call actually happened.
+    expect(mock.calls.some((c) => c.args.includes('status') && c.args.includes('--ignored'))).toBe(true);
   });
 
   it('does not remove empty worktree in dry-run mode', async () => {

--- a/src/agent/worktree-sweep.test.ts
+++ b/src/agent/worktree-sweep.test.ts
@@ -164,6 +164,94 @@ describe('empty-detection', () => {
     expect(result.dryRun).toBe(false);
   });
 
+  // #759: bare `status --porcelain` never lists IGNORED files, so a tree whose
+  // only content is ignored read CLEAN and every removal path runs
+  // `remove --force`, deleting it. Committed work survives (branch refs live in
+  // the shared .git) but worktree-local `.env`/scratch state does not.
+  it('does NOT reap a clean tree holding a non-rebuildable ignored file (.env)', async () => {
+    const worktreePath = join(afkWorktreesDir, 'afk-has-dotenv');
+    await fs.mkdir(worktreePath, { recursive: true });
+    await fs.writeFile(
+      join(worktreePath, '.afk-worktree-meta.json'),
+      JSON.stringify({ owner: 'interactive', createdAt: new Date(Date.now() - 86_400_000 * 20).toISOString(), baseSha: 'base123', baseBranch: 'main' }),
+    );
+
+    const porcelainOut =
+      `${worktreeBlock({ path: repoRoot, head: 'base123' })}\n\n` +
+      `${worktreeBlock({ path: worktreePath, head: 'base123', branch: 'refs/heads/afk/has-dotenv' })}\n`;
+
+    const mock = makeMock(async ({ args }) => {
+      if (args.includes('list') && args.includes('--porcelain')) {
+        return { stdout: porcelainOut, stderr: '' };
+      }
+      // The ignored-aware probe is a DIFFERENT call than the bare dirty check.
+      if (args.includes('status') && args.includes('--ignored')) {
+        return { stdout: '!! .env\n!! node_modules/\n', stderr: '' };
+      }
+      if (args.includes('status') && args.includes('--porcelain')) {
+        return { stdout: '', stderr: '' }; // tracked tree is clean
+      }
+      if (args.includes('rev-list') && args.includes('--count')) {
+        return { stdout: '0\n', stderr: '' };
+      }
+      return { stdout: '', stderr: '' };
+    });
+
+    const result = await runSweep({
+      execFile: mock as ExecFileFn,
+      repoRoot,
+      lockPath: lockFile,
+      dryRun: false,
+      telemetryPath: telemetryFile,
+    });
+
+    expect(result.candidates.some((c) => c.verdict === 'empty')).toBe(false);
+    expect(result.removed).not.toContain(worktreePath);
+    expect(mock.calls.some((c) => c.args.includes('remove'))).toBe(false);
+  });
+
+  // The counterweight: if ANY ignored entry were protective, node_modules/ and
+  // dist/ would make every worktree immortal and the sweep would never reclaim.
+  it('still reaps a clean tree whose only ignored content is rebuildable output', async () => {
+    const worktreePath = join(afkWorktreesDir, 'afk-only-build-output');
+    await fs.mkdir(worktreePath, { recursive: true });
+    await fs.writeFile(
+      join(worktreePath, '.afk-worktree-meta.json'),
+      JSON.stringify({ owner: 'interactive', createdAt: new Date(Date.now() - 86_400_000 * 20).toISOString(), baseSha: 'base123', baseBranch: 'main' }),
+    );
+
+    const porcelainOut =
+      `${worktreeBlock({ path: repoRoot, head: 'base123' })}\n\n` +
+      `${worktreeBlock({ path: worktreePath, head: 'base123', branch: 'refs/heads/afk/only-build-output' })}\n`;
+
+    const mock = makeMock(async ({ args }) => {
+      if (args.includes('list') && args.includes('--porcelain')) {
+        return { stdout: porcelainOut, stderr: '' };
+      }
+      if (args.includes('status') && args.includes('--ignored')) {
+        return { stdout: '!! node_modules/\n!! dist/\n!! coverage/\n!! tsconfig.tsbuildinfo\n', stderr: '' };
+      }
+      if (args.includes('status') && args.includes('--porcelain')) {
+        return { stdout: '', stderr: '' };
+      }
+      if (args.includes('rev-list') && args.includes('--count')) {
+        return { stdout: '0\n', stderr: '' };
+      }
+      return { stdout: '', stderr: '' };
+    });
+
+    const result = await runSweep({
+      execFile: mock as ExecFileFn,
+      repoRoot,
+      lockPath: lockFile,
+      dryRun: false,
+      telemetryPath: telemetryFile,
+    });
+
+    expect(result.candidates.some((c) => c.verdict === 'empty')).toBe(true);
+    expect(result.removed).toContain(worktreePath);
+  });
+
   it('does not remove empty worktree in dry-run mode', async () => {
     const worktreePath = join(afkWorktreesDir, 'afk-empty-dry');
     await fs.mkdir(worktreePath, { recursive: true });

--- a/src/agent/worktree-sweep.test.ts
+++ b/src/agent/worktree-sweep.test.ts
@@ -1894,6 +1894,115 @@ describe('empty-verdict liveness gate (#380)', () => {
     );
     expect(removeCalls).toHaveLength(0);
   });
+
+  /**
+   * Invariant: what actually protects a worktree hosting a running subagent is
+   * the LIVE PID stamped by `touchWorktreeOccupancy`, not the age gate. A
+   * forked subagent runs in this same OS process, so `ownerLiveness` resolves
+   * 'alive' for its whole run and `empty` — which requires
+   * `ownerLiveness !== 'alive'` — is unreachable however old the tree gets.
+   *
+   * These two cases pin that relationship in the direction the occupancy
+   * heartbeat depends on. Without them the heartbeat's rationale is untestable
+   * prose: nothing failed when the module docblock claimed a live child "ages
+   * back into the `empty` verdict", because no test drove the heartbeat's
+   * effect through `runSweep` at all.
+   */
+  it('never reaps a clean tree whose meta carries a live pid, however old', async () => {
+    const worktreePath = join(afkWorktreesDir, 'afk-live-pid-old-wt');
+    await fs.mkdir(worktreePath, { recursive: true });
+    await fs.writeFile(
+      join(worktreePath, '.afk-worktree-meta.json'),
+      JSON.stringify({
+        owner: 'agent',
+        pid: process.pid, // alive — exactly what touchWorktreeOccupancy stamps
+        createdAt: new Date(Date.now() - 86_400_000 * 7).toISOString(), // 7d ≫ 1h gate
+        baseSha: 'base123',
+        baseBranch: 'main',
+      }),
+    );
+
+    const mainBlock = worktreeBlock({ path: repoRoot, head: 'base123' });
+    const wtBlock = worktreeBlock({
+      path: worktreePath,
+      head: 'base123',
+      branch: 'refs/heads/afk/live-pid-old-wt',
+    });
+    const mock = makeMock(async ({ args }) => {
+      if (args.includes('list') && args.includes('--porcelain')) {
+        return { stdout: `${mainBlock}\n\n${wtBlock}\n`, stderr: '' };
+      }
+      if (args.includes('status') && args.includes('--porcelain')) {
+        return { stdout: '', stderr: '' };
+      }
+      if (args.includes('rev-list') && args.includes('--count')) {
+        return { stdout: '0\n', stderr: '' };
+      }
+      return { stdout: '', stderr: '' };
+    });
+
+    const result = await runSweep({
+      execFile: mock as ExecFileFn,
+      repoRoot,
+      lockPath: lockFile,
+      dryRun: false,
+      telemetryPath: telemetryFile,
+      readPresence: async () => [],
+    });
+
+    const candidate = result.candidates.find((c) => c.path === worktreePath);
+    expect(candidate?.verdict).not.toBe('empty');
+    expect(candidate?.verdict).not.toBe('dead-owner');
+    expect(result.removed).not.toContain(worktreePath);
+  });
+
+  it('DOES reap an aged clean tree whose meta has no pid — the state the heartbeat defends', async () => {
+    const worktreePath = join(afkWorktreesDir, 'afk-no-pid-old-wt');
+    await fs.mkdir(worktreePath, { recursive: true });
+    // No `pid`: the stamp never landed, or the meta was written by something
+    // else. ownerLiveness → 'unknown', so MIN_EMPTY_AGE_MS is the only guard —
+    // which is precisely why the heartbeat keeps re-asserting `createdAt`.
+    await fs.writeFile(
+      join(worktreePath, '.afk-worktree-meta.json'),
+      JSON.stringify({
+        owner: 'agent',
+        createdAt: new Date(Date.now() - 86_400_000 * 7).toISOString(),
+        baseSha: 'base123',
+        baseBranch: 'main',
+      }),
+    );
+
+    const mainBlock = worktreeBlock({ path: repoRoot, head: 'base123' });
+    const wtBlock = worktreeBlock({
+      path: worktreePath,
+      head: 'base123',
+      branch: 'refs/heads/afk/no-pid-old-wt',
+    });
+    const mock = makeMock(async ({ args }) => {
+      if (args.includes('list') && args.includes('--porcelain')) {
+        return { stdout: `${mainBlock}\n\n${wtBlock}\n`, stderr: '' };
+      }
+      if (args.includes('status') && args.includes('--porcelain')) {
+        return { stdout: '', stderr: '' };
+      }
+      if (args.includes('rev-list') && args.includes('--count')) {
+        return { stdout: '0\n', stderr: '' };
+      }
+      return { stdout: '', stderr: '' };
+    });
+
+    const result = await runSweep({
+      execFile: mock as ExecFileFn,
+      repoRoot,
+      lockPath: lockFile,
+      dryRun: true, // classification only — no filesystem mutation needed
+      telemetryPath: telemetryFile,
+      readPresence: async () => [],
+    });
+
+    const candidate = result.candidates.find((c) => c.path === worktreePath);
+    expect(candidate?.verdict).toBe('empty');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/agent/worktree-sweep.test.ts
+++ b/src/agent/worktree-sweep.test.ts
@@ -512,6 +512,102 @@ describe('stale-dirty-never-removes', () => {
     expect(result.removed).not.toContain(worktreePath);
     expect(result.warnings.some((w) => w.includes('stale-dirty') || w.includes(worktreePath))).toBe(true);
   });
+
+  // An ignored-state protect is reported through the SAME stale-dirty path as a
+  // real diff, so the warning used to tell the reader to go look for uncommitted
+  // changes in a tree `git status` calls clean. Pin the honest label.
+  it('names ignored local state as the reason, not "uncommitted changes"', async () => {
+    const worktreePath = join(afkWorktreesDir, 'afk-ignored-only-old');
+    await fs.mkdir(worktreePath, { recursive: true });
+    await fs.writeFile(
+      join(worktreePath, '.afk-worktree-meta.json'),
+      JSON.stringify({
+        owner: 'interactive',
+        createdAt: new Date(Date.now() - 86_400_000 * 40).toISOString(),
+        baseSha: 'base123',
+      }),
+    );
+
+    const mainBlock = worktreeBlock({ path: repoRoot });
+    const wtBlock = worktreeBlock({ path: worktreePath, head: 'tip456' });
+    const porcelainOut = `${mainBlock}\n\n${wtBlock}\n`;
+
+    const mock = makeMock(async ({ args }) => {
+      if (args.includes('list') && args.includes('--porcelain')) {
+        return { stdout: porcelainOut, stderr: '' };
+      }
+      // The ignored probe: a hand-kept file no rebuild restores.
+      if (args.includes('--ignored')) {
+        return { stdout: '!! local-notes.md\n', stderr: '' };
+      }
+      // Bare status: CLEAN. This is the whole point — the tree has no diff.
+      if (args.includes('status') && args.includes('--porcelain')) {
+        return { stdout: '', stderr: '' };
+      }
+      return { stdout: '', stderr: '' };
+    });
+
+    const result = await runSweep({
+      execFile: mock as ExecFileFn,
+      repoRoot,
+      lockPath: lockFile,
+      dryRun: false,
+      maxAgeDaysDirty: 30,
+      telemetryPath: telemetryFile,
+    });
+
+    expect(result.removed).not.toContain(worktreePath);
+    const warning = result.warnings.find((w) => w.includes(worktreePath) && w.includes('stale-dirty'));
+    expect(warning).toBeDefined();
+    expect(warning).toContain('non-rebuildable ignored files');
+    expect(warning).not.toContain('uncommitted changes');
+  });
+
+  // A probe that protects because git FAILED must say so; otherwise the tree is
+  // preserved forever with no trace of why.
+  it('warns distinctly when the ignored probe itself fails', async () => {
+    const worktreePath = join(afkWorktreesDir, 'afk-probe-broken');
+    await fs.mkdir(worktreePath, { recursive: true });
+    await fs.writeFile(
+      join(worktreePath, '.afk-worktree-meta.json'),
+      JSON.stringify({
+        owner: 'interactive',
+        createdAt: new Date(Date.now() - 86_400_000 * 40).toISOString(),
+        baseSha: 'base123',
+      }),
+    );
+
+    const mainBlock = worktreeBlock({ path: repoRoot });
+    const wtBlock = worktreeBlock({ path: worktreePath, head: 'tip456' });
+    const porcelainOut = `${mainBlock}\n\n${wtBlock}\n`;
+
+    const mock = makeMock(async ({ args }) => {
+      if (args.includes('list') && args.includes('--porcelain')) {
+        return { stdout: porcelainOut, stderr: '' };
+      }
+      if (args.includes('--ignored')) throw new Error('stdout maxBuffer length exceeded');
+      if (args.includes('status') && args.includes('--porcelain')) {
+        return { stdout: '', stderr: '' };
+      }
+      return { stdout: '', stderr: '' };
+    });
+
+    const result = await runSweep({
+      execFile: mock as ExecFileFn,
+      repoRoot,
+      lockPath: lockFile,
+      dryRun: false,
+      maxAgeDaysDirty: 30,
+      telemetryPath: telemetryFile,
+    });
+
+    expect(result.removed).not.toContain(worktreePath);
+    expect(
+      result.warnings.some(
+        (w) => w.includes('ignored-file probe failed') && w.includes(worktreePath),
+      ),
+    ).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/agent/worktree-sweep.ts
+++ b/src/agent/worktree-sweep.ts
@@ -16,7 +16,7 @@ import { readPresenceFiles, type PresenceRecord } from './awareness/presence.js'
 // going the other way (worktree-ignored-probe.ts importing ExecFileFn from
 // THIS file) is `import type`, which TypeScript erases at compile time — so
 // no runtime require()/import cycle exists between the two modules.
-import { hasNonRebuildableIgnoredFiles } from './worktree-ignored-probe.js';
+import { probeNonRebuildableIgnoredFiles } from './worktree-ignored-probe.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -30,8 +30,32 @@ import { hasNonRebuildableIgnoredFiles } from './worktree-ignored-probe.js';
 export type ExecFileFn = (
   file: string,
   args: string[],
-  opts?: { cwd?: string },
+  opts?: {
+    cwd?: string;
+    /**
+     * Contract: callers that can produce large output MUST set this. Node's
+     * default `execFile` maxBuffer is 1MB and an overflow REJECTS the promise
+     * rather than truncating, so an unbounded call silently converts "lots of
+     * output" into "git failed" — and every failure path in the ignored probe
+     * fails safe by protecting, which quietly makes the worktree immortal.
+     */
+    maxBuffer?: number;
+    timeout?: number;
+  },
 ) => Promise<{ stdout: string; stderr: string }>;
+
+/**
+ * Why a candidate reads dirty. Carried so a preservation warning can name the
+ * actual cause: an ignored-state protect is NOT "uncommitted changes" — git
+ * status calls that tree clean — and reporting it as such sends the reader
+ * looking for a diff that does not exist.
+ */
+type DirtyReason =
+  | 'clean'
+  | 'uncommitted changes'
+  | 'git status failed'
+  | 'non-rebuildable ignored files'
+  | 'ignored-file probe failed';
 
 interface WorktreeMeta {
   owner: 'interactive' | 'diagnose' | string;
@@ -60,6 +84,8 @@ interface WorktreeCandidate {
   meta?: WorktreeMeta;
   ageMs: number;
   isDirty: boolean;
+  /** Populated whenever `isDirty` is true; `'clean'` otherwise. */
+  dirtyReason: DirtyReason;
   commitsAhead: number;
   /**
    * Commits on this worktree's HEAD that exist NOWHERE but this checkout —
@@ -607,11 +633,16 @@ export async function runSweep(options: SweepOptions): Promise<SweepResult> {
 
       // Check dirty status
       let isDirty = false;
+      let dirtyReason: DirtyReason = 'clean';
       let commitsAhead = 0;
       try {
         const statusResult = await execFile('git', ['-C', entry.path, 'status', '--porcelain']);
         isDirty = statusResult.stdout.trim().length > 0;
-      } catch { isDirty = true; /* treat as dirty — safe fallback */ }
+        if (isDirty) dirtyReason = 'uncommitted changes';
+      } catch {
+        isDirty = true; /* treat as dirty — safe fallback */
+        dirtyReason = 'git status failed';
+      }
 
       // Invariant: bare `--porcelain` reports untracked files but NEVER ignored
       // ones, so a tree holding only ignored content reads clean here and every
@@ -622,7 +653,22 @@ export async function runSweep(options: SweepOptions): Promise<SweepResult> {
       // (node_modules/, dist/, caches) is deliberately NOT protective — that
       // would make every worktree immortal and defeat the sweep.
       if (!isDirty) {
-        isDirty = await hasNonRebuildableIgnoredFiles(execFile, entry.path);
+        const probe = await probeNonRebuildableIgnoredFiles(execFile, entry.path);
+        isDirty = probe.protect;
+        if (probe.protect) {
+          dirtyReason =
+            probe.because === 'git-failed'
+              ? 'ignored-file probe failed'
+              : 'non-rebuildable ignored files';
+        }
+        // A protect-on-failure is indistinguishable from a real find at the
+        // verdict level, so surface it: otherwise a worktree that git can no
+        // longer read stays preserved forever with no trace of why.
+        if (probe.protect && probe.because === 'git-failed') {
+          result.warnings.push(
+            `[WARN] ignored-file probe failed for ${entry.path} — preserving (${probe.detail})`,
+          );
+        }
       }
 
       if (!isDirty && entry.head) {
@@ -709,6 +755,7 @@ export async function runSweep(options: SweepOptions): Promise<SweepResult> {
         meta,
         ageMs,
         isDirty,
+        dirtyReason,
         commitsAhead,
         commitsUnpushed,
         ownerLiveness,
@@ -777,7 +824,7 @@ export async function runSweep(options: SweepOptions): Promise<SweepResult> {
           );
         } else if (verdict === 'stale-dirty') {
           result.warnings.push(
-            `[WARN] stale-dirty worktree preserved (uncommitted changes): ${entry.path}`,
+            `[WARN] stale-dirty worktree preserved (${candidate.dirtyReason}): ${entry.path}`,
           );
         }
         // 'locked', 'active' → no-op

--- a/src/agent/worktree-sweep.ts
+++ b/src/agent/worktree-sweep.ts
@@ -12,6 +12,8 @@ import { join, relative, isAbsolute } from 'node:path';
 import { createInterface } from 'node:readline';
 import { getWorktreeSweepLockPath, getTelemetryPath } from '../paths.js';
 import { readPresenceFiles, type PresenceRecord } from './awareness/presence.js';
+// Type-only back-import there, so this pairing carries no runtime cycle.
+import { hasNonRebuildableIgnoredFiles } from './worktree-ignored-probe.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -602,6 +604,18 @@ export async function runSweep(options: SweepOptions): Promise<SweepResult> {
         const statusResult = await execFile('git', ['-C', entry.path, 'status', '--porcelain']);
         isDirty = statusResult.stdout.trim().length > 0;
       } catch { isDirty = true; /* treat as dirty — safe fallback */ }
+
+      // Invariant: bare `--porcelain` reports untracked files but NEVER ignored
+      // ones, so a tree holding only ignored content reads clean here and every
+      // removal path below runs `remove --force`, deleting it. Committed work
+      // survives (branch refs live in the shared .git), but a worktree-local
+      // `.env` or scratch file does not (#759). Probe for ignored content a
+      // rebuild could NOT restore and treat it as dirty. Rebuildable output
+      // (node_modules/, dist/, caches) is deliberately NOT protective — that
+      // would make every worktree immortal and defeat the sweep.
+      if (!isDirty) {
+        isDirty = await hasNonRebuildableIgnoredFiles(execFile, entry.path);
+      }
 
       if (!isDirty && entry.head) {
         // Contract: `commitsAhead > 0` marks a worktree as holding unmerged

--- a/src/agent/worktree-sweep.ts
+++ b/src/agent/worktree-sweep.ts
@@ -12,7 +12,10 @@ import { join, relative, isAbsolute } from 'node:path';
 import { createInterface } from 'node:readline';
 import { getWorktreeSweepLockPath, getTelemetryPath } from '../paths.js';
 import { readPresenceFiles, type PresenceRecord } from './awareness/presence.js';
-// Type-only back-import there, so this pairing carries no runtime cycle.
+// Runtime value import. Safe despite the mutual reference: the only import
+// going the other way (worktree-ignored-probe.ts importing ExecFileFn from
+// THIS file) is `import type`, which TypeScript erases at compile time — so
+// no runtime require()/import cycle exists between the two modules.
 import { hasNonRebuildableIgnoredFiles } from './worktree-ignored-probe.js';
 
 // ---------------------------------------------------------------------------
@@ -163,8 +166,13 @@ export interface SweepResult {
  * same tick. One hour is generous enough to cover any human-paced workflow
  * while still letting `empty` survive a sweep when the user has had time to
  * commit.
+ *
+ * Exported so `worktree-occupancy.ts`'s `DEFAULT_HEARTBEAT_INTERVAL_MS` can be
+ * checked against it directly instead of via a prose comment linking two
+ * private constants in different files — raising the heartbeat interval above
+ * this gate would silently re-break #759 with no test failures otherwise.
  */
-const MIN_EMPTY_AGE_MS = 3_600_000; // 1 hour
+export const MIN_EMPTY_AGE_MS = 3_600_000; // 1 hour
 
 /**
  * Maximum age of a `.afk-worktree-meta.json` whose `pid` field we still

--- a/src/cli/commands/interactive/worktree.test.ts
+++ b/src/cli/commands/interactive/worktree.test.ts
@@ -188,6 +188,64 @@ describe('setupWorktree', () => {
     expect(removeIdx).toBeLessThan(branchIdx);
   });
 
+  // Invariant: bare `git status --porcelain` never reports IGNORED files, so a
+  // tree whose only content is a gitignored `.env` reads clean and used to fall
+  // straight through to `remove --force` — destroying it (#759). Session-end
+  // cleanup is the most frequently executed removal path, so this guard is the
+  // one that matters most.
+  it('cleanup preserves a clean tree that holds a non-rebuildable ignored file', async () => {
+    const mock = makeMock(async ({ args }) => {
+      if (args.includes('rev-parse')) {
+        return { stdout: `${repoRoot}/.git\n`, stderr: '' };
+      }
+      if (args.includes('status') && args.includes('--ignored')) {
+        return { stdout: '!! .env\n!! node_modules/\n', stderr: '' };
+      }
+      if (args.includes('status') && args.includes('--porcelain')) {
+        return { stdout: '', stderr: '' }; // clean to the dirty check
+      }
+      return { stdout: '', stderr: '' };
+    });
+
+    const handle = await setupWorktree('feat-x', { execFile: mock });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const callsBefore = mock.calls.length;
+    await handle.cleanup();
+    const cleanupCalls = mock.calls.slice(callsBefore);
+
+    expect(
+      cleanupCalls.some((c) => c.args.includes('worktree') && c.args.includes('remove')),
+    ).toBe(false);
+    const logged = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logged).toMatch(/preserved/);
+    expect(logged).toMatch(/ignored/);
+    logSpy.mockRestore();
+  });
+
+  it('cleanup still removes a clean tree whose ignored content is only build output', async () => {
+    const mock = makeMock(async ({ args }) => {
+      if (args.includes('rev-parse')) {
+        return { stdout: `${repoRoot}/.git\n`, stderr: '' };
+      }
+      if (args.includes('status') && args.includes('--ignored')) {
+        return { stdout: '!! node_modules/\n!! .afk-worktree-meta.json\n', stderr: '' };
+      }
+      if (args.includes('status') && args.includes('--porcelain')) {
+        return { stdout: '', stderr: '' };
+      }
+      return { stdout: '', stderr: '' };
+    });
+
+    const handle = await setupWorktree('feat-x', { execFile: mock });
+    const callsBefore = mock.calls.length;
+    await handle.cleanup();
+    const cleanupCalls = mock.calls.slice(callsBefore);
+
+    expect(
+      cleanupCalls.some((c) => c.args.includes('worktree') && c.args.includes('remove')),
+    ).toBe(true);
+  });
+
   it('cleanup with a dirty tree preserves the worktree and logs', async () => {
     const mock = makeMock(async ({ args }) => {
       if (args.includes('rev-parse')) {

--- a/src/cli/commands/interactive/worktree.ts
+++ b/src/cli/commands/interactive/worktree.ts
@@ -19,6 +19,7 @@ import { randomBytes } from 'node:crypto';
 
 import { recordCdIntent, shellWrapperActive } from '../../../utils/cd-on-exit.js';
 import { detectShellFromEnv } from '../shell-init.js';
+import { hasNonRebuildableIgnoredFiles } from '../../../agent/worktree-ignored-probe.js';
 
 const execFileDefault = promisify(execFileCallback);
 
@@ -638,6 +639,8 @@ async function createWorktreeAt(
 
       if (opts?.force === true) {
         // Zero-turn session: no work was done, so skip the dirty-state check
+        // AND the ignored-state probe below — nothing can have been written in
+        // a session that took zero turns, so there is nothing to preserve.
         // and remove unconditionally. Log before the git call so the user sees
         // confirmation even if the removal fails.
         // eslint-disable-next-line no-console
@@ -674,10 +677,10 @@ async function createWorktreeAt(
         return;
       }
 
-      if (status.stdout.trim().length > 0) {
+      const preserveWorktree = (reason: string): void => {
         // eslint-disable-next-line no-console
         console.log(
-          `Worktree preserved at ${currentPath} (branch: ${currentBranch}) — uncommitted changes.`,
+          `Worktree preserved at ${currentPath} (branch: ${currentBranch}) — ${reason}.`,
         );
         // Record the worktree as the parent shell's desired cwd. The
         // optional `afk` shell wrapper (installed via `afk shell-init`)
@@ -697,6 +700,27 @@ async function createWorktreeAt(
           // eslint-disable-next-line no-console
           console.log(`  → cd ${currentPath}\n  → Or install one-time:  ${installHint}`);
         }
+      };
+
+      if (status.stdout.trim().length > 0) {
+        preserveWorktree('uncommitted changes');
+        return;
+      }
+
+      // Invariant: the `git status --porcelain` above reports untracked files
+      // but NEVER ignored ones, so a tree whose only content is ignored reads
+      // clean here and falls straight through to `remove --force` below. That
+      // deletes a worktree-local `.env` or gitignored scratch file with no
+      // warning and no recovery (#759) — this is the same defect the sweep
+      // engine and the `worktree` tool's remove path already guard against, and
+      // it is the most frequently executed removal path of the three.
+      // Rebuildable output (node_modules/, dist/) stays non-protective on
+      // purpose: treating it as protective would strand every worktree the
+      // user ever finished with.
+      if (await hasNonRebuildableIgnoredFiles(execFile, currentPath)) {
+        preserveWorktree(
+          'non-rebuildable ignored files (e.g. .env) that `git status` cannot see',
+        );
         return;
       }
 


### PR DESCRIPTION
Fixes #759.

Two independent paths by which the background sweep destroys data. Committed work is never at risk in either (branch refs live in the shared `.git`) — what is at risk is a live checkout and worktree-local ignored state.

## 1. A live worktree could be force-removed mid-flight

`classifyCandidate`'s `empty` verdict requires `ownerLiveness !== 'alive'`, a clean tree, no unreplaceable commits, and `ageMs >= MIN_EMPTY_AGE_MS` (1 hour). Occupancy was stamped **exactly once**, at dispatch (`subagent.ts`), and the sweep derives `ageMs` from `meta.createdAt` — so one touch bought only an hour of protection. Any subagent running longer than that aged back into `empty` while still working, and `git worktree remove --force` took its checkout out from under it.

**Fix:** `startWorktreeOccupancyHeartbeat()` re-asserts the occupation every 10 minutes (comfortably inside the 1h gate) for as long as the child runs.

Lifecycle details, since a stray timer is its own bug:
- the timer is `unref()`d, so a leaked one can never hold the process open;
- its stop handle is captured **before** the child session is constructed, so no exit path can arm a timer it has no handle to cancel;
- it is disarmed from the settle callback — which fires on success, failure, timeout **and** abort — and separately from the construction-failure path.

## 2. The dirty guard was blind to ignored files

`git status --porcelain` reports untracked files but **never ignored** ones. A worktree whose only content was ignored therefore read *clean*, satisfied `empty`, and was `remove --force`d — deleting it. `node_modules/` and `dist/` are merely annoying to lose; a worktree-local `.env` or an un-ignored-by-habit secrets file is unrecoverable.

**Fix:** new `worktree-ignored-probe.ts` treats ignored content a rebuild would **not** restore as dirty.

The judgment call here is the filter, and it matters in both directions. Protecting on *any* ignored entry would make effectively every worktree immortal — `node_modules/`/`dist/` exist in every checkout — which defeats the sweep and regrows the very leak it exists to prevent. So the default stays "reapable", and only an entry that fails to match a known-rebuildable pattern protects the tree. Unrecognised entries (`.env*`, `.vscode/`, `.idea/`, anything unfamiliar) and any git failure fail **safe**, toward protecting. The probe uses `--ignored` in traditional mode on purpose: it collapses an ignored directory to a single `!! node_modules/` line rather than listing every file underneath.

## Posture: deliberately unchanged

A **meta-less** tree stays reapable. The alternative — never reaping a tree without meta — trades a bounded data-loss bug for an unbounded leak, and worktrees already accumulate in practice. The two fixes above close the actual loss paths without that trade.

## Verification

| Gate | Result |
|---|---|
| `pnpm test src/agent/worktree-ignored-probe.test.ts` | 37 passed |
| `pnpm test src/agent/worktree-occupancy.test.ts` | 13 passed |
| `pnpm test src/agent/worktree-sweep.test.ts` | 43 passed |
| `pnpm test src/agent/subagent.test.ts` | 87 passed |
| `pnpm test src/agent/tools/subagent/subagent-executor.isolation.test.ts` | 7 passed |
| `pnpm lint` (`tsc --noEmit`) | clean |

New regression coverage: a clean tree holding `.env` is not reaped; a clean tree holding only build output still is; the heartbeat refreshes a backdated meta below the 1h gate, halts on `stop()`, is idempotent, and stays inert outside a managed tree.

## Two things for the reviewer

1. **File size.** The repo's 350-line-per-file convention: the new behaviour went into a new file (`worktree-ignored-probe.ts`, 114 lines) rather than inline, but the two pre-existing files still grew — `worktree-sweep.ts` 783 → 797 and `subagent.ts` 1138 → 1155, both already well over the ceiling. Extracting `classifyCandidate` + the verdict types into `worktree-sweep-classify.ts` is the obvious next cut (verified: those types have **zero** importers outside `worktree-sweep.ts`, and the suite drives everything through `runSweep`, so the move is safe). I deliberately left it out — it is a pure code move, and bundling one with a behavioural fix is how a move hides a regression. Happy to send it as a standalone follow-up.
2. **The rebuildable pattern list** is a heuristic and the place where a wrong call has real cost. Worth a second pair of eyes on what belongs in it — an over-inclusive entry silently re-opens the deletion path for that name.
