### PR TITLE
fix(tui): bound grouped tool summaries to terminal width

### DIFF
--- a/src/cli/commands/interactive/tool-lane-render-agent.ts
+++ b/src/cli/commands/interactive/tool-lane-render-agent.ts
@@ -253,17 +253,30 @@ function renderGroupedRootTools(
   homeDir?: string,
 ): string[] {
   const lines: string[] = [];
-  // Read once per call: diff body lines below are clamped to this width so
-  // long file content never soft-wraps to column 0 in scrollback (orphaning
-  // its continuation past the indent). Mirrors the clamp on every other
-  // diff-emission path; see tool-lane-render-children.ts.
+  // Read once per call: EVERY line this function emits is clamped to this
+  // width so nothing soft-wraps to column 0 in scrollback (orphaning its
+  // continuation past the indent). Mirrors the clamp on every other
+  // emission path; see tool-lane-render-children.ts.
+  //
+  // Invariant: root entries arrive here with an UNBOUNDED prefix — the root
+  // dispatch path (stream-renderer-orchestrator.ts) calls
+  // addStartWithAgentContext without a maxWidth, unlike the subagent-child
+  // path (stream-renderer-subagent.ts) which budgets it at cols - 14. So the
+  // clamp here is the only thing standing between a 350-column bash command
+  // and a wrapped scrollback row. The live overlay already clamps its
+  // equivalents (tool-lane.ts); flush must not be the lone exception.
   const cols = getTerminalWidth();
   for (const toolName of groupOrder) {
     const entries = groups.get(toolName)!;
     if (entries.length === 1) {
       const e = entries[0]!;
       if (e.result) {
-        lines.push('  ' + e.prefix + palette.dim(' — ') + doneGlyph(e.result.isError) + ' ' + formatOutcome(e.result, homeDir, 60, e.toolName) + batchBadge(e.result));
+        // Plain clamp, not suffix-reservation as in the grouped path: for a
+        // single entry the args ARE the identity and the outcome is the
+        // expendable tail, which is exactly how the overlay clamps the same
+        // row ("clamping should elide the outcome tail, not the leading
+        // prefix that carries the tool identity" — tool-lane.test.ts).
+        lines.push(clampLineToTerminal('  ' + e.prefix + palette.dim(' — ') + doneGlyph(e.result.isError) + ' ' + formatOutcome(e.result, homeDir, 60, e.toolName) + batchBadge(e.result), cols));
         if (e.diff && !e.result.isError) {
           // Root-level scrollback diff: indent 4 spaces so it sits under
           // the outcome line (2 for the row indent, 2 more to clear the
@@ -273,7 +286,7 @@ function renderGroupedRootTools(
           }
         }
       } else {
-        lines.push('  ' + e.prefix);
+        lines.push(clampLineToTerminal('  ' + e.prefix, cols));
       }
     } else {
       lines.push(formatGroupedToolResults(toolName, entries, cols, homeDir));
@@ -305,7 +318,7 @@ function renderGroupedRootTools(
           // fully scrubbed before linkification adds our own escapes.
           const sanitized = sanitizeLabel(e.toolInput);
           const label = shortenPaths(sanitized).trim() || sanitized.trim();
-          lines.push('    ' + palette.dim(`── ${label} ──`));
+          lines.push(clampLineToTerminal('    ' + palette.dim(`── ${label} ──`), cols));
         }
         for (const line of formatDiffBlock(e.diff!, 'flush', '    ')) {
           lines.push(clampLineToTerminal(line, cols));

--- a/src/cli/commands/interactive/tool-lane-render-agent.ts
+++ b/src/cli/commands/interactive/tool-lane-render-agent.ts
@@ -1,5 +1,4 @@
 import { palette } from '../../palette.js';
-import { styleForToolName } from '../../tool-category.js';
 import { getTerminalWidth } from '../../terminal-size.js';
 import { formatToolCallStat } from '../../format-utils.js';
 import {
@@ -14,6 +13,7 @@ import {
 import type { ToolEntry, Entry } from './tool-lane-render.js';
 import { getGlyphs, clampLineToTerminal } from './tool-lane-render.js';
 import { renderFlushChildren } from './tool-lane-render-children.js';
+import { formatGroupedToolResults } from './tool-lane-render-grouped-root.js';
 
 /**
  * Compose a NESTING root's committed-scrollback closer — the `Done (…)` line —
@@ -276,7 +276,7 @@ function renderGroupedRootTools(
         lines.push('  ' + e.prefix);
       }
     } else {
-      lines.push(formatGroupedToolResults(toolName, entries, homeDir));
+      lines.push(formatGroupedToolResults(toolName, entries, cols, homeDir));
       // Emit per-entry diff blocks under the grouped header. Each diff hangs
       // at the same 4-space indent as the single-entry path above, giving
       // the grouped case the same visual treatment as individual entries.
@@ -314,60 +314,6 @@ function renderGroupedRootTools(
     }
   }
   return lines;
-}
-
-function formatGroupedToolResults(
-  toolName: string,
-  entries: ToolEntry[],
-  homeDir?: string,
-): string {
-  const { color, glyph } = styleForToolName(toolName);
-  // sanitizeLabel before shortenPaths — same ordering rationale as the
-  // diff-separator labels above (shortenPaths emits OSC 8 hyperlinks that
-  // sanitizeLabel would strip).
-  const targets = entries.map((e) => shortenPaths(sanitizeLabel(e.toolInput)).trim());
-  const header =
-    color(glyph + ' ') +
-    color.bold(toolName) +
-    palette.dim(` ×${entries.length}`) +
-    ' ' +
-    palette.toolArg(targets.join(', '));
-
-  const completed = entries.filter((e) => e.result);
-  const errors = completed.filter((e) => e.result!.isError);
-
-  if (errors.length > 0) {
-    const successCount = completed.length - errors.length;
-    const lineCounts = completed
-      .filter((e) => !e.result!.isError)
-      .map((e) => e.result!.lineCount)
-      .filter((c): c is number => c !== undefined);
-    const totalLines = lineCounts.reduce((a, b) => a + b, 0);
-    const parts: string[] = [];
-    if (totalLines > 0) parts.push(`${totalLines} lines`);
-    if (successCount > 0) parts.push(`${successCount} ok`);
-    parts.push(palette.error(`${errors.length} error${errors.length > 1 ? 's' : ''}`));
-    return '  ' + header + palette.dim(' — ') + parts.join(palette.dim(', '));
-  }
-
-  const lineCounts = completed
-    .map((e) => e.result?.lineCount)
-    .filter((c): c is number => c !== undefined);
-  if (lineCounts.length === completed.length && lineCounts.length > 0) {
-    const allSame = lineCounts.every((c) => c === lineCounts[0]);
-    if (allSame) {
-      return '  ' + header + palette.dim(` — ${lineCounts[0]} lines each`);
-    }
-    const total = lineCounts.reduce((a, b) => a + b, 0);
-    return '  ' + header + palette.dim(` — ${total} lines total`);
-  }
-
-  if (completed.length > 0) {
-    const outcomes = completed.map((e) => formatOutcome(e.result!, homeDir, 60, e.toolName));
-    return '  ' + header + palette.dim(' — ') + outcomes.join(palette.dim(', '));
-  }
-
-  return '  ' + header;
 }
 
 export {

--- a/src/cli/commands/interactive/tool-lane-render-grouped-root.ts
+++ b/src/cli/commands/interactive/tool-lane-render-grouped-root.ts
@@ -76,7 +76,13 @@ export function formatGroupedToolResults(
     .map((entry) => shortenPaths(sanitizeLabel(entry.toolInput)).trim())
     .join(', ');
   const targetWidth = Math.max(0, cols - displayWidth(prefix) - displayWidth(suffix));
-  const targetPreview = truncateDisplayWidth(targets, targetWidth);
+  // Colorize BEFORE truncating: `palette.toolArg` is the same dim wrapper the
+  // single-entry path applies via formatToolLine, so grouped args must not
+  // render brighter than their ungrouped siblings. Wrapping first is safe
+  // because truncateDisplayWidth tokenizes ANSI — escapes cost zero width, so
+  // the reserved `targetWidth` budget is unaffected — and it re-closes both
+  // the OSC 8 span and the SGR state when the cut lands inside them.
+  const targetPreview = truncateDisplayWidth(palette.toolArg(targets), targetWidth);
 
   return clampLineToTerminal(prefix + targetPreview + suffix, cols);
 }

--- a/src/cli/commands/interactive/tool-lane-render-grouped-root.ts
+++ b/src/cli/commands/interactive/tool-lane-render-grouped-root.ts
@@ -1,0 +1,82 @@
+import { displayWidth, truncateDisplayWidth } from '../../display.js';
+import { palette } from '../../palette.js';
+import { styleForToolName } from '../../tool-category.js';
+import {
+  formatOutcome,
+  sanitizeLabel,
+  shortenPaths,
+} from './tool-lane-format.js';
+import type { ToolEntry } from './tool-lane-render.js';
+import { clampLineToTerminal } from './tool-lane-render.js';
+
+function groupedResultSuffix(
+  entries: ToolEntry[],
+  homeDir?: string,
+): string {
+  const completed = entries.filter((entry) => entry.result);
+  const errors = completed.filter((entry) => entry.result!.isError);
+
+  if (errors.length > 0) {
+    const successCount = completed.length - errors.length;
+    const lineCounts = completed
+      .filter((entry) => !entry.result!.isError)
+      .map((entry) => entry.result!.lineCount)
+      .filter((count): count is number => count !== undefined);
+    const totalLines = lineCounts.reduce((sum, count) => sum + count, 0);
+    const parts: string[] = [];
+    if (totalLines > 0) parts.push(`${totalLines} lines`);
+    if (successCount > 0) parts.push(`${successCount} ok`);
+    parts.push(palette.error(`${errors.length} error${errors.length > 1 ? 's' : ''}`));
+    return palette.dim(' — ') + parts.join(palette.dim(', '));
+  }
+
+  const lineCounts = completed
+    .map((entry) => entry.result?.lineCount)
+    .filter((count): count is number => count !== undefined);
+  if (lineCounts.length === completed.length && lineCounts.length > 0) {
+    const allSame = lineCounts.every((count) => count === lineCounts[0]);
+    if (allSame) return palette.dim(` — ${lineCounts[0]} lines each`);
+    const total = lineCounts.reduce((sum, count) => sum + count, 0);
+    return palette.dim(` — ${total} lines total`);
+  }
+
+  if (completed.length > 0) {
+    const outcomes = completed.map((entry) =>
+      formatOutcome(entry.result!, homeDir, 60, entry.toolName),
+    );
+    return palette.dim(' — ') + outcomes.join(palette.dim(', '));
+  }
+
+  return '';
+}
+
+/**
+ * Render a root-level same-tool group as one terminal-width-safe row.
+ *
+ * Invariant: the result summary is more durable than the repeated argument
+ * previews, so its display width is reserved before the joined targets are
+ * truncated. A final clamp protects very narrow terminals where the fixed
+ * tool identity plus summary cannot fit even after targets are removed.
+ */
+export function formatGroupedToolResults(
+  toolName: string,
+  entries: ToolEntry[],
+  cols: number,
+  homeDir?: string,
+): string {
+  const { color, glyph } = styleForToolName(toolName);
+  const prefix =
+    '  ' +
+    color(glyph + ' ') +
+    color.bold(toolName) +
+    palette.dim(` ×${entries.length}`) +
+    ' ';
+  const suffix = groupedResultSuffix(entries, homeDir);
+  const targets = entries
+    .map((entry) => shortenPaths(sanitizeLabel(entry.toolInput)).trim())
+    .join(', ');
+  const targetWidth = Math.max(0, cols - displayWidth(prefix) - displayWidth(suffix));
+  const targetPreview = truncateDisplayWidth(targets, targetWidth);
+
+  return clampLineToTerminal(prefix + targetPreview + suffix, cols);
+}

--- a/src/cli/commands/interactive/tool-lane.test.ts
+++ b/src/cli/commands/interactive/tool-lane.test.ts
@@ -650,6 +650,34 @@ describe('ToolLane.upsertTextChild / removeTextChildrenUnder', () => {
       expect(stripAnsi(overlay)).toContain('bash');
     });
 
+    it('grouped root bash reserves its result summary and fits within terminal width', () => {
+      const lane = new ToolLane();
+      const cols = process.stdout.columns ?? 88;
+      const commands = [
+        'cd credential-floor-gaps && echo "=== 1. INLINE REVIEW COMMENTS ===" && gh api repos/griffinwork40/agent-afk/pulls/753/comments --paginate',
+        'cd credential-floor-gaps && echo "=== 2. REVIEW SUMMARY BODIES ===" && gh pr view 753 --json reviews,comments,latestReviews',
+        'cd credential-floor-gaps && echo "=== 4. CI CHECKS ===" && gh pr checks 753 2>&1 | head -40',
+      ];
+      const lineCounts = [20, 20, 19];
+      for (const [index, command] of commands.entries()) {
+        const id = `bash-group-${index}`;
+        lane.addStart(id, 'bash', ` ${command}`);
+        lane.addResult(id, { ...makeResult('output'), lineCount: lineCounts[index] });
+      }
+
+      const lines = lane.flush();
+      const rendered = stripAnsi(lines.join('\n'));
+      expect(rendered).toContain('bash ×3');
+      expect(rendered).toContain('59 lines total');
+      expect(rendered).toContain('…');
+      for (const line of lines) {
+        expect(
+          displayWidth(stripAnsi(line)),
+          `grouped root line exceeds terminal width (${cols}): ${JSON.stringify(line)}`,
+        ).toBeLessThanOrEqual(cols);
+      }
+    });
+
     it('orchestrator-root in-progress bash with long input fits within terminal width', () => {
       const lane = new ToolLane();
       const cols = process.stdout.columns ?? 88;

--- a/src/cli/commands/interactive/tool-lane.test.ts
+++ b/src/cli/commands/interactive/tool-lane.test.ts
@@ -10,8 +10,10 @@
  */
 
 import { afterEach, beforeEach, describe, it, expect } from 'vitest';
+import chalk from 'chalk';
 import { ToolLane } from './tool-lane.js';
 import { displayWidth, stripAnsi } from '../../display.js';
+import { palette } from '../../palette.js';
 import type { ToolResultChunk } from '../../../agent/types/message-types.js';
 import type { OutputEvent, SubagentProgressMeta } from '../../../agent/types.js';
 
@@ -675,6 +677,44 @@ describe('ToolLane.upsertTextChild / removeTextChildrenUnder', () => {
           displayWidth(stripAnsi(line)),
           `grouped root line exceeds terminal width (${cols}): ${JSON.stringify(line)}`,
         ).toBeLessThanOrEqual(cols);
+      }
+    });
+
+    /**
+     * Regression for the styling half of the width fix: bounding the grouped
+     * row must not cost it the `palette.toolArg` dim wrapper that the
+     * single-entry path still applies via `formatToolLine`
+     * (tool-lane-format-args.ts). The first cut of this fix dropped it, so
+     * grouped args rendered at full brightness beside dimmed ungrouped ones —
+     * invisible to every other assertion in this block, because they all
+     * compare ANSI-stripped text.
+     *
+     * `chalk.level` is forced because the suite runs non-TTY, where the
+     * palette collapses to identity and the assertion would be vacuous. Safe
+     * to mutate: every theme is built from the shared chalk export, which
+     * reads the global level at call time (see palette.ts).
+     */
+    it('grouped root targets keep the dim toolArg styling', () => {
+      const originalLevel = chalk.level;
+      chalk.level = 3;
+      try {
+        const lane = new ToolLane();
+        // Three entries: bash is a leaf tool, which collapses at
+        // GROUP_THRESHOLD_LEAF = 3. Short commands keep the row inside 88
+        // cols, so the targets reach the assertion untruncated and the
+        // expected escape sequence is exact.
+        const commands = ['git status', 'git log', 'git diff'];
+        for (const [index, command] of commands.entries()) {
+          const id = `bash-style-${index}`;
+          lane.addStart(id, 'bash', ` ${command}`);
+          lane.addResult(id, { ...makeResult('output'), lineCount: 2 });
+        }
+
+        const row = lane.flush().join('\n');
+        expect(stripAnsi(row)).toContain('bash ×3');
+        expect(row).toContain(palette.toolArg(commands.join(', ')));
+      } finally {
+        chalk.level = originalLevel;
       }
     });
 

--- a/src/cli/commands/interactive/tool-lane.test.ts
+++ b/src/cli/commands/interactive/tool-lane.test.ts
@@ -718,6 +718,73 @@ describe('ToolLane.upsertTextChild / removeTextChildrenUnder', () => {
       }
     });
 
+    /**
+     * Regression for the sibling rows of the grouped-width fix.
+     * `renderGroupedRootTools` emits four row shapes; only the grouped one was
+     * bounded, so the same long bash command rendered correctly in the live
+     * overlay (which clamps every row) and then wrapped the moment it
+     * committed to scrollback via flush().
+     *
+     * Root entries are the exposed case: the root dispatch path
+     * (stream-renderer-orchestrator.ts) calls addStartWithAgentContext with no
+     * maxWidth, so `prefix` arrives unbudgeted — unlike subagent children
+     * (stream-renderer-subagent.ts), which cap it at cols - 14. The call shape
+     * below mirrors that root path exactly; using addStart() instead would
+     * test a path production never takes.
+     */
+    it('flush root rows fit within terminal width (completed, in-flight, diff separators)', () => {
+      const cols = process.stdout.columns ?? 88;
+      const longCommand = ' ' + 'echo hello world '.repeat(20);
+
+      const completed = new ToolLane();
+      completed.addStartWithAgentContext('root-done', 'bash', longCommand, undefined);
+      completed.addResult('root-done', { ...makeResult('output'), lineCount: 40 });
+
+      const inFlight = new ToolLane();
+      inFlight.addStartWithAgentContext('root-live', 'bash', longCommand, undefined);
+
+      // Two grouped entries carrying diffs trigger the labeled `── file ──`
+      // separator. A long BASENAME is what overflows it — shortenPaths
+      // collapses directories, so a long directory alone would not reproduce.
+      const separators = new ToolLane();
+      const longName = 'src/generated/' + 'very-long-component-name'.repeat(3);
+      for (const suffix of ['a', 'b']) {
+        const id = `write-${suffix}`;
+        separators.addStartWithAgentContext(id, 'write_file', ` ${longName}-${suffix}.ts`, undefined);
+        separators.addResult(id, { ...makeResult('ok'), lineCount: 3 });
+        separators.addDiff(id, {
+          addedLines: 1,
+          removedLines: 0,
+          hunks: [{
+            oldStart: 1, oldLines: 0, newStart: 1, newLines: 1,
+            lines: [{ kind: '+', text: 'short' }],
+          }],
+        });
+      }
+
+      // flush() drains the lane, so capture each render exactly once.
+      const rendered: ReadonlyArray<readonly [string, string[]]> = [
+        ['completed', completed.flush()],
+        ['in-flight', inFlight.flush()],
+        ['diff separators', separators.flush()],
+      ];
+
+      for (const [label, lines] of rendered) {
+        expect(lines.length, `${label}: rendered nothing`).toBeGreaterThan(0);
+        for (const line of lines) {
+          expect(
+            displayWidth(stripAnsi(line)),
+            `${label} flush line exceeds terminal width (${cols}): ${JSON.stringify(line)}`,
+          ).toBeLessThanOrEqual(cols);
+        }
+      }
+
+      // Tool identity must survive the clamp — the outcome tail is the
+      // expendable part, matching the overlay contract pinned above.
+      expect(stripAnsi((rendered[0]![1]).join('\n'))).toContain('bash');
+      expect(stripAnsi((rendered[2]![1]).join('\n'))).toContain('──');
+    });
+
     it('orchestrator-root in-progress bash with long input fits within terminal width', () => {
       const lane = new ToolLane();
       const cols = process.stdout.columns ?? 88;


### PR DESCRIPTION
## Summary

- keep grouped root tool summaries within the current terminal width
- reserve space for durable result summaries such as `59 lines total` before truncating repeated command previews
- add a regression test modeled on the reported `bash ×3` clipping case

## Root cause

`renderGroupedRootTools()` emitted `formatGroupedToolResults()` directly. That formatter joined every grouped command and appended the result summary into one unbounded logical line, so three long Bash commands produced a 350-column row in an 88-column terminal.

## Verification

- `pnpm test src/cli/commands/interactive/tool-lane.test.ts -t "grouped root bash reserves"`
- `pnpm test src/cli/commands/interactive/tool-lane.test.ts` (112/112)
- `pnpm lint`
- completion reconciliation: BACKED
