### PR TITLE
fix(awareness): refresh the system-prompt date line when the local day rolls over

### DIFF
--- a/src/agent/awareness/index.ts
+++ b/src/agent/awareness/index.ts
@@ -28,6 +28,7 @@ export {
   buildRuntimeSnapshot,
   parseView,
   formatEnvironmentFragment,
+  formatEnvironmentDateLine,
 } from './runtime-snapshot.js';
 
 export {

--- a/src/agent/awareness/runtime-snapshot.ts
+++ b/src/agent/awareness/runtime-snapshot.ts
@@ -134,9 +134,12 @@ export function formatEnvironmentFragment(args: {
   // (relative-date math, "latest"/"recent" reasoning, weekday-gated skills,
   // log interpretation). Date granularity (not clock time) keeps this block
   // stable across turns within a session, so the cached system-prompt
-  // breakpoint is not busted per turn (the block is built once per provider
-  // query()). `now`/`timeZone` are injectable for deterministic tests.
-  lines.push(`- Date: ${formatDateLine(args.now ?? new Date(), args.timeZone)}`);
+  // breakpoint is not busted per turn. The block is built once per provider
+  // query(), which alone would freeze the date for the life of a resident
+  // session; `query/date-rollover.ts` re-renders this one line when the local
+  // day actually changes, preserving the per-turn stability that motivates the
+  // date granularity. `now`/`timeZone` are injectable for deterministic tests.
+  lines.push(`- Date: ${formatEnvironmentDateLine(args.now ?? new Date(), args.timeZone)}`);
 
   const idShort =
     typeof args.sessionId === 'string' && args.sessionId.length > 0
@@ -197,8 +200,13 @@ export function formatEnvironmentFragment(args: {
  * try/catch because this runs inside system-prompt assembly on every query:
  * an invalid `timeZone` (only reachable via a bad caller-supplied value) must
  * never throw and abort the request — it falls back to a UTC ISO date.
+ *
+ * Exported so `query/date-rollover.ts` re-renders the line through the SAME
+ * formatter that produced it. Two renderers would drift, and a drifted render
+ * would look like a date rollover on every turn — busting the prompt cache
+ * continuously instead of once per midnight.
  */
-function formatDateLine(now: Date, timeZone?: string): string {
+export function formatEnvironmentDateLine(now: Date, timeZone?: string): string {
   try {
     const tz = timeZone ?? Intl.DateTimeFormat().resolvedOptions().timeZone ?? 'UTC';
     const parts = new Intl.DateTimeFormat('en-CA', {

--- a/src/agent/providers/anthropic-direct/date-rollover-system-payload.test.ts
+++ b/src/agent/providers/anthropic-direct/date-rollover-system-payload.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Integration test for mid-session date rollover in the system payload.
+ *
+ * The unit tests in `query/date-rollover.test.ts` cover the pure rewrite. This
+ * file covers the seam that actually carried the defect: `userSystem` is
+ * assembled once per `provider.query()`, and `composeSystem()` re-reads that
+ * frozen string every turn — so before the fix, a session resident across local
+ * midnight kept sending yesterday's `- Date:` line for the rest of its life.
+ *
+ * Asserted at the `messages.create` boundary (mirrors
+ * `plan-mode-system-payload.test.ts`) — the closest observable point to what
+ * the model actually sees. Only `Date` is faked; timers stay real so the
+ * streaming machinery is untouched. The two instants are 48h apart so the local
+ * date differs in EVERY host timezone, keeping the assertion valid on the
+ * ubuntu/macos/windows CI legs.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type Anthropic from '@anthropic-ai/sdk';
+import type { ContentBlockParam, RawMessageStreamEvent } from '@anthropic-ai/sdk/resources';
+import { AnthropicDirectProvider, __setAnthropicClientFactory } from './index.js';
+
+const messagesCreateMock = vi.fn();
+
+class MockAnthropic {
+  public messages: { create: typeof messagesCreateMock };
+  constructor() {
+    this.messages = { create: messagesCreateMock };
+  }
+}
+
+async function* fromArray<T>(arr: T[]): AsyncIterable<T> {
+  for (const x of arr) yield x;
+}
+
+async function* twoTurns(): AsyncIterable<{ content: string }> {
+  yield { content: 'first' };
+  yield { content: 'second' };
+}
+
+function makeTextStream(text: string): RawMessageStreamEvent[] {
+  return [
+    {
+      type: 'message_start',
+      message: {
+        id: 'msg_test',
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model: 'claude-sonnet-5',
+        stop_reason: null,
+        stop_sequence: null,
+        usage: {
+          input_tokens: 5,
+          output_tokens: 0,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+          server_tool_use: null,
+          service_tier: null,
+        },
+      },
+    } as unknown as RawMessageStreamEvent,
+    {
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'text', text: '', citations: [] },
+    } as unknown as RawMessageStreamEvent,
+    {
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'text_delta', text },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'content_block_stop', index: 0 } as unknown as RawMessageStreamEvent,
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'end_turn', stop_sequence: null },
+      usage: { output_tokens: 4 },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'message_stop' } as unknown as RawMessageStreamEvent,
+  ];
+}
+
+function extractSystemText(systemArg: unknown): string {
+  if (typeof systemArg === 'string') return systemArg;
+  if (!Array.isArray(systemArg)) return '';
+  return (systemArg as ContentBlockParam[])
+    .map((b) => (b.type === 'text' && typeof b.text === 'string' ? b.text : ''))
+    .join('\n');
+}
+
+function systemTextOfCall(i: number): string {
+  const call = messagesCreateMock.mock.calls[i];
+  return extractSystemText((call?.[0] as { system?: unknown } | undefined)?.system);
+}
+
+function dateLineOf(systemText: string): string | undefined {
+  return systemText.split('\n').find((l) => l.startsWith('- Date: '));
+}
+
+/** Advance the fake clock to `at` after the Nth `messages.create` call. */
+function rollClockAfterFirstCall(at: Date | null): void {
+  let calls = 0;
+  messagesCreateMock.mockImplementation(() => {
+    calls += 1;
+    if (calls === 1 && at !== null) vi.setSystemTime(at);
+    return fromArray(makeTextStream('ok'));
+  });
+}
+
+async function drain(query: AsyncIterable<unknown>): Promise<void> {
+  for await (const _ev of query) {
+    void _ev;
+  }
+}
+
+function runTwoTurns(): AsyncIterable<unknown> {
+  const provider = new AnthropicDirectProvider();
+  return provider.query({
+    prompt: twoTurns(),
+    config: { model: 'claude-sonnet-5', apiKey: 'sk-ant-oat01-test' },
+  }) as AsyncIterable<unknown>;
+}
+
+const DAY_ONE = new Date('2026-07-30T12:00:00Z');
+const DAY_THREE = new Date('2026-08-01T12:00:00Z'); // +48h: a different local date everywhere
+
+describe('AnthropicDirectQuery — mid-session date rollover', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(DAY_ONE);
+    messagesCreateMock.mockReset();
+    __setAnthropicClientFactory(null);
+    __setAnthropicClientFactory(() => new MockAnthropic() as unknown as Anthropic);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    __setAnthropicClientFactory(null);
+  });
+
+  it('re-renders the Date line on the turn after the local day changes', async () => {
+    rollClockAfterFirstCall(DAY_THREE);
+    await drain(runTwoTurns());
+
+    expect(messagesCreateMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+    const first = dateLineOf(systemTextOfCall(0));
+    const second = dateLineOf(systemTextOfCall(1));
+
+    expect(first).toMatch(/^- Date: \w+, \d{4}-\d{2}-\d{2} \(.+\)$/);
+    expect(second).toMatch(/^- Date: \w+, \d{4}-\d{2}-\d{2} \(.+\)$/);
+    expect(second).not.toBe(first);
+  });
+
+  it('changes ONLY the Date line — the rest of the system payload is byte-identical', async () => {
+    rollClockAfterFirstCall(DAY_THREE);
+    await drain(runTwoTurns());
+
+    const a = systemTextOfCall(0).split('\n');
+    const b = systemTextOfCall(1).split('\n');
+    expect(b).toHaveLength(a.length);
+    const differing = a.map((l, i) => (l === b[i] ? null : i)).filter((i) => i !== null);
+    expect(differing).toHaveLength(1);
+    expect(a[differing[0] as number]).toMatch(/^- Date: /);
+  });
+
+  // Cache economics: PR #268 froze the date to keep the system block stable
+  // across turns. That property must survive the fix — same-day turns stay
+  // byte-identical, so the prompt-cache breakpoint is busted at most once per
+  // midnight crossing rather than once per turn.
+  it('leaves the system payload untouched across turns within the same day', async () => {
+    rollClockAfterFirstCall(null);
+    await drain(runTwoTurns());
+
+    expect(messagesCreateMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(systemTextOfCall(1)).toBe(systemTextOfCall(0));
+  });
+});

--- a/src/agent/providers/anthropic-direct/query.ts
+++ b/src/agent/providers/anthropic-direct/query.ts
@@ -57,6 +57,7 @@ import {
 } from './cache-policy.js';
 import { buildPlanModeAddendumBlock } from './plan-mode-addendum.js';
 import { buildAfkModeAddendumBlock } from './afk-mode-addendum.js';
+import { refreshEnvironmentDate } from './query/date-rollover.js';
 import { EXIT_PLAN_MODE_TOOL_NAME } from '../../tools/handlers/exit-plan-mode.js';
 import { collectSupportedCommands } from '../shared/supported-commands.js';
 import { contextLimitFor, autoCompactLimitFor } from '../../model-limits.js';
@@ -589,6 +590,14 @@ export class AnthropicDirectQuery implements ProviderQuery {
    * side has anything to contribute — the loop omits the field entirely.
    */
   private composeSystem(): ContentBlockParam[] | null {
+    // Date rollover: `userSystem` was assembled once at session start, so a
+    // session resident across local midnight would keep telling the model it
+    // is still yesterday. This re-renders that one line only when the rendered
+    // date actually changes, so same-day turns are byte-identical and the
+    // cache breakpoint below still hits. See query/date-rollover.ts.
+    if (this.state.userSystem) {
+      this.state.userSystem = refreshEnvironmentDate(this.state.userSystem);
+    }
     const prefix = this.systemPrefix;
     const userSys = this.state.userSystem;
     const blocks: ContentBlockParam[] = [];

--- a/src/agent/providers/anthropic-direct/query/date-rollover.test.ts
+++ b/src/agent/providers/anthropic-direct/query/date-rollover.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import { refreshEnvironmentDate } from './date-rollover.js';
+import { formatEnvironmentFragment } from '../../../awareness/index.js';
+import { assembleSystemPrompt, buildStableSystemPrefix } from './system-prompt.js';
+
+const TZ = 'America/New_York';
+/** 2026-07-30 18:00 UTC = Thursday 14:00 in New York. */
+const THU = new Date('2026-07-30T18:00:00Z');
+/** 2026-07-31 04:00 UTC = Friday 00:00 in New York — one minute past rollover. */
+const FRI = new Date('2026-07-31T04:01:00Z');
+
+function envBlock(now: Date): string {
+  return formatEnvironmentFragment({ cwd: '/repo', now, timeZone: TZ });
+}
+
+describe('refreshEnvironmentDate', () => {
+  it('is a no-op within the same local day', () => {
+    const prompt = `PREAMBLE\n\n${envBlock(THU)}`;
+    const sameDayLater = new Date('2026-07-30T23:59:00Z'); // still Thursday in NY
+    const out = refreshEnvironmentDate(prompt, sameDayLater, TZ);
+    expect(out).toBe(prompt);
+  });
+
+  it('re-renders the date line once the local day has rolled over', () => {
+    const prompt = `PREAMBLE\n\n${envBlock(THU)}`;
+    expect(prompt).toContain('- Date: Thursday, 2026-07-30 (America/New_York)');
+
+    const out = refreshEnvironmentDate(prompt, FRI, TZ);
+    expect(out).toContain('- Date: Friday, 2026-07-31 (America/New_York)');
+    expect(out).not.toContain('Thursday, 2026-07-30');
+  });
+
+  it('rewrites exactly one line and preserves every other byte', () => {
+    const prompt = [
+      'TOOLS',
+      '',
+      '# Operator configuration\nbe terse',
+      '',
+      formatEnvironmentFragment({
+        cwd: '/repo',
+        now: THU,
+        timeZone: TZ,
+        sessionId: 'abcdef1234',
+        surface: 'repl',
+        workspace: { branch: 'main', headSha: 'deadbee', dirty: false, dirtyCount: 0, remoteUrl: null },
+      }),
+      '',
+      'Available skills:\n- orient',
+    ].join('\n');
+
+    const out = refreshEnvironmentDate(prompt, FRI, TZ);
+    const before = prompt.split('\n');
+    const after = out.split('\n');
+    expect(after).toHaveLength(before.length);
+    const changed = before.map((l, i) => (l === after[i] ? null : i)).filter((i) => i !== null);
+    expect(changed).toHaveLength(1);
+    expect(after[changed[0] as number]).toBe('- Date: Friday, 2026-07-31 (America/New_York)');
+    // Trailing lines of the block and the manifest after it survive intact.
+    expect(out).toContain('- Session: abcdef12 (repl)');
+    expect(out).toContain('- Workspace: main @ deadbee (clean)');
+    expect(out.endsWith('Available skills:\n- orient')).toBe(true);
+  });
+
+  it('anchors on the LAST environment block, so a decoy in operator text cannot win', () => {
+    const decoy = '# Environment\n- Working directory: /fake\n- Date: Monday, 1999-01-04 (UTC)';
+    const prompt = `${decoy}\n\n${envBlock(THU)}`;
+    const out = refreshEnvironmentDate(prompt, FRI, TZ);
+    expect(out).toContain(decoy); // untouched
+    expect(out).toContain('- Date: Friday, 2026-07-31 (America/New_York)');
+  });
+
+  it('passes through unchanged when there is no environment block', () => {
+    const prompt = 'just a system prompt\nwith no environment fragment';
+    expect(refreshEnvironmentDate(prompt, FRI, TZ)).toBe(prompt);
+  });
+
+  it('passes through unchanged when the block has no date line', () => {
+    const prompt = '# Environment\n- Working directory: /repo\n- Session: abc (repl)';
+    expect(refreshEnvironmentDate(prompt, FRI, TZ)).toBe(prompt);
+  });
+
+  it('passes through unchanged when the cwd line is unterminated (block is truncated)', () => {
+    const prompt = '# Environment\n- Working directory: /repo';
+    expect(refreshEnvironmentDate(prompt, FRI, TZ)).toBe(prompt);
+  });
+
+  it('handles the date line being the final line of the prompt', () => {
+    const prompt = '# Environment\n- Working directory: /repo\n- Date: Thursday, 2026-07-30 (America/New_York)';
+    const out = refreshEnvironmentDate(prompt, FRI, TZ);
+    expect(out).toBe('# Environment\n- Working directory: /repo\n- Date: Friday, 2026-07-31 (America/New_York)');
+  });
+
+  it('does not throw on an invalid timezone', () => {
+    const prompt = `X\n\n${envBlock(THU)}`;
+    expect(() => refreshEnvironmentDate(prompt, FRI, 'Not/AZone')).not.toThrow();
+  });
+
+  // Drift guard: the refresher and the assembler must share one renderer. If
+  // they ever diverge, this goes red — and in production a divergence would
+  // look like a rollover on EVERY turn, busting the prompt cache continuously.
+  it('is a no-op against a freshly assembled prompt at the same instant', () => {
+    const assembled = assembleSystemPrompt(
+      buildStableSystemPrefix({
+        toolBase: 'TOOL',
+        memoryPrompt: 'MEM',
+        hotMemory: '',
+        manifest: 'SKILLS',
+        userSystem: 'OPERATOR',
+      }),
+      '/repo',
+      { surface: 'repl', sessionId: 'abcdef1234', depth: undefined, maxDepth: undefined, workspace: null },
+    );
+    expect(refreshEnvironmentDate(assembled)).toBe(assembled);
+  });
+});

--- a/src/agent/providers/anthropic-direct/query/date-rollover.ts
+++ b/src/agent/providers/anthropic-direct/query/date-rollover.ts
@@ -1,0 +1,80 @@
+/**
+ * Mid-session date-rollover refresh for the `# Environment` block.
+ *
+ * Invariant: the `- Date:` line the model reads must name TODAY, not the day
+ * the session happened to start. The assembled system prompt is built once per
+ * `provider.query()` — i.e. once per session — and re-spliced only by
+ * `setCwd()` (`query/cwd-dependents.ts`), so a session that outlives local
+ * midnight otherwise reports its start date for the rest of its life. That hits
+ * exactly the surfaces that stay resident: an overnight REPL, the long-lived
+ * Telegram bot's per-chat session, and any resumed session. One-shot `chat` and
+ * daemon cron ticks are unaffected — each builds a fresh prompt.
+ *
+ * The refresh is gated on the RENDERED DATE STRING changing, never on the clock
+ * ticking: {@link refreshEnvironmentDate} returns its input by reference on
+ * every turn within the same local day, so the prompt-cache breakpoint stamped
+ * on the system block is invalidated at most once per midnight crossing rather
+ * than once per turn. PR #268 accepted the staleness precisely to avoid a
+ * per-turn cache bust; that rationale conflated "recompute the date" with "emit
+ * a different date", and only the latter costs anything. `setCwd()` already
+ * re-splices this same block mid-session, so a mid-session mutation here is not
+ * a new class of event.
+ *
+ * @module agent/providers/anthropic-direct/query/date-rollover
+ */
+
+import { formatEnvironmentDateLine } from '../../../awareness/index.js';
+
+const ENV_ANCHOR = '# Environment\n- Working directory: ';
+const DATE_PREFIX = '- Date: ';
+
+/**
+ * Return `systemPrompt` with its `# Environment` date line re-rendered for
+ * `now`, or the identical string when nothing needs to change.
+ *
+ * Contract:
+ * - Returns the input by reference when the rendered date is unchanged, when
+ *   the `# Environment` anchor is absent, or when the block's shape does not
+ *   match what `formatEnvironmentFragment` emits. Never throws; a prompt it
+ *   cannot parse is passed through untouched, so an unrecognised shape
+ *   degrades to today's (stale-date) behaviour rather than to a corrupt
+ *   prompt.
+ * - Rewrites exactly one line and preserves every other byte, including the
+ *   trailing `- Session:` / `- Workspace:` lines and the manifest that follows.
+ * - Anchors on the LAST `# Environment\n- Working directory: ` occurrence. The
+ *   assembler (`query/system-prompt.ts`) always splices the real fragment
+ *   second-to-last, after the operator overlay and hot memory, so a decoy block
+ *   inside user-supplied text can never win.
+ *
+ * @param systemPrompt Assembled system prompt from `assembleSystemPrompt`.
+ * @param now Clock, injectable for deterministic tests. Defaults to `new Date()`.
+ * @param timeZone IANA zone; defaults to the host zone, as at assembly time.
+ */
+export function refreshEnvironmentDate(
+  systemPrompt: string,
+  now?: Date,
+  timeZone?: string,
+): string {
+  const anchor = systemPrompt.lastIndexOf(ENV_ANCHOR);
+  if (anchor === -1) return systemPrompt;
+
+  // The cwd line runs to its own newline; the date line is the next one.
+  const cwdLineEnd = systemPrompt.indexOf('\n', anchor + ENV_ANCHOR.length);
+  if (cwdLineEnd === -1) return systemPrompt;
+
+  const dateLineStart = cwdLineEnd + 1;
+  if (!systemPrompt.startsWith(DATE_PREFIX, dateLineStart)) return systemPrompt;
+
+  const nextNewline = systemPrompt.indexOf('\n', dateLineStart);
+  const dateLineEnd = nextNewline === -1 ? systemPrompt.length : nextNewline;
+
+  const current = systemPrompt.slice(dateLineStart + DATE_PREFIX.length, dateLineEnd);
+  const fresh = formatEnvironmentDateLine(now ?? new Date(), timeZone);
+  if (current === fresh) return systemPrompt;
+
+  return (
+    systemPrompt.slice(0, dateLineStart + DATE_PREFIX.length) +
+    fresh +
+    systemPrompt.slice(dateLineEnd)
+  );
+}


### PR DESCRIPTION
## The bug

The `- Date:` line in the model's `# Environment` block is assembled **once per `provider.query()`** — i.e. once per session — and re-spliced only by `setCwd()`. A session that outlives local midnight keeps sending its **start date** for the rest of its life.

Reproduced at the `messages.create` boundary: with the fix disabled, turn 2 on **Aug 1** still tells the model it is **Thursday, 2026-07-30**.

Consequences, all silent:
- relative-date math against the wrong today ("recent", "8 days ago", log interpretation)
- weekday-gated skills misfire (`/weekly-reflect` triggers on the model reading the date line, not on deterministic code)
- dated artifacts get stamped wrong — `/orient` writes `/tmp/orient-<ISO8601>.md` from the model's notion of now

**Affected:** overnight REPL, the Telegram bot's long-lived per-chat session, any resumed session.
**Not affected:** one-shot `chat` and daemon cron ticks — each builds a fresh prompt.

## Why this was accepted before, and why the reasoning doesn't hold

PR #268, which added the line, documented it:

> Known limitation: a single long-lived REPL/Telegram session left open across midnight shows the start date until restart — identical to how the existing `Session`/`Workspace` fields behave.

The stated cost was busting the system-block prompt cache per turn. That conflates **recompute the date** with **emit a different date** — only the latter costs anything. `refreshEnvironmentDate` returns the prompt **by reference** whenever the rendered date is unchanged, so:

- same-day turns are byte-identical → cache breakpoint still hits
- the breakpoint is invalidated **at most once per midnight crossing**, not once per turn

`setCwd()` already re-splices this exact block mid-session (`query/cwd-dependents.ts:92`), so a mid-session rewrite is not a new class of event.

## The change

| File | |
|---|---|
| `query/date-rollover.ts` | **new**, 85 LOC — pure, no state plumbing. Anchors on the last `# Environment\n- Working directory: ` occurrence, rewrites exactly one line, passes an unparseable prompt through untouched. |
| `query.ts` | +9 — one guarded call at the top of `composeSystem()` (the per-turn read of `state.userSystem`). |
| `runtime-snapshot.ts` | `formatDateLine` exported as `formatEnvironmentDateLine`; the stale "built once per provider query()" comment corrected. |

One renderer, deliberately: two would drift, and a drifted render would read as a rollover on *every* turn — continuously busting the cache, which is exactly the failure #268 guarded against. A test pins this.

## Verification

- **13 new tests.** 10 unit (no-op within a day, decoy `# Environment` blocks in operator text, malformed/truncated blocks, invalid timezone, drift guard vs. a freshly assembled prompt) + 3 integration at the `messages.create` boundary.
- **Negative control run:** both integration rollover tests go red with the hook disabled; the same-day-stability test stays green either way (correct — it is the cache-economics guard).
- Integration instants are 48h apart so the local date differs in **every** timezone — valid on the ubuntu/macos/windows CI legs. Only `Date` is faked; timers stay real so streaming is untouched.
- Full suite **714 files / 13,541 passed**, `tsc --noEmit` clean, `audit:sdk:check` + `audit:env:check` + `scan:env:check` all green.

## Known gap

The **openai-compatible provider has the same freeze** at its own assembly site (`providers/openai-compatible/index.ts:326-333`, baked into `patchedConfig.systemPrompt`; `messages.ts:191` re-reads the frozen string). Not fixed here to keep this reviewable — it is a ~10-line wiring job against the same exported helper. Filing a follow-up issue.