### PR TITLE
fix(tui): clamp agent frame head rows to terminal width

### DIFF
--- a/src/cli/commands/interactive/tool-lane-render-agent.ts
+++ b/src/cli/commands/interactive/tool-lane-render-agent.ts
@@ -1,19 +1,10 @@
 import { palette } from '../../palette.js';
 import { getTerminalWidth } from '../../terminal-size.js';
 import { formatToolCallStat } from '../../format-utils.js';
-import {
-  MAX_VISIBLE_CHILDREN,
-  formatOutcome,
-  formatDiffBlock,
-  doneGlyph,
-  sanitizeLabel,
-  shortenPaths,
-  batchBadge,
-} from './tool-lane-format.js';
+import { MAX_VISIBLE_CHILDREN, batchBadge } from './tool-lane-format.js';
 import type { ToolEntry, Entry } from './tool-lane-render.js';
-import { getGlyphs, clampLineToTerminal } from './tool-lane-render.js';
+import { getGlyphs } from './tool-lane-render.js';
 import { renderFlushChildren } from './tool-lane-render-children.js';
-import { formatGroupedToolResults } from './tool-lane-render-grouped-root.js';
 
 /**
  * Compose a NESTING root's committed-scrollback closer — the `Done (…)` line —
@@ -247,92 +238,5 @@ function formatAgentChildren(
   );
 }
 
-function renderGroupedRootTools(
-  groups: Map<string, ToolEntry[]>,
-  groupOrder: string[],
-  homeDir?: string,
-): string[] {
-  const lines: string[] = [];
-  // Read once per call: EVERY line this function emits is clamped to this
-  // width so nothing soft-wraps to column 0 in scrollback (orphaning its
-  // continuation past the indent). Mirrors the clamp on every other
-  // emission path; see tool-lane-render-children.ts.
-  //
-  // Invariant: root entries arrive here with an UNBOUNDED prefix — the root
-  // dispatch path (stream-renderer-orchestrator.ts) calls
-  // addStartWithAgentContext without a maxWidth, unlike the subagent-child
-  // path (stream-renderer-subagent.ts) which budgets it at cols - 14. So the
-  // clamp here is the only thing standing between a 350-column bash command
-  // and a wrapped scrollback row. The live overlay already clamps its
-  // equivalents (tool-lane.ts); flush must not be the lone exception.
-  const cols = getTerminalWidth();
-  for (const toolName of groupOrder) {
-    const entries = groups.get(toolName)!;
-    if (entries.length === 1) {
-      const e = entries[0]!;
-      if (e.result) {
-        // Plain clamp, not suffix-reservation as in the grouped path: for a
-        // single entry the args ARE the identity and the outcome is the
-        // expendable tail, which is exactly how the overlay clamps the same
-        // row ("clamping should elide the outcome tail, not the leading
-        // prefix that carries the tool identity" — tool-lane.test.ts).
-        lines.push(clampLineToTerminal('  ' + e.prefix + palette.dim(' — ') + doneGlyph(e.result.isError) + ' ' + formatOutcome(e.result, homeDir, 60, e.toolName) + batchBadge(e.result), cols));
-        if (e.diff && !e.result.isError) {
-          // Root-level scrollback diff: indent 4 spaces so it sits under
-          // the outcome line (2 for the row indent, 2 more to clear the
-          // tool-name column visually).
-          for (const line of formatDiffBlock(e.diff, 'flush', '    ')) {
-            lines.push(clampLineToTerminal(line, cols));
-          }
-        }
-      } else {
-        lines.push(clampLineToTerminal('  ' + e.prefix, cols));
-      }
-    } else {
-      lines.push(formatGroupedToolResults(toolName, entries, cols, homeDir));
-      // Emit per-entry diff blocks under the grouped header. Each diff hangs
-      // at the same 4-space indent as the single-entry path above, giving
-      // the grouped case the same visual treatment as individual entries.
-      // When multiple entries have diffs, emit a labeled `── filename ──`
-      // separator before each diff block so the reader can attribute hunks
-      // to specific files at a glance (e.g. write_file ×2 renders two diffs
-      // with "── globals.css ──" / "── layout.tsx ──" labels).
-      //
-      // External constraint (presentation invariant): when N>1 grouped entries
-      // each contribute a diff block, the blocks must be visually separated by
-      // a labeled divider so a reader can attribute hunks to specific files.
-      // Without the divider, two 62-line `write_file` diffs fuse into one
-      // 124-line block in the rendered transcript with no file boundary
-      // visible — see audit RC-3.
-      // `sanitizeLabel` wraps the user-controlled toolInput to prevent
-      // control-sequence injection into the dim separator line.
-      const entriesWithDiffs = entries.filter((e) => e.diff && e.result && !e.result.isError);
-      const needSeparators = entriesWithDiffs.length > 1;
-      for (const e of entriesWithDiffs) {
-        if (needSeparators) {
-          // Order is load-bearing: sanitizeLabel BEFORE shortenPaths.
-          // shortenPaths emits OSC 8 hyperlink escapes (the one sanctioned
-          // escape producer in the lane); sanitizeLabel strips ALL ANSI, so
-          // running it after would kill the link. Sanitizing first is
-          // equally safe — toolInput is the injection surface, and it is
-          // fully scrubbed before linkification adds our own escapes.
-          const sanitized = sanitizeLabel(e.toolInput);
-          const label = shortenPaths(sanitized).trim() || sanitized.trim();
-          lines.push(clampLineToTerminal('    ' + palette.dim(`── ${label} ──`), cols));
-        }
-        for (const line of formatDiffBlock(e.diff!, 'flush', '    ')) {
-          lines.push(clampLineToTerminal(line, cols));
-        }
-      }
-    }
-  }
-  return lines;
-}
 
-export {
-  formatAgentSummary,
-  formatAgentHeader,
-  formatAgentChildren,
-  renderGroupedRootTools,
-  formatGroupedToolResults,
-};
+export { formatAgentSummary, formatAgentHeader, formatAgentChildren };

--- a/src/cli/commands/interactive/tool-lane-render-agent.ts
+++ b/src/cli/commands/interactive/tool-lane-render-agent.ts
@@ -3,7 +3,7 @@ import { getTerminalWidth } from '../../terminal-size.js';
 import { formatToolCallStat } from '../../format-utils.js';
 import { MAX_VISIBLE_CHILDREN, batchBadge } from './tool-lane-format.js';
 import type { ToolEntry, Entry } from './tool-lane-render.js';
-import { getGlyphs } from './tool-lane-render.js';
+import { getGlyphs, clampLineToTerminal } from './tool-lane-render.js';
 import { renderFlushChildren } from './tool-lane-render-children.js';
 
 /**
@@ -123,17 +123,31 @@ function formatAgentSummary(
   const externalAncestors: readonly boolean[] = ancestorIsLast;
 
   const head = palette.dim(g.turnRoot);
-  const agentLine = stats.length > 0
-    ? ancestorPrefix + head + agent.prefix + palette.dim(' — ' + stats.join(' · '))
-    : ancestorPrefix + head + agent.prefix;
+  // Invariant: ONE width read per render frame, shared by the head row below
+  // and the recursive child frame. Two reads could straddle a resize and emit
+  // a head row clamped to the old width above children clamped to the new one.
+  const cols = getTerminalWidth();
+  // Clamped for the same reason every child row is: a root nesting entry
+  // arrives with an unbounded prefix (the root dispatch path passes no
+  // maxWidth), and the stats tail adds ~28 columns on top — a depth-0 `agent`
+  // frame with more than MAX_VISIBLE_CHILDREN children measures ~109 columns
+  // in an 88-column terminal. Plain clamp, not the grouped path's suffix
+  // reservation: identity leads the row and the stats tail is expendable,
+  // matching how the live overlay clamps the same row.
+  const agentLine = clampLineToTerminal(
+    stats.length > 0
+      ? ancestorPrefix + head + agent.prefix + palette.dim(' — ' + stats.join(' · '))
+      : ancestorPrefix + head + agent.prefix,
+    cols,
+  );
 
   // Pass agentResultSummary into renderFlushChildren so it is added as a
   // synthetic sibling BEFORE assignConnectors runs — ensuring the Done line
   // receives the correct LAST connector (not a hardcoded '⎿', which was Bug #5).
-  // Thread `g` so the head row and child rows share one glyph set. `cols` is
-  // read here at the head so the recursive flush frame uses the same width.
-  // `externalAncestors` extends the spine column-set leftward by `extraDepth`
-  // so descendant rows align under the head row's ancestor spines.
+  // Thread `g` so the head row and child rows share one glyph set, and `cols`
+  // (read once above) so the head row and the recursive flush frame agree on
+  // width. `externalAncestors` extends the spine column-set leftward by
+  // `extraDepth` so descendant rows align under the head row's ancestor spines.
   const childLines = renderFlushChildren(
     children,
     childMap,
@@ -141,7 +155,7 @@ function formatAgentSummary(
     // #532: badge the closer (Done line) when this NESTING root ran in a
     // parallel wave. See summaryWithBatchBadge for why the closer, not the head.
     summaryWithBatchBadge(agent),
-    getTerminalWidth(),
+    cols,
     externalAncestors,
     g,
   );
@@ -172,6 +186,10 @@ function formatAgentSummary(
  * outermost ancestor floating without a spine that connects to its
  * children.
  *
+ * That shared encoding includes the terminal-width clamp: both paths clamp the
+ * head row to `getTerminalWidth()`, so a row that overflows is elided
+ * identically no matter which path committed it.
+ *
  * Width invariant matches formatAgentSummary: `g.spine` is 2 cells,
  * `g.turnRoot` is 2 cells, so the total head-row indent is
  * `2 * (ancestorIsLast.length + 1)` cells before `agent.prefix` — exactly the
@@ -187,7 +205,11 @@ function formatAgentHeader(agent: ToolEntry, ancestorIsLast: readonly boolean[] 
   const g = getGlyphs();
   const ancestorPrefix = palette.dim(g.spine.repeat(ancestorIsLast.length));
   const head = palette.dim(g.turnRoot);
-  return ancestorPrefix + head + agent.prefix;
+  // The terminal-width clamp is part of the shared head-row encoding — see the
+  // encoding constraint above. formatAgentSummary clamps its head row, so this
+  // one must too, or the same entry committed through the two paths would
+  // differ whenever the row exceeds the terminal width.
+  return clampLineToTerminal(ancestorPrefix + head + agent.prefix, getTerminalWidth());
 }
 
 /**

--- a/src/cli/commands/interactive/tool-lane-render-grouped-root.ts
+++ b/src/cli/commands/interactive/tool-lane-render-grouped-root.ts
@@ -1,7 +1,11 @@
 import { displayWidth, truncateDisplayWidth } from '../../display.js';
 import { palette } from '../../palette.js';
+import { getTerminalWidth } from '../../terminal-size.js';
 import { styleForToolName } from '../../tool-category.js';
 import {
+  batchBadge,
+  doneGlyph,
+  formatDiffBlock,
   formatOutcome,
   sanitizeLabel,
   shortenPaths,
@@ -85,4 +89,86 @@ export function formatGroupedToolResults(
   const targetPreview = truncateDisplayWidth(palette.toolArg(targets), targetWidth);
 
   return clampLineToTerminal(prefix + targetPreview + suffix, cols);
+}
+
+export function renderGroupedRootTools(
+  groups: Map<string, ToolEntry[]>,
+  groupOrder: string[],
+  homeDir?: string,
+): string[] {
+  const lines: string[] = [];
+  // Read once per call: EVERY line this function emits is clamped to this
+  // width so nothing soft-wraps to column 0 in scrollback (orphaning its
+  // continuation past the indent). Mirrors the clamp on every other
+  // emission path; see tool-lane-render-children.ts.
+  //
+  // Invariant: root entries arrive here with an UNBOUNDED prefix — the root
+  // dispatch path (stream-renderer-orchestrator.ts) calls
+  // addStartWithAgentContext without a maxWidth, unlike the subagent-child
+  // path (stream-renderer-subagent.ts) which budgets it at cols - 14. So the
+  // clamp here is the only thing standing between a 350-column bash command
+  // and a wrapped scrollback row. The live overlay already clamps its
+  // equivalents (tool-lane.ts); flush must not be the lone exception.
+  const cols = getTerminalWidth();
+  for (const toolName of groupOrder) {
+    const entries = groups.get(toolName)!;
+    if (entries.length === 1) {
+      const e = entries[0]!;
+      if (e.result) {
+        // Plain clamp, not suffix-reservation as in the grouped path: for a
+        // single entry the args ARE the identity and the outcome is the
+        // expendable tail, which is exactly how the overlay clamps the same
+        // row ("clamping should elide the outcome tail, not the leading
+        // prefix that carries the tool identity" — tool-lane.test.ts).
+        lines.push(clampLineToTerminal('  ' + e.prefix + palette.dim(' — ') + doneGlyph(e.result.isError) + ' ' + formatOutcome(e.result, homeDir, 60, e.toolName) + batchBadge(e.result), cols));
+        if (e.diff && !e.result.isError) {
+          // Root-level scrollback diff: indent 4 spaces so it sits under
+          // the outcome line (2 for the row indent, 2 more to clear the
+          // tool-name column visually).
+          for (const line of formatDiffBlock(e.diff, 'flush', '    ')) {
+            lines.push(clampLineToTerminal(line, cols));
+          }
+        }
+      } else {
+        lines.push(clampLineToTerminal('  ' + e.prefix, cols));
+      }
+    } else {
+      lines.push(formatGroupedToolResults(toolName, entries, cols, homeDir));
+      // Emit per-entry diff blocks under the grouped header. Each diff hangs
+      // at the same 4-space indent as the single-entry path above, giving
+      // the grouped case the same visual treatment as individual entries.
+      // When multiple entries have diffs, emit a labeled `── filename ──`
+      // separator before each diff block so the reader can attribute hunks
+      // to specific files at a glance (e.g. write_file ×2 renders two diffs
+      // with "── globals.css ──" / "── layout.tsx ──" labels).
+      //
+      // External constraint (presentation invariant): when N>1 grouped entries
+      // each contribute a diff block, the blocks must be visually separated by
+      // a labeled divider so a reader can attribute hunks to specific files.
+      // Without the divider, two 62-line `write_file` diffs fuse into one
+      // 124-line block in the rendered transcript with no file boundary
+      // visible — see audit RC-3.
+      // `sanitizeLabel` wraps the user-controlled toolInput to prevent
+      // control-sequence injection into the dim separator line.
+      const entriesWithDiffs = entries.filter((e) => e.diff && e.result && !e.result.isError);
+      const needSeparators = entriesWithDiffs.length > 1;
+      for (const e of entriesWithDiffs) {
+        if (needSeparators) {
+          // Order is load-bearing: sanitizeLabel BEFORE shortenPaths.
+          // shortenPaths emits OSC 8 hyperlink escapes (the one sanctioned
+          // escape producer in the lane); sanitizeLabel strips ALL ANSI, so
+          // running it after would kill the link. Sanitizing first is
+          // equally safe — toolInput is the injection surface, and it is
+          // fully scrubbed before linkification adds our own escapes.
+          const sanitized = sanitizeLabel(e.toolInput);
+          const label = shortenPaths(sanitized).trim() || sanitized.trim();
+          lines.push(clampLineToTerminal('    ' + palette.dim(`── ${label} ──`), cols));
+        }
+        for (const line of formatDiffBlock(e.diff!, 'flush', '    ')) {
+          lines.push(clampLineToTerminal(line, cols));
+        }
+      }
+    }
+  }
+  return lines;
 }

--- a/src/cli/commands/interactive/tool-lane-render.ts
+++ b/src/cli/commands/interactive/tool-lane-render.ts
@@ -309,6 +309,10 @@ export {
   formatAgentSummary,
   formatAgentHeader,
   formatAgentChildren,
+} from './tool-lane-render-agent.js';
+
+// Re-export from grouped-root module
+export {
   renderGroupedRootTools,
   formatGroupedToolResults,
-} from './tool-lane-render-agent.js';
+} from './tool-lane-render-grouped-root.js';

--- a/src/cli/commands/interactive/tool-lane.test.ts
+++ b/src/cli/commands/interactive/tool-lane.test.ts
@@ -785,6 +785,83 @@ describe('ToolLane.upsertTextChild / removeTextChildrenUnder', () => {
       expect(stripAnsi((rendered[2]![1]).join('\n'))).toContain('──');
     });
 
+    /**
+     * Regression for the agent-frame HEAD rows, the last unbounded rows in the
+     * flush path. `formatAgentSummary` and `formatAgentHeader` both emit a head
+     * row for the same entry (eagerly via flushSource, or at dispose-time), and
+     * their encodings are contractually coupled — so both clamp, or neither
+     * can. Measured at cols=88 before the fix: 109 for the summary head with
+     * stats, 181 for the eager header, 105 for the heartbeat-annotated label.
+     *
+     * Nesting labels are already clipped to NESTING_LABEL_MAX = 60, so the
+     * overflow comes from what surrounds them: the spine indent, the tool name,
+     * the `[subagent]` dispatch tag and — for the summary head — the
+     * ` — N tool calls · M lines` stats tail, which only appears once a frame
+     * has more than MAX_VISIBLE_CHILDREN (3) children. That makes the common
+     * case a plain root `agent` dispatch that made four or more tool calls.
+     */
+    it('agent frame head rows fit within terminal width', () => {
+      const cols = process.stdout.columns ?? 88;
+      const longPrompt = JSON.stringify({
+        prompt:
+          'Audit every emission site in the tool lane renderer and classify each as bounded or unbounded with file:line citations',
+        agent_type: 'research-agent',
+      });
+
+      // Summary head WITH the stats tail: >3 children is what makes stats
+      // render. Root dispatch shape — no maxWidth, as the orchestrator calls it.
+      const summary = new ToolLane();
+      summary.addStartWithAgentContext('parent', 'agent', ` (${longPrompt})`, undefined);
+      for (let i = 0; i < 5; i++) {
+        summary.addStartWithAgentContext(`child-${i}`, 'read_file', ` src/file-${i}.ts`, 'parent');
+        summary.addResult(`child-${i}`, { ...makeResult('output'), lineCount: 120 });
+      }
+      summary.addResult('parent', { ...makeResult('done'), lineCount: 4 });
+
+      // Eager header committed by flushSource for a still-live ancestor.
+      const eager = new ToolLane();
+      eager.addStartWithAgentContext('skill-1', 'skill', ` (${longPrompt})`, undefined);
+      eager.addStartWithAgentContext('agent-1', 'agent', ` (${longPrompt})`, 'skill-1');
+      eager.addStartWithAgentContext('tool-1', 'bash', ' git status', 'agent-1');
+      eager.addResult('tool-1', { ...makeResult('output'), lineCount: 3 });
+      eager.addResult('agent-1', { ...makeResult('done'), lineCount: 2 });
+
+      // Heartbeat/pause refresh: stream-renderer.ts re-labels the synthetic
+      // Agent entry with an annotation and passes no maxWidth at all.
+      const heartbeat = new ToolLane();
+      heartbeat.addStartWithAgentContext(
+        'synth',
+        'Agent',
+        ' (awa-private:research-agent-investigating-tool-lane-emission-sites) · waiting 2m 45s',
+        undefined,
+      );
+      heartbeat.addStartWithAgentContext('hb-child', 'bash', ' git status', 'synth');
+      heartbeat.addResult('hb-child', { ...makeResult('output'), lineCount: 3 });
+      heartbeat.addResult('synth', { ...makeResult('done'), lineCount: 1 });
+
+      const rendered: ReadonlyArray<readonly [string, string[]]> = [
+        ['summary head', summary.flush()],
+        ['eager header', eager.flushSource('agent-1')],
+        ['heartbeat label', heartbeat.flush()],
+      ];
+
+      for (const [label, blocks] of rendered) {
+        expect(blocks.length, `${label}: rendered nothing`).toBeGreaterThan(0);
+        // formatAgentSummary returns head + children joined by \n, so split
+        // before measuring — display width of a string containing \n is
+        // meaningless and would mask a wrapped head row.
+        for (const line of blocks.flatMap((block) => block.split('\n'))) {
+          expect(
+            displayWidth(stripAnsi(line)),
+            `${label} line exceeds terminal width (${cols}): ${JSON.stringify(line)}`,
+          ).toBeLessThanOrEqual(cols);
+        }
+      }
+
+      // The frame must still be identifiable after the clamp.
+      expect(stripAnsi((rendered[0]![1]).join('\n'))).toContain('agent');
+    });
+
     it('orchestrator-root in-progress bash with long input fits within terminal width', () => {
       const lane = new ToolLane();
       const cols = process.stdout.columns ?? 88;


### PR DESCRIPTION
## Summary

The agent-frame head rows were the last unbounded rows in the flush (scrollback) path. This clamps them, and moves `renderGroupedRootTools` into the grouped-root module to keep `tool-lane-render-agent.ts` under the 350-line ceiling.

Follow-up to #773, which fixed the grouped root row. Found while reviewing that PR.

## Measurements

At `cols=88`, in the production dispatch shape — `addStartWithAgentContext` with no `maxWidth`, as `stream-renderer-orchestrator.ts` calls it for root tools:

| Row | before | after |
|---|---|---|
| `formatAgentSummary` head, depth 0, with stats | 109 | 88 |
| `formatAgentHeader` eager row (`flushSource`) | 181 | 88 |
| `Agent` label refreshed by the heartbeat path | 105 | 88 |

Nesting labels are already clipped to `NESTING_LABEL_MAX = 60`, so the overflow comes from everything around them: the spine indent, the tool name, the `[subagent]` dispatch tag, and — for the summary head — the ` — N tool calls · M lines` stats tail. Stats only render above `MAX_VISIBLE_CHILDREN = 3`, which makes the common case an ordinary root `agent` dispatch that made four or more tool calls. Not a corner case.

## Why both head rows are clamped

`formatAgentSummary` and `formatAgentHeader` emit a head row for the **same entry** at different times — eagerly via `flushSource`, or at dispose-time `flush()` — under an encoding constraint documented on `formatAgentHeader`: if the two encodings diverge, rows committed by one path sit at a different column than descendants rendered by the other, and the user sees a topology break. Clamping only the row that overflowed would itself be a divergence, so both are clamped identically.

`getTerminalWidth()` is now read **once** per summary frame and shared by the head row and the recursive child frame — which is what the comment there already claimed. Two reads could straddle a resize and emit a head row clamped to the old width above children clamped to the new one.

Plain clamp rather than the grouped path's suffix reservation: identity leads the row and the stats tail is expendable, matching how the live overlay already clamps the same row.

## Commits

1. `refactor(tui): move renderGroupedRootTools into the grouped-root module` — pure move, no behavior change. #773 extracted `formatGroupedToolResults` but left its only caller behind; this reunites them and takes `tool-lane-render-agent.ts` from 338 → 264 lines, making room for the clamp. Re-exports move with the symbols, so `tool-lane.ts`'s import surface is unchanged.
2. `fix(tui): clamp agent frame head rows to terminal width` — the behavior change plus its regression test.

Reviewing commit-by-commit separates the move from the behavior change.

## Verification

- `pnpm test src/cli/commands/interactive/tool-lane.test.ts` → 115/115
- Full `src/cli` tree → 4973/4973 (up 1: the new test)
- `pnpm lint` (tsc --noEmit, strict) → clean
- New test fails on the parent commit: `expected 109 to be less than or equal to 88`
- File sizes after: `tool-lane-render-agent.ts` 264, `tool-lane-render-grouped-root.ts` 174 — both under the 350 ceiling
- Re-verified after rebasing onto `main` post-#773 merge (main had also moved to v5.82.9 + #769)

## History note

This PR was originally opened against `afk/fix-grouped-tool-width` (#773) because that file was over the line ceiling on `main` at the time. #773 was squash-merged while this work was in flight, so GitHub retargeted this PR to `main`; the two commits here have since been rebased onto `main` so #773's squashed content is no longer duplicated.

## Not in scope

The nested/child rows (`renderFlushChildren`) and the live overlay were already clamped — verified, not changed.
