### PR TITLE
test(bundled): delete the dead cross-repo drift comparison

### DIFF
--- a/src/bundled-plugins/awa-bundled/bundled.test.ts
+++ b/src/bundled-plugins/awa-bundled/bundled.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -7,38 +7,36 @@ import { fileURLToPath } from 'node:url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-// Pinned hashes for the bundled skills shipped under awa-bundled/. These
-// files mirror — but are NOT byte-equal to — corresponding upstream skills.
-// Permanent intentional differences include:
+// Contract: pinned hashes for the bundled skills shipped under awa-bundled/.
+// Some of these files also exist in a separate upstream plugin repo, but they
+// are NOT byte-equal to it and byte-equality is a false invariant: namespace
+// prefixes differ (upstream plugin-namespaced form → bare `/skill` here),
+// sub-agent dispatch identifiers differ, and wording diverges between
+// maintainers. So the only guard here is the pinned-hash snapshot: any
+// unauthored edit to a bundled SKILL.md fails the test until the developer
+// explicitly bumps the hash below.
 //
-//   - Namespace prefixes (upstream plugin-namespaced form → bare `/skill` here)
-//   - Sub-agent dispatch identifiers (namespaced form → bare name)
-//   - Occasional wording divergence between maintainers
-//
-// Because byte-equality is a false invariant, this file enforces only the
-// pinned-hash snapshot: any unauthored edit to a bundled SKILL.md fails the
-// test until the developer explicitly bumps the hash here. That bump is the
-// forcing function for cross-repo discipline:
+// That bump is also the forcing function for cross-repo discipline, since no
+// automated check compares the copies:
 //
 //   *** Workflow when bumping a pinned hash ***
 //   1. Identify what changed in the bundled SKILL.md.
-//   2. Check whether the same change applies upstream.
+//   2. Check whether the same change applies to an upstream copy, if one exists.
 //   3. If yes → open a parallel PR upstream. Land both before either
 //      is released.
 //   4. If no → document why the change is bundled-only in the PR description.
 //   5. Only then update the hash below.
 //
 // This convention exists because in November 2026 a critical /ship guardrail
-// (the "Branch lock" + "Never push to main" Hard Rules in commit 63f3ed3)
-// was added to the bundled mirror but never back-ported to example-plugin. The
-// deployed plugin therefore lacked the guardrail until the next sync. This
-// test cannot prevent that on its own — but the hash-bump moment forces the
-// developer to look at both copies.
+// (the "Branch lock" + "Never push to main" Hard Rules in commit 63f3ed3) was
+// added to the bundled mirror but never back-ported upstream. The deployed
+// plugin therefore lacked the guardrail until the next sync. This test cannot
+// prevent that on its own — but the hash-bump moment forces the developer to
+// look at both copies.
 const PINNED_HASHES = {
   // automate: afk-native scheduled-run skill (create_schedule + send_telegram +
-  // `afk service install daemon`). Mirrors the upstream framework plugin;
-  // vendored byte-equal, so no INTENTIONAL_DIFFS entry is needed. Drift row is
-  // wired in UPSTREAM_PATHS below (skips until example-plugin is co-located).
+  // `afk service install daemon`). Vendored byte-equal from the upstream
+  // framework plugin at the time it was bundled.
   automate: '93380f58316e607f6b95b27a9c2375f0a5403f3a42eb695d0490b50225d8838c',
   contract: '0ea822d8124f5fc55103a3e5e6d0fcb43889bf3f089bc722350da02ecf4f960f',
   // Hash re-bumped during PR #187 review: the Merge section now routes the
@@ -51,10 +49,10 @@ const PINNED_HASHES = {
   // verdicts are internal to Wave 3.5 (distinct from shadow-verify's vocab),
   // and states the 3-way terminal decision (original / ≠original+≥2-critic
   // convergence / ≠original+1-critic) explicitly. No frontmatter change
-  // (context: load preserved). Bundled-only body; no upstream back-port row.
+  // (context: load preserved). Bundled-only body; nothing to back-port.
   'devils-advocate':
     'd301929f02180b742700060d0de094b84ffafab9e16c771b20ee0eba76cd1238',
-  // diagnose is bundled-only (no upstream example-plugin counterpart). It ships
+  // diagnose is bundled-only (no upstream counterpart). It ships
   // as the agent-driven /diagnose (context: fork) that replaced the retired
   // vendored TS orchestrator (src/skills/diagnose/). Hash bumps need no parallel
   // PR — document the change in the commit message instead.
@@ -71,7 +69,7 @@ const PINNED_HASHES = {
   // (2026-06 skill-execution-mode work). `context` is an agent-afk-specific
   // field; Claude Code upstream skills are natively inline/progressive-disclosure,
   // so there is NO upstream counterpart to back-port — permanent bundled-only
-  // divergence (allowlisted in INTENTIONAL_DIFFS below). See docs/skill-load-mode.md.
+  // divergence. See docs/skill-load-mode.md.
   gather: '26ef18dde7db7c313655b0fe3097f14966763298ff5a2fe643ccf18d0f6b29c0',
   'ground-claim':
     'e3ceabc8d6b9b19526eb30441c17e763b56cb779d7549f54b45835b06a90fb8b',
@@ -79,8 +77,8 @@ const PINNED_HASHES = {
   // the read-only-skill feature (PR #5) and the 2026-06 load-by-default flip
   // (PR #7): `read-only: true` (forked child gets the RECON tool allowlist +
   // mutating-bash guard) AND `context: fork` (pins it to forking so the recon
-  // wave keeps dispatching). Both lines are allowlisted in
-  // INTENTIONAL_DIFFS['ground-state'] below so the normalized-drift test passes.
+  // wave keeps dispatching). The upstream ground-state has neither layer, so
+  // both lines are permanent bundled-only divergence.
   'ground-state':
     'a9d6da1956a60dd4362eecb26321998b0e512db40d571671e9b4427bfb8e5d6e',
   // intent-lock is bundled-only (no upstream counterpart).
@@ -91,7 +89,7 @@ const PINNED_HASHES = {
   // parallelize: bundled-only `context: load` added — see the gather note above.
   parallelize:
     'be8b2a301fe35d86d96d4be6f8418bf497dd9050767a3837cf057d7d5a1cd719',
-  // refactor is bundled-only (no upstream example-plugin counterpart); verbatim
+  // refactor is bundled-only (no upstream counterpart); verbatim
   // copy of the user-scope /refactor at ~/.afk/skills/.
   // Hash bumped (#611): the contract-extractor's `test_commands` example was
   // changed from the pnpm footgun form `pnpm test -- --grep "AuthService"` (under
@@ -101,23 +99,30 @@ const PINNED_HASHES = {
   // ~/.afk/skills/ if it drifts back.
   refactor: '3adf801b9a61eba80afd34fef1e8c78a892ec07256dabb073370622a62d1b40f',
   research: 'abe79d75a5f3c74696ef002293dbe8714e446f8955de97089d1005f1e70bc269',
-  // Hash bumped (#726): Wave 1's per-agent citation requirement no longer
-  // mandates a `git show` re-read at the reviewed ref. `research-agent` has no
-  // shell, so that clause forced every Wave 1 agent to nest a `git-investigator`
-  // purely to run one command — doubling the concurrency of a declared 2-agent
-  // wave and cascading into 429s. Ref-anchored verification is now centralized:
-  // Wave 1.5 runs INLINE in the orchestrator (which already holds the read-only
-  // shell it needs) instead of as a fourth sub-agent, absence-claim grounding
-  // uses the shell-free `Grep` tool, and a "Concurrency floor" block documents
-  // the real budget (peak 2 concurrent, 3 dispatched, zero nesting) so the
-  // regression cannot be reintroduced silently — now guarded by an assertion,
-  // not just this comment (see 'review Wave 1 keeps the no-git citation
-  // contract' below). Re-bumped after review feedback on PR #777: the
-  // concurrency floor now states its conditional post-synthesis budget and
-  // bounds the shadow-verify wave, Wave 1.5 Check A verifies `file-state`
-  // citations at EVERY severity (not just blocking/critical/high, which left
-  // medium-and-lower citations permanently unverified), and the research-agent
-  // `tools:` quote is now exact.
+  // History: hash bumped (#726): Wave 1's per-agent citation requirement no
+  // longer mandates a `git show` re-read at the reviewed ref. `research-agent`
+  // has no shell, so that clause forced every Wave 1 agent to nest a
+  // `git-investigator` purely to run one command — doubling the concurrency of
+  // a declared 2-agent wave and cascading into 429s. Ref-anchored verification
+  // is now centralized: Wave 1.5 runs INLINE in the orchestrator (which already
+  // holds the read-only shell it needs) instead of as a fourth sub-agent,
+  // absence-claim grounding uses the shell-free `Grep` tool, and a "Concurrency
+  // floor" block documents the real budget (peak 2 concurrent, 3 dispatched,
+  // zero nesting) so the regression cannot be reintroduced silently — now
+  // guarded by an assertion, not just this comment (see 'review Wave 1 keeps
+  // the no-git citation contract' below). Re-bumped after review feedback on
+  // PR #777: the concurrency floor now states its conditional post-synthesis
+  // budget and bounds the shadow-verify wave, Wave 1.5 Check A verifies
+  // `file-state` citations at EVERY severity (not just blocking/critical/high,
+  // which left medium-and-lower citations permanently unverified), and the
+  // research-agent `tools:` quote is now exact.
+  //
+  // The bundled copy is the SOLE copy of /review: upstream deleted its own
+  // review skill on 2026-07-24 (ce27e45), a deliberate dedup of a skill that
+  // only ever shadowed this one. So #726 had nothing to back-port. The defect
+  // CLASS was ported to the one place it still lived upstream: /weekly-reflect
+  // dispatched two shell-mandating survey waves as `research-agent` (upstream
+  // PR #77; all 40 upstream SKILL.md scanned, no other instance).
   review: 'fde056df77dc4e8769376ed40398cd5e6a32226b6e1c69cc272baa387be3f666',
   // Hash bumped 2026-06-09 (PR #52): records the confidence-trigger enhancement
   // landed in this branch's commit 1e35850 — adds high-confidence language
@@ -151,10 +156,9 @@ const PINNED_HASHES = {
   // quotes (markdown bodies almost always do) — the shell parsed them before
   // git/gh ran, failing the call or recording a mangled/truncated body. The
   // file-based form matches the safe convention already used in src/agent/gh.ts.
-  // BACK-PORT GAP: the same fix should land in the upstream example-plugin /ship
-  // skill (drift test is skipped here — example-plugin not co-located).
+  // BACK-PORT GAP: the same fix should still land in the upstream /ship skill.
   ship: '4b082cdcbfe51453a20edd03231b473812775a7cc452b661bb786ff9735f0066',
-  // simplify is bundled-only (no upstream example-plugin counterpart).
+  // simplify is bundled-only (no upstream counterpart).
   simplify:
     'ce720df16e81eff5e6022db38067d376f2177e08a9783fc377e04cf520c7bf3c',
   spec: '167e7cbb84de5b716efa11bb9f20a6e4b940f6f9a6d1812a7fbd735dae4f67dd',
@@ -163,252 +167,6 @@ const PINNED_HASHES = {
 type SkillName = keyof typeof PINNED_HASHES;
 
 const SKILLS = Object.keys(PINNED_HASHES) as SkillName[];
-
-// ── Namespace-normalized drift detection ──────────────────────────────────────
-//
-// Workspace root is four levels above __dirname (src/bundled-plugins/awa-bundled).
-// example-plugin is a sibling of agent-afk at the workspace root level.
-// This mirrors the pattern used in src/skills/_agents/vendored.test.ts.
-const WORKSPACE_ROOT = join(__dirname, '../../../..');
-
-// Upstream source paths relative to WORKSPACE_ROOT.
-// intent-lock, simplify, refactor are bundled-only — no upstream comparison row.
-const UPSTREAM_PATHS: Partial<Record<SkillName, string>> = {
-  automate: 'example-plugin/plugins/framework/skills/automate/SKILL.md',
-  contract: 'example-plugin/plugins/framework/skills/contract/SKILL.md',
-  gather: 'example-plugin/plugins/framework/skills/gather/SKILL.md',
-  'ground-claim': 'example-plugin/plugins/framework/skills/ground-claim/SKILL.md',
-  'ground-state': 'example-plugin/plugins/framework/skills/ground-state/SKILL.md',
-  research: 'example-plugin/plugins/framework/skills/research/SKILL.md',
-  ship: 'example-plugin/plugins/framework/skills/ship/SKILL.md',
-  spec: 'example-plugin/plugins/framework/skills/spec/SKILL.md',
-  'devils-advocate':
-    'example-plugin/plugins/example-plugin/skills/devils-advocate/SKILL.md',
-  parallelize: 'example-plugin/plugins/example-plugin/skills/parallelize/SKILL.md',
-  review: 'example-plugin/plugins/example-plugin/skills/review/SKILL.md',
-  'shadow-verify':
-    'example-plugin/plugins/example-plugin/skills/shadow-verify/SKILL.md',
-};
-
-// Normalize both copies before comparing, removing all permanent intentional
-// namespace shifts (upstream plugin-prefixed forms → bare skill names here).
-//
-// After normalization, any remaining diff is either real drift (a change
-// landed in one mirror but not the other) or an explicitly allowlisted
-// intentional divergence documented in INTENTIONAL_DIFFS below.
-function normalize(content: string): string {
-  return content
-    .replace(/\/framework:/g, '/')
-    .replace(/\/example-plugin:/g, '/')
-    .replace(/`framework:/g, '`')
-    .replace(/`example-plugin:/g, '`')
-    .replace(/"framework:/g, '"')
-    .replace(/"example-plugin:/g, '"');
-}
-
-// INTENTIONAL_DIFFS: per-skill array of RegExp patterns.  A normalized diff
-// line matching any pattern for that skill is silently accepted — the line is
-// removed from BOTH sides before comparison (each pattern is applied to both
-// the bundled and upstream line arrays independently).
-//
-// *** Adding an entry here requires an inline comment justifying why the
-// divergence is intentional.  "It seems fine" is NOT sufficient — if you
-// cannot defensibly justify it, surface it as unclassified drift in the PR
-// body instead. ***
-const INTENTIONAL_DIFFS: Partial<Record<SkillName, RegExp[]>> = {
-  // devils-advocate, parallelize, shadow-verify:
-  //   Both sides contain a "Sub-agent contract" invocation line immediately
-  //   after the frontmatter block, but they use different plugin namespaces:
-  //
-  //     Bundled:  /contract          (resolves to the co-bundled contract skill)
-  //     Upstream: /agent-workflow-amplifiers:contract  (third-party plugin ns)
-  //
-  //   The `normalize()` function only strips framework and `example-plugin:`
-  //   prefixes; it intentionally does NOT touch `agent-workflow-amplifiers:`
-  //   because that is a distinct third-party plugin, not a namespace shift of
-  //   the same plugin.  Both copies invoke the same logical skill — the
-  //   difference is which plugin registry entry resolves the name.  This is
-  //   intentional structural divergence: bundled uses self-contained routing;
-  //   upstream relies on the agent-workflow-amplifiers plugin being installed.
-  //
-  //   Pattern rationale: we match both the bare `/contract` line (bundled side)
-  //   and the namespaced `/agent-workflow-amplifiers:contract` line (upstream
-  //   side) so both are removed before the equality check.
-  'devils-advocate': [
-    // Bundled side: bare /contract invocation (no plugin prefix).
-    /^\/contract$/,
-    // Upstream side: /agent-workflow-amplifiers:contract invocation.
-    /\/agent-workflow-amplifiers:contract/,
-    // Bundled-only agent-afk execution-mode field. LOAD (not fork): the current
-    // agent orchestrates the critic wave and the advisory recommendation feeds
-    // ITS OWN decision (structurally identical to /parallelize). The critics +
-    // synthesizer stay independent as dispatched sub-agents either way, so fork
-    // adds an orchestration layer without adding independence. (Moved fork→load
-    // by user review, 2026-06.) Claude Code skills are natively inline → no
-    // upstream counterpart. See docs/skill-load-mode.md.
-    /^context: load$/,
-  ],
-  parallelize: [
-    // Same structural divergence as devils-advocate — different contract
-    // skill namespace on bundled vs upstream.
-    /^\/contract$/,
-    /\/agent-workflow-amplifiers:contract/,
-    // Bundled-only agent-afk execution-mode field (no upstream equivalent —
-    // Claude Code skills are natively inline). See docs/skill-load-mode.md.
-    /^context: load$/,
-  ],
-  'shadow-verify': [
-    // Same structural divergence as devils-advocate.
-    /^\/contract$/,
-    /\/agent-workflow-amplifiers:contract/,
-    // Bundled-only `context: fork` pin — independence of the verifier wave
-    // requires an isolated context, so it must keep forking after the
-    // load-by-default flip. See devils-advocate note.
-    /^context: fork$/,
-  ],
-
-  // gather: bundled-only `context: load` execution-mode field (no upstream
-  // equivalent — Claude Code skills are natively inline). See docs/skill-load-mode.md.
-  gather: [/^context: load$/],
-
-  // research — 1-line divergence, #441 back-port gap:
-  //   "if the research-agent is not available" (bundled) vs
-  //   "if the private plugin is not installed" (upstream).
-  //   Bundled users have no concept of "private plugin" — the research-agent
-  //   IS bundled, so "not available" is the correct user-facing phrase.  The
-  //   upstream wording assumed plugin-based deployment context.  This divergence
-  //   is intentional for bundled context; upstream should ideally adopt a
-  //   context-neutral phrasing.  Flagged for #441 reconciliation.
-  research: [
-    /if the research-agent is not available/,
-    /if the private plugin is not installed/,
-    // Bundled-only `context: fork` pin — research fans out parallel
-    // context-gathering sub-agents and must keep that work in an isolated
-    // context after the load-by-default flip. See devils-advocate note.
-    /^context: fork$/,
-  ],
-
-  // ship — 3 divergences, all #441 back-port gaps:
-  //
-  //   1. Phase 3 heading:
-  //        Bundled: "Phase 3 — Draft commit message."
-  //        Upstream: "Phase 3 — Draft commit message (user-approval gate)."
-  //      The "(user-approval gate)" annotation was added in upstream but not
-  //      back-ported to bundled.  Both copies have the same behavior (no
-  //      approval gate); the annotation is a clarifying label.  Real drift,
-  //      flagged for #441 back-port.
-  //
-  //   2. Phase 3 body prose:
-  //        Bundled: "Print the draft message + file list to the user as
-  //          info-only output, then **immediately** invoke Phase 4.
-  //          **This is not a gate. Do not ask "does this look good?" Do not
-  //          wait for approval.** The user surface is one continuous turn:
-  //          draft → commit → push → PR URL."
-  //        Upstream: "Surface the draft message + file list to the user for
-  //          visibility, then proceed immediately to commit. Do not wait for
-  //          approval."
-  //      Upstream simplified the prose; semantics are identical.  Real drift
-  //      (editorial improvement in upstream not back-ported).  Flagged for #441.
-  //
-  //   3. Phase 5 Never-push-main bullet order:
-  //        Bundled: bullet appears after "Non-fast-forward rejection" bullet.
-  //        Upstream: bullet appears before "Upstream unset" bullet (earlier).
-  //      Same safety rule, different list position.  Real drift (harmless
-  //      reordering).  Flagged for #441 back-port.
-  ship: [
-    // Heading divergence (1 above).
-    /Phase 3 — Draft commit message\./,
-    /Phase 3 — Draft commit message \(user-approval gate\)\./,
-    // Prose divergence (2 above) — match the diverging body paragraph.
-    /Print the draft message \+ file list to the user as info-only output/,
-    /then \*\*immediately\*\* invoke Phase 4\./,
-    /\*\*This is not a gate\. Do not ask "does this look good\?" Do not wait for approval\.\*\*/,
-    /The user surface is one continuous turn: draft → commit → push → PR URL\./,
-    /Surface the draft message \+ file list to the user for visibility/,
-    /then proceed immediately to commit\. Do not wait for approval\./,
-    // Bullet ordering divergence (3 above).
-    /\*\*Never\*\* `git push origin main` \(or `master`\)\. Pushing the feature branch is the only allowed form\./,
-    // Bundled-only `context: fork` pin — /ship is a heavy multi-phase release
-    // orchestrator kept in an isolated context after the load-by-default flip.
-    // See devils-advocate note.
-    /^context: fork$/,
-  ],
-
-  // History: review — namespace-only divergence (back-port landed; #441 closed):
-  //   The bundled review is now the de-namespaced mirror of upstream
-  //   example-plugin review. The previously-allowlisted #441 drift —
-  //   Wave 1.5 (citation + absence-claim verification), reviewed-ref
-  //   capture / SHA pinning, the citation-requirement block, the severity
-  //   sort-order block, epistemic scope disclosure, and the ref:<sha>
-  //   finding-schema fields — has been back-ported into bundled; and the
-  //   api-compat reachability + absence-claim grounding gates were ported
-  //   the other way into upstream (example-plugin#40). Both
-  //   copies now carry the full superset, so the only remaining divergence
-  //   is the same contract-namespace shift as devils-advocate / parallelize
-  //   / shadow-verify: bundled uses /contract (self-contained routing),
-  //   upstream uses /agent-workflow-amplifiers:contract (third-party ns).
-  //
-  //   NEW DRIFT (#726) — bundled scopes Wave 1 citations to diff-context and
-  //   hoists Wave 1.5 inline, because a shell-less research-agent had to nest a
-  //   git-investigator to satisfy the old per-agent `git show` clause (a 2-agent
-  //   wave was really 4+ sessions). There is NO upstream copy to back-port to:
-  //   upstream deleted its review skill on 2026-07-24 (ce27e45), deliberate
-  //   dedup of a skill that only ever shadowed this one — sibling commit abb54c5
-  //   names `review` as "shadowing bundled agent-afk copies", and the #596/#624
-  //   mirrors were hand-syncs of this file. Consequences: bundled is now the
-  //   SOLE copy, UPSTREAM_PATHS['review'] names a path that no longer exists,
-  //   and the drift row below can only ever skip — do NOT read that skip as
-  //   "upstream verified", it is indistinguishable from "sibling not checked
-  //   out". The defect CLASS was ported to the one place it still lived
-  //   upstream: /weekly-reflect dispatched two shell-mandating survey waves as
-  //   `research-agent` (upstream PR #77; all 40 upstream SKILL.md scanned, no
-  //   other instance). Nothing is allowlisted for review — with the upstream
-  //   file gone there is no diff left to silence.
-  review: [
-    // Bundled side: bare /contract invocation (no plugin prefix).
-    /^\/contract$/,
-    // Upstream side: /agent-workflow-amplifiers:contract invocation.
-    /\/agent-workflow-amplifiers:contract/,
-    // Bundled-only `context: fork` pin — review dispatches parallel dimension
-    // agents and must keep that work isolated after the load-by-default flip.
-    // (Already carried `context: fork` before the flip; allowlisted here for
-    // the co-located drift comparison.) See devils-advocate note.
-    /^context: fork$/,
-    // argument-hint divergence — bundled-only `--post {github,telegram}` flag.
-    // `/review --post` is an agent-afk dispatch-layer publishing feature (PR #35,
-    // 7830a0f) handled in src/cli/slash/plugin-skills.ts; the upstream
-    // example-plugin review skill has NO --post publisher, so its argument-hint
-    // omits the flag. Anchored on the stable line prefix so it removes the
-    // argument-hint line from BOTH sides (bundled w/ --post, upstream w/o),
-    // leaving the rest of the line guarded. No upstream back-port applies —
-    // the feature does not exist there. (bundled.test.ts workflow option 4.)
-    /^argument-hint: "\[diff\|pr-url\|pr-number/,
-  ],
-
-  // ground-state — TWO bundled-only frontmatter lines, both allowlisted:
-  //   1. `read-only: true` (read-only-skill feature): the marker the agent-afk
-  //      runtime keys on to give ground-state's forked reconnaissance subagent a
-  //      restricted RECON tool allowlist (no write_file/edit_file) plus a
-  //      mutating-bash guard — enforcing the "never edits files" constraint that
-  //      was previously prose-only (the subagent had FULL write tools and was
-  //      observed making 22 edit_file + 27 bash calls in one session).
-  //   2. `context: fork` (2026-06 load-by-default flip): pins ground-state to
-  //      forking so its recon wave keeps dispatching.
-  //   The upstream ground-state SKILL.md has neither layer yet, so both lines are
-  //   bundled-only. When upstream adopts either, mirror the frontmatter there and
-  //   drop the matching pattern. Flagged for cross-repo reconciliation.
-  'ground-state': [/^read-only: true$/, /^context: fork$/],
-  spec: [/^context: fork$/],
-
-  // ground-claim: bundled-only `context: load` field. Unlike the fork-pinned
-  // skills, ground-claim dispatches NO sub-agents — it is a pre-answer guard
-  // that must run in the caller's context to see the reasoning it grounds
-  // (a forked guard cannot inspect the parent's accumulated context). A
-  // /devils-advocate review (2026-06) flagged the original fork pin as a
-  // semantic error and moved it to load. Claude Code skills are natively
-  // inline → no upstream counterpart. See docs/skill-load-mode.md.
-  'ground-claim': [/^context: load$/],
-};
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -422,53 +180,6 @@ function bundledPath(name: SkillName): string {
 
 function readBundled(name: SkillName): string {
   return readFileSync(bundledPath(name), 'utf8');
-}
-
-function upstreamAbsPath(name: SkillName): string | null {
-  const rel = UPSTREAM_PATHS[name];
-  if (!rel) return null;
-  return join(WORKSPACE_ROOT, rel);
-}
-
-function upstreamAvailable(name: SkillName): boolean {
-  const abs = upstreamAbsPath(name);
-  return abs !== null && existsSync(abs);
-}
-
-// isAllowlisted returns true if the given line matches any pattern in the
-// skill's INTENTIONAL_DIFFS entry.
-function isAllowlisted(line: string, name: SkillName): boolean {
-  const patterns = INTENTIONAL_DIFFS[name] ?? [];
-  return patterns.some((re) => re.test(line));
-}
-
-// diffLines computes the symmetric difference between two ordered line arrays:
-// lines that are in `aLines` but not `bLines` (bundled-only), and lines that
-// are in `bLines` but not `aLines` (upstream-only).  Returns the two sets.
-// This is intentionally set-based (not position-sensitive) to avoid false
-// positives from harmless reorderings of identical content.
-function diffLines(
-  aLines: string[],
-  bLines: string[],
-): { bundledOnly: string[]; upstreamOnly: string[] } {
-  const aCount = new Map<string, number>();
-  const bCount = new Map<string, number>();
-  for (const l of aLines) aCount.set(l, (aCount.get(l) ?? 0) + 1);
-  for (const l of bLines) bCount.set(l, (bCount.get(l) ?? 0) + 1);
-
-  const bundledOnly: string[] = [];
-  const upstreamOnly: string[] = [];
-
-  for (const [l, cnt] of aCount) {
-    const excess = cnt - (bCount.get(l) ?? 0);
-    for (let i = 0; i < excess; i++) bundledOnly.push(l);
-  }
-  for (const [l, cnt] of bCount) {
-    const excess = cnt - (aCount.get(l) ?? 0);
-    for (let i = 0; i < excess; i++) upstreamOnly.push(l);
-  }
-
-  return { bundledOnly, upstreamOnly };
 }
 
 // ── Test suites ───────────────────────────────────────────────────────────────
@@ -522,86 +233,5 @@ describe('bundled skills', () => {
         '**Wave 1.5 — Citation + absence-claim verification (INLINE',
       );
     });
-  });
-
-  // ── Namespace-normalized drift comparison ──────────────────────────────────
-  //
-  // Each test below compares a bundled SKILL.md against its upstream
-  // counterpart after normalization (namespace prefixes stripped) and
-  // allowlisting (known intentional divergences removed).
-  //
-  // The test is skipped — NOT failed — when example-plugin is not co-located
-  // (e.g. standalone CI clone).  The pinned-hash tests above still guard
-  // against local-only edits.  These tests guard against the cross-repo case:
-  // a change landing in one mirror without being back-ported to the other.
-  //
-  // Workflow when a test fails here:
-  //   1. Is the diff intentional?  Add a justified entry to INTENTIONAL_DIFFS.
-  //   2. Is it real drift?  Land the back-port and re-run.  Then bump the hash.
-  //   3. Is it unclassifiable?  Surface it as unclassified drift in the PR body.
-  describe('namespace-normalized drift comparison (skipped if example-plugin not co-located)', () => {
-    // Invariant: for every mirrorable skill, after normalize() and after
-    // removing allowlisted lines, the bundled and upstream copies must be
-    // line-for-line identical.  Any remaining difference is a back-port gap.
-
-    const mirrorableSkills = SKILLS.filter(
-      (s) =>
-        s !== 'intent-lock' &&
-        s !== 'simplify' &&
-        s !== 'refactor' &&
-        s !== 'diagnose',
-    );
-
-    for (const name of mirrorableSkills) {
-      it.skipIf(!upstreamAvailable(name))(
-        `${name}: normalized bundled matches normalized upstream (after allowlist)`,
-        () => {
-          // Contract: upstreamAbsPath is non-null when upstreamAvailable() is true.
-          const abs = upstreamAbsPath(name) as string;
-          const bundledRaw = readBundled(name);
-          const upstreamRaw = readFileSync(abs, 'utf8');
-
-          const bundledLines = normalize(bundledRaw).split('\n');
-          const upstreamLines = normalize(upstreamRaw).split('\n');
-
-          // Compute symmetric difference: lines unique to each side.
-          // Context lines (identical on both sides) are ignored — we only care
-          // about lines that changed.
-          const { bundledOnly, upstreamOnly } = diffLines(
-            bundledLines,
-            upstreamLines,
-          );
-
-          // Remove allowlisted divergences from each side.
-          const unexpectedBundledOnly = bundledOnly.filter(
-            (l) => !isAllowlisted(l, name),
-          );
-          const unexpectedUpstreamOnly = upstreamOnly.filter(
-            (l) => !isAllowlisted(l, name),
-          );
-
-          if (
-            unexpectedBundledOnly.length > 0 ||
-            unexpectedUpstreamOnly.length > 0
-          ) {
-            const lines: string[] = [
-              `--- bundled (normalized, non-allowlisted unique lines)`,
-              `+++ upstream (normalized, non-allowlisted unique lines)`,
-            ];
-            for (const l of unexpectedBundledOnly) lines.push(`-${l}`);
-            for (const l of unexpectedUpstreamOnly) lines.push(`+${l}`);
-
-            throw new Error(
-              `Namespace-normalized drift detected in ${name}.\n` +
-                `  Bundled:  ${bundledPath(name)}\n` +
-                `  Upstream: ${abs}\n` +
-                `  If the diff is intentional, add a justified entry to INTENTIONAL_DIFFS['${name}'].\n` +
-                `  If it is real drift, back-port the change and bump the pinned hash.\n\n` +
-                lines.join('\n'),
-            );
-          }
-        },
-      );
-    }
   });
 });


### PR DESCRIPTION
Deletes the namespace-normalized cross-repo drift comparison from `src/bundled-plugins/awa-bundled/bundled.test.ts`, keeping the pinned-hash guard that actually works.

> **Stacked on #777.** Base is `afk/review-citation-scope-726`, not `main`, because #777 edits the same regions of this file. GitHub will retarget this to `main` automatically when #777 merges. Diff here is exactly 1 commit / 1 file.

## The defect

That file carried two independent guards:

- **Pinned-hash snapshots** — compute `sha256` over each bundled `SKILL.md` and compare to a checked-in constant. These work; one caught a real edit earlier today.
- **Namespace-normalized drift comparison** — compare each bundled `SKILL.md` against its counterpart in the upstream plugin repo, after stripping namespace prefixes and removing allowlisted divergences. **This has not run since that repo was reorganized, and cannot run in CI by design.**

Four stacked causes, each verified:

| # | cause |
|---|---|
| 1 | `UPSTREAM_PATHS` names an upstream repo directory that no longer exists under that name. |
| 2 | It also names inner plugin directories — `plugins/framework/` (8 rows) and `plugins/example-plugin/` (4 rows) — that were likewise renamed. Correcting only the repo segment would still miss **every** row. |
| 3 | `WORKSPACE_ROOT = join(__dirname, '../../../..')` resolves four levels up from `src/bundled-plugins/awa-bundled` — the repo root's **parent**. Inside an afk worktree that is `<repo>/.afk-worktrees`, so every worktree run was unresolvable by construction. Worktrees are the normal dev workflow here. |
| 4 | The upstream repo is not a sibling of `agent-afk` on the maintainer's machine either — different parent directory, which no in-scheme path correction reaches. |

So `upstreamAvailable()` was false for all 12 rows and every comparison silently skipped. **Twelve permanently-skipped tests are worse than zero tests** — they read as coverage in every run, and the skip was indistinguishable from "sibling repo just isn't checked out right now."

Two further signs the mechanism had rotted: two of the 12 rows (`review`, `parallelize`) pointed at files upstream **deleted outright** in `ce27e45` (2026-07-24); and `normalize()` stripped `/framework:` / `/example-plugin:` prefixes, no form of which appears upstream any more — it was inert.

## Why delete rather than repair

Repair is ~30 lines (fix both path segments, fix `WORKSPACE_ROOT`, drop the two deleted rows, make the upstream root configurable so it resolves from a worktree). But even fully repaired the guard only ever runs on one machine — CI has no upstream checkout, so its CI value stays zero either way. Cross-repo parity belongs in the upstream repo's own CI, where both plugin copies sit side by side and a check can actually execute. The pinned hashes remain the forcing function that makes an undocumented bundled edit fail loudly.

## What was kept, byte-identical

All 16 hash **values** (verified by extracting and diffing every 64-hex literal against the base), `PINNED_HASHES`, `SkillName`/`SKILLS`, `computeHash`/`bundledPath`/`readBundled`, the pinned-hash snapshot suite, `covers every bundled skill directory`, and `review Wave 1 keeps the no-git citation contract (#726)`.

Seven comments documenting the deleted mechanism were swept, preserving the durable fact in each — why a given hash moved, and **real back-port debt that still exists as debt** (the `/ship` gap is retained). Two rewritten blocks crossed the repo's 15-line comment threshold and took the required `Contract:` / `History:` prefix.

## How was this tested?

- `pnpm lint` (`tsc --noEmit`, strict — `noUnusedLocals` would catch any orphaned symbol) — clean
- `pnpm test src/bundled-plugins/awa-bundled/bundled.test.ts` — **18 passed, 0 skipped** (before: 18 passed, 12 skipped)
- `pnpm test tests/copy-bundled-plugins.test.ts` — 4 passed
- `pnpm fix:pins:check` — all hash pins up to date (proves no `SKILL.md` was touched and no hash moved)
- Structural verification independent of the above: all 9 deleted symbols confirmed at 0 occurrences; the 3 kept test bodies confirmed byte-identical by hashing; no dangling `example-plugin` / `co-located` / `UPSTREAM_PATHS` references remain
- File length **607 → 237** lines

**CI does not run on this PR.** `.github/workflows/ci.yml` triggers only on `pull_request: branches: [main]` and `push: branches: [main]`, so a PR stacked on a feature branch gets no Lint/Test jobs — only the Vercel checks. Every gate above was therefore run locally and reproduced independently by the orchestrator. The Actions suite will run once this retargets to `main`, which GitHub does automatically when #777 merges.

The one gate not run locally is the full `pnpm test:coverage`. The deleted tests all skipped, so they exercised no source lines and cannot move coverage.

## Follow-ups, deliberately not here

1. `src/skills/_agents/vendored.test.ts` uses the same sibling-path pattern for vendored agent prompts and may have the same latent staleness — unaudited, separate concern.
2. The `shadow-verify` hash comment is a pre-existing 23-line block with no `Invariant:`/`Contract:`/`History:` prefix. Confirmed byte-identical to base, so it is not a regression from this change; worth a one-line fix separately.
3. Cross-repo parity coverage should be re-established in the upstream repo's CI.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes (scoped — see above)
- [x] Commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] No secrets, tokens, or private paths in the diff

