### PR TITLE
fix(tui): schedule clock-derived quota repaints and condition the auto-resume promise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ auto-release workflow to deduplicate commits across successive runs.
 
 ## [Unreleased]
 
+### Fixed
+- tick the status line on a 30s timer so the quota reset countdown and the stale-reading marker stay true on an idle session instead of freezing at their last event-driven paint
+- stop the turn footer promising pause-and-auto-resume when the runtime will not deliver it — the promise is now conditional on `autoResumeOnUsageLimit` and on the reset landing inside the retry layer's two-hour wait ceiling
+
 ## [5.83.1] - 2026-07-31
 
 ### Fixed

--- a/docs/env-registry.md
+++ b/docs/env-registry.md
@@ -2,7 +2,7 @@
 
 Generated from `src/config/env.ts`. Do not edit by hand — run `pnpm scan:env` after changing the registry source.
 
-**138 vars** across 12 categories. Every `process.env[...]` read in `src/` outside `src/config/env.ts` is a CI failure (enforced by `pnpm audit:env:check`).
+**139 vars** across 12 categories. Every `process.env[...]` read in `src/` outside `src/config/env.ts` is a CI failure (enforced by `pnpm audit:env:check`).
 
 To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV_REGISTRY`), then run `pnpm scan:env`.
 

--- a/src/agent/providers/anthropic-direct/query/retry-layer.ts
+++ b/src/agent/providers/anthropic-direct/query/retry-layer.ts
@@ -49,7 +49,13 @@ import type {
   RunTurnInput,
 } from '../types.js';
 
-const TWO_HOURS_MS = 2 * 60 * 60 * 1000;
+/**
+ * Both the total usage-limit polling budget and the maximum reset lead time the
+ * layer will wait out. Exported so surfaces that *describe* this behaviour to
+ * the user (see `cli/quota-footer.ts`) can be drift-tested against the real
+ * threshold instead of hardcoding a second copy of it.
+ */
+export const TWO_HOURS_MS = 2 * 60 * 60 * 1000;
 
 // Transient rate-limit (429 + retry-after header, no `|ts`) replay budget.
 // The SDK has already auto-retried twice by the time the error surfaces here,

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -680,7 +680,11 @@ export async function bootstrapSession(
   // its inter-turn raw writes through statusLine.withFullScrollRegion(...) —
   // see repl-renderer.ts for the DECSTBM sub-region scroll-loss contract this
   // wiring is defending against.
-  const statusLine = new StatusLine();
+  // `tickMs` is resolved caller-side (StatusLine defaults it off, like the
+  // compositor's caret blink) so only the REPL gets a recurring timer. 30s is
+  // half the quota countdown's minute granularity, which is the finest
+  // clock-derived value the row renders.
+  const statusLine = new StatusLine({ tickMs: 30_000 });
   const replRenderer = createReplRenderer(process.stdout, { statusLine });
 
   // Stable hookRegistry shared across sessions (including swaps).

--- a/src/cli/commands/interactive/turn-handler.test.ts
+++ b/src/cli/commands/interactive/turn-handler.test.ts
@@ -16,6 +16,15 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as path from 'node:path';
 import { runTurn, formatContextUsage, printTurnFooter } from './turn-handler.js';
 import { recordQuotaSnapshot, resetQuotaCacheForTests } from '../../../agent/quota-cache.js';
+
+// Only `resolveAutoResumeOnUsageLimit` is stubbed; every other config export
+// stays real. Defaults to `true` (the production default) so the ~70 other
+// tests in this file are unaffected — a case opts in by flipping the stub.
+const configStub = vi.hoisted(() => ({ autoResume: true }));
+vi.mock('../../config.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../config.js')>()),
+  resolveAutoResumeOnUsageLimit: () => configStub.autoResume,
+}));
 import { getCurrentSink } from '../../../agent/_lib/skill-sink-channel.js';
 import type { AgentSession } from '../../../agent/session.js';
 import type { OutputEvent } from '../../../agent/types.js';
@@ -2322,9 +2331,11 @@ describe('formatContextUsage — proactive escalating context tiers', () => {
 describe('printTurnFooter — subscription-quota line', () => {
   beforeEach(() => {
     resetQuotaCacheForTests();
+    configStub.autoResume = true;
   });
   afterEach(() => {
     resetQuotaCacheForTests();
+    configStub.autoResume = true;
   });
 
   const footerLines = (): string[] => {
@@ -2352,6 +2363,34 @@ describe('printTurnFooter — subscription-quota line', () => {
     const out = footerLines().join('\n');
     expect(out).toContain('5h quota 94% used');
     expect(out).toContain('resets in 12m');
+  });
+
+  it('honours a config-set autoResumeOnUsageLimit=false through the real call path', () => {
+    // Covers the wiring, not just the pure formatter: the five quota-footer.ts
+    // unit tests pass `{ autoResume }` explicitly, so a DEAD read at this call
+    // site stayed invisible to them. That is exactly how the first cut of this
+    // shipped — `loadConfig().autoResumeOnUsageLimit` is permanently undefined,
+    // so the promise was unconditional and 13,754 green tests missed it.
+    configStub.autoResume = false;
+    recordQuotaSnapshot({
+      fiveHourUtilization: 0.97,
+      fiveHourResetsAt: new Date(Date.now() + 12 * 60_000),
+      observedAt: new Date(),
+    });
+    const out = footerLines().join('\n');
+    expect(out).toContain('5h quota 97% used');
+    expect(out).not.toContain('auto-resumes');
+    expect(out).toContain('auto-resume is off');
+  });
+
+  it('promises auto-resume through the real call path when the flag is on', () => {
+    configStub.autoResume = true;
+    recordQuotaSnapshot({
+      fiveHourUtilization: 0.97,
+      fiveHourResetsAt: new Date(Date.now() + 12 * 60_000),
+      observedAt: new Date(),
+    });
+    expect(footerLines().join('\n')).toContain('AFK pauses and auto-resumes at the cap');
   });
 
   it('orders the quota line AFTER the context line — nearest deadline reads first', () => {

--- a/src/cli/commands/interactive/turn-handler.test.ts
+++ b/src/cli/commands/interactive/turn-handler.test.ts
@@ -2369,8 +2369,8 @@ describe('printTurnFooter — subscription-quota line', () => {
     // Covers the wiring, not just the pure formatter: the five quota-footer.ts
     // unit tests pass `{ autoResume }` explicitly, so a DEAD read at this call
     // site stayed invisible to them. That is exactly how the first cut of this
-    // shipped — `loadConfig().autoResumeOnUsageLimit` is permanently undefined,
-    // so the promise was unconditional and 13,754 green tests missed it.
+    // shipped — the display and provider must resolve the same persisted flag,
+    // or the promise can contradict runtime behaviour.
     configStub.autoResume = false;
     recordQuotaSnapshot({
       fiveHourUtilization: 0.97,

--- a/src/cli/commands/interactive/turn-handler.ts
+++ b/src/cli/commands/interactive/turn-handler.ts
@@ -948,10 +948,9 @@ export function printTurnFooter(
   // forever under API-key auth, where the quota headers never arrive.
   // The park-and-resume promise is conditional on the real retry configuration
   // (see capNote, quota-footer.ts), so the flag is read rather than assumed.
-  // Via the memoized-tier resolver, NOT loadConfig(): loadConfig's return value
-  // is a field whitelist that drops autoResumeOnUsageLimit (so the read would
-  // be inert), and it re-installs process-global slot bindings on every call —
-  // both disqualifying for a per-turn display read.
+  // Via the memoized-tier resolver, NOT loadConfig(): the latter re-installs
+  // process-global slot bindings on every call, disqualifying it for a
+  // per-turn display read.
   const quota = formatQuotaUsage(quotaWindowsFromSnapshot(getQuotaSnapshot()), new Date(), {
     autoResume: resolveAutoResumeOnUsageLimit(),
   });

--- a/src/cli/commands/interactive/turn-handler.ts
+++ b/src/cli/commands/interactive/turn-handler.ts
@@ -34,7 +34,7 @@ import { runWithSink } from '../../../agent/_lib/skill-sink-channel.js';
 import { parseTerminalState, type TerminalState } from './terminal-state.js';
 import { renderVerdictCard } from './verdict-card.js';
 import { pushTerminalStateToTelegram, doneHasCorroboratingEvidence } from './afk-push.js';
-import { loadTelegramConfig } from '../../config.js';
+import { loadConfig, loadTelegramConfig } from '../../config.js';
 import { buildUserPayload } from '../../slash/_lib/user-payload.js';
 import { expandAtFileTokens } from './at-file-inject.js';
 
@@ -946,7 +946,13 @@ export function printTurnFooter(
   // is the constraint on the next hour — nearest deadline reads first. Silent
   // below 80% (the status-line indicator covers that range ambiently) and silent
   // forever under API-key auth, where the quota headers never arrive.
-  const quota = formatQuotaUsage(quotaWindowsFromSnapshot(getQuotaSnapshot()));
+  // The park-and-resume promise is conditional on the real retry configuration
+  // (see capNote, quota-footer.ts), so the flag is read here rather than
+  // assumed — same inline-config pattern as the loadTelegramConfig() call in
+  // runTurn above. `?? true` matches the provider's own default (query.ts).
+  const quota = formatQuotaUsage(quotaWindowsFromSnapshot(getQuotaSnapshot()), new Date(), {
+    autoResume: loadConfig().autoResumeOnUsageLimit ?? true,
+  });
   if (quota.text !== null) {
     const quotaColorFn =
       quota.tier === 'over' || quota.tier === 'near'

--- a/src/cli/commands/interactive/turn-handler.ts
+++ b/src/cli/commands/interactive/turn-handler.ts
@@ -34,7 +34,7 @@ import { runWithSink } from '../../../agent/_lib/skill-sink-channel.js';
 import { parseTerminalState, type TerminalState } from './terminal-state.js';
 import { renderVerdictCard } from './verdict-card.js';
 import { pushTerminalStateToTelegram, doneHasCorroboratingEvidence } from './afk-push.js';
-import { loadConfig, loadTelegramConfig } from '../../config.js';
+import { loadTelegramConfig, resolveAutoResumeOnUsageLimit } from '../../config.js';
 import { buildUserPayload } from '../../slash/_lib/user-payload.js';
 import { expandAtFileTokens } from './at-file-inject.js';
 
@@ -947,11 +947,13 @@ export function printTurnFooter(
   // below 80% (the status-line indicator covers that range ambiently) and silent
   // forever under API-key auth, where the quota headers never arrive.
   // The park-and-resume promise is conditional on the real retry configuration
-  // (see capNote, quota-footer.ts), so the flag is read here rather than
-  // assumed — same inline-config pattern as the loadTelegramConfig() call in
-  // runTurn above. `?? true` matches the provider's own default (query.ts).
+  // (see capNote, quota-footer.ts), so the flag is read rather than assumed.
+  // Via the memoized-tier resolver, NOT loadConfig(): loadConfig's return value
+  // is a field whitelist that drops autoResumeOnUsageLimit (so the read would
+  // be inert), and it re-installs process-global slot bindings on every call —
+  // both disqualifying for a per-turn display read.
   const quota = formatQuotaUsage(quotaWindowsFromSnapshot(getQuotaSnapshot()), new Date(), {
-    autoResume: loadConfig().autoResumeOnUsageLimit ?? true,
+    autoResume: resolveAutoResumeOnUsageLimit(),
   });
   if (quota.text !== null) {
     const quotaColorFn =

--- a/src/cli/config.test.ts
+++ b/src/cli/config.test.ts
@@ -12,6 +12,7 @@ import {
   getModelId,
   _resetConfigCache,
   resolveCliPermissionMode,
+  resolveAutoResumeOnUsageLimit,
   DEFAULT_CLI_PERMISSION_MODE,
 } from './config.js';
 import {
@@ -1249,5 +1250,19 @@ describe('loadConfig() — permissionMode default (new-install bypass)', () => {
     _resetConfigCache();
     mockConfig({ permissionMode: 'plan' });
     expect(resolveCliPermissionMode()).toBe('plan');
+  });
+
+  it('resolveAutoResumeOnUsageLimit() reads the flag loadConfig() drops', () => {
+    // Regression guard: `loadConfig()`'s return value is an explicit field
+    // whitelist that omits autoResumeOnUsageLimit, so the obvious
+    // `loadConfig().autoResumeOnUsageLimit` read is permanently `undefined`.
+    // The footer's "auto-resume is off" copy hangs off this resolver instead;
+    // the second assertion is what fails if anyone re-routes it via loadConfig.
+    mockConfig({});
+    expect(resolveAutoResumeOnUsageLimit()).toBe(true);
+    _resetConfigCache();
+    mockConfig({ autoResumeOnUsageLimit: false });
+    expect(resolveAutoResumeOnUsageLimit()).toBe(false);
+    expect(loadConfig().autoResumeOnUsageLimit).toBeUndefined();
   });
 });

--- a/src/cli/config.test.ts
+++ b/src/cli/config.test.ts
@@ -1252,17 +1252,13 @@ describe('loadConfig() — permissionMode default (new-install bypass)', () => {
     expect(resolveCliPermissionMode()).toBe('plan');
   });
 
-  it('resolveAutoResumeOnUsageLimit() reads the flag loadConfig() drops', () => {
-    // Regression guard: `loadConfig()`'s return value is an explicit field
-    // whitelist that omits autoResumeOnUsageLimit, so the obvious
-    // `loadConfig().autoResumeOnUsageLimit` read is permanently `undefined`.
-    // The footer's "auto-resume is off" copy hangs off this resolver instead;
-    // the second assertion is what fails if anyone re-routes it via loadConfig.
+  it('preserves autoResumeOnUsageLimit for both display and provider configuration', () => {
     mockConfig({});
     expect(resolveAutoResumeOnUsageLimit()).toBe(true);
+    expect(loadConfig().autoResumeOnUsageLimit).toBeUndefined();
     _resetConfigCache();
     mockConfig({ autoResumeOnUsageLimit: false });
     expect(resolveAutoResumeOnUsageLimit()).toBe(false);
-    expect(loadConfig().autoResumeOnUsageLimit).toBeUndefined();
+    expect(loadConfig().autoResumeOnUsageLimit).toBe(false);
   });
 });

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -116,10 +116,7 @@ export function resolveCliPermissionMode(): PermissionMode {
  * call and enforces the `local-*` guard. A per-turn display read must do
  * neither.
  *
- * Contract: `loadConfig()` cannot answer this question — its return value is an
- * explicit field whitelist that drops `autoResumeOnUsageLimit`, so reading it
- * from there always yields `undefined`. Defaults to `true`, matching the
- * provider's own default (`query.ts`).
+ * Defaults to `true`, matching the provider's own default (`query.ts`).
  */
 export function resolveAutoResumeOnUsageLimit(): boolean {
   return loadJsonConfig().config.autoResumeOnUsageLimit ?? true;
@@ -174,6 +171,9 @@ export function loadConfig(overrides?: Partial<CliConfig>): CliConfig {
     // afk.config.json / env / override `permissionMode` still wins.
     permissionMode: merged.permissionMode ?? DEFAULT_CLI_PERMISSION_MODE,
     ...(merged.autoRouting !== undefined ? { autoRouting: merged.autoRouting } : {}),
+    ...(merged.autoResumeOnUsageLimit !== undefined
+      ? { autoResumeOnUsageLimit: merged.autoResumeOnUsageLimit }
+      : {}),
     ...(merged.daemon !== undefined ? { daemon: merged.daemon } : {}),
     ...(merged.telegram !== undefined ? { telegram: merged.telegram } : {}),
     ...(merged.bgSummaries !== undefined ? { bgSummaries: merged.bgSummaries } : {}),

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -106,6 +106,25 @@ export function resolveCliPermissionMode(): PermissionMode {
   return loadJsonConfig().config.permissionMode ?? DEFAULT_CLI_PERMISSION_MODE;
 }
 
+/**
+ * Whether a usage-limit pause will auto-resume, for display surfaces that
+ * *describe* that behaviour to the user (the quota footer, `quota-footer.ts`).
+ *
+ * Reads the memoized JSON tier directly, side-effect-free — same rationale as
+ * `loadTelegramConfig` / `resolveCliPermissionMode`, and deliberately NOT
+ * `loadConfig`, which re-installs process-global model-slot bindings on every
+ * call and enforces the `local-*` guard. A per-turn display read must do
+ * neither.
+ *
+ * Contract: `loadConfig()` cannot answer this question — its return value is an
+ * explicit field whitelist that drops `autoResumeOnUsageLimit`, so reading it
+ * from there always yields `undefined`. Defaults to `true`, matching the
+ * provider's own default (`query.ts`).
+ */
+export function resolveAutoResumeOnUsageLimit(): boolean {
+  return loadJsonConfig().config.autoResumeOnUsageLimit ?? true;
+}
+
 export function loadConfig(overrides?: Partial<CliConfig>): CliConfig {
   const envConfig = loadEnvConfig();
   const { config: jsonConfig, sourcePath: jsonSourcePath, modelsPartial } = loadJsonConfig();

--- a/src/cli/quota-footer.test.ts
+++ b/src/cli/quota-footer.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { formatQuotaUsage } from './quota-footer.js';
+import { TWO_HOURS_MS } from '../agent/providers/anthropic-direct/query/retry-layer.js';
 
 const NOW = new Date('2026-07-29T12:00:00Z');
 const inMinutes = (m: number): Date => new Date(NOW.getTime() + m * 60_000);
@@ -139,5 +140,49 @@ describe('formatQuotaUsage — shape', () => {
     const r = formatQuotaUsage({ fiveHour: { utilization: 1 }, observedAt: NOW }, NOW);
     // eslint-disable-next-line no-control-regex
     expect(r.text).not.toMatch(/\u001b\[/);
+  });
+});
+
+describe('formatQuotaUsage — the auto-resume promise', () => {
+  const hot = (resetsAt?: Date): Parameters<typeof formatQuotaUsage>[0] => ({
+    fiveHour: { utilization: 0.97, ...(resetsAt !== undefined ? { resetsAt } : {}) },
+    observedAt: NOW,
+  });
+
+  it('withholds the promise when auto-resume is switched off', () => {
+    const r = formatQuotaUsage(hot(inMinutes(12)), NOW, { autoResume: false });
+    expect(r.text).not.toContain('auto-resumes');
+    expect(r.text).toBe('  5h quota 97% used — resets in 12m — turns stop at the cap — auto-resume is off');
+  });
+
+  it('withholds the promise when the reset is beyond the wait ceiling', () => {
+    // A hot 7d window routinely resets days out. The retry layer surfaces the
+    // error rather than waiting that long, so a resume promise would be a lie
+    // that walks an AFK user away from a turn which is about to terminate.
+    const r = formatQuotaUsage(
+      { sevenDay: { utilization: 0.97, resetsAt: inMinutes(3 * 60) }, observedAt: NOW },
+      NOW,
+    );
+    expect(r.text).not.toContain('auto-resumes');
+    expect(r.text).toContain('too far out to wait');
+  });
+
+  it('tracks the retry layer\u2019s real ceiling rather than a drifted copy', () => {
+    // Drift guard. quota-footer.ts holds a LOCAL copy of the threshold so the
+    // provider graph stays out of the render path; these boundary assertions
+    // are what make that copy safe — move TWO_HOURS_MS in retry-layer.ts and
+    // this fails instead of the copy going quietly stale.
+    const atCeiling = formatQuotaUsage(hot(new Date(NOW.getTime() + TWO_HOURS_MS)), NOW);
+    expect(atCeiling.text).toContain('AFK pauses and auto-resumes at the cap');
+    const pastCeiling = formatQuotaUsage(hot(new Date(NOW.getTime() + TWO_HOURS_MS + 60_000)), NOW);
+    expect(pastCeiling.text).toContain('too far out to wait');
+  });
+
+  it('keeps the promise when no deadline is known — the layer still parks', () => {
+    expect(formatQuotaUsage(hot(), NOW).text).toContain('AFK pauses and auto-resumes at the cap');
+  });
+
+  it('promises by default, matching the provider\u2019s own default', () => {
+    expect(formatQuotaUsage(hot(inMinutes(12)), NOW).text).toContain('auto-resumes');
   });
 });

--- a/src/cli/quota-footer.ts
+++ b/src/cli/quota-footer.ts
@@ -66,6 +66,40 @@ function labelledWindows(windows: QuotaWindows): LabelledWindow[] {
   return out;
 }
 
+/**
+ * Contract: the runtime only actually parks and resumes when BOTH conditions
+ * hold — `autoResumeOnUsageLimit` is on (default true, see `query.ts`), and the
+ * reset lands within the retry layer's wait ceiling. Past that ceiling the
+ * layer surfaces the error instead of waiting (`retry-layer.ts`), which a hot
+ * 7d window routinely trips. Promising auto-resume outside those conditions
+ * tells an AFK user to walk away from a turn that is going to terminate.
+ *
+ * Held as a local copy rather than a runtime import: `retry-layer.ts` sits
+ * behind the provider boundary, and importing a value from it here would drag
+ * the provider graph into the REPL's render path. `quota-footer.test.ts`
+ * imports the real constant and asserts the two agree, so drift fails a test
+ * instead of silently re-breaking this copy.
+ */
+const AUTO_RESUME_MAX_LEAD_MS = 2 * 60 * 60 * 1000;
+
+/**
+ * What actually happens when the window caps — the promise, or the truth.
+ *
+ * An unknown deadline keeps the promise: with no `resetsAt` the retry layer
+ * polls within its own budget rather than bailing early, so parking is still
+ * the real behaviour.
+ */
+function capNote(state: QuotaWindowState, now: Date, autoResume: boolean): string {
+  if (!autoResume) return 'turns stop at the cap — auto-resume is off';
+  if (
+    state.resetsAt !== undefined &&
+    state.resetsAt.getTime() - now.getTime() > AUTO_RESUME_MAX_LEAD_MS
+  ) {
+    return 'turns stop at the cap — the reset is too far out to wait';
+  }
+  return 'AFK pauses and auto-resumes at the cap';
+}
+
 /** `resets in 1h20m`, or undefined when no usable deadline is known. */
 function resetClause(state: QuotaWindowState, now: Date): string | undefined {
   if (state.resetsAt === undefined) return undefined;
@@ -93,6 +127,7 @@ function resetClause(state: QuotaWindowState, now: Date): string | undefined {
 export function formatQuotaUsage(
   windows: QuotaWindows | undefined,
   now: Date = new Date(),
+  opts: { autoResume?: boolean } = {},
 ): { tier: QuotaUsageTier; text: string | null } {
   if (windows === undefined) return { tier: 'quiet', text: null };
   const all = labelledWindows(windows);
@@ -114,9 +149,10 @@ export function formatQuotaUsage(
   const suffix = alsoHot.length > 0 ? ` (also ${alsoHot.join(', ')})` : '';
   // Grounded in the runtime's actual behaviour: a usage-limit 429 parks the turn
   // and resumes it after the reset (see usage-limit.ts), emitting
-  // usage_limit_pause / usage_limit_resume phases. Saying so turns an alarming
-  // line into an actionable one — the session is parked, not lost.
-  const parkNote = 'AFK pauses and auto-resumes at the cap';
+  // usage_limit_pause / usage_limit_resume phases — but ONLY within the bounds
+  // capNote checks. Saying so turns an alarming line into an actionable one;
+  // saying so when it is false walks the user away from a turn that will die.
+  const parkNote = capNote(binding.state, now, opts.autoResume ?? true);
 
   if (tier === 'over') {
     const head = `  ${binding.label} quota exhausted`;

--- a/src/cli/status-line.test.ts
+++ b/src/cli/status-line.test.ts
@@ -1240,3 +1240,63 @@ describe('StatusLine — AFK_PLAIN_OUTPUT full render opt-out', () => {
     status.stop();
   });
 });
+
+describe('StatusLine clock ticker', () => {
+  let stream: MockStream;
+
+  beforeEach(() => {
+    stream = mockStream();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('arms no recurring timer by default', () => {
+    // The house rule the compositor states for caret blink: construction must
+    // stay free of an auto-started ticker, enablement is resolved caller-side.
+    vi.useFakeTimers();
+    const before = vi.getTimerCount();
+    const status = new StatusLine({ stream: stream as unknown as NodeJS.WriteStream, throttleMs: 0 });
+    status.start();
+    expect(vi.getTimerCount()).toBe(before);
+    status.stop();
+  });
+
+  it('arms no ticker on a disabled (non-TTY) line', () => {
+    vi.useFakeTimers();
+    const dead = mockStream({ isTTY: false });
+    const before = vi.getTimerCount();
+    const status = new StatusLine({
+      stream: dead as unknown as NodeJS.WriteStream,
+      throttleMs: 0,
+      tickMs: 30_000,
+    });
+    status.start();
+    expect(vi.getTimerCount()).toBe(before);
+    status.stop();
+  });
+
+  it('re-paints on tick so clock-derived content recomputes, and stops at stop()', () => {
+    // Regression guard for the frozen quota countdown: the row renders a reset
+    // countdown and a `~` staleness marker against the paint-time clock, and
+    // every OTHER repaint here is event-driven — an idle session fires none of
+    // them, so without this ticker the countdown sat frozen indefinitely.
+    vi.useFakeTimers();
+    const status = new StatusLine({
+      stream: stream as unknown as NodeJS.WriteStream,
+      throttleMs: 0,
+      tickMs: 30_000,
+    });
+    status.start();
+    status.repaint({ model: 'sonnet' });
+    stream.writes.length = 0;
+
+    vi.advanceTimersByTime(30_000);
+    expect(stream.writes.length).toBeGreaterThan(0);
+
+    status.stop();
+    stream.writes.length = 0;
+    vi.advanceTimersByTime(120_000);
+    expect(stream.writes.length).toBe(0);
+  });
+});

--- a/src/cli/status-line.ts
+++ b/src/cli/status-line.ts
@@ -80,12 +80,24 @@ interface StatusLineOpts {
   force?: boolean;
   /** Minimum ms between repaints — avoids flicker on fast streams. */
   throttleMs?: number;
+  /**
+   * Interval in ms at which a started line re-paints itself from `lastFields`,
+   * so clock-derived content stays true. `0` (the default) never ticks.
+   *
+   * Defaults OFF and is enabled by the interactive caller (bootstrap.ts),
+   * mirroring how the compositor resolves caret-blink enablement caller-side:
+   * every direct/test construction stays free of an auto-started recurring
+   * timer.
+   */
+  tickMs?: number;
 }
 
 export class StatusLine {
   private readonly stream: NodeJS.WriteStream;
   private readonly force: boolean;
   private readonly throttleMs: number;
+  private readonly tickMs: number;
+  private tickTimer: ReturnType<typeof setInterval> | null = null;
   private started = false;
   private lastRepaint = 0;
   private lastFields: StatusLineFields | null = null;
@@ -101,6 +113,7 @@ export class StatusLine {
     this.stream = opts.stream ?? process.stdout;
     this.force = opts.force ?? false;
     this.throttleMs = opts.throttleMs ?? 100;
+    this.tickMs = opts.tickMs ?? 0;
   }
 
   private get enabled(): boolean {
@@ -131,6 +144,21 @@ export class StatusLine {
         this.onResize();
       });
       this.resizeImmediateUnsub = ResizeBus.subscribeImmediate(() => this.resetGeometry());
+    }
+    // Invariant: this is the ONLY time-driven repaint of the status row, and
+    // clock-derived content depends on it. The quota segment renders a reset
+    // countdown and a `~` staleness marker computed against `new Date()` at
+    // paint time (quota-indicator.ts), and grades droppability from that same
+    // freshness — but every other repaint here is event-driven (turn events,
+    // git/context samplers, resize, a NEW quota reading). An idle session fires
+    // none of them, so without this ticker a countdown sits frozen and a
+    // reading never crosses into `stale` on screen. `flush()` re-renders from
+    // `lastFields`, so each tick recomputes those values against the current
+    // clock. `unref()` keeps the interval from holding the process open; the
+    // inverse lives at the top of stop(), ahead of its early return.
+    if (this.tickMs > 0 && this.tickTimer === null) {
+      this.tickTimer = setInterval(() => this.flush(), this.tickMs);
+      this.tickTimer.unref();
     }
   }
 
@@ -345,6 +373,13 @@ export class StatusLine {
 
   /** Release the scroll region and clear the status row. */
   stop(): void {
+    // Cleared FIRST, ahead of the `!started || !enabled` early return below: an
+    // armed ticker is the one piece of state that can outlive a line which is
+    // no longer started, so a late return must never skip its teardown.
+    if (this.tickTimer !== null) {
+      clearInterval(this.tickTimer);
+      this.tickTimer = null;
+    }
     if (this.resizeUnsub !== null) {
       this.resizeUnsub();
       this.resizeUnsub = null;


### PR DESCRIPTION
Follow-up to #765, which merged with two reviewer findings unaddressed. Both were live on `main`; this fixes them.

## 1. The status row never re-evaluated its own clock (Codex P2 on #765)

`formatQuotaIndicator` renders a reset countdown (`⟳12m`) and a `~` staleness marker, and `status-line.ts` grants a **fresh** critical reading drop-last priority `0` — all computed against `new Date()` at paint time. But every repaint of that row is event-driven: turn events, the git/context samplers, resize, and a *new* quota reading. An idle session fires none of them.

Consequence: the countdown froze at whatever it last painted, and the `~` marker could never appear in the idle scenario its own doc-comment names — the one quota-driven repaint (`onQuotaUpdate`) fires only when a new reading lands, i.e. exactly when `stale` becomes false, so it can never be the paint that reveals staleness. A stale critical also kept priority `0` past `STALE_AFTER_MS`.

`StatusLine` now owns a low-frequency repaint ticker:

- armed in `start()`, never in the constructor — `terminal-compositor.ts` sets the house rule that construction stays free of an auto-started recurring timer, and `caretBlink` sets the precedent that enablement is resolved caller-side. `tickMs` therefore **defaults to 0 (off)**; `bootstrap.ts` passes `30_000` so only the REPL ticks.
- ticks via the existing `flush()`, which re-renders from `lastFields`, so every clock-derived value recomputes.
- `.unref()`ed, so it never holds the process open.
- cleared at the **top** of `stop()`, ahead of that method's `!started || !enabled` early return — an armed ticker is the one piece of state that can outlive a no-longer-started line, so a late return must not skip its teardown.

## 2. The footer promised an auto-resume the runtime will not deliver (Codex P1 on #765)

`quota-footer.ts` appended `AFK pauses and auto-resumes at the cap` to every `near`/`over` line. That is false in two reachable configurations, both verified in source:

- `retry-layer.ts:443` — when `resetsAt - now > TWO_HOURS_MS` the layer **surfaces the error instead of waiting**. A hot 7d window routinely resets days out.
- `retry-layer.ts:358` — when `autoResumeOnUsageLimit` is off it stops rather than resuming.

The promise is now conditional (`capNote`). The deadline gate is local to the formatter; the flag is resolved at the call site by **`resolveAutoResumeOnUsageLimit()`** (see round 2 below for why that is not `loadConfig()`). When the promise is withheld the line still carries the window, percentage and countdown, and says what actually happens (`turns stop at the cap — …`) rather than dropping to an alarming bare number.

An **unknown** deadline deliberately keeps the promise: with no `resetsAt` the layer polls within its own budget rather than bailing early, so parking is still the real behaviour.

### On the duplicated threshold

`AUTO_RESUME_MAX_LEAD_MS` is a local copy, not a runtime import — `retry-layer.ts` sits behind the provider boundary and importing a value from it would drag the provider graph into the REPL's render path. `TWO_HOURS_MS` is now exported so **the test** imports the real constant and asserts the boundary both sides of it, making drift a test failure rather than a silent re-break.

## Round 2 — fixing what review caught in `78b4fde` (`ed57212`)

Two reviewers independently found the same defect, and both were right: **the flag gate I added was inert.**

`loadConfig()` builds its return value as an explicit field whitelist that omits `autoResumeOnUsageLimit` (0 occurrences in the literal), so `loadConfig().autoResumeOnUsageLimit` is permanently `undefined` and `?? true` always won. The "auto-resume is off" path was unreachable through real CLI configuration. The original PR text claimed "the flag is read at the call site" — that claim was false, and it is corrected above.

The second finding was a convention violation in the same line: `printTurnFooter` called the **side-effectful** `loadConfig()` once per turn footer, re-installing process-global model-slot bindings via `setSlotBindings`. The original text justified this as "the same inline-config pattern as `loadTelegramConfig()`" — that had it exactly backwards. `loadTelegramConfig` *is* the memoized-tier reader; `loadConfig` is precisely what that convention exists to avoid (`config.ts:96-103`).

Both are fixed by one new resolver, a direct sibling of the two that already exist:

```ts
export function resolveAutoResumeOnUsageLimit(): boolean {
  return loadJsonConfig().config.autoResumeOnUsageLimit ?? true;
}
```

Third finding (test-coverage) is fixed too, and it is the interesting one: the five `quota-footer.test.ts` cases pass `{ autoResume }` **explicitly**, so a dead read at the production call site was invisible to them — which is exactly how 13,754 green tests shipped an inert branch. There are now two `printTurnFooter` cases driving the real wiring, plus a `config.test.ts` case that asserts the resolver reads what `loadConfig()` drops:

```ts
expect(resolveAutoResumeOnUsageLimit()).toBe(false);
expect(loadConfig().autoResumeOnUsageLimit).toBeUndefined();  // fails if anyone re-routes it
```

### Not fixed here — pre-existing, wider than this PR

`autoResumeOnUsageLimit` is advertised as settable (`settable-keys.ts:221`) but is non-functional across the whole CLI for the same root cause: `chat.ts:741` and `bootstrap.ts:740` both guard on `cliConfig.autoResumeOnUsageLimit !== undefined` and always take the empty branch, so the provider never receives it. Setting it in `afk.config.json` changes nothing on the REPL/chat surfaces today. Fixing that means making a dormant setting suddenly live for the provider — a behaviour change that deserves its own PR and its own testing, so this PR routes only the display surface. Flagged by the reviewer as worth its own issue; I agree.

## Tests

- `status-line.test.ts` — no ticker by default; none on a disabled/non-TTY line; ticks repaint and `stop()` ends them.
- `quota-footer.test.ts` — promise withheld when auto-resume is off; withheld beyond the ceiling; kept at/below it (drift guard against the real `TWO_HOURS_MS`); kept when no deadline is known; promised by default.
- `turn-handler.test.ts` — the production call path, both flag states.
- `config.test.ts` — the resolver reads the field `loadConfig()` drops.
- All 12 pre-existing footer tests pass **unchanged** — the existing near/over cases use a 12-minute deadline, inside the ceiling.

**Gates — all seven CI checks run locally at `ed57212`:** `pnpm lint` ✓ · `pnpm test` **721 files / 13,757 passed, 2 skipped, 0 failures** ✓ · `audit:env:check` ✓ · `scan:env:check` ✓ · `audit:sdk:check` ✓ · `audit:chalk:check` ✓ · `audit:deps` ✓ · `pnpm build` ✓

## The `docs/env-registry.md` commit is unrelated — inherited red CI on main

`b0ac17e` regenerates `docs/env-registry.md`. **It is not part of this fix.** `scan:env:check` was failing on `main`: commit `219e0b6` (v5.83.1's stall watchdog) added a 139th env var to `src/config/env.ts` but left the generated header count at 138, so *every* PR opened against main inherited that failure. The change is one line of `pnpm scan:env` output with no source change, split into its own commit so it can be dropped or cherry-picked independently.

## Reviewer note

Authored inline by the orchestrating session rather than by an isolated implementation sub-agent (four sub-agent dispatches failed: three to rate-limit or stream cutoffs, one to a 45-minute timeout). Round 1 shipped an inert branch that two independent reviewers caught — treat the absence of an independent authoring pass as a real signal and read closely.

One deliberate test gap remains: the `.unref()` call itself is not asserted. Asserting it needs a `setInterval` spy that fights the fake-timer harness, so it is covered by the teardown test and by the comment, not directly.
