### PR TITLE
fix(ci): regenerate the env-registry var count so scan:env:check passes

### DIFF
--- a/docs/env-registry.md
+++ b/docs/env-registry.md
@@ -2,7 +2,7 @@
 
 Generated from `src/config/env.ts`. Do not edit by hand — run `pnpm scan:env` after changing the registry source.
 
-**138 vars** across 12 categories. Every `process.env[...]` read in `src/` outside `src/config/env.ts` is a CI failure (enforced by `pnpm audit:env:check`).
+**139 vars** across 12 categories. Every `process.env[...]` read in `src/` outside `src/config/env.ts` is a CI failure (enforced by `pnpm audit:env:check`).
 
 To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV_REGISTRY`), then run `pnpm scan:env`.
 


### PR DESCRIPTION
## What

One generated line. `docs/env-registry.md` header still reads **138 vars**; `src/config/env.ts` now holds **139**. `pnpm scan:env` regenerates it — that count line is the entire diff.

## Why it matters now

`pnpm scan:env:check` is a required step of the **Lint & Build** job, so this drift is currently failing CI on `main` itself (run [30623755639](https://github.com/griffinwork40/agent-afk/actions/runs/30623755639), `180882f`) **and on the merge-ref of every open PR** — e.g. #772, whose `Test (ubuntu-latest)` passes while Lint & Build fails on this and only this.

## How it landed ungated

#763 added `AFK_MODEL_STALL_TIMEOUT_MS` and updated the registry entries, but not the count line. That PR's CI run ([30623684987](https://github.com/griffinwork40/agent-afk/actions/runs/30623684987)) was **cancelled** before Lint & Build reported, so the gate never spoke. The failure surfaced on the next push to main (#784) and has been red since.

## Verification

All seven Lint & Build steps run locally against this branch:

```
lint (tsc --noEmit)    PASS
audit:env:check        PASS
scan:env:check         PASS   <- was the failure
audit:sdk:check        PASS
audit:chalk:check      PASS
audit:deps             PASS
build                  PASS
```

Generated artifact only — no source, test, or config file touched.

## Follow-up, not in scope

`Test (windows-latest)` is **also** failing on main in the same run and is unrelated to this drift; it needs its own look.