### PR TITLE
fix(subagent): credit provider-paused time against the wall-clock ceiling

### DIFF
--- a/src/agent/subagent/handle.test.ts
+++ b/src/agent/subagent/handle.test.ts
@@ -197,3 +197,136 @@ describe('R1 — runInBackground unhandled-rejection safety', () => {
     expect(unhandledErrors).toHaveLength(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Pause-aware wall-clock ceiling — end-to-end wiring through the handle.
+//
+// The unit behaviour of the extension policy lives in `pause-ceiling.test.ts`.
+// These tests prove the policy is actually WIRED: that the handle feeds streamed
+// pause events to the ceiling attached to its own `withTimeout` call, so a fork
+// parked by the provider is no longer guaranteed to die at its wall-clock
+// budget. Regression target: a `/forge` fork lost 1h49m of work this way.
+// ---------------------------------------------------------------------------
+
+describe('pause-aware wall-clock ceiling (handle wiring)', () => {
+  let abortGraph: AbortGraph;
+  let controller: AbortController;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    abortGraph = new AbortGraph();
+    controller = new AbortController();
+    abortGraph.register('root', controller);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  /** A session that emits `events`, then stalls forever (never completes). */
+  function makeStallingSession(events: OutputEvent[]): IAgentSession {
+    return makeMinimalSession({
+      async *sendMessageStream(): AsyncIterable<OutputEvent> {
+        for (const event of events) yield event;
+        // Park indefinitely: only a timeout can end this turn.
+        await new Promise<never>(() => {});
+      },
+    });
+  }
+
+  function makeHandle(session: IAgentSession, timeoutMs: number): SubagentHandleImpl<unknown> {
+    return new SubagentHandleImpl(
+      'forge-rework-2',
+      session,
+      controller,
+      abortGraph,
+      undefined, // outputSchema
+      timeoutMs,
+      undefined, // hookRegistry
+      vi.fn(), // onTerminal
+    );
+  }
+
+  it('still fires at the wall-clock budget when no pause event arrives', async () => {
+    const BUDGET = 60_000;
+    const handle = makeHandle(makeStallingSession([]), BUDGET);
+
+    const settled = handle.run('prompt').then(
+      () => 'resolved',
+      (err: unknown) => err,
+    );
+
+    await vi.advanceTimersByTimeAsync(BUDGET - 1);
+    // Nothing has fired yet: the budget is intact.
+    await vi.advanceTimersByTimeAsync(1);
+
+    const outcome = await settled;
+    expect(outcome).toBeInstanceOf(Error);
+    // Unchanged message shape for the no-pause path.
+    expect((outcome as Error).message).toBe(
+      'Operation timed out after 60000ms (forge-rework-2)',
+    );
+  });
+
+  it('extends past the budget when the child streams a provider `paused` event', async () => {
+    const BUDGET = 60_000;
+    const parkMs = 10 * 60_000; // park far longer than the budget
+    const handle = makeHandle(
+      makeStallingSession([
+        {
+          type: 'paused',
+          reason: 'usage-limit',
+          resetsAt: new Date(Date.now() + parkMs),
+        },
+      ]),
+      BUDGET,
+    );
+
+    let settled = false;
+    const outcome = handle.run('prompt').then(
+      () => 'resolved',
+      (err: unknown) => {
+        settled = true;
+        return err;
+      },
+    );
+
+    // Pre-fix the turn died exactly here. Post-fix the parked time is credited.
+    await vi.advanceTimersByTimeAsync(BUDGET + 1);
+    expect(settled).toBe(false);
+
+    // Finite: it still dies once the credited park is consumed.
+    await vi.advanceTimersByTimeAsync(parkMs + 60_000);
+    const err = await outcome;
+    expect(err).toBeInstanceOf(Error);
+    // And the failure now names the pause context instead of a bare timeout.
+    expect((err as Error).message).toContain('pause-aware ceiling');
+    expect((err as Error).message).toContain('last provider pause: paused (usage-limit');
+  });
+
+  it('does NOT extend when the child only streams ordinary content', async () => {
+    const BUDGET = 60_000;
+    const handle = makeHandle(
+      makeStallingSession([
+        { type: 'chunk', chunk: { type: 'content', content: 'working hard' } },
+        { type: 'chunk', chunk: { type: 'thinking', thinking: 'still working' } },
+      ]),
+      BUDGET,
+    );
+
+    const settled = handle.run('prompt').then(
+      () => 'resolved',
+      (err: unknown) => err,
+    );
+
+    await vi.advanceTimersByTimeAsync(BUDGET + 1);
+
+    const outcome = await settled;
+    expect(outcome).toBeInstanceOf(Error);
+    // Anti-gaming: child output buys no extension, so the message is the plain one.
+    expect((outcome as Error).message).toBe(
+      'Operation timed out after 60000ms (forge-rework-2)',
+    );
+  });
+});

--- a/src/agent/subagent/handle.ts
+++ b/src/agent/subagent/handle.ts
@@ -20,7 +20,7 @@ import { dispatchSubagentStop } from '../subagent-hooks.js';
 import { emitSessionPhase, emitSubagentLifecycle } from '../trace/emit.js';
 import type { TraceWriter } from '../trace/index.js';
 import { IdleWatchdog } from './idle-watchdog.js';
-import { PauseAwareCeiling } from './pause-ceiling.js';
+import { PauseAwareCeiling, SUBAGENT_MAX_PAUSE_EXTENSION_MS } from './pause-ceiling.js';
 import {
   buildResultFromMessage,
   buildResultFromError,
@@ -217,7 +217,25 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
     // applies (`timeoutMs <= 0`): there is no ceiling to extend.
     const pauseCeiling =
       Number.isFinite(this.timeoutMs) && this.timeoutMs > 0
-        ? new PauseAwareCeiling(this.timeoutMs)
+        ? new PauseAwareCeiling(this.timeoutMs, SUBAGENT_MAX_PAUSE_EXTENSION_MS, (info) => {
+            // Witness-layer: each non-zero pause extension is now observable in
+            // the trace, not just in the eventual terminal timeout error. Fire-
+            // and-forget so a slow trace write can never delay the deadline
+            // re-arm (mirrors the `idle_watchdog_fired` emit a few lines down).
+            void emitSessionPhase(this.traceWriter, {
+              phase: 'pause_extension_granted',
+              metadata: {
+                subagentId: this.id,
+                grantMs: info.grantMs,
+                totalGrantedMs: info.totalGrantedMs,
+                remainingCapMs: info.remainingCapMs,
+                grantCount: info.grantCount,
+                ...(info.pauseDescription !== undefined && {
+                  pauseDescription: info.pauseDescription,
+                }),
+              },
+            });
+          })
         : undefined;
     this.pauseCeiling = pauseCeiling;
     const p = withTimeout(this.streamToFinalMessage(prompt, sinkOverride), this.timeoutMs, {

--- a/src/agent/subagent/handle.ts
+++ b/src/agent/subagent/handle.ts
@@ -20,6 +20,7 @@ import { dispatchSubagentStop } from '../subagent-hooks.js';
 import { emitSessionPhase, emitSubagentLifecycle } from '../trace/emit.js';
 import type { TraceWriter } from '../trace/index.js';
 import { IdleWatchdog } from './idle-watchdog.js';
+import { PauseAwareCeiling } from './pause-ceiling.js';
 import {
   buildResultFromMessage,
   buildResultFromError,
@@ -127,6 +128,15 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
    */
   private lastStreamedContent: string = '';
   /**
+   * Pause-aware extension policy for the CURRENT run's wall-clock ceiling.
+   * Created in `run()` (which owns `withTimeout`) but fed from the stream loop
+   * in `streamToFinalMessage`, so — like `lastStreamedContent` — it lives as an
+   * instance field to bridge those two scopes. `undefined` between runs and
+   * whenever no wall-clock budget applies (`timeoutMs <= 0`), in which case
+   * there is no ceiling to extend.
+   */
+  private pauseCeiling: PauseAwareCeiling | undefined;
+  /**
    * The provider's terminal stop reason captured from the most recent run's
    * `done` event (e.g. `'end_turn'`, `'tool_use_loop_capped'`). Persisted as
    * an instance field so `runToResult` can attach it to the built
@@ -197,9 +207,23 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
 
     this.currentStatus = 'running';
     const startTime = Date.now();
+    // Pause-aware wall-clock ceiling. The ceiling is still un-resettable BY THE
+    // CHILD — only a provider-reported pause (`paused` w/ resetsAt, `rate_limit`
+    // w/ retryAfterMs) can move it, each grant is bounded by that reported
+    // window, and total accumulated extension is capped by
+    // SUBAGENT_MAX_PAUSE_EXTENSION_MS, so worst-case lifetime stays finite and
+    // predictable. Without pause events the extender grants nothing and
+    // withTimeout behaves exactly as before. Skipped entirely when no budget
+    // applies (`timeoutMs <= 0`): there is no ceiling to extend.
+    const pauseCeiling =
+      Number.isFinite(this.timeoutMs) && this.timeoutMs > 0
+        ? new PauseAwareCeiling(this.timeoutMs)
+        : undefined;
+    this.pauseCeiling = pauseCeiling;
     const p = withTimeout(this.streamToFinalMessage(prompt, sinkOverride), this.timeoutMs, {
       controller: this.controller,
       label: this.id,
+      ...(pauseCeiling !== undefined && { extender: pauseCeiling }),
     });
     this.inFlight = p;
     try {
@@ -406,6 +430,11 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
         // streamed event. This is the ONLY progress signal — a real OutputEvent
         // from the provider loop, never a caller-facing heartbeat.
         idleWatchdog.onEvent(event);
+        // Feed the SAME stream to the wall-clock ceiling's extension policy.
+        // Unlike the idle watchdog it ignores everything except provider pause
+        // signals (`paused`/`rate_limit`/`resumed`), so child output and tool
+        // activity cannot move the ceiling — see PauseAwareCeiling.
+        this.pauseCeiling?.onEvent(event);
 
         if (event.type === 'chunk') {
           const chunk = event.chunk;

--- a/src/agent/subagent/idle-watchdog.ts
+++ b/src/agent/subagent/idle-watchdog.ts
@@ -54,6 +54,7 @@
 
 import { IdleWatchdogError } from '../../utils/errors.js';
 import type { OutputEvent } from '../types/session-types.js';
+import { PAUSE_WINDOW_SLACK_MS, pauseWindowMs } from './pause-window.js';
 
 /**
  * Slack added to a recognized pause window (OAuth `paused` / `rate_limit`
@@ -61,8 +62,12 @@ import type { OutputEvent } from '../types/session-types.js';
  * the instant a provider says it will resume — the resume + first replayed
  * token needs a moment to actually stream. 30s, matching the spec's proposed
  * OAuth-pause slack (Open Q4) and the order of the Telegram streaming precedent.
+ *
+ * Alias of {@link PAUSE_WINDOW_SLACK_MS}, which is now shared with the
+ * pause-aware wall-clock ceiling so the two bounds cannot drift apart. Retained
+ * as a named export for existing importers.
  */
-export const IDLE_WATCHDOG_PAUSE_SLACK_MS = 30_000;
+export const IDLE_WATCHDOG_PAUSE_SLACK_MS = PAUSE_WINDOW_SLACK_MS;
 
 /**
  * Progress-aware idle watchdog over one forked sub-agent turn.
@@ -177,12 +182,13 @@ export class IdleWatchdog {
     if (this.inFlightTools.size > 0) return;
 
     if (event.type === 'paused') {
-      this.arm(this.pausedWindowMs(event.resetsAt), event.type);
+      this.arm(this.pausedWindowMs(event), event.type);
       return;
     }
     if (event.type === 'rate_limit') {
-      if (typeof event.retryAfterMs === 'number' && event.retryAfterMs > 0) {
-        this.arm(event.retryAfterMs + IDLE_WATCHDOG_PAUSE_SLACK_MS, event.type);
+      const windowMs = pauseWindowMs(event);
+      if (windowMs !== undefined && windowMs > 0) {
+        this.arm(windowMs, event.type);
         return;
       }
       // A rate_limit with no retryAfterMs is still a live-stream signal; fall
@@ -202,11 +208,15 @@ export class IdleWatchdog {
    * with normal cadence rather than parking blind for hours; a genuinely long
    * park will re-arm on the eventual `resumed`/next event, and a wedged one
    * still fires.
+   *
+   * The `resetsAt + slack` arithmetic itself lives in {@link pauseWindowMs},
+   * shared with the pause-aware wall-clock ceiling; the idle-window FLOOR below
+   * is this watchdog's own policy and stays here.
    */
-  private pausedWindowMs(resetsAt: Date | undefined): number {
-    if (resetsAt === undefined) return this.idleTimeoutMs;
-    const untilResetMs = resetsAt.getTime() - Date.now();
-    return Math.max(this.idleTimeoutMs, untilResetMs + IDLE_WATCHDOG_PAUSE_SLACK_MS);
+  private pausedWindowMs(event: OutputEvent): number {
+    const windowMs = pauseWindowMs(event);
+    if (windowMs === undefined) return this.idleTimeoutMs;
+    return Math.max(this.idleTimeoutMs, windowMs);
   }
 
   /**

--- a/src/agent/subagent/pause-ceiling.test.ts
+++ b/src/agent/subagent/pause-ceiling.test.ts
@@ -1,0 +1,366 @@
+/**
+ * Unit tests for {@link PauseAwareCeiling} — the pause-aware wall-clock ceiling
+ * for forked sub-agent turns — and its integration with {@link withTimeout}.
+ *
+ * Regression target: a `/forge` fork dispatched with the default 45-min budget
+ * while the provider had parked the account died at exactly dispatch +
+ * 2,700,000 ms — 81 seconds AFTER the pause reset — having spent 43m38s of its
+ * budget parked and getting ~81s of actual working time. 1h49m of work was lost.
+ * The idle watchdog correctly extended over that pause; the wall clock ignored
+ * the same signal.
+ *
+ * Contract pinned here: the budget bounds the child's WORKING time —
+ * `effective ceiling = timeoutMs + min(provider-parked time, cap)` — while
+ * staying finite, and un-resettable by the child.
+ *
+ * Fake-timer convention mirrors `idle-watchdog.test.ts` (`vi.useFakeTimers()`):
+ * arm → advance → assert fired (or not). Covers:
+ *   - no pause event → ceiling fires at the normal deadline (behaviour unchanged)
+ *   - the no-extender error message stays byte-for-byte identical
+ *   - `paused` carrying resetsAt credits parked time back to the budget
+ *   - `rate_limit` carrying retryAfterMs credits parked time back
+ *   - credit is bounded by the provider's reported window (an unresumed park
+ *     stops accruing at its stated end)
+ *   - accumulated extension is capped by SUBAGENT_MAX_PAUSE_EXTENSION_MS, then fires
+ *   - ordinary content / thinking / tool / message events NEVER extend (anti-gaming)
+ *   - `resumed` banks the closed pause's credit and stops further accrual
+ *   - a pause with no knowable window grants nothing
+ *   - overlapping pause signals keep the furthest-out reported end
+ *   - the TimeoutError message names the pause context when it fires under pause
+ *   - an extender that throws never strands the wait
+ *   - the real incident timeline now yields a full working budget
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { PauseAwareCeiling, SUBAGENT_MAX_PAUSE_EXTENSION_MS } from './pause-ceiling.js';
+import { PAUSE_WINDOW_SLACK_MS } from './pause-window.js';
+import { withTimeout, type TimeoutExtender } from '../timeout.js';
+import { TimeoutError } from '../../utils/errors.js';
+import type { OutputEvent } from '../types/session-types.js';
+
+const BUDGET = 45 * 60_000; // SUBAGENT_DEFAULT_TIMEOUT_MS — the incident's budget
+
+/**
+ * Start a never-settling wait guarded by `ceiling`, returning a probe of whether
+ * the ceiling has fired yet plus the captured error. The guarded promise never
+ * resolves, so the ceiling is the only thing that can end it.
+ */
+function startGuarded(
+  ceiling: TimeoutExtender,
+  timeoutMs = BUDGET,
+  label?: string,
+): { fired: () => boolean; error: () => unknown; done: Promise<void> } {
+  let settled = false;
+  let captured: unknown;
+  const done = withTimeout(new Promise<never>(() => {}), timeoutMs, {
+    ...(label !== undefined && { label }),
+    extender: ceiling,
+  }).catch((err: unknown) => {
+    settled = true;
+    captured = err;
+  });
+  return { fired: () => settled, error: () => captured, done };
+}
+
+/** Ordinary child-authored progress events — must never extend the ceiling. */
+const contentEvent: OutputEvent = { type: 'chunk', chunk: { type: 'content', content: 'hi' } };
+const thinkingEvent: OutputEvent = {
+  type: 'chunk',
+  chunk: { type: 'thinking', thinking: 'hmm' },
+};
+const toolStartEvent: OutputEvent = {
+  type: 'chunk',
+  chunk: { type: 'tool_use_detail', toolUseId: 't1', toolName: 'bash', toolInput: 'sleep 600' },
+};
+const toolResultEvent: OutputEvent = {
+  type: 'chunk',
+  chunk: { type: 'tool_result', toolUseId: 't1', content: 'done' },
+};
+
+describe('PauseAwareCeiling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fires at the normal deadline when no pause event arrives', async () => {
+    const ceiling = new PauseAwareCeiling(BUDGET);
+    const run = startGuarded(ceiling);
+
+    await vi.advanceTimersByTimeAsync(BUDGET - 1);
+    expect(run.fired()).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+
+    await run.done;
+    expect(run.fired()).toBe(true);
+    expect(run.error()).toBeInstanceOf(TimeoutError);
+    expect(ceiling.totalGrantedMs).toBe(0);
+  });
+
+  it('leaves the error message byte-for-byte unchanged when no pause was observed', async () => {
+    const withCeiling = startGuarded(new PauseAwareCeiling(1_000), 1_000, 'child-1');
+    let plain: unknown;
+    const withoutCeiling = withTimeout(new Promise<never>(() => {}), 1_000, {
+      label: 'child-1',
+    }).catch((err: unknown) => {
+      plain = err;
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await Promise.all([withCeiling.done, withoutCeiling]);
+
+    expect((withCeiling.error() as Error).message).toBe('Operation timed out after 1000ms (child-1)');
+    expect((plain as Error).message).toBe('Operation timed out after 1000ms (child-1)');
+  });
+
+  it('credits parked time back to the budget on a `paused` event carrying resetsAt', async () => {
+    const ceiling = new PauseAwareCeiling(BUDGET);
+    const run = startGuarded(ceiling);
+
+    // Provider parks the account for 60 min — longer than the whole budget.
+    const parkMs = 60 * 60_000;
+    ceiling.onEvent({
+      type: 'paused',
+      reason: 'usage-limit',
+      resetsAt: new Date(Date.now() + parkMs),
+    });
+
+    // The base budget elapses: pre-fix this is exactly where the child died.
+    await vi.advanceTimersByTimeAsync(BUDGET);
+    expect(run.fired()).toBe(false);
+    expect(ceiling.totalGrantedMs).toBeGreaterThan(0);
+
+    // Effective ceiling = budget + credited park (park window + slack), so the
+    // remaining wait past the base deadline is the full credited span.
+    const creditMs = parkMs + PAUSE_WINDOW_SLACK_MS;
+    await vi.advanceTimersByTimeAsync(creditMs - 1);
+    expect(run.fired()).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+
+    await run.done;
+    expect(run.fired()).toBe(true);
+    expect(ceiling.totalGrantedMs).toBe(creditMs);
+  });
+
+  it('credits parked time back on a `rate_limit` event carrying retryAfterMs', async () => {
+    const ceiling = new PauseAwareCeiling(BUDGET);
+    const run = startGuarded(ceiling);
+
+    const retryAfterMs = 50 * 60_000; // 50 min > the 45-min budget
+    ceiling.onEvent({ type: 'rate_limit', retryAfterMs });
+
+    await vi.advanceTimersByTimeAsync(BUDGET);
+    expect(run.fired()).toBe(false);
+
+    const creditMs = retryAfterMs + PAUSE_WINDOW_SLACK_MS;
+    await vi.advanceTimersByTimeAsync(creditMs);
+    await run.done;
+    expect(run.fired()).toBe(true);
+    expect(ceiling.totalGrantedMs).toBe(creditMs);
+  });
+
+  it('bounds credit by the provider-reported window when a park never resumes', async () => {
+    const ceiling = new PauseAwareCeiling(BUDGET);
+    const run = startGuarded(ceiling);
+
+    // A 10-min park that is never followed by `resumed`. The child is owed those
+    // 10 minutes of working time — and NOT a millisecond more, even though the
+    // stream stays silent long after the stated end.
+    const parkMs = 10 * 60_000;
+    ceiling.onEvent({
+      type: 'paused',
+      reason: 'usage-limit',
+      resetsAt: new Date(Date.now() + parkMs),
+    });
+
+    const creditMs = parkMs + PAUSE_WINDOW_SLACK_MS;
+    await vi.advanceTimersByTimeAsync(BUDGET + creditMs - 1);
+    expect(run.fired()).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+
+    await run.done;
+    expect(run.fired()).toBe(true);
+    // Credit stopped accruing at the reported end: strictly bounded.
+    expect(ceiling.totalGrantedMs).toBe(creditMs);
+  });
+
+  it('caps accumulated extension at SUBAGENT_MAX_PAUSE_EXTENSION_MS and then fires', async () => {
+    const ceiling = new PauseAwareCeiling(BUDGET);
+    const run = startGuarded(ceiling);
+
+    // A pathological/lying provider: re-reports a fresh 1h park every 10 min,
+    // which would extend forever if the cap did not exist.
+    const stepMs = 10 * 60_000;
+    const totalSpanMs = BUDGET + SUBAGENT_MAX_PAUSE_EXTENSION_MS + 2 * 60 * 60_000;
+    for (let elapsed = 0; elapsed < totalSpanMs && !run.fired(); elapsed += stepMs) {
+      ceiling.onEvent({
+        type: 'paused',
+        reason: 'usage-limit',
+        resetsAt: new Date(Date.now() + 60 * 60_000),
+      });
+      await vi.advanceTimersByTimeAsync(stepMs);
+    }
+
+    await run.done;
+    // The bound held: finite lifetime despite unbounded pause signals.
+    expect(run.fired()).toBe(true);
+    expect(ceiling.totalGrantedMs).toBe(SUBAGENT_MAX_PAUSE_EXTENSION_MS);
+    expect((run.error() as Error).message).toContain('EXHAUSTED');
+  });
+
+  it('never extends on child-generated content, thinking, tool, or message events', async () => {
+    const ceiling = new PauseAwareCeiling(BUDGET);
+    const run = startGuarded(ceiling);
+
+    // A maximally chatty child: streams content and runs tools right up to the
+    // deadline. None of this may buy it a single extra millisecond.
+    for (let i = 0; i < 10; i++) {
+      ceiling.onEvent(contentEvent);
+      ceiling.onEvent(thinkingEvent);
+      ceiling.onEvent(toolStartEvent);
+      ceiling.onEvent(toolResultEvent);
+      ceiling.onEvent({ type: 'stream_retry' });
+      await vi.advanceTimersByTimeAsync(BUDGET / 10 - 1);
+    }
+    expect(run.fired()).toBe(false);
+    expect(ceiling.totalGrantedMs).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(10);
+    await run.done;
+    expect(run.fired()).toBe(true);
+    expect(ceiling.totalGrantedMs).toBe(0);
+    // No pause was ever observed, so no pause context is attached.
+    expect(ceiling.describe()).toBeUndefined();
+  });
+
+  it('banks a closed pause on `resumed` and stops accruing further credit', async () => {
+    const ceiling = new PauseAwareCeiling(BUDGET);
+    const run = startGuarded(ceiling);
+
+    // Parked for 5 min, then the provider resumes.
+    const parkedForMs = 5 * 60_000;
+    ceiling.onEvent({
+      type: 'paused',
+      reason: 'usage-limit',
+      resetsAt: new Date(Date.now() + 30 * 60_000),
+    });
+    await vi.advanceTimersByTimeAsync(parkedForMs);
+    ceiling.onEvent({ type: 'resumed', hotSwapped: false });
+
+    // Owed exactly the 5 min actually spent parked — not the 30 min advertised.
+    await vi.advanceTimersByTimeAsync(BUDGET - parkedForMs);
+    expect(run.fired()).toBe(false);
+    await vi.advanceTimersByTimeAsync(parkedForMs - 1);
+    expect(run.fired()).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+
+    await run.done;
+    expect(run.fired()).toBe(true);
+    expect(ceiling.totalGrantedMs).toBe(parkedForMs);
+  });
+
+  it('grants nothing for a pause with no knowable window', async () => {
+    const ceiling = new PauseAwareCeiling(BUDGET);
+    const run = startGuarded(ceiling);
+
+    // oauth-limit-no-ts: parked, but the provider did not say until when.
+    ceiling.onEvent({ type: 'paused', reason: 'usage-limit' });
+    // A rate_limit with no retry-after is equally unknowable.
+    ceiling.onEvent({ type: 'rate_limit' });
+
+    await vi.advanceTimersByTimeAsync(BUDGET);
+    await run.done;
+    expect(run.fired()).toBe(true);
+    expect(ceiling.totalGrantedMs).toBe(0);
+  });
+
+  it('keeps the furthest-out window when pause signals overlap', () => {
+    const ceiling = new PauseAwareCeiling(BUDGET);
+    // A short transient 429 arriving during a long OAuth park must not shorten it.
+    ceiling.onEvent({
+      type: 'paused',
+      reason: 'usage-limit',
+      resetsAt: new Date(Date.now() + 90 * 60_000),
+    });
+    ceiling.onEvent({ type: 'rate_limit', retryAfterMs: 60_000 });
+
+    // Advance past the short signal's window; the long park still governs.
+    vi.advanceTimersByTime(BUDGET);
+    expect(ceiling.onDeadline()).toBe(BUDGET);
+  });
+
+  it('names the pause context in the timeout error when it fires under pause', async () => {
+    const ceiling = new PauseAwareCeiling(BUDGET);
+    const run = startGuarded(ceiling, BUDGET, 'forge-rework-2');
+
+    const resetsAt = new Date(Date.now() + 60 * 60_000);
+    ceiling.onEvent({ type: 'paused', reason: 'usage-limit', resetsAt });
+
+    await vi.advanceTimersByTimeAsync(BUDGET + 60 * 60_000 + PAUSE_WINDOW_SLACK_MS);
+    await run.done;
+    expect(run.fired()).toBe(true);
+
+    // The message must carry enough to diagnose the failure without the trace.
+    const message = (run.error() as Error).message;
+    expect(message).toContain('pause-aware ceiling');
+    expect(message).toContain('forge-rework-2');
+    expect(message).toContain(`base budget ${BUDGET}ms`);
+    expect(message).toContain('pause extension granted');
+    expect(message).toContain(resetsAt.toISOString());
+    // The reported elapsed time reflects the FULL wait, not just the base budget.
+    expect((run.error() as TimeoutError).timeoutMs).toBeGreaterThan(BUDGET);
+  });
+
+  it('fires normally when the extender throws (a faulty policy never strands the wait)', async () => {
+    const boom: TimeoutExtender = {
+      onDeadline() {
+        throw new Error('extender boom');
+      },
+      describe() {
+        throw new Error('describe boom');
+      },
+    };
+    const run = startGuarded(boom, 1_000, 'child-x');
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await run.done;
+    expect(run.fired()).toBe(true);
+    expect((run.error() as Error).message).toBe('Operation timed out after 1000ms (child-x)');
+  });
+
+  it('survives the real incident: 45-min budget vs a ~43m38s parked span', async () => {
+    // Forensics: dispatch 02:26:21.307Z, budget 2,700,000ms, provider parked
+    // until 03:10:00.000Z (reported at 01:16:47Z with retryAfterMs 6792000).
+    // Pre-fix the child died at 03:11:21.307Z — 81s AFTER the reset — having
+    // worked for only those 81 seconds.
+    const dispatchedAt = new Date('2026-07-31T02:26:21.307Z');
+    const resetsAt = new Date('2026-07-31T03:10:00.000Z');
+    vi.setSystemTime(dispatchedAt);
+
+    const ceiling = new PauseAwareCeiling(BUDGET);
+    const run = startGuarded(ceiling, BUDGET, 'forge-rework-2');
+
+    ceiling.onEvent({ type: 'paused', reason: 'usage-limit', resetsAt });
+
+    // Advance to the pre-fix death instant: 03:11:21.307Z.
+    await vi.advanceTimersByTimeAsync(BUDGET);
+    expect(run.fired()).toBe(false); // would have been `true` before this change
+    expect(new Date().toISOString()).toBe('2026-07-31T03:11:21.307Z');
+
+    // The park ended at 03:10:00Z, so the parked span (+slack) is credited back:
+    // the child now gets a genuine 45 minutes of WORKING time past the reset.
+    const parkedMs = resetsAt.getTime() - dispatchedAt.getTime() + PAUSE_WINDOW_SLACK_MS;
+    expect(ceiling.totalGrantedMs).toBe(parkedMs);
+    await vi.advanceTimersByTimeAsync(parkedMs - 1);
+    expect(run.fired()).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await run.done;
+    expect(run.fired()).toBe(true);
+    // Finite and predictable: never beyond budget + cap.
+    expect(ceiling.totalGrantedMs).toBeLessThanOrEqual(SUBAGENT_MAX_PAUSE_EXTENSION_MS);
+  });
+});

--- a/src/agent/subagent/pause-ceiling.test.ts
+++ b/src/agent/subagent/pause-ceiling.test.ts
@@ -262,6 +262,39 @@ describe('PauseAwareCeiling', () => {
     expect(ceiling.totalGrantedMs).toBe(parkedForMs);
   });
 
+  it('does NOT credit working time when repeated `rate_limit`s never pair with `resumed`', async () => {
+    // Regression: `resumed` is emitted ONLY on the OAuth park path
+    // (`retry-layer.ts:415,512`) — a transient `rate_limit` never has one. An
+    // earlier revision left such a pause open forever, so each later signal
+    // widened its window by the elapsed gap and credited ordinary WORKING time
+    // 1:1: a 5s retry-after seen every 10 min credited the full 10 min, quietly
+    // inflating the budget toward `timeoutMs + cap`.
+    const ceiling = new PauseAwareCeiling(BUDGET);
+    const run = startGuarded(ceiling);
+
+    const retryAfterMs = 5_000;
+    const gapMs = 10 * 60_000;
+    let parkedMs = 0;
+    // Four brief throttles spread across (and past) the budget.
+    for (let i = 0; i < 4; i++) {
+      ceiling.onEvent({ type: 'rate_limit', retryAfterMs });
+      parkedMs += retryAfterMs + PAUSE_WINDOW_SLACK_MS;
+      await vi.advanceTimersByTimeAsync(gapMs);
+      // The child is demonstrably working between throttles.
+      ceiling.onEvent(contentEvent);
+    }
+
+    // 40 min elapsed so far; cross the 45-min budget plus any credited park.
+    await vi.advanceTimersByTimeAsync(10 * 60_000);
+
+    await run.done;
+    expect(run.fired()).toBe(true);
+    // Credit reflects only the ~4 brief reported windows (140s), NOT the 40 min
+    // of wall time that elapsed while the child was working.
+    expect(ceiling.totalGrantedMs).toBeLessThanOrEqual(parkedMs);
+    expect(ceiling.totalGrantedMs).toBeLessThan(gapMs);
+  });
+
   it('grants nothing for a pause with no knowable window', async () => {
     const ceiling = new PauseAwareCeiling(BUDGET);
     const run = startGuarded(ceiling);

--- a/src/agent/subagent/pause-ceiling.test.ts
+++ b/src/agent/subagent/pause-ceiling.test.ts
@@ -34,6 +34,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import { PauseAwareCeiling, SUBAGENT_MAX_PAUSE_EXTENSION_MS } from './pause-ceiling.js';
+import type { PauseExtensionGrantInfo } from './pause-ceiling.js';
 import { PAUSE_WINDOW_SLACK_MS } from './pause-window.js';
 import { withTimeout, type TimeoutExtender } from '../timeout.js';
 import { TimeoutError } from '../../utils/errors.js';
@@ -395,5 +396,61 @@ describe('PauseAwareCeiling', () => {
     expect(run.fired()).toBe(true);
     // Finite and predictable: never beyond budget + cap.
     expect(ceiling.totalGrantedMs).toBeLessThanOrEqual(SUBAGENT_MAX_PAUSE_EXTENSION_MS);
+  });
+
+  it('invokes the onGrant observer with the extension details on each non-zero grant', async () => {
+    // Observability wiring: the handle passes an onGrant callback that emits a
+    // `pause_extension_grated` witness event. Here we verify the callback
+    // receives the grant amount, running totals, remaining cap, count, and the
+    // pause description — the exact fields the trace event carries.
+    const grants: PauseExtensionGrantInfo[] = [];
+    const ceiling = new PauseAwareCeiling(
+      BUDGET,
+      SUBAGENT_MAX_PAUSE_EXTENSION_MS,
+      (info) => {
+        grants.push(info);
+      },
+    );
+    const run = startGuarded(ceiling);
+
+    // A 5-min provider park; credit accrues while it is open.
+    const parkMs = 5 * 60_000;
+    const resetsAt = new Date(Date.now() + parkMs);
+    ceiling.onEvent({ type: 'paused', reason: 'usage-limit', resetsAt });
+
+    // Base deadline reached → onDeadline grants the credited park window.
+    await vi.advanceTimersByTimeAsync(BUDGET);
+    expect(run.fired()).toBe(false);
+    expect(grants).toHaveLength(1);
+
+    const g = grants[0]!;
+    expect(g.grantMs).toBe(parkMs + PAUSE_WINDOW_SLACK_MS);
+    expect(g.totalGrantedMs).toBe(g.grantMs);
+    expect(g.grantCount).toBe(1);
+    expect(g.remainingCapMs).toBe(SUBAGENT_MAX_PAUSE_EXTENSION_MS - g.grantMs);
+    expect(g.pauseDescription).toBe(`paused (usage-limit, resetsAt=${resetsAt.toISOString()})`);
+
+    // Drive the re-armed wait to completion so no promise is left dangling.
+    await vi.advanceTimersByTimeAsync(g.grantMs + 1);
+    await run.done;
+    expect(run.fired()).toBe(true);
+  });
+
+  it('does NOT invoke onGrant when no extension is granted (no pause observed)', async () => {
+    const grants: PauseExtensionGrantInfo[] = [];
+    const ceiling = new PauseAwareCeiling(
+      BUDGET,
+      SUBAGENT_MAX_PAUSE_EXTENSION_MS,
+      (info) => {
+        grants.push(info);
+      },
+    );
+    const run = startGuarded(ceiling);
+
+    // No pause event: the ceiling fires at the budget and never calls onGrant.
+    await vi.advanceTimersByTimeAsync(BUDGET);
+    await run.done;
+    expect(run.fired()).toBe(true);
+    expect(grants).toHaveLength(0);
   });
 });

--- a/src/agent/subagent/pause-ceiling.ts
+++ b/src/agent/subagent/pause-ceiling.ts
@@ -1,0 +1,264 @@
+/**
+ * Pause-aware wall-clock ceiling for forked sub-agent turns.
+ *
+ * ## Why this exists (revises a shipped decision)
+ *
+ * `.afk/plans/subagent-idle-watchdog.md:88` locked the wall-clock as the
+ * "un-resettable ceiling", and #672 deliberately built pause-awareness into
+ * {@link import('./idle-watchdog.js').IdleWatchdog} alone so it would NOT touch
+ * `withTimeout`. That split has a fatal consequence, observed in production:
+ *
+ * A `/forge` fork was dispatched at 02:26:21.307Z with no explicit `timeoutMs`,
+ * inheriting `SUBAGENT_DEFAULT_TIMEOUT_MS` (2,700,000 ms). The provider had
+ * already parked the account at 01:16:47Z with HTTP 429 `retryAfterMs:
+ * 6792000` (`resetsAt: 03:10:00.000Z`, a ~113-minute account-level pause). The
+ * child died at 03:11:21.307Z — exactly dispatch + 2,700,000 ms — 81 seconds
+ * AFTER the pause reset, losing 1h49m of work. The idle watchdog never fired at
+ * its 8-minute window, which proves the runtime recognized the pause and
+ * correctly extended the idle deadline. The wall clock ignored the very same
+ * signal and killed the child anyway.
+ *
+ * A fork parked by a provider-imposed pause longer than its ceiling is
+ * therefore GUARANTEED to die, no matter what the caller does: the only knob
+ * bounds wall time, and callers cannot pre-compute a safe `timeoutMs` because
+ * the pause window is unknowable at dispatch. The sole escape is
+ * `timeoutMs: 0` (fully unbounded), which is strictly worse.
+ *
+ * ## What is preserved
+ *
+ * This honors the PURPOSE of that invariant — a fork's lifetime must have a
+ * guaranteed finite, predictable upper bound — rather than its letter:
+ *
+ * - Extensions are granted ONLY by a provider-reported pause signal (`paused`
+ *   with `resetsAt`, `rate_limit` with `retryAfterMs`) — the same events
+ *   `IdleWatchdog` already consumes, originating in the provider retry layer.
+ *   Child-generated content, token output, thinking, and tool activity NEVER
+ *   extend the ceiling. It remains un-resettable by the child: the child cannot
+ *   author the only signal that moves it.
+ * - Each grant is bounded by the known pause window (via the shared
+ *   {@link pauseWindowMs} arithmetic, including its slack), never open-ended.
+ * - Total accumulated extension is bounded by
+ *   {@link SUBAGENT_MAX_PAUSE_EXTENSION_MS}. Once exhausted the ceiling fires
+ *   exactly as it does today. Worst-case lifetime stays finite and predictable:
+ *   `timeoutMs + SUBAGENT_MAX_PAUSE_EXTENSION_MS`.
+ * - With no pause events the object never grants anything, so default behaviour
+ *   is byte-for-byte unchanged.
+ *
+ * @module agent/subagent/pause-ceiling
+ */
+
+import type { TimeoutExtender } from '../timeout.js';
+import type { OutputEvent } from '../types/session-types.js';
+import { describePauseEvent, pauseWindowMs } from './pause-window.js';
+
+/**
+ * Absolute cap on the TOTAL extension a single forked turn's wall-clock ceiling
+ * may accumulate from provider pause signals, across all pauses.
+ *
+ * 2 hours. Rationale: the OAuth subscription park this is defending against is
+ * itself bounded — a usage-limit window resets on a ≤2h cadence (see
+ * `.afk/plans/subagent-idle-watchdog.md:64`, "subscription park, ≤2h"), and the
+ * real incident that motivated this change was a ~113-minute (1h53m) park, which
+ * 2h covers with ~7 minutes of headroom. Choosing the provider's own maximum
+ * park as the cap means a legitimately parked child survives any pause the
+ * provider can impose, while a child parked by anything ELSE (a lying or looping
+ * pause signal) is still bounded.
+ *
+ * Worst-case fork lifetime with the default 45-minute budget is therefore
+ * 45min + 2h = 2h45m — finite, predictable, and reached only when a provider
+ * actively reports being parked for that entire span.
+ */
+export const SUBAGENT_MAX_PAUSE_EXTENSION_MS = 2 * 60 * 60_000;
+
+/**
+ * Wall-clock ceiling extender driven exclusively by provider pause signals.
+ *
+ * ## Semantics: the budget bounds WORKING time, not wall time
+ *
+ * The knob callers have always wanted — and the one the incident proves is
+ * missing — is "bound the child's *working* time". This class provides exactly
+ * that by CREDITING provider-parked time back to the budget:
+ *
+ *     effective ceiling = timeoutMs + min(total provider-parked time, cap)
+ *
+ * Crediting (rather than merely asking "is a pause in effect right now?") is
+ * load-bearing. In the real incident the park ended at 03:10:00Z and the
+ * deadline landed at 03:11:21.307Z — 81 seconds LATER. A right-now check grants
+ * nothing at that instant and the child dies exactly as before, having spent
+ * 43m38s of its 45-minute budget parked and getting 81 seconds of actual work.
+ * Crediting the parked time returns those ~44 minutes, so the child gets a full
+ * budget of real working time.
+ *
+ * Only the provider's OWN reported window is creditable, and only up to
+ * {@link SUBAGENT_MAX_PAUSE_EXTENSION_MS} in total, so the bound stays finite:
+ * worst case `timeoutMs + SUBAGENT_MAX_PAUSE_EXTENSION_MS`.
+ *
+ * Lifecycle: construct → pass as `WithTimeoutOptions.extender` → feed every
+ * streamed {@link OutputEvent} to {@link onEvent} → `withTimeout` calls
+ * {@link onDeadline} when its deadline is reached, which either grants a bounded
+ * extension (re-arming the ceiling) or returns `0` to let it fire.
+ *
+ * Not a timer: this object holds only the pause bookkeeping. `withTimeout` owns
+ * the single timer, exactly as before.
+ */
+export class PauseAwareCeiling implements TimeoutExtender {
+  /**
+   * Wall-clock ms timestamp at which the currently-open pause began, or
+   * `undefined` when no pause is open. Anchors the credit accrued by the pause
+   * in flight; cleared (after finalizing its credit) on `resumed`.
+   */
+  private pauseStartedAtMs: number | undefined;
+
+  /**
+   * Maximum creditable duration of the currently-open pause — the provider's own
+   * reported window (+ slack). Credit for that pause never exceeds this, so a
+   * park that is signaled and then never resumed cannot accrue credit forever
+   * (requirement: each extension is bounded by the known pause window).
+   */
+  private pauseWindowCapMs = 0;
+
+  /** Credit from pauses that have already closed (`resumed`), in ms. */
+  private closedCreditMs = 0;
+
+  /** Human-readable description of the most recent pause signal, for the error message. */
+  private lastPauseDescription: string | undefined;
+
+  /** Total extension granted so far, in ms. Monotonically increasing, capped. */
+  private grantedMs = 0;
+
+  /** Number of separate extensions granted (diagnostics only). */
+  private grantCount = 0;
+
+  /**
+   * @param baseTimeoutMs — the fork's configured wall-clock budget, echoed into
+   *   the error message so the base budget and the granted extension are
+   *   separately legible.
+   * @param maxExtensionMs — absolute cap on total accumulated extension.
+   *   Defaults to {@link SUBAGENT_MAX_PAUSE_EXTENSION_MS}; a non-positive value
+   *   disables extension entirely (the pre-change behaviour).
+   */
+  constructor(
+    private readonly baseTimeoutMs: number,
+    private readonly maxExtensionMs: number = SUBAGENT_MAX_PAUSE_EXTENSION_MS,
+  ) {}
+
+  /**
+   * Feed one streamed {@link OutputEvent}.
+   *
+   * Only three event types are meaningful, all provider-authored:
+   * - `paused` with `resetsAt` / `rate_limit` with `retryAfterMs` → record the
+   *   pause window (the deadline is NOT moved here; the extension is granted
+   *   lazily at {@link onDeadline}, so a pause that ends before the ceiling is
+   *   reached costs nothing).
+   * - `resumed` → the park is over; clear it so no further extension is granted.
+   *
+   * Every other event — `chunk` (content, thinking, tool_use_detail,
+   * tool_result), `message`, `progress`, `done`, … — is ignored outright. This
+   * is the anti-gaming property: a child cannot extend its own ceiling by
+   * producing output or running tools.
+   */
+  onEvent(event: OutputEvent): void {
+    if (event.type === 'resumed') {
+      // The park is over: bank its credit and close it. Banking (rather than
+      // discarding) is the point — the time the child spent parked was never
+      // working time, so it is owed back even though the pause has ended.
+      this.closedCreditMs += this.openPauseCreditMs();
+      this.pauseStartedAtMs = undefined;
+      this.pauseWindowCapMs = 0;
+      return;
+    }
+    if (event.type !== 'paused' && event.type !== 'rate_limit') return;
+
+    const windowMs = pauseWindowMs(event);
+    if (windowMs === undefined || windowMs <= 0) {
+      // A pause with no knowable window (`oauth-limit-no-ts`, or a
+      // `rate_limit` with no usable `retryAfterMs`) grants nothing: an
+      // open-ended extension is exactly what this design forbids. The idle
+      // watchdog still governs that silence on its normal cadence.
+      return;
+    }
+
+    const now = Date.now();
+    if (this.pauseStartedAtMs === undefined) {
+      this.pauseStartedAtMs = now;
+      this.pauseWindowCapMs = windowMs;
+    } else {
+      // Overlapping signals (a transient `rate_limit` during an OAuth park):
+      // keep the furthest-out reported end so a short signal can never shorten
+      // an already-reported longer park.
+      const elapsedIntoPause = now - this.pauseStartedAtMs;
+      this.pauseWindowCapMs = Math.max(this.pauseWindowCapMs, elapsedIntoPause + windowMs);
+    }
+    this.lastPauseDescription = describePauseEvent(event);
+  }
+
+  /**
+   * Creditable ms accrued by the pause currently open — elapsed time since it
+   * began, clamped to the provider's reported window so an unresumed park stops
+   * accruing at its stated end. `0` when no pause is open.
+   */
+  private openPauseCreditMs(): number {
+    if (this.pauseStartedAtMs === undefined) return 0;
+    const elapsed = Date.now() - this.pauseStartedAtMs;
+    return Math.max(0, Math.min(elapsed, this.pauseWindowCapMs));
+  }
+
+  /**
+   * Called by `withTimeout` when the ceiling deadline is reached. Returns the ms
+   * to extend by, or `0` to let the timeout fire.
+   *
+   * Grants the provider-parked time not yet credited, capped by the remaining
+   * absolute allowance: `min(totalCredit - alreadyGranted, cap - alreadyGranted)`.
+   * Time the child spent parked is thereby returned to it as working time —
+   * including for a pause that has already CLOSED before the deadline was
+   * reached, which is precisely the incident shape (park ended 81s before the
+   * deadline).
+   *
+   * Termination: `grantedMs` is monotonically increasing and bounded by
+   * `maxExtensionMs`, and credit only accrues while a provider says it is
+   * parked, so the re-arm loop always terminates.
+   */
+  onDeadline(): number {
+    const remainingCapMs = this.maxExtensionMs - this.grantedMs;
+    if (!(remainingCapMs > 0)) return 0; // cap exhausted → fire as before
+
+    const totalCreditMs = this.closedCreditMs + this.openPauseCreditMs();
+    const uncreditedMs = totalCreditMs - this.grantedMs;
+    if (uncreditedMs <= 0) return 0; // no parked time owed → fire as before
+
+    const grantMs = Math.min(uncreditedMs, remainingCapMs);
+    this.grantedMs += grantMs;
+    this.grantCount += 1;
+    return grantMs;
+  }
+
+  /**
+   * Pause context appended to the {@link TimeoutError} message when the ceiling
+   * finally fires, so the failure is diagnosable instead of a bare "Operation
+   * timed out after 2700000ms". `undefined` when no pause was ever observed, which
+   * keeps the no-pause error message byte-for-byte identical to today's.
+   */
+  describe(): string | undefined {
+    if (this.lastPauseDescription === undefined) return undefined;
+
+    const parts = [
+      `base budget ${this.baseTimeoutMs}ms`,
+      `pause extension granted ${this.grantedMs}ms across ${this.grantCount} ` +
+        `extension${this.grantCount === 1 ? '' : 's'} (cap ${this.maxExtensionMs}ms` +
+        `${this.grantedMs >= this.maxExtensionMs ? ', EXHAUSTED' : ''})`,
+      `last provider pause: ${this.lastPauseDescription}`,
+    ];
+    if (this.pauseStartedAtMs !== undefined) {
+      parts.push(
+        `pause still open since ${new Date(this.pauseStartedAtMs).toISOString()} ` +
+          `(reported window ${this.pauseWindowCapMs}ms)`,
+      );
+    }
+    return `[pause-aware ceiling: ${parts.join('; ')}]`;
+  }
+
+  /** Total extension granted so far (ms). Diagnostics/tests. */
+  get totalGrantedMs(): number {
+    return this.grantedMs;
+  }
+}

--- a/src/agent/subagent/pause-ceiling.ts
+++ b/src/agent/subagent/pause-ceiling.ts
@@ -71,6 +71,16 @@ import { describePauseEvent, pauseWindowMs } from './pause-window.js';
 export const SUBAGENT_MAX_PAUSE_EXTENSION_MS = 2 * 60 * 60_000;
 
 /**
+ * Minimum size of a single granted extension. Prevents a pathological re-arm
+ * cadence: without a floor, a deadline landing ~1ms after a pause opens would
+ * grant ~1ms at a time and re-arm the timer millions of times across a long
+ * park. Purely a timer-efficiency guard — it never lets total extension exceed
+ * {@link SUBAGENT_MAX_PAUSE_EXTENSION_MS}, so the finite worst-case bound is
+ * unchanged.
+ */
+const MIN_EXTENSION_GRANT_MS = 1_000;
+
+/**
  * Wall-clock ceiling extender driven exclusively by provider pause signals.
  *
  * ## Semantics: the budget bounds WORKING time, not wall time
@@ -162,12 +172,21 @@ export class PauseAwareCeiling implements TimeoutExtender {
       // The park is over: bank its credit and close it. Banking (rather than
       // discarding) is the point — the time the child spent parked was never
       // working time, so it is owed back even though the pause has ended.
-      this.closedCreditMs += this.openPauseCreditMs();
-      this.pauseStartedAtMs = undefined;
-      this.pauseWindowCapMs = 0;
+      this.closePause();
       return;
     }
     if (event.type !== 'paused' && event.type !== 'rate_limit') return;
+
+    // Self-close an expired pause before recording a new one. `resumed` is
+    // emitted ONLY on the OAuth park path (`retry-layer.ts:415,512`); a
+    // transient `rate_limit` NEVER has a matching `resumed`. Without this, a
+    // rate_limit pause would stay open forever and each later signal would
+    // widen its window by the elapsed gap (`elapsedIntoPause + windowMs`),
+    // crediting ordinary WORKING time 1:1 — e.g. a 5s retry-after seen every
+    // 10 min would credit the full 10 min. A pause is therefore closed as soon
+    // as its OWN reported window has elapsed, so credit can only ever reflect
+    // time the provider actually said it was parked.
+    this.closeExpiredPause();
 
     const windowMs = pauseWindowMs(event);
     if (windowMs === undefined || windowMs <= 0) {
@@ -203,6 +222,25 @@ export class PauseAwareCeiling implements TimeoutExtender {
     return Math.max(0, Math.min(elapsed, this.pauseWindowCapMs));
   }
 
+  /** Bank the open pause's credit and close it. No-op when none is open. */
+  private closePause(): void {
+    if (this.pauseStartedAtMs === undefined) return;
+    this.closedCreditMs += this.openPauseCreditMs();
+    this.pauseStartedAtMs = undefined;
+    this.pauseWindowCapMs = 0;
+  }
+
+  /**
+   * Close the open pause if its provider-reported window has already elapsed.
+   * Keeps an unresumed pause (every `rate_limit`, and an OAuth park whose
+   * `resumed` never arrives) from accruing beyond what the provider stated, and
+   * prevents a later signal from retroactively widening a stale window.
+   */
+  private closeExpiredPause(): void {
+    if (this.pauseStartedAtMs === undefined) return;
+    if (Date.now() - this.pauseStartedAtMs >= this.pauseWindowCapMs) this.closePause();
+  }
+
   /**
    * Called by `withTimeout` when the ceiling deadline is reached. Returns the ms
    * to extend by, or `0` to let the timeout fire.
@@ -222,11 +260,16 @@ export class PauseAwareCeiling implements TimeoutExtender {
     const remainingCapMs = this.maxExtensionMs - this.grantedMs;
     if (!(remainingCapMs > 0)) return 0; // cap exhausted → fire as before
 
+    this.closeExpiredPause();
+
     const totalCreditMs = this.closedCreditMs + this.openPauseCreditMs();
     const uncreditedMs = totalCreditMs - this.grantedMs;
     if (uncreditedMs <= 0) return 0; // no parked time owed → fire as before
 
-    const grantMs = Math.min(uncreditedMs, remainingCapMs);
+    // Floor each grant so a deadline landing a hair after a pause opens cannot
+    // produce a long run of ~1ms re-arms (millions of timer wakeups). Never
+    // exceeds the remaining cap, so the finite worst-case bound is unaffected.
+    const grantMs = Math.min(Math.max(uncreditedMs, MIN_EXTENSION_GRANT_MS), remainingCapMs);
     this.grantedMs += grantMs;
     this.grantCount += 1;
     return grantMs;
@@ -249,8 +292,10 @@ export class PauseAwareCeiling implements TimeoutExtender {
       `last provider pause: ${this.lastPauseDescription}`,
     ];
     if (this.pauseStartedAtMs !== undefined) {
+      const elapsed = Date.now() - this.pauseStartedAtMs;
+      const state = elapsed >= this.pauseWindowCapMs ? 'expired' : 'still open';
       parts.push(
-        `pause still open since ${new Date(this.pauseStartedAtMs).toISOString()} ` +
+        `last pause ${state}, opened ${new Date(this.pauseStartedAtMs).toISOString()} ` +
           `(reported window ${this.pauseWindowCapMs}ms)`,
       );
     }

--- a/src/agent/subagent/pause-ceiling.ts
+++ b/src/agent/subagent/pause-ceiling.ts
@@ -81,6 +81,25 @@ export const SUBAGENT_MAX_PAUSE_EXTENSION_MS = 2 * 60 * 60_000;
 const MIN_EXTENSION_GRANT_MS = 1_000;
 
 /**
+ * Snapshot handed to {@link PauseAwareCeiling}'s `onGrant` observer each time
+ * `onDeadline` grants a bounded extension. Lets the handle emit a
+ * `pause_extension_granted` witness event without the ceiling itself importing
+ * the trace layer.
+ */
+export interface PauseExtensionGrantInfo {
+  /** ms granted by THIS deadline decision (floored to MIN_EXTENSION_GRANT_MS). */
+  grantMs: number;
+  /** total ms granted across all deadlines so far, capped at `maxExtensionMs`. */
+  totalGrantedMs: number;
+  /** ms of extension budget remaining after this grant (0 ⇒ cap exhausted). */
+  remainingCapMs: number;
+  /** number of separate grants made so far, including this one. */
+  grantCount: number;
+  /** human-readable description of the most recent pause signal, if any. */
+  pauseDescription: string | undefined;
+}
+
+/**
  * Wall-clock ceiling extender driven exclusively by provider pause signals.
  *
  * ## Semantics: the budget bounds WORKING time, not wall time
@@ -140,17 +159,33 @@ export class PauseAwareCeiling implements TimeoutExtender {
   private grantCount = 0;
 
   /**
+   * Optional observer invoked once per NON-ZERO grant, AFTER `grantedMs` and
+   * `grantCount` are updated. Decouples the ceiling from the trace layer: the
+   * handle wires a callback that emits a `pause_extension_granted` witness
+   * event, so the ceiling itself needs no trace import and stays pure
+   * (testable without a trace writer). Never throws back into `onDeadline` —
+   * callers must keep it side-effect-free beyond observation.
+   */
+  private readonly onGrant?: (info: PauseExtensionGrantInfo) => void;
+
+  /**
    * @param baseTimeoutMs — the fork's configured wall-clock budget, echoed into
    *   the error message so the base budget and the granted extension are
    *   separately legible.
    * @param maxExtensionMs — absolute cap on total accumulated extension.
    *   Defaults to {@link SUBAGENT_MAX_PAUSE_EXTENSION_MS}; a non-positive value
    *   disables extension entirely (the pre-change behaviour).
+   * @param onGrant — optional observer invoked each time `onDeadline` grants a
+   *   bounded extension, carrying the grant details for observability. Omit for
+   *   the pre-change behaviour (no observer).
    */
   constructor(
     private readonly baseTimeoutMs: number,
     private readonly maxExtensionMs: number = SUBAGENT_MAX_PAUSE_EXTENSION_MS,
-  ) {}
+    onGrant?: (info: PauseExtensionGrantInfo) => void,
+  ) {
+    this.onGrant = onGrant;
+  }
 
   /**
    * Feed one streamed {@link OutputEvent}.
@@ -272,6 +307,22 @@ export class PauseAwareCeiling implements TimeoutExtender {
     const grantMs = Math.min(Math.max(uncreditedMs, MIN_EXTENSION_GRANT_MS), remainingCapMs);
     this.grantedMs += grantMs;
     this.grantCount += 1;
+    // Observe the grant for witness-layer traceability. A throw here must never
+    // strand the wait — wrap so a faulty observer cannot suppress the extension.
+    if (this.onGrant) {
+      try {
+        this.onGrant({
+          grantMs,
+          totalGrantedMs: this.grantedMs,
+          remainingCapMs: this.maxExtensionMs - this.grantedMs,
+          grantCount: this.grantCount,
+          pauseDescription: this.lastPauseDescription,
+        });
+      } catch {
+        // Observability is best-effort: never let an observer fault eat the
+        // extension the provider pause entitles the child to.
+      }
+    }
     return grantMs;
   }
 

--- a/src/agent/subagent/pause-window.test.ts
+++ b/src/agent/subagent/pause-window.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit tests for the shared pause-window arithmetic consumed by BOTH bounds on a
+ * forked sub-agent turn — {@link import('./idle-watchdog.js').IdleWatchdog} (the
+ * resettable idle bound) and
+ * {@link import('./pause-ceiling.js').PauseAwareCeiling} (the wall-clock
+ * ceiling). Extracted so the two cannot drift apart. Covers:
+ *   - `paused` with resetsAt → resetsAt - now + slack
+ *   - `paused` without resetsAt → undefined (no knowable window)
+ *   - `rate_limit` with retryAfterMs → retryAfterMs + slack
+ *   - `rate_limit` with absent / zero / negative / non-finite retryAfterMs → undefined
+ *   - a resetsAt already in the past yields a non-positive window (callers floor it)
+ *   - non-pause events → undefined
+ *   - describePauseEvent renders diagnosable context for pause events only
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { PAUSE_WINDOW_SLACK_MS, describePauseEvent, pauseWindowMs } from './pause-window.js';
+import type { OutputEvent } from '../types/session-types.js';
+
+describe('pauseWindowMs', () => {
+  const now = Date.parse('2026-07-31T02:00:00.000Z');
+
+  it('returns resetsAt - now + slack for a `paused` event carrying resetsAt', () => {
+    const event: OutputEvent = {
+      type: 'paused',
+      reason: 'usage-limit',
+      resetsAt: new Date(now + 90 * 60_000),
+    };
+    expect(pauseWindowMs(event, now)).toBe(90 * 60_000 + PAUSE_WINDOW_SLACK_MS);
+  });
+
+  it('returns undefined for a `paused` event with no resetsAt (oauth-limit-no-ts)', () => {
+    expect(pauseWindowMs({ type: 'paused', reason: 'usage-limit' }, now)).toBeUndefined();
+  });
+
+  it('returns retryAfterMs + slack for a `rate_limit` event carrying retryAfterMs', () => {
+    expect(pauseWindowMs({ type: 'rate_limit', retryAfterMs: 60_000 }, now)).toBe(
+      60_000 + PAUSE_WINDOW_SLACK_MS,
+    );
+  });
+
+  it('returns undefined for a `rate_limit` with an absent or unusable retryAfterMs', () => {
+    expect(pauseWindowMs({ type: 'rate_limit' }, now)).toBeUndefined();
+    expect(pauseWindowMs({ type: 'rate_limit', retryAfterMs: 0 }, now)).toBeUndefined();
+    expect(pauseWindowMs({ type: 'rate_limit', retryAfterMs: -5 }, now)).toBeUndefined();
+    expect(pauseWindowMs({ type: 'rate_limit', retryAfterMs: Number.NaN }, now)).toBeUndefined();
+    expect(
+      pauseWindowMs({ type: 'rate_limit', retryAfterMs: Number.POSITIVE_INFINITY }, now),
+    ).toBeUndefined();
+  });
+
+  it('yields a non-positive window when resetsAt has already passed (callers apply the floor)', () => {
+    const event: OutputEvent = {
+      type: 'paused',
+      reason: 'usage-limit',
+      resetsAt: new Date(now - 10 * 60_000),
+    };
+    // Deliberately NOT clamped here: the idle watchdog floors up to a normal
+    // idle window, while the ceiling grants no extension. Neither may inherit
+    // the other's policy.
+    expect(pauseWindowMs(event, now)).toBe(-10 * 60_000 + PAUSE_WINDOW_SLACK_MS);
+  });
+
+  it('returns undefined for non-pause events', () => {
+    expect(pauseWindowMs({ type: 'chunk', chunk: { type: 'content', content: 'x' } }, now)).toBeUndefined();
+    expect(pauseWindowMs({ type: 'resumed', hotSwapped: false }, now)).toBeUndefined();
+    expect(pauseWindowMs({ type: 'stream_retry' }, now)).toBeUndefined();
+  });
+});
+
+describe('describePauseEvent', () => {
+  it('names the reason and resetsAt for a `paused` event', () => {
+    const resetsAt = new Date('2026-07-31T03:10:00.000Z');
+    expect(describePauseEvent({ type: 'paused', reason: 'usage-limit', resetsAt })).toBe(
+      'paused (usage-limit, resetsAt=2026-07-31T03:10:00.000Z)',
+    );
+  });
+
+  it('marks an unknown resetsAt rather than omitting it', () => {
+    expect(describePauseEvent({ type: 'paused', reason: 'usage-limit' })).toContain(
+      'resetsAt=unknown',
+    );
+  });
+
+  it('names retryAfterMs for a `rate_limit` event', () => {
+    expect(describePauseEvent({ type: 'rate_limit', retryAfterMs: 6_792_000 })).toBe(
+      'rate_limit (retryAfterMs=6792000)',
+    );
+    expect(describePauseEvent({ type: 'rate_limit' })).toContain('retryAfterMs=unknown');
+  });
+
+  it('returns undefined for non-pause events', () => {
+    expect(describePauseEvent({ type: 'resumed', hotSwapped: false })).toBeUndefined();
+    expect(
+      describePauseEvent({ type: 'chunk', chunk: { type: 'content', content: 'x' } }),
+    ).toBeUndefined();
+  });
+});

--- a/src/agent/subagent/pause-window.ts
+++ b/src/agent/subagent/pause-window.ts
@@ -1,0 +1,88 @@
+/**
+ * Shared pause-window arithmetic for provider-communicated backoff brackets.
+ *
+ * Two independent bounds on a forked sub-agent turn need the SAME answer to the
+ * same question — "the provider told us it is parked; how long is that park,
+ * measured from now?":
+ *
+ * 1. {@link import('./idle-watchdog.js').IdleWatchdog} — the tighter,
+ *    resettable idle bound, which EXTENDS its deadline over a recognized pause
+ *    so legitimate waiting never counts as unexplained silence.
+ * 2. {@link import('./pause-ceiling.js').PauseAwareCeiling} — the wall-clock
+ *    ceiling, which extends by the same window (bounded by an absolute cap) so
+ *    a child parked longer than its ceiling is not guaranteed to die.
+ *
+ * This module is the single source of that arithmetic so the two bounds cannot
+ * drift apart. It is deliberately pure: no timers, no state, no I/O — just
+ * `OutputEvent` → window ms, so both consumers can unit-test their own policy
+ * (floor, cap, re-arm) against a fixed shared primitive.
+ *
+ * @module agent/subagent/pause-window
+ */
+
+import type { OutputEvent } from '../types/session-types.js';
+
+/**
+ * Slack added to a recognized pause window before either deadline. Guards
+ * against a deadline firing the instant a provider says it will resume — the
+ * resume + first replayed token needs a moment to actually stream. 30s, matching
+ * the idle watchdog's original constant (spec Open Q4) and the order of the
+ * Telegram streaming precedent (`src/telegram/streaming.ts:374-376`).
+ */
+export const PAUSE_WINDOW_SLACK_MS = 30_000;
+
+/**
+ * The provider-communicated pause window for `event`, measured from `now` and
+ * including {@link PAUSE_WINDOW_SLACK_MS}; `undefined` when the event is not a
+ * pause signal with a knowable window.
+ *
+ * Recognized signals — and ONLY these two, both originating in the provider's
+ * retry layer, never in child-generated content:
+ *
+ * - `paused` (OAuth subscription park) carrying `resetsAt` → `resetsAt - now + slack`.
+ *   The result may be ≤ 0 when the reset time has already passed; callers apply
+ *   their own floor (the idle watchdog clamps up to a normal idle window; the
+ *   ceiling grants no extension). Deliberately NOT clamped here so neither
+ *   caller inherits the other's floor semantics.
+ * - `rate_limit` carrying a finite, positive `retryAfterMs` → `retryAfterMs + slack`.
+ *
+ * A `paused` without `resetsAt` (the `oauth-limit-no-ts` case) returns
+ * `undefined`: the provider has not said when it will resume, so there is no
+ * window to honor and callers must fall back to their normal bound rather than
+ * park blind.
+ */
+export function pauseWindowMs(event: OutputEvent, now: number = Date.now()): number | undefined {
+  if (event.type === 'paused') {
+    if (event.resetsAt === undefined) return undefined;
+    return event.resetsAt.getTime() - now + PAUSE_WINDOW_SLACK_MS;
+  }
+  if (event.type === 'rate_limit') {
+    const retryAfterMs = event.retryAfterMs;
+    // Finiteness guard: a non-finite retry-after would otherwise arm a bogus
+    // timer (Node clamps a non-finite delay to 1ms with a TimeoutOverflowWarning).
+    // Treated as "no knowable window" so callers use their normal bound.
+    if (typeof retryAfterMs !== 'number' || !Number.isFinite(retryAfterMs) || retryAfterMs <= 0) {
+      return undefined;
+    }
+    return retryAfterMs + PAUSE_WINDOW_SLACK_MS;
+  }
+  return undefined;
+}
+
+/**
+ * One-line human-readable description of a pause signal, for weaving the pause
+ * context into a timeout error message so the failure is diagnosable instead of
+ * a bare "Operation timed out after 2700000ms". Returns `undefined` for events
+ * that are not pause signals.
+ */
+export function describePauseEvent(event: OutputEvent): string | undefined {
+  if (event.type === 'paused') {
+    const resetsAt = event.resetsAt !== undefined ? event.resetsAt.toISOString() : 'unknown';
+    return `paused (${event.reason}, resetsAt=${resetsAt})`;
+  }
+  if (event.type === 'rate_limit') {
+    const retryAfterMs = event.retryAfterMs;
+    return `rate_limit (retryAfterMs=${typeof retryAfterMs === 'number' ? retryAfterMs : 'unknown'})`;
+  }
+  return undefined;
+}

--- a/src/agent/timeout.ts
+++ b/src/agent/timeout.ts
@@ -22,11 +22,46 @@ export const DEFAULT_SESSION_TIMEOUT_MS = 0;
  */
 export const RESET_DRAIN_TIMEOUT_MS = 5_000;
 
+/**
+ * Optional policy object that may grant a BOUNDED extension when the timeout
+ * deadline is reached, instead of firing immediately.
+ *
+ * Exists so a wall-clock budget can honor a provider-communicated pause (HTTP
+ * 429 / OAuth subscription park) without becoming resettable by the work it
+ * bounds. The extender is consulted ONLY at the deadline, and the guarantee that
+ * matters is delegated to it: an implementation must cap total accumulated
+ * extension so the overall wait stays finite and predictable. See
+ * {@link import('./subagent/pause-ceiling.js').PauseAwareCeiling}.
+ *
+ * When no extender is supplied, {@link withTimeout} behaves exactly as it did
+ * before this seam existed: one timer, one fire, identical error message.
+ */
+export interface TimeoutExtender {
+  /**
+   * Called when the deadline is reached. Return the number of ms to extend by,
+   * or `0` (or any non-positive/non-finite value) to let the timeout fire.
+   * Must eventually return `0` — an implementation that always extends would
+   * never let the timeout fire.
+   */
+  onDeadline(): number;
+  /**
+   * Optional context appended to the {@link TimeoutError} message when the
+   * timeout finally does fire, so a pause-related expiry is diagnosable.
+   * Returning `undefined` leaves the message unchanged.
+   */
+  describe?(): string | undefined;
+}
+
 export interface WithTimeoutOptions {
   /** Controller aborted on timeout so the underlying work can wind down. */
   controller?: AbortController;
   /** Human-readable label used in the error message (e.g. session id). */
   label?: string;
+  /**
+   * Optional bounded-extension policy consulted at the deadline. Omit for the
+   * classic single-shot behaviour.
+   */
+  extender?: TimeoutExtender;
 }
 
 export async function withTimeout<T>(
@@ -41,14 +76,54 @@ export async function withTimeout<T>(
   let timer: ReturnType<typeof setTimeout> | undefined;
 
   const timeoutPromise = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => {
-      const label = options.label ? ` (${options.label})` : '';
-      const err = new TimeoutError(`Operation timed out after ${timeoutMs}ms${label}`, timeoutMs);
-      if (options.controller && !options.controller.signal.aborted) {
-        options.controller.abort(err);
-      }
-      reject(err);
-    }, timeoutMs);
+    // Total ms actually waited across the initial window plus every granted
+    // extension. Reported in the error so the effective budget is legible when
+    // an extension was in play; equals `timeoutMs` in the no-extender case, which
+    // keeps that message byte-for-byte identical.
+    let waitedMs = 0;
+
+    const arm = (windowMs: number): void => {
+      timer = setTimeout(() => {
+        waitedMs += windowMs;
+        // Consult the extension policy (if any) BEFORE building the error: a
+        // granted extension re-arms the same single timer and nothing else
+        // observes the deadline having been reached. Extender faults must never
+        // strand the wait, so a throw is treated as "no extension" and fires.
+        let extensionMs = 0;
+        if (options.extender) {
+          try {
+            extensionMs = options.extender.onDeadline();
+          } catch {
+            extensionMs = 0;
+          }
+        }
+        if (Number.isFinite(extensionMs) && extensionMs > 0) {
+          arm(extensionMs);
+          return;
+        }
+
+        const label = options.label ? ` (${options.label})` : '';
+        let context = '';
+        if (options.extender?.describe) {
+          try {
+            const described = options.extender.describe();
+            if (described !== undefined && described !== '') context = ` ${described}`;
+          } catch {
+            // Diagnostics are best-effort; never suppress the timeout.
+          }
+        }
+        const err = new TimeoutError(
+          `Operation timed out after ${waitedMs}ms${label}${context}`,
+          waitedMs,
+        );
+        if (options.controller && !options.controller.signal.aborted) {
+          options.controller.abort(err);
+        }
+        reject(err);
+      }, windowMs);
+    };
+
+    arm(timeoutMs);
   });
 
   try {

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -414,6 +414,11 @@ export const SessionPhaseNameSchema = z.enum([
   'usage_limit_pause',
   'usage_limit_resume',
   'idle_watchdog_fired',
+  // A fork's wall-clock ceiling granted a bounded pause extension (see
+  // subagent/pause-ceiling.ts). Single event per grant; metadata carries
+  // subagentId, grantMs, totalGrantedMs, remainingCapMs, grantCount, and
+  // optionally pauseDescription.
+  'pause_extension_granted',
   'suspected_loop',
   // Per-session compaction disable (single event, at most once). See
   // SessionPhaseName JSDoc in types.ts — metadata names the wire and cause.

--- a/src/agent/trace/session-phase.test.ts
+++ b/src/agent/trace/session-phase.test.ts
@@ -261,6 +261,7 @@ describe('SessionPhaseName union ↔ SessionPhaseNameSchema parity', () => {
     usage_limit_pause: true,
     usage_limit_resume: true,
     idle_watchdog_fired: true,
+    pause_extension_granted: true,
     suspected_loop: true,
     compaction_disabled: true,
   };

--- a/src/agent/trace/types.ts
+++ b/src/agent/trace/types.ts
@@ -718,6 +718,17 @@ export type SessionPhaseName =
   // `rate_limit`/`usage_limit_*`, which mark LEGITIMATE waits — this marks an
   // unexplained stall that fired.
   | 'idle_watchdog_fired'
+  // A forked sub-agent turn's wall-clock ceiling granted a bounded extension
+  // because the provider reported being parked (`paused` w/ resetsAt or
+  // `rate_limit` w/ retryAfterMs). See subagent/pause-ceiling.ts. A single event
+  // per grant (no paired start), emitted fire-and-forget from the handle when
+  // `PauseAwareCeiling.onDeadline()` returns a positive grant. Carries, in
+  // `metadata`, the `subagentId`, `grantMs`, `totalGrantedMs`, `remainingCapMs`,
+  // `grantCount`, and (when known) the `pauseDescription`. PURE OBSERVABILITY:
+  // without it, a pause-driven extension is invisible until the eventual
+  // terminal timeout error — reconstructing "the child got N extensions
+  // totaling Xms across this park" required the error string alone.
+  | 'pause_extension_granted'
   // OBSERVE-ONLY loop telemetry (see tools/suspected-loop-detector.ts): a
   // FORKED sub-agent issued the same (tool, normalized-args) fingerprint
   // >= N times within the last M tool rounds on one dispatcher (per-turn).

--- a/src/cli/commands/interactive/turn-handler.test.ts
+++ b/src/cli/commands/interactive/turn-handler.test.ts
@@ -2320,10 +2320,18 @@ describe('formatContextUsage — proactive escalating context tiers', () => {
 });
 
 describe('printTurnFooter — subscription-quota line', () => {
+  // Invariant: the countdown floors `resetsAt - now` to whole minutes and
+  // re-reads `now` at render time (not at snapshot time), so on a real clock
+  // an exactly-12-minute deadline can degrade to 719_999ms elapsed and floor
+  // to `11m` — a flake that races the runner's speed. Freezing the clock
+  // makes the deadline arithmetic exact instead of racing the runner.
   beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
     resetQuotaCacheForTests();
   });
   afterEach(() => {
+    vi.useRealTimers();
     resetQuotaCacheForTests();
   });
 


### PR DESCRIPTION
## The incident

On 2026-07-31 a code-backed `/forge` run lost **1h49m of work**. Verified from `~/.afk/agent-framework/forge-telemetry.jsonl` and witness traces:

| Time (UTC) | Event |
|---|---|
| 01:16:47 | Provider returns HTTP 429, `retryAfterMs: 6792000`; runtime logs `usage_limit_pause` with `resetsAt: 2026-07-31T03:10:00.000Z` (~113-min account-level pause) |
| 02:26:21.307 | Forge forks `forge-rework-2` with no explicit `timeoutMs` → inherits `SUBAGENT_DEFAULT_TIMEOUT_MS` (2,700,000 ms) |
| ~02:34 | Idle watchdog does **not** fire at its 8-min window — the runtime *recognized* the pause and correctly extended the idle deadline |
| 03:11:21.307 | Child dies — exactly dispatch + 2,700,000 ms, **81 seconds after the pause reset** — with a bare wall-clock `TimeoutError` |

The idle watchdog consumed the pause signal correctly. The wall clock ignored the very same signal and killed the child anyway. The child had spent **43m38s of its 45-minute budget parked** and received roughly **81 seconds** of actual working time.

Net effect: a fork parked by a provider-imposed pause longer than its ceiling is **guaranteed** to die, no matter what the caller does. The only knob bounds *wall* time, so there was no way to express "bound the child's *working* time". Callers cannot pre-compute a safe `timeoutMs` because the pause window is unknowable at dispatch; the only escape was `timeoutMs: 0` (fully unbounded), which is worse.

## The decision this revises

`.afk/plans/subagent-idle-watchdog.md` **L88** states verbatim:

> idle watchdog is the tighter first-to-fire bound; **wall-clock stays as the un-resettable ceiling**. Both run concurrently via `Promise.race`.

**#672** built pause-awareness into a separate `IdleWatchdog` *specifically so it would not touch `withTimeout`*. This PR is a **deliberate revision of that shipped architectural decision, not a gap-fill.**

The revision honors the *purpose* of the invariant — a fork's lifetime must have a guaranteed finite, predictable upper bound — rather than its letter, which made the actually-desired bound inexpressible. The ceiling remains un-resettable **by the child**; it is now movable only by the provider.

## Design: bounded credit, not a reset

The budget now bounds **working** time:

```
effective ceiling = timeoutMs + min(provider-parked time, SUBAGENT_MAX_PAUSE_EXTENSION_MS)
```

Crediting parked time — rather than asking "is a pause in effect *right now*?" — is load-bearing. In the incident the park ended **81s before** the deadline, so a right-now check grants nothing and the child dies exactly as before. My first implementation made precisely that mistake; the incident-replay test caught it.

Guarantees:

1. **Provider-only signal.** Only `paused` (with `resetsAt`) and `rate_limit` (with `retryAfterMs`) — the same events `IdleWatchdog` already consumes, originating in the provider retry layer. Child content, tokens, thinking, tool activity, `message`, `stream_retry` grant **nothing**. The child cannot author the only signal that moves the ceiling.
2. **Each grant bounded by the reported window.** A pause self-closes once its own stated window elapses, so an unresumed park stops accruing at its stated end. Never open-ended.
3. **Absolute cap: `SUBAGENT_MAX_PAUSE_EXTENSION_MS = 2h.`** Justification: the OAuth subscription park this defends against is itself bounded (plan doc L64, "subscription park, ≤2h"), and the observed real park was ~113 min (1h53m), which 2h covers with ~7 min of headroom. Choosing the provider's own maximum park means a legitimately parked child survives any pause the provider can impose, while a child parked by anything else is still bounded. Worst-case lifetime at the default budget: **45min + 2h = 2h45m** — finite and predictable, reached only when a provider actively reports being parked that entire span.
4. **Diagnosable failure.** Firing under pause now yields `... [pause-aware ceiling: base budget 2700000ms; pause extension granted Nms across K extensions (cap 7200000ms); last provider pause: paused (usage-limit, resetsAt=...)]` instead of a bare `Operation timed out after 2700000ms`.
5. **No-pause behaviour is unchanged.** With no pause events the extender grants nothing: same single timer, same fire time, same error message string, same `TimeoutError.timeoutMs`, same controller-abort semantics. Pinned by an explicit byte-for-byte test against the no-extender path.

### Shared arithmetic (no duplication)

`pausedWindowMs`-style logic is extracted into `src/agent/subagent/pause-window.ts`, consumed by **both** `IdleWatchdog` and the new ceiling so the two bounds cannot drift apart. `IDLE_WATCHDOG_PAUSE_SLACK_MS` is now an alias of the shared `PAUSE_WINDOW_SLACK_MS`. All 20 pre-existing idle-watchdog tests pass **unchanged**.

### Files

| File | Δ | Note |
|---|---|---|
| `src/agent/timeout.ts` | +91/-10 (134 LOC) | Additive `TimeoutExtender` seam; consulted only at the deadline |
| `src/agent/subagent/pause-window.ts` | **new**, 88 LOC | Shared pause arithmetic + slack constant |
| `src/agent/subagent/pause-ceiling.ts` | **new**, 309 LOC | `PauseAwareCeiling` + `SUBAGENT_MAX_PAUSE_EXTENSION_MS` |
| `src/agent/subagent/handle.ts` | +29 | Attach extender to `withTimeout`; feed the stream |
| `src/agent/subagent/idle-watchdog.ts` | +18/-8 | Delegate to shared arithmetic |

Every source file stays under the 350-LOC limit; new concerns went into new files rather than growing existing ones.

## Tests

`pause-ceiling.test.ts` (14), `pause-window.test.ts` (10), `handle.test.ts` (+3 wiring):

- ceiling fires at the normal deadline with no pause event (**regression guard: unchanged behaviour**)
- error message byte-for-byte identical to the no-extender path when no pause was seen
- ceiling extends on `paused` carrying `resetsAt`
- ceiling extends on `rate_limit` carrying `retryAfterMs`
- credit bounded by the reported window when a park never resumes
- accumulated extension capped by the absolute cap, then the ceiling fires (`EXHAUSTED` in the message)
- content / thinking / tool_use_detail / tool_result / stream_retry **never** extend (anti-gaming)
- `resumed` banks the closed pause's credit and stops further accrual
- repeated `rate_limit`s that never pair with `resumed` do **not** credit working time (see below)
- pause with no knowable window grants nothing; overlapping signals keep the furthest-out end
- timeout error names the pause context when firing under pause
- a throwing extender never strands the wait
- **incident replay**: 45-min budget vs the real ~43m38s parked span — asserts the child is still alive at 03:11:21.307Z (where it previously died) and that the bound stays ≤ cap
- handle-level wiring: a real fork survives a streamed `paused`, and does *not* extend on ordinary content

## Adversarial review caught a real bug (2nd commit)

I dispatched an independent read-only verifier to re-derive finiteness, anti-gaming, no-pause identity, and refactor safety. It confirmed three and **found a genuine merge-blocker in my first commit**:

A pause was closed only on `resumed` — but `resumed` is emitted *only* on the OAuth path (`retry-layer.ts:415,512`); a transient `rate_limit` never has one. That pause stayed open forever, and since a later signal widens the window by the elapsed gap, each new throttle retroactively credited the ordinary **working** time between throttles. A 5s retry-after seen every 10 min credited the full 10 min. Finiteness was never at risk (the cap still bound it) but the budget's *meaning* was.

Fixed in `0053360`: a pause self-closes once its reported window elapses. Verified — 4×5s throttles across 40 min now credit **140s** (the reported windows), not 40 minutes. Regression test added. The same review also prompted a 1s floor on grants (avoids millions of ~1ms timer re-arms) and an `expired` vs `still open` distinction in the error text.

## Verification

| Gate | Result |
|---|---|
| `pnpm lint` (`tsc --noEmit`) | clean, exit 0 |
| `pnpm vitest run src/agent/subagent/ src/agent/timeout.test.ts` | **131 passed** (9 files) |
| `pnpm test` (full) | **723 files, 13772 passed, 2 skipped** |

## For reviewers to scrutinize

- **The cap value (2h).** Defensible but a judgment call; it is the one number here worth arguing about.
- **`SubagentHandleImpl.pauseCeiling` is per-run instance state**, mirroring `lastStreamedContent`, because `run()` owns `withTimeout` while the stream loop lives in `streamToFinalMessage`.
- **Latent behaviour change surfaced by the refactor:** a `rate_limit` with `retryAfterMs: Infinity` previously passed `Infinity > 0` into `setTimeout`, which Node clamps to 1ms → spurious instant idle-fire. The shared guard now treats it as "no knowable window". Strictly a fix, but it *is* an observable change in that edge case.
- `retryAfterMs > 2^31-1` still clamps inside `IdleWatchdog.arm` — pre-existing, untouched here.
