### PR TITLE
fix(tui): keep the hanging indent when a list or blockquote token exceeds the wrap budget

### DIFF
--- a/src/cli/formatter.test.ts
+++ b/src/cli/formatter.test.ts
@@ -339,6 +339,74 @@ describe('renderMarkdownToTerminal', () => {
     });
   });
 
+  describe('lists — unbreakable tokens wider than the item budget', () => {
+    // Regression (observed in a real REPL transcript): the two tests above use
+    // word-wrappable prose, so the list branch's word-wrap (hard:false) always
+    // found a space to break at and the width invariant held by accident. A
+    // single token WIDER than (maxWidth - prefixWidth) — a bare path, URL, or
+    // `file.ts:12-34` codespan, which afk emits constantly — was left unbroken,
+    // so the item escaped the branch OVER budget and the production commit pass
+    // (markdown-stream-format.ts, wrapToWidth with breakLongWords:true) split it
+    // at column 0. On screen: `1. src/cli/…/tool-lane-format-` / `args.ts:77-81`
+    // flush-left, the list dissolved.
+    //
+    // The `{ breakLongWords: true }` argument below is load-bearing: it mirrors
+    // what the commit pipeline actually does. Re-wrapping without it (as the
+    // sibling test above does) cannot observe this failure at all.
+    const longToken = 'src/cli/commands/interactive/tool-lane-format-args.ts:77-81';
+    const COMMIT = { breakLongWords: true } as const;
+
+    it('ordered item: an over-wide token is broken WITH the hanging indent, not at column 0', () => {
+      const md = `1. \`${longToken}\` deletes the wrapper at render time.`;
+      const rendered = renderMarkdownToTerminal(md, { maxWidth: 56 });
+      const lines = stripAnsi(wrapToWidth(rendered, 56, COMMIT))
+        .split('\n')
+        .filter((l) => l.length > 0);
+
+      expect(lines.length).toBeGreaterThan(1); // it actually broke the token
+      expect(lines[0]).toMatch(/^  1\. \S/); // marker row carries content, not a bare "1."
+      // Every continuation sits at the ordered marker's content column ("  1. "
+      // = 5), never flush-left.
+      for (const line of lines.slice(1)) {
+        expect(line).toMatch(/^ {5}\S/);
+      }
+      for (const line of lines) {
+        expect(stringWidth(line)).toBeLessThanOrEqual(56);
+      }
+    });
+
+    it('bullet item: an over-wide token is broken WITH the hanging indent', () => {
+      const md = `- \`${longToken}\` deletes the wrapper.`;
+      const rendered = renderMarkdownToTerminal(md, { maxWidth: 48 });
+      const lines = stripAnsi(wrapToWidth(rendered, 48, COMMIT))
+        .split('\n')
+        .filter((l) => l.length > 0);
+
+      expect(lines.length).toBeGreaterThan(1);
+      expect(lines[0]).toMatch(/^  • \S/);
+      for (const line of lines.slice(1)) {
+        expect(line).toMatch(/^ {4}\S/);
+      }
+      for (const line of lines) {
+        expect(stringWidth(line)).toBeLessThanOrEqual(48);
+      }
+    });
+
+    it('blockquote: an over-wide token keeps the │ gutter on every row', () => {
+      const md = `> see \`${longToken}\` for the strip`;
+      const rendered = renderMarkdownToTerminal(md, { maxWidth: 48 });
+      const lines = stripAnsi(wrapToWidth(rendered, 48, COMMIT))
+        .split('\n')
+        .filter((l) => l.trim().length > 0);
+
+      expect(lines.length).toBeGreaterThan(1);
+      for (const line of lines) {
+        expect(line).toMatch(/^ {2}│ \S/);
+        expect(stringWidth(line)).toBeLessThanOrEqual(48);
+      }
+    });
+  });
+
   describe('renderCardLine', () => {
     it('renders bold markdown as ANSI bold', () => {
       const out = renderCardLine('**PR #163 opened**: https://example.com');

--- a/src/cli/formatter.ts
+++ b/src/cli/formatter.ts
@@ -258,9 +258,19 @@ export function renderMarkdownToTerminal(text: string, opts: RenderMarkdownOptio
             // (maxTableWidth - prefixWidth) so prefix + content == maxTableWidth
             // == the outer wrap width; the outer pass then never re-splits these
             // lines. Mirrors the blockquote branch below.
+            //
+            // breakLongWords is load-bearing, not cosmetic: word-wrap alone
+            // (hard:false) leaves a token WIDER than innerWidth unbroken — a
+            // bare path/URL/`file.ts:12-34` codespan, which afk emits
+            // constantly — so the line escapes this branch over budget and the
+            // indent-blind commit pass breaks it at column 0, dropping the
+            // hanging indent. That is precisely the dissolution the invariant
+            // above forbids; enforcing the width here is what makes it true.
             const innerWidth = maxTableWidth ? Math.max(1, maxTableWidth - prefixWidth) : undefined;
             for (const srcLine of itemText.trim().split('\n')) {
-              const wrapped = innerWidth ? wrapToWidth(srcLine, innerWidth) : srcLine;
+              const wrapped = innerWidth
+                ? wrapToWidth(srcLine, innerWidth, { breakLongWords: true })
+                : srcLine;
               const segs = wrapped.split('\n');
               for (let s = 0; s < segs.length; s++) {
                 // wrapToWidth runs wrap-ansi with trim:false, so a wrap at a
@@ -309,7 +319,14 @@ export function renderMarkdownToTerminal(text: string, opts: RenderMarkdownOptio
           const innerWidth = maxTableWidth ? Math.max(1, maxTableWidth - prefixCols) : undefined;
           const lines: string[] = [];
           for (const para of inner.split('\n')) {
-            const wrapped = innerWidth ? wrapToWidth(para, innerWidth) : para;
+            // breakLongWords: same contract as the list branch above — an
+            // unbreakable token wider than innerWidth would otherwise leave
+            // here over budget, and the indent-blind commit-time wrap would
+            // re-split it at column 0, orphaning the continuation outside the
+            // `│ ` gutter.
+            const wrapped = innerWidth
+              ? wrapToWidth(para, innerWidth, { breakLongWords: true })
+              : para;
             for (const line of wrapped.split('\n')) {
               // Only stamp the prefix on non-empty lines; empty lines (produced
               // by trailing \n\n on the inner paragraph token) must not become


### PR DESCRIPTION
## Symptom

Assistant markdown rendered in the REPL at ~56 columns. A list item whose text starts with a long inline-code token:

```
  1. src/agent/providers/shared/tool-input-summary.
ts:76-82                          ← column 0, hanging indent gone
     flattens the whole command    ← prose resumes the correct indent
```

The token is hard-broken mid-path and its remainder lands flush-left, outside the list. Blockquotes lose their `│ ` gutter the same way. Observed in a real transcript, not synthesized.

## Root cause — a hole between two wrap passes

1. `src/cli/formatter.ts` list (`:263` pre-diff) and blockquote (`:322` pre-diff) wrapped content to `maxWidth − prefixWidth` with **word-wrap only** (`wrapToWidth`, `hard: false`). wrap-ansi in that mode never splits a token wider than the budget, so the line left the formatter **over budget** — measured at 59 and 64 display columns for a 56-column budget.
2. `src/cli/markdown-stream-format.ts:110` then applies the commit-time wrap with `breakLongWords: true`. That pass is **indent-blind by construction** — `applyIndent` runs on line 111, *after* the wrap — so it breaks the over-wide token at the column boundary and emits the remainder with no prefix.

Production path confirmed: `markdown-stream.ts:130` → `formatBlockForCommit` → `markdown-stream-format.ts:110`.

`formatter.ts:252-260` already declared this invariant — *"if a long item line leaves here unwrapped, that pass reflows the continuation to column 0 and the list visually dissolves"* — the code just never enforced it for unbreakable tokens. Bare paths, URLs and `file.ts:12-34` citations are the dominant token shape afk prints, so this fires constantly on narrow terminals.

## Fix

`{ breakLongWords: true }` on both inner wraps, so `prefix + content ≤ maxWidth` actually holds and the outer pass has nothing left to re-split. Two call sites, one bug class, no new branching, no behavior change for content that already fit.

## Verification

**Test gate:** `vitest run src/cli` → **283 files / 5020 tests passed**. `tsc --noEmit` → **exit 0**.

**Non-vacuity (the load-bearing check):** the 3 added tests **fail 3/3 with the fix stashed** (`3 failed | 67 passed`) and pass with it applied (`70 passed`). They re-wrap using the production `breakLongWords: true` flag — the existing sibling test at `formatter.test.ts:326` does not, which is precisely why this bug survived it.

**Adversarial pass — pre-fix vs post-fix diffed on each case at width 48:**

| case | verdict |
|---|---|
| nested list + over-wide token | **fixed** — was `t-args.ts:77-81` at column 0, now indent-preserved |
| CJK / wide chars | safe — breaks on a grapheme boundary, line exactly 48 cols, no lone surrogates |
| emoji ZWJ sequences | safe — untouched, no surrogate splitting |
| bold+code styled token | safe — no dangling ESC, OSC 8 spans balanced |
| tables | **byte-identical** — the table-cell wrap at `formatter.ts:476` truncates each line on the next statement, so it can never leave the branch over budget |
| fenced code inside a list item | **byte-identical pre/post** (word-wrappable, never needed the hard break) |

Zero over-width lines in every case. Every `wrapToWidth` call site in `formatter.ts` is accounted for: `:272` and `:328` fixed here, `:476` safe by construction (immediately truncated), no others.

## Follow-up (pre-existing, out of scope — verified identical before and after this diff)

- A fenced code block **inside** a list item loses its `│ ` gutter on wrapped continuations.
- Nested list items flatten onto the parent row (`• outer item  • inner`).
- Unrelated layer: `src/agent/providers/shared/tool-input-summary.ts:29` — the 160-char `COMMAND_SUMMARY_MAX` cap is spent on a `cd <dir> && ` prefix that the tool lane strips at render time (`tool-lane-format-args.ts:77-81`), so a deep-cwd bash command renders ~77 of ~113 available columns. Diagnosed, deliberately untouched here.
