### PR TITLE
fix(config): stop a blank env var from shadowing the real value in afk.env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ auto-release workflow to deduplicate commits across successive runs.
 
 ## [Unreleased]
 
+### Fixed
+- stop a blank environment variable from permanently shadowing the real value in `afk.env` — a shell profile with `export OPENAI_API_KEY=""` masked the key in `~/.afk/config/afk.env` (dotenv's `override: false` skip is presence-based, not value-based), so an OpenAI-compatible-only operator was told to "set OPENAI_API_KEY" for a key they had already set, after the auth chain fell through to `~/.codex/auth.json`
+
 ## [5.83.5] - 2026-07-31
 
 ### Fixed

--- a/src/cli/config/env-tier.test.ts
+++ b/src/cli/config/env-tier.test.ts
@@ -1,0 +1,138 @@
+// Contract: regression coverage for the env tier's "blank ambient value must
+// not shadow an env file" precedence rule.
+//
+// History: a shell profile containing `export OPENAI_API_KEY=""` permanently
+// masked the real key in `~/.afk/config/afk.env`, because dotenv's
+// `override: false` skip is presence-based (`key in process.env`) rather than
+// value-based. The OpenAI auth resolver then fell through to
+// `~/.codex/auth.json` and told the operator to "set OPENAI_API_KEY" — a key
+// they had already set. `src/cli/config.test.ts` mocks dotenv wholesale, so the
+// real load path had no coverage; these tests exercise it directly.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { _clearBlankEnvShadows, _resetBlankEnvShadowWarnCache } from './env-tier.js';
+
+const TRACKED_KEYS = [
+  'OPENAI_API_KEY',
+  'AFK_BLANK_SHADOW_PROBE',
+  'AFK_REAL_AMBIENT_PROBE',
+  'AFK_HOME',
+] as const;
+
+let tmpRoot: string;
+let saved: Record<string, string | undefined>;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'afk-env-tier-'));
+  saved = {};
+  for (const k of TRACKED_KEYS) saved[k] = process.env[k];
+  _resetBlankEnvShadowWarnCache();
+  // Silence the one-shot operator warning; asserted explicitly where relevant.
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  for (const k of TRACKED_KEYS) {
+    const v = saved[k];
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  rmSync(tmpRoot, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+function writeEnvFile(contents: string): string {
+  const p = join(tmpRoot, 'afk.env');
+  writeFileSync(p, contents, 'utf8');
+  return p;
+}
+
+describe('_clearBlankEnvShadows', () => {
+  it('unshadows a blank ambient value when the file supplies a real one', () => {
+    process.env['OPENAI_API_KEY'] = '';
+    const p = writeEnvFile('OPENAI_API_KEY=sk-real-value\n');
+
+    expect(_clearBlankEnvShadows(p)).toEqual(['OPENAI_API_KEY']);
+    // Deleted (not blanked) so dotenv's presence check sees it as absent.
+    expect('OPENAI_API_KEY' in process.env).toBe(false);
+  });
+
+  it('treats a whitespace-only ambient value as blank', () => {
+    process.env['AFK_BLANK_SHADOW_PROBE'] = '   ';
+    const p = writeEnvFile('AFK_BLANK_SHADOW_PROBE=real\n');
+
+    expect(_clearBlankEnvShadows(p)).toEqual(['AFK_BLANK_SHADOW_PROBE']);
+    expect('AFK_BLANK_SHADOW_PROBE' in process.env).toBe(false);
+  });
+
+  it('leaves a real ambient value untouched (standard dotenv precedence)', () => {
+    process.env['AFK_REAL_AMBIENT_PROBE'] = 'ambient-wins';
+    const p = writeEnvFile('AFK_REAL_AMBIENT_PROBE=file-value\n');
+
+    expect(_clearBlankEnvShadows(p)).toEqual([]);
+    expect(process.env['AFK_REAL_AMBIENT_PROBE']).toBe('ambient-wins');
+  });
+
+  it('is a no-op when the file value is also blank', () => {
+    process.env['AFK_BLANK_SHADOW_PROBE'] = '';
+    const p = writeEnvFile('AFK_BLANK_SHADOW_PROBE=\n');
+
+    expect(_clearBlankEnvShadows(p)).toEqual([]);
+    expect(process.env['AFK_BLANK_SHADOW_PROBE']).toBe('');
+  });
+
+  it('ignores keys the file does not define', () => {
+    process.env['OPENAI_API_KEY'] = '';
+    const p = writeEnvFile('SOMETHING_ELSE=1\n');
+
+    expect(_clearBlankEnvShadows(p)).toEqual([]);
+    expect(process.env['OPENAI_API_KEY']).toBe('');
+  });
+
+  it('returns [] for an unreadable file instead of throwing', () => {
+    expect(_clearBlankEnvShadows(join(tmpRoot, 'does-not-exist.env'))).toEqual([]);
+  });
+});
+
+describe('loadEnvConfig (real dotenv path)', () => {
+  it('loads the afk.env key even when the shell exports it blank', async () => {
+    // Reproduces the reported failure: blank shell export + real afk.env key.
+    const home = join(tmpRoot, 'afkhome');
+    mkdirSync(join(home, 'config'), { recursive: true });
+    writeFileSync(
+      join(home, 'config', 'afk.env'),
+      'OPENAI_API_KEY=sk-from-afk-env\n',
+      'utf8',
+    );
+    process.env['AFK_HOME'] = home;
+    process.env['OPENAI_API_KEY'] = '';
+
+    // Fresh module instance: `dotenvLoaded` is a deliberate one-shot latch.
+    vi.resetModules();
+    const mod = await import('./env-tier.js');
+    mod.loadEnvConfig();
+
+    expect(process.env['OPENAI_API_KEY']).toBe('sk-from-afk-env');
+  });
+
+  it('still lets a real shell value win over afk.env', async () => {
+    const home = join(tmpRoot, 'afkhome2');
+    mkdirSync(join(home, 'config'), { recursive: true });
+    writeFileSync(
+      join(home, 'config', 'afk.env'),
+      'OPENAI_API_KEY=sk-from-afk-env\n',
+      'utf8',
+    );
+    process.env['AFK_HOME'] = home;
+    process.env['OPENAI_API_KEY'] = 'sk-from-shell';
+
+    vi.resetModules();
+    const mod = await import('./env-tier.js');
+    mod.loadEnvConfig();
+
+    expect(process.env['OPENAI_API_KEY']).toBe('sk-from-shell');
+  });
+});

--- a/src/cli/config/env-tier.ts
+++ b/src/cli/config/env-tier.ts
@@ -6,9 +6,9 @@
 // ESM importers cannot reassign an imported binding (same pattern as
 // `setState()` in the #366 plugin-skills split).
 
-import { existsSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
-import { config as dotenvConfig } from 'dotenv';
+import { config as dotenvConfig, parse as dotenvParse } from 'dotenv';
 import { isValidModel } from '../../agent/session/model-resolution.js';
 import { providerForModel } from '../../agent/providers/index.js';
 import { getEnvConfigPath, getLegacyEnvConfigPath } from '../../paths.js';
@@ -111,6 +111,62 @@ export function _resetOpenAIBaseUrlWarnCache(): void {
   warnedOpenAIBaseUrlSuffix.clear();
 }
 
+/** Warn-once tracker for blank ambient env vars unshadowed by an env file. */
+const warnedBlankEnvShadow = new Set<string>();
+
+/** Test-only hook to reset the blank-shadow warn-once tracker. Internal API. */
+export function _resetBlankEnvShadowWarnCache(): void {
+  warnedBlankEnvShadow.clear();
+}
+
+/**
+ * Invariant: an empty or whitespace-only environment variable carries no
+ * configuration value, so it must never shadow a real value defined by an
+ * afk env file. dotenv's `override: false` skip is PRESENCE-based
+ * (`key in process.env`), not value-based, so a dotfile that exports
+ * `OPENAI_API_KEY=""` — a common idiom for "clear this key" — permanently masks
+ * the real key in `~/.afk/config/afk.env`. The OpenAI auth resolver correctly
+ * treats the blank as absent (`auth.ts` guards `.length > 0`) and falls through
+ * to `~/.codex/auth.json`, so the operator gets a "set OPENAI_API_KEY" error
+ * for a key they demonstrably HAVE set. Same failure shape for any credential.
+ *
+ * Deleting the blank entry for exactly the keys this file defines restores
+ * file-beats-blank precedence while leaving real ambient values authoritative
+ * (standard dotenv behavior is unchanged). Applied before EVERY file in the
+ * chain, so a blank in an earlier file cannot shadow a real value in a later
+ * one either — "blank means unset" holds uniformly at every layer.
+ *
+ * Returns the key names that were unshadowed (never their values).
+ *
+ * Exported under the `_` internal-API prefix (same idiom as the `_reset*` hooks
+ * above) so the precedence rule is unit-testable without driving the whole
+ * `loadEnvConfig()` path, whose `dotenvLoaded` latch is deliberately one-shot.
+ */
+export function _clearBlankEnvShadows(filePath: string): string[] {
+  let parsed: Record<string, string>;
+  try {
+    parsed = dotenvParse(readFileSync(filePath));
+  } catch {
+    // Unreadable/malformed file: let dotenvConfig report it as it always has.
+    return [];
+  }
+
+  const cleared: string[] = [];
+  for (const key of Object.keys(parsed)) {
+    // Keys are arbitrary operator-authored names parsed from the env file, so
+    // they cannot route through the typed `env.X` getters in src/config/env.ts.
+    const ambient = process.env[key]; // audit-env-access: allow dynamic key from parsed env file
+    if (ambient !== undefined && ambient.trim() === '') {
+      // Only unshadow when the file supplies a real replacement — a blank
+      // overriding a blank is a no-op and not worth reporting.
+      if ((parsed[key] ?? '').trim() === '') continue;
+      delete process.env[key]; // audit-env-access: allow dynamic key from parsed env file
+      cleared.push(key);
+    }
+  }
+  return cleared;
+}
+
 export function loadEnvConfig(): Partial<CliConfig> {
   if (envConfigCache !== undefined) return envConfigCache;
   if (!dotenvLoaded) {
@@ -125,7 +181,20 @@ export function loadEnvConfig(): Partial<CliConfig> {
 
     for (const envPath of envPaths) {
       if (existsSync(envPath)) {
+        // Must run BEFORE dotenvConfig: it mutates process.env so dotenv's
+        // presence-based `override: false` check sees the blank as absent.
+        const unshadowed = _clearBlankEnvShadows(envPath);
         dotenvConfig({ path: envPath, override: false });
+        for (const key of unshadowed) {
+          if (warnedBlankEnvShadow.has(key)) continue;
+          warnedBlankEnvShadow.add(key);
+          // eslint-disable-next-line no-console -- one-shot operator UX warning
+          console.warn(
+            `[afk] ${key} is set to an empty value in your shell environment; ` +
+              `using the value from ${envPath} instead.\n` +
+              `      Remove the blank \`export ${key}=""\` from your shell profile to silence this.`,
+          );
+        }
       }
     }
 


### PR DESCRIPTION
## Problem

A shell profile containing `export OPENAI_API_KEY=""` permanently masks the real key in `~/.afk/config/afk.env`.

`loadEnvConfig()` loads each env file with dotenv's `override: false`, and that skip check is **presence-based** (`key in process.env`), not value-based. A blank ambient value therefore wins forever over a real file value.

The symptom was a **misdiagnosis**, which is what made this expensive to debug. `resolveOpenAIAuth()` correctly treats the blank as absent (it guards `.length > 0`), so the chain fell through to `~/.codex/auth.json`, found ChatGPT OAuth credentials there, and emitted:

> Found ChatGPT/OAuth credentials in `~/.codex/auth.json` but the OpenAI provider is in API-key mode. […] Otherwise run `codex login --api-key` or set `OPENAI_API_KEY`.

…telling the operator to set a key they had already set. An openai-compatible-only operator (no Claude or Codex login — e.g. running opencode Zen) hits a hard stop with no actionable signal.

Reproduced on a live install, with `AFK_PROVIDER=openai-compatible` and `AFK_OPENAI_BASE_URL=https://opencode.ai/zen/go/v1`:

| shell | `OPENAI_API_KEY` | result |
|---|---|---|
| interactive (sources `.zshrc` with `export OPENAI_API_KEY=""`) | `""` | ✖ error above |
| same shell + `unset OPENAI_API_KEY` | absent | ✔ works |

Nothing else in that config was wrong — provider routing, base-URL plumbing, model-slot aliases, tool calls, and subagent dispatch all worked once the blank var was out of the way.

## Fix

Before each env file loads, delete ambient entries that are empty or whitespace-only **for exactly the keys that file defines**, so dotenv sees them as absent and the file value applies.

- Real ambient values remain authoritative — standard dotenv precedence is unchanged.
- Applied before every file in the chain, so a blank in an earlier file cannot shadow a real value in a later one either: "blank means unset" holds uniformly at every layer.
- Blank-over-blank is a no-op (not reported).
- A one-shot warning names the shadowed key (**never** its value), so the situation is self-diagnosing next time.

## Tests

Adds `src/cli/config/env-tier.test.ts` (8 cases) driving the **real** dotenv path. `src/cli/config.test.ts` mocks dotenv wholesale, so this precedence rule had zero coverage before.

Negative control — with the fix disabled, the integration case fails with exactly the reported bug:

```
× loadEnvConfig (real dotenv path) > loads the afk.env key even when the shell exports it blank
  → expected '' to be 'sk-from-afk-env'
```

## Gates

- `pnpm lint` (tsc --noEmit) — clean
- `pnpm test` — 723 files, 13,866 passed, 2 skipped
- `pnpm audit:env:check` — clean; the two dynamic `process.env[key]` accesses use keys parsed from an operator-authored file, so they carry the sanctioned inline `audit-env-access: allow` tag rather than a whole-file allowlist entry
- `pnpm audit:sdk:check` — clean
- `env-tier.ts` 243 → 312 LOC, under the 350 ceiling
