### PR TITLE
refactor(tools): extract two named concerns over the 350-LOC ceiling

### DIFF
--- a/src/agent/tools/hooks/afk-home-refs.ts
+++ b/src/agent/tools/hooks/afk-home-refs.ts
@@ -1,0 +1,69 @@
+/**
+ * AFK_HOME spelling concern for the bash-restriction hook.
+ *
+ * Extracted from `bash-restriction-hook.ts` (#782) — a pure move, zero logic
+ * change. The bash hook's lexical scan must match AFK_HOME in whatever spelling
+ * a command uses (raw env value, `$AFK_HOME`, `~`-normal form), so this module
+ * owns the one place AFK_HOME is resolved to a canonical absolute form
+ * ({@link configuredAfkHome}) and the relocated sensitive roots / allowlist
+ * file forms derived from it. Keeping AFK_HOME resolution here means every
+ * downstream consumer shares one spelling and the needle/`includes()` mismatch
+ * documented in the host module cannot recur.
+ *
+ * @module agent/tools/hooks/afk-home-refs
+ */
+
+import path from 'path';
+import { READ_ALLOWLIST_REL, isReadDenied } from '../handlers/read-denylist.js';
+import { getAfkHome } from '../../../paths.js';
+import { warnAfkHomeRejectedOnce } from '../afk-home-warn.js';
+
+/**
+ * Return AFK_HOME's configured absolute spelling, or nothing when malformed.
+ *
+ * Invariant: `path.resolve` here — NOT the raw `getAfkHome()` string — is what
+ * keeps this spelling and the `path.join`-built needles
+ * ({@link relocatedAfkSensitiveRoots}, {@link afkAllowlistFileForms}) in the
+ * same normal form. `getAfkHome()` only rejects non-absolute paths and `/`
+ * (`src/paths.ts`); it does NOT collapse a trailing separator. With
+ * `AFK_HOME=/opt/my-afk/`, substituting the raw string into the command text
+ * produced `/opt/my-afk//config/afk.env` (interior `//`), while
+ * `path.join(afkHome, 'config')` collapses to `/opt/my-afk/config` — a literal
+ * `includes()` between the two then misses, and the command that opens the
+ * very file the guard exists to block sails through. Resolving once, here at
+ * the source, means every downstream consumer of this function's return value
+ * shares one spelling and the mismatch cannot recur.
+ */
+export function configuredAfkHome(): string | undefined {
+  try {
+    return path.resolve(getAfkHome());
+  } catch (err) {
+    warnAfkHomeRejectedOnce(err);
+    return undefined;
+  }
+}
+
+/**
+ * The relocated forms of the read-denylist exact-file carve-outs (`~/.afk/...`
+ * entries under `READ_ALLOWLIST_REL`), in every spelling a bash command can
+ * plausibly use — filtered through {@link isReadDenied} so the precedence
+ * contract of `AFK_READ_DENYLIST` is reused rather than re-derived.
+ *
+ * The absolute form covers a normalized `$AFK_HOME`/`$HOME` command; the
+ * `$AFK_HOME/` form covers the env-var spelling the hook leaves alone until
+ * `configuredAfkHome()` resolves it. Returns `[]` when AFK_HOME is unset or
+ * malformed.
+ */
+export function afkAllowlistFileForms(afkHome: string): string[] {
+  return READ_ALLOWLIST_REL.flatMap((rel) => {
+    if (!rel.startsWith('.afk/')) return [];
+    const relocated = path.join(afkHome, rel.slice('.afk/'.length));
+    if (isReadDenied(relocated).denied) return [];
+    return [relocated, `$AFK_HOME/${rel.slice('.afk/'.length)}`];
+  });
+}
+
+export function relocatedAfkSensitiveRoots(): string[] {
+  const afkHome = configuredAfkHome();
+  return afkHome === undefined ? [] : [path.join(afkHome, 'config')];
+}

--- a/src/agent/tools/hooks/bash-restriction-hook.ts
+++ b/src/agent/tools/hooks/bash-restriction-hook.ts
@@ -85,8 +85,11 @@ import {
   parseReadDenylistEntries,
 } from '../handlers/read-denylist.js';
 import { env } from '../../../config/env.js';
-import { getAfkHome } from '../../../paths.js';
-import { warnAfkHomeRejectedOnce } from '../afk-home-warn.js';
+import {
+  configuredAfkHome,
+  afkAllowlistFileForms,
+  relocatedAfkSensitiveRoots,
+} from './afk-home-refs.js';
 
 /**
  * Interpreter denylist regex. Matches `<interpreter> -<flag>` where flag is
@@ -332,36 +335,6 @@ function normalizeHomeRefs(command: string, home: string, afkHome: string | unde
  */
 const PATH_LIKE_SPAN = /\/[^\s'"`;|&()<>]*/g;
 
-/**
- * Return AFK_HOME's configured absolute spelling, or nothing when malformed.
- *
- * Invariant: `path.resolve` here — NOT the raw `getAfkHome()` string — is what
- * keeps this spelling and the `path.join`-built needles
- * ({@link relocatedAfkSensitiveRoots}, {@link allowlistedFileForms}) in the
- * same normal form. `getAfkHome()` only rejects non-absolute paths and `/`
- * (`src/paths.ts`); it does NOT collapse a trailing separator. With
- * `AFK_HOME=/opt/my-afk/`, substituting the raw string into the command text
- * produced `/opt/my-afk//config/afk.env` (interior `//`), while
- * `path.join(afkHome, 'config')` collapses to `/opt/my-afk/config` — a literal
- * `includes()` between the two then misses, and the command that opens the
- * very file the guard exists to block sails through. Resolving once, here at
- * the source, means every downstream consumer of this function's return value
- * shares one spelling and the mismatch cannot recur.
- */
-function configuredAfkHome(): string | undefined {
-  try {
-    return path.resolve(getAfkHome());
-  } catch (err) {
-    warnAfkHomeRejectedOnce(err);
-    return undefined;
-  }
-}
-
-function relocatedAfkSensitiveRoots(): string[] {
-  const afkHome = configuredAfkHome();
-  return afkHome === undefined ? [] : [path.join(afkHome, 'config')];
-}
-
 /** Placeholder left behind by {@link scrubAllowlistedRefs}. Deliberately free of
  * any path characters so it can never itself satisfy a root or signal match. */
 const ALLOWLISTED_PLACEHOLDER = '<allowlisted-file>';
@@ -382,6 +355,11 @@ function escapeRegExp(literal: string): string {
  * alone (`expanduser('~/.afk/config/mcp.json')`). The `$HOME/` form is
  * unreachable while normalization runs first, and is kept as the one spelling
  * that would silently stop being carved out if that order ever changed.
+ *
+ * The AFK_HOME-relocated forms (the `$AFK_HOME/...` spellings and their
+ * resolved absolute twin) live in {@link afkAllowlistFileForms}; this function
+ * builds only the home-anchored forms and merges in the AFK-anchored set when
+ * AFK_HOME is configured, preserving the original deduped union.
  */
 function allowlistedFileForms(home: string, afkHome: string | undefined): string[] {
   const homeForms = READ_ALLOWLIST_REL.flatMap((rel) => {
@@ -390,12 +368,7 @@ function allowlistedFileForms(home: string, afkHome: string | undefined): string
   });
   if (afkHome === undefined) return homeForms;
 
-  const afkForms = READ_ALLOWLIST_REL.flatMap((rel) => {
-    if (!rel.startsWith('.afk/')) return [];
-    const relocated = path.join(afkHome, rel.slice('.afk/'.length));
-    if (isReadDenied(relocated).denied) return [];
-    return [relocated, `$AFK_HOME/${rel.slice('.afk/'.length)}`];
-  });
+  const afkForms = afkAllowlistFileForms(afkHome);
   return [...new Set([...homeForms, ...afkForms])];
 }
 

--- a/src/agent/tools/subagent/input-parse.ts
+++ b/src/agent/tools/subagent/input-parse.ts
@@ -8,76 +8,10 @@
  * @module agent/tools/subagent/input-parse
  */
 
-import { isAbsolute, parse as parsePath, resolve as resolvePath, relative as relativePath } from 'node:path';
-import { homedir } from 'node:os';
+import { isAbsolute, resolve as resolvePath } from 'node:path';
 import { isReadDenied } from '../handlers/read-denylist.js';
 import { realpathSafe } from '../handlers/_cwd-utils.js';
-import { getAfkHome, getAfkStateDir } from '../../../paths.js';
-import { warnAfkHomeRejectedOnce } from '../afk-home-warn.js';
-
-// Home targets for the shared breadth guard below. Computed once at module
-// scope — `homedir()` is stable per process, so there is no need to
-// re-resolve it on every `parseAgentInput` call. Check against BOTH the
-// lexical home and its realpath: if the home dir is itself behind a symlink,
-// a symlink-resolved candidate would otherwise slip past a lexical-only home
-// comparison.
-const HOME_TARGETS: readonly string[] = [...new Set([homedir(), realpathSafe(homedir())])];
-
-/**
- * The AFK-anchored breadth targets, resolved PER CALL rather than at module
- * scope.
- *
- * Invariant: unlike `homedir()`, these are env-driven (`AFK_HOME`,
- * `AFK_STATE_DIR`) and therefore NOT stable per process — hoisting them would
- * snapshot one spelling at import and never observe a runtime relocation. This
- * is the same trap the read denylist documents: derive inside the call, not at
- * module scope.
- *
- * Why they belong in the breadth guard at all: a granted root that is at-or-
- * above the AFK home empties that child's AFK-anchored credential floor by
- * exactly the route `$HOME` emptied the home-anchored one. The bash hook's
- * grant filter (`deriveRestrictedSubstrings`) drops any candidate an ancestor
- * of which has been granted, and `${AFK_HOME}/config` is such a candidate. A
- * relocated `AFK_HOME` (say `/opt/my-afk`) is neither the home dir nor an
- * ancestor of it, so the home-only targets did not catch it.
- *
- * A malformed env var throws; caught and skipped so a bad value can never
- * loosen the guard, and surfaced once via the shared warn latch.
- */
-function afkBreadthTargets(): string[] {
-  const targets: string[] = [];
-  for (const derive of [getAfkHome, getAfkStateDir]) {
-    try {
-      const dir = derive();
-      targets.push(dir, realpathSafe(dir));
-    } catch (err) {
-      warnAfkHomeRejectedOnce(err);
-    }
-  }
-  return targets;
-}
-
-/**
- * True when `candidate` is "too broad" to pre-grant as a `cwd`, `writeRoots`,
- * or `readRoots` entry: a filesystem root, the home dir itself, or an
- * ANCESTOR of home (home lexically inside it → relative(candidate, home)
- * neither escapes with '..' nor is absolute).
- *
- * Shared by all three fields (#740): each one ends up in the child's grant
- * snapshot and feeds the bash-restriction hook's grant filter
- * (`deriveRestrictedSubstrings`), where an ancestor-based containment check
- * drops any credential root beneath a granted path. A too-broad grant on ANY
- * of the three — not just `readRoots`, which already carried this guard —
- * silently empties that child's credential floor, so the rejection must be
- * identical across all three call sites.
- */
-function isTooBroadRoot(candidate: string): boolean {
-  if (candidate === parsePath(candidate).root) return true;
-  return [...HOME_TARGETS, ...afkBreadthTargets()].some((h) => {
-    const rel = relativePath(candidate, h);
-    return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
-  });
-}
+import { isTooBroadRoot } from './root-validation.js';
 
 export type AgentExecutionMode = 'foreground' | 'background';
 

--- a/src/agent/tools/subagent/root-validation.ts
+++ b/src/agent/tools/subagent/root-validation.ts
@@ -1,0 +1,85 @@
+/**
+ * The path-root breadth guard: rejects a `cwd`, `writeRoots`, or `readRoots`
+ * entry that is a filesystem root, the home dir, an ancestor of home, or an
+ * AFK-anchored credential root.
+ *
+ * Extracted from `input-parse.ts` (#782) — a pure move, zero logic change. The
+ * host file's three grant fields (`cwd`, `writeRoots`, `readRoots`) each feed
+ * the child's grant snapshot and the bash-restriction hook's grant filter
+ * (`deriveRestrictedSubstrings`), where an ancestor-based containment check
+ * drops any credential root beneath a granted path; a too-broad grant on ANY
+ * of the three silently empties that child's credential floor, so the rejection
+ * must be identical across all three call sites.
+ *
+ * @module agent/tools/subagent/root-validation
+ */
+
+import { isAbsolute, parse as parsePath, relative as relativePath } from 'node:path';
+import { homedir } from 'node:os';
+import { realpathSafe } from '../handlers/_cwd-utils.js';
+import { getAfkHome, getAfkStateDir } from '../../../paths.js';
+import { warnAfkHomeRejectedOnce } from '../afk-home-warn.js';
+
+// Home targets for the shared breadth guard below. Computed once at module
+// scope — `homedir()` is stable per process, so there is no need to
+// re-resolve it on every `parseAgentInput` call. Check against BOTH the
+// lexical home and its realpath: if the home dir is itself behind a symlink,
+// a symlink-resolved candidate would otherwise slip past a lexical-only home
+// comparison.
+const HOME_TARGETS: readonly string[] = [...new Set([homedir(), realpathSafe(homedir())])];
+
+/**
+ * The AFK-anchored breadth targets, resolved PER CALL rather than at module
+ * scope.
+ *
+ * Invariant: unlike `homedir()`, these are env-driven (`AFK_HOME`,
+ * `AFK_STATE_DIR`) and therefore NOT stable per process — hoisting them would
+ * snapshot one spelling at import and never observe a runtime relocation. This
+ * is the same trap the read denylist documents: derive inside the call, not at
+ * module scope.
+ *
+ * Why they belong in the breadth guard at all: a granted root that is at-or-
+ * above the AFK home empties that child's AFK-anchored credential floor by
+ * exactly the route `$HOME` emptied the home-anchored one. The bash hook's
+ * grant filter (`deriveRestrictedSubstrings`) drops any candidate an ancestor
+ * of which has been granted, and `${AFK_HOME}/config` is such a candidate. A
+ * relocated `AFK_HOME` (say `/opt/my-afk`) is neither the home dir nor an
+ * ancestor of it, so the home-only targets did not catch it.
+ *
+ * A malformed env var throws; caught and skipped so a bad value can never
+ * loosen the guard, and surfaced once via the shared warn latch.
+ */
+function afkBreadthTargets(): string[] {
+  const targets: string[] = [];
+  for (const derive of [getAfkHome, getAfkStateDir]) {
+    try {
+      const dir = derive();
+      targets.push(dir, realpathSafe(dir));
+    } catch (err) {
+      warnAfkHomeRejectedOnce(err);
+    }
+  }
+  return targets;
+}
+
+/**
+ * True when `candidate` is "too broad" to pre-grant as a `cwd`, `writeRoots`,
+ * or `readRoots` entry: a filesystem root, the home dir itself, or an
+ * ANCESTOR of home (home lexically inside it → relative(candidate, home)
+ * neither escapes with '..' nor is absolute).
+ *
+ * Shared by all three fields (#740): each one ends up in the child's grant
+ * snapshot and feeds the bash-restriction hook's grant filter
+ * (`deriveRestrictedSubstrings`), where an ancestor-based containment check
+ * drops any credential root beneath a granted path. A too-broad grant on ANY
+ * of the three — not just `readRoots`, which already carried this guard —
+ * silently empties that child's credential floor, so the rejection must be
+ * identical across all three call sites.
+ */
+export function isTooBroadRoot(candidate: string): boolean {
+  if (candidate === parsePath(candidate).root) return true;
+  return [...HOME_TARGETS, ...afkBreadthTargets()].some((h) => {
+    const rel = relativePath(candidate, h);
+    return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+  });
+}


### PR DESCRIPTION
Closes #782.

## Summary

Pure-move refactor: extracts the two named concerns #782 calls out, with **zero logic change**. Both files were over the project's 350-LOC ceiling.

| file | before | after | concern extracted |
|---|---|---|---|
| `src/agent/tools/subagent/input-parse.ts` | 528 | 462 | path-root breadth guard -> `root-validation.ts` |
| `src/agent/tools/hooks/bash-restriction-hook.ts` | 584 | 557 | AFK_HOME spelling -> `afk-home-refs.ts` |

### `input-parse.ts` -> `src/agent/tools/subagent/root-validation.ts`
Moves `isTooBroadRoot`, `HOME_TARGETS`, and `afkBreadthTargets` (the realpath helper they share, `realpathSafe`, is already its own module). The breadth guard is called from exactly three sites -- `cwd`, `writeRoots`, `readRoots` -- so the seam was already clean; `root-validation.ts` exports only `isTooBroadRoot`.

### `bash-restriction-hook.ts` -> `src/agent/tools/hooks/afk-home-refs.ts`
Moves `configuredAfkHome`, `relocatedAfkSensitiveRoots`, and the relocated forms inside `allowlistedFileForms` (now `afkAllowlistFileForms`, imported by the host and merged with the home-anchored forms, preserving the original deduped union). The now-unused `getAfkHome` / `warnAfkHomeRejectedOnce` imports are dropped from the host.

## Constraint (per #782)
> These are **pure moves** -- zero logic change. Every existing test must pass unchanged; that is the gate.

No function bodies, control flow, or import semantics changed -- only where each symbol lives. The moved code keeps its full explanatory comments.

## Verification
- `pnpm lint` (`tsc --noEmit`, strict) -- clean
- `pnpm build` -- clean
- Direct tests **unchanged, all pass**: `bash-restriction-hook.test.ts` (75) + `input-parse.test.ts` (105) = 180 pass
- Full suite: **723 files, 13866 passed** | 2 skipped

## Notes
Both files remain over the 350 ceiling after this move (they carry substantial load-bearing security-threat-model comments the issue itself documents as irreducible for the accidental-prevention floor). #782 frames the size-check CI gate as "arguably the more durable half of this issue" -- a separate proposal -- so this PR delivers only the two named extractions, as specified. If either extraction had not been confidently behavior-preserving, #782 asks to leave the file alone; both were clean seams and verified by the unchanged suites.