### PR TITLE
fix(telegram): accept common truthy values for TELEGRAM_VERBOSE

### DIFF
--- a/docs/env-registry.json
+++ b/docs/env-registry.json
@@ -1096,7 +1096,7 @@
     },
     {
       "name": "TELEGRAM_VERBOSE",
-      "description": "Set to 'true' to log per-message details from the Telegram bot — chat IDs, message text, latency. (The code checks the literal string 'true'.)",
+      "description": "Set to a truthy value ('1'/'true'/'yes'/'on', case-insensitive) to log per-message details from the Telegram bot — chat IDs, message text, latency.",
       "type": "boolean",
       "required": false,
       "example": "true",

--- a/docs/env-registry.md
+++ b/docs/env-registry.md
@@ -79,7 +79,7 @@ To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV
 | `AFK_TELEGRAM_TAG_ONLY_CHAT_IDS` | string |  |  | `-100987654321,123456789` | Comma-separated list of Telegram chat IDs where the bot answers only when addressed (a reply to the bot, an @mention of the bot, or a text_mention resolving to the bot). Slash-commands are unaffected; chats not listed behave as usual. The afk.config.json telegram.tagOnlyChats block takes precedence. Requires Telegram privacy mode OFF (BotFather /setprivacy Disable) for non-addressed group messages to reach the bot. |
 | `TELEGRAM_BOT_TOKEN` | string |  |  |  | Telegram bot token from @BotFather. Required to run the Telegram bot surface. |
 | `TELEGRAM_DATA_DIR` | string |  |  |  | Override the directory where Telegram bot state is stored. Defaults to ~/.afk/state/telegram/. |
-| `TELEGRAM_VERBOSE` | boolean |  |  | `true` | Set to 'true' to log per-message details from the Telegram bot — chat IDs, message text, latency. (The code checks the literal string 'true'.) |
+| `TELEGRAM_VERBOSE` | boolean |  |  | `true` | Set to a truthy value ('1'/'true'/'yes'/'on', case-insensitive) to log per-message details from the Telegram bot — chat IDs, message text, latency. |
 
 ## Paths
 

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -722,7 +722,7 @@ export const ENV_REGISTRY: readonly EnvVarMeta[] = [
   },
   {
     name: 'TELEGRAM_VERBOSE',
-    description: "Set to 'true' to log per-message details from the Telegram bot — chat IDs, message text, latency. (The code checks the literal string 'true'.)",
+    description: "Set to a truthy value ('1'/'true'/'yes'/'on', case-insensitive) to log per-message details from the Telegram bot — chat IDs, message text, latency.",
     type: 'boolean',
     required: false,
     example: 'true',

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -209,7 +209,7 @@ async function main() {
     apiKey: config.apiKey ?? '',
     dataDir: env.TELEGRAM_DATA_DIR || './data/telegram-sessions',
     defaultModel: config.model as AgentModelInput,
-    verbose: env.TELEGRAM_VERBOSE === 'true',
+    verbose: ['1', 'true', 'yes', 'on'].includes((env.TELEGRAM_VERBOSE ?? '').trim().toLowerCase()),
     allowedChatIds,
     tagOnlyChats,
     // Only meaningful for the Anthropic provider — the Codex adapter


### PR DESCRIPTION
## Summary
`TELEGRAM_VERBOSE` is declared `type: 'boolean'` in the env registry, but `src/telegram.ts` only honored the exact literal string `'true'` (`env.TELEGRAM_VERBOSE === 'true'`). Setting `TELEGRAM_VERBOSE=1` (or `yes`/`on`/`TRUE`) silently no-op'd, unlike every other VERBOSE-style flag in the codebase (`AFK_SKILL_STREAM_VERBOSE`, `AFK_DEBUG`, etc.), which accept the common truthy set.

Widened the check to `['1', 'true', 'yes', 'on'].includes(...)` (trimmed, case-insensitive), matching the declared boolean type. Also simplified the `ENV_REGISTRY` description in `src/config/env.ts` that previously called out the literal-`'true'`-only strictness (added by #681), since that sharp edge is now gone — and regenerated `docs/env-registry.{json,md}` via `pnpm scan:env` to keep the CI-gated docs in sync.

No test added — see rationale below.

## How was it tested?
- `pnpm lint` (`tsc --noEmit`, strict) — clean, no errors.
- `pnpm scan:env:check` — `docs/env-registry.{json,md}` in sync with `src/config/env.ts` (139 vars).
- `pnpm audit:env:check` — 0 violations.
- `pnpm test src/config/env.test.ts` — 20/20 passed.
- `pnpm test src/telegram/manager.test.ts` — 5/5 passed.
- Full suite: `pnpm test` — 723 test files, 13866 tests passed, 2 pre-existing skips, 0 failures.

**Test added?** No. The `verbose:` line lives inline in `src/telegram.ts`'s `main()`, which runs unconditionally at import time (`main().catch(...)`, no `import.meta` guard) and only reaches this line after config load, credential resolution, and a live `validateBotToken()` network call — there's no existing `src/telegram.ts` test to extend. Extracting a helper just to unit-test one boolean expression would duplicate the `envFlagEnabled`/`parseBooleanEnv` helpers that already exist elsewhere in the codebase for other flags, which is out of scope for a one-line fix. Per the issue's own guidance, a brittle integration test was not forced.

## Checklist
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/) — see [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] No secrets, tokens, or private paths in the diff

Closes #683
