### PR TITLE
fix(provider): re-render the # Environment date line per turn in openai-compatible (#785)

### DIFF
--- a/src/agent/providers/anthropic-direct/query/date-rollover.ts
+++ b/src/agent/providers/anthropic-direct/query/date-rollover.ts
@@ -1,80 +1,13 @@
 /**
- * Mid-session date-rollover refresh for the `# Environment` block.
+ * Re-export shim — the canonical implementation has moved to
+ * `../../shared/date-rollover.ts`.
  *
- * Invariant: the `- Date:` line the model reads must name TODAY, not the day
- * the session happened to start. The assembled system prompt is built once per
- * `provider.query()` — i.e. once per session — and re-spliced only by
- * `setCwd()` (`query/cwd-dependents.ts`), so a session that outlives local
- * midnight otherwise reports its start date for the rest of its life. That hits
- * exactly the surfaces that stay resident: an overnight REPL, the long-lived
- * Telegram bot's per-chat session, and any resumed session. One-shot `chat` and
- * daemon cron ticks are unaffected — each builds a fresh prompt.
- *
- * The refresh is gated on the RENDERED DATE STRING changing, never on the clock
- * ticking: {@link refreshEnvironmentDate} returns its input by reference on
- * every turn within the same local day, so the prompt-cache breakpoint stamped
- * on the system block is invalidated at most once per midnight crossing rather
- * than once per turn. PR #268 accepted the staleness precisely to avoid a
- * per-turn cache bust; that rationale conflated "recompute the date" with "emit
- * a different date", and only the latter costs anything. `setCwd()` already
- * re-splices this same block mid-session, so a mid-session mutation here is not
- * a new class of event.
+ * This file is kept so existing imports (`./date-rollover.js` from
+ * `query.ts`) continue to resolve without modification.
  *
  * @module agent/providers/anthropic-direct/query/date-rollover
  */
 
-import { formatEnvironmentDateLine } from '../../../awareness/index.js';
-
-const ENV_ANCHOR = '# Environment\n- Working directory: ';
-const DATE_PREFIX = '- Date: ';
-
-/**
- * Return `systemPrompt` with its `# Environment` date line re-rendered for
- * `now`, or the identical string when nothing needs to change.
- *
- * Contract:
- * - Returns the input by reference when the rendered date is unchanged, when
- *   the `# Environment` anchor is absent, or when the block's shape does not
- *   match what `formatEnvironmentFragment` emits. Never throws; a prompt it
- *   cannot parse is passed through untouched, so an unrecognised shape
- *   degrades to today's (stale-date) behaviour rather than to a corrupt
- *   prompt.
- * - Rewrites exactly one line and preserves every other byte, including the
- *   trailing `- Session:` / `- Workspace:` lines and the manifest that follows.
- * - Anchors on the LAST `# Environment\n- Working directory: ` occurrence. The
- *   assembler (`query/system-prompt.ts`) always splices the real fragment
- *   second-to-last, after the operator overlay and hot memory, so a decoy block
- *   inside user-supplied text can never win.
- *
- * @param systemPrompt Assembled system prompt from `assembleSystemPrompt`.
- * @param now Clock, injectable for deterministic tests. Defaults to `new Date()`.
- * @param timeZone IANA zone; defaults to the host zone, as at assembly time.
- */
-export function refreshEnvironmentDate(
-  systemPrompt: string,
-  now?: Date,
-  timeZone?: string,
-): string {
-  const anchor = systemPrompt.lastIndexOf(ENV_ANCHOR);
-  if (anchor === -1) return systemPrompt;
-
-  // The cwd line runs to its own newline; the date line is the next one.
-  const cwdLineEnd = systemPrompt.indexOf('\n', anchor + ENV_ANCHOR.length);
-  if (cwdLineEnd === -1) return systemPrompt;
-
-  const dateLineStart = cwdLineEnd + 1;
-  if (!systemPrompt.startsWith(DATE_PREFIX, dateLineStart)) return systemPrompt;
-
-  const nextNewline = systemPrompt.indexOf('\n', dateLineStart);
-  const dateLineEnd = nextNewline === -1 ? systemPrompt.length : nextNewline;
-
-  const current = systemPrompt.slice(dateLineStart + DATE_PREFIX.length, dateLineEnd);
-  const fresh = formatEnvironmentDateLine(now ?? new Date(), timeZone);
-  if (current === fresh) return systemPrompt;
-
-  return (
-    systemPrompt.slice(0, dateLineStart + DATE_PREFIX.length) +
-    fresh +
-    systemPrompt.slice(dateLineEnd)
-  );
-}
+export {
+  refreshEnvironmentDate,
+} from '../../shared/date-rollover.js';

--- a/src/agent/providers/openai-compatible/date-rollover-system-payload.test.ts
+++ b/src/agent/providers/openai-compatible/date-rollover-system-payload.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Integration test for mid-session date rollover in the openai-compatible
+ * provider's system payload — the twin of
+ * `anthropic-direct/date-rollover-system-payload.test.ts` for issue #785.
+ *
+ * `OpenAICompatibleProvider.query()` assembles the `# Environment` fragment
+ * (and the rest of the system prompt) ONCE per `query()` call, exactly like
+ * anthropic-direct's `userSystem`. Before the fix, `buildMessages()`
+ * (messages.ts) read that frozen string on every turn via
+ * `resolveSystemPrompt()`, so a session resident across local midnight kept
+ * sending yesterday's `- Date:` line for the rest of its life. The fix calls
+ * `refreshEnvironmentDate()` on the resolved system string inside
+ * `buildMessages()`, which runs once per `runIteration()` — i.e. once per turn.
+ *
+ * Asserted at the `chat.completions.create` boundary — the closest observable
+ * point to what the model actually sees. Only `Date` is faked; timers stay
+ * real so the streaming machinery is untouched. The two instants are 48h
+ * apart so the local date differs in EVERY host timezone, keeping the
+ * assertion valid on the ubuntu/macos/windows CI legs.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type OpenAI from 'openai';
+import type { AgentConfig } from '../../types/config-types.js';
+import type { ProviderUserTurn } from '../../provider.js';
+import { __setOpenAIClientFactory, type OpenAIClientFactory } from './query.js';
+import { OpenAICompatibleProvider } from './index.js';
+import type { OpenAIChunk } from './translate.js';
+
+const createCalls: Array<{ args: { messages: Array<{ role: string; content: string }> } }> = [];
+let callCount = 0;
+let rollAt: Date | null = null;
+
+function makeTextStream(text: string): OpenAIChunk[] {
+  return [
+    { choices: [{ delta: { content: text } }] },
+    {
+      choices: [{ delta: {}, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 5, completion_tokens: 1, total_tokens: 6 },
+    },
+  ];
+}
+
+/** Roll the fake clock to `rollAt` right after the FIRST `create()` call is
+ * recorded — mirrors `rollClockAfterFirstCall` in the anthropic-direct sibling
+ * test, so turn 2's `buildMessages()` runs on the far side of the rollover. */
+function installClockRollingClient(): void {
+  const factory: OpenAIClientFactory = () =>
+    ({
+      chat: {
+        completions: {
+          create: async (args: { stream?: boolean }) => {
+            if (!args.stream) throw new Error('mock only supports streaming mode');
+            createCalls.push({ args: args as never });
+            callCount += 1;
+            if (callCount === 1 && rollAt !== null) vi.setSystemTime(rollAt);
+            const chunks = makeTextStream('ok');
+            return (async function* () {
+              for (const c of chunks) yield c;
+            })();
+          },
+        },
+      },
+    }) as unknown as OpenAI;
+  __setOpenAIClientFactory(factory);
+}
+
+async function* twoTurns(): AsyncIterable<ProviderUserTurn> {
+  yield { content: 'first' };
+  yield { content: 'second' };
+}
+
+async function drain(query: AsyncIterable<unknown>): Promise<void> {
+  for await (const _ev of query) {
+    void _ev;
+  }
+}
+
+function runTwoTurns(): AsyncIterable<unknown> {
+  const provider = new OpenAICompatibleProvider();
+  return provider.query({
+    prompt: twoTurns(),
+    config: { model: 'gpt-4o-mini', apiKey: 'sk-test-key' } as AgentConfig,
+  }) as AsyncIterable<unknown>;
+}
+
+function systemTextOfCall(i: number): string {
+  return createCalls[i]?.args.messages[0]?.content ?? '';
+}
+
+function dateLineOf(systemText: string): string | undefined {
+  return systemText.split('\n').find((l) => l.startsWith('- Date: '));
+}
+
+const DAY_ONE = new Date('2026-07-30T12:00:00Z');
+const DAY_THREE = new Date('2026-08-01T12:00:00Z'); // +48h: a different local date everywhere
+
+describe('OpenAICompatibleQuery — mid-session date rollover (#785)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(DAY_ONE);
+    createCalls.length = 0;
+    callCount = 0;
+    rollAt = null;
+    __setOpenAIClientFactory(null);
+    installClockRollingClient();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    __setOpenAIClientFactory(null);
+  });
+
+  it('re-renders the Date line on the turn after the local day changes', async () => {
+    rollAt = DAY_THREE;
+    await drain(runTwoTurns());
+
+    expect(createCalls.length).toBeGreaterThanOrEqual(2);
+    const first = dateLineOf(systemTextOfCall(0));
+    const second = dateLineOf(systemTextOfCall(1));
+
+    expect(first).toMatch(/^- Date: \w+, \d{4}-\d{2}-\d{2} \(.+\)$/);
+    expect(second).toMatch(/^- Date: \w+, \d{4}-\d{2}-\d{2} \(.+\)$/);
+    expect(second).not.toBe(first);
+  });
+
+  // Cache economics: the same-day payload must be byte-identical — ideally
+  // the same string reference — which is what proves the fix does not churn
+  // the request payload (and, on backends that cache by prefix, the
+  // prompt-cache breakpoint) on every turn. `refreshEnvironmentDate` returns
+  // its input by reference when the rendered date is unchanged, and
+  // `resolveSystemPrompt` reads the same frozen `config.systemPrompt` string
+  // every turn, so the `content` sent on turn 2 is the same value (and
+  // reference, for the underlying string) as the one sent on turn 1.
+  it('leaves the system payload untouched (same reference) across turns within the same day', async () => {
+    rollAt = null;
+    await drain(runTwoTurns());
+
+    expect(createCalls.length).toBeGreaterThanOrEqual(2);
+    const first = systemTextOfCall(0);
+    const second = systemTextOfCall(1);
+    expect(second).toBe(first);
+  });
+});

--- a/src/agent/providers/openai-compatible/index.ts
+++ b/src/agent/providers/openai-compatible/index.ts
@@ -173,11 +173,13 @@ export class OpenAICompatibleProvider implements ModelProvider {
       schemas.push(...memoryToolSchemas);
     }
     // Awareness layer (Phase 1) — parity with anthropic-direct. The
-    // system-prompt identity fragment is NOT added here because the
-    // openai-compatible message builder (messages.ts) does not currently
-    // emit a `# Environment` block at all — extending it is Phase 2 work.
-    // The `get_runtime_state` tool remains available so the model can
-    // pull identity on demand.
+    // system-prompt identity fragment is NOT built here: it's assembled
+    // per-query below (`envFragment`, Phase 2, ~line 325) once `config.cwd`
+    // and `runtimeStateSource` are available, then re-rendered per turn by
+    // `refreshEnvironmentDate()` in messages.ts so a resident session's
+    // `# Environment` block never goes stale across a local midnight. The
+    // `get_runtime_state` tool remains available so the model can also pull
+    // identity on demand.
     schemas.push(getRuntimeStateTool);
     // Custom (consumer-registered) tool schemas are appended last so their
     // names never silently shadow a builtin. A custom schema whose name

--- a/src/agent/providers/openai-compatible/messages.ts
+++ b/src/agent/providers/openai-compatible/messages.ts
@@ -12,6 +12,7 @@
 import type { ContentBlockParam } from '@anthropic-ai/sdk/resources';
 import type { AgentConfig, ResumeHistoryTurn } from '../../types/config-types.js';
 import type { ProviderUserTurn } from '../../provider.js';
+import { refreshEnvironmentDate } from '../shared/date-rollover.js';
 
 /**
  * A single OpenAI Chat Completions content part. The multimodal `content`
@@ -227,7 +228,14 @@ export function buildMessages(args: {
 
   const sys = resolveSystemPrompt(args.config);
   if (sys !== undefined) {
-    messages.push({ role: 'system', content: sys });
+    // Invariant: buildMessages() runs once per runIteration() — i.e. once per
+    // turn — so re-rendering the `# Environment` date line here (rather than
+    // once at session construction) is what keeps a resident session's
+    // reported date current across a local-midnight crossing. Mirrors the
+    // anthropic-direct fix in query.ts; see providers/shared/date-rollover.ts
+    // for why this is safe for the prompt-cache: the string is returned by
+    // reference on same-day turns.
+    messages.push({ role: 'system', content: refreshEnvironmentDate(sys) });
   }
 
   if (args.resumeHistory) {

--- a/src/agent/providers/shared/date-rollover.test.ts
+++ b/src/agent/providers/shared/date-rollover.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { refreshEnvironmentDate } from './date-rollover.js';
-import { formatEnvironmentFragment } from '../../../awareness/index.js';
-import { assembleSystemPrompt, buildStableSystemPrefix } from './system-prompt.js';
+import { formatEnvironmentFragment } from '../../awareness/index.js';
+import { assembleSystemPrompt, buildStableSystemPrefix } from '../anthropic-direct/query/system-prompt.js';
 
 const TZ = 'America/New_York';
 /** 2026-07-30 18:00 UTC = Thursday 14:00 in New York. */

--- a/src/agent/providers/shared/date-rollover.ts
+++ b/src/agent/providers/shared/date-rollover.ts
@@ -1,0 +1,80 @@
+/**
+ * Mid-session date-rollover refresh for the `# Environment` block.
+ *
+ * Invariant: the `- Date:` line the model reads must name TODAY, not the day
+ * the session happened to start. The assembled system prompt is built once per
+ * `provider.query()` — i.e. once per session — and re-spliced only by
+ * `setCwd()` (`query/cwd-dependents.ts`), so a session that outlives local
+ * midnight otherwise reports its start date for the rest of its life. That hits
+ * exactly the surfaces that stay resident: an overnight REPL, the long-lived
+ * Telegram bot's per-chat session, and any resumed session. One-shot `chat` and
+ * daemon cron ticks are unaffected — each builds a fresh prompt.
+ *
+ * The refresh is gated on the RENDERED DATE STRING changing, never on the clock
+ * ticking: {@link refreshEnvironmentDate} returns its input by reference on
+ * every turn within the same local day, so the prompt-cache breakpoint stamped
+ * on the system block is invalidated at most once per midnight crossing rather
+ * than once per turn. PR #268 accepted the staleness precisely to avoid a
+ * per-turn cache bust; that rationale conflated "recompute the date" with "emit
+ * a different date", and only the latter costs anything. `setCwd()` already
+ * re-splices this same block mid-session, so a mid-session mutation here is not
+ * a new class of event.
+ *
+ * @module agent/providers/shared/date-rollover
+ */
+
+import { formatEnvironmentDateLine } from '../../awareness/index.js';
+
+const ENV_ANCHOR = '# Environment\n- Working directory: ';
+const DATE_PREFIX = '- Date: ';
+
+/**
+ * Return `systemPrompt` with its `# Environment` date line re-rendered for
+ * `now`, or the identical string when nothing needs to change.
+ *
+ * Contract:
+ * - Returns the input by reference when the rendered date is unchanged, when
+ *   the `# Environment` anchor is absent, or when the block's shape does not
+ *   match what `formatEnvironmentFragment` emits. Never throws; a prompt it
+ *   cannot parse is passed through untouched, so an unrecognised shape
+ *   degrades to today's (stale-date) behaviour rather than to a corrupt
+ *   prompt.
+ * - Rewrites exactly one line and preserves every other byte, including the
+ *   trailing `- Session:` / `- Workspace:` lines and the manifest that follows.
+ * - Anchors on the LAST `# Environment\n- Working directory: ` occurrence. The
+ *   assembler (`query/system-prompt.ts`) always splices the real fragment
+ *   second-to-last, after the operator overlay and hot memory, so a decoy block
+ *   inside user-supplied text can never win.
+ *
+ * @param systemPrompt Assembled system prompt from `assembleSystemPrompt`.
+ * @param now Clock, injectable for deterministic tests. Defaults to `new Date()`.
+ * @param timeZone IANA zone; defaults to the host zone, as at assembly time.
+ */
+export function refreshEnvironmentDate(
+  systemPrompt: string,
+  now?: Date,
+  timeZone?: string,
+): string {
+  const anchor = systemPrompt.lastIndexOf(ENV_ANCHOR);
+  if (anchor === -1) return systemPrompt;
+
+  // The cwd line runs to its own newline; the date line is the next one.
+  const cwdLineEnd = systemPrompt.indexOf('\n', anchor + ENV_ANCHOR.length);
+  if (cwdLineEnd === -1) return systemPrompt;
+
+  const dateLineStart = cwdLineEnd + 1;
+  if (!systemPrompt.startsWith(DATE_PREFIX, dateLineStart)) return systemPrompt;
+
+  const nextNewline = systemPrompt.indexOf('\n', dateLineStart);
+  const dateLineEnd = nextNewline === -1 ? systemPrompt.length : nextNewline;
+
+  const current = systemPrompt.slice(dateLineStart + DATE_PREFIX.length, dateLineEnd);
+  const fresh = formatEnvironmentDateLine(now ?? new Date(), timeZone);
+  if (current === fresh) return systemPrompt;
+
+  return (
+    systemPrompt.slice(0, dateLineStart + DATE_PREFIX.length) +
+    fresh +
+    systemPrompt.slice(dateLineEnd)
+  );
+}


### PR DESCRIPTION
## Summary

`- Date:` in the `# Environment` block of the system prompt is frozen for a session's life in the `openai-compatible` provider — a session resident across local midnight reports its start date forever. #784 fixed the identical freeze in `anthropic-direct`; this is the same fix for its twin.

## Root cause (file:line)

- `openai-compatible/index.ts:325-333` builds the `# Environment` fragment (including the `- Date:` line) once inside `query()`, then folds it into `patchedConfig.systemPrompt` — i.e. once per session, not once per turn.
- `openai-compatible/messages.ts:191-200` (`resolveSystemPrompt`) reads that frozen `config.systemPrompt` string as-is.
- `openai-compatible/messages.ts:228-230` (`buildMessages`), called once per `runIteration()` (`query.ts:788`) — i.e. once per turn — pushed that frozen string as the `system` message on every turn, so the date line never changed after session start.

## Change

- **Relocation**: moved `refreshEnvironmentDate` from `anthropic-direct/query/date-rollover.ts` → `providers/shared/date-rollover.ts` (79 LOC) so both providers can call it without cross-importing. This mirrors the repo's existing pattern for provider-shared helpers (`plan-mode-addendum.ts`, `afk-mode-addendum.ts`, `sumProviderUsage` at `anthropic-direct/types.ts:587-595`).
- **Shim**: left a 13-LOC re-export shim at the old path (`anthropic-direct/query/date-rollover.ts`), mirroring `plan-mode-addendum.ts` verbatim, so the one non-test importer (`anthropic-direct/query.ts:60`) resolves unchanged.
- **Call site**: `openai-compatible/messages.ts:buildMessages()` now calls `refreshEnvironmentDate(sys)` on the resolved system string before pushing the system message — since `buildMessages()` runs once per turn, the date now re-renders per turn instead of reading the frozen string.
- **Comment fix**: rewrote the stale doc-comment in `openai-compatible/index.ts` (previously ~175-180) that claimed the provider "does not currently emit a `# Environment` block at all" — directly contradicted by the code a few lines below it. Now describes where the fragment is actually built and how it stays fresh.

## Prompt-cache safety

`refreshEnvironmentDate` returns its input **by reference** when the rendered date string is unchanged. So a same-day second turn's system payload is the same value (and reference) as the first turn's — no extra request-body churn, and no wasted cache invalidation on any backend/proxy that caches by prefix. Verified by a dedicated test (below) asserting `toBe` (reference equality), not just `toEqual`.

## Tests

- `providers/openai-compatible/date-rollover-system-payload.test.ts` (new, 2 tests): fake-timer integration test at the `chat.completions.create` boundary, mirroring `anthropic-direct/date-rollover-system-payload.test.ts`'s approach.
  - Across a simulated midnight (48h jump, so the local date differs on every CI OS), the second turn's system message carries the new date and differs from the first.
  - A same-day second turn sends the byte-identical (`toBe`) system string as the first — the prompt-cache-safety property.
- `providers/shared/date-rollover.test.ts` (relocated from `anthropic-direct/query/`, imports fixed, otherwise unchanged): the pure-function unit tests for the rewrite itself.

## Gates run

| Gate | Result |
|---|---|
| `pnpm lint` (`tsc --noEmit`, strict) | ✅ pass |
| `pnpm exec vitest run src/agent/providers/shared/date-rollover.test.ts src/agent/providers/openai-compatible/date-rollover-system-payload.test.ts` | ✅ 12/12 pass |
| `pnpm exec vitest run src/agent/providers/openai-compatible/` | ✅ 300/300 pass |
| `pnpm exec vitest run src/agent/providers/anthropic-direct/` | ✅ 465/465 pass (proves the shim didn't break the old import path) |
| `pnpm audit:sdk:check` | ✅ pass, lock matches current imports |

Full `pnpm test` intentionally skipped per task instructions — CI runs it.

Fixes #785. Twin of #784 (`anthropic-direct`).
