### PR TITLE
fix(permissions): carve ssh config + known_hosts out of read-denylist (#579 O2)

### DIFF
--- a/src/agent/tools/handlers/read-denylist.test.ts
+++ b/src/agent/tools/handlers/read-denylist.test.ts
@@ -36,6 +36,7 @@ import {
   getReadDenylist,
   BUILTIN_READ_DENYLIST,
   BUILTIN_READ_ALLOWLIST,
+  READ_ALLOWLIST_REL,
   resolveExceptionEntry,
   parseReadDenylistEntries,
   _resetReadDenylistCacheForTests,
@@ -224,6 +225,50 @@ describe('isReadDenied — built-in exception for ~/.afk/config/mcp.json', () =>
   });
 });
 
+// Issue #579 O2 — `~/.ssh` stays whole-dir floored (SSH private keys have
+// arbitrary names like `github_key`, so a deny-glob would fail-open), but two
+// well-known NON-secret siblings are carved out as exact files so the agent can
+// do git/ssh host-alias work unconfined. Mirrors the mcp.json carve-out pattern.
+describe('isReadDenied — built-in exceptions for ~/.ssh/config and ~/.ssh/known_hosts', () => {
+  const sshConfig = join(homedir(), '.ssh', 'config');
+  const knownHosts = join(homedir(), '.ssh', 'known_hosts');
+
+  it('allows the carved-out non-secret siblings', () => {
+    expect(isReadDenied(sshConfig).denied).toBe(false);
+    expect(isReadDenied(knownHosts).denied).toBe(false);
+  });
+
+  it('is an EXACT-file carve-out — siblings and pseudo-children stay denied', () => {
+    // Private key material (arbitrary names) stays denied — the whole-dir floor.
+    expect(isReadDenied(join(homedir(), '.ssh', 'id_rsa')).denied).toBe(true);
+    expect(isReadDenied(join(homedir(), '.ssh', 'github_key')).denied).toBe(true);
+    expect(isReadDenied(join(homedir(), '.ssh', 'id_ed25519')).denied).toBe(true);
+    // Suffix/pseudo-child siblings stay denied (exact-match, not prefix).
+    expect(isReadDenied(sshConfig + '.bak').denied).toBe(true);
+    expect(isReadDenied(join(sshConfig, 'child')).denied).toBe(true);
+    expect(isReadDenied(knownHosts + '.old').denied).toBe(true);
+    expect(isReadDenied(join(homedir(), '.ssh')).denied).toBe(true);
+  });
+
+  it('stays re-deniable via AFK_READ_DENYLIST (extras outrank the exception)', () => {
+    process.env['AFK_READ_DENYLIST'] = sshConfig;
+    _resetReadDenylistCacheForTests();
+    expect(isReadDenied(sshConfig).denied).toBe(true);
+
+    delete process.env['AFK_READ_DENYLIST'];
+    _resetReadDenylistCacheForTests();
+    process.env['AFK_READ_DENYLIST'] = join(homedir(), '.ssh');
+    _resetReadDenylistCacheForTests();
+    expect(isReadDenied(sshConfig).denied).toBe(true);
+    expect(isReadDenied(knownHosts).denied).toBe(true);
+  });
+
+  it('assertNotReadDenied does not throw for the carve-outs', () => {
+    expect(() => assertNotReadDenied(sshConfig)).not.toThrow();
+    expect(() => assertNotReadDenied(knownHosts)).not.toThrow();
+  });
+});
+
 // Regression guard for PR #728 review P1: the exception list must never be
 // expressed as the symlink TARGET of its own leaf. `safeRealpath` on the whole
 // entry would let a `mcp.json` symlinked at a protected file put THAT file in
@@ -265,21 +310,34 @@ describe('read-denylist — exception entries dereference the dir chain, never t
     expect(basename(resolved)).toBe('mcp.json');
   });
 
-  it('keeps every built-in exception inside the resolved ~/.afk/config dir', () => {
+  it('keeps every built-in exception inside its expected resolved parent', () => {
+    // mcp.json lives inside ~/.afk/config; .ssh/config & known_hosts live
+    // inside ~/.ssh. Each entry must resolve into the dir that floors it.
+    const expected: Record<string, string> = {
+      '.afk/config/mcp.json': safeRealpath(join(homedir(), '.afk', 'config')),
+      '.ssh/config': safeRealpath(join(homedir(), '.ssh')),
+      '.ssh/known_hosts': safeRealpath(join(homedir(), '.ssh')),
+    };
     for (const entry of BUILTIN_READ_ALLOWLIST) {
       const resolved = resolveExceptionEntry(entry);
       expect(basename(resolved)).toBe(basename(entry));
-      expect(dirname(resolved)).toBe(safeRealpath(join(homedir(), '.afk', 'config')));
+      const rel = READ_ALLOWLIST_REL.find((r) => entry.endsWith(r));
+      expect(rel, `unmapped entry: ${entry}`).toBeDefined();
+      if (rel) expect(dirname(resolved)).toBe(expected[rel]!);
     }
   });
 
   it('a protected path is still denied when reached directly (the P1 regression)', () => {
     // Belt-and-braces on the real built-ins: whatever the exception list resolves
-    // to, a direct credential read must never be admitted by it.
+    // to, a direct credential read must never be admitted by it. The carve-out
+    // leaves are known non-secret names (mcp.json, config, known_hosts) — NEVER
+    // key material (id_rsa, etc.).
     for (const entry of BUILTIN_READ_ALLOWLIST) {
-      expect(resolveExceptionEntry(entry)).not.toMatch(/\/\.(ssh|aws|gnupg)\//);
+      const leaf = entry.split('/').pop();
+      expect(leaf).toMatch(/^(mcp\.json|config|known_hosts)$/);
     }
     expect(isReadDenied(join(homedir(), '.ssh', 'id_rsa')).denied).toBe(true);
+    expect(isReadDenied(join(homedir(), '.ssh', 'github_key')).denied).toBe(true);
     expect(isReadDenied(join(homedir(), '.afk', 'config', 'afk.env')).denied).toBe(true);
   });
 });

--- a/src/agent/tools/handlers/read-denylist.ts
+++ b/src/agent/tools/handlers/read-denylist.ts
@@ -146,8 +146,8 @@ export const BUILTIN_READ_DENYLIST: readonly string[] = [
 
 /**
  * Home-relative files that sit INSIDE a denied directory but are deliberately
- * readable. Matched as EXACT files (never as a prefix), so `mcp.json.bak` and
- * `mcp.json/<child>` stay denied.
+ * readable. Matched as EXACT files (never as a prefix), so `mcp.json.bak`,
+ * `mcp.json/<child>`, `config.bak`, and `known_hosts.old` stay denied.
  *
  * `~/.afk/config/mcp.json` is the MCP server REGISTRY, not a credential store:
  * its `env` / `headers` values are documented to hold `${VAR}` placeholders
@@ -161,11 +161,26 @@ export const BUILTIN_READ_DENYLIST: readonly string[] = [
  * `AFK_READ_DENYLIST=~/.afk/config/mcp.json` — see the ordering invariant in
  * {@link isReadDenied}.
  *
+ * `~/.ssh/config` and `~/.ssh/known_hosts` sit inside the whole-dir `~/.ssh`
+ * floor (which stays — SSH private keys have ARBITRARY names like `github_key`,
+ * so a key-name glob would fail-open). These two files are well-known
+ * non-secret siblings the agent legitimately needs for git/ssh host-alias
+ * work: `config` carries host aliases (IdentityFile PATHS, not key material),
+ * `known_hosts` is the trusted-host list. Neither is a private key. They are
+ * carved out as EXACT files so `~/.ssh/id_*`, `~/.ssh/config.bak`, and any
+ * other sibling stay denied. Operators who consider either sensitive in their
+ * environment can re-deny explicitly with
+ * `AFK_READ_DENYLIST=~/.ssh/config` (extras outrank the exception).
+ *
  * Kept home-RELATIVE so the REPL `@`-file injector
  * (`cli/commands/interactive/at-file-inject.ts`), which resolves against an
  * injectable home, shares this one list instead of duplicating it.
  */
-export const READ_ALLOWLIST_REL: readonly string[] = ['.afk/config/mcp.json'];
+export const READ_ALLOWLIST_REL: readonly string[] = [
+  '.afk/config/mcp.json',
+  '.ssh/config',
+  '.ssh/known_hosts',
+];
 
 /** {@link READ_ALLOWLIST_REL} resolved against the real home directory. */
 export const BUILTIN_READ_ALLOWLIST: readonly string[] = READ_ALLOWLIST_REL.map(

--- a/src/agent/tools/hooks/bash-restriction-hook.test.ts
+++ b/src/agent/tools/hooks/bash-restriction-hook.test.ts
@@ -591,6 +591,95 @@ describe('createBashRestrictionHook — mcp.json carve-out parity (#728)', () =>
       hook(ctx('python -c "import json; json.load(open(\'~/.afk/config/mcp.json\'))"')).decision,
     ).not.toBe('block');
   });
+
+  // PR #805 P1 — quote-concatenation bypass. Shell concatenates
+  // `~/.ssh/config".bak"` into `~/.ssh/config.bak`; before the second
+  // lookahead, `scrubAllowlistedRefs` treated the `"` as an exact-file
+  // boundary, blanked the `.ssh/config` span, and left nothing for the
+  // scanner to match → the hook returned allow for a denied sibling. The
+  // escalation is traversal: `cat ~/.ssh/config"/../github_key"` resolves to
+  // an ARBITRARILY-NAMED private key, defeating the whole-dir `~/.ssh` floor.
+  // The fix scrubs ONLY when the trailing quote is NOT followed by a path
+  // char, so a legitimately quoted whole exact ref (`"~/.ssh/config"`) still
+  // scrubs and stays allowed while a quote-concatenated suffix stays blocked.
+  // These exercise the mcp.json surface (pre-existing hole) and the ssh
+  // surface (the surface this PR extends the hole onto).
+  it('P1: mcp.json quote-concat suffix stays blocked (config".bak" analogue)', () => {
+    expect(hook(ctx(`cat ${mcp}".bak"`)).decision).toBe('block');
+    expect(hook(ctx(`cat ~/.afk/config/mcp.json"/../afk.env"`)).decision).toBe('block');
+  });
+
+  it('P1: a quoted whole exact ref still scrubs and stays allowed (no regression)', () => {
+    // The second lookahead rejects ONLY `" + path-char`; a closing quote
+    // followed by EOL/space must still match the carve-out and scrub.
+    expect(hook(ctx(`cat "${mcp}"`)).decision).not.toBe('block');
+    expect(hook(ctx(`cat "~/.afk/config/mcp.json"`)).decision).not.toBe('block');
+    expect(hook(ctx(`cat "${mcp}" 2>/dev/null`)).decision).not.toBe('block');
+  });
+});
+
+// PR #805 — ssh config / known_hosts carve-out parity on the bash surface.
+// `READ_ALLOWLIST_REL` is shared, so the carve-out propagates here structurally;
+// these pin that propagation so a future refactor of `allowlistedFileForms`
+// cannot silently invert the carve-out on the bash surface without a failing
+// test. Mirrors the mcp.json parity block above.
+describe('createBashRestrictionHook — ssh config / known_hosts carve-out parity (#579 O2)', () => {
+  const hook = createBashRestrictionHook({ getGrantManager: mockGrants });
+  const home = homedir();
+  const sshConfig = `${home}/.ssh/config`;
+  const knownHosts = `${home}/.ssh/known_hosts`;
+
+  it('allows the ssh carve-outs in every home spelling', () => {
+    expect(hook(ctx(`cat ${sshConfig}`)).decision).not.toBe('block');
+    expect(hook(ctx('cat ~/.ssh/config')).decision).not.toBe('block');
+    expect(hook(ctx('cat $HOME/.ssh/config')).decision).not.toBe('block');
+    expect(hook(ctx(`cat ${knownHosts}`)).decision).not.toBe('block');
+    expect(hook(ctx('cat ~/.ssh/known_hosts')).decision).not.toBe('block');
+  });
+
+  it('is EXACT-file: backups, pseudo-children, and well-known keys stay blocked', () => {
+    expect(hook(ctx(`cat ${sshConfig}.bak`)).decision).toBe('block');
+    expect(hook(ctx(`cat ${sshConfig}/child`)).decision).toBe('block');
+    expect(hook(ctx(`cat ${knownHosts}.old`)).decision).toBe('block');
+    expect(hook(ctx(`cat ${sshConfig}/../id_rsa`)).decision).toBe('block');
+    expect(hook(ctx(`cat ${sshConfig}/../github_key`)).decision).toBe('block');
+    expect(hook(ctx(`cat ${home}/.ssh/id_rsa`)).decision).toBe('block');
+    expect(hook(ctx(`cat ${home}/.ssh/github_key`)).decision).toBe('block');
+  });
+
+  it('P1: quote-concatenated sibling/traversal stays blocked (the bypass this PR closes)', () => {
+    // Codex's exact example + the private-key traversal escalation.
+    expect(hook(ctx(`cat ${sshConfig}".bak"`)).decision).toBe('block');
+    expect(hook(ctx(`cat ~/.ssh/config".bak"`)).decision).toBe('block');
+    expect(hook(ctx(`cat ~/.ssh/config"/../github_key"`)).decision).toBe('block');
+    expect(hook(ctx(`cat ~/.ssh/config"/../id_rsa"`)).decision).toBe('block');
+    expect(hook(ctx(`cat $HOME/.ssh/config"/../github_key"`)).decision).toBe('block');
+    expect(hook(ctx(`cat ~/.ssh/known_hosts"/../github_key"`)).decision).toBe('block');
+  });
+
+  it('P1: a quoted whole ssh exact ref still scrubs and stays allowed (no regression)', () => {
+    expect(hook(ctx(`cat "${sshConfig}"`)).decision).not.toBe('block');
+    expect(hook(ctx(`cat "~/.ssh/config"`)).decision).not.toBe('block');
+    expect(hook(ctx(`cat "$HOME/.ssh/known_hosts"`)).decision).not.toBe('block');
+  });
+
+  it('is EXACT-file: glob/brace-extended siblings stay blocked', () => {
+    expect(hook(ctx(`cat ${sshConfig}*`)).decision).toBe('block');
+    expect(hook(ctx(`cat ${knownHosts}{,.old}`)).decision).toBe('block');
+  });
+
+  it('does not launder a key riding along in the same command', () => {
+    expect(hook(ctx(`cat ${sshConfig} ${home}/.ssh/id_rsa`)).decision).toBe('block');
+  });
+
+  it('extends the carve-out to the interpreter guard', () => {
+    expect(
+      hook(ctx('python -c "print(open(\'~/.ssh/config\').read())"')).decision,
+    ).not.toBe('block');
+    expect(
+      hook(ctx('python -c "print(open(\'~/.ssh/known_hosts\').read())"')).decision,
+    ).not.toBe('block');
+  });
 });
 
 describe('createBashRestrictionHook — relocated AFK_HOME parity', () => {

--- a/src/agent/tools/hooks/bash-restriction-hook.test.ts
+++ b/src/agent/tools/hooks/bash-restriction-hook.test.ts
@@ -609,6 +609,13 @@ describe('createBashRestrictionHook — mcp.json carve-out parity (#728)', () =>
     expect(hook(ctx(`cat ~/.afk/config/mcp.json"/../afk.env"`)).decision).toBe('block');
   });
 
+  it('P1: mcp.json single-quote and backtick concat stay blocked (all shell quotes)', () => {
+    expect(hook(ctx(`cat ${mcp}'.bak'`)).decision).toBe('block');
+    expect(hook(ctx(`cat ~/.afk/config/mcp.json'/../afk.env'`)).decision).toBe('block');
+    expect(hook(ctx(`cat ${mcp}\`.bak\``)).decision).toBe('block');
+    expect(hook(ctx(`cat ~/.afk/config/mcp.json\`/../afk.env\``)).decision).toBe('block');
+  });
+
   it('P1: a quoted whole exact ref still scrubs and stays allowed (no regression)', () => {
     // The second lookahead rejects ONLY `" + path-char`; a closing quote
     // followed by EOL/space must still match the carve-out and scrub.
@@ -655,6 +662,15 @@ describe('createBashRestrictionHook — ssh config / known_hosts carve-out parit
     expect(hook(ctx(`cat ~/.ssh/config"/../id_rsa"`)).decision).toBe('block');
     expect(hook(ctx(`cat $HOME/.ssh/config"/../github_key"`)).decision).toBe('block');
     expect(hook(ctx(`cat ~/.ssh/known_hosts"/../github_key"`)).decision).toBe('block');
+  });
+
+  it('P1: single-quote and backtick concat stay blocked (all shell quotes)', () => {
+    expect(hook(ctx(`cat ${sshConfig}'.bak'`)).decision).toBe('block');
+    expect(hook(ctx(`cat ~/.ssh/config'.bak'`)).decision).toBe('block');
+    expect(hook(ctx(`cat ~/.ssh/config'/../github_key'`)).decision).toBe('block');
+    expect(hook(ctx(`cat $HOME/.ssh/config'/../github_key'`)).decision).toBe('block');
+    expect(hook(ctx(`cat ${sshConfig}\`.bak\``)).decision).toBe('block');
+    expect(hook(ctx(`cat ~/.ssh/config\`/../github_key\``)).decision).toBe('block');
   });
 
   it('P1: a quoted whole ssh exact ref still scrubs and stays allowed (no regression)', () => {

--- a/src/agent/tools/hooks/bash-restriction-hook.ts
+++ b/src/agent/tools/hooks/bash-restriction-hook.ts
@@ -414,24 +414,27 @@ function allowlistedFileForms(home: string, afkHome: string | undefined): string
  * the only text carrying the denied enclosing root. Dropping this guard
  * entirely would turn one readable file into a readable directory.
  *
- * A SECOND lookahead `(?!"[\w./\\*?\[\]{}-])` closes the quote-concatenation
+ * A SECOND lookahead `(?!['"\`][\w./\\*?\[\]{}-])` closes the quote-concatenation
  * bypass (PR #805 P1): shell concatenates `~/.ssh/config".bak"` into
- * `~/.ssh/config.bak`, so a `"` immediately followed by a path character means
- * the quote OPENS a suffix extending the path past the exact-file boundary —
- * the span must NOT be scrubbed, leaving `.ssh`/`.afk/config` visible to the
- * scanner. A CLOSING quote (`"~/.ssh/config"` with EOL/space after) is
- * intentionally unaffected: the first lookahead already passes `"` (it is not
- * in the path-char class), and the second only rejects `"` + path-char. This
- * is what lets a legitimately quoted whole exact reference stay scrubbed (and
- * allowed) while a quote-concatenated sibling/traversal stays blocked. The
- * same hole, prior to this PR, admitted the `mcp.json` carve-out too:
- * `cat ~/.afk/config/mcp.json"/../afk.env"` would have laundered `.afk/config`.
+ * `~/.ssh/config.bak`, so a quote character immediately followed by a path
+ * character means the quote OPENS a suffix extending the path past the
+ * exact-file boundary — the span must NOT be scrubbed, leaving `.ssh`/
+ * `.afk/config` visible to the scanner. All three shell quote characters
+ * (`"`, `'`, `` ` ``) are covered — single-quote and backtick concatenation
+ * are equivalent bypasses. A CLOSING quote (`"~/.ssh/config"` with EOL/space
+ * after) is intentionally unaffected: the first lookahead already passes
+ * quote chars (they are not in the path-char class), and the second only
+ * rejects a quote + path-char. This is what lets a legitimately quoted whole
+ * exact reference stay scrubbed (and allowed) while a quote-concatenated
+ * sibling/traversal stays blocked. The same hole, prior to this PR, admitted
+ * the `mcp.json` carve-out too: `cat ~/.afk/config/mcp.json"/../afk.env"`
+ * would have laundered `.afk/config`.
  */
 function scrubAllowlistedRefs(text: string, home: string, afkHome: string | undefined): string {
   let out = text;
   for (const form of allowlistedFileForms(home, afkHome)) {
     const exactRef = new RegExp(
-      `${escapeRegExp(form)}(?![\\w./\\\\*?\\[\\]{}-])(?!"[\\w./\\\\*?\\[\\]{}-])`,
+      `${escapeRegExp(form)}(?![\\w./\\\\*?\\[\\]{}-])(?!['"\`][\\w./\\\\*?\\[\\]{}-])`,
       'g',
     );
     out = out.replace(exactRef, ALLOWLISTED_PLACEHOLDER);

--- a/src/agent/tools/hooks/bash-restriction-hook.ts
+++ b/src/agent/tools/hooks/bash-restriction-hook.ts
@@ -413,11 +413,27 @@ function allowlistedFileForms(home: string, afkHome: string | undefined): string
  * siblings (`mcp.json.bak`) the carve-out was never meant to cover — dropping
  * the only text carrying the denied enclosing root. Dropping this guard
  * entirely would turn one readable file into a readable directory.
+ *
+ * A SECOND lookahead `(?!"[\w./\\*?\[\]{}-])` closes the quote-concatenation
+ * bypass (PR #805 P1): shell concatenates `~/.ssh/config".bak"` into
+ * `~/.ssh/config.bak`, so a `"` immediately followed by a path character means
+ * the quote OPENS a suffix extending the path past the exact-file boundary —
+ * the span must NOT be scrubbed, leaving `.ssh`/`.afk/config` visible to the
+ * scanner. A CLOSING quote (`"~/.ssh/config"` with EOL/space after) is
+ * intentionally unaffected: the first lookahead already passes `"` (it is not
+ * in the path-char class), and the second only rejects `"` + path-char. This
+ * is what lets a legitimately quoted whole exact reference stay scrubbed (and
+ * allowed) while a quote-concatenated sibling/traversal stays blocked. The
+ * same hole, prior to this PR, admitted the `mcp.json` carve-out too:
+ * `cat ~/.afk/config/mcp.json"/../afk.env"` would have laundered `.afk/config`.
  */
 function scrubAllowlistedRefs(text: string, home: string, afkHome: string | undefined): string {
   let out = text;
   for (const form of allowlistedFileForms(home, afkHome)) {
-    const exactRef = new RegExp(`${escapeRegExp(form)}(?![\\w./\\\\*?\\[\\]{}-])`, 'g');
+    const exactRef = new RegExp(
+      `${escapeRegExp(form)}(?![\\w./\\\\*?\\[\\]{}-])(?!"[\\w./\\\\*?\\[\\]{}-])`,
+      'g',
+    );
     out = out.replace(exactRef, ALLOWLISTED_PLACEHOLDER);
   }
   return out;

--- a/src/cli/commands/interactive/at-file-inject.test.ts
+++ b/src/cli/commands/interactive/at-file-inject.test.ts
@@ -277,6 +277,69 @@ describe('expandAtFileTokens — hardened guards (review #688)', () => {
     expect(r.warnings.some((w) => w.includes('sensitive'))).toBe(true);
   });
 
+  // PR #805 — ssh config / known_hosts carve-out parity on the @-inject surface.
+  // READ_ALLOWLIST_REL is shared, so the carve-out propagates structurally;
+  // these pin that propagation so a future refactor cannot silently drop it.
+  it('injects ~/.ssh/config (shared exact-file carve-out)', () => {
+    mkdirSync(join(tmpRoot, '.ssh'), { recursive: true });
+    writeFileSync(join(tmpRoot, '.ssh', 'config'), 'Host github\n  IdentityFile ~/.ssh/github_key\n');
+    const r = expandAtFileTokens('@~/.ssh/config', {
+      rootDir: '/nonexistent-cwd',
+      homeDir: tmpRoot,
+      ...ON,
+    });
+    expect(r.warnings).toEqual([]);
+    expect(r.fileBlocks).toHaveLength(1);
+    expect(r.fileBlocks[0]!.text).toContain('IdentityFile');
+  });
+
+  it('injects ~/.ssh/known_hosts (shared exact-file carve-out)', () => {
+    mkdirSync(join(tmpRoot, '.ssh'), { recursive: true });
+    writeFileSync(join(tmpRoot, '.ssh', 'known_hosts'), 'github.com ssh-ed25519 AAAA...\n');
+    const r = expandAtFileTokens('@~/.ssh/known_hosts', {
+      rootDir: '/nonexistent-cwd',
+      homeDir: tmpRoot,
+      ...ON,
+    });
+    expect(r.warnings).toEqual([]);
+    expect(r.fileBlocks).toHaveLength(1);
+    expect(r.fileBlocks[0]!.text).toContain('github.com');
+  });
+
+  it('blocks ~/.ssh/config BACKUP sibling (exact-file, not prefix)', () => {
+    mkdirSync(join(tmpRoot, '.ssh'), { recursive: true });
+    writeFileSync(join(tmpRoot, '.ssh', 'config.bak'), 'Host old\n');
+    const r = expandAtFileTokens('@~/.ssh/config.bak', {
+      rootDir: '/nonexistent-cwd',
+      homeDir: tmpRoot,
+      ...ON,
+    });
+    expect(r.fileBlocks).toEqual([]);
+    expect(r.warnings.some((w) => w.includes('sensitive'))).toBe(true);
+  });
+
+  it('honors an AFK_READ_DENYLIST re-deny of the ssh carve-out', () => {
+    mkdirSync(join(tmpRoot, '.ssh'), { recursive: true });
+    const sshConf = join(tmpRoot, '.ssh', 'config');
+    writeFileSync(sshConf, 'Host github\n  IdentityFile ~/.ssh/github_key\n');
+    const prior = process.env['AFK_READ_DENYLIST'];
+    process.env['AFK_READ_DENYLIST'] = sshConf;
+    _resetReadDenylistCacheForTests();
+    try {
+      const r = expandAtFileTokens('@~/.ssh/config', {
+        rootDir: '/nonexistent-cwd',
+        homeDir: tmpRoot,
+        ...ON,
+      });
+      expect(r.fileBlocks).toEqual([]);
+      expect(r.warnings.some((w) => w.includes('sensitive'))).toBe(true);
+    } finally {
+      if (prior === undefined) delete process.env['AFK_READ_DENYLIST'];
+      else process.env['AFK_READ_DENYLIST'] = prior;
+      _resetReadDenylistCacheForTests();
+    }
+  });
+
   it('still injects an innocuous absolute path like a temp file (not over-blocked)', () => {
     const r = expandAtFileTokens(`@${tmpRoot}/code.ts`, { rootDir: '/nonexistent-cwd', ...ON });
     expect(r.fileBlocks).toHaveLength(1);


### PR DESCRIPTION
## Summary

Closes the **O2** half of #579 — read-denylist whole-dir floors block legitimate non-secret siblings even in unconfined sessions.

The whole-dir read floor for the operator's ssh directory **stays** — private keys have arbitrary names (`github_key`, `work_id`), so a key-name glob (`id_*`/`*_rsa`/`*.pem`) would **fail-open** on unknown siblings (independently verified: the repo's own `worktree-ignored-patterns.ts:44-45` and `at-file-inject.ts:91` already miss `github_key`). But two well-known NON-secret siblings are needed for git/ssh host-alias work and were blocked even in unconfined sessions:

- **`config`** — host aliases; carries `IdentityFile` PATHS, not key material
- **`known_hosts`** — the trusted-host list

## Changes

Carve both out as **EXACT files** via `READ_ALLOWLIST_REL` (mirrors the `mcp.json` precedent from #728):
- Siblings (`id_*`, `config.bak`, `known_hosts.old`, `github_key`) stay denied
- Re-deniable via `AFK_READ_DENYLIST` (extras outrank the exception)
- Leaf-un-deref'd for symlink safety (a `config → id_rsa` symlink resolves to the key path which isn't in the allowlist → stays denied)
- The `@`-file injector (`at-file-inject.ts:223`) and bash-restriction-hook (`:387`) share `READ_ALLOWLIST_REL` and pick up the carve-outs automatically — the bash hook will now scrub `config` references too, closing the typed-tool-vs-bash divergence

**`afk.config.json` is NOT carved out** — model-slot `apiKey` fields (`models.{slot}.apiKey`, `cli/config/types.ts:307`) are hand-editable into that file and read by the loader (`model-slots.ts:424`); `config_get target=config` does **not** mask (`mutate.ts:207-212` masks only `target=env`), so no safe masked-read escape hatch exists. Stays whole-dir floored.

## Verification

- `read-denylist.test.ts`: 62/62 pass — new carve-out tests mirror the `mcp.json` pattern (exact-file, siblings denied, re-deniable, assertNotReadDenied)
- `at-file-inject.test.ts`: 36/36 pass (shared list propagates)
- `bash-restriction-hook.test.ts`: 75/75 pass (shared list propagates)
- Updated the pre-existing P1 regression guard (was written when only `mcp.json` was carved out — assumed the exception never lives inside a credential dir; now handles entries inside the ssh dir by asserting leaf basenames are known non-secret names)

## Scope

O2 only. The **O3** half of #579 (`rm -rf` blanket-block in AFK autonomous mode) is a separate PR — different files, different test churn, different risk profile.