### PR TITLE
fix(tui): stop annihilating whitespace-only text deltas and fusing round-boundary prose

### DIFF
--- a/src/cli/commands/interactive/turn-handler.test.ts
+++ b/src/cli/commands/interactive/turn-handler.test.ts
@@ -136,6 +136,38 @@ describe('runTurn — happy path', () => {
     expect(onAfterTurn).toHaveBeenCalledTimes(1);
   });
 
+  it('separates round-boundary text so the text before a tool call does not fuse with the text after it', async () => {
+    // Regression: responseText accumulated EVERY round's text with '' between
+    // them, so the assistant text block before a tool call fused with the block
+    // after it and the paragraph break vanished. Persisted transcripts showed
+    // "…(build doesn't type/lint check).All lint errors are pre-existing" and
+    // "…the affected test suites.Diff is clean" — the reported missing-space
+    // artifacts. Verbatim '' joining is still correct WITHIN a round (deltas
+    // split mid-word), so only the round seam gets a separator.
+    const events: OutputEvent[] = [
+      { type: 'chunk', chunk: { type: 'content', content: "Now running lint (build doesn't type/lint check)." } },
+      { type: 'chunk', chunk: { type: 'tool_use_detail', toolName: 'bash', toolUseId: 'tu-1', toolInput: '{"command":"pnpm lint"}' } },
+      { type: 'chunk', chunk: { type: 'tool_result', toolUseId: 'tu-1', content: '6 problems' } },
+      // Two deltas of the NEXT round's text: they must fuse with each other
+      // (mid-word split) but not with the pre-tool-call text.
+      { type: 'chunk', chunk: { type: 'content', content: 'All lint errors are pre-' } },
+      { type: 'chunk', chunk: { type: 'content', content: 'existing.' } },
+      { type: 'done', metadata: { durationMs: 10 } },
+    ];
+
+    const session = streamFrom(events);
+    const { h, onTurnComplete } = makeHandles();
+    const stats = makeStats();
+
+    await runTurn({ text: 'run lint', attachments: [] }, session, stats, h);
+
+    const recorded = onTurnComplete.mock.calls[0]?.[1] as string;
+    expect(recorded).not.toContain('check).All');
+    expect(recorded).toBe(
+      "Now running lint (build doesn't type/lint check).\n\nAll lint errors are pre-existing.",
+    );
+  });
+
   it('uses message event content when no content chunks streamed', async () => {
     const events: OutputEvent[] = [
       { type: 'message', message: { role: 'assistant', content: 'no-stream answer' } },

--- a/src/cli/commands/interactive/turn-handler.ts
+++ b/src/cli/commands/interactive/turn-handler.ts
@@ -32,6 +32,7 @@ import {
 } from '../../_lib/capture-mode.js';
 import { runWithSink } from '../../../agent/_lib/skill-sink-channel.js';
 import { parseTerminalState, type TerminalState } from './terminal-state.js';
+import { joinAtRoundSeam } from './turn-text-seam.js';
 import { renderVerdictCard } from './verdict-card.js';
 import { pushTerminalStateToTelegram, doneHasCorroboratingEvidence } from './afk-push.js';
 import { loadTelegramConfig, resolveAutoResumeOnUsageLimit } from '../../config.js';
@@ -82,6 +83,11 @@ export async function runTurn(
   // the duplicated partial text. Prior rounds (before the checkpoint) are
   // untouched — the retry is per-round, not per-turn.
   let roundStartResponseLen = 0;
+  // Set when a tool_result closes a round, consumed by the next content chunk:
+  // that chunk opens a NEW assistant text block, so it joins across a round
+  // seam (paragraph break) rather than concatenating verbatim like an
+  // intra-round delta. See {@link joinAtRoundSeam}.
+  let pendingRoundSeam = false;
   let streamingStarted = false;
   let streamErrorRendered = false;
   let rendererDisposed = false;
@@ -399,7 +405,10 @@ export async function runTurn(
         }
 
         if (event.type === 'chunk' && event.chunk.type === 'content') {
-          responseText += event.chunk.content;
+          responseText = pendingRoundSeam
+            ? joinAtRoundSeam(responseText, event.chunk.content)
+            : responseText + event.chunk.content;
+          pendingRoundSeam = false;
           streamingStarted = true;
         } else if (event.type === 'message' && !streamingStarted) {
           responseText = event.message.content;
@@ -412,6 +421,10 @@ export async function runTurn(
           // renderer.process(event) below, which resets the live display via
           // handleOrchestratorEvent's `stream_retry` case.
           responseText = responseText.slice(0, roundStartResponseLen);
+          // Truncating back to the round checkpoint also removes the seam break
+          // this round's first chunk inserted, so re-arm it: the re-streamed
+          // round is still a new text block after the prior round's text.
+          pendingRoundSeam = responseText.length > 0;
         }
 
         if (event.type === 'chunk' && event.chunk.type === 'tool_use_detail') {
@@ -424,6 +437,9 @@ export async function runTurn(
           // Round boundary: the next round's text appends after this point.
           // Checkpoint so a `stream_retry` truncates back to here, not to 0.
           roundStartResponseLen = responseText.length;
+          // This tool_result closes a round: the next content chunk starts a new
+          // assistant text block and must join across the seam, not fuse.
+          pendingRoundSeam = true;
           const pending = pendingTools.get(c.toolUseId);
           if (pending) {
             pending.result = c.content;
@@ -586,6 +602,7 @@ export async function runTurn(
           // above the freshly-armed overlay, not the disposed one.
           responseText = '';
           roundStartResponseLen = 0;
+          pendingRoundSeam = false;
           streamingStarted = false;
           toolEvents.length = 0;
           pendingTools.clear();

--- a/src/cli/commands/interactive/turn-text-seam.ts
+++ b/src/cli/commands/interactive/turn-text-seam.ts
@@ -1,0 +1,35 @@
+/**
+ * Round-boundary seam for accumulated assistant text.
+ *
+ * @module cli/commands/interactive/turn-text-seam
+ */
+
+/**
+ * Contract: join `next` (the first text of a NEW tool-use round) onto
+ * `accumulated` (every prior round's text) across a ROUND SEAM, inserting the
+ * paragraph break the seam itself carries no character for.
+ *
+ * Why a separator is needed at all: within one round, assistant text arrives as
+ * mid-sentence `delta.text` chunks that MUST concatenate verbatim ('' join) —
+ * inserting anything there would corrupt words. But a tool-use round boundary
+ * is a different seam: the text before a tool call and the text after it are
+ * two distinct assistant text blocks, and the API transmits their separation
+ * structurally (separate content blocks) rather than as whitespace in either
+ * block's payload. Appending with '' therefore fused them, which is how
+ * persisted transcripts ended up with "…(build doesn't type/lint check).All
+ * lint errors are pre-existing" and "…the affected test suites.Diff is clean" —
+ * the reported "missing space" artifacts. Restoring '\n\n' here reproduces the
+ * paragraph break the model expressed as a block boundary.
+ *
+ * Idempotent at the seam: when either side already carries whitespace across it
+ * (a round whose text ends with a newline, or a next block whose first delta
+ * opens with one), the existing whitespace is authoritative and nothing is
+ * added — so a repeated or already-separated seam never accumulates blank
+ * lines. An empty accumulator returns `next` unchanged, so the first round of a
+ * turn is never prefixed.
+ */
+export function joinAtRoundSeam(accumulated: string, next: string): string {
+  if (accumulated.length === 0 || next.length === 0) return accumulated + next;
+  if (/\s$/.test(accumulated) || /^\s/.test(next)) return accumulated + next;
+  return accumulated + '\n\n' + next;
+}

--- a/src/cli/slash/_lib/command-tags.test.ts
+++ b/src/cli/slash/_lib/command-tags.test.ts
@@ -210,3 +210,42 @@ describe('streaming-chunk safety — extractSkillTag', () => {
     expect(result.text).toBe('Paragraph ends here.\n');
   });
 });
+
+describe('whitespace-only deltas survive (word-separator preservation)', () => {
+  // Regression: `/^[ \t]+$/gm` also matched a delta that was ENTIRELY spaces,
+  // because /m anchors match the string's own ends. Both functions run per-delta
+  // in the streaming orchestrator, whose `if (!cleaned) return` then dropped the
+  // emptied delta — so the space between two words was destroyed and the words
+  // fused on screen ("The6 lint errors", "branch,as requested.").
+  it.each([' ', '  ', '\t', ' \t '])(
+    'stripCommandTags passes a whitespace-only delta %j through verbatim',
+    (delta) => {
+      expect(stripCommandTags(delta)).toBe(delta);
+    },
+  );
+
+  it.each([' ', '  ', '\t'])(
+    'extractSkillTag passes a whitespace-only delta %j through verbatim',
+    (delta) => {
+      const result = extractSkillTag(delta, 'ship');
+      expect(result.found).toBe(false);
+      expect(result.text).toBe(delta);
+    },
+  );
+
+  it('reassembles a delta stream whose separator arrives as its own chunk', () => {
+    // The exact observed failure: Anthropic split "The 6 lint errors" so the
+    // space was its own text_delta.
+    const deltas = ['The', ' ', '6 lint errors are pre-existing'];
+    const rendered = deltas.map((d) => stripCommandTags(d)).filter((c) => c).join('');
+    expect(rendered).toBe('The 6 lint errors are pre-existing');
+    expect(rendered).not.toContain('The6');
+  });
+
+  it('still normalizes an interior whitespace-only line to keep paragraph breaks detectable', () => {
+    // The behavior the regex exists for: a blank line carrying stray indentation
+    // must become a true '\n\n' so findBlockBoundary sees the paragraph break.
+    expect(stripCommandTags('para one\n   \npara two')).toBe('para one\n\npara two');
+    expect(extractSkillTag('para one\n  \npara two', 'ship').text).toBe('para one\n\npara two');
+  });
+});

--- a/src/cli/slash/_lib/command-tags.ts
+++ b/src/cli/slash/_lib/command-tags.ts
@@ -34,6 +34,28 @@ const COMMAND_TAG_PAT = `<(?:${COMMAND_NAME_TAG}|${COMMAND_MESSAGE_TAG}|${COMMAN
 const COMMAND_LINE_TAG_RE = new RegExp(`(\\n|^)[ \\t]*${COMMAND_TAG_PAT}[ \\t]*\\n?`, 'gm');
 const COMMAND_INLINE_TAG_RE = new RegExp(COMMAND_TAG_PAT, 'g');
 
+/**
+ * Invariant (line-scoped, never string-scoped): normalize a whitespace-only
+ * LINE to empty so `\n   \n` still reads as a paragraph break ('\n\n') to
+ * findBlockBoundary — but ONLY when the input actually contains a line boundary.
+ *
+ * `^`/`$` under /m also match the STRING's own ends, so a bare `/^[ \t]+$/gm`
+ * matched an input consisting solely of spaces. Both callers run PER DELTA in
+ * the streaming orchestrator, where a lone ' ' delta is an ordinary word
+ * separator, not a blank line. Annihilating it there — the empty result is then
+ * discarded outright by the orchestrator's `if (!cleaned) return` guard — fused
+ * the neighbouring words on screen: "The" + " " + "6 lint errors" rendered as
+ * "The6 lint errors", and "branch," + " " + "as requested." as "branch,as
+ * requested.". Requiring a newline preserves the blank-line normalization
+ * (which by definition needs a line boundary to exist) while letting a
+ * separator-only delta through verbatim. Same reasoning as each caller's
+ * `tagsRemoved` guard on the leading/trailing newline trim, for spaces.
+ */
+function normalizeWhitespaceOnlyLines(text: string): string {
+  if (!text.includes('\n')) return text;
+  return text.replace(/^[ \t]+$/gm, '');
+}
+
 export function stripCommandTags(text: string): string {
   let tagsRemoved = false;
   // Pass 1 — line-level tags: restore the preceding \n but eat the tag line
@@ -46,7 +68,7 @@ export function stripCommandTags(text: string): string {
     tagsRemoved = true;
     return '';
   });
-  result = result.replace(/^[ \t]+$/gm, '');
+  result = normalizeWhitespaceOnlyLines(result);
   result = result.replace(/\n{3,}/g, '\n\n');
   // Only trim string-level leading/trailing newlines when we removed a tag —
   // a delta that is purely '\n' with no tags must survive unchanged.
@@ -86,7 +108,7 @@ export function extractSkillTag(
   result = result.replace(closeLineRe, (_, pre: string) => { tagsRemoved = true; return pre; });
   result = result.replace(openInlineRe, () => { tagsRemoved = true; return ''; });
   result = result.replace(closeInlineRe, () => { tagsRemoved = true; return ''; });
-  result = result.replace(/^[ \t]+$/gm, '');
+  result = normalizeWhitespaceOnlyLines(result);
   result = result.replace(/\n{3,}/g, '\n\n');
   if (tagsRemoved) {
     result = result.replace(/^\n+/, '').replace(/\n+$/, '');


### PR DESCRIPTION
## Summary

Reported symptom: the TUI rendered `"The6 lint errors"` where the model wrote `"The 6 lint errors"`, and `"branch,as requested."` for `"branch, as requested."` — a space silently missing from streamed prose.

Root cause is **not** the wrap or markdown layer. `stripCommandTags` and `extractSkillTag` both ran `/^[ \t]+$/gm` on **every streamed delta**. Under `/m`, `^`/`$` also match the *string's own ends*, so a delta consisting of nothing but a space matched as a "whitespace-only line" and was replaced with `''`; the orchestrator's `if (!cleaned) return` guard (`stream-renderer-orchestrator.ts:331`) then discarded the emptied delta outright. When the provider split `"The 6 lint errors"` such that the space arrived as its own `text_delta`, the sequence `"The"` + `" "` + `"6 lint errors"` rendered as `"The6 lint errors"`.

The regex's purpose is legitimate — normalizing `\n   \n` into a true `\n\n` so `findBlockBoundary` still sees the paragraph break — it just needed to be **line-scoped instead of string-scoped**. Both copies now call one `normalizeWhitespaceOnlyLines` helper that requires a newline to be present. This mirrors the `tagsRemoved` guard that already protects newline-only deltas, documented in that file's own header (lines 23–32) — the `'\n'` case was fixed there previously; the space case was missed.

While tracing it, persisted transcripts surfaced a **second, independent instance of the same class**: `turn-handler` accumulated every tool-use round's text with `''`, fusing the text *before* a tool call with the text *after* it — `"check).All lint errors"`, `"test suites.Diff is clean"`, `` "`commitThinkingPhase`:Edit 2" ``. A `tool_result` now arms a round seam consumed by the next content chunk via `joinAtRoundSeam`, in its own file (`turn-handler.ts` is already 984 LOC). Intra-round deltas still concatenate verbatim, since those legitimately split mid-word.

**Ruled out with evidence, not reasoning:** `wrapToWidth`/`hardWrapToWidth` preserve the break space (it becomes a leading space on the continuation row — which is why wrapped lines look 1-space-indented); `renderMarkdownToTerminal` and `formatBlockForCommit` preserve `"The 6"` at every width 80–240; `markdown-stream.ts:240` accumulates verbatim with no trim; the compositor has no row-edge trim. A git-archaeology pass found no wrap commit that could reach short mid-line words.

## How was this tested?

- **The repro genuinely fails pre-fix:** reverting only the helper body fails **8** of the new cases; restoring it passes all 41. The `still normalizes an interior whitespace-only line` case passes in **both** directions, proving the regex's original blank-line purpose survives rather than being deleted.
- New coverage: whitespace-only deltas (`' '`, `'  '`, `'\t'`, `' \t '`) pass through both functions verbatim; a three-delta stream `['The', ' ', '6 lint errors…']` reassembles with its space; a round-boundary turn keeps `\n\n` between the pre- and post-tool-call blocks while two deltas of one round still fuse mid-word.
- `pnpm lint` (`tsc --noEmit`, strict) — clean.
- `pnpm vitest run src/cli` — **284 files / 5049 tests passed**, on this branch's base (current `main`).

## Not covered

- The tool-lane artifact `pnpm vitest run src/agent/subagent/ srcsession-phase.test.ts` observed in the same screenshot does **not** share this cause — tool args stream as `input_json_delta` and never pass through `stripCommandTags`. Separate arg-formatting/truncation question, not investigated here.
- `translate.ts:114`'s `textParts.join('')` is a third latent instance of this class (fuses multiple text blocks within one message). Left alone deliberately: it feeds conversation history and needs its own blast-radius check.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes (`src/cli`: 284 files / 5049 tests; full-suite gates run in CI)
- [x] Commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] No secrets, tokens, or private paths in the diff