### PR TITLE
fix(worktree): gate orphaned-dir removal on age and content (#794)

### DIFF
--- a/src/agent/worktree-orphan-guard.test.ts
+++ b/src/agent/worktree-orphan-guard.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { classifyOrphanDir } from './worktree-orphan-guard.js';
+
+const HOUR_MS = 3_600_000;
+const AGED_MS = HOUR_MS * 2;
+
+let root: string;
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'afk-orphan-guard-'));
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+describe('classifyOrphanDir — age gate', () => {
+  it('preserves an orphan younger than the age gate (an in-flight worktree add)', async () => {
+    await writeFile(join(root, '.env'), 'SECRET=1');
+    const verdict = await classifyOrphanDir(root, 5_000, HOUR_MS);
+    expect(verdict).toEqual({
+      remove: false,
+      because: 'too-young',
+      detail: 'age 5000ms < 3600000ms',
+    });
+  });
+
+  it('preserves when the caller could not stat the directory (age 0)', async () => {
+    // Contract: a failed stat must pass 0, which the age gate refuses — it must
+    // never read as "infinitely old" and authorise a delete.
+    const verdict = await classifyOrphanDir(root, 0, HOUR_MS);
+    expect(verdict.remove).toBe(false);
+    if (!verdict.remove) expect(verdict.because).toBe('too-young');
+  });
+
+  it('preserves on a non-finite age rather than trusting the comparison', async () => {
+    const verdict = await classifyOrphanDir(root, Number.NaN, HOUR_MS);
+    expect(verdict.remove).toBe(false);
+  });
+});
+
+describe('classifyOrphanDir — content probe', () => {
+  it('preserves an aged orphan holding a non-rebuildable ignored file', async () => {
+    await writeFile(join(root, '.env'), 'TOKEN=abc');
+    const verdict = await classifyOrphanDir(root, AGED_MS, HOUR_MS);
+    expect(verdict).toEqual({
+      remove: false,
+      because: 'non-rebuildable-content',
+      detail: '.env',
+    });
+  });
+
+  it('preserves an aged orphan holding an untracked source file', async () => {
+    await mkdir(join(root, 'src'), { recursive: true });
+    await writeFile(join(root, 'src', 'index.ts'), 'export {};');
+    const verdict = await classifyOrphanDir(root, AGED_MS, HOUR_MS);
+    expect(verdict.remove).toBe(false);
+    if (!verdict.remove) {
+      expect(verdict.because).toBe('non-rebuildable-content');
+      expect(verdict.detail).toBe('src/index.ts');
+    }
+  });
+
+  it('preserves a secret nested under a build-output directory', async () => {
+    await mkdir(join(root, 'dist'), { recursive: true });
+    await writeFile(join(root, 'dist', 'prod.env'), 'K=v');
+    const verdict = await classifyOrphanDir(root, AGED_MS, HOUR_MS);
+    expect(verdict.remove).toBe(false);
+    if (!verdict.remove) expect(verdict.because).toBe('non-rebuildable-content');
+  });
+
+  it('removes an aged, genuinely empty orphan', async () => {
+    const verdict = await classifyOrphanDir(root, AGED_MS, HOUR_MS);
+    expect(verdict).toEqual({ remove: true });
+  });
+
+  it('removes an aged orphan whose only content is a dependency tree', async () => {
+    // The sweep must still reclaim the common case — a failed `worktree add`
+    // that got as far as installing deps — or the guard defeats its purpose.
+    await mkdir(join(root, 'node_modules', 'left-pad'), { recursive: true });
+    await writeFile(join(root, 'node_modules', 'left-pad', 'index.js'), 'module.exports=1;');
+    const verdict = await classifyOrphanDir(root, AGED_MS, HOUR_MS);
+    expect(verdict).toEqual({ remove: true });
+  });
+});
+
+describe('classifyOrphanDir — failure and bounds', () => {
+  it('preserves when the directory cannot be read', async () => {
+    const verdict = await classifyOrphanDir(join(root, 'does-not-exist'), AGED_MS, HOUR_MS);
+    expect(verdict.remove).toBe(false);
+    if (!verdict.remove) expect(verdict.because).toBe('scan-failed');
+  });
+
+  it('preserves when the walk outgrows its entry budget', async () => {
+    await mkdir(join(root, 'build'), { recursive: true });
+    for (let i = 0; i < 4; i++) {
+      await writeFile(join(root, 'build', `chunk-${i}.js`), '0');
+    }
+    const verdict = await classifyOrphanDir(root, AGED_MS, HOUR_MS, { maxEntries: 2 });
+    expect(verdict.remove).toBe(false);
+    if (!verdict.remove) expect(verdict.because).toBe('scan-budget-exhausted');
+  });
+
+  it('preserves rather than descending past the depth bound', async () => {
+    await mkdir(join(root, 'a', 'b', 'c'), { recursive: true });
+    const verdict = await classifyOrphanDir(root, AGED_MS, HOUR_MS, { maxDepth: 1 });
+    expect(verdict.remove).toBe(false);
+    if (!verdict.remove) expect(verdict.because).toBe('scan-failed');
+  });
+
+  it('never throws on a path that is a file rather than a directory', async () => {
+    const filePath = join(root, 'plain.txt');
+    await writeFile(filePath, 'x');
+    const verdict = await classifyOrphanDir(filePath, AGED_MS, HOUR_MS);
+    expect(verdict.remove).toBe(false);
+  });
+});

--- a/src/agent/worktree-orphan-guard.ts
+++ b/src/agent/worktree-orphan-guard.ts
@@ -1,0 +1,159 @@
+/**
+ * Removal gate for UNREGISTERED directories under `.afk-worktrees/`.
+ *
+ * Invariant: the sweep's orphan path has no git information to work with. The
+ * directory is absent from `git worktree list`, so `git status --porcelain` —
+ * the sweep's only dirty signal — cannot classify it, and every protection the
+ * registered-candidate path applies (dirty check, ignored-file probe, age gate)
+ * is unreachable there. This module is the substitute floor: it decides from the
+ * filesystem alone, and every uncertain answer preserves.
+ *
+ * Contract: `classifyOrphanDir` never deletes and never throws. It returns
+ * `{ remove: true }` only for a directory that is BOTH older than the caller's
+ * minimum age AND provably free of content a rebuild would not restore. Anything
+ * else — a fresh directory, an unreadable one, a scan that outgrows its budget,
+ * or a single unrecognised entry — yields `{ remove: false }` with a reason the
+ * caller can print.
+ *
+ * The asymmetry is deliberate: preserving a dead orphan costs one leaked
+ * directory, reclaimed when it ages out or is removed explicitly. Deleting a
+ * live one destroys uncommitted work and `.env` files with no recovery path,
+ * because an unregistered directory has no branch ref holding its contents
+ * (#794, following #759).
+ *
+ * @module agent/worktree-orphan-guard
+ */
+
+import { readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { classifyIgnoredEntry } from './worktree-ignored-patterns.js';
+
+/**
+ * Contract: `classifyIgnoredEntry` is the shared policy and it defaults an
+ * unrecognised path to `'protected'`. That default is what makes this walk
+ * correct for a directory git never classified at all: an ordinary source file
+ * is as protective as a stray secret, so only recognisably rebuildable output
+ * can clear the way for a delete. Depending on the pure policy module (rather
+ * than the probe's boolean wrapper) keeps this module free of git IO.
+ */
+function isRebuildable(relPath: string): boolean {
+  return classifyIgnoredEntry(relPath) !== 'protected';
+}
+
+/** Why an orphaned directory must be left on disk. */
+export type OrphanPreserveReason =
+  /** Younger than the age gate — very likely an in-flight `git worktree add`. */
+  | 'too-young'
+  /** Holds at least one entry a rebuild would not restore. */
+  | 'non-rebuildable-content'
+  /** The directory could not be read, so its contents are unknown. */
+  | 'scan-failed'
+  /** The walk outgrew its bounds before it could prove the tree disposable. */
+  | 'scan-budget-exhausted';
+
+/** Fate of one unregistered directory under `.afk-worktrees/`. */
+export type OrphanVerdict =
+  | { remove: true }
+  | { remove: false; because: OrphanPreserveReason; detail?: string };
+
+/**
+ * Walk bounds. A failed `worktree add` can still have left a full
+ * `node_modules/` behind, so the walk must not be free to enumerate it — but
+ * rebuildable directories are skipped WHOLESALE (never descended into), which
+ * keeps the real cost proportional to hand-authored content rather than to
+ * dependency-tree size.
+ */
+export const ORPHAN_SCAN_MAX_DEPTH = 8;
+export const ORPHAN_SCAN_MAX_ENTRIES = 4_000;
+
+/**
+ * Decide whether an unregistered `.afk-worktrees/` directory may be removed.
+ *
+ * @param orphanPath  Absolute path to the directory.
+ * @param orphanAgeMs Age from directory birthtime. A caller that could not stat
+ *                    the directory must pass `0`, which preserves via the age
+ *                    gate rather than reading as "infinitely old".
+ * @param minAgeMs    Minimum age before removal is considered at all.
+ */
+export async function classifyOrphanDir(
+  orphanPath: string,
+  orphanAgeMs: number,
+  minAgeMs: number,
+  limits: { maxDepth?: number; maxEntries?: number } = {},
+): Promise<OrphanVerdict> {
+  // Age gate first: it is the cheapest check and the one that covers the most
+  // likely cause of an orphan, a `git worktree add` still in flight.
+  if (!Number.isFinite(orphanAgeMs) || orphanAgeMs < minAgeMs) {
+    return {
+      remove: false,
+      because: 'too-young',
+      detail: `age ${Math.max(0, Math.round(orphanAgeMs))}ms < ${minAgeMs}ms`,
+    };
+  }
+
+  const maxDepth = limits.maxDepth ?? ORPHAN_SCAN_MAX_DEPTH;
+  const maxEntries = limits.maxEntries ?? ORPHAN_SCAN_MAX_ENTRIES;
+
+  let remaining = maxEntries;
+  const pending: Array<{ abs: string; rel: string; depth: number }> = [
+    { abs: orphanPath, rel: '', depth: 0 },
+  ];
+
+  while (pending.length > 0) {
+    const dir = pending.pop();
+    if (dir === undefined) break;
+
+    let entries;
+    try {
+      entries = await readdir(dir.abs, { withFileTypes: true });
+    } catch (err) {
+      return {
+        remove: false,
+        because: 'scan-failed',
+        detail: `${dir.rel === '' ? orphanPath : dir.rel}: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+
+    for (const entry of entries) {
+      if (--remaining < 0) {
+        return {
+          remove: false,
+          because: 'scan-budget-exhausted',
+          detail: `exceeded ${maxEntries} entries`,
+        };
+      }
+
+      const rel = dir.rel === '' ? entry.name : `${dir.rel}/${entry.name}`;
+
+      if (entry.isDirectory()) {
+        // Invariant: only an `opaque` directory may be skipped wholesale. The
+        // shared policy separates dependency trees (`opaque` — enormous, and
+        // machine-owned, so descending costs more than it can ever find) from
+        // build output (`inspectable` — small, and demonstrably able to hide
+        // local state: `dist/prod.env` is the #759 case). Skipping both would
+        // reproduce that bug on the orphan path. Anything unrecognised is
+        // descended into as well, so the preserve reason can name the real file
+        // rather than the directory, and an empty unrecognised directory does
+        // not block reclamation.
+        // Trailing slash: the patterns are written against git's `--ignored`
+        // output, where a directory always ends in `/`.
+        if (classifyIgnoredEntry(`${rel}/`) === 'opaque') continue;
+        if (dir.depth + 1 > maxDepth) {
+          return { remove: false, because: 'scan-failed', detail: `depth limit at ${rel}` };
+        }
+        pending.push({ abs: join(dir.abs, entry.name), rel, depth: dir.depth + 1 });
+        continue;
+      }
+
+      // Files, symlinks, sockets — anything not a directory. An entry that is
+      // not recognisably rebuildable output protects the tree, which is also
+      // how an ordinary source file or a stray secret is caught: the shared
+      // policy defaults unrecognised paths to 'protected'.
+      if (!isRebuildable(rel)) {
+        return { remove: false, because: 'non-rebuildable-content', detail: rel };
+      }
+    }
+  }
+
+  return { remove: true };
+}

--- a/src/agent/worktree-sweep.test.ts
+++ b/src/agent/worktree-sweep.test.ts
@@ -655,12 +655,13 @@ describe('locked-always-skipped', () => {
 // ---------------------------------------------------------------------------
 
 describe('orphaned-dir-cleanup', () => {
-  // Invariant: an unregistered directory is still DETECTED as `orphaned-dir`,
-  // but detection no longer authorises removal. The orphan path has no git
-  // information (git does not list the directory, so `status` cannot classify
-  // it), so removal is gated on the filesystem guard instead — age first, then
-  // content. A directory created seconds ago is almost always an in-flight
-  // `git worktree add`, and deleting it destroys work no branch ref holds (#794).
+  // Invariant: an unregistered directory is detected, but only receives the
+  // prunable `orphaned-dir` verdict after the guard authorises removal. The
+  // orphan path has no git information (git does not list the directory, so
+  // `status` cannot classify it), so removal is gated on the filesystem guard
+  // instead — age first, then content. A directory created seconds ago is
+  // almost always an in-flight `git worktree add`, and deleting it destroys
+  // work no branch ref holds (#794).
   it('detects but PRESERVES a freshly-created unregistered directory', async () => {
     const orphanPath = join(afkWorktreesDir, 'afk-orphaned-dir');
     await fs.mkdir(orphanPath, { recursive: true });
@@ -687,10 +688,49 @@ describe('orphaned-dir-cleanup', () => {
       telemetryPath: telemetryFile,
     });
 
-    expect(result.candidates.some((c) => c.verdict === 'orphaned-dir')).toBe(true);
+    expect(result.candidates.some((c) => c.verdict === 'orphaned-dir-preserved')).toBe(true);
     expect(result.removed).not.toContain(orphanPath);
     expect(fsSpy).not.toHaveBeenCalledWith(orphanPath, { recursive: true, force: true });
     expect(result.warnings.some((w) => w.includes('orphaned dir preserved') && w.includes(orphanPath))).toBe(true);
+  });
+
+  it('PRESERVES an orphan when the filesystem reports no birth time', async () => {
+    const orphanPath = join(afkWorktreesDir, 'afk-orphaned-no-birthtime');
+    await fs.mkdir(orphanPath, { recursive: true });
+
+    const mainBlock = worktreeBlock({ path: repoRoot });
+    const mock = makeMock(async ({ args }) => {
+      if (args.includes('list') && args.includes('--porcelain')) {
+        return { stdout: `${mainBlock}\n`, stderr: '' };
+      }
+      return { stdout: '', stderr: '' };
+    });
+
+    const realStat = fs.stat.bind(fs);
+    vi.spyOn(fs, 'stat').mockImplementation(async (target: Parameters<typeof fs.stat>[0]) => {
+      const stat = await realStat(target);
+      if (String(target) === orphanPath) {
+        Object.defineProperty(stat, 'birthtimeMs', { value: 0, configurable: true });
+      }
+      return stat;
+    });
+
+    const result = await runSweep({
+      execFile: mock as ExecFileFn,
+      repoRoot,
+      lockPath: lockFile,
+      dryRun: false,
+      telemetryPath: telemetryFile,
+    });
+
+    expect(result.candidates).toContainEqual({
+      path: orphanPath,
+      verdict: 'orphaned-dir-preserved',
+      owner: 'interactive',
+      ageMs: 0,
+    });
+    expect(result.removed).not.toContain(orphanPath);
+    await expect(fs.stat(orphanPath)).resolves.toBeDefined();
   });
 
   it('removes an AGED unregistered directory holding only rebuildable content', async () => {
@@ -734,6 +774,7 @@ describe('orphaned-dir-cleanup', () => {
     });
 
     expect(result.removed).toContain(orphanPath);
+    expect(result.candidates.some((c) => c.verdict === 'orphaned-dir')).toBe(true);
     expect(fsSpy).toHaveBeenCalledWith(orphanPath, { recursive: true, force: true });
   });
 
@@ -773,6 +814,7 @@ describe('orphaned-dir-cleanup', () => {
     });
 
     expect(result.removed).not.toContain(orphanPath);
+    expect(result.candidates.some((c) => c.verdict === 'orphaned-dir-preserved')).toBe(true);
     expect(
       result.warnings.some((w) => w.includes('non-rebuildable-content') && w.includes(orphanPath)),
     ).toBe(true);
@@ -800,7 +842,7 @@ describe('orphaned-dir-cleanup', () => {
       telemetryPath: telemetryFile,
     });
 
-    expect(result.candidates.some((c) => c.verdict === 'orphaned-dir')).toBe(true);
+    expect(result.candidates.some((c) => c.verdict === 'orphaned-dir-preserved')).toBe(true);
     expect(result.removed).not.toContain(orphanPath);
     // Directory should still exist
     const exists = await fs.stat(orphanPath).then(() => true).catch(() => false);

--- a/src/agent/worktree-sweep.test.ts
+++ b/src/agent/worktree-sweep.test.ts
@@ -655,8 +655,13 @@ describe('locked-always-skipped', () => {
 // ---------------------------------------------------------------------------
 
 describe('orphaned-dir-cleanup', () => {
-  it('detects and removes directories in .afk-worktrees/ not registered in git', async () => {
-    // Create an orphaned directory under .afk-worktrees/
+  // Invariant: an unregistered directory is still DETECTED as `orphaned-dir`,
+  // but detection no longer authorises removal. The orphan path has no git
+  // information (git does not list the directory, so `status` cannot classify
+  // it), so removal is gated on the filesystem guard instead — age first, then
+  // content. A directory created seconds ago is almost always an in-flight
+  // `git worktree add`, and deleting it destroys work no branch ref holds (#794).
+  it('detects but PRESERVES a freshly-created unregistered directory', async () => {
     const orphanPath = join(afkWorktreesDir, 'afk-orphaned-dir');
     await fs.mkdir(orphanPath, { recursive: true });
     await fs.writeFile(join(orphanPath, 'somefile.txt'), 'content');
@@ -683,8 +688,94 @@ describe('orphaned-dir-cleanup', () => {
     });
 
     expect(result.candidates.some((c) => c.verdict === 'orphaned-dir')).toBe(true);
+    expect(result.removed).not.toContain(orphanPath);
+    expect(fsSpy).not.toHaveBeenCalledWith(orphanPath, { recursive: true, force: true });
+    expect(result.warnings.some((w) => w.includes('orphaned dir preserved') && w.includes(orphanPath))).toBe(true);
+  });
+
+  it('removes an AGED unregistered directory holding only rebuildable content', async () => {
+    // The sweep must still reclaim genuine leaks, or the guard defeats its
+    // purpose. Birthtime cannot be backdated portably, so the age is injected
+    // by stubbing the single `fs.stat` the orphan path performs.
+    const orphanPath = join(afkWorktreesDir, 'afk-orphaned-aged');
+    await fs.mkdir(join(orphanPath, 'node_modules', 'left-pad'), { recursive: true });
+    await fs.writeFile(join(orphanPath, 'node_modules', 'left-pad', 'index.js'), '0');
+
+    const mainBlock = worktreeBlock({ path: repoRoot });
+    const porcelainOut = `${mainBlock}\n`;
+
+    const mock = makeMock(async ({ args }) => {
+      if (args.includes('list') && args.includes('--porcelain')) {
+        return { stdout: porcelainOut, stderr: '' };
+      }
+      return { stdout: '', stderr: '' };
+    });
+
+    const realStat = fs.stat.bind(fs);
+    vi.spyOn(fs, 'stat').mockImplementation(async (target: Parameters<typeof fs.stat>[0]) => {
+      const stat = await realStat(target);
+      if (String(target) === orphanPath) {
+        Object.defineProperty(stat, 'birthtimeMs', {
+          value: Date.now() - 7 * 86_400_000,
+          configurable: true,
+        });
+      }
+      return stat;
+    });
+
+    const fsSpy = vi.spyOn(fs, 'rm');
+
+    const result = await runSweep({
+      execFile: mock as ExecFileFn,
+      repoRoot,
+      lockPath: lockFile,
+      dryRun: false,
+      telemetryPath: telemetryFile,
+    });
+
     expect(result.removed).toContain(orphanPath);
     expect(fsSpy).toHaveBeenCalledWith(orphanPath, { recursive: true, force: true });
+  });
+
+  it('PRESERVES an aged unregistered directory holding a non-rebuildable file', async () => {
+    const orphanPath = join(afkWorktreesDir, 'afk-orphaned-secret');
+    await fs.mkdir(orphanPath, { recursive: true });
+    await fs.writeFile(join(orphanPath, '.env'), 'TOKEN=abc');
+
+    const mainBlock = worktreeBlock({ path: repoRoot });
+    const porcelainOut = `${mainBlock}\n`;
+
+    const mock = makeMock(async ({ args }) => {
+      if (args.includes('list') && args.includes('--porcelain')) {
+        return { stdout: porcelainOut, stderr: '' };
+      }
+      return { stdout: '', stderr: '' };
+    });
+
+    const realStat = fs.stat.bind(fs);
+    vi.spyOn(fs, 'stat').mockImplementation(async (target: Parameters<typeof fs.stat>[0]) => {
+      const stat = await realStat(target);
+      if (String(target) === orphanPath) {
+        Object.defineProperty(stat, 'birthtimeMs', {
+          value: Date.now() - 7 * 86_400_000,
+          configurable: true,
+        });
+      }
+      return stat;
+    });
+
+    const result = await runSweep({
+      execFile: mock as ExecFileFn,
+      repoRoot,
+      lockPath: lockFile,
+      dryRun: false,
+      telemetryPath: telemetryFile,
+    });
+
+    expect(result.removed).not.toContain(orphanPath);
+    expect(
+      result.warnings.some((w) => w.includes('non-rebuildable-content') && w.includes(orphanPath)),
+    ).toBe(true);
   });
 
   it('does not remove orphaned dir in dry-run mode', async () => {

--- a/src/agent/worktree-sweep.ts
+++ b/src/agent/worktree-sweep.ts
@@ -120,6 +120,8 @@ type WorktreeVerdict =
   | 'locked'
   | 'active'
   | 'orphaned-dir'
+  /** An unregistered directory that the orphan guard could not prove safe to remove. */
+  | 'orphaned-dir-preserved'
   | 'orphaned-registration'
   /**
    * The owning process recorded in `.afk-worktree-meta.json` is gone, the
@@ -537,20 +539,25 @@ export async function runSweep(options: SweepOptions): Promise<SweepResult> {
         let orphanAgeMs = 0;
         try {
           const stat = await fs.stat(orphanPath);
-          orphanAgeMs = Date.now() - stat.birthtimeMs;
+          // Some filesystems report a zero/invalid birth time when creation
+          // time is unavailable. Treat that as unknown (age 0), not as an
+          // epoch-old directory eligible for immediate removal.
+          if (Number.isFinite(stat.birthtimeMs) && stat.birthtimeMs > 0) {
+            orphanAgeMs = Math.max(0, Date.now() - stat.birthtimeMs);
+          }
         } catch { /* use 0 */ }
-        result.candidates.push({
-          path: orphanPath,
-          verdict: 'orphaned-dir',
-          owner: 'interactive',
-          ageMs: orphanAgeMs,
-        });
         // Invariant: the orphan path has no git information — the directory is
         // absent from `git worktree list`, so `git status` cannot classify it
         // and none of the registered-candidate protections apply. The guard is
         // the substitute floor and it runs in dry-run too, so `list` reports the
         // preservation instead of implying the next tick will delete (#794).
         const guard = await classifyOrphanDir(orphanPath, orphanAgeMs, MIN_EMPTY_AGE_MS);
+        result.candidates.push({
+          path: orphanPath,
+          verdict: guard.remove ? 'orphaned-dir' : 'orphaned-dir-preserved',
+          owner: 'interactive',
+          ageMs: orphanAgeMs,
+        });
         if (!guard.remove) {
           result.warnings.push(
             `[WARN] orphaned dir preserved (${guard.because}` +

--- a/src/agent/worktree-sweep.ts
+++ b/src/agent/worktree-sweep.ts
@@ -17,6 +17,7 @@ import { readPresenceFiles, type PresenceRecord } from './awareness/presence.js'
 // THIS file) is `import type`, which TypeScript erases at compile time — so
 // no runtime require()/import cycle exists between the two modules.
 import { probeNonRebuildableIgnoredFiles } from './worktree-ignored-probe.js';
+import { classifyOrphanDir } from './worktree-orphan-guard.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -544,6 +545,19 @@ export async function runSweep(options: SweepOptions): Promise<SweepResult> {
           owner: 'interactive',
           ageMs: orphanAgeMs,
         });
+        // Invariant: the orphan path has no git information — the directory is
+        // absent from `git worktree list`, so `git status` cannot classify it
+        // and none of the registered-candidate protections apply. The guard is
+        // the substitute floor and it runs in dry-run too, so `list` reports the
+        // preservation instead of implying the next tick will delete (#794).
+        const guard = await classifyOrphanDir(orphanPath, orphanAgeMs, MIN_EMPTY_AGE_MS);
+        if (!guard.remove) {
+          result.warnings.push(
+            `[WARN] orphaned dir preserved (${guard.because}` +
+              `${guard.detail === undefined ? '' : `: ${guard.detail}`}): ${orphanPath}`,
+          );
+          continue;
+        }
         if (!effectiveDryRun) {
           try {
             await fs.rm(orphanPath, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

`#770` closed the reaper's data-loss paths for worktrees git **knows about**. The `orphaned-dir` branch was the fourth removal path and it bypassed every one of those protections — it deleted recursively with no dirty check, no ignored-file probe, and no age gate. This routes it through an equivalent floor.

Preserving an orphan costs one leaked directory, reclaimed when it ages out or is removed explicitly. Deleting a live one is unrecoverable — so every uncertain answer now preserves.

## Root cause

`src/agent/worktree-sweep.ts:534-556` (at `5456b75`):

- **No dirty check, no probe.** Registered candidates run `git status --porcelain` and then `probeNonRebuildableIgnoredFiles`. The orphan loop called neither — it went straight from "not in the registry" to `fs.rm(orphanPath, { recursive: true, force: true })`.
- **No age gate, despite computing the age.** `orphanAgeMs` was computed and attached to the candidate, then never compared to anything. The thresholds exist but are only consulted inside `classifyCandidate`, which this path never calls — it hard-codes `verdict: 'orphaned-dir'`. A directory created *seconds* ago was eligible.
- **Raw `fs.rm`.** It never went through the guarded-remove helpers, so none of #770's preservation logic was reachable.

Unlike #759, an unregistered directory has **no branch ref holding its contents**, so there is no recovery path: uncommitted work and `.env` files are simply gone.

## Change

New module **`src/agent/worktree-orphan-guard.ts`** (138 LOC) exporting `classifyOrphanDir()`, which never deletes and never throws:

1. **Age gate first** (no IO) — an orphan younger than `MIN_EMPTY_AGE_MS` is never touched. This is the most likely cause of an orphan in practice: an in-flight `git worktree add`. A caller that could not `stat` the directory passes `0`, which preserves rather than reading as "infinitely old".
2. **Bounded content walk** — each entry is classified with the existing shared policy (`classifyIgnoredEntry`), which defaults unrecognised paths to `protected`. Any non-rebuildable entry preserves and names the file.
3. **Fail-safe in one direction only** — unreadable directory, depth bound, or exhausted entry budget all preserve.

It lives in its own file because `worktree-sweep.ts` is already **852 LOC**, 2.4× over the repo's hard 350-LOC ceiling; the call site there is a thin 12-line edit. This follows the existing split precedent (`worktree-ignored-probe.ts` = IO, `worktree-ignored-patterns.ts` = policy).

**One design point worth review:** only `opaque` directories (dependency trees) are skipped wholesale. `inspectable` build output **is** descended into, because `dist/prod.env` is precisely the case #759 was filed for — skipping both classes would have reproduced that bug on the orphan path. A regression test pins it.

The guard also runs in **dry-run**, so `afk worktree list` reports the preservation and its reason instead of implying the next tick will delete. The `scope === 'all' || scope === 'interactive'` guard is untouched.

## Tests

New `src/agent/worktree-orphan-guard.test.ts` — 12 cases: fresh orphan preserved; failed-stat (age 0) and non-finite age preserved; `.env` preserved; untracked source file preserved (naming the file); secret nested under `dist/` preserved; aged empty orphan removed; aged dependency-tree-only orphan removed; unreadable path preserved; entry-budget and depth bounds preserved; a plain file as the target does not throw.

In `worktree-sweep.test.ts`, the existing case *"detects and removes directories in .afk-worktrees/ not registered in git"* **asserted the buggy contract** — it created a fresh orphan holding `somefile.txt` and expected removal. It is replaced by three integration cases: fresh orphan detected but preserved (with the warning); aged rebuildable-only orphan still removed (age injected by stubbing the one `fs.stat` the orphan path performs, since birthtime cannot be backdated portably); aged orphan with a non-rebuildable file preserved.

## Gates

| Gate | Result |
|---|---|
| `pnpm lint` (tsc --noEmit, strict) | pass |
| `pnpm exec vitest run src/agent/worktree-orphan-guard.test.ts` | 12/12 pass |
| `pnpm exec vitest run src/agent/worktree-sweep.test.ts` | 49/49 pass |
| Combined run | 61/61 pass |

Full `pnpm test` not run locally — CI runs it on this PR.

## Risk and blast radius

- **Behaviour change:** unregistered directories are no longer removed on sight. A genuine leak now waits out `MIN_EMPTY_AGE_MS` (1 hour) and must hold only rebuildable content. The trade is deliberate and stated in the issue.
- **Over-preservation is the failure mode**, by construction. An orphan holding an unrecognised file is now immortal until removed explicitly — acceptable given the alternative was silent unrecoverable deletion, but worth knowing.
- Touches the same file family as open PRs #799 and #771. Kept additive with no renamed exports to minimise conflict; the call-site edit is 12 lines.

Fixes #794
