### PR TITLE
fix(build): fail the bundle build when a prompt read cannot be inlined (#776)

### DIFF
--- a/scripts/assert-inlined-prompts.mjs
+++ b/scripts/assert-inlined-prompts.mjs
@@ -1,0 +1,91 @@
+/**
+ * Fail-closed assertion that no prompt read survived inlining (#776).
+ *
+ * Invariant: this runs against the PREPARED SOURCE TREE, not `dist/*.mjs`. The
+ * issue suggested grepping the bundle, and that was reconsidered deliberately:
+ * inlined prompt bodies land in the bundle as template literals, and several of
+ * this repo's prompts contain code examples — including `readFileSync` and `.md`
+ * filenames — so a proximity grep over minified output would false-positive on
+ * prompt CONTENT and fail a correct build. Minification also renames local
+ * bindings, making the call shape unreliable to match.
+ *
+ * The prepared tree has neither problem: it is unminified TypeScript, every
+ * inlining pass has already run, and a surviving `readFileSync(...'.md')` there is
+ * unambiguously an escape. Checking one layer earlier is strictly more reliable
+ * and catches Pattern A, B and C escapes uniformly.
+ *
+ * Contract: throws with every offending file:line on the first failure; returns
+ * the number of files scanned otherwise. Never mutates anything.
+ *
+ * @module scripts/assert-inlined-prompts
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+/**
+ * Any `readFileSync` call naming a `.md` path, in any quote style. Deliberately
+ * broader than the inliner's own resolver pattern: this is the backstop, so it
+ * must catch shapes the resolver never claimed to handle.
+ */
+const SURVIVING_MD_READ = /readFileSync\([^)]{0,400}?\.md['"`]/g;
+
+/**
+ * Invariant: only a read anchored to the MODULE'S OWN directory is in scope.
+ * Plenty of legitimate runtime `.md` reads exist and must not fail the build —
+ * `/changelog` reads the user's repo `CHANGELOG.md`, `user-skills.ts` reads
+ * user-authored `SKILL.md` from disk, and tests read temp fixtures. Those target
+ * files on the USER's disk, which the package never ships and never should.
+ * A `__dirname`/`here` anchor is what distinguishes "this file must be inside the
+ * published package" from "this path belongs to the user" — an unanchored scan
+ * flagged 13 correct call sites on the first run.
+ */
+function isPackageRelativeRead(callText) {
+  return /__dirname|\bhere\b/.test(callText);
+}
+
+function walkTsFiles(dir, onFile) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkTsFiles(full, onFile);
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith('.ts')) onFile(full);
+  }
+}
+
+/**
+ * @param {string} preparedSrc Root of the prepared (post-inlining) source tree.
+ * @returns {number} Files scanned.
+ */
+export function assertNoRemainingPromptReads(preparedSrc) {
+  const offenders = [];
+  let scanned = 0;
+
+  walkTsFiles(preparedSrc, (filePath) => {
+    scanned++;
+    const content = readFileSync(filePath, 'utf-8');
+    if (!content.includes('readFileSync')) return;
+    for (const match of content.matchAll(SURVIVING_MD_READ)) {
+      if (!isPackageRelativeRead(match[0])) continue;
+      const line = content.slice(0, match.index).split('\n').length;
+      offenders.push(
+        `  ${relative(preparedSrc, filePath)}:${line}  ${match[0].replace(/\s+/g, ' ').slice(0, 120)}`,
+      );
+    }
+  });
+
+  if (offenders.length > 0) {
+    throw new Error(
+      `[assert-inlined-prompts] ${offenders.length} prompt read(s) survived inlining:\n` +
+        `${offenders.join('\n')}\n` +
+        `  These would ship as runtime reads of .md files that are NOT in the published\n` +
+        `  package, failing only when a user runs the published artifact. Either make the\n` +
+        `  path a string literal the inliner can resolve, or extend the inliner to handle\n` +
+        `  the shape. See scripts/esbuild-plugin-inline-prompts.mjs.`,
+    );
+  }
+
+  return scanned;
+}

--- a/scripts/build-dist.mjs
+++ b/scripts/build-dist.mjs
@@ -82,13 +82,13 @@ mkdirSync(distDir, { recursive: true });
 // Step 1: pre-transform sources
 const { tmpSrc, tmpBase } = prepareSources();
 
-// Step 1b: fail CLOSED before bundling if any prompt read survived inlining
-// (#776). Checked on the prepared tree rather than dist/ — see the module
-// docblock for why the bundle is the wrong layer to grep.
-const scannedForPromptReads = assertNoRemainingPromptReads(tmpSrc);
-console.log(`  [assert-inlined-prompts] ${scannedForPromptReads} files verified: no runtime .md reads`);
-
 try {
+  // Step 1b: fail CLOSED before bundling if any prompt read survived inlining
+  // (#776). Checked on the prepared tree rather than dist/ — see the module
+  // docblock for why the bundle is the wrong layer to grep.
+  const scannedForPromptReads = assertNoRemainingPromptReads(tmpSrc);
+  console.log(`  [assert-inlined-prompts] ${scannedForPromptReads} files verified: no runtime .md reads`);
+
   // Step 2: bundle from transformed sources
   await build({
     entryPoints: {

--- a/scripts/build-dist.mjs
+++ b/scripts/build-dist.mjs
@@ -18,6 +18,7 @@ import { readFileSync, writeFileSync, rmSync, mkdirSync, statSync, chmodSync, co
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { prepareSources } from './esbuild-plugin-inline-prompts.mjs';
+import { assertNoRemainingPromptReads } from './assert-inlined-prompts.mjs';
 import { copyBundledPlugins } from './lib/copy-bundled-plugins.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -80,6 +81,12 @@ mkdirSync(distDir, { recursive: true });
 
 // Step 1: pre-transform sources
 const { tmpSrc, tmpBase } = prepareSources();
+
+// Step 1b: fail CLOSED before bundling if any prompt read survived inlining
+// (#776). Checked on the prepared tree rather than dist/ — see the module
+// docblock for why the bundle is the wrong layer to grep.
+const scannedForPromptReads = assertNoRemainingPromptReads(tmpSrc);
+console.log(`  [assert-inlined-prompts] ${scannedForPromptReads} files verified: no runtime .md reads`);
 
 try {
   // Step 2: bundle from transformed sources

--- a/scripts/esbuild-plugin-inline-prompts.mjs
+++ b/scripts/esbuild-plugin-inline-prompts.mjs
@@ -286,7 +286,11 @@ export function prepareSources() {
       stats.inlinedFiles++;
       stats.replacedCalls++;
     } else {
-      console.log(`  [inline-prompts] WARNING: Could not find loadSystemPrompt() in shared-helpers.ts`);
+      throw new Error(
+        '[inline-prompts] Could not find loadSystemPrompt() in shared-helpers.ts\n' +
+        '  Pattern C replacement failed. The function body may have changed.\n' +
+        '  Update the oldFn string in prepareSources() to match the current code.'
+      );
     }
   }
 

--- a/scripts/esbuild-plugin-inline-prompts.mjs
+++ b/scripts/esbuild-plugin-inline-prompts.mjs
@@ -107,6 +107,18 @@ function escapeForTemplate(str) {
   return str.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$/g, '\\$');
 }
 
+/**
+ * Contract: true when a call LOOKS like a prompt read this plugin is responsible
+ * for inlining — it resolves a path against the module's own directory and names
+ * a `.md` file — regardless of whether the path could be resolved. Used to tell a
+ * genuine near-miss (parameterized prompt path, must fail the build) from an
+ * unrelated `readFileSync` the plugin has no business touching (no `__dirname`
+ * anchor, or not a markdown file), which must stay silent.
+ */
+function isPromptShapedRead(callText) {
+  return /__dirname|\bhere\b/.test(callText) && /\.md['"`]/.test(callText);
+}
+
 function tryResolveReadFileSyncPath(callText, fileDir) {
   const joinMatch = callText.match(
     /readFileSync\(\s*(?:join|resolve)\s*\(\s*(?:__dirname|here)\s*,\s*(.+?)\)\s*,\s*['"]utf-?8['"]\s*\)/
@@ -182,7 +194,12 @@ export function prepareSources() {
       if (tmpPath === promptLoaderPath) continue;
 
       const content = readFileSync(tmpPath, 'utf-8');
-      if (!content.includes('readFileSync') || !/\.md['"]/.test(content)) continue;
+      // Invariant: the `.md` probe must accept a BACKTICK as well as a quote.
+      // A parameterized read ends its path in a template literal
+      // (`${name}.md`), so a quote-only test skipped the whole file here and the
+      // near-miss check below could never see it — the resolver was unreachable
+      // for exactly the shape that ships a broken bundle (#776).
+      if (!content.includes('readFileSync') || !/\.md['"`]/.test(content)) continue;
 
       // Use the ORIGINAL directory for path resolution (tmp copy won't have .md files
       // if they're not in the ts tree, but the original src does)
@@ -214,6 +231,23 @@ export function prepareSources() {
           const replacement = '`' + escapeForTemplate(mdContent) + '`';
           result = result.slice(0, match.index) + replacement + result.slice(match.index + match[0].length);
           stats.replacedCalls++;
+        } else if (isPromptShapedRead(match[0])) {
+          // Fail CLOSED (#776). Previously this branch did not exist: an
+          // unresolvable path left the call untouched and the build SUCCEEDED,
+          // shipping a bundle that reads a .md absent from the package. Every
+          // other gate misses it — lint and tests run against src/, and the
+          // non-dist build copies all .md unconditionally, masking it entirely.
+          const line = content.slice(0, match.index).split('\n').length;
+          throw new Error(
+            `[inline-prompts] Unresolvable prompt read at ${relative(repoRoot, origPath)}:${line}\n` +
+              `    ${match[0].replace(/\s+/g, ' ').slice(0, 160)}\n` +
+              `  Every join()/resolve() argument must be a string LITERAL so the path can be\n` +
+              `  resolved at build time and the prompt inlined. A parameterized path (template\n` +
+              `  literal or variable) cannot be resolved here, and leaving it in place would\n` +
+              `  ship a runtime readFileSync on a file that is not in the published package.\n` +
+              `  Fix: use a literal path at this call site, or teach\n` +
+              `  tryResolveReadFileSyncPath() to understand this shape.`,
+          );
         }
       }
 


### PR DESCRIPTION
## Summary

A parameterized prompt path made the inliner silently skip a call, leaving a runtime `readFileSync` on a `.md` that is not in the published package — with a **green build**. This makes that case fail the build, at two independent layers.

## Why every existing gate missed it

| Gate | Why it passed |
|---|---|
| `pnpm lint` | valid TypeScript |
| `pnpm test` | tests run against `src/`, never the bundle |
| `pnpm build` | `copy-prompts.js` copies all `src` `.md` unconditionally — **masks it entirely** |
| `pnpm build:dist` | `stats.inlinedFiles` silently decremented; exit 0 |

It surfaced only when a user ran the published npm artifact. Nothing asserted that the set of prompt reads *found* equals the set *inlined*.

## The finding that changes the fix

The issue proposed detecting the near-miss inside `tryResolveReadFileSyncPath`. That alone **could never have fired**. The file-level gate one layer up is:

```js
if (!content.includes('readFileSync') || !/\.md['"]/.test(content)) continue;
```

It requires a **quote** immediately after `.md`. A parameterized read ends its path in a template literal — `` `${name}.md` `` — which ends in a **backtick**, so the issue's own canonical example was skipped at the *file* level and never reached the resolver at all. Widening that probe is what makes the trap reachable; the throw is what makes it fatal.

## Change

**1. `scripts/esbuild-plugin-inline-prompts.mjs`** (262 → 296 LOC)
- File-level `.md` probe now accepts a backtick, so parameterized shapes reach the resolver.
- The resolver's `null` branch now **throws**, naming file and line plus the remedy (use a literal path, or teach the resolver the shape).
- Gated on a new `isPromptShapedRead()` predicate — the call must be anchored to `__dirname`/`here` **and** name a `.md`. Unrelated `readFileSync` calls stay silent, so there are no false positives on reads the plugin was never responsible for.

**2. New `scripts/assert-inlined-prompts.mjs`** (91 LOC), wired into `build-dist.mjs` before bundling — the backstop that catches Pattern B/C escapes and future shapes, not just Pattern A.

**Deliberate deviation from the issue, which suggested grepping `dist/*.mjs`:** inlined prompt bodies land in the bundle as template literals, and several of this repo's prompts contain code examples including `readFileSync` and `.md` filenames — so a proximity grep over minified output would false-positive on prompt *content* and fail a correct build. Minification also renames local bindings. The prepared source tree has neither problem: unminified, post-inlining, and a survivor there is unambiguous. Checking one layer earlier is strictly more reliable.

**Second deviation, forced by evidence:** the backstop only flags reads anchored to the module's own directory. An unanchored scan flagged **13 correct call sites** on its first run — `/changelog` reads the user's repo `CHANGELOG.md`, `user-skills.ts` reads user-authored `SKILL.md`, tests read temp fixtures. Those target files on the *user's* disk, which the package never ships and never should. The `__dirname`/`here` anchor is what separates "must be inside the published package" from "belongs to the user."

## Proof

**Clean build — no false positive on the three existing literal-path callers:**
```
[inline-prompts] Summary: 4 files inlined, 0 internal-tier stubs, 4 readFileSync calls replaced, prompt-loader replaced
[assert-inlined-prompts] 1427 files verified: no runtime .md reads
Build complete:
```

**Deliberate regression — `src/skills/_agents/contract.ts` temporarily converted to the issue's parameterized shape:**
```
Error: [inline-prompts] Unresolvable prompt read at src/skills/_agents/contract.ts:10
  Every join()/resolve() argument must be a string LITERAL so the path can be
  resolved at build time and the prompt inlined. A parameterized path (template
  literal or variable) cannot be resolved here, and leaving it in place would
  ship a runtime readFileSync on a file that is not in the published package.
  Fix: use a literal path at this call site, or teach
  tryResolveReadFileSyncPath() to understand this shape.
 ELIFECYCLE  Command failed with exit code 1.
```
That scratch change was reverted (`git diff` on the file is empty) and `build:dist` re-verified green afterwards. It is **not** in this diff.

## Gates

| Gate | Result |
|---|---|
| `pnpm build:dist` (clean) | pass — 4 inlined, 1427 files verified |
| `pnpm build:dist` (deliberate regression) | **fails as designed**, names file:line |
| `pnpm build:dist` (after revert) | pass |
| `pnpm lint` | pass |

No `src/` file changed, so no test suites are affected. `scripts/assert-moat-clean.mjs` does not exist in this repo (private-tier), so there was no existing post-build grep to mirror — hence the new module.

## Risk

This guards the **publish path**, so a false positive would block releases. Two things bound that: the throw fires only on a `__dirname`-anchored `.md` read that cannot be resolved — the exact shape that is already broken — and the backstop's anchor requirement was derived empirically from the 13 legitimate call sites above rather than guessed. Both were verified green on a clean build before and after the regression test.

The residual risk is the opposite direction: a genuinely new *legitimate* pattern for reading a shipped `.md` anchored at `__dirname` would now fail the build until either the resolver or the anchor list is extended. That is the intended fail-closed trade.

Fixes #776
