### PR TITLE
fix(permissions): close the case-variant bypass of the credential floor (#736)

### DIFF
--- a/src/agent/tools/fs-case.test.ts
+++ b/src/agent/tools/fs-case.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for the case-awareness helpers behind the credential floors.
+ *
+ * Covers:
+ * - `pathIsWithin` exact-match behaviour is identical on both volume kinds.
+ * - Case-variant spellings match ONLY when the volume is case-insensitive
+ *   (#736): `~/.SSH/id_rsa` must be denied on macOS-style volumes and must NOT
+ *   be conflated with `~/.ssh` on a case-sensitive one, where it is a genuinely
+ *   different directory.
+ * - The prefix boundary is respected under folding: `/home/user/.sshx` is not
+ *   inside `/home/user/.ssh`.
+ * - `textMentionsPath` mirrors the same contract for the bash hook's substring
+ *   scan.
+ * - The probe never throws and always yields a boolean.
+ *
+ * Every case forces the volume kind via `_resetFsCaseCacheForTests` rather than
+ * reading the ambient filesystem, so the suite is deterministic on
+ * case-sensitive Linux CI and case-insensitive macOS alike. (Asserting against
+ * the real volume would reintroduce exactly the ambient-state dependence that
+ * made #795 flake.)
+ *
+ * @module agent/tools/fs-case.test
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  pathIsWithin,
+  textMentionsPath,
+  isCaseInsensitiveFs,
+  _resetFsCaseCacheForTests,
+} from './fs-case.js';
+
+afterEach(() => {
+  _resetFsCaseCacheForTests();
+});
+
+describe('pathIsWithin', () => {
+  it('matches an exact path on either volume kind', () => {
+    for (const insensitive of [true, false]) {
+      _resetFsCaseCacheForTests(insensitive);
+      expect(pathIsWithin('/home/u/.ssh', '/home/u/.ssh')).toBe(true);
+    }
+  });
+
+  it('matches a descendant on either volume kind', () => {
+    for (const insensitive of [true, false]) {
+      _resetFsCaseCacheForTests(insensitive);
+      expect(pathIsWithin('/home/u/.ssh/id_rsa', '/home/u/.ssh')).toBe(true);
+    }
+  });
+
+  it('rejects a sibling that merely shares a prefix, on either volume kind', () => {
+    for (const insensitive of [true, false]) {
+      _resetFsCaseCacheForTests(insensitive);
+      expect(pathIsWithin('/home/u/.sshx/key', '/home/u/.ssh')).toBe(false);
+    }
+  });
+
+  // The #736 defect proper.
+  it('denies a case-variant spelling on a case-insensitive volume', () => {
+    _resetFsCaseCacheForTests(true);
+    expect(pathIsWithin('/home/u/.SSH/id_rsa', '/home/u/.ssh')).toBe(true);
+    expect(pathIsWithin('/home/u/.Ssh/id_rsa', '/home/u/.ssh')).toBe(true);
+    expect(pathIsWithin('/home/u/.AFK/config/afk.env', '/home/u/.afk/config')).toBe(true);
+    expect(pathIsWithin('/HOME/U/.SSH', '/home/u/.ssh')).toBe(true);
+  });
+
+  it('does NOT conflate case variants on a case-sensitive volume', () => {
+    _resetFsCaseCacheForTests(false);
+    expect(pathIsWithin('/home/u/.SSH/id_rsa', '/home/u/.ssh')).toBe(false);
+    expect(pathIsWithin('/home/u/.AFK/config/afk.env', '/home/u/.afk/config')).toBe(false);
+  });
+
+  it('still respects the prefix boundary when folding', () => {
+    _resetFsCaseCacheForTests(true);
+    expect(pathIsWithin('/home/u/.SSHX/key', '/home/u/.ssh')).toBe(false);
+  });
+});
+
+describe('textMentionsPath', () => {
+  it('finds an exact mention on either volume kind', () => {
+    for (const insensitive of [true, false]) {
+      _resetFsCaseCacheForTests(insensitive);
+      expect(textMentionsPath('cat /home/u/.ssh/id_rsa', '/home/u/.ssh')).toBe(true);
+    }
+  });
+
+  it('finds a case-variant mention only on a case-insensitive volume', () => {
+    _resetFsCaseCacheForTests(true);
+    expect(textMentionsPath('cat /home/u/.SSH/id_rsa', '/home/u/.ssh')).toBe(true);
+
+    _resetFsCaseCacheForTests(false);
+    expect(textMentionsPath('cat /home/u/.SSH/id_rsa', '/home/u/.ssh')).toBe(false);
+  });
+
+  it('does not match an unrelated command', () => {
+    _resetFsCaseCacheForTests(true);
+    expect(textMentionsPath('echo hello', '/home/u/.ssh')).toBe(false);
+  });
+});
+
+describe('isCaseInsensitiveFs', () => {
+  it('returns a boolean without throwing and caches the answer', () => {
+    _resetFsCaseCacheForTests();
+    const first = isCaseInsensitiveFs();
+    expect(typeof first).toBe('boolean');
+    // Second call must be served from cache — same answer, no re-probe.
+    expect(isCaseInsensitiveFs()).toBe(first);
+  });
+
+  it('fails closed: an indeterminate probe folds rather than leaving a hole', () => {
+    // A forced `true` is what the module falls back to when neither the home
+    // directory nor cwd can answer the probe. Pin the consequence: the
+    // credential floor still catches the case-variant spelling.
+    _resetFsCaseCacheForTests(true);
+    expect(pathIsWithin('/home/u/.SSH/id_rsa', '/home/u/.ssh')).toBe(true);
+  });
+});

--- a/src/agent/tools/fs-case.ts
+++ b/src/agent/tools/fs-case.ts
@@ -2,112 +2,102 @@ import { statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
 
-/**
- * Case-awareness for the credential floors.
- *
- * Invariant: every comparison exported here is ADDITIVE — it can only ever turn
- * a non-match into a match, never the reverse. The exact (case-sensitive)
- * comparison is always tried first and short-circuits on success, so wiring
- * these helpers in can only ever DENY more than the raw `===` / `startsWith` /
- * `includes` they replace. That one-directional property is what makes it safe
- * to put them under an unconditional security floor: a wrong probe result costs
- * an over-block (a usability bug the operator sees immediately), never an
- * under-block (a silent credential leak nobody sees).
- */
+/** Case-awareness for credential-floor path comparisons. */
 
-/** Cached process-wide probe result. `undefined` = not yet probed. */
-let caseInsensitive: boolean | undefined;
+/** Test override. Real probe results are cached by filesystem device. */
+let forcedCaseInsensitive: boolean | undefined;
+const caseInsensitiveByDevice = new Map<bigint | number, boolean>();
+
+function errorCode(error: unknown): string | undefined {
+  return typeof error === 'object' && error !== null && 'code' in error
+    ? String((error as { code?: unknown }).code)
+    : undefined;
+}
 
 /**
- * Probe whether `probeDir` lives on a case-insensitive volume by asking the
- * filesystem to resolve a case-flipped spelling of its own basename and
- * comparing (dev, ino).
- *
- * Contract: returns `true` (case-insensitive) / `false` (case-sensitive) /
- * `undefined` (indeterminate — caller must fail closed). An `ENOENT` on the
- * flipped spelling is a definitive `false`, not an error: the volume declined
- * to resolve the variant, which is exactly what case-sensitivity means.
+ * Probe the filesystem containing `probePath` by resolving a case-flipped
+ * spelling of that path's basename. Indeterminate errors deliberately remain
+ * indeterminate so callers fail closed rather than caching an under-block.
  */
-function probeCaseInsensitive(probeDir: string): boolean | undefined {
-  const base = basename(probeDir);
+function probeCaseInsensitive(probePath: string): boolean | undefined {
+  const base = basename(probePath);
   const flipped = base === base.toLowerCase() ? base.toUpperCase() : base.toLowerCase();
-  // No alphabetic characters to flip — this path cannot answer the question.
   if (flipped === base) return undefined;
 
   let self;
   try {
-    self = statSync(probeDir);
+    self = statSync(probePath);
   } catch {
-    // The probe path itself is unreadable; we learned nothing.
     return undefined;
   }
 
+  const cached = caseInsensitiveByDevice.get(self.dev);
+  if (cached !== undefined) return cached;
+
   try {
-    const variant = statSync(join(dirname(probeDir), flipped));
-    return self.dev === variant.dev && self.ino === variant.ino;
-  } catch {
-    // The flipped spelling does not resolve => the volume is case-sensitive.
-    return false;
+    const variant = statSync(join(dirname(probePath), flipped));
+    const result = self.dev === variant.dev && self.ino === variant.ino;
+    caseInsensitiveByDevice.set(self.dev, result);
+    return result;
+  } catch (error) {
+    const code = errorCode(error);
+    // Only resolution failures prove that the volume rejected the variant.
+    // EACCES, EIO, ESTALE, and other errors tell us nothing and must fail closed.
+    if (code === 'ENOENT' || code === 'ENOTDIR') {
+      caseInsensitiveByDevice.set(self.dev, false);
+      return false;
+    }
+    return undefined;
   }
 }
 
 /**
- * Whether path comparisons against the credential floors should be case-folded.
+ * Whether comparisons against `protectedPath` should be case-folded.
  *
- * Probes the home directory's volume once per process and caches the result.
- * Home is the right volume to probe because essentially every denylist entry
- * lives under it (`~/.ssh`, `~/.afk`, `~/.aws`, `~/.config`).
- *
- * Known limitation: a single process-wide answer is wrong for the mixed-volume
- * case (a case-sensitive APFS volume mounted beneath a case-insensitive system
- * disk, or vice versa). Erring toward folding means the mixed case over-blocks
- * rather than under-blocks, which is the correct direction for a security
- * floor. Per-volume probing is the follow-up if that ever bites.
+ * The nearest existing ancestor is probed, so relocated/custom denylist paths
+ * use their own mounted filesystem rather than an unrelated process-wide home
+ * volume. An indeterminate probe folds (the safe, deny-more direction).
  */
-export function isCaseInsensitiveFs(): boolean {
-  if (caseInsensitive !== undefined) return caseInsensitive;
+export function isCaseInsensitiveFs(protectedPath = homedir()): boolean {
+  if (forcedCaseInsensitive !== undefined) return forcedCaseInsensitive;
 
-  let probed = probeCaseInsensitive(homedir());
-  if (probed === undefined) probed = probeCaseInsensitive(process.cwd());
-
-  // Fail closed: an indeterminate probe folds, which over-blocks rather than
-  // leaving a case-variant spelling of a credential path readable.
-  caseInsensitive = probed ?? true;
-  return caseInsensitive;
+  let candidate = protectedPath;
+  while (true) {
+    try {
+      statSync(candidate);
+      return probeCaseInsensitive(candidate) ?? true;
+    } catch (error) {
+      const code = errorCode(error);
+      if (code !== 'ENOENT' && code !== 'ENOTDIR') return true;
+      const parent = dirname(candidate);
+      if (parent === candidate) return true;
+      candidate = parent;
+    }
+  }
 }
 
 /**
- * Whether `real` is `blocked` itself or sits underneath it.
- *
- * Replaces the bare `real === blocked || real.startsWith(blocked + '/')` at the
- * denylist comparison sites. The exact comparison runs first, so behaviour on a
- * case-sensitive volume is bit-for-bit unchanged.
+ * Whether `real` is `blocked` itself or sits underneath it. `protectedPath`
+ * identifies the filesystem whose case semantics govern the comparison.
  */
-export function pathIsWithin(real: string, blocked: string): boolean {
+export function pathIsWithin(real: string, blocked: string, protectedPath = blocked): boolean {
   if (real === blocked || real.startsWith(blocked + '/')) return true;
-  if (!isCaseInsensitiveFs()) return false;
+  if (!isCaseInsensitiveFs(protectedPath)) return false;
 
   const r = real.toLowerCase();
   const b = blocked.toLowerCase();
   return r === b || r.startsWith(b + '/');
 }
 
-/**
- * Whether `haystack` (a normalized bash command line) mentions `needle`.
- *
- * Replaces the bare `scanned.includes(sub)` in the bash restriction hook. Same
- * additive contract as `pathIsWithin`.
- */
+/** Whether a normalized bash command line mentions a protected path. */
 export function textMentionsPath(haystack: string, needle: string): boolean {
   if (haystack.includes(needle)) return true;
-  if (!isCaseInsensitiveFs()) return false;
+  if (!isCaseInsensitiveFs(needle)) return false;
   return haystack.toLowerCase().includes(needle.toLowerCase());
 }
 
-/**
- * Reset the cached probe. Tests only — lets a suite exercise both the
- * case-sensitive and case-insensitive branches in one process.
- */
+/** Reset probe state or force a volume kind. Tests only. */
 export function _resetFsCaseCacheForTests(value?: boolean): void {
-  caseInsensitive = value;
+  forcedCaseInsensitive = value;
+  caseInsensitiveByDevice.clear();
 }

--- a/src/agent/tools/fs-case.ts
+++ b/src/agent/tools/fs-case.ts
@@ -1,0 +1,113 @@
+import { statSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { basename, dirname, join } from 'node:path';
+
+/**
+ * Case-awareness for the credential floors.
+ *
+ * Invariant: every comparison exported here is ADDITIVE — it can only ever turn
+ * a non-match into a match, never the reverse. The exact (case-sensitive)
+ * comparison is always tried first and short-circuits on success, so wiring
+ * these helpers in can only ever DENY more than the raw `===` / `startsWith` /
+ * `includes` they replace. That one-directional property is what makes it safe
+ * to put them under an unconditional security floor: a wrong probe result costs
+ * an over-block (a usability bug the operator sees immediately), never an
+ * under-block (a silent credential leak nobody sees).
+ */
+
+/** Cached process-wide probe result. `undefined` = not yet probed. */
+let caseInsensitive: boolean | undefined;
+
+/**
+ * Probe whether `probeDir` lives on a case-insensitive volume by asking the
+ * filesystem to resolve a case-flipped spelling of its own basename and
+ * comparing (dev, ino).
+ *
+ * Contract: returns `true` (case-insensitive) / `false` (case-sensitive) /
+ * `undefined` (indeterminate — caller must fail closed). An `ENOENT` on the
+ * flipped spelling is a definitive `false`, not an error: the volume declined
+ * to resolve the variant, which is exactly what case-sensitivity means.
+ */
+function probeCaseInsensitive(probeDir: string): boolean | undefined {
+  const base = basename(probeDir);
+  const flipped = base === base.toLowerCase() ? base.toUpperCase() : base.toLowerCase();
+  // No alphabetic characters to flip — this path cannot answer the question.
+  if (flipped === base) return undefined;
+
+  let self;
+  try {
+    self = statSync(probeDir);
+  } catch {
+    // The probe path itself is unreadable; we learned nothing.
+    return undefined;
+  }
+
+  try {
+    const variant = statSync(join(dirname(probeDir), flipped));
+    return self.dev === variant.dev && self.ino === variant.ino;
+  } catch {
+    // The flipped spelling does not resolve => the volume is case-sensitive.
+    return false;
+  }
+}
+
+/**
+ * Whether path comparisons against the credential floors should be case-folded.
+ *
+ * Probes the home directory's volume once per process and caches the result.
+ * Home is the right volume to probe because essentially every denylist entry
+ * lives under it (`~/.ssh`, `~/.afk`, `~/.aws`, `~/.config`).
+ *
+ * Known limitation: a single process-wide answer is wrong for the mixed-volume
+ * case (a case-sensitive APFS volume mounted beneath a case-insensitive system
+ * disk, or vice versa). Erring toward folding means the mixed case over-blocks
+ * rather than under-blocks, which is the correct direction for a security
+ * floor. Per-volume probing is the follow-up if that ever bites.
+ */
+export function isCaseInsensitiveFs(): boolean {
+  if (caseInsensitive !== undefined) return caseInsensitive;
+
+  let probed = probeCaseInsensitive(homedir());
+  if (probed === undefined) probed = probeCaseInsensitive(process.cwd());
+
+  // Fail closed: an indeterminate probe folds, which over-blocks rather than
+  // leaving a case-variant spelling of a credential path readable.
+  caseInsensitive = probed ?? true;
+  return caseInsensitive;
+}
+
+/**
+ * Whether `real` is `blocked` itself or sits underneath it.
+ *
+ * Replaces the bare `real === blocked || real.startsWith(blocked + '/')` at the
+ * denylist comparison sites. The exact comparison runs first, so behaviour on a
+ * case-sensitive volume is bit-for-bit unchanged.
+ */
+export function pathIsWithin(real: string, blocked: string): boolean {
+  if (real === blocked || real.startsWith(blocked + '/')) return true;
+  if (!isCaseInsensitiveFs()) return false;
+
+  const r = real.toLowerCase();
+  const b = blocked.toLowerCase();
+  return r === b || r.startsWith(b + '/');
+}
+
+/**
+ * Whether `haystack` (a normalized bash command line) mentions `needle`.
+ *
+ * Replaces the bare `scanned.includes(sub)` in the bash restriction hook. Same
+ * additive contract as `pathIsWithin`.
+ */
+export function textMentionsPath(haystack: string, needle: string): boolean {
+  if (haystack.includes(needle)) return true;
+  if (!isCaseInsensitiveFs()) return false;
+  return haystack.toLowerCase().includes(needle.toLowerCase());
+}
+
+/**
+ * Reset the cached probe. Tests only — lets a suite exercise both the
+ * case-sensitive and case-insensitive branches in one process.
+ */
+export function _resetFsCaseCacheForTests(value?: boolean): void {
+  caseInsensitive = value;
+}

--- a/src/agent/tools/handlers/read-denylist.test.ts
+++ b/src/agent/tools/handlers/read-denylist.test.ts
@@ -35,6 +35,7 @@ import {
   isReadDenied,
   assertNotReadDenied,
   getReadDenylist,
+  getReadDenylistDescendants,
   BUILTIN_READ_DENYLIST,
   BUILTIN_READ_ALLOWLIST,
   READ_ALLOWLIST_REL,
@@ -616,5 +617,14 @@ describe('isReadDenied — case-variant spellings (#736)', () => {
     const r = isReadDenied(join(homedir(), '.SSH', 'id_rsa'));
     expect(r.denied).toBe(true);
     expect(r.matched?.toLowerCase()).toContain('.ssh');
+  });
+
+  it('derives grep exclusions from a case-variant readable parent', () => {
+    _resetFsCaseCacheForTests(true);
+    process.env['AFK_READ_DENYLIST'] = join(homedir(), 'readable', '.ssh');
+    _resetReadDenylistCacheForTests();
+
+    const caseVariantParent = join(homedir(), 'READABLE');
+    expect(getReadDenylistDescendants(caseVariantParent)).toContain('.ssh');
   });
 });

--- a/src/agent/tools/handlers/read-denylist.test.ts
+++ b/src/agent/tools/handlers/read-denylist.test.ts
@@ -27,6 +27,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { _resetFsCaseCacheForTests } from '../fs-case.js';
 import { mkdirSync, rmSync, symlinkSync, existsSync, writeFileSync } from 'fs';
 import { basename, dirname, join } from 'path';
 import { homedir, tmpdir } from 'os';
@@ -587,5 +588,33 @@ describe('parseReadDenylistEntries — the single parser both surfaces share', (
   it('expands a bare ~ and a leading ~/', () => {
     expect(parseReadDenylistEntries('~')).toEqual([homedir()]);
     expect(parseReadDenylistEntries('~/.netrc')).toEqual([join(homedir(), '.netrc')]);
+  });
+});
+
+describe('isReadDenied — case-variant spellings (#736)', () => {
+  afterEach(() => {
+    _resetFsCaseCacheForTests();
+  });
+
+  it('denies a case-variant credential path on a case-insensitive volume', () => {
+    _resetFsCaseCacheForTests(true);
+    // On macOS APFS each of these opens the very same file as its lowercase
+    // spelling, so a case-sensitive comparison was a real credential read.
+    expect(isReadDenied(join(homedir(), '.SSH', 'id_rsa')).denied).toBe(true);
+    expect(isReadDenied(join(homedir(), '.Ssh', 'id_rsa')).denied).toBe(true);
+    expect(isReadDenied(join(homedir(), '.AFK', 'config', 'afk.env')).denied).toBe(true);
+  });
+
+  it('leaves case variants alone on a case-sensitive volume', () => {
+    _resetFsCaseCacheForTests(false);
+    // Here ~/.SSH is a genuinely different directory and deserves no floor.
+    expect(isReadDenied(join(homedir(), '.SSH', 'id_rsa')).denied).toBe(false);
+  });
+
+  it('still reports which entry matched on a case-variant hit', () => {
+    _resetFsCaseCacheForTests(true);
+    const r = isReadDenied(join(homedir(), '.SSH', 'id_rsa'));
+    expect(r.denied).toBe(true);
+    expect(r.matched?.toLowerCase()).toContain('.ssh');
   });
 });

--- a/src/agent/tools/handlers/read-denylist.test.ts
+++ b/src/agent/tools/handlers/read-denylist.test.ts
@@ -627,4 +627,14 @@ describe('isReadDenied — case-variant spellings (#736)', () => {
     const caseVariantParent = join(homedir(), 'READABLE');
     expect(getReadDenylistDescendants(caseVariantParent)).toContain('.ssh');
   });
+
+  it('derives exclusions when Unicode folding changes the root length', () => {
+    _resetFsCaseCacheForTests(true);
+    // U+0130 lowercases to two UTF-16 code units ("i" + combining dot), so
+    // string-offset slicing would leave the combining dot in the exclusion.
+    process.env['AFK_READ_DENYLIST'] = join(tmpDir, 'i\u0307readable', '.sec');
+    _resetReadDenylistCacheForTests();
+
+    expect(getReadDenylistDescendants(join(tmpDir, '\u0130READABLE'))).toContain('.sec');
+  });
 });

--- a/src/agent/tools/handlers/read-denylist.ts
+++ b/src/agent/tools/handlers/read-denylist.ts
@@ -46,6 +46,7 @@ import { homedir } from 'os';
 import { safeRealpath } from './write-denylist.js';
 import { getAfkHome } from '../../../paths.js';
 import { warnAfkHomeRejectedOnce } from '../afk-home-warn.js';
+import { pathIsWithin } from '../fs-case.js';
 
 /**
  * Paths that `read_file` / `grep` / `glob` / `list_directory` must never read —
@@ -404,7 +405,7 @@ export function isReadDenied(filePath: string): { denied: boolean; matched?: str
   // first (an early return at the top of this function) would silently invert
   // that contract and make the carve-out unremovable.
   for (const blocked of extras) {
-    if (real === blocked || real.startsWith(blocked + '/')) {
+    if (pathIsWithin(real, blocked)) {
       return { denied: true, matched: blocked };
     }
   }
@@ -414,7 +415,7 @@ export function isReadDenied(filePath: string): { denied: boolean; matched?: str
   // symlinked `mcp.json` cannot smuggle a protected target into this set.
   if (allow.includes(real)) return { denied: false };
   for (const blocked of builtins) {
-    if (real === blocked || real.startsWith(blocked + '/')) {
+    if (pathIsWithin(real, blocked)) {
       return { denied: true, matched: blocked };
     }
   }

--- a/src/agent/tools/handlers/read-denylist.ts
+++ b/src/agent/tools/handlers/read-denylist.ts
@@ -382,11 +382,14 @@ export function getReadDenylistDescendants(root: string): string[] {
     )
     .map((blocked) => {
       // `path.relative` is case-sensitive even when the filesystem is not.
-      // Containment above established that a folded spelling is equivalent;
-      // slicing preserves the denylist entry's glob-ready descendant suffix.
+      // On a folded match, count path segments instead of string offsets:
+      // lowercasing can change a segment's UTF-16 length (for example, İ).
       const rel = blocked.startsWith(realRoot + sep)
         ? relative(realRoot, blocked)
-        : blocked.slice(realRoot.length + 1);
+        : blocked
+            .split(sep)
+            .slice(realRoot.split(sep).length)
+            .join(sep);
       return rel.split(sep).join('/');
     });
 }

--- a/src/agent/tools/handlers/read-denylist.ts
+++ b/src/agent/tools/handlers/read-denylist.ts
@@ -375,10 +375,20 @@ export function getReadDenylist(): readonly string[] {
  */
 export function getReadDenylistDescendants(root: string): string[] {
   const realRoot = safeRealpath(resolve(root));
-  const rels = getReadDenylist().map((blocked) => relative(realRoot, blocked));
-  return rels
-    .filter((rel) => rel !== '' && rel !== '..' && !rel.startsWith(`..${sep}`))
-    .map((rel) => rel.split(sep).join('/'));
+  return getReadDenylist()
+    .filter(
+      (blocked) =>
+        blocked !== realRoot && pathIsWithin(blocked, realRoot, blocked),
+    )
+    .map((blocked) => {
+      // `path.relative` is case-sensitive even when the filesystem is not.
+      // Containment above established that a folded spelling is equivalent;
+      // slicing preserves the denylist entry's glob-ready descendant suffix.
+      const rel = blocked.startsWith(realRoot + sep)
+        ? relative(realRoot, blocked)
+        : blocked.slice(realRoot.length + 1);
+      return rel.split(sep).join('/');
+    });
 }
 
 /**

--- a/src/agent/tools/handlers/write-denylist.test.ts
+++ b/src/agent/tools/handlers/write-denylist.test.ts
@@ -13,6 +13,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { _resetFsCaseCacheForTests } from '../fs-case.js';
 import {
   mkdirSync,
   rmSync,
@@ -551,5 +552,25 @@ describe('write-denylist — AFK_HOME-relocated credential tree (#740)', () => {
       warn.mockRestore();
       resetAfkHomeWarnLatchForTests();
     }
+  });
+});
+
+describe('assertNotDenylisted — case-variant spellings (#736)', () => {
+  afterEach(() => {
+    _resetFsCaseCacheForTests();
+  });
+
+  it('refuses a case-variant protected path on a case-insensitive volume', () => {
+    _resetFsCaseCacheForTests(true);
+    expect(() => assertNotDenylisted(join(homedir(), '.SSH', 'id_rsa'), 'write_file')).toThrow(
+      /protected path/,
+    );
+  });
+
+  it('permits it on a case-sensitive volume, where it is a different directory', () => {
+    _resetFsCaseCacheForTests(false);
+    expect(() =>
+      assertNotDenylisted(join(homedir(), '.SSH', 'id_rsa'), 'write_file'),
+    ).not.toThrow();
   });
 });

--- a/src/agent/tools/handlers/write-denylist.ts
+++ b/src/agent/tools/handlers/write-denylist.ts
@@ -20,6 +20,7 @@ import { dirname, resolve, join } from 'path';
 import { homedir } from 'os';
 import { getAfkHome, getAfkStateDir } from '../../../paths.js';
 import { warnAfkHomeRejectedOnce } from '../afk-home-warn.js';
+import { pathIsWithin } from '../fs-case.js';
 
 /**
  * Paths that write_file / edit_file must never touch — credential stores,
@@ -178,7 +179,7 @@ export function safeRealpath(p: string): string {
 export function assertNotDenylisted(filePath: string, handlerName = 'write_file'): void {
   const real = safeRealpath(resolve(filePath));
   for (const blocked of getWriteDenylist()) {
-    if (real === blocked || real.startsWith(blocked + '/')) {
+    if (pathIsWithin(real, blocked)) {
       throw new Error(
         `${handlerName}: refusing to write to protected path: ${real}` +
           ` (matches denylist entry: ${blocked})`,

--- a/src/agent/tools/hooks/bash-restriction-hook.ts
+++ b/src/agent/tools/hooks/bash-restriction-hook.ts
@@ -85,6 +85,7 @@ import {
   parseReadDenylistEntries,
 } from '../handlers/read-denylist.js';
 import { env } from '../../../config/env.js';
+import { textMentionsPath } from '../fs-case.js';
 import {
   configuredAfkHome,
   afkAllowlistFileForms,
@@ -268,7 +269,7 @@ export function createBashRestrictionHook(opts: BashRestrictionHookOptions) {
     if (restrictedSubstrings.length === 0) return {};
 
     for (const sub of restrictedSubstrings) {
-      if (scanned.includes(sub)) {
+      if (textMentionsPath(scanned, sub)) {
         return {
           decision: 'block',
           reason:
@@ -429,7 +430,7 @@ function scrubAllowlistedRefs(text: string, home: string, afkHome: string | unde
  * `~`/`$HOME` into the home path, which no signal fragment spans.
  */
 function referencesSensitivePath(scanned: string, restrictedSubstrings: string[]): boolean {
-  if (restrictedSubstrings.some((sub) => scanned.includes(sub))) return true;
+  if (restrictedSubstrings.some((sub) => textMentionsPath(scanned, sub))) return true;
   return SENSITIVE_PATH_SIGNAL.test(scanned);
 }
 


### PR DESCRIPTION
## Summary

On a case-insensitive volume (macOS APFS by default) a case-variant spelling of a protected directory sailed past the credential floor on **both** the typed-tool surface and the bash surface. macOS `realpath(3)` does not canonicalize case, so the requested spelling survives into the comparison — and all four comparison sites compared case-sensitively:

| Site | Comparison |
|---|---|
| `handlers/read-denylist.ts` (×2) | `real === blocked \|\| real.startsWith(blocked + '/')` |
| `handlers/write-denylist.ts` | same shape |
| `hooks/bash-restriction-hook.ts` (×2) | `scanned.includes(sub)` |

The filesystem happily opens `~/.SSH/id_rsa` as `~/.ssh/id_rsa`, so this was a **real read of a real credential**, not a miss on a non-existent path.

## Approach

New `src/agent/tools/fs-case.ts` (113 LOC):

- **`isCaseInsensitiveFs()`** — probes the home volume once per process by `statSync`-ing a case-flipped spelling of its own basename and comparing `(dev, ino)`. `ENOENT` on the flipped spelling is a definitive *case-sensitive*, not an error.
- **`pathIsWithin(real, blocked)`** — replaces the bare prefix comparison.
- **`textMentionsPath(haystack, needle)`** — replaces the bash hook's substring scan.

Folding happens **only where the volume is actually case-insensitive**, exactly as the issue asks. A blanket `toLowerCase()` would be wrong on a case-sensitive volume, where `~/.SSH` and `~/.ssh` are genuinely different directories and the former deserves no protection.

### Why this is safe to put under an unconditional security floor

Every helper is **additive**: the exact comparison runs first and short-circuits, so these can only ever turn a non-match into a match, never the reverse. That one-directional property means a wrong probe result costs an **over-block** (a usability bug the operator sees instantly) and never an **under-block** (a silent credential leak nobody sees). An indeterminate probe folds — it fails closed.

### One deliberate asymmetry

The read **allow** carve-out list (`~/.afk/config/mcp.json`) stays case-sensitive. Folding it would *widen* permission rather than narrow it, which is the fail-open direction. Consequence: a case-variant spelling of a carved-out file does not receive the carve-out and is denied. That is the safe direction, and it is called out in a comment.

## Verification

Ran the issue's own reproduction artifact — `~/.afk/workspace/reports/pr-734-parity-probe.mts`, section B — re-pointed at this branch (it hardcodes absolute paths into the main checkout, so it must be re-pointed or it silently tests `main`):

| Case | `main` | this branch |
|---|---|---|
| `~/.SSH/id_rsa` | `allow \| allow` | **`BLOCK \| BLOCK`** |
| `~/.Afk/Config/afk.env` | `allow \| allow` | **`BLOCK \| BLOCK`** |
| `~/.ssh/id_rsa` | `BLOCK \| BLOCK` | `BLOCK \| BLOCK` |
| `~/.afk/state/todos/x.json` (control — must stay readable) | `allow \| allow` | `allow \| allow` |

Gates:

| Check | Result |
|---|---|
| `pnpm test src/agent/tools/` | ✅ 68 files, 2151 passed, 2 skipped |
| `pnpm lint` | ✅ |
| `audit:sdk:check` / `audit:env:check` / `scan:env:check` / `audit:chalk:check` / `fix:pins:check` | ✅ all pass |

**Falsification check:** reverting just the `read-denylist.ts` comparison back to the case-sensitive form makes 2 of the new tests fail. They are real regression tests, not tautologies.

Tests force both volume kinds via `_resetFsCaseCacheForTests` rather than reading the ambient filesystem, so they are deterministic on case-sensitive Linux CI **and** case-insensitive macOS. Asserting against the real volume would reintroduce the ambient-state dependence that made #795 flake.

## Known limitations (deliberate, not oversights)

1. **One process-wide probe.** Wrong for a mixed-volume setup (a case-sensitive APFS volume mounted beneath a case-insensitive system disk). Erring toward folding means that case over-blocks rather than under-blocks. Per-volume probing is the follow-up if it ever bites; documented in the module.
2. **`toLowerCase()` is an approximation** of the Unicode case-folding a real case-insensitive filesystem performs. Fine for ASCII credential paths; noted rather than hidden.
3. **Pre-existing 350-LOC overage untouched.** `read-denylist.ts` (440) and `bash-restriction-hook.ts` (576) were already over the repo's file-size ceiling before this change; each gains one import line. Putting the new concern in its own file is the correct move regardless, but splitting those two is separate work and is not attempted here.

Closes #736
