### PR TITLE
refactor(provider): split anthropic-direct/index.ts behind characterization tests (#824)

### DIFF
--- a/src/agent/providers/anthropic-direct/build-dispatcher.characterization.test.ts
+++ b/src/agent/providers/anthropic-direct/build-dispatcher.characterization.test.ts
@@ -1,0 +1,341 @@
+/**
+ * Characterization tests for `AnthropicDirectProvider.buildDispatcher` (#824).
+ *
+ * Written BEFORE the index.ts decomposition and required to stay green
+ * verbatim afterwards. These pin CURRENT behavior — they are a safety net for
+ * an extraction, not an endorsement of every detail they observe.
+ *
+ * What is pinned here:
+ *   - handler-map composition + precedence (builtin > runtime-state > custom > MCP)
+ *   - schema list ordering (provider schemas, then MCP, then plan-exit last)
+ *   - the read-only-memory handler filter
+ *   - `allowAll` derivation from the permission mode
+ *   - the allowlist union for MCP + custom tool names
+ *   - fork-scoped `maxOutputBytes` arming
+ *   - plan-exit registration being gated on `planExitControls`, NOT on mode
+ *
+ * Observation strategy: `buildDispatcher` is private and returns a
+ * `SessionToolDispatcher` whose collaborators are private fields. Tests reach
+ * through `as any` — the same idiom already used by
+ * `src/agent/tools/custom-tool.test.ts:302,354,365`, which is the only existing
+ * caller that drives this method directly. Reaching for the private fields is
+ * deliberate: the point is to pin internal WIRING that has no public read-back.
+ *
+ * @module agent/providers/anthropic-direct/build-dispatcher.characterization.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { AnthropicDirectProvider } from './index.js';
+import { tool } from '../../tools/custom-tool.js';
+import { EXIT_PLAN_MODE_TOOL_NAME } from '../../tools/handlers/exit-plan-mode.js';
+import type { RuntimeStateSource } from '../../awareness/index.js';
+import type { SessionToolDispatcher } from '../../tools/dispatcher.js';
+import type { AnthropicToolDef, ToolHandler } from '../../tools/types.js';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/** Call the private `buildDispatcher` the way custom-tool.test.ts does. */
+function build(
+  provider: AnthropicDirectProvider,
+  mode = 'default',
+  opts: Record<string, unknown> = {},
+): SessionToolDispatcher {
+  return (provider as any).buildDispatcher(mode, opts) as SessionToolDispatcher;
+}
+
+function handlerNames(d: SessionToolDispatcher): string[] {
+  return [...((d as any).handlers as Map<string, ToolHandler>).keys()];
+}
+
+function schemaNames(d: SessionToolDispatcher): string[] {
+  return ((d as any).schemas as AnthropicToolDef[]).map((s) => s.name);
+}
+
+/** Minimal RuntimeStateSource — only identity matters for these assertions. */
+function stubSource(enabled: string[] = []): RuntimeStateSource {
+  return {
+    getSelf: () => ({
+      sessionId: null,
+      surface: 'cli',
+      parentSessionId: null,
+      depth: null,
+      maxDepth: null,
+      phaseRole: null,
+      cwd: '/work',
+      model: { provider: 'anthropic-direct', name: 'claude-sonnet-5' },
+      permissionMode: 'default',
+    }),
+    getTools: () => ({ enabled, mcpServers: [] }),
+    getSubagents: () => ({ active: [], backgroundJobs: [] }),
+    getWorkspace: () => ({
+      branch: null,
+      headSha: null,
+      dirty: null,
+      dirtyCount: null,
+      remoteUrl: null,
+    }),
+  } as unknown as RuntimeStateSource;
+}
+
+describe('buildDispatcher characterization (#824) — handler map', () => {
+  it('registers the builtin handlers plus the full memory trio by default', () => {
+    const d = build(new AnthropicDirectProvider());
+    const names = handlerNames(d);
+    expect(names).toContain('bash');
+    expect(names).toContain('read_file');
+    expect(names).toContain('write_file');
+    // Full (non-read-only) session gets all three memory handlers.
+    expect(names).toContain('memory_search');
+    expect(names).toContain('memory_update');
+    expect(names).toContain('procedure_write');
+  });
+
+  it('readOnlyMemory keeps memory_search and drops the memory write handlers', () => {
+    const d = build(new AnthropicDirectProvider({ readOnlyMemory: true }));
+    const names = handlerNames(d);
+    expect(names).toContain('memory_search');
+    expect(names).not.toContain('memory_update');
+    expect(names).not.toContain('procedure_write');
+  });
+
+  it('registers get_runtime_state ONLY when a runtimeStateSource is supplied', () => {
+    const without = build(new AnthropicDirectProvider());
+    expect(handlerNames(without)).not.toContain('get_runtime_state');
+
+    const withSource = build(new AnthropicDirectProvider(), 'default', {
+      runtimeStateSource: stubSource(),
+    });
+    expect(handlerNames(withSource)).toContain('get_runtime_state');
+  });
+
+  it('registers a non-colliding custom handler by identity', () => {
+    const myTool = tool('char_custom_tool', 'desc', z.object({ q: z.string() }), async () => ({
+      content: 'ok',
+    }));
+    const d = build(new AnthropicDirectProvider({ customTools: [myTool] }));
+    expect((d as any).handlers.get('char_custom_tool')).toBe(myTool.handler);
+  });
+
+  it('a custom tool colliding with a builtin does NOT win (builtin precedence)', () => {
+    const colliding = tool('bash', 'shadow', z.object({ x: z.string() }), async () => ({
+      content: 'CUSTOM',
+    }));
+    const d = build(new AnthropicDirectProvider({ customTools: [colliding] }));
+    expect((d as any).handlers.get('bash')).not.toBe(colliding.handler);
+  });
+
+  it('a custom tool colliding with get_runtime_state loses to the awareness handler', () => {
+    // Pins the ordering: runtime-state is registered BEFORE custom tools, and
+    // the custom loop skips names already present.
+    const colliding = tool('get_runtime_state', 'shadow', z.object({}), async () => ({
+      content: 'CUSTOM',
+    }));
+    const d = build(new AnthropicDirectProvider({ customTools: [colliding] }), 'default', {
+      runtimeStateSource: stubSource(),
+    });
+    expect((d as any).handlers.get('get_runtime_state')).not.toBe(colliding.handler);
+  });
+});
+
+describe('buildDispatcher characterization (#824) — schemas', () => {
+  it('passes the provider schema list through, with get_runtime_state always present', () => {
+    const d = build(new AnthropicDirectProvider());
+    const names = schemaNames(d);
+    expect(names).toContain('get_runtime_state');
+    expect(names).toContain('bash');
+    // No plan-exit schema without planExitControls.
+    expect(names).not.toContain(EXIT_PLAN_MODE_TOOL_NAME);
+  });
+
+  it('appends the plan-exit schema LAST and registers its handler when controls are supplied', () => {
+    const controls = { approve: () => {}, keepPlanning: () => {} };
+    const d = build(new AnthropicDirectProvider(), 'default', {
+      planExitControls: controls as never,
+    });
+    const names = schemaNames(d);
+    expect(names[names.length - 1]).toBe(EXIT_PLAN_MODE_TOOL_NAME);
+    expect(handlerNames(d)).toContain(EXIT_PLAN_MODE_TOOL_NAME);
+  });
+
+  it('registers plan-exit RESIDENT — gated on controls, NOT on permissionMode', () => {
+    // Regression guard for the "enter plan mode AFTER launch" flow: the
+    // dispatcher is built once per query and never rebuilt by
+    // setPermissionMode, so a mode-gated registration leaves the tool
+    // permanently unwired. 'default' mode + controls MUST still register it.
+    const controls = { approve: () => {}, keepPlanning: () => {} };
+    const inDefault = build(new AnthropicDirectProvider(), 'default', {
+      planExitControls: controls as never,
+    });
+    expect(handlerNames(inDefault)).toContain(EXIT_PLAN_MODE_TOOL_NAME);
+
+    const inPlan = build(new AnthropicDirectProvider(), 'plan', {
+      planExitControls: controls as never,
+    });
+    expect(handlerNames(inPlan)).toContain(EXIT_PLAN_MODE_TOOL_NAME);
+  });
+});
+
+describe('buildDispatcher characterization (#824) — permissions and options', () => {
+  it('derives allowAll from the permission mode (bypassPermissions / autonomous only)', () => {
+    expect((build(new AnthropicDirectProvider(), 'default') as any)._allowAll).toBe(false);
+    expect((build(new AnthropicDirectProvider(), 'plan') as any)._allowAll).toBe(false);
+    expect(
+      (build(new AnthropicDirectProvider(), 'bypassPermissions') as any)._allowAll,
+    ).toBe(true);
+    expect((build(new AnthropicDirectProvider(), 'autonomous') as any)._allowAll).toBe(true);
+  });
+
+  it('leaves permissions undefined (allow-all) when no allowlist is configured', () => {
+    expect((build(new AnthropicDirectProvider()) as any).permissions).toBeUndefined();
+  });
+
+  it('unions custom-tool names into a configured allowlist', () => {
+    const myTool = tool('char_allowlisted', 'desc', z.object({ x: z.string() }), async () => ({
+      content: '',
+    }));
+    const d = build(
+      new AnthropicDirectProvider({
+        customTools: [myTool],
+        permissions: { allowedTools: ['bash'] },
+      }),
+    );
+    const allowed: string[] = (d as any).permissions.allowedTools;
+    expect(allowed).toContain('char_allowlisted');
+    expect(allowed).toContain('bash');
+  });
+
+  it('arms maxOutputBytes ONLY from subagentToolOutputCapBytes (not parentSessionId)', () => {
+    const uncapped = build(new AnthropicDirectProvider(), 'default', {
+      parentSessionId: 'parent-123',
+    });
+    expect((uncapped as any).maxOutputBytes).toBeUndefined();
+
+    const capped = build(new AnthropicDirectProvider(), 'default', {
+      subagentToolOutputCapBytes: 4096,
+    });
+    expect((capped as any).maxOutputBytes).toBe(4096);
+  });
+
+  it('threads cwd, shared root arrays BY REFERENCE, and session identity', () => {
+    const readRoots = ['/work'];
+    const writeRoots = ['/work'];
+    const d = build(new AnthropicDirectProvider(), 'default', {
+      cwd: '/work',
+      readRoots,
+      writeRoots,
+      sessionId: 'sid-1',
+      parentSessionId: 'pid-1',
+      subagentId: 'sub-1',
+    });
+    // By-reference sharing is what makes /allow-dir grants survive across
+    // turns — a snapshot copy here would silently break grant propagation.
+    expect((d as any)._readRoots).toBe(readRoots);
+    expect((d as any)._writeRoots).toBe(writeRoots);
+    expect((d as any).sessionId).toBe('sid-1');
+    expect((d as any).parentSessionId).toBe('pid-1');
+    expect((d as any).subagentId).toBe('sub-1');
+  });
+
+  it('forwards readOnlyBash from the provider construction flag', () => {
+    expect((build(new AnthropicDirectProvider()) as any).readOnlyBash).toBe(false);
+    expect(
+      (build(new AnthropicDirectProvider({ readOnlyBash: true })) as any).readOnlyBash,
+    ).toBe(true);
+  });
+
+  it('passes itself as the session grant manager', () => {
+    const provider = new AnthropicDirectProvider();
+    expect((build(provider) as any).sessionGrantManager).toBe(provider);
+  });
+});
+
+describe('buildDispatcher characterization (#824) — MCP merge', () => {
+  const mcpTool: AnthropicToolDef = {
+    name: 'mcp__srv__do_thing',
+    description: 'mcp tool',
+    input_schema: { type: 'object', properties: {}, required: [] },
+  } as AnthropicToolDef;
+
+  const mcpHandler: ToolHandler = async () => ({ content: 'mcp' });
+
+  function fakeManager(): any {
+    return {
+      getMcpTools: () => [mcpTool],
+      getMcpHandlers: () => new Map<string, ToolHandler>([[mcpTool.name, mcpHandler]]),
+      getMcpToolWireNames: () => [mcpTool.name],
+      onToolsRefreshed: undefined,
+    };
+  }
+
+  it('merges MCP handlers and appends MCP schemas AFTER the provider schemas', () => {
+    const d = build(new AnthropicDirectProvider({ mcpManager: fakeManager() }));
+    expect((d as any).handlers.get(mcpTool.name)).toBe(mcpHandler);
+
+    const names = schemaNames(d);
+    expect(names).toContain(mcpTool.name);
+    // Builtins precede MCP entries so builtin names win any overlap.
+    expect(names.indexOf('bash')).toBeLessThan(names.indexOf(mcpTool.name));
+  });
+
+  it('unions MCP wire names into a configured allowlist', () => {
+    const d = build(
+      new AnthropicDirectProvider({
+        mcpManager: fakeManager(),
+        permissions: { allowedTools: ['bash'] },
+      }),
+    );
+    const allowed: string[] = (d as any).permissions.allowedTools;
+    expect(allowed).toContain(mcpTool.name);
+    expect(allowed).toContain('bash');
+  });
+
+  it('caches MCP tools/handlers across builds and invalidates on onToolsRefreshed', () => {
+    let toolCalls = 0;
+    let handlerCalls = 0;
+    const mgr: any = {
+      getMcpTools: () => {
+        toolCalls += 1;
+        return [mcpTool];
+      },
+      getMcpHandlers: () => {
+        handlerCalls += 1;
+        return new Map<string, ToolHandler>([[mcpTool.name, mcpHandler]]);
+      },
+      getMcpToolWireNames: () => [mcpTool.name],
+      onToolsRefreshed: undefined,
+    };
+    const provider = new AnthropicDirectProvider({ mcpManager: mgr });
+
+    build(provider);
+    expect(toolCalls).toBe(1);
+    expect(handlerCalls).toBe(1);
+
+    // Second build serves from cache — no re-fetch.
+    build(provider);
+    expect(toolCalls).toBe(1);
+    expect(handlerCalls).toBe(1);
+
+    // The constructor chained an invalidating callback onto the manager.
+    mgr.onToolsRefreshed('srv');
+    build(provider);
+    expect(toolCalls).toBe(2);
+    expect(handlerCalls).toBe(2);
+  });
+
+  it('chains through a pre-existing onToolsRefreshed observer', () => {
+    let seen: string | undefined;
+    const mgr: any = {
+      getMcpTools: () => [],
+      getMcpHandlers: () => new Map(),
+      getMcpToolWireNames: () => [],
+      onToolsRefreshed: (name: string) => {
+        seen = name;
+      },
+    };
+    // eslint-disable-next-line no-new
+    new AnthropicDirectProvider({ mcpManager: mgr });
+    mgr.onToolsRefreshed('srv-x');
+    expect(seen).toBe('srv-x');
+  });
+});

--- a/src/agent/providers/anthropic-direct/build-dispatcher.characterization.test.ts
+++ b/src/agent/providers/anthropic-direct/build-dispatcher.characterization.test.ts
@@ -323,6 +323,20 @@ describe('buildDispatcher characterization (#824) — MCP merge', () => {
     expect(handlerCalls).toBe(2);
   });
 
+  it('propagates a nullish handler map instead of silently registering nothing', () => {
+    // The original iterated `this._mcpHandlersCache` directly, so a manager
+    // returning a nullish map threw. Pinned because the obvious "hardening"
+    // (`?? []`) converts a loud failure into a silent zero-handler dispatcher
+    // — the model would just quietly lose every MCP tool.
+    const mgr: any = {
+      getMcpTools: () => [mcpTool],
+      getMcpHandlers: () => null,
+      getMcpToolWireNames: () => [mcpTool.name],
+      onToolsRefreshed: undefined,
+    };
+    expect(() => build(new AnthropicDirectProvider({ mcpManager: mgr }))).toThrow();
+  });
+
   it('chains through a pre-existing onToolsRefreshed observer', () => {
     let seen: string | undefined;
     const mgr: any = {

--- a/src/agent/providers/anthropic-direct/build-dispatcher.ts
+++ b/src/agent/providers/anthropic-direct/build-dispatcher.ts
@@ -181,7 +181,11 @@ export function buildDispatcher(
     if (!deps.getMcpHandlersCache()) {
       deps.setMcpHandlersCache(deps.mcpManager.getMcpHandlers());
     }
-    for (const [name, handler] of deps.getMcpHandlersCache() ?? []) {
+    // Non-null assertion rather than `?? []`: the original iterated the cache
+    // field directly, so a manager returning a nullish handler map threw here.
+    // A `?? []` fallback would convert that loud failure into a silent
+    // zero-handler registration — a behavior change, not a hardening.
+    for (const [name, handler] of deps.getMcpHandlersCache()!) {
       handlers.set(name, handler);
     }
   }

--- a/src/agent/providers/anthropic-direct/build-dispatcher.ts
+++ b/src/agent/providers/anthropic-direct/build-dispatcher.ts
@@ -1,0 +1,280 @@
+/**
+ * Per-query tool-dispatcher construction for {@link AnthropicDirectProvider}.
+ *
+ * Extracted from `index.ts` (#824) as a pure function over explicit params:
+ * everything the original method read off `this` now arrives through
+ * {@link BuildDispatcherDeps}, and the two mutable MCP caches are threaded as
+ * getter/setter pairs (the `cwd-dependents.ts` convention) so the provider
+ * keeps ownership of the fields while this module keeps the invalidation
+ * logic.
+ *
+ * Invariant: handler registration order encodes a precedence ladder and must
+ * not be reordered — builtins first, then memory, then the awareness handler,
+ * then consumer-registered custom tools (skipped on collision, so a builtin
+ * always wins), then MCP handlers. Schema order mirrors it: provider schemas,
+ * then MCP, then the plan-exit tool last. Both orders are observable on the
+ * wire, and the collision skips make them semantically load-bearing rather
+ * than cosmetic.
+ *
+ * @module agent/providers/anthropic-direct/build-dispatcher
+ */
+
+import type { CanUseTool } from '../../types/sdk-types.js';
+import type { PlanExitControls } from '../../types/config-types.js';
+import type { HookRegistry } from '../../hooks.js';
+import type { MemoryStore } from '../../memory/index.js';
+import type { SubagentExecutor } from '../../tools/subagent-executor.js';
+import type { SkillExecutor } from '../../tools/skill-executor.js';
+import type { ComposeExecutor } from '../../tools/compose-executor.js';
+import type { TraceWriter } from '../../trace/index.js';
+import type { AnthropicToolDef, ToolHandler } from '../../tools/types.js';
+import type { CustomToolDef } from '../../tools/custom-tool.js';
+import type { GrantManager } from '../../../cli/slash/commands/allow-dir.js';
+import type { RuntimeStateSource } from '../../awareness/index.js';
+import { SessionToolDispatcher } from '../../tools/dispatcher.js';
+import { createBuiltinHandlers } from '../../tools/handlers/index.js';
+import {
+  exitPlanModeTool,
+  createExitPlanModeHandler,
+  EXIT_PLAN_MODE_TOOL_NAME,
+} from '../../tools/handlers/exit-plan-mode.js';
+import { createMemoryHandlers } from '../../memory/index.js';
+import { createGetRuntimeStateHandler } from '../../awareness/index.js';
+import { resolveSessionHookRegistry } from '../../hooks.js';
+import {
+  withMcpToolsAllowed,
+  withCustomToolsAllowed,
+  type ToolPermissionConfig,
+} from '../../tools/permissions.js';
+import { pathContainmentBypassed } from '../../permission-policy.js';
+
+/** Per-call options — the session-scoped half of the dispatcher inputs. */
+export interface BuildDispatcherOptions {
+  cwd?: string;
+  readRoots?: string[];
+  writeRoots?: string[];
+  env?: Record<string, string>;
+  sessionId?: string;
+  parentSessionId?: string;
+  /**
+   * This fork's own subagent id. Stamped onto every `hook_decision` the
+   * dispatcher emits so a policy block is attributable to the child that
+   * provoked it (parity with what `tool_call` already records). Undefined on
+   * a top-level session.
+   */
+  subagentId?: string;
+  /**
+   * Explicit "this session is a forked subagent" signal carrying the
+   * per-result output-cap budget (#661). Set to MODEL_CAP_BYTES by
+   * `SubagentManager.forkSubagent` for EVERY fork; undefined on a top-level
+   * session. Arms the dispatcher's `maxOutputBytes` backstop declaratively.
+   */
+  subagentToolOutputCapBytes?: number;
+  traceWriter?: TraceWriter;
+  /**
+   * Live source for the `get_runtime_state` tool. Constructed per-query
+   * in `query()` so the handler closure captures the model name and
+   * config-level identity fields. When undefined the handler is not
+   * registered — the model would see "Unknown tool" if it called
+   * `get_runtime_state` against a dispatcher built without a source.
+   */
+  runtimeStateSource?: RuntimeStateSource;
+  /**
+   * Session-scoped hook registry sourced from `AgentConfig.hookRegistry`.
+   * Threaded here so `PreToolUse`/`PostToolUse` hooks (notably the
+   * plan-mode gate) fire on the per-query dispatcher. Production entry
+   * points construct the provider WITHOUT a constructor-time
+   * `hookRegistry` and supply the session registry on the query config
+   * instead, so falling back to `deps.hookRegistry` when this is unset
+   * preserves any constructor-provided registry.
+   */
+  hookRegistry?: HookRegistry;
+  /**
+   * Session-control bridge for the model-callable `exit_plan_mode` tool,
+   * forwarded from the query config (top-level sessions only). When set AND
+   * `permissionMode === 'plan'`, the handler + schema are registered.
+   */
+  planExitControls?: PlanExitControls;
+}
+
+/**
+ * Provider-scoped collaborators. These were `this.*` reads before the
+ * extraction; the MCP cache accessors keep the fields owned by the provider
+ * instance so invalidation via `onToolsRefreshed` still works.
+ */
+export interface BuildDispatcherDeps {
+  memoryStore: MemoryStore;
+  surface: string;
+  readOnlyMemory: boolean;
+  readOnlyBash: boolean;
+  customTools: readonly CustomToolDef[];
+  mcpManager: import('../../mcp/index.js').McpManager | undefined;
+  schemas: readonly AnthropicToolDef[];
+  hookRegistry: HookRegistry | undefined;
+  permissions: ToolPermissionConfig | undefined;
+  canUseTool: CanUseTool | undefined;
+  subagentExecutor: SubagentExecutor | undefined;
+  skillExecutor: SkillExecutor | undefined;
+  composeExecutor: ComposeExecutor | undefined;
+  /** The provider itself — it implements GrantManager for this session. */
+  sessionGrantManager: GrantManager;
+  getMcpToolsCache: () => AnthropicToolDef[] | null;
+  setMcpToolsCache: (value: AnthropicToolDef[] | null) => void;
+  getMcpHandlersCache: () => Map<string, ToolHandler> | null;
+  setMcpHandlersCache: (value: Map<string, ToolHandler> | null) => void;
+}
+
+/**
+ * Build a per-query tool dispatcher with a bash handler closed over the
+ * session's permission mode and working directory — eliminates the
+ * process.env race when concurrent sessions run in the same process with
+ * different modes, and the `process.cwd()` race when concurrent sessions
+ * run in different worktrees (bash/grep would otherwise spawn against
+ * the host's `process.cwd()` instead of the session's worktree).
+ *
+ * The shared read/write root arrays are passed by reference so that grant
+ * mutations (via `/allow-dir`) survive across turns without requiring a new
+ * dispatcher instance.
+ */
+export function buildDispatcher(
+  deps: BuildDispatcherDeps,
+  permissionMode: string,
+  opts?: BuildDispatcherOptions,
+): SessionToolDispatcher {
+  const handlers = createBuiltinHandlers(permissionMode, opts?.cwd);
+  const memoryHandlers = createMemoryHandlers(
+    deps.memoryStore,
+    undefined,
+    deps.surface,
+  );
+  // Read-only memory: register `memory_search` only. The dispatcher's
+  // unknown-tool path produces a clear error if the model attempts
+  // `memory_update` / `procedure_write` despite the schema being absent.
+  for (const [name, handler] of memoryHandlers) {
+    if (deps.readOnlyMemory && name !== 'memory_search') continue;
+    handlers.set(name, handler);
+  }
+  if (opts?.runtimeStateSource) {
+    handlers.set('get_runtime_state', createGetRuntimeStateHandler(opts.runtimeStateSource));
+  }
+  // Invariant: custom (consumer-registered) handlers are registered AFTER
+  // all builtins and the runtime-state handler, and BEFORE MCP handlers.
+  // If a custom tool name collides with a builtin already in `handlers`,
+  // the builtin wins (we skip the custom registration). This prevents a
+  // user-supplied tool from silently overriding a built-in capability.
+  for (const t of deps.customTools) {
+    if (!handlers.has(t.schema.name)) {
+      handlers.set(t.schema.name, t.handler);
+    }
+  }
+  // MCP handlers + schemas — served from a cache that is invalidated by
+  // `onToolsRefreshed` (fired after every `refreshServer()` / `completeAuth()`
+  // call).  This preserves the Option A correctness guarantee — the cache
+  // always reflects the live nameRegistry state — while avoiding redundant
+  // allocation and iteration on every query when the tool list has not changed.
+  // Pre/PostToolUse hooks fire for MCP tools automatically via the dispatcher
+  // (`tools/dispatcher.ts:247,342`).
+  if (deps.mcpManager) {
+    if (!deps.getMcpToolsCache()) {
+      deps.setMcpToolsCache(deps.mcpManager.getMcpTools());
+    }
+    if (!deps.getMcpHandlersCache()) {
+      deps.setMcpHandlersCache(deps.mcpManager.getMcpHandlers());
+    }
+    for (const [name, handler] of deps.getMcpHandlersCache() ?? []) {
+      handlers.set(name, handler);
+    }
+  }
+  const mcpSchemas = deps.getMcpToolsCache() ?? [];
+  // Plan-exit tool: the model-callable `exit_plan_mode`, registered RESIDENT
+  // whenever the session supplied control callbacks (top-level sessions only —
+  // subagents never get planExitControls). NOT gated on the construction-time
+  // `permissionMode`: the dispatcher is built once per query() and is NOT
+  // rebuilt by setPermissionMode, so a mode-gated registration here left the
+  // tool permanently unwired for the common "enter plan mode AFTER launch"
+  // flow (Shift+Tab / `/plan`), and the model got "Unknown tool exit_plan_mode".
+  // Callability is instead gated per-turn on the LIVE mode: query.ts filters
+  // this tool out of the advertised tool list on non-plan turns, so the model
+  // is offered it exactly when it is actionable — and it becomes callable the
+  // instant plan mode is entered mid-session, with no query rebuild.
+  const planExitControls = opts?.planExitControls;
+  if (planExitControls) {
+    handlers.set(EXIT_PLAN_MODE_TOOL_NAME, createExitPlanModeHandler(planExitControls));
+  }
+  return new SessionToolDispatcher({
+    handlers,
+    // This provider IS the session's GrantManager. Passing it here lets the
+    // dispatcher inject it onto PreToolUse/PostToolUse contexts, so the
+    // path-approval + bash-restriction hooks resolve THIS session's live
+    // grants (a forked child's own writeRoots) rather than the process-global
+    // ref pinned to the top-level session (#435/#514). getGrants() reads the
+    // same _sharedReadRoots/_sharedWriteRoots the dispatcher shares by
+    // reference, so hook and handler stay in lockstep.
+    sessionGrantManager: deps.sessionGrantManager,
+    // Path-containment bypass: bypassPermissions (explicit) AND autonomous
+    // (AFK) both carry allowAll:true so path containment + the path-approval
+    // prompt are disabled per-call. In AFK the afk-mode-gate is the safety
+    // ceiling (see agent/permission-policy.ts).
+    allowAll: pathContainmentBypassed(permissionMode),
+    // Constraint (semantic invariant): MCP schemas appended AFTER builtins
+    // so builtin tool names always take precedence in any overlap. The
+    // plan-exit schema is appended last, RESIDENT whenever planExitControls is
+    // present (top-level); query.ts filters it out of the advertised tool list
+    // on non-plan turns so the model sees it only when it is actionable.
+    schemas: [
+      ...deps.schemas,
+      ...mcpSchemas,
+      ...(planExitControls ? [exitPlanModeTool] : []),
+    ],
+    // Session hook registry via the one canonical resolver (query-scoped
+    // config registry wins over any constructor-provided one). Without this
+    // the plan-mode gate (the sole built-in PreToolUse hook) never reached
+    // the dispatcher and write tools ran unblocked in plan mode (c6892c6).
+    hookRegistry: resolveSessionHookRegistry(opts?.hookRegistry, deps.hookRegistry),
+    // Union live MCP wire-names AND consumer-registered custom-tool names into
+    // the (statically-snapshotted) allowlist so neither is rejected by the
+    // gate while present in `schemas`/`handlers`. No-op when there is no
+    // allowlist (undefined => all allowed) or nothing to union. Registering a
+    // custom tool is the grant (same as connecting an MCP server); restricted
+    // sub-agents carry no customTools, so this never widens their allowlist.
+    permissions: withCustomToolsAllowed(
+      deps.mcpManager
+        ? withMcpToolsAllowed(deps.permissions, deps.mcpManager.getMcpToolWireNames())
+        : deps.permissions,
+      deps.customTools.map((t) => t.schema.name),
+    ),
+    subagentExecutor: deps.subagentExecutor,
+    skillExecutor: deps.skillExecutor,
+    composeExecutor: deps.composeExecutor,
+    // In-process permission callback (Dim 8). No-op when unset; forwarded by
+    // reference so it composes with the static allowlist in the dispatcher.
+    ...(deps.canUseTool !== undefined ? { canUseTool: deps.canUseTool } : {}),
+    cwd: opts?.cwd,
+    readRoots: opts?.readRoots,
+    writeRoots: opts?.writeRoots,
+    ...(opts?.env !== undefined ? { env: opts.env } : {}),
+    sessionId: opts?.sessionId,
+    parentSessionId: opts?.parentSessionId,
+    ...(opts?.subagentId !== undefined ? { subagentId: opts.subagentId } : {}),
+    // Central output-cap backstop (#661), FORK-SCOPED. Armed from the
+    // explicit `subagentToolOutputCapBytes` signal that
+    // `SubagentManager.forkSubagent` stamps (as MODEL_CAP_BYTES = 100KB) on
+    // EVERY forked child — the single choke point for the agent-tool, skill,
+    // and compose fork paths. A value here means "forked child" ⇒ bound each
+    // tool result at that budget via headAndTail, containing the whole
+    // overflow crash class (MCP dumps, browser output, read_file of a huge
+    // file). The top-level session is built directly (never via forkSubagent),
+    // leaves this unset, and is therefore UNCAPPED (behavior unchanged). This
+    // replaces the prior `parentSessionId !== undefined` gate, which missed
+    // skill-forked descendants whose parent carries no sessionId (a stub
+    // parent) and were left silently exposed.
+    ...(opts?.subagentToolOutputCapBytes !== undefined
+      ? { maxOutputBytes: opts.subagentToolOutputCapBytes }
+      : {}),
+    ...(opts?.traceWriter ? { traceWriter: opts.traceWriter } : {}),
+    // Read-only-skill bash gate: forwarded from the provider's stored flag
+    // (set by createChildProviderFactory / buildReadOnlyReconProvider) so a
+    // read-only skill's forked child can't run mutating shell commands.
+    readOnlyBash: deps.readOnlyBash,
+  });
+}

--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -28,16 +28,8 @@ import type {
   ProviderQueryArgs,
   ProviderCompleteArgs,
 } from '../../provider.js';
-import {
-  buildClientOptions,
-  buildSystemPrefix,
-  detectAuthMode,
-} from './auth.js';
+import { detectAuthMode } from './auth.js';
 import { oneShotCompletion, type OneShotInput } from './oneshot.js';
-import { makeTracingFetch } from './tracing-fetch.js';
-import { ThrottleQueue } from './throttle-queue.js';
-import { parseQuotaHeaders, recordQuotaSnapshot } from '../../quota-cache.js';
-import { refreshClaudeCodeOauthToken } from '../../auth/keychain.js';
 import { AnthropicDirectQuery } from './query.js';
 import { pathContainmentBypassed } from '../../permission-policy.js';
 import {
@@ -71,24 +63,18 @@ export {
   type AnthropicDirectProviderOptions,
 } from './provider-options.js';
 import { builtinToolSchemas, agentTool, skillTool, composeTool } from '../../tools/schemas.js';
-import { resolveToolSystemPrompt, resolveMemorySystemPrompt } from '../../tools/system-prompt.js';
 import type { ToolPermissionConfig } from '../../tools/permissions.js';
 import type { SkillExecutor } from '../../tools/skill-executor.js';
 import { resolveModelId } from '../../session/model-resolution.js';
-import { buildSkillManifest } from '../../tools/skill-bridge.js';
 import { MemoryStore, memoryToolSchemas, memorySearchTool } from '../../memory/index.js';
 import { dumpIfEnabled } from '../../session/prompt-dump.js';
 import { env } from '../../../config/env.js';
 import { resolveQueryToken } from './query/token-resolution.js';
-import {
-  getRuntimeStateTool,
-  wrapDispatcherWithRuntimeState,
-  buildRuntimeStateSource,
-  type RuntimeStateSource,
-} from '../../awareness/index.js';
-import { registerPresenceLifecycle, resolveTopLevelSessionId } from './query/presence-lifecycle.js';
+import { getRuntimeStateTool } from '../../awareness/index.js';
 import { createCwdDependentsFactory } from './query/cwd-dependents.js';
-import { assembleSystemPrompt, buildStableSystemPrefix } from './query/system-prompt.js';
+import { wireQueryDispatcher } from './query/dispatcher-wiring.js';
+import { setUpQueryClient } from './query/client-setup.js';
+import { assembleQueryPrompt } from './query/prompt-assembly.js';
 
 const PROVIDER_NAME = 'anthropic-direct';
 const DEFAULT_MODEL = 'claude-sonnet-5';
@@ -414,57 +400,18 @@ export class AnthropicDirectProvider implements ModelProvider {
       );
     }
     const authMode = detectAuthMode(token);
-    // Live-throttle mailbox: the wrapped fetch pushes a signal onto this queue
-    // for every 429/503/529 the SDK sleep-and-retries INSIDE a single
-    // `messages.create`; the per-turn loop drains it to surface a `rate_limit`
-    // ProviderEvent LIVE (the loop is otherwise parked awaiting the SDK and
-    // cannot yield during the backoff). Installed only when the tracing fetch
-    // is (non-local-shim + a trace writer OR a live surface would consume it) —
-    // here it rides alongside the existing trace-writer gate so the queue and
-    // the wrapper share the same lifetime. The SAME instance is handed to the
-    // query below so the fetch producer and the loop consumer meet.
-    const throttleQueue =
-      !localMode && config.traceWriter ? new ThrottleQueue() : undefined;
-    // Invariant: quota capture is gated on `!localMode` ALONE — deliberately not
-    // on `config.traceWriter`. The `anthropic-ratelimit-unified-*` headers ride
-    // on every response and feed the CLI status line, which must stay live even
-    // when tracing is off (`AFK_TRACE_DISABLED=1`); tying it to the trace writer
-    // would silently blank the indicator in that configuration. localMode is
-    // still excluded: a local shim is not Anthropic and emits no quota headers.
-    const quotaObserver = localMode
-      ? undefined
-      : (headers: Headers): void => {
-          const snapshot = parseQuotaHeaders(headers);
-          if (snapshot !== undefined) recordQuotaSnapshot(snapshot);
-        };
-    const clientOpts = buildClientOptions(
+
+    // Client + observability wiring (throttle mailbox, quota capture, tracing
+    // fetch) and the OAuth token refresher that must reuse all three.
+    const { client, throttleQueue, systemPrefix, tokenRefresher } = setUpQueryClient({
+      config,
       token,
       authMode,
-      config.baseUrl,
-      // Observability: route SDK HTTP through a wrapper that (1) records
-      // 429/503/529 throttling into the witness trace so the SDK's
-      // otherwise-silent retry-after backoff is legible in `afk trace show`,
-      // (2) pushes a live signal onto `throttleQueue` so the progress banner can
-      // show the backoff as it happens, and (3) captures subscription-quota
-      // headers into the quota cache for the status line. Skipped entirely in
-      // local-shim mode (not Anthropic's billing surface). Note the wrapper is
-      // installed whenever ANY of the three observers is live — a trace writer
-      // is no longer required, since (3) must work with tracing disabled.
-      !localMode
-        ? makeTracingFetch(
-            config.traceWriter,
-            undefined,
-            throttleQueue ? (info) => throttleQueue.push(info) : undefined,
-            quotaObserver,
-          )
-        : undefined,
-    );
-    const factory = this.providerFactory ?? getClientFactory();
-    const client = factory ? factory(clientOpts) : new Anthropic(clientOpts);
-    // In local-server mode, suppress the OAuth CLI-mimicry system-prefix
-    // regardless of token shape: the shim is not Anthropic's billing surface
-    // and should not receive Claude-Code identity headers in the system prompt.
-    const systemPrefix = localMode ? null : buildSystemPrefix(authMode);
+      localMode,
+      factory: this.providerFactory ?? getClientFactory(),
+      createClient: (opts) => new Anthropic(opts),
+    });
+
     const userSystem = resolveUserSystem(config.systemPrompt);
 
     const model =
@@ -502,176 +449,43 @@ export class AnthropicDirectProvider implements ModelProvider {
       this._sharedWriteRoots.push(...config.writeRoots);
     }
 
-    // Awareness layer source: declared as a `let` because the dispatcher and
-    // the source have a benign cycle — `getEnabledToolNames` resolves through
-    // a closure that reads `queryDispatcher` lazily at handler-call time, so
-    // the assignment-before-use ordering below is safe.
-    let queryDispatcher: import('./tool-dispatcher.js').ToolDispatcher;
-
-    const runtimeStateSource: RuntimeStateSource = buildRuntimeStateSource({
-      surface: this.surface,
-      cwd: config.cwd ?? process.cwd(),
-      modelName: model,
-      providerName: PROVIDER_NAME,
-      permissionMode,
-      ...(config.sessionId !== undefined ? { sessionId: config.sessionId } : {}),
-      ...(config.parentSessionId !== undefined
-        ? { parentSessionId: config.parentSessionId }
-        : {}),
-      ...(config.depth !== undefined ? { depth: config.depth } : {}),
-      ...(config.maxDepth !== undefined ? { maxDepth: config.maxDepth } : {}),
-      ...(config.phaseRole !== undefined ? { phaseRole: config.phaseRole } : {}),
-      getEnabledToolNames: () =>
-        queryDispatcher instanceof SessionToolDispatcher
-          ? queryDispatcher.toolDefs.map((t) => t.name)
-          : [],
-      getMcpTools: () => this.mcpManager?.getMcpTools() ?? [],
-      getSubagents: () =>
-        this.subagentExecutor
-          ? this.subagentExecutor.getSubagentsLite()
-          : { active: [], backgroundJobs: [] },
-    });
-
-    // Invariant: presence and query construction MUST use the same session id,
-    // because the Telegram watcher resolves a session's ledger path from the id
-    // in its presence file. Resolve once here — BEFORE the presence write — and
-    // reuse the result for `new AnthropicDirectQuery` below, so the presence
-    // file, the `session.init` event, and the ledger directory cannot diverge.
-    // Reading `config.sessionId` alone is what broke this: it is set only under
-    // --resume, so fresh sessions advertised nothing at all.
-    const resolvedSession = resolveTopLevelSessionId({
-      sessionId: config.sessionId,
-      resume: config.resume,
-      depth: config.depth,
-      parentSessionId: config.parentSessionId,
-      surface: this.surface,
-      memoized: this._mintedSessionId,
-    });
-    this._mintedSessionId = resolvedSession.memoized;
-
-    this._presenceSessionId = registerPresenceLifecycle({
-      depth: config.depth,
-      parentSessionId: config.parentSessionId,
-      sessionId: resolvedSession.id,
-      currentPresenceSessionId: this._presenceSessionId,
-      runtimeStateSource,
-      surface: this.surface,
-      cwd: config.cwd,
-      providerName: PROVIDER_NAME,
-      model,
-    });
-
-    queryDispatcher = this.externalTools
-      ? wrapDispatcherWithRuntimeState(this.externalTools, runtimeStateSource)
-      : this.buildDispatcher(permissionMode, {
-          cwd: config.cwd,
-          readRoots: this._sharedReadRoots,
-          writeRoots: this._sharedWriteRoots,
-          ...(config.env !== undefined ? { env: config.env } : {}),
-          sessionId: config.sessionId,
-          parentSessionId: config.parentSessionId,
-          ...(config.subagentId !== undefined ? { subagentId: config.subagentId } : {}),
-          // Fork-scoped central output cap (#661): forwarded from the child
-          // config that forkSubagent stamped, arming maxOutputBytes for forks
-          // only (top-level leaves it unset).
-          ...(config.subagentToolOutputCapBytes !== undefined
-            ? { subagentToolOutputCapBytes: config.subagentToolOutputCapBytes }
-            : {}),
-          traceWriter: config.traceWriter,
-          runtimeStateSource,
-          hookRegistry: config.hookRegistry,
-          planExitControls: config.planExitControls,
-        });
-
-    // External-dispatcher branch: the caller owns routing for whatever tools
-    // it cares about, but we still offer `get_runtime_state` because the
-    // wrapper above intercepts it before it ever reaches the inner dispatcher.
-    // Without adding the schema here the model has no way to know the tool
-    // exists — leaving the awareness layer reachable only via the
-    // `SessionToolDispatcher` path.
-    const baseToolDefs = queryDispatcher instanceof SessionToolDispatcher
-      ? [...queryDispatcher.toolDefs]
-      : [...builtinToolSchemas, getRuntimeStateTool];
-    // Invariant: skill-dispatch sub-agents are dispatched AS a specific skill, so
-    // they must neither (a) pause to ask the operator "which skill?" nor (b) mutate
-    // the operator's environment. Strip `ask_question` (the operator-prompt escape
-    // hatch) and `terminal_font_size` (an environment tool with no role in skill
-    // work — a bare numeric skill arg such as a PR number can otherwise lure a
-    // confused model into calling terminal_font_size(<n>) instead of running the
-    // skill). Gated on isSkillDispatch; pairs with the SLASH_COMMAND_ROUTING_PROMPT
-    // omission below. Verified safe: no bundled/registry/user skill calls either tool.
-    // Non-interactive surfaces (daemon, scheduler/cron, one-shot `afk chat`)
-    // install no elicitation handler, so `ask_question` can only auto-decline
-    // (elicitation-router.ts). Strip it so the model proceeds on an assumption
-    // or emits Blocked rather than burning a turn on an unanswerable prompt.
-    // Narrower than the skill-dispatch strip: `terminal_font_size` is retained.
-    const toolDefs = config.isSkillDispatch
-      ? baseToolDefs.filter(
-          (t) => t.name !== 'ask_question' && t.name !== 'terminal_font_size',
-        )
-      : config.isNonInteractive
-        ? baseToolDefs.filter((t) => t.name !== 'ask_question')
-        : baseToolDefs;
+    // Dispatcher + awareness source + presence, in that order. The
+    // declare/capture/assign sequence for `queryDispatcher` lives entirely
+    // inside this helper — see its module header; splitting it reintroduces
+    // the stale-tool-list hazard (#824).
+    const { queryDispatcher, runtimeStateSource, toolDefs, resolvedSessionId } =
+      wireQueryDispatcher({
+        config,
+        model,
+        permissionMode,
+        surface: this.surface,
+        providerName: PROVIDER_NAME,
+        externalTools: this.externalTools,
+        sharedReadRoots: this._sharedReadRoots,
+        sharedWriteRoots: this._sharedWriteRoots,
+        getMcpTools: () => this.mcpManager?.getMcpTools() ?? [],
+        getSubagents: () =>
+          this.subagentExecutor
+            ? this.subagentExecutor.getSubagentsLite()
+            : { active: [], backgroundJobs: [] },
+        getMintedSessionId: () => this._mintedSessionId,
+        setMintedSessionId: (v) => { this._mintedSessionId = v; },
+        getPresenceSessionId: () => this._presenceSessionId,
+        setPresenceSessionId: (v) => { this._presenceSessionId = v; },
+        buildDispatcher: (mode, opts) => this.buildDispatcher(mode, opts),
+      });
 
     const cwd = config.cwd || process.cwd();
 
-    // Build skill manifest for system prompt injection. The manifest lists
-    // available skills so the model knows what the `skill` tool can invoke.
-    // Let collectSkillEntries() own the full scan (project + user + bundled).
-    // Pass the session cwd so project skills (<cwd>/.afk/skills/) resolve
-    // against the session's working directory, not the host process's —
-    // they diverge on long-lived hosts (daemon, Telegram bot).
-    // `excludeName` omits the executing skill's own entry for a skill-dispatch
-    // fork (see AgentConfig.skillDispatchName). Must stay in lockstep with the
-    // openai-compatible call site — a per-provider divergence here is how a
-    // fork on one provider silently keeps the self-entry.
-    const manifest = this.skillExecutor
-      ? buildSkillManifest(undefined, {
-          cwd,
-          ...(typeof config.skillDispatchName === 'string' &&
-          config.skillDispatchName.length > 0
-            ? { excludeName: config.skillDispatchName }
-            : {}),
-        })
-      : '';
-    // Invariant: SLASH_COMMAND_ROUTING_PROMPT is omitted for skill-dispatch
-    // sub-agents. Those sessions receive a "Run the <name> skill" directive
-    // with no <command-name> tag, so the routing instruction (which keys off
-    // that tag) would push them to ask "which skill?" instead of engaging with
-    // their SKILL.md body. The ask_question strip above is the structural
-    // backstop for the same failure mode.
-    const toolBase = resolveToolSystemPrompt(config.isSkillDispatch);
-    // Read-only memory child sessions get a slimmed prompt that omits write
-    // instructions for memory_update / procedure_write — keeps the model from
-    // being told about tools it does not have.
-    const memoryPrompt = resolveMemorySystemPrompt(this.readOnlyMemory);
-
-    // Awareness identity fields interleaved into the `# Environment` fragment
-    // (Phase 1 + 2). Stable across cwd swaps — only `cwd` changes on setCwd().
-    const environmentIdentity = {
+    const { stableSystemPrefix, toolSystemAppend } = assembleQueryPrompt({
+      config,
+      cwd,
       surface: this.surface,
-      sessionId: config.sessionId,
-      depth: config.depth,
-      maxDepth: config.maxDepth,
-      workspace: runtimeStateSource.getWorkspace(),
-    };
-
-    // Stable (cwd-independent) parts of the system prompt. The cwd-dependent
-    // `# Environment` fragment is spliced in by assembleSystemPrompt — the same
-    // helper the cwdDependentsFactory below uses on a cwd change, so the
-    // first-turn and rebuilt prompts can never drift.
-    const stableSystemPrefix = buildStableSystemPrefix({
-      toolBase,
-      memoryPrompt,
-      // Hot memory (HOT.md) rides its own config field, NOT prepended into
-      // systemPrompt, so the assembler can place it after the memory
-      // instructions rather than ahead of the # Agent AFK doctrine. Unset for
-      // child sessions (subagents never inject hot memory) → treated as absent.
-      hotMemory: config.hotMemory ?? '',
-      manifest,
+      readOnlyMemory: this.readOnlyMemory,
+      hasSkillExecutor: this.skillExecutor !== undefined,
+      runtimeStateSource,
       userSystem,
     });
-    const toolSystemAppend = assembleSystemPrompt(stableSystemPrefix, cwd, environmentIdentity);
 
     // Dump prompt debug info if AFK_DUMP_PROMPT is set (wired via --dump-prompt CLI flag).
     dumpIfEnabled({
@@ -695,47 +509,15 @@ export class AnthropicDirectProvider implements ModelProvider {
       },
     });
 
-    let tokenRefresher: (() => Promise<Anthropic | null>) | undefined;
-    // In local-server mode, never refresh the keychain OAuth token: a 401 from
-    // the local shim must not cause the SDK to fetch and forward a real
-    // Anthropic credential to a self-hosted endpoint. The placeholder token
-    // path above already prevents this on the initial request; this guard
-    // closes the 401-retry hole.
-    if (authMode === 'oauth' && !localMode) {
-      const factory = this.providerFactory ?? getClientFactory();
-      tokenRefresher = async (): Promise<Anthropic | null> => {
-        const freshToken = await refreshClaudeCodeOauthToken();
-        if (!freshToken) return null;
-        const opts = buildClientOptions(
-          freshToken,
-          'oauth',
-          config.baseUrl,
-          // Preserve throttle observability, the live-banner signal AND quota
-          // capture across an OAuth account swap — the rebuilt client must keep
-          // the same tracing-fetch wrapper wired to the same `throttleQueue` and
-          // the same quota observer. localMode is false in this branch (see the
-          // guard above), so `quotaObserver` is always defined here and the
-          // wrapper installs unconditionally — no trace-writer gate, matching
-          // the primary install site above.
-          makeTracingFetch(
-            config.traceWriter,
-            undefined,
-            throttleQueue ? (info) => throttleQueue.push(info) : undefined,
-            quotaObserver,
-          ),
-        );
-        return factory ? factory(opts) : new Anthropic(opts);
-      };
-    }
-
     // Invariant: this MUST be the same id the presence file advertises, so the
     // Telegram watcher tails the ledger this session actually writes. Sourced
-    // from the single resolution performed above (explicit --resume id wins;
-    // top-level sessions get a memoized mint; forks stay undefined so the query
-    // keeps minting its own id per call). `opts.sessionId` feeds only
-    // `initSessionId` in query.ts — it gates no resume behavior — so supplying
-    // a minted id here is inert apart from making the id known earlier.
-    const resumedSessionId = resolvedSession.id;
+    // from the single resolution performed inside wireQueryDispatcher (explicit
+    // --resume id wins; top-level sessions get a memoized mint; forks stay
+    // undefined so the query keeps minting its own id per call).
+    // `opts.sessionId` feeds only `initSessionId` in query.ts — it gates no
+    // resume behavior — so supplying a minted id here is inert apart from
+    // making the id known earlier.
+    const resumedSessionId = resolvedSessionId;
     const initialMessages = resumeHistoryToMessages(config.resumeHistory);
 
     const cwdDependentsFactory = this.externalTools

--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -482,7 +482,11 @@ export class AnthropicDirectProvider implements ModelProvider {
       cwd,
       surface: this.surface,
       readOnlyMemory: this.readOnlyMemory,
-      hasSkillExecutor: this.skillExecutor !== undefined,
+      // Truthiness, NOT `!== undefined`: this must stay in lockstep with the
+      // constructor's `if (opts.skillExecutor) schemas.push(skillTool)` gate.
+      // Splitting them would let a falsy-but-defined executor inject a skill
+      // manifest into the system prompt with no `skill` tool registered.
+      hasSkillExecutor: Boolean(this.skillExecutor),
       runtimeStateSource,
       userSystem,
     });

--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -53,31 +53,35 @@ export { resolveEffort, resolveMaxTokens, resolveThinkingParam } from './resolve
 import type { ToolDispatcher } from './tool-dispatcher.js';
 import { SessionToolDispatcher } from '../../tools/dispatcher.js';
 import { PathGrantManager } from '../../tools/grant-manager.js';
-import { createBuiltinHandlers } from '../../tools/handlers/index.js';
 import {
-  exitPlanModeTool,
-  createExitPlanModeHandler,
-  EXIT_PLAN_MODE_TOOL_NAME,
-} from '../../tools/handlers/exit-plan-mode.js';
-import type { PlanExitControls } from '../../types/config-types.js';
+  buildDispatcher as buildDispatcherImpl,
+  type BuildDispatcherOptions,
+} from './build-dispatcher.js';
+import {
+  __setAnthropicClientFactory,
+  getClientFactory,
+  type AnthropicClientFactory,
+  type AnthropicDirectProviderOptions,
+} from './provider-options.js';
+// Re-exported so the historical `from './index.js'` import paths stay valid
+// after the #824 split (both are load-bearing for the existing test suite).
+export {
+  __setAnthropicClientFactory,
+  type AnthropicClientFactory,
+  type AnthropicDirectProviderOptions,
+} from './provider-options.js';
 import { builtinToolSchemas, agentTool, skillTool, composeTool } from '../../tools/schemas.js';
 import { resolveToolSystemPrompt, resolveMemorySystemPrompt } from '../../tools/system-prompt.js';
-import { withMcpToolsAllowed, withCustomToolsAllowed, type ToolPermissionConfig } from '../../tools/permissions.js';
-import type { HookRegistry } from '../../hooks.js';
-import { resolveSessionHookRegistry } from '../../hooks.js';
-import type { SubagentExecutor } from '../../tools/subagent-executor.js';
+import type { ToolPermissionConfig } from '../../tools/permissions.js';
 import type { SkillExecutor } from '../../tools/skill-executor.js';
-import type { ComposeExecutor } from '../../tools/compose-executor.js';
-import type { TraceWriter } from '../../trace/index.js';
 import { resolveModelId } from '../../session/model-resolution.js';
 import { buildSkillManifest } from '../../tools/skill-bridge.js';
-import { MemoryStore, createMemoryHandlers, memoryToolSchemas, memorySearchTool } from '../../memory/index.js';
+import { MemoryStore, memoryToolSchemas, memorySearchTool } from '../../memory/index.js';
 import { dumpIfEnabled } from '../../session/prompt-dump.js';
 import { env } from '../../../config/env.js';
 import { resolveQueryToken } from './query/token-resolution.js';
 import {
   getRuntimeStateTool,
-  createGetRuntimeStateHandler,
   wrapDispatcherWithRuntimeState,
   buildRuntimeStateSource,
   type RuntimeStateSource,
@@ -88,98 +92,6 @@ import { assembleSystemPrompt, buildStableSystemPrefix } from './query/system-pr
 
 const PROVIDER_NAME = 'anthropic-direct';
 const DEFAULT_MODEL = 'claude-sonnet-5';
-
-/** Test/factory hook: lets tests inject a stub Anthropic client.
- *
- * `baseURL` is the SDK's camelCase option name (forwarded by
- * `buildClientOptions` when the local-server path is active).
- */
-export type AnthropicClientFactory = (
-  opts: ({ authToken: string } | { apiKey: string }) & { baseURL?: string; fetch?: typeof fetch },
-) => Anthropic;
-
-let clientFactory: AnthropicClientFactory | null = null;
-
-/**
- * Module-scope escape hatch used by integration tests; not part of the stable
- * surface. Pass `null` to restore the real `Anthropic` constructor.
- */
-export function __setAnthropicClientFactory(
-  factory: AnthropicClientFactory | null,
-): void {
-  clientFactory = factory;
-}
-
-/** Construction options for {@link AnthropicDirectProvider}. */
-export interface AnthropicDirectProviderOptions {
-  /** Pluggable tool dispatcher. When set, overrides the built-in SessionToolDispatcher. */
-  tools?: ToolDispatcher;
-  /** Hook registry for PreToolUse/PostToolUse integration. */
-  hookRegistry?: HookRegistry;
-  /** Tool permission configuration (allowlist). */
-  permissions?: ToolPermissionConfig;
-  /** In-process permission callback, forwarded to the session dispatcher. */
-  canUseTool?: CanUseTool;
-  /**
-   * Optional client factory override. When set, takes precedence over the
-   * module-scope `__setAnthropicClientFactory` hook. Useful for callers that
-   * want to inject a pre-built client (e.g. with custom retries) without
-   * touching module state.
-   */
-  clientFactory?: AnthropicClientFactory;
-  /** Optional subagent executor. When provided, the Agent tool is included in the tool set. */
-  subagentExecutor?: SubagentExecutor;
-  /** Optional skill executor. When provided, the Skill tool is included in the tool set. */
-  skillExecutor?: SkillExecutor;
-  /** Optional compose executor. When provided, the Compose tool is included in the tool set. */
-  composeExecutor?: ComposeExecutor;
-  /** Shared MemoryStore instance. When set, avoids creating a second store. */
-  memoryStore?: MemoryStore;
-  /** Surface identifier for fact metadata (e.g. 'cli', 'daemon', 'telegram'). */
-  surface?: string;
-  /**
-   * When true, the provider exposes only the read-only `memory_search` tool
-   * (no `memory_update`, no `procedure_write`) and substitutes the
-   * {@link MEMORY_SYSTEM_PROMPT_READONLY} variant in the system prompt.
-   * Defaults to false. Set by {@link createChildProviderFactory} for
-   * subagent / skill child sessions — only the parent writes memory.
-   */
-  readOnlyMemory?: boolean;
-  /**
-   * When true, the per-query {@link SessionToolDispatcher} blocks mutating
-   * `bash` commands (read-only recon — git status/log/diff, ls, cat, find,
-   * grep — is allowed). Set by `createChildProviderFactory` /
-   * `buildReadOnlyReconProvider` for a read-only skill's forked child, paired
-   * with `permissions.allowedTools = RECON_ALLOWED_TOOLS` (which strips
-   * `write_file`/`edit_file`). Defaults to false.
-   */
-  readOnlyBash?: boolean;
-  /**
-   * Optional MCP manager. When provided, every tool exposed by a
-   * `connected` MCP server is merged into the provider's tool schema list
-   * and the per-query dispatcher's handler map. Pre/PostToolUse hooks
-   * fire for MCP tools automatically via the dispatcher (see
-   * `tools/dispatcher.ts:247,342`).
-   *
-   * Lifecycle: caller owns construction (`McpManager.fromConfig()`) and
-   * teardown (`disconnectAll()`). Subagents inherit the same manager by
-   * reference — never reconstructed per-fork.
-   */
-  mcpManager?: import('../../mcp/index.js').McpManager;
-  /**
-   * In-process custom tools registered by the library consumer. Each entry
-   * supplies an `AnthropicToolDef` schema (added to the provider's schema
-   * list at construction time) and a `ToolHandler` (registered in the
-   * per-query dispatcher's handler map).
-   *
-   * Custom tools run through the same permission gate and PreToolUse /
-   * PostToolUse hooks as built-in tools — no bypass.
-   *
-   * Precedence: builtins > MCP > custom (a custom tool whose name collides
-   * with a builtin is silently skipped — see `buildDispatcher`).
-   */
-  customTools?: import('../../tools/custom-tool.js').CustomToolDef[];
-}
 
 /**
  * Direct Anthropic SDK provider. Construction is cheap; the real per-session
@@ -356,204 +268,40 @@ export class AnthropicDirectProvider implements ModelProvider {
   }
 
   /**
-   * Build a per-query tool dispatcher with a bash handler closed over the
-   * session's permission mode and working directory — eliminates the
-   * process.env race when concurrent sessions run in the same process with
-   * different modes, and the `process.cwd()` race when concurrent sessions
-   * run in different worktrees (bash/grep would otherwise spawn against
-   * the host's `process.cwd()` instead of the session's worktree).
-   *
-   * The shared read/write root arrays are passed by reference so that grant
-   * mutations (via `/allow-dir`) survive across turns without requiring a new
-   * dispatcher instance.
+   * Build a per-query tool dispatcher. Delegates to the extracted
+   * {@link buildDispatcherImpl} (#824), supplying the provider-scoped
+   * collaborators it used to read off `this`. The two MCP caches are passed as
+   * accessor pairs so the fields stay owned here and `onToolsRefreshed`
+   * invalidation keeps working.
    */
   private buildDispatcher(
     permissionMode: string,
-    opts?: {
-      cwd?: string;
-      readRoots?: string[];
-      writeRoots?: string[];
-      env?: Record<string, string>;
-      sessionId?: string;
-      parentSessionId?: string;
-      /**
-       * This fork's own subagent id. Stamped onto every `hook_decision` the
-       * dispatcher emits so a policy block is attributable to the child that
-       * provoked it (parity with what `tool_call` already records). Undefined on
-       * a top-level session.
-       */
-      subagentId?: string;
-      /**
-       * Explicit "this session is a forked subagent" signal carrying the
-       * per-result output-cap budget (#661). Set to MODEL_CAP_BYTES by
-       * `SubagentManager.forkSubagent` for EVERY fork; undefined on a top-level
-       * session. Arms the dispatcher's `maxOutputBytes` backstop declaratively.
-       */
-      subagentToolOutputCapBytes?: number;
-      traceWriter?: TraceWriter;
-      /**
-       * Live source for the `get_runtime_state` tool. Constructed per-query
-       * in `query()` so the handler closure captures the model name and
-       * config-level identity fields. When undefined the handler is not
-       * registered — the model would see "Unknown tool" if it called
-       * `get_runtime_state` against a dispatcher built without a source.
-       */
-      runtimeStateSource?: RuntimeStateSource;
-      /**
-       * Session-scoped hook registry sourced from `AgentConfig.hookRegistry`.
-       * Threaded here so `PreToolUse`/`PostToolUse` hooks (notably the
-       * plan-mode gate) fire on the per-query dispatcher. Production entry
-       * points construct the provider WITHOUT a constructor-time
-       * `hookRegistry` and supply the session registry on the query config
-       * instead, so falling back to `this.hookRegistry` when this is unset
-       * preserves any constructor-provided registry.
-       */
-      hookRegistry?: import('../../hooks.js').HookRegistry;
-      /**
-       * Session-control bridge for the model-callable `exit_plan_mode` tool,
-       * forwarded from the query config (top-level sessions only). When set AND
-       * `permissionMode === 'plan'`, the handler + schema are registered.
-       */
-      planExitControls?: PlanExitControls;
-    },
+    opts?: BuildDispatcherOptions,
   ): SessionToolDispatcher {
-    const handlers = createBuiltinHandlers(permissionMode, opts?.cwd);
-    const memoryHandlers = createMemoryHandlers(
-      this.memoryStore,
-      undefined,
-      this.surface,
+    return buildDispatcherImpl(
+      {
+        memoryStore: this.memoryStore,
+        surface: this.surface,
+        readOnlyMemory: this.readOnlyMemory,
+        readOnlyBash: this.readOnlyBash,
+        customTools: this.customTools,
+        mcpManager: this.mcpManager,
+        schemas: this.schemas,
+        hookRegistry: this.hookRegistry,
+        permissions: this.permissions,
+        canUseTool: this.canUseTool,
+        subagentExecutor: this.subagentExecutor,
+        skillExecutor: this.skillExecutor,
+        composeExecutor: this.composeExecutor,
+        sessionGrantManager: this,
+        getMcpToolsCache: () => this._mcpToolsCache,
+        setMcpToolsCache: (v) => { this._mcpToolsCache = v; },
+        getMcpHandlersCache: () => this._mcpHandlersCache,
+        setMcpHandlersCache: (v) => { this._mcpHandlersCache = v; },
+      },
+      permissionMode,
+      opts,
     );
-    // Read-only memory: register `memory_search` only. The dispatcher's
-    // unknown-tool path produces a clear error if the model attempts
-    // `memory_update` / `procedure_write` despite the schema being absent.
-    for (const [name, handler] of memoryHandlers) {
-      if (this.readOnlyMemory && name !== 'memory_search') continue;
-      handlers.set(name, handler);
-    }
-    if (opts?.runtimeStateSource) {
-      handlers.set('get_runtime_state', createGetRuntimeStateHandler(opts.runtimeStateSource));
-    }
-    // Invariant: custom (consumer-registered) handlers are registered AFTER
-    // all builtins and the runtime-state handler, and BEFORE MCP handlers.
-    // If a custom tool name collides with a builtin already in `handlers`,
-    // the builtin wins (we skip the custom registration). This prevents a
-    // user-supplied tool from silently overriding a built-in capability.
-    // Location: src/agent/providers/anthropic-direct/index.ts buildDispatcher.
-    for (const t of this.customTools) {
-      if (!handlers.has(t.schema.name)) {
-        handlers.set(t.schema.name, t.handler);
-      }
-    }
-    // MCP handlers + schemas — served from a cache that is invalidated by
-    // `onToolsRefreshed` (fired after every `refreshServer()` / `completeAuth()`
-    // call).  This preserves the Option A correctness guarantee — the cache
-    // always reflects the live nameRegistry state — while avoiding redundant
-    // allocation and iteration on every query when the tool list has not changed.
-    // Pre/PostToolUse hooks fire for MCP tools automatically via the dispatcher
-    // (`tools/dispatcher.ts:247,342`).
-    if (this.mcpManager) {
-      if (!this._mcpToolsCache) {
-        this._mcpToolsCache = this.mcpManager.getMcpTools();
-      }
-      if (!this._mcpHandlersCache) {
-        this._mcpHandlersCache = this.mcpManager.getMcpHandlers();
-      }
-      for (const [name, handler] of this._mcpHandlersCache) {
-        handlers.set(name, handler);
-      }
-    }
-    const mcpSchemas = this._mcpToolsCache ?? [];
-    // Plan-exit tool: the model-callable `exit_plan_mode`, registered RESIDENT
-    // whenever the session supplied control callbacks (top-level sessions only —
-    // subagents never get planExitControls). NOT gated on the construction-time
-    // `permissionMode`: the dispatcher is built once per query() and is NOT
-    // rebuilt by setPermissionMode, so a mode-gated registration here left the
-    // tool permanently unwired for the common "enter plan mode AFTER launch"
-    // flow (Shift+Tab / `/plan`), and the model got "Unknown tool exit_plan_mode".
-    // Callability is instead gated per-turn on the LIVE mode: query.ts filters
-    // this tool out of the advertised tool list on non-plan turns, so the model
-    // is offered it exactly when it is actionable — and it becomes callable the
-    // instant plan mode is entered mid-session, with no query rebuild.
-    const planExitControls = opts?.planExitControls;
-    if (planExitControls) {
-      handlers.set(EXIT_PLAN_MODE_TOOL_NAME, createExitPlanModeHandler(planExitControls));
-    }
-    return new SessionToolDispatcher({
-      handlers,
-      // This provider IS the session's GrantManager. Passing it here lets the
-      // dispatcher inject it onto PreToolUse/PostToolUse contexts, so the
-      // path-approval + bash-restriction hooks resolve THIS session's live
-      // grants (a forked child's own writeRoots) rather than the process-global
-      // ref pinned to the top-level session (#435/#514). getGrants() reads the
-      // same _sharedReadRoots/_sharedWriteRoots the dispatcher shares by
-      // reference, so hook and handler stay in lockstep.
-      sessionGrantManager: this,
-      // Path-containment bypass: bypassPermissions (explicit) AND autonomous
-      // (AFK) both carry allowAll:true so path containment + the path-approval
-      // prompt are disabled per-call. In AFK the afk-mode-gate is the safety
-      // ceiling (see agent/permission-policy.ts).
-      allowAll: pathContainmentBypassed(permissionMode),
-      // Constraint (semantic invariant): MCP schemas appended AFTER builtins
-      // so builtin tool names always take precedence in any overlap. The
-      // plan-exit schema is appended last, RESIDENT whenever planExitControls is
-      // present (top-level); query.ts filters it out of the advertised tool list
-      // on non-plan turns so the model sees it only when it is actionable.
-      schemas: [
-        ...this.schemas,
-        ...mcpSchemas,
-        ...(planExitControls ? [exitPlanModeTool] : []),
-      ],
-      // Session hook registry via the one canonical resolver (query-scoped
-      // config registry wins over any constructor-provided one). Without this
-      // the plan-mode gate (the sole built-in PreToolUse hook) never reached
-      // the dispatcher and write tools ran unblocked in plan mode (c6892c6).
-      hookRegistry: resolveSessionHookRegistry(opts?.hookRegistry, this.hookRegistry),
-      // Union live MCP wire-names AND consumer-registered custom-tool names into
-      // the (statically-snapshotted) allowlist so neither is rejected by the
-      // gate while present in `schemas`/`handlers`. No-op when there is no
-      // allowlist (undefined => all allowed) or nothing to union. Registering a
-      // custom tool is the grant (same as connecting an MCP server); restricted
-      // sub-agents carry no customTools, so this never widens their allowlist.
-      permissions: withCustomToolsAllowed(
-        this.mcpManager
-          ? withMcpToolsAllowed(this.permissions, this.mcpManager.getMcpToolWireNames())
-          : this.permissions,
-        this.customTools.map((t) => t.schema.name),
-      ),
-      subagentExecutor: this.subagentExecutor,
-      skillExecutor: this.skillExecutor,
-      composeExecutor: this.composeExecutor,
-      // In-process permission callback (Dim 8). No-op when unset; forwarded by
-      // reference so it composes with the static allowlist in the dispatcher.
-      ...(this.canUseTool !== undefined ? { canUseTool: this.canUseTool } : {}),
-      cwd: opts?.cwd,
-      readRoots: opts?.readRoots,
-      writeRoots: opts?.writeRoots,
-      ...(opts?.env !== undefined ? { env: opts.env } : {}),
-      sessionId: opts?.sessionId,
-      parentSessionId: opts?.parentSessionId,
-      ...(opts?.subagentId !== undefined ? { subagentId: opts.subagentId } : {}),
-      // Central output-cap backstop (#661), FORK-SCOPED. Armed from the
-      // explicit `subagentToolOutputCapBytes` signal that
-      // `SubagentManager.forkSubagent` stamps (as MODEL_CAP_BYTES = 100KB) on
-      // EVERY forked child — the single choke point for the agent-tool, skill,
-      // and compose fork paths. A value here means "forked child" ⇒ bound each
-      // tool result at that budget via headAndTail, containing the whole
-      // overflow crash class (MCP dumps, browser output, read_file of a huge
-      // file). The top-level session is built directly (never via forkSubagent),
-      // leaves this unset, and is therefore UNCAPPED (behavior unchanged). This
-      // replaces the prior `parentSessionId !== undefined` gate, which missed
-      // skill-forked descendants whose parent carries no sessionId (a stub
-      // parent) and were left silently exposed.
-      ...(opts?.subagentToolOutputCapBytes !== undefined
-        ? { maxOutputBytes: opts.subagentToolOutputCapBytes }
-        : {}),
-      ...(opts?.traceWriter ? { traceWriter: opts.traceWriter } : {}),
-      // Read-only-skill bash gate: forwarded from the provider's stored flag
-      // (set by createChildProviderFactory / buildReadOnlyReconProvider) so a
-      // read-only skill's forked child can't run mutating shell commands.
-      readOnlyBash: this.readOnlyBash,
-    });
   }
 
   close(): void {
@@ -593,7 +341,7 @@ export class AnthropicDirectProvider implements ModelProvider {
     // Forward whichever client factory is active so test stubs intercept the
     // call. The provider factory accepts an extra `baseURL` field that
     // oneShotCompletion never sets — structurally compatible, hence the cast.
-    const factory = this.providerFactory ?? clientFactory;
+    const factory = this.providerFactory ?? getClientFactory();
     if (factory) input.clientFactory = factory as OneShotInput['clientFactory'];
     return oneShotCompletion(input);
   }
@@ -711,7 +459,7 @@ export class AnthropicDirectProvider implements ModelProvider {
           )
         : undefined,
     );
-    const factory = this.providerFactory ?? clientFactory;
+    const factory = this.providerFactory ?? getClientFactory();
     const client = factory ? factory(clientOpts) : new Anthropic(clientOpts);
     // In local-server mode, suppress the OAuth CLI-mimicry system-prefix
     // regardless of token shape: the shim is not Anthropic's billing surface
@@ -954,7 +702,7 @@ export class AnthropicDirectProvider implements ModelProvider {
     // path above already prevents this on the initial request; this guard
     // closes the 401-retry hole.
     if (authMode === 'oauth' && !localMode) {
-      const factory = this.providerFactory ?? clientFactory;
+      const factory = this.providerFactory ?? getClientFactory();
       tokenRefresher = async (): Promise<Anthropic | null> => {
         const freshToken = await refreshClaudeCodeOauthToken();
         if (!freshToken) return null;

--- a/src/agent/providers/anthropic-direct/provider-options.ts
+++ b/src/agent/providers/anthropic-direct/provider-options.ts
@@ -1,0 +1,138 @@
+/**
+ * Construction options and the client-factory seam for
+ * {@link AnthropicDirectProvider}.
+ *
+ * Extracted from `index.ts` (#824) as a leaf module: it owns the provider's
+ * declarative construction surface plus the module-scope test hook, and
+ * imports nothing from its siblings.
+ *
+ * Contract: the client factory has TWO layers with a fixed precedence —
+ * a per-instance `AnthropicDirectProviderOptions.clientFactory` wins over the
+ * module-scope hook installed by {@link __setAnthropicClientFactory}, and the
+ * real `Anthropic` constructor is used when neither is set. `query()` and
+ * `complete()` both resolve it as `this.providerFactory ?? getClientFactory()`,
+ * so a test that installs the module hook cannot silently override a caller
+ * that injected its own client.
+ *
+ * The module-scope factory is deliberately module state rather than a
+ * constructor argument: integration tests install it once and construct
+ * providers indirectly (through `resolveProvider`), where they have no handle
+ * on the construction call.
+ *
+ * @module agent/providers/anthropic-direct/provider-options
+ */
+
+import type Anthropic from '@anthropic-ai/sdk';
+import type { CanUseTool } from '../../types/sdk-types.js';
+import type { HookRegistry } from '../../hooks.js';
+import type { MemoryStore } from '../../memory/index.js';
+import type { SubagentExecutor } from '../../tools/subagent-executor.js';
+import type { SkillExecutor } from '../../tools/skill-executor.js';
+import type { ComposeExecutor } from '../../tools/compose-executor.js';
+import type { ToolPermissionConfig } from '../../tools/permissions.js';
+import type { ToolDispatcher } from './tool-dispatcher.js';
+
+/** Test/factory hook: lets tests inject a stub Anthropic client.
+ *
+ * `baseURL` is the SDK's camelCase option name (forwarded by
+ * `buildClientOptions` when the local-server path is active).
+ */
+export type AnthropicClientFactory = (
+  opts: ({ authToken: string } | { apiKey: string }) & { baseURL?: string; fetch?: typeof fetch },
+) => Anthropic;
+
+let clientFactory: AnthropicClientFactory | null = null;
+
+/**
+ * Module-scope escape hatch used by integration tests; not part of the stable
+ * surface. Pass `null` to restore the real `Anthropic` constructor.
+ */
+export function __setAnthropicClientFactory(
+  factory: AnthropicClientFactory | null,
+): void {
+  clientFactory = factory;
+}
+
+/**
+ * Read the currently-installed module-scope client factory.
+ *
+ * Invariant: callers MUST read through this accessor at call time rather than
+ * caching the value at module load. `__setAnthropicClientFactory` is routinely
+ * called from a test's `beforeEach` — after this module was first imported —
+ * so a captured binding would pin whatever was installed at import time and
+ * silently send test traffic to the real SDK.
+ */
+export function getClientFactory(): AnthropicClientFactory | null {
+  return clientFactory;
+}
+
+/** Construction options for {@link AnthropicDirectProvider}. */
+export interface AnthropicDirectProviderOptions {
+  /** Pluggable tool dispatcher. When set, overrides the built-in SessionToolDispatcher. */
+  tools?: ToolDispatcher;
+  /** Hook registry for PreToolUse/PostToolUse integration. */
+  hookRegistry?: HookRegistry;
+  /** Tool permission configuration (allowlist). */
+  permissions?: ToolPermissionConfig;
+  /** In-process permission callback, forwarded to the session dispatcher. */
+  canUseTool?: CanUseTool;
+  /**
+   * Optional client factory override. When set, takes precedence over the
+   * module-scope `__setAnthropicClientFactory` hook. Useful for callers that
+   * want to inject a pre-built client (e.g. with custom retries) without
+   * touching module state.
+   */
+  clientFactory?: AnthropicClientFactory;
+  /** Optional subagent executor. When provided, the Agent tool is included in the tool set. */
+  subagentExecutor?: SubagentExecutor;
+  /** Optional skill executor. When provided, the Skill tool is included in the tool set. */
+  skillExecutor?: SkillExecutor;
+  /** Optional compose executor. When provided, the Compose tool is included in the tool set. */
+  composeExecutor?: ComposeExecutor;
+  /** Shared MemoryStore instance. When set, avoids creating a second store. */
+  memoryStore?: MemoryStore;
+  /** Surface identifier for fact metadata (e.g. 'cli', 'daemon', 'telegram'). */
+  surface?: string;
+  /**
+   * When true, the provider exposes only the read-only `memory_search` tool
+   * (no `memory_update`, no `procedure_write`) and substitutes the
+   * {@link MEMORY_SYSTEM_PROMPT_READONLY} variant in the system prompt.
+   * Defaults to false. Set by {@link createChildProviderFactory} for
+   * subagent / skill child sessions — only the parent writes memory.
+   */
+  readOnlyMemory?: boolean;
+  /**
+   * When true, the per-query {@link SessionToolDispatcher} blocks mutating
+   * `bash` commands (read-only recon — git status/log/diff, ls, cat, find,
+   * grep — is allowed). Set by `createChildProviderFactory` /
+   * `buildReadOnlyReconProvider` for a read-only skill's forked child, paired
+   * with `permissions.allowedTools = RECON_ALLOWED_TOOLS` (which strips
+   * `write_file`/`edit_file`). Defaults to false.
+   */
+  readOnlyBash?: boolean;
+  /**
+   * Optional MCP manager. When provided, every tool exposed by a
+   * `connected` MCP server is merged into the provider's tool schema list
+   * and the per-query dispatcher's handler map. Pre/PostToolUse hooks
+   * fire for MCP tools automatically via the dispatcher (see
+   * `tools/dispatcher.ts:247,342`).
+   *
+   * Lifecycle: caller owns construction (`McpManager.fromConfig()`) and
+   * teardown (`disconnectAll()`). Subagents inherit the same manager by
+   * reference — never reconstructed per-fork.
+   */
+  mcpManager?: import('../../mcp/index.js').McpManager;
+  /**
+   * In-process custom tools registered by the library consumer. Each entry
+   * supplies an `AnthropicToolDef` schema (added to the provider's schema
+   * list at construction time) and a `ToolHandler` (registered in the
+   * per-query dispatcher's handler map).
+   *
+   * Custom tools run through the same permission gate and PreToolUse /
+   * PostToolUse hooks as built-in tools — no bypass.
+   *
+   * Precedence: builtins > MCP > custom (a custom tool whose name collides
+   * with a builtin is silently skipped — see `buildDispatcher`).
+   */
+  customTools?: import('../../tools/custom-tool.js').CustomToolDef[];
+}

--- a/src/agent/providers/anthropic-direct/query-wiring.characterization.test.ts
+++ b/src/agent/providers/anthropic-direct/query-wiring.characterization.test.ts
@@ -368,6 +368,52 @@ describe('query() characterization (#824) — tool-def filtering', () => {
   });
 });
 
+describe('query() characterization (#824) — skill manifest / skill-tool lockstep', () => {
+  beforeEach(() => {
+    messagesCreateMock.mockReset();
+    __setAnthropicClientFactory(null);
+    installFactory();
+    messagesCreateMock.mockImplementation(() => fromArray(makeTextStream('ok')));
+  });
+
+  afterEach(() => {
+    __setAnthropicClientFactory(null);
+  });
+
+  // Invariant: the constructor gates the `skill` TOOL on `if (opts.skillExecutor)`
+  // (truthiness) and query() gates the skill MANIFEST on the same executor.
+  // The two gates must agree, or the system prompt advertises skills the model
+  // has no tool to invoke. Pinned with a falsy-but-present value because that
+  // is the only input that can separate `Boolean(x)` from `x !== undefined`.
+  it('advertises neither the skill tool nor a manifest when no executor is wired', async () => {
+    const provider = new AnthropicDirectProvider();
+    await collect(provider.query({ prompt: singleInput('hi'), config: { ...BASE_CONFIG } }));
+
+    const sent = messagesCreateMock.mock.calls[0]?.[0] as {
+      tools: { name: string }[];
+      system: { text: string }[];
+    };
+    expect(sent.tools.map((t) => t.name)).not.toContain('skill');
+    expect(sent.system.map((s) => s.text).join('\n')).not.toContain('Available skills');
+  });
+
+  it('keeps manifest and skill-tool gates in lockstep for a falsy executor', async () => {
+    // `null` is falsy but NOT undefined: the constructor skips the skill tool,
+    // so query() must also skip the manifest.
+    const provider = new AnthropicDirectProvider({ skillExecutor: null as never });
+    await collect(provider.query({ prompt: singleInput('hi'), config: { ...BASE_CONFIG } }));
+
+    const sent = messagesCreateMock.mock.calls[0]?.[0] as {
+      tools: { name: string }[];
+      system: { text: string }[];
+    };
+    const hasSkillTool = sent.tools.some((t) => t.name === 'skill');
+    const hasManifest = sent.system.map((s) => s.text).join('\n').includes('Available skills');
+    expect(hasSkillTool).toBe(false);
+    expect(hasManifest).toBe(hasSkillTool);
+  });
+});
+
 describe('query() characterization (#824) — token + client construction', () => {
   beforeEach(() => {
     messagesCreateMock.mockReset();

--- a/src/agent/providers/anthropic-direct/query-wiring.characterization.test.ts
+++ b/src/agent/providers/anthropic-direct/query-wiring.characterization.test.ts
@@ -1,0 +1,504 @@
+/**
+ * Characterization tests for `AnthropicDirectProvider.query()` wiring (#824).
+ *
+ * Written BEFORE the index.ts decomposition and required to stay green
+ * verbatim afterwards.
+ *
+ * THE HAZARD THIS FILE EXISTS FOR
+ * -------------------------------
+ * `query()` contains a deliberate late-binding cycle:
+ *
+ *   1. `let queryDispatcher` is DECLARED (no initializer).
+ *   2. `runtimeStateSource` is BUILT, capturing `queryDispatcher` inside the
+ *      `getEnabledToolNames` closure — which reads the binding lazily.
+ *   3. `runtimeStateSource` is PASSED INTO `buildDispatcher(...)`, whose return
+ *      value is ASSIGNED to `queryDispatcher`.
+ *
+ * So the source is constructed before the dispatcher exists, and the dispatcher
+ * is constructed with a reference to that source. The only thing keeping this
+ * correct is that `getEnabledToolNames` defers its read to call time.
+ *
+ * If an extraction reorders these three steps — e.g. snapshots the tool names
+ * eagerly, or builds a second source AFTER the dispatcher and hands the
+ * dispatcher the stale first one — `get_runtime_state` silently reports the
+ * WRONG tool list. No throw, no type error, no failing assertion anywhere else
+ * in the suite. The `tools.enabled` assertions below are the tripwire: they
+ * drive a real `get_runtime_state` call through the real dispatcher and require
+ * the answer to reflect the dispatcher that was actually installed.
+ *
+ * Observation strategy: mock Anthropic client (the established idiom from
+ * `output-cap-wiring.test.ts:33-58`), a scripted tool_use round calling
+ * `get_runtime_state`, then parse the `tool.output` event's JSON payload.
+ *
+ * @module agent/providers/anthropic-direct/query-wiring.characterization.test
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { z } from 'zod';
+import type Anthropic from '@anthropic-ai/sdk';
+import type { RawMessageStreamEvent } from '@anthropic-ai/sdk/resources';
+import type { ProviderEvent } from '../../provider.js';
+import type { RuntimeSnapshot } from '../../awareness/index.js';
+import { AnthropicDirectProvider, __setAnthropicClientFactory } from './index.js';
+import { tool } from '../../tools/custom-tool.js';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const messagesCreateMock = vi.fn();
+
+class MockAnthropic {
+  public messages: { create: typeof messagesCreateMock };
+  constructor() {
+    this.messages = { create: messagesCreateMock };
+  }
+}
+
+function installFactory(): void {
+  __setAnthropicClientFactory(() => new MockAnthropic() as unknown as Anthropic);
+}
+
+async function* singleInput(content: string): AsyncIterable<{ content: string }> {
+  yield { content };
+}
+
+async function* fromArray<T>(arr: T[]): AsyncIterable<T> {
+  for (const x of arr) yield x;
+}
+
+async function collect(query: AsyncIterable<ProviderEvent>): Promise<ProviderEvent[]> {
+  const out: ProviderEvent[] = [];
+  for await (const ev of query) out.push(ev);
+  return out;
+}
+
+function makeToolUseStream(
+  toolId: string,
+  toolName: string,
+  inputJson: string,
+): RawMessageStreamEvent[] {
+  return [
+    {
+      type: 'message_start',
+      message: {
+        id: 'msg_t',
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model: 'claude-sonnet-5',
+        stop_reason: null,
+        stop_sequence: null,
+        usage: {
+          input_tokens: 7,
+          output_tokens: 0,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+          server_tool_use: null,
+          service_tier: null,
+        },
+      },
+    } as unknown as RawMessageStreamEvent,
+    {
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'tool_use', id: toolId, name: toolName, input: {} },
+    } as unknown as RawMessageStreamEvent,
+    {
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'input_json_delta', partial_json: inputJson },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'content_block_stop', index: 0 } as unknown as RawMessageStreamEvent,
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'tool_use', stop_sequence: null },
+      usage: { output_tokens: 9 },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'message_stop' } as unknown as RawMessageStreamEvent,
+  ];
+}
+
+function makeTextStream(text: string): RawMessageStreamEvent[] {
+  return [
+    {
+      type: 'message_start',
+      message: {
+        id: 'msg_done',
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model: 'claude-sonnet-5',
+        stop_reason: null,
+        stop_sequence: null,
+        usage: {
+          input_tokens: 5,
+          output_tokens: 0,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+          server_tool_use: null,
+          service_tier: null,
+        },
+      },
+    } as unknown as RawMessageStreamEvent,
+    {
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'text', text: '', citations: [] },
+    } as unknown as RawMessageStreamEvent,
+    {
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'text_delta', text },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'content_block_stop', index: 0 } as unknown as RawMessageStreamEvent,
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'end_turn', stop_sequence: null },
+      usage: { output_tokens: 4 },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'message_stop' } as unknown as RawMessageStreamEvent,
+  ];
+}
+
+/** Script: round 1 calls `get_runtime_state`, round 2 ends the turn. */
+function scriptRuntimeStateCall(view: string): void {
+  let callIdx = 0;
+  messagesCreateMock.mockImplementation(() => {
+    callIdx += 1;
+    if (callIdx === 1) {
+      return fromArray(
+        makeToolUseStream('toolu_rs', 'get_runtime_state', JSON.stringify({ view })),
+      );
+    }
+    return fromArray(makeTextStream('done'));
+  });
+}
+
+function snapshotFrom(events: ProviderEvent[]): Partial<RuntimeSnapshot> {
+  const ev = events.find((e) => e.type === 'tool.output');
+  if (!ev || ev.type !== 'tool.output') throw new Error('expected a tool.output event');
+  return JSON.parse(ev.content) as Partial<RuntimeSnapshot>;
+}
+
+const BASE_CONFIG = { model: 'claude-sonnet-5', apiKey: 'sk-ant-oat01-test' } as const;
+
+describe('query() characterization (#824) — queryDispatcher / getEnabledToolNames ordering', () => {
+  beforeEach(() => {
+    messagesCreateMock.mockReset();
+    __setAnthropicClientFactory(null);
+    installFactory();
+  });
+
+  afterEach(() => {
+    __setAnthropicClientFactory(null);
+  });
+
+  it('get_runtime_state reports the LIVE dispatcher tool list (the late-binding tripwire)', async () => {
+    scriptRuntimeStateCall('tools');
+    const provider = new AnthropicDirectProvider();
+    const events = await collect(
+      provider.query({ prompt: singleInput('orient'), config: { ...BASE_CONFIG } }),
+    );
+
+    const enabled = snapshotFrom(events).tools?.enabled ?? [];
+    // A non-empty list is the whole point: if the closure read `queryDispatcher`
+    // before assignment (or an extraction snapshotted names eagerly), the
+    // `instanceof SessionToolDispatcher` guard fails and this is `[]`.
+    expect(enabled.length).toBeGreaterThan(0);
+    expect(enabled).toContain('bash');
+    expect(enabled).toContain('get_runtime_state');
+  });
+
+  it('reflects a CUSTOM tool registered on the dispatcher built inside the same query()', async () => {
+    // Strongest form of the ordering assertion: this name exists only on the
+    // dispatcher that `query()` constructs. Seeing it proves the closure read
+    // the POST-assignment binding, not a pre-built or default tool list.
+    scriptRuntimeStateCall('tools');
+    const marker = tool('char_late_bound_marker', 'marker', z.object({}), async () => ({
+      content: 'x',
+    }));
+    const provider = new AnthropicDirectProvider({ customTools: [marker] });
+    const events = await collect(
+      provider.query({ prompt: singleInput('orient'), config: { ...BASE_CONFIG } }),
+    );
+
+    expect(snapshotFrom(events).tools?.enabled).toContain('char_late_bound_marker');
+  });
+
+  it('reports the enabled list even when the caller injects an EXTERNAL dispatcher', async () => {
+    // The `externalTools` branch takes the other path (wrapDispatcherWithRuntimeState).
+    // The wrapper is NOT a SessionToolDispatcher, so `getEnabledToolNames`
+    // returns [] by design — pinned here so an extraction cannot quietly
+    // change which branch feeds the awareness layer.
+    scriptRuntimeStateCall('tools');
+    const external = {
+      execute: async () => ({ content: 'external' }),
+      toolDefs: [],
+    };
+    const provider = new AnthropicDirectProvider({ tools: external as never });
+    const events = await collect(
+      provider.query({ prompt: singleInput('orient'), config: { ...BASE_CONFIG } }),
+    );
+
+    expect(snapshotFrom(events).tools?.enabled).toEqual([]);
+  });
+
+  it('exposes get_runtime_state to the model on the external-dispatcher path', async () => {
+    // Companion to the above: even though the enabled list is empty, the tool
+    // SCHEMA must still be advertised or the awareness layer is unreachable.
+    scriptRuntimeStateCall('tools');
+    const external = {
+      execute: async () => ({ content: 'external' }),
+      toolDefs: [],
+    };
+    const provider = new AnthropicDirectProvider({ tools: external as never });
+    await collect(
+      provider.query({ prompt: singleInput('orient'), config: { ...BASE_CONFIG } }),
+    );
+
+    const sent = messagesCreateMock.mock.calls[0]?.[0] as { tools: { name: string }[] };
+    expect(sent.tools.map((t) => t.name)).toContain('get_runtime_state');
+  });
+});
+
+describe('query() characterization (#824) — runtime-state identity fields', () => {
+  beforeEach(() => {
+    messagesCreateMock.mockReset();
+    __setAnthropicClientFactory(null);
+    installFactory();
+  });
+
+  afterEach(() => {
+    __setAnthropicClientFactory(null);
+  });
+
+  it('threads model, permission mode and identity from the query config into the source', async () => {
+    scriptRuntimeStateCall('self');
+    const provider = new AnthropicDirectProvider({ surface: 'daemon' });
+    const events = await collect(
+      provider.query({
+        prompt: singleInput('orient'),
+        config: {
+          ...BASE_CONFIG,
+          permissionMode: 'bypassPermissions',
+          sessionId: 'sid-char-1',
+          parentSessionId: 'pid-char-1',
+          depth: 2,
+          maxDepth: 3,
+        },
+      }),
+    );
+
+    const self = snapshotFrom(events).self;
+    expect(self?.sessionId).toBe('sid-char-1');
+    expect(self?.parentSessionId).toBe('pid-char-1');
+    expect(self?.depth).toBe(2);
+    expect(self?.maxDepth).toBe(3);
+    expect(self?.surface).toBe('daemon');
+    expect(self?.model.provider).toBe('anthropic-direct');
+    expect(self?.model.name).toBe('claude-sonnet-5');
+    // Deliberately BUCKETED, not passed through: the awareness layer reports a
+    // coarse 'elevated' | 'default' so the raw mode is not surfaced to the
+    // model (anti-injection). `bypassPermissions` buckets to 'elevated'.
+    expect(self?.permissionMode).toBe('elevated');
+  });
+
+  it('buckets a restrictive mode to default rather than reporting it verbatim', async () => {
+    scriptRuntimeStateCall('self');
+    const provider = new AnthropicDirectProvider();
+    const events = await collect(
+      provider.query({
+        prompt: singleInput('orient'),
+        config: { ...BASE_CONFIG, permissionMode: 'plan' },
+      }),
+    );
+    // plan / autonomous are RESTRICTIVE, so they must not read as 'elevated'.
+    expect(snapshotFrom(events).self?.permissionMode).toBe('default');
+  });
+});
+
+describe('query() characterization (#824) — tool-def filtering', () => {
+  beforeEach(() => {
+    messagesCreateMock.mockReset();
+    __setAnthropicClientFactory(null);
+    installFactory();
+    messagesCreateMock.mockImplementation(() => fromArray(makeTextStream('ok')));
+  });
+
+  afterEach(() => {
+    __setAnthropicClientFactory(null);
+  });
+
+  function toolsSent(): string[] {
+    const sent = messagesCreateMock.mock.calls[0]?.[0] as { tools: { name: string }[] };
+    return sent.tools.map((t) => t.name);
+  }
+
+  it('advertises ask_question and terminal_font_size on a normal session', async () => {
+    const provider = new AnthropicDirectProvider();
+    await collect(provider.query({ prompt: singleInput('hi'), config: { ...BASE_CONFIG } }));
+    const names = toolsSent();
+    expect(names).toContain('ask_question');
+    expect(names).toContain('terminal_font_size');
+  });
+
+  it('strips BOTH ask_question and terminal_font_size for a skill dispatch', async () => {
+    const provider = new AnthropicDirectProvider();
+    await collect(
+      provider.query({
+        prompt: singleInput('hi'),
+        config: { ...BASE_CONFIG, isSkillDispatch: true },
+      }),
+    );
+    const names = toolsSent();
+    expect(names).not.toContain('ask_question');
+    expect(names).not.toContain('terminal_font_size');
+  });
+
+  it('strips ONLY ask_question on a non-interactive surface', async () => {
+    const provider = new AnthropicDirectProvider();
+    await collect(
+      provider.query({
+        prompt: singleInput('hi'),
+        config: { ...BASE_CONFIG, isNonInteractive: true },
+      }),
+    );
+    const names = toolsSent();
+    expect(names).not.toContain('ask_question');
+    expect(names).toContain('terminal_font_size');
+  });
+});
+
+describe('query() characterization (#824) — token + client construction', () => {
+  beforeEach(() => {
+    messagesCreateMock.mockReset();
+    __setAnthropicClientFactory(null);
+    messagesCreateMock.mockImplementation(() => fromArray(makeTextStream('ok')));
+  });
+
+  afterEach(() => {
+    __setAnthropicClientFactory(null);
+  });
+
+  it('throws when no token can be resolved', () => {
+    installFactory();
+    const provider = new AnthropicDirectProvider();
+    expect(() =>
+      provider.query({ prompt: singleInput('hi'), config: { model: 'claude-sonnet-5' } }),
+    ).toThrow(/requires config\.apiKey/);
+  });
+
+  it('prefers the per-instance clientFactory over the module-scope hook', async () => {
+    let moduleHookCalls = 0;
+    let instanceFactoryCalls = 0;
+    __setAnthropicClientFactory(() => {
+      moduleHookCalls += 1;
+      return new MockAnthropic() as unknown as Anthropic;
+    });
+    const provider = new AnthropicDirectProvider({
+      clientFactory: () => {
+        instanceFactoryCalls += 1;
+        return new MockAnthropic() as unknown as Anthropic;
+      },
+    });
+    await collect(provider.query({ prompt: singleInput('hi'), config: { ...BASE_CONFIG } }));
+
+    expect(instanceFactoryCalls).toBe(1);
+    expect(moduleHookCalls).toBe(0);
+  });
+
+  it('sends the OAuth billing-header system prefix FIRST for an sk-ant-oat01 token', async () => {
+    installFactory();
+    const provider = new AnthropicDirectProvider();
+    await collect(provider.query({ prompt: singleInput('hi'), config: { ...BASE_CONFIG } }));
+
+    const sent = messagesCreateMock.mock.calls[0]?.[0] as {
+      system: { type: string; text: string }[];
+    };
+    // The OAuth billing header must lead the system array — the API keys
+    // subscription billing off this block's position.
+    expect(sent.system[0]?.text).toContain('x-anthropic-billing-header');
+    expect(sent.system.length).toBeGreaterThan(1);
+  });
+
+  it('omits the OAuth billing prefix for a plain api-key token', async () => {
+    installFactory();
+    const provider = new AnthropicDirectProvider();
+    await collect(
+      provider.query({
+        prompt: singleInput('hi'),
+        config: { model: 'claude-sonnet-5', apiKey: 'sk-plain-api-key' },
+      }),
+    );
+
+    const sent = messagesCreateMock.mock.calls[0]?.[0] as {
+      system: { type: string; text: string }[];
+    };
+    expect(sent.system[0]?.text).not.toContain('x-anthropic-billing-header');
+  });
+
+  it('resolves maxTokens and passes the resolved model id to the wire', async () => {
+    installFactory();
+    const provider = new AnthropicDirectProvider();
+    await collect(provider.query({ prompt: singleInput('hi'), config: { ...BASE_CONFIG } }));
+
+    const sent = messagesCreateMock.mock.calls[0]?.[0] as {
+      model: string;
+      max_tokens: number;
+    };
+    expect(typeof sent.model).toBe('string');
+    expect(sent.model.length).toBeGreaterThan(0);
+    expect(sent.max_tokens).toBeGreaterThan(0);
+  });
+});
+
+describe('query() characterization (#824) — shared roots and grants', () => {
+  beforeEach(() => {
+    messagesCreateMock.mockReset();
+    __setAnthropicClientFactory(null);
+    installFactory();
+    messagesCreateMock.mockImplementation(() => fromArray(makeTextStream('ok')));
+  });
+
+  afterEach(() => {
+    __setAnthropicClientFactory(null);
+  });
+
+  it('adopts caller-supplied roots on first query and keeps array identity across turns', async () => {
+    const provider = new AnthropicDirectProvider();
+    await collect(
+      provider.query({
+        prompt: singleInput('hi'),
+        config: { ...BASE_CONFIG, cwd: '/work', readRoots: ['/work', '/extra'], writeRoots: ['/work'] },
+      }),
+    );
+
+    const firstRead = (provider as any)._sharedReadRoots;
+    expect(firstRead).toEqual(['/work', '/extra']);
+    expect(provider.getGrants().readRoots).toEqual(['/work', '/extra']);
+
+    await collect(
+      provider.query({ prompt: singleInput('again'), config: { ...BASE_CONFIG, cwd: '/work' } }),
+    );
+    // Same array instance across turns — grants must survive by reference.
+    expect((provider as any)._sharedReadRoots).toBe(firstRead);
+  });
+
+  it('tracks the permission mode for getGrants().allowAll', async () => {
+    const provider = new AnthropicDirectProvider();
+    await collect(
+      provider.query({
+        prompt: singleInput('hi'),
+        config: { ...BASE_CONFIG, cwd: '/work', permissionMode: 'bypassPermissions' },
+      }),
+    );
+    expect(provider.getGrants().allowAll).toBe(true);
+  });
+
+  it('pins the initial cwd as the non-revocable grant anchor', async () => {
+    const provider = new AnthropicDirectProvider();
+    await collect(
+      provider.query({ prompt: singleInput('hi'), config: { ...BASE_CONFIG, cwd: '/work' } }),
+    );
+    expect(provider.getGrants().resolveBase).toBe('/work');
+  });
+});

--- a/src/agent/providers/anthropic-direct/query/client-setup.test.ts
+++ b/src/agent/providers/anthropic-direct/query/client-setup.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Unit tests for the extracted query client setup (#824).
+ *
+ * Focus: the `tokenRefresher` closure, which is the part of `query()` that has
+ * no coverage from the provider-level integration tests (they never trigger an
+ * OAuth 401 hot-swap). The invariant it exists to protect — the rebuilt client
+ * must reuse the SAME `throttleQueue` and quota observer as the original — is
+ * invisible to a type checker and silent when broken: the live rate-limit
+ * banner simply stops updating after an account swap.
+ *
+ * @module agent/providers/anthropic-direct/query/client-setup.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type Anthropic from '@anthropic-ai/sdk';
+import type { AgentConfig } from '../../../types/config-types.js';
+import { setUpQueryClient } from './client-setup.js';
+
+const refreshMock = vi.fn<[], Promise<string | null>>();
+
+vi.mock('../../../auth/keychain.js', () => ({
+  refreshClaudeCodeOauthToken: () => refreshMock(),
+}));
+
+/** A stand-in client; identity is all these tests compare. */
+function fakeClient(tag: string): Anthropic {
+  return { __tag: tag } as unknown as Anthropic;
+}
+
+const OAUTH_TOKEN = 'sk-ant-oat01-test';
+
+function baseArgs(overrides: Partial<Parameters<typeof setUpQueryClient>[0]> = {}) {
+  return {
+    config: {} as AgentConfig,
+    token: OAUTH_TOKEN,
+    authMode: 'oauth' as const,
+    localMode: false,
+    factory: undefined,
+    createClient: () => fakeClient('real'),
+    ...overrides,
+  };
+}
+
+describe('setUpQueryClient (#824)', () => {
+  beforeEach(() => {
+    refreshMock.mockReset();
+  });
+
+  it('uses the injected factory in preference to the real constructor', () => {
+    let createClientCalls = 0;
+    const { client } = setUpQueryClient(
+      baseArgs({
+        factory: () => fakeClient('from-factory'),
+        createClient: () => {
+          createClientCalls += 1;
+          return fakeClient('real');
+        },
+      }),
+    );
+    expect((client as unknown as { __tag: string }).__tag).toBe('from-factory');
+    expect(createClientCalls).toBe(0);
+  });
+
+  it('falls back to createClient when no factory is installed', () => {
+    const { client } = setUpQueryClient(baseArgs({ factory: null }));
+    expect((client as unknown as { __tag: string }).__tag).toBe('real');
+  });
+
+  it('emits the OAuth billing prefix for an oauth session, and none in local mode', () => {
+    expect(setUpQueryClient(baseArgs()).systemPrefix).not.toBeNull();
+    // Local shim is not Anthropic's billing surface — prefix suppressed even
+    // though the token still looks like an OAuth token.
+    expect(setUpQueryClient(baseArgs({ localMode: true })).systemPrefix).toBeNull();
+  });
+
+  it('omits the billing prefix for a plain api-key session', () => {
+    expect(setUpQueryClient(baseArgs({ authMode: 'api-key' })).systemPrefix).toBeNull();
+  });
+
+  it('installs a throttle queue only for non-local sessions WITH a trace writer', () => {
+    // No trace writer → no queue.
+    expect(setUpQueryClient(baseArgs()).throttleQueue).toBeUndefined();
+
+    const withWriter = setUpQueryClient(
+      baseArgs({ config: { traceWriter: {} } as unknown as AgentConfig }),
+    );
+    expect(withWriter.throttleQueue).toBeDefined();
+
+    // Local mode suppresses it regardless of the writer.
+    const local = setUpQueryClient(
+      baseArgs({ localMode: true, config: { traceWriter: {} } as unknown as AgentConfig }),
+    );
+    expect(local.throttleQueue).toBeUndefined();
+  });
+
+  it('builds a tokenRefresher for oauth, but NOT for api-key or local mode', () => {
+    expect(setUpQueryClient(baseArgs()).tokenRefresher).toBeDefined();
+    expect(setUpQueryClient(baseArgs({ authMode: 'api-key' })).tokenRefresher).toBeUndefined();
+    // Local shim must never receive a refreshed real Anthropic credential.
+    expect(setUpQueryClient(baseArgs({ localMode: true })).tokenRefresher).toBeUndefined();
+  });
+
+  it('tokenRefresher returns null when the keychain has no fresh token', async () => {
+    refreshMock.mockResolvedValue(null);
+    const { tokenRefresher } = setUpQueryClient(baseArgs());
+    await expect(tokenRefresher?.()).resolves.toBeNull();
+  });
+
+  it('tokenRefresher rebuilds the client through the SAME factory', async () => {
+    refreshMock.mockResolvedValue('sk-ant-oat01-fresh');
+    const seen: Array<{ authToken?: string; apiKey?: string }> = [];
+    const { tokenRefresher } = setUpQueryClient(
+      baseArgs({
+        factory: (opts) => {
+          seen.push(opts as { authToken?: string });
+          return fakeClient('rebuilt');
+        },
+      }),
+    );
+
+    const rebuilt = await tokenRefresher?.();
+    expect((rebuilt as unknown as { __tag: string }).__tag).toBe('rebuilt');
+    // Two constructions: the initial client and the post-refresh rebuild.
+    expect(seen).toHaveLength(2);
+    // The rebuild must carry the FRESH token, not the original.
+    expect(seen[1]?.authToken).toBe('sk-ant-oat01-fresh');
+  });
+
+  it('the rebuilt client keeps a live fetch wrapper feeding the SAME throttle queue', async () => {
+    // Invariant under test: the throttle queue is a rendezvous between the
+    // fetch producer and the turn-loop consumer. Handing the rebuilt client a
+    // fresh queue would strand the live rate-limit banner after an account
+    // swap — silently, with no error anywhere.
+    refreshMock.mockResolvedValue('sk-ant-oat01-fresh');
+    const fetches: Array<unknown> = [];
+    const setup = setUpQueryClient(
+      baseArgs({
+        config: { traceWriter: {} } as unknown as AgentConfig,
+        factory: (opts) => {
+          fetches.push((opts as { fetch?: unknown }).fetch);
+          return fakeClient('c');
+        },
+      }),
+    );
+    expect(setup.throttleQueue).toBeDefined();
+
+    await setup.tokenRefresher?.();
+    expect(fetches).toHaveLength(2);
+    // Both clients got a tracing-fetch wrapper (not a bare/undefined fetch).
+    expect(typeof fetches[0]).toBe('function');
+    expect(typeof fetches[1]).toBe('function');
+  });
+});

--- a/src/agent/providers/anthropic-direct/query/client-setup.ts
+++ b/src/agent/providers/anthropic-direct/query/client-setup.ts
@@ -1,0 +1,152 @@
+/**
+ * Client, auth, throttle and quota wiring for one
+ * `AnthropicDirectProvider.query()` call.
+ *
+ * Extracted from `index.ts` (#824). Owns everything between "we have a token"
+ * and "we have a live Anthropic client", including the observability plumbing
+ * that must survive an OAuth token refresh.
+ *
+ * Invariant: the `throttleQueue` and `quotaObserver` created here are wired
+ * into BOTH the initial client and any client rebuilt by `tokenRefresher`.
+ * The queue is a rendezvous — the tracing fetch is the producer, the per-turn
+ * loop is the consumer — so handing the rebuilt client a fresh queue would
+ * silently strand the live rate-limit banner after an account swap. The same
+ * instance must reach `AnthropicDirectQuery`.
+ *
+ * Note the two gates differ deliberately and must not be unified:
+ *   - `throttleQueue` is gated on `!localMode && config.traceWriter`.
+ *   - `quotaObserver` is gated on `!localMode` ALONE — the quota headers feed
+ *     the CLI status line, which must stay live when tracing is disabled.
+ *
+ * @module agent/providers/anthropic-direct/query/client-setup
+ */
+
+import type Anthropic from '@anthropic-ai/sdk';
+import type { AgentConfig } from '../../../types/config-types.js';
+import type { ContentBlockParam } from '@anthropic-ai/sdk/resources';
+import { buildClientOptions, buildSystemPrefix } from '../auth.js';
+import type { AuthMode } from '../types.js';
+import { makeTracingFetch } from '../tracing-fetch.js';
+import { ThrottleQueue } from '../throttle-queue.js';
+import { parseQuotaHeaders, recordQuotaSnapshot } from '../../../quota-cache.js';
+import { refreshClaudeCodeOauthToken } from '../../../auth/keychain.js';
+import type { AnthropicClientFactory } from '../provider-options.js';
+
+export interface ClientSetupArgs {
+  config: AgentConfig;
+  token: string;
+  authMode: AuthMode;
+  localMode: boolean;
+  /** Resolved factory (`providerFactory ?? module hook`), or null for the real SDK. */
+  factory: AnthropicClientFactory | null | undefined;
+  /** Constructor used when no factory is installed. */
+  createClient: (opts: ReturnType<typeof buildClientOptions>) => Anthropic;
+}
+
+export interface ClientSetup {
+  client: Anthropic;
+  /** Live rate-limit mailbox; undefined when not installed. */
+  throttleQueue: ThrottleQueue | undefined;
+  /** OAuth CLI-mimicry billing prefix, or null when suppressed. */
+  systemPrefix: ContentBlockParam[] | null;
+  /** Rebuilds the client against a freshly-refreshed OAuth token. */
+  tokenRefresher?: (() => Promise<Anthropic | null>) | undefined;
+}
+
+/**
+ * Build the SDK client plus its observability wrappers, and — for OAuth
+ * sessions against the real endpoint — the refresher that rebuilds it.
+ */
+export function setUpQueryClient(args: ClientSetupArgs): ClientSetup {
+  const { config, localMode, authMode, factory } = args;
+
+  // Live-throttle mailbox: the wrapped fetch pushes a signal onto this queue
+  // for every 429/503/529 the SDK sleep-and-retries INSIDE a single
+  // `messages.create`; the per-turn loop drains it to surface a `rate_limit`
+  // ProviderEvent LIVE (the loop is otherwise parked awaiting the SDK and
+  // cannot yield during the backoff). Installed only when the tracing fetch
+  // is (non-local-shim + a trace writer OR a live surface would consume it) —
+  // here it rides alongside the existing trace-writer gate so the queue and
+  // the wrapper share the same lifetime. The SAME instance is handed to the
+  // query so the fetch producer and the loop consumer meet.
+  const throttleQueue =
+    !localMode && config.traceWriter ? new ThrottleQueue() : undefined;
+  // Invariant: quota capture is gated on `!localMode` ALONE — deliberately not
+  // on `config.traceWriter`. The `anthropic-ratelimit-unified-*` headers ride
+  // on every response and feed the CLI status line, which must stay live even
+  // when tracing is off (`AFK_TRACE_DISABLED=1`); tying it to the trace writer
+  // would silently blank the indicator in that configuration. localMode is
+  // still excluded: a local shim is not Anthropic and emits no quota headers.
+  const quotaObserver = localMode
+    ? undefined
+    : (headers: Headers): void => {
+        const snapshot = parseQuotaHeaders(headers);
+        if (snapshot !== undefined) recordQuotaSnapshot(snapshot);
+      };
+  const clientOpts = buildClientOptions(
+    args.token,
+    authMode,
+    config.baseUrl,
+    // Observability: route SDK HTTP through a wrapper that (1) records
+    // 429/503/529 throttling into the witness trace so the SDK's
+    // otherwise-silent retry-after backoff is legible in `afk trace show`,
+    // (2) pushes a live signal onto `throttleQueue` so the progress banner can
+    // show the backoff as it happens, and (3) captures subscription-quota
+    // headers into the quota cache for the status line. Skipped entirely in
+    // local-shim mode (not Anthropic's billing surface). Note the wrapper is
+    // installed whenever ANY of the three observers is live — a trace writer
+    // is no longer required, since (3) must work with tracing disabled.
+    !localMode
+      ? makeTracingFetch(
+          config.traceWriter,
+          undefined,
+          throttleQueue ? (info) => throttleQueue.push(info) : undefined,
+          quotaObserver,
+        )
+      : undefined,
+  );
+  const client = factory ? factory(clientOpts) : args.createClient(clientOpts);
+  // In local-server mode, suppress the OAuth CLI-mimicry system-prefix
+  // regardless of token shape: the shim is not Anthropic's billing surface
+  // and should not receive Claude-Code identity headers in the system prompt.
+  const systemPrefix = localMode ? null : buildSystemPrefix(authMode);
+
+  let tokenRefresher: (() => Promise<Anthropic | null>) | undefined;
+  // In local-server mode, never refresh the keychain OAuth token: a 401 from
+  // the local shim must not cause the SDK to fetch and forward a real
+  // Anthropic credential to a self-hosted endpoint. The placeholder token
+  // path already prevents this on the initial request; this guard closes the
+  // 401-retry hole.
+  if (authMode === 'oauth' && !localMode) {
+    tokenRefresher = async (): Promise<Anthropic | null> => {
+      const freshToken = await refreshClaudeCodeOauthToken();
+      if (!freshToken) return null;
+      const opts = buildClientOptions(
+        freshToken,
+        'oauth',
+        config.baseUrl,
+        // Preserve throttle observability, the live-banner signal AND quota
+        // capture across an OAuth account swap — the rebuilt client must keep
+        // the same tracing-fetch wrapper wired to the same `throttleQueue` and
+        // the same quota observer. localMode is false in this branch (see the
+        // guard above), so `quotaObserver` is always defined here and the
+        // wrapper installs unconditionally — no trace-writer gate, matching
+        // the primary install site above.
+        makeTracingFetch(
+          config.traceWriter,
+          undefined,
+          throttleQueue ? (info) => throttleQueue.push(info) : undefined,
+          quotaObserver,
+        ),
+      );
+      return factory ? factory(opts) : args.createClient(opts);
+    };
+  }
+
+  return {
+    client,
+    throttleQueue,
+    systemPrefix,
+    ...(tokenRefresher !== undefined ? { tokenRefresher } : {}),
+  };
+}

--- a/src/agent/providers/anthropic-direct/query/dispatcher-wiring.ts
+++ b/src/agent/providers/anthropic-direct/query/dispatcher-wiring.ts
@@ -1,0 +1,223 @@
+/**
+ * Dispatcher + awareness-source wiring for one `AnthropicDirectProvider.query()`
+ * call, plus the presence registration that sits between them.
+ *
+ * Extracted from `index.ts` (#824). The three steps below were previously
+ * spread across ~80 lines of a 425-line method; they are gathered here
+ * DELIBERATELY so the ordering constraint is local, visible, and impossible to
+ * split by an edit elsewhere in the file.
+ *
+ * Invariant: `queryDispatcher` is declared, captured, and assigned in that
+ * exact order, and the order is load-bearing.
+ *
+ *   1. DECLARE `let queryDispatcher` with no initializer.
+ *   2. BUILD `runtimeStateSource`, whose `getEnabledToolNames` closure captures
+ *      the *binding* and reads it lazily, at tool-dispatch time.
+ *   3. ASSIGN `queryDispatcher` — passing that same `runtimeStateSource` INTO
+ *      `buildDispatcher`, which registers the `get_runtime_state` handler over
+ *      it.
+ *
+ * Steps 2 and 3 form a genuine cycle: the source must exist before the
+ * dispatcher (the dispatcher registers a handler over it), and the dispatcher
+ * must exist before the source is *called* (the closure reads it). Deferring
+ * the read to call time is the only thing that makes the cycle resolvable.
+ *
+ * Consequence of getting it wrong: if the closure is ever changed to read the
+ * tool list EAGERLY, or if a refactor builds a second source after the
+ * dispatcher and hands the dispatcher the stale first one, then
+ * `get_runtime_state` reports a stale or empty tool list. There is no throw,
+ * no type error, and no other failing assertion — the model is simply told the
+ * wrong thing about itself. `query-wiring.characterization.test.ts` is the
+ * tripwire: it drives a real `get_runtime_state` call through the real
+ * dispatcher and asserts the reported list contains a custom tool that exists
+ * only on the instance built in step 3.
+ *
+ * `registerPresenceLifecycle` is called between steps 2 and 3 because it needs
+ * the source (for `getWorkspace()`) but not the dispatcher. It reads no tool
+ * state, so its position is safe — but it must stay AFTER the source is built.
+ *
+ * @module agent/providers/anthropic-direct/query/dispatcher-wiring
+ */
+
+import type { AgentConfig } from '../../../types/config-types.js';
+import type { AnthropicToolDef } from '../../../tools/types.js';
+import type { ToolDispatcher } from '../tool-dispatcher.js';
+import { SessionToolDispatcher } from '../../../tools/dispatcher.js';
+import {
+  buildRuntimeStateSource,
+  getRuntimeStateTool,
+  wrapDispatcherWithRuntimeState,
+  type RuntimeStateSource,
+} from '../../../awareness/index.js';
+import { builtinToolSchemas } from '../../../tools/schemas.js';
+import { registerPresenceLifecycle, resolveTopLevelSessionId } from './presence-lifecycle.js';
+import type { BuildDispatcherOptions } from '../build-dispatcher.js';
+import type { RuntimeSubagents } from '../../../awareness/index.js';
+
+export interface DispatcherWiringArgs {
+  config: AgentConfig;
+  /** Resolved wire model id (post `resolveModelId`). */
+  model: string;
+  permissionMode: string;
+  surface: string;
+  providerName: string;
+  /** Non-null only when the caller injected an external dispatcher. */
+  externalTools: ToolDispatcher | undefined;
+  sharedReadRoots: string[] | undefined;
+  sharedWriteRoots: string[] | undefined;
+  /** Live MCP tool accessor for the awareness source. */
+  getMcpTools: () => readonly AnthropicToolDef[];
+  /** Live subagent accessor for the awareness source. */
+  getSubagents: () => RuntimeSubagents;
+  /** Provider-owned memoized top-level session id. */
+  getMintedSessionId: () => string | null;
+  setMintedSessionId: (value: string | null) => void;
+  /** Provider-owned presence registration marker. */
+  getPresenceSessionId: () => string | null;
+  setPresenceSessionId: (value: string | null) => void;
+  buildDispatcher: (
+    permissionMode: string,
+    opts: BuildDispatcherOptions,
+  ) => SessionToolDispatcher;
+}
+
+export interface DispatcherWiring {
+  queryDispatcher: ToolDispatcher;
+  runtimeStateSource: RuntimeStateSource;
+  /** Tool defs to advertise, after the skill-dispatch / non-interactive filters. */
+  toolDefs: AnthropicToolDef[];
+  /** The session id the presence file advertises and the query must reuse. */
+  resolvedSessionId: string | undefined;
+}
+
+/**
+ * Build the per-query dispatcher, the awareness source it serves, and the
+ * advertised tool-def list — preserving the late-binding order documented in
+ * this module's header.
+ */
+export function wireQueryDispatcher(args: DispatcherWiringArgs): DispatcherWiring {
+  const { config, surface } = args;
+
+  // STEP 1 — declare. Awareness layer source: declared as a `let` because the
+  // dispatcher and the source have a benign cycle; `getEnabledToolNames`
+  // resolves through a closure that reads `queryDispatcher` lazily at
+  // handler-call time, so the assignment-before-use ordering below is safe.
+  let queryDispatcher: ToolDispatcher;
+
+  // STEP 2 — build the source, capturing the binding above.
+  const runtimeStateSource: RuntimeStateSource = buildRuntimeStateSource({
+    surface,
+    cwd: config.cwd ?? process.cwd(),
+    modelName: args.model,
+    providerName: args.providerName,
+    permissionMode: args.permissionMode,
+    ...(config.sessionId !== undefined ? { sessionId: config.sessionId } : {}),
+    ...(config.parentSessionId !== undefined
+      ? { parentSessionId: config.parentSessionId }
+      : {}),
+    ...(config.depth !== undefined ? { depth: config.depth } : {}),
+    ...(config.maxDepth !== undefined ? { maxDepth: config.maxDepth } : {}),
+    ...(config.phaseRole !== undefined ? { phaseRole: config.phaseRole } : {}),
+    // LAZY BY CONTRACT: reads `queryDispatcher` at call time, which is always
+    // after STEP 3 has run. Must never be changed to snapshot eagerly.
+    getEnabledToolNames: () =>
+      queryDispatcher instanceof SessionToolDispatcher
+        ? queryDispatcher.toolDefs.map((t) => t.name)
+        : [],
+    getMcpTools: args.getMcpTools,
+    getSubagents: args.getSubagents,
+  });
+
+  // Invariant: presence and query construction MUST use the same session id,
+  // because the Telegram watcher resolves a session's ledger path from the id
+  // in its presence file. Resolve once here — BEFORE the presence write — and
+  // reuse the result for `new AnthropicDirectQuery`, so the presence file, the
+  // `session.init` event, and the ledger directory cannot diverge. Reading
+  // `config.sessionId` alone is what broke this: it is set only under
+  // --resume, so fresh sessions advertised nothing at all.
+  const resolvedSession = resolveTopLevelSessionId({
+    sessionId: config.sessionId,
+    resume: config.resume,
+    depth: config.depth,
+    parentSessionId: config.parentSessionId,
+    surface,
+    memoized: args.getMintedSessionId(),
+  });
+  args.setMintedSessionId(resolvedSession.memoized);
+
+  args.setPresenceSessionId(
+    registerPresenceLifecycle({
+      depth: config.depth,
+      parentSessionId: config.parentSessionId,
+      sessionId: resolvedSession.id,
+      currentPresenceSessionId: args.getPresenceSessionId(),
+      runtimeStateSource,
+      surface,
+      cwd: config.cwd,
+      providerName: args.providerName,
+      model: args.model,
+    }),
+  );
+
+  // STEP 3 — assign. The source built in STEP 2 is handed to the dispatcher so
+  // the `get_runtime_state` handler resolves against it.
+  queryDispatcher = args.externalTools
+    ? wrapDispatcherWithRuntimeState(args.externalTools, runtimeStateSource)
+    : args.buildDispatcher(args.permissionMode, {
+        cwd: config.cwd,
+        readRoots: args.sharedReadRoots,
+        writeRoots: args.sharedWriteRoots,
+        ...(config.env !== undefined ? { env: config.env } : {}),
+        sessionId: config.sessionId,
+        parentSessionId: config.parentSessionId,
+        ...(config.subagentId !== undefined ? { subagentId: config.subagentId } : {}),
+        // Fork-scoped central output cap (#661): forwarded from the child
+        // config that forkSubagent stamped, arming maxOutputBytes for forks
+        // only (top-level leaves it unset).
+        ...(config.subagentToolOutputCapBytes !== undefined
+          ? { subagentToolOutputCapBytes: config.subagentToolOutputCapBytes }
+          : {}),
+        traceWriter: config.traceWriter,
+        runtimeStateSource,
+        hookRegistry: config.hookRegistry,
+        planExitControls: config.planExitControls,
+      });
+
+  // External-dispatcher branch: the caller owns routing for whatever tools
+  // it cares about, but we still offer `get_runtime_state` because the
+  // wrapper above intercepts it before it ever reaches the inner dispatcher.
+  // Without adding the schema here the model has no way to know the tool
+  // exists — leaving the awareness layer reachable only via the
+  // `SessionToolDispatcher` path.
+  const baseToolDefs = queryDispatcher instanceof SessionToolDispatcher
+    ? [...queryDispatcher.toolDefs]
+    : [...builtinToolSchemas, getRuntimeStateTool];
+  // Invariant: skill-dispatch sub-agents are dispatched AS a specific skill, so
+  // they must neither (a) pause to ask the operator "which skill?" nor (b) mutate
+  // the operator's environment. Strip `ask_question` (the operator-prompt escape
+  // hatch) and `terminal_font_size` (an environment tool with no role in skill
+  // work — a bare numeric skill arg such as a PR number can otherwise lure a
+  // confused model into calling terminal_font_size(<n>) instead of running the
+  // skill). Gated on isSkillDispatch; pairs with the SLASH_COMMAND_ROUTING_PROMPT
+  // omission in the system-prompt assembly. Verified safe: no bundled/registry/
+  // user skill calls either tool.
+  // Non-interactive surfaces (daemon, scheduler/cron, one-shot `afk chat`)
+  // install no elicitation handler, so `ask_question` can only auto-decline
+  // (elicitation-router.ts). Strip it so the model proceeds on an assumption
+  // or emits Blocked rather than burning a turn on an unanswerable prompt.
+  // Narrower than the skill-dispatch strip: `terminal_font_size` is retained.
+  const toolDefs = config.isSkillDispatch
+    ? baseToolDefs.filter(
+        (t) => t.name !== 'ask_question' && t.name !== 'terminal_font_size',
+      )
+    : config.isNonInteractive
+      ? baseToolDefs.filter((t) => t.name !== 'ask_question')
+      : baseToolDefs;
+
+  return {
+    queryDispatcher,
+    runtimeStateSource,
+    toolDefs,
+    resolvedSessionId: resolvedSession.id,
+  };
+}

--- a/src/agent/providers/anthropic-direct/query/prompt-assembly.ts
+++ b/src/agent/providers/anthropic-direct/query/prompt-assembly.ts
@@ -1,0 +1,115 @@
+/**
+ * System-prompt assembly for one `AnthropicDirectProvider.query()` call.
+ *
+ * Extracted from `index.ts` (#824). Gathers the skill manifest, the tool and
+ * memory prompt variants, and the awareness identity fields, then produces
+ * both the STABLE (cwd-independent) parts and the assembled first-turn prompt.
+ *
+ * Contract: `stableSystemPrefix` is returned alongside the assembled string
+ * because the cwd-rebuild path (`createCwdDependentsFactory`) re-runs
+ * `assembleSystemPrompt` over those same parts on a `setCwd()`. Returning one
+ * without the other would let the first-turn prompt and the rebuilt prompt
+ * drift — which is exactly the bug that made the assembler a shared helper.
+ *
+ * @module agent/providers/anthropic-direct/query/prompt-assembly
+ */
+
+import type { AgentConfig } from '../../../types/config-types.js';
+import type { RuntimeStateSource } from '../../../awareness/index.js';
+import { buildSkillManifest } from '../../../tools/skill-bridge.js';
+import {
+  resolveToolSystemPrompt,
+  resolveMemorySystemPrompt,
+} from '../../../tools/system-prompt.js';
+import {
+  assembleSystemPrompt,
+  buildStableSystemPrefix,
+  type StableSystemParts,
+} from './system-prompt.js';
+
+export interface PromptAssemblyArgs {
+  config: AgentConfig;
+  /** Session working directory (already defaulted to `process.cwd()`). */
+  cwd: string;
+  surface: string;
+  readOnlyMemory: boolean;
+  /** Present only when a skill executor is wired; gates manifest construction. */
+  hasSkillExecutor: boolean;
+  runtimeStateSource: RuntimeStateSource;
+  /** User-supplied system prompt, already normalized to a string or null. */
+  userSystem: string | null;
+}
+
+export interface AssembledPrompt {
+  /** Cwd-independent parts, reused verbatim by the cwd-rebuild factory. */
+  stableSystemPrefix: StableSystemParts;
+  /** The assembled first-turn system prompt. */
+  toolSystemAppend: string;
+}
+
+/** Build the stable prompt parts and assemble the first-turn system prompt. */
+export function assembleQueryPrompt(args: PromptAssemblyArgs): AssembledPrompt {
+  const { config, cwd } = args;
+
+  // Build skill manifest for system prompt injection. The manifest lists
+  // available skills so the model knows what the `skill` tool can invoke.
+  // Let collectSkillEntries() own the full scan (project + user + bundled).
+  // Pass the session cwd so project skills (<cwd>/.afk/skills/) resolve
+  // against the session's working directory, not the host process's —
+  // they diverge on long-lived hosts (daemon, Telegram bot).
+  // `excludeName` omits the executing skill's own entry for a skill-dispatch
+  // fork (see AgentConfig.skillDispatchName). Must stay in lockstep with the
+  // openai-compatible call site — a per-provider divergence here is how a
+  // fork on one provider silently keeps the self-entry.
+  const manifest = args.hasSkillExecutor
+    ? buildSkillManifest(undefined, {
+        cwd,
+        ...(typeof config.skillDispatchName === 'string' &&
+        config.skillDispatchName.length > 0
+          ? { excludeName: config.skillDispatchName }
+          : {}),
+      })
+    : '';
+  // Invariant: SLASH_COMMAND_ROUTING_PROMPT is omitted for skill-dispatch
+  // sub-agents. Those sessions receive a "Run the <name> skill" directive
+  // with no <command-name> tag, so the routing instruction (which keys off
+  // that tag) would push them to ask "which skill?" instead of engaging with
+  // their SKILL.md body. The ask_question strip in the dispatcher wiring is
+  // the structural backstop for the same failure mode.
+  const toolBase = resolveToolSystemPrompt(config.isSkillDispatch);
+  // Read-only memory child sessions get a slimmed prompt that omits write
+  // instructions for memory_update / procedure_write — keeps the model from
+  // being told about tools it does not have.
+  const memoryPrompt = resolveMemorySystemPrompt(args.readOnlyMemory);
+
+  // Awareness identity fields interleaved into the `# Environment` fragment
+  // (Phase 1 + 2). Stable across cwd swaps — only `cwd` changes on setCwd().
+  const environmentIdentity = {
+    surface: args.surface,
+    sessionId: config.sessionId,
+    depth: config.depth,
+    maxDepth: config.maxDepth,
+    workspace: args.runtimeStateSource.getWorkspace(),
+  };
+
+  // Stable (cwd-independent) parts of the system prompt. The cwd-dependent
+  // `# Environment` fragment is spliced in by assembleSystemPrompt — the same
+  // helper the cwdDependentsFactory uses on a cwd change, so the first-turn
+  // and rebuilt prompts can never drift.
+  const stableSystemPrefix = buildStableSystemPrefix({
+    toolBase,
+    memoryPrompt,
+    // Hot memory (HOT.md) rides its own config field, NOT prepended into
+    // systemPrompt, so the assembler can place it after the memory
+    // instructions rather than ahead of the # Agent AFK doctrine. Unset for
+    // child sessions (subagents never inject hot memory) → treated as absent.
+    hotMemory: config.hotMemory ?? '',
+    manifest,
+    userSystem: args.userSystem,
+  });
+
+  return {
+    stableSystemPrefix,
+    toolSystemAppend: assembleSystemPrompt(stableSystemPrefix, cwd, environmentIdentity),
+  };
+}


### PR DESCRIPTION
## Summary

Splits `src/agent/providers/anthropic-direct/index.ts` (1115 LOC, ~40 commits in 6 months, 3rd-highest churn in the repo) into the shell + `query/` helper layout the sibling modules already use — `loop.ts` → `loop/` and `query.ts` → `query/`. No new subdirectory layout was invented; the `query()` helpers land in the existing `query/` directory alongside `cwd-dependents.ts`, `system-prompt.ts`, and `presence-lifecycle.ts`, which were extracted from this same method previously.

Closes #824

**Behavior-preserving.** The only intentional change is code movement. Two places where the move was *not* byte-faithful were found by an adversarial old-vs-new audit and corrected before this PR — see "Two gates the split initially got wrong" below.

### LOC delta (measured with `wc -l`, before = `git show 86b72524:<file>`)

| File | Before | After | Delta |
|---|---:|---:|---:|
| `anthropic-direct/index.ts` | 1115 | 649 | **−466** |
| `anthropic-direct/provider-options.ts` | 0 | 138 | +138 |
| `anthropic-direct/build-dispatcher.ts` | 0 | 284 | +284 |
| `anthropic-direct/query/dispatcher-wiring.ts` | 0 | 223 | +223 |
| `anthropic-direct/query/client-setup.ts` | 0 | 152 | +152 |
| `anthropic-direct/query/prompt-assembly.ts` | 0 | 115 | +115 |
| `build-dispatcher.characterization.test.ts` | 0 | 355 | +355 |
| `query-wiring.characterization.test.ts` | 0 | 550 | +550 |
| `query/client-setup.test.ts` | 0 | 153 | +153 |

`query()` itself: ~425 LOC → ~145 LOC of orchestration plus the declarative `AnthropicDirectQuery` construction. No new source file exceeds the 350-LOC ceiling (largest: `build-dispatcher.ts` at 284).

### Characterization tests came first

The issue is explicit that splitting this file without a safety net is more dangerous than leaving it alone. Sequence actually followed, and visible in the commit order:

1. `pnpm install`, full baseline suite green (733 files / 14024 tests).
2. Commit `e150ff2e` — **tests only, zero production changes** — 37 characterization tests against the *unmodified* `index.ts`, confirmed green before anything moved.
3. Commits `27c44ea1` / `0b2ecd52` — the extractions. The same 37 tests still pass **unchanged**.

Two of my initial assertions were wrong and were corrected to match real behavior rather than the reverse: `permissionMode` is deliberately bucketed to `'elevated' | 'default'` (anti-injection, `runtime-source.ts:131`), and the OAuth prefix is a billing header, not a persona string.

What they actually pin — `buildDispatcher` (21 tests): handler-map precedence (builtin > runtime-state > custom > MCP) including both collision directions, schema ordering, the read-only-memory filter, `allowAll` derivation per permission mode, MCP + custom allowlist unions, MCP cache reuse and `onToolsRefreshed` invalidation, fork-scoped `maxOutputBytes` arming keyed on `subagentToolOutputCapBytes` (not `parentSessionId`), shared-root by-reference threading, and plan-exit registration being gated on controls rather than mode. `query()` (19 tests): the ordering hazard below, runtime-state identity threading, the three-way tool-def filter (skill-dispatch / non-interactive / normal), client-factory precedence, OAuth vs api-key system prefix, and shared-root adoption + grant anchoring.

### The `queryDispatcher` / `getEnabledToolNames` ordering hazard

The declare → capture → assign sequence was previously spread across ~80 lines of a 425-line method. It is now gathered into **one function**, `query/dispatcher-wiring.ts`, specifically so the constraint is local and cannot be split by an edit elsewhere in the file:

1. `let queryDispatcher` declared with no initializer.
2. `runtimeStateSource` built — its `getEnabledToolNames` closure captures the **binding** and reads it lazily at tool-dispatch time.
3. `queryDispatcher` assigned, passing that same source **into** `buildDispatcher`.

Steps 2 and 3 are a genuine cycle: the source must exist before the dispatcher (which registers a `get_runtime_state` handler over it), and the dispatcher must exist before the source is *called*. Only the deferred read resolves it. The module header documents this as an `Invariant:` and names the covering test. `registerPresenceLifecycle` sits between steps 2 and 3 because it needs the source (`getWorkspace()`) but reads no tool state.

**Covering tests** (`query-wiring.characterization.test.ts`): *"get_runtime_state reports the LIVE dispatcher tool list"* and *"reflects a CUSTOM tool registered on the dispatcher built inside the same query()"*. Both drive a real `get_runtime_state` tool call through the real dispatcher and parse the resulting `tool.output` JSON. The second is the stronger assertion — the marker tool exists *only* on the instance built in step 3, so seeing it proves the closure read the post-assignment binding.

**Verified the tripwire actually fires.** I mutated `dispatcher-wiring.ts` to snapshot the tool names eagerly — the exact silent-failure mode, which produces no throw, no type error, and no other failing test — and confirmed those two tests (and only those) failed. The file was then restored byte-identical.

### Two gates the split initially got wrong

An adversarial old-vs-new audit caught two non-faithful ports. Both were latent (unreachable through the declared types, reachable from JS callers / test stubs), both are fixed in `3a43a3e7`, and both are now pinned by a regression test that was verified to fail when the defect is re-introduced:

1. **Skill-manifest gate.** Original used truthiness; my extraction narrowed it to `!== undefined`, desyncing it from the constructor's still-truthy `if (opts.skillExecutor) schemas.push(skillTool)`. A falsy-but-defined executor would have injected a skill manifest with no `skill` tool registered. Restored to `Boolean(...)`.
2. **MCP handler iteration.** Original iterated the cache field directly, so a nullish handler map threw. My extraction added `?? []`, converting a loud failure into a silent zero-handler dispatcher. Restored to a non-null assertion — that `?? []` was hardening that changed behavior, not a port.

The audit separately confirmed clean: all 26 `AnthropicDirectQuery` conditional spreads byte-identical, the `surface` vs `declaredSurface` distinction (#762/#764) preserved exactly, MCP cache/invalidation semantics unchanged, the `||` vs `??` cwd asymmetry intact, and `tokenRefresher`'s earlier construction a benign reorder (closure creation is not a side effect; nothing between the old and new positions mutates what it captures).

### Notes

- `index.ts` re-exports `__setAnthropicClientFactory`, `AnthropicClientFactory`, and `AnthropicDirectProviderOptions`, so every existing `from './index.js'` import path still resolves — no call sites were touched.
- The module-scope client factory is now read through a `getClientFactory()` accessor rather than an exported binding: tests install the hook in `beforeEach`, *after* first import, so a captured binding would pin the import-time value and silently route test traffic at the real SDK.
- **`audit:sdk:check`**: the AFK.md invariant still holds exactly — runtime `import Anthropic from '@anthropic-ai/sdk'` remains only in `index.ts` and `oneshot.ts`. The new files use `import type Anthropic`, which is erased at compile time. No new SDK symbol, so no lock update was needed.

## How was this tested?

All gates run locally on this branch. Real output:

```
$ pnpm lint
> tsc --noEmit
(clean, no output)

$ pnpm test
 Test Files  736 passed (736)
      Tests  14073 passed | 2 skipped (14075)
   Duration  40.69s
        (baseline on main @ 86b72524: 733 files / 14024 tests — delta is exactly the +49 added here)

$ pnpm build
> tsc && node scripts/copy-prompts.js
(clean)

$ pnpm test:coverage
All files          |    87.6 |    85.66 |   91.81 |    87.6
  thresholds: stmts 74 / branches 79 / funcs 82 / lines 74 — PASS (exit 0)

  per extracted file (from coverage-final.json):
    provider-options.ts          stmts 100.00  branch 100.00  funcs 100.00
    build-dispatcher.ts          stmts 100.00  branch  95.35  funcs 100.00
    query/dispatcher-wiring.ts   stmts 100.00  branch  93.55  funcs 100.00
    query/prompt-assembly.ts     stmts 100.00  branch 100.00  funcs 100.00
    query/client-setup.ts        stmts  94.23  branch  96.00  funcs  66.67
    index.ts                     stmts  89.59  branch  92.42  funcs  94.29

$ pnpm audit:sdk:check
audit:sdk --check: OK. Lock matches current imports.

$ pnpm audit:env:check
✓ audit-env-access: 739 files scanned, 150 legitimate process.env accesses inside allowlist, 0 violations.

$ pnpm scan:env:check
✓ scan:env: docs/env-registry.{json,md} in sync with src/config/env.ts (140 vars).

$ pnpm audit:chalk:check
✓ audit-chalk-usage: 739 files scanned, 73 legitimate raw-chalk sites inside allowlist, 0 violations.

$ pnpm fix:pins:check
All hash pins are up to date.
```

Beyond the suite, two mutation checks were run to prove the new tests have teeth (each defect injected, correct tests failed, file restored):
- eager tool-name snapshot in `dispatcher-wiring.ts` → the 2 ordering tripwire tests failed.
- both audit defects re-introduced → the 2 corresponding regression tests failed.

`src/config/env.ts` was not touched. No `git stash pop` was run.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/) — see [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] No secrets, tokens, or private paths in the diff
