### PR TITLE
refactor(session): extract a shared wireExecutors() factory (#822)

### DIFF
--- a/src/agent/session/wire-executors.ts
+++ b/src/agent/session/wire-executors.ts
@@ -1,0 +1,286 @@
+/**
+ * Invariant: shared executor wiring for every top-level surface (REPL,
+ * `afk chat`, Telegram, daemon). The construction ORDER below is load-bearing —
+ * each step closes over the ones above it:
+ *   1. SubagentManager          — the single root manager for all forked children
+ *   2. childProviderFactory     — routes child model → AnthropicDirect / OpenAICompatible
+ *   3. agentRegistry            — named-agent scan (builtin + user + project)
+ *   4. childSkillExecutorFactory— depth-aware factory for nested skill children
+ *   5. SubagentExecutor         — wires the `agent` tool
+ *   6. SkillExecutor            — wires the `skill` tool
+ *   7. ComposeExecutor          — wires the `compose` tool
+ *
+ * Exactly ONE {@link SubagentManager} is constructed per call and shared by
+ * every executor. Callers must reuse the returned `rootManager` rather than
+ * building a second one: read-scope inheritance (#547), the abort graph, and
+ * the subagent-success rollup are all keyed to that single instance.
+ *
+ * Per-surface differences are expressed as explicit parameters on
+ * {@link WireExecutorsOptions} — never as `if (surface === …)` branching in
+ * here. Three pairs of fields exist purely to preserve pre-existing per-surface
+ * wiring asymmetries (`model`/`managerParentModel`, `cwd`/`nestedCwd`,
+ * `traceWriter`/`skillTraceWriter`); each is documented at its declaration.
+ */
+import { SubagentManager } from '../subagent.js';
+import { SubagentExecutor } from '../tools/subagent-executor.js';
+import { SkillExecutor } from '../tools/skill-executor.js';
+import { ComposeExecutor } from '../tools/compose-executor.js';
+import { createChildProviderFactory, createChildSkillExecutorFactory } from '../tools/nesting.js';
+import { loadAgentRegistry } from '../agents/index.js';
+import { discoverPluginAgents } from '../tools/skill-bridge.js';
+import type { SubagentExecutorContext } from '../tools/subagent-executor.js';
+import type { BackgroundAgentRegistry } from '../background-registry.js';
+import type { TraceWriter } from '../trace/writer.js';
+import type { Surface } from '../awareness/types.js';
+import type { AgentModelInput } from '../types.js';
+
+/** Options for {@link wireExecutors}. */
+export interface WireExecutorsOptions {
+  /**
+   * User-facing surface that owns these executors. Threaded into the root
+   * manager (so forked `agent`-tool children inherit `origin` instead of
+   * `'unknown'`) and onto every executor for routing-decision telemetry.
+   */
+  surface: Surface;
+  /**
+   * The parent-session view the executors fork from. Surfaces that construct
+   * their session AFTER the executors pass a deferred proxy whose getters read
+   * through a mutable ref, so a mid-session swap stays transparent; the daemon
+   * passes a stub bound to its own abort signal.
+   */
+  parentSession: SubagentExecutorContext['parentSession'];
+  /** Parent credential. May be undefined when only per-model resolution applies. */
+  apiKey: string | undefined;
+  /**
+   * The dispatching session's model. Used as `defaultModel` (skill/compose)
+   * and as the `inherit` anchor for named-agent model resolution.
+   */
+  model: AgentModelInput;
+  /**
+   * The model that {@link WireExecutorsOptions.apiKey} was resolved FROM.
+   * Distinct from `model` on purpose: the root manager derives its fork-time
+   * credential-fallback provider via `providerForModel(parentModel)`, so it
+   * must key off the credential's own model (`getModel()` on the CLI surfaces,
+   * which may differ from a `--model`-overridden session model) or the
+   * fallback can cross the provider boundary.
+   */
+  managerParentModel: AgentModelInput;
+  /** Resolved default model for dispatches that omit one. */
+  defaultSubagentModel: AgentModelInput;
+  /**
+   * Per-model credential resolver (canonically `getApiKeyForModel`). Injected
+   * rather than imported so this module stays free of a `src/cli` dependency.
+   */
+  resolveApiKeyForModel: (model: string) => string | undefined;
+  /**
+   * Raw base system prompt (pre-assembly) inherited by forked children and
+   * compose nodes — intentionally excludes ROUTING_DIRECTIVE and
+   * TOOL_SYSTEM_PROMPT so children stay task workers. Compose coerces
+   * `undefined` to `''`.
+   */
+  systemPrompt?: string;
+  /** Anthropic-compatible endpoint forwarded to children. */
+  baseUrl?: string;
+  /** OpenAI-compatible endpoint forwarded to OpenAI-routed children. */
+  openaiBaseUrl?: string;
+  /**
+   * Session/worktree cwd. Anchors the root manager, the named-agent scan, the
+   * nested skill-executor factory, and compose DAG nodes.
+   */
+  cwd?: string;
+  /**
+   * Cwd for the `agent`/`skill` executors themselves, which anchors depth ≥ 2
+   * forks and skill-dispatched subagents.
+   *
+   * Contract: separate from {@link WireExecutorsOptions.cwd} because Telegram
+   * historically set cwd on the manager/registry/compose path but NOT on these
+   * two executors. Surfaces that want uniform anchoring pass the same value for
+   * both; Telegram passes `undefined` here to preserve its existing (narrower)
+   * behaviour. Collapsing the two would be a behaviour change, not a refactor.
+   */
+  nestedCwd?: string;
+  /**
+   * Witness-layer writer for the root manager, the `agent` executor, and
+   * compose DAG nodes.
+   */
+  traceWriter?: TraceWriter;
+  /**
+   * Witness-layer writer for the `skill` executor and the nested
+   * skill-executor factory.
+   *
+   * Contract: separate from {@link WireExecutorsOptions.traceWriter} because
+   * Telegram traces its manager/agent/compose paths but leaves skill forks
+   * untraced. Other surfaces pass the same writer for both.
+   */
+  skillTraceWriter?: TraceWriter;
+  /**
+   * Registry backing `agent` dispatches with `mode: 'background'`. Only the
+   * REPL wires one; elsewhere background dispatch reports as unconfigured
+   * rather than silently downgrading to foreground.
+   */
+  backgroundRegistry?: BackgroundAgentRegistry;
+  /**
+   * Sink for named-agent scan warnings (e.g. a user agent file shadowing a
+   * tool-restricted builtin). When omitted, `loadAgentRegistry` uses its
+   * default writer.
+   */
+  agentRegistryWarn?: (message: string) => void;
+}
+
+/** The wired executor set returned by {@link wireExecutors}. */
+export interface WiredExecutors {
+  /**
+   * The single root manager shared by all three executors. Reuse it — do not
+   * construct another for the same session.
+   */
+  rootManager: SubagentManager;
+  subagentExecutor: SubagentExecutor;
+  skillExecutor: SkillExecutor;
+  composeExecutor: ComposeExecutor;
+}
+
+/**
+ * Construct the `agent` / `skill` / `compose` executor trio plus the single
+ * root {@link SubagentManager} they share.
+ *
+ * @see WireExecutorsOptions for the per-surface parameters.
+ */
+export function wireExecutors(opts: WireExecutorsOptions): WiredExecutors {
+  const {
+    surface,
+    parentSession,
+    apiKey,
+    model,
+    managerParentModel,
+    defaultSubagentModel,
+    resolveApiKeyForModel,
+    systemPrompt,
+    baseUrl,
+    openaiBaseUrl,
+    cwd,
+    nestedCwd,
+    traceWriter,
+    skillTraceWriter,
+    backgroundRegistry,
+    agentRegistryWarn,
+  } = opts;
+
+  // Conditional spreads (rather than `field: value` with a possibly-undefined
+  // value) are preserved from the original call sites so an absent option stays
+  // an absent key.
+  const baseUrlOpt = baseUrl !== undefined ? { baseUrl } : {};
+  const openaiBaseUrlOpt = openaiBaseUrl !== undefined ? { openaiBaseUrl } : {};
+  const cwdOpt = cwd !== undefined ? { cwd } : {};
+  const nestedCwdOpt = nestedCwd !== undefined ? { cwd: nestedCwd } : {};
+  const traceOpt = traceWriter !== undefined ? { traceWriter } : {};
+  const skillTraceOpt = skillTraceWriter !== undefined ? { traceWriter: skillTraceWriter } : {};
+  const apiKeyOpt = apiKey !== undefined ? { apiKey } : {};
+  const bgRegistryOpt = backgroundRegistry !== undefined ? { backgroundRegistry } : {};
+
+  // 1. The single root manager. Every executor below reads through this
+  //    instance; a second manager would fork children outside the abort graph
+  //    and outside the parent's read scope.
+  const rootManager = new SubagentManager({
+    ...apiKeyOpt,
+    parentModel: managerParentModel,
+    ...baseUrlOpt,
+    ...cwdOpt,
+    ...traceOpt,
+    surface,
+  });
+
+  // 2. Routes each child model to AnthropicDirect / OpenAICompatible, pointing
+  //    OpenAI-routed children at the configured local shim when set.
+  const childProviderFactory = createChildProviderFactory(openaiBaseUrlOpt);
+
+  // 3. Named-agent registry: session-static scan enabling `agent_type`
+  //    dispatch at every depth.
+  const agentRegistry = loadAgentRegistry({
+    ...cwdOpt,
+    pluginAgents: discoverPluginAgents(),
+    ...(agentRegistryWarn !== undefined ? { warn: agentRegistryWarn } : {}),
+  });
+
+  // 4. Shared by the `agent` and `skill` executors so plugin skill children
+  //    nest with identical depth-aware wiring at every hop.
+  const childSkillExecutorFactory = createChildSkillExecutorFactory(
+    model,
+    apiKey,
+    childProviderFactory,
+    baseUrl,
+    skillTraceWriter,
+    backgroundRegistry,
+    cwd,
+    resolveApiKeyForModel,
+    surface,
+    defaultSubagentModel,
+    agentRegistry,
+    openaiBaseUrl,
+  );
+
+  // 5. `agent` tool.
+  const subagentExecutor = new SubagentExecutor({
+    subagentManager: rootManager,
+    parentSession,
+    surface,
+    defaultConfig: {
+      ...apiKeyOpt,
+      ...(systemPrompt !== undefined ? { systemPrompt } : {}),
+      ...baseUrlOpt,
+      ...openaiBaseUrlOpt,
+    },
+    defaultSubagentModel,
+    childProviderFactory,
+    childSkillExecutorFactory,
+    ...bgRegistryOpt,
+    resolveApiKeyForModel,
+    // Top-level wiring → explicit depth 0. See SubagentExecutorContext.depth
+    // for why this is required rather than defaulted.
+    depth: 0,
+    ...nestedCwdOpt,
+    agentRegistry,
+    parentModel: model,
+    ...traceOpt,
+  });
+
+  // 6. `skill` tool.
+  const skillExecutor = new SkillExecutor({
+    parentSession,
+    surface,
+    defaultModel: model,
+    defaultSubagentModel,
+    ...apiKeyOpt,
+    childProviderFactory,
+    childSkillExecutorFactory,
+    agentRegistry,
+    ...bgRegistryOpt,
+    ...baseUrlOpt,
+    ...openaiBaseUrlOpt,
+    resolveApiKeyForModel,
+    ...skillTraceOpt,
+    ...nestedCwdOpt,
+    // Read-scope inheritance (#547): skill-forked children inherit the parent
+    // session's read scope via the root manager — symmetric with the `agent`
+    // tool. Read fresh so mid-session setCwd re-anchors are reflected.
+    getReadScopeInputs: () => rootManager.getReadScopeInputs(),
+  });
+
+  // 7. `compose` tool. Nodes receive the raw base prompt so they stay task
+  //    workers that cannot spawn nested DAGs or recurse into skills.
+  const composeExecutor = new ComposeExecutor({
+    parentSession,
+    defaultModel: model,
+    defaultSubagentModel,
+    ...apiKeyOpt,
+    resolveApiKeyForModel,
+    getReadScopeInputs: () => rootManager.getReadScopeInputs(),
+    ...baseUrlOpt,
+    ...cwdOpt,
+    systemPrompt: systemPrompt ?? '',
+    surface,
+    depth: 0,
+    ...traceOpt,
+  });
+
+  return { rootManager, subagentExecutor, skillExecutor, composeExecutor };
+}

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -20,13 +20,8 @@ import { applyTheme, resolveTheme, resolveThemeMode, parseThemeFlag } from '../t
 import { assembleSystemPrompt } from '../../agent/routing-directive.js';
 import { renderMarkdownToTerminal } from '../formatter.js';
 import { formatSubagentCompletion } from './interactive/progress-banner.js';
-import { SubagentManager } from '../../agent/subagent.js';
-import { SubagentExecutor } from '../../agent/tools/subagent-executor.js';
-import { SkillExecutor } from '../../agent/tools/skill-executor.js';
-import { ComposeExecutor } from '../../agent/tools/compose-executor.js';
-import { ensurePluginEntrypointsLoaded, discoverPluginAgents } from '../../agent/tools/skill-bridge.js';
-import { createChildProviderFactory, createChildSkillExecutorFactory } from '../../agent/tools/nesting.js';
-import { loadAgentRegistry } from '../../agent/agents/index.js';
+import { wireExecutors } from '../../agent/session/wire-executors.js';
+import { ensurePluginEntrypointsLoaded } from '../../agent/tools/skill-bridge.js';
 import { AnthropicDirectProvider } from '../../agent/providers/anthropic-direct/index.js';
 import { createDefaultTraceWriter } from '../../agent/trace/factory.js';
 import { receiptPathsFor } from '../../agent/trace/receipt.js';
@@ -447,40 +442,8 @@ export function registerChatCommand(program: Command): void {
         const trace = createDefaultTraceWriter();
         receiptTracePath = trace?.tracePath;
 
-        const rootManager = new SubagentManager({
-          apiKey,
-          // Provider source of truth for the fork-time credential fallback:
-          // `apiKey` is `getApiKey()`, which keys off `getModel()` (AFK_MODEL),
-          // so the parent key's provider is `providerForModel(getModel())`.
-          // Passing that keeps the fallback from crossing the provider boundary
-          // (see SubagentManager.parentProvider).
-          parentModel: getModel(),
-          ...(cliConfig.baseUrl !== undefined ? { baseUrl: cliConfig.baseUrl } : {}),
-          // Propagate the worktree cwd into every forked subagent so their
-          // bash/grep run in the isolated tree, not the Node host's
-          // process.cwd().
-          ...(worktreeCwd !== undefined ? { cwd: worktreeCwd } : {}),
-          // Witness layer: manager-level writer so `agent`-tool forks (which
-          // never set config.traceWriter) emit subagent_lifecycle events and
-          // hand the writer to their handles. Mirrors bootstrap.ts.
-          ...(trace?.writer !== undefined ? { traceWriter: trace.writer } : {}),
-          // Origin attribution: `afk chat` is a `cli` entrypoint. Thread the
-          // surface so forked `agent`-tool children inherit origin 'cli' (not
-          // 'unknown') via forkSubagent's parentSurface fill. Mirrors farm.ts.
-          surface: 'cli',
-        });
-
-        // Pass openaiBaseUrl so OpenAI-routed children point at the
-        // configured local shim (mlx_lm.server, Ollama, vLLM, llama.cpp,
-        // LM Studio) instead of the default api.openai.com. The factory
-        // routes per-call between AnthropicDirect / OpenAICompatible by
-        // `providerForModel(model)`.
-        const childProviderFactory = createChildProviderFactory(
-          cliConfig.openaiBaseUrl !== undefined
-            ? { openaiBaseUrl: cliConfig.openaiBaseUrl }
-            : {},
-        );
-
+        // The session is constructed after the executors, so the parent view
+        // they fork from reads through `boundSession` lazily.
         const deferredParent = {
           get sessionId() { return boundSession?.sessionId; },
           getInputStreamRef() { return boundSession?.getInputStreamRef?.() ?? { pushUserMessage: () => {} }; },
@@ -492,137 +455,36 @@ export function registerChatCommand(program: Command): void {
           get hookRegistry() { return boundSession?.hookRegistry; },
         };
 
-        // Share a single childSkillExecutorFactory between SubagentExecutor
-        // and SkillExecutor so both code paths use the same depth-aware
-        // nesting wiring. Wiring SkillExecutor with these factories is
-        // load-bearing: without them, plugin skill children fork with the
-        // bare AnthropicDirectProvider singleton (which omits the `agent`
-        // and `skill` tools, see anthropic-direct/index.ts:108–110) and
-        // any SKILL.md instruction to "dispatch sub-agents via the Agent
-        // tool" becomes unimplementable.
-        // Named-agent registry: session-static scan (builtin + user
-        // ~/.afk/agents + project .afk/agents & .claude/agents). Enables
-        // `agent_type` dispatch on the `agent` tool at every depth.
-        const agentRegistry = loadAgentRegistry({
-          ...(worktreeCwd !== undefined ? { cwd: worktreeCwd } : {}),
-          pluginAgents: discoverPluginAgents(),
-        });
-
-        const childSkillExecutorFactory = createChildSkillExecutorFactory(
-          options.model,
-          apiKey,
-          childProviderFactory,
-          cliConfig.baseUrl,
-          trace?.writer,
-          // No backgroundRegistry on the one-shot chat path — background
-          // dispatch is interactive-only by contract.
-          undefined,
-          // Worktree cwd propagates into every depth of the skill-executor
-          // chain. See bootstrap.ts for the same wiring.
-          worktreeCwd,
-          // Per-model credential resolver — see bootstrap.ts for rationale.
-          getApiKeyForModel,
-          // Surface: chat skill executor children inherit origin 'cli'.
-          'cli',
-          // Resolved default-subagent model threaded into nested skill
-          // executors so skill→skill / skill→agent chains inherit the SAME
-          // policy as the top-level executors — closing the leak where a
-          // nested subagent silently defaulted to Anthropic `sonnet` under an
-          // OpenAI-routed parent.
-          getDefaultSubagentModel(options.model),
-          // Named-agent registry propagates to nested skill executors.
-          agentRegistry,
-          // OpenAI endpoint → nested restricted/depth-cap provider builders.
-          cliConfig.openaiBaseUrl,
-        );
-
-        // Pass `options.model` so `getDefaultSubagentModel` can fall back
-        // to the parent model when AFK_DEFAULT_SUBAGENT_MODEL is unset
-        // AND the parent routes to openai-compatible — preventing the
-        // legacy `'sonnet'` literal from silently dispatching OpenAI-parent
-        // subagents to api.anthropic.com. Claude parents still default to
-        // 'sonnet' (preserves the historical cost-management intent).
-        const subagentExecutor = new SubagentExecutor({
-          subagentManager: rootManager,
-          parentSession: deferredParent,
-          // Session origin for routing-decision telemetry (afk chat → cli).
+        // Invariant: ONE root manager per session, shared by all three
+        // executors. The trace writer is opened above so the manager and every
+        // executor inherit it — without it, skill-forked subagents emit zero
+        // trace events and become undebuggable from disk.
+        const { subagentExecutor, skillExecutor, composeExecutor } = wireExecutors({
+          // Origin attribution: `afk chat` is a `cli` entrypoint.
           surface: 'cli',
-          defaultConfig: {
-            apiKey,
-            systemPrompt: basePrompt,
-            ...(cliConfig.baseUrl !== undefined ? { baseUrl: cliConfig.baseUrl } : {}),
-            ...(cliConfig.openaiBaseUrl !== undefined ? { openaiBaseUrl: cliConfig.openaiBaseUrl } : {}),
-          },
+          parentSession: deferredParent,
+          apiKey,
+          model: options.model,
+          // `apiKey` is getApiKey(), which keys off getModel() (AFK_MODEL), so
+          // the manager's credential-fallback provider must be derived from
+          // THAT model — not the possibly-overridden session model — or the
+          // fallback can cross the provider boundary.
+          managerParentModel: getModel(),
           defaultSubagentModel: getDefaultSubagentModel(options.model),
-          childProviderFactory,
-          childSkillExecutorFactory,
-          // Per-model credential resolver — see bootstrap.ts for rationale.
           resolveApiKeyForModel: getApiKeyForModel,
-          // Top-level CLI wiring → explicit depth 0. See SubagentExecutorContext.depth
-          // jsdoc for why this is required rather than defaulted.
-          depth: 0,
-          // Worktree isolation for depth ≥ 2 `agent` dispatch. See
-          // bootstrap.ts for the same wiring.
-          ...(worktreeCwd !== undefined ? { cwd: worktreeCwd } : {}),
-          // Named-agent dispatch: registry + the session model as the
-          // `inherit` anchor for named-agent model resolution.
-          agentRegistry,
-          parentModel: options.model,
-          // Witness layer: thread the writer so depth ≥ 2 `agent` forks stay
-          // visible in the trace. Mirrors bootstrap.ts.
-          ...(trace?.writer !== undefined ? { traceWriter: trace.writer } : {}),
-        });
-
-        const skillExecutor = new SkillExecutor({
-          parentSession: deferredParent,
-          // Session origin for skill-invocation + routing telemetry (afk chat → cli).
-          surface: 'cli',
-          defaultModel: options.model,
-          defaultSubagentModel: getDefaultSubagentModel(options.model),
-          apiKey,
-          childProviderFactory,
-          childSkillExecutorFactory,
-          // Named-agent registry for skill-forked orchestrator children.
-          agentRegistry,
+          // Raw base prompt (pre-assembly): children and compose nodes stay
+          // task workers, without ROUTING_DIRECTIVE / TOOL_SYSTEM_PROMPT.
+          ...(basePrompt !== undefined ? { systemPrompt: basePrompt } : {}),
           ...(cliConfig.baseUrl !== undefined ? { baseUrl: cliConfig.baseUrl } : {}),
           ...(cliConfig.openaiBaseUrl !== undefined ? { openaiBaseUrl: cliConfig.openaiBaseUrl } : {}),
-          // Per-model credential resolver — mirrors bootstrap.ts wiring.
-          resolveApiKeyForModel: getApiKeyForModel,
-          // See bootstrap.ts SkillExecutor wiring for rationale: without
-          // this, every skill-forked subagent is invisible in the witness
-          // trace.
-          ...(trace?.writer !== undefined ? { traceWriter: trace.writer } : {}),
-          // Worktree isolation for skill-dispatched subagents. See
-          // bootstrap.ts for the same wiring.
-          ...(worktreeCwd !== undefined ? { cwd: worktreeCwd } : {}),
-          // Read-scope inheritance (#547): skill-forked children inherit the
-          // parent session's read scope via the root manager. See bootstrap.ts.
-          getReadScopeInputs: () => rootManager.getReadScopeInputs(),
-        });
-
-        // Pass the raw base prompt (pre-assembly) so compose subagents do not
-        // inherit ROUTING_DIRECTIVE or TOOL_SYSTEM_PROMPT — keeping them as
-        // task workers that cannot spawn nested DAGs or recurse into skills.
-        // Mirrors the SubagentExecutor defaultConfig.systemPrompt convention.
-        const composeExecutor = new ComposeExecutor({
-          parentSession: deferredParent,
-          defaultModel: options.model,
-          defaultSubagentModel: getDefaultSubagentModel(options.model),
-          apiKey,
-          // Per-model credential resolver — mirrors #640 for the compose fork-path.
-          resolveApiKeyForModel: getApiKeyForModel,
-          // Read-scope inheritance (#547): DAG nodes inherit the parent session's
-          // read scope via the root manager. See bootstrap.ts.
-          getReadScopeInputs: () => rootManager.getReadScopeInputs(),
-          ...(cliConfig.baseUrl !== undefined ? { baseUrl: cliConfig.baseUrl } : {}),
-          // Anchor DAG nodes to the worktree (re-anchored via composeExecutor.setCwd).
-          ...(worktreeCwd !== undefined ? { cwd: worktreeCwd } : {}),
-          systemPrompt: basePrompt ?? '',
-          // Session identity for routing-decision rows (afk chat → cli).
-          surface: 'cli',
-          depth: 0,
-          // Witness layer: DAG nodes emit subagent_lifecycle into the session trace.
-          ...(trace?.writer !== undefined ? { traceWriter: trace.writer } : {}),
+          // Worktree cwd propagates to every depth so forked bash/grep run in
+          // the isolated tree, not the Node host's process.cwd().
+          ...(worktreeCwd !== undefined ? { cwd: worktreeCwd, nestedCwd: worktreeCwd } : {}),
+          ...(trace?.writer !== undefined
+            ? { traceWriter: trace.writer, skillTraceWriter: trace.writer }
+            : {}),
+          // No backgroundRegistry on the one-shot chat path — background
+          // dispatch is interactive-only by contract.
         });
 
         sharedMemoryStore = new MemoryStore();

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -30,13 +30,9 @@ import { loadSchedules, toScheduledTask } from '../../agent/daemon/schedule-stor
 import { AgentSession } from '../../agent/session.js';
 import { MemoryStore, injectHotMemory } from '../../agent/memory/index.js';
 import { injectCompanionPrimer } from '../../agent/companion/index.js';
-import { SubagentManager } from '../../agent/subagent.js';
-import { SubagentExecutor } from '../../agent/tools/subagent-executor.js';
-import { SkillExecutor } from '../../agent/tools/skill-executor.js';
-import { ComposeExecutor } from '../../agent/tools/compose-executor.js';
-import { ensurePluginEntrypointsLoaded, discoverPluginAgents } from '../../agent/tools/skill-bridge.js';
-import { createChildProviderFactory, createChildSkillExecutorFactory, createStubParentSession } from '../../agent/tools/nesting.js';
-import { loadAgentRegistry } from '../../agent/agents/index.js';
+import { wireExecutors } from '../../agent/session/wire-executors.js';
+import { ensurePluginEntrypointsLoaded } from '../../agent/tools/skill-bridge.js';
+import { createStubParentSession } from '../../agent/tools/nesting.js';
 import { AnthropicDirectProvider } from '../../agent/providers/anthropic-direct/index.js';
 import { BUILTIN_TOOL_NAMES } from '../../agent/tools/schemas.js';
 import { MEMORY_TOOL_NAMES } from '../../agent/memory/index.js';
@@ -58,21 +54,13 @@ export interface BuildDaemonSessionFactoryOpts {
  * skill-dispatching commands like `/forge-friction --auto` or `/review pr 123`
  * can call the `skill`, `agent`, and `compose` tools.
  *
- * // Invariant: mirrors the executor-wiring order in chat.ts.
- * // The order matters because each executor closes over the ones constructed
- * // above it:
- * //   1. SubagentManager  — root manager for all forked children
- * //   2. childProviderFactory — routes child model → AnthropicDirect / OpenAICompatible
- * //   3. childSkillExecutorFactory — depth-aware factory for nested skill children
- * //   4. SubagentExecutor — wires the `agent` tool
- * //   5. SkillExecutor    — wires the `skill` tool
- * //   6. ComposeExecutor  — wires the `compose` tool
- * //   7. parseProvider()  — builds the root provider with all three executors,
- * //      falling back to AnthropicDirectProvider for Anthropic-routed models.
- * //
- * // The returned factory receives a config that spawnSession() has already
- * // populated (including permissionMode:'bypassPermissions'). The config is
- * // preserved via spread so no caller-set field is lost.
+ * The executor trio (and the single root SubagentManager they share) comes from
+ * `wireExecutors()`; `parseProvider()` then builds the root provider around
+ * them, falling back to AnthropicDirectProvider for Anthropic-routed models.
+ *
+ * The returned factory receives a config that spawnSession() has already
+ * populated (including permissionMode:'bypassPermissions'). The config is
+ * preserved via spread so no caller-set field is lost.
  */
 export function buildDaemonSessionFactory(
   opts: BuildDaemonSessionFactoryOpts,
@@ -94,138 +82,30 @@ export function buildDaemonSessionFactory(
     const abortCtrl = new AbortController();
     const stubParent = createStubParentSession(abortCtrl.signal);
 
-    const rootManager = new SubagentManager({
-      ...(opts.apiKey !== undefined ? { apiKey: opts.apiKey } : {}),
-      // Parent model → provider, so the fork-time credential fallback never
-      // crosses the provider boundary (see SubagentManager.parentProvider).
-      parentModel: opts.model,
-      ...(opts.baseUrl !== undefined ? { baseUrl: opts.baseUrl } : {}),
-      ...(opts.cwd !== undefined ? { cwd: opts.cwd } : {}),
-      // Witness layer: manager-level writer so daemon-forked `agent`-tool
-      // children (which never set config.timeoutMs / config.traceWriter) still
-      // emit subagent_lifecycle events and hand the writer to their handles.
-      // The scheduler (scheduler.ts:spawnSession) already opened a per-tick
-      // trace and threaded it in as config.traceWriter — reuse THAT SAME
-      // instance here (do not create a duplicate). Mirrors bootstrap.ts:246.
-      // Undefined under AFK_TRACE_DISABLED=1, in which case the spread is
-      // absent and behaviour is unchanged.
-      ...(config.traceWriter !== undefined ? { traceWriter: config.traceWriter } : {}),
-      // Origin attribution: the daemon is a `daemon` entrypoint. Thread the
-      // surface so forked `agent`-tool children inherit origin 'daemon' (not
-      // 'unknown') via forkSubagent's parentSurface fill. Mirrors farm.ts.
+    // Invariant: ONE root manager per session, shared by all three executors.
+    // The scheduler (scheduler.ts:spawnSession) already opened a per-tick trace
+    // and threaded it in as config.traceWriter — reuse THAT SAME instance here
+    // rather than creating a duplicate. Undefined under AFK_TRACE_DISABLED=1,
+    // in which case the option is absent and behaviour is unchanged.
+    const { subagentExecutor, skillExecutor, composeExecutor } = wireExecutors({
       surface: 'daemon',
-    });
-
-    const childProviderFactory = createChildProviderFactory(
-      opts.openaiBaseUrl !== undefined ? { openaiBaseUrl: opts.openaiBaseUrl } : {},
-    );
-
-    // Named-agent registry: session-static scan enabling `agent_type`
-    // dispatch for daemon-run tasks (builtin + user + project scopes).
-    const agentRegistry = loadAgentRegistry({
-      ...(opts.cwd !== undefined ? { cwd: opts.cwd } : {}),
-      pluginAgents: discoverPluginAgents(),
-    });
-
-    const childSkillExecutorFactory = createChildSkillExecutorFactory(
-      opts.model,
-      opts.apiKey,
-      childProviderFactory,
-      opts.baseUrl,
-      // traceWriter: reuse the scheduler's per-tick writer (threaded in as
-      // config.traceWriter) so depth>0 skill forks stay visible in the witness
-      // trace. Undefined under AFK_TRACE_DISABLED=1. Mirrors bootstrap.ts:333.
-      config.traceWriter,
-      // backgroundRegistry: daemon has no background registry — pass undefined
-      undefined,
-      opts.cwd,
-      // Per-model credential resolver — see bootstrap.ts for rationale.
-      getApiKeyForModel,
-      // Surface: daemon skill executor children inherit origin 'daemon'.
-      'daemon',
-      // Resolved default-subagent model threaded into nested skill executors
-      // so skill→skill / skill→agent chains inherit the SAME policy as the
-      // top-level executors — closing the leak where a nested subagent
-      // silently defaulted to Anthropic `sonnet` under an OpenAI-routed parent.
-      getDefaultSubagentModel(opts.model),
-      // Named-agent registry propagates to nested skill executors.
-      agentRegistry,
-      // OpenAI endpoint → nested restricted/depth-cap provider builders.
-      opts.openaiBaseUrl,
-    );
-
-    const subagentExecutor = new SubagentExecutor({
-      subagentManager: rootManager,
       parentSession: stubParent,
-      // Session origin for routing-decision telemetry (daemon/scheduler → daemon).
-      surface: 'daemon',
-      defaultConfig: {
-        ...(opts.apiKey !== undefined ? { apiKey: opts.apiKey } : {}),
-        ...(opts.baseUrl !== undefined ? { baseUrl: opts.baseUrl } : {}),
-        ...(opts.openaiBaseUrl !== undefined ? { openaiBaseUrl: opts.openaiBaseUrl } : {}),
-      },
+      apiKey: opts.apiKey,
+      model: opts.model,
+      // The daemon resolves its credential from the task model itself, so the
+      // manager's credential-fallback anchor is the same model.
+      managerParentModel: opts.model,
       defaultSubagentModel: getDefaultSubagentModel(opts.model),
-      childProviderFactory,
-      childSkillExecutorFactory,
-      // Per-model credential resolver — see bootstrap.ts for rationale.
       resolveApiKeyForModel: getApiKeyForModel,
-      depth: 0,
-      ...(opts.cwd !== undefined ? { cwd: opts.cwd } : {}),
-      // Named-agent dispatch: registry + `inherit` anchor.
-      agentRegistry,
-      parentModel: opts.model,
-      // Witness layer: thread the scheduler's per-tick writer so depth ≥ 2
-      // `agent` forks (nested child managers built inside execute()) stay
-      // visible. Depth-1 forks are covered by rootManager above. Mirrors
-      // bootstrap.ts:395.
-      ...(config.traceWriter !== undefined ? { traceWriter: config.traceWriter } : {}),
-    });
-
-    const skillExecutor = new SkillExecutor({
-      parentSession: stubParent,
-      // Session origin for skill-invocation + routing telemetry (daemon → daemon).
-      surface: 'daemon',
-      defaultModel: opts.model,
-      defaultSubagentModel: getDefaultSubagentModel(opts.model),
-      ...(opts.apiKey !== undefined ? { apiKey: opts.apiKey } : {}),
-      childProviderFactory,
-      childSkillExecutorFactory,
-      // Named-agent registry for skill-forked orchestrator children.
-      agentRegistry,
-      // Per-model credential resolver — mirrors bootstrap.ts / chat.ts.
-      resolveApiKeyForModel: getApiKeyForModel,
+      // Daemon tasks carry no base prompt: compose nodes get '' (preserved by
+      // wireExecutors) and forked children fall back to the handoff contract.
       ...(opts.baseUrl !== undefined ? { baseUrl: opts.baseUrl } : {}),
       ...(opts.openaiBaseUrl !== undefined ? { openaiBaseUrl: opts.openaiBaseUrl } : {}),
-      ...(opts.cwd !== undefined ? { cwd: opts.cwd } : {}),
-      // Witness layer: without this, daemon skill-forked subagents (every
-      // /forge-friction, /review, etc. fired by a task) emit zero trace events,
-      // making subagent failures undebuggable from disk. Mirrors bootstrap.ts:424.
-      ...(config.traceWriter !== undefined ? { traceWriter: config.traceWriter } : {}),
-      // Read-scope inheritance (#547): skill-forked children inherit the parent
-      // session's read scope via the root manager. See bootstrap.ts.
-      getReadScopeInputs: () => rootManager.getReadScopeInputs(),
-    });
-
-    const composeExecutor = new ComposeExecutor({
-      parentSession: stubParent,
-      defaultModel: opts.model,
-      defaultSubagentModel: getDefaultSubagentModel(opts.model),
-      ...(opts.apiKey !== undefined ? { apiKey: opts.apiKey } : {}),
-      // Per-model credential resolver — mirrors #640 for the compose fork-path.
-      resolveApiKeyForModel: getApiKeyForModel,
-      // Read-scope inheritance (#547): DAG nodes inherit the parent session's
-      // read scope via the root manager. See bootstrap.ts.
-      getReadScopeInputs: () => rootManager.getReadScopeInputs(),
-      ...(opts.baseUrl !== undefined ? { baseUrl: opts.baseUrl } : {}),
-      // Anchor DAG nodes to the worktree (re-anchored via composeExecutor.setCwd).
-      ...(opts.cwd !== undefined ? { cwd: opts.cwd } : {}),
-      systemPrompt: '',
-      // Session identity for routing-decision rows (daemon/scheduler → daemon).
-      surface: 'daemon',
-      depth: 0,
-      // Witness layer: DAG nodes emit subagent_lifecycle into the session
-      // trace. Reuses the scheduler's per-tick writer. Mirrors bootstrap.ts:460.
-      ...(config.traceWriter !== undefined ? { traceWriter: config.traceWriter } : {}),
+      ...(opts.cwd !== undefined ? { cwd: opts.cwd, nestedCwd: opts.cwd } : {}),
+      ...(config.traceWriter !== undefined
+        ? { traceWriter: config.traceWriter, skillTraceWriter: config.traceWriter }
+        : {}),
+      // No backgroundRegistry: background dispatch is interactive-only.
     });
 
     memoryStore ??= new MemoryStore();

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -42,20 +42,15 @@ import { formatTrustedSkillCompletion, formatTrustedSkillInFlight } from '../../
 import type { TrustedSkillResult } from '../../../agent/trusted-skill-result.js';
 import { emitSubagentCompletion } from './progress-banner.js';
 import { ContextSampler } from '../../context-sampler.js';
-import { SubagentManager } from '../../../agent/subagent.js';
-import { SubagentExecutor } from '../../../agent/tools/subagent-executor.js';
+import { wireExecutors } from '../../../agent/session/wire-executors.js';
 import { BackgroundAgentRegistry } from '../../../agent/background-registry.js';
 import { BackgroundSummarizer } from '../../../agent/background-summarizer.js';
 import { setBgsubRegistry, setBgsubSummarizer } from '../../slash/commands/bgsub.js';
-import { SkillExecutor } from '../../../agent/tools/skill-executor.js';
-import { ComposeExecutor } from '../../../agent/tools/compose-executor.js';
-import { createChildProviderFactory, createChildSkillExecutorFactory } from '../../../agent/tools/nesting.js';
-import { loadAgentRegistry } from '../../../agent/agents/index.js';
 import { AnthropicDirectProvider } from '../../../agent/providers/anthropic-direct/index.js';
 import { seedPersistedGrants } from '../../../agent/permissions-store.js';
 import { providerForModel } from '../../../agent/providers/index.js';
 import { createMemoizedProviderFactory } from './provider-factory.js';
-import { ensurePluginEntrypointsLoaded, discoverPluginAgents } from '../../../agent/tools/skill-bridge.js';
+import { ensurePluginEntrypointsLoaded } from '../../../agent/tools/skill-bridge.js';
 import { McpManager, loadMcpConfig, getMcpConfigPath } from '../../../agent/mcp/index.js';
 import { loadImportFromConfig, resolveImportedRoots } from '../../../config/import-sources.js';
 import { env } from '../../../config/env.js';
@@ -225,32 +220,6 @@ export async function bootstrapSession(
   );
 
   const apiKey = getApiKey();
-  const rootManager = new SubagentManager({
-    apiKey,
-    // Provider source of truth for the fork-time credential fallback: `apiKey`
-    // is `getApiKey()`, which keys off `getModel()` (AFK_MODEL), so the parent
-    // key's provider is `providerForModel(getModel())`. Passing that keeps the
-    // fallback from crossing the provider boundary (see parentProvider).
-    parentModel: getModel(),
-    ...(cliConfig.baseUrl !== undefined ? { baseUrl: cliConfig.baseUrl } : {}),
-    // Propagate the worktree cwd (when `afk i --worktree` set it) into every
-    // forked subagent so their tool handlers' resolveBase + readRoots anchor
-    // to the worktree, not the Node host's process.cwd(). Without this,
-    // subagents resolve relative paths like `src/foo.ts` against the parent
-    // repo and the `read_file` handler returns parent-repo contents instead
-    // of the worktree's. Mirrors `chat.ts:163` for the one-shot path.
-    ...(effectiveCwd !== undefined ? { cwd: effectiveCwd } : {}),
-    // Witness layer: manager-level writer so `agent`-tool forks (which never
-    // set config.traceWriter) still emit subagent_lifecycle events and hand
-    // the writer to their handles. Skill forks already thread it via
-    // SkillExecutorContext; this closes the same gap for raw agent dispatch.
-    ...(trace?.writer !== undefined ? { traceWriter: trace.writer } : {}),
-    // Origin attribution: the REPL is a `cli` entrypoint. Threading the surface
-    // into the manager makes forked `agent`-tool children inherit origin 'cli'
-    // (not 'unknown') via forkSubagent's parentSurface fill — mirrors the
-    // traceWriter/cwd inheritance above and farm.ts. See session-identity.ts.
-    surface: 'cli',
-  });
   // Witness layer: trace writer is now live — emit the bootstrap_start marker.
   // (Total bootstrap span is reported by bootstrap_done, measured from the
   // function-entry timestamp captured above.)
@@ -278,16 +247,6 @@ export async function bootstrapSession(
   bgSummarizer?.start();
   setBgsubSummarizer(bgSummarizer);
 
-  // Pass openaiBaseUrl so OpenAI-routed children point at the configured
-  // local shim (mlx_lm.server, Ollama, vLLM, llama.cpp, LM Studio) instead
-  // of api.openai.com. The factory itself routes per-call between
-  // AnthropicDirect / OpenAICompatible by `providerForModel(model)`.
-  const childProviderFactory = createChildProviderFactory(
-    cliConfig.openaiBaseUrl !== undefined
-      ? { openaiBaseUrl: cliConfig.openaiBaseUrl }
-      : {},
-  );
-
   // External constraint: deferredParent reads through sessionRef.current so
   // a mid-session swap (mutating sessionRef.current) is transparent to all
   // child executors — they hold a reference to this proxy object, which
@@ -306,19 +265,6 @@ export async function bootstrapSession(
     get hookRegistry() { return sessionRef.current?.hookRegistry; },
   };
 
-  // Shared child-skill-executor factory — both SubagentExecutor and
-  // SkillExecutor need it for plugin skill children to nest properly.
-  // See skill-executor.ts:buildForkedChildConfig for the wiring rationale.
-  // traceWriter propagates so depth>0 skill forks remain visible in the
-  // witness trace (otherwise nested skill→skill chains go invisible after
-  // the first hop).
-  // backgroundRegistry propagates so a plugin/registry skill whose subagent
-  // calls `agent` with `mode:"background"` (the SKILL.md "Dispatch N
-  // sub-agents in parallel" idiom) reaches the registry through every
-  // depth — root → skill-forked child → skill-forked grandchild. Without
-  // this, the dispatch fast-fails with a 163-byte "BackgroundAgentRegistry
-  // is not wired" error after ~24ms (no model call).
-
   // Bootstrap warnings that must outlive the startup screen clear. Everything
   // written to stdout/stderr from here until `interactive.ts` finishes clearing
   // is destroyed — `\x1b[3J` erases scrollback, not just the viewport — so
@@ -333,154 +279,48 @@ export async function bootstrapSession(
   // care get a local bucket and the prior behaviour.
   const bootWarnings: string[] = extras?.bootWarnings ?? [];
 
-  // Named-agent registry: session-static scan (builtin + user ~/.afk/agents
-  // + project .afk/agents & .claude/agents). Enables `agent_type` dispatch
-  // on the `agent` tool at every depth of this REPL session.
-  //
-  // `warn` is routed into bootWarnings rather than left to default: the
-  // built-in-shadow warning (an agent file replacing a tool-restricted builtin
-  // like `research-agent`) is a safety signal, and the default writer prints
-  // straight to stderr where the clear eats it.
-  const agentRegistry = loadAgentRegistry({
-    ...(effectiveCwd !== undefined ? { cwd: effectiveCwd } : {}),
-    pluginAgents: discoverPluginAgents(),
-    warn: (message: string) => bootWarnings.push(message),
-  });
-
-  const childSkillExecutorFactory = createChildSkillExecutorFactory(
-    sessionModel,
-    apiKey,
-    childProviderFactory,
-    cliConfig.baseUrl,
-    trace?.writer,
-    backgroundRegistry,
-    // Worktree cwd propagates into every depth of the skill-executor chain
-    // (grandchild SkillExecutor → its per-call SubagentManager → forked
-    // subagent config). Without this, depth ≥ 1 skill children silently
-    // lose worktree isolation. `effectiveCwd` also carries a resumed
-    // session's restored cwd (see resolveResumeCwd above).
-    effectiveCwd,
-    // Per-model credential resolver: resolves credentials by child model
-    // rather than forwarding the parent's captured apiKey — fixes Anthropic
-    // children starving when the main model is OpenAI-routed.
-    getApiKeyForModel,
-    // Surface: REPL skill executor children inherit origin 'cli'.
-    'cli',
-    // Resolved default-subagent model threaded into nested skill executors so
-    // skill→skill / skill→agent chains inherit the SAME policy as the top-level
-    // executors below — closing the leak where a nested subagent silently
-    // defaulted to Anthropic `sonnet` under an OpenAI-routed parent.
-    getDefaultSubagentModel(sessionModel),
-    // Named-agent registry propagates to nested skill executors.
-    agentRegistry,
-    // OpenAI endpoint → nested restricted/depth-cap provider builders.
-    cliConfig.openaiBaseUrl,
-  );
-
-  // Pass `sessionModel` to `getDefaultSubagentModel` so OpenAI-routed
-  // parents (gpt-*, o*, codex-*, HF-style `org/model`) default to the
-  // parent model for dispatched subagents — preventing the legacy
-  // `'sonnet'` literal from silently routing local-only sessions to
-  // api.anthropic.com. Claude parents still default to 'sonnet'.
-  const subagentExecutor = new SubagentExecutor({
-    subagentManager: rootManager,
-    parentSession: deferredParent,
-    // Session origin for routing-decision telemetry (REPL → cli).
+  // Invariant: ONE root manager per session, shared by all three executors.
+  // Constructed here (not earlier) so it can be created together with the
+  // executors that close over it; the SubagentManager constructor is pure —
+  // it emits no trace events — so this placement does not reorder the
+  // witness trace relative to `bootstrap_start` above.
+  const { rootManager, subagentExecutor, skillExecutor, composeExecutor } = wireExecutors({
+    // Origin attribution: the REPL is a `cli` entrypoint, so forked children
+    // inherit origin 'cli' (not 'unknown'). See session-identity.ts.
     surface: 'cli',
-    defaultConfig: {
-      apiKey,
-      systemPrompt: basePrompt,
-      ...(cliConfig.baseUrl !== undefined ? { baseUrl: cliConfig.baseUrl } : {}),
-      ...(cliConfig.openaiBaseUrl !== undefined ? { openaiBaseUrl: cliConfig.openaiBaseUrl } : {}),
-    },
+    parentSession: deferredParent,
+    apiKey,
+    model: sessionModel,
+    // `apiKey` is getApiKey(), which keys off getModel() (AFK_MODEL), so the
+    // manager's credential-fallback provider must be derived from THAT model —
+    // not the possibly-resumed session model — or the fallback can cross the
+    // provider boundary.
+    managerParentModel: getModel(),
+    // OpenAI-routed parents default dispatched subagents to the parent model
+    // rather than the legacy `'sonnet'` literal, which would silently route
+    // local-only sessions to api.anthropic.com. Claude parents still get 'sonnet'.
     defaultSubagentModel: getDefaultSubagentModel(sessionModel),
-    childProviderFactory,
-    childSkillExecutorFactory,
-    backgroundRegistry,
-    // Per-model credential resolver: resolves credentials by child model
-    // at fork time — fixes Anthropic children starving when main is OpenAI.
     resolveApiKeyForModel: getApiKeyForModel,
-    // Top-level CLI wiring → explicit depth 0. See SubagentExecutorContext.depth
-    // jsdoc for why this is required rather than defaulted.
-    depth: 0,
-    // Worktree isolation for depth ≥ 2 `agent` dispatch — `rootManager`
-    // already carries cwd for depth-1, but the per-call childManager
-    // constructed inside SubagentExecutor.execute() needs cwd too.
-    ...(effectiveCwd !== undefined ? { cwd: effectiveCwd } : {}),
-    // Named-agent dispatch: registry + the session model as the `inherit`
-    // anchor for named-agent model resolution.
-    agentRegistry,
-    parentModel: sessionModel,
-    // Witness layer: thread the writer so depth ≥ 2 `agent` forks (nested
-    // child managers built inside execute()) stay visible in the trace.
-    // Depth-1 forks are covered by rootManager's traceWriter above.
-    ...(trace?.writer !== undefined ? { traceWriter: trace.writer } : {}),
-  });
-
-  const skillExecutor = new SkillExecutor({
-    parentSession: deferredParent,
-    // Session origin for skill-invocation + routing telemetry (REPL → cli).
-    surface: 'cli',
-    defaultModel: sessionModel,
-    defaultSubagentModel: getDefaultSubagentModel(sessionModel),
-    apiKey,
-    childProviderFactory,
-    childSkillExecutorFactory,
-    // Named-agent registry for skill-forked orchestrator children.
-    agentRegistry,
-    // Background dispatch: a plugin skill's subagent calling `agent` with
-    // `mode:"background"` is the SKILL.md "Dispatch N sub-agents in parallel"
-    // idiom — `/research`, `/diagnose`, `/shadow-verify`, etc. The registry
-    // must be forwarded into every SubagentExecutor in the chain (root
-    // executor → forked child → forked grandchild) via
-    // SkillExecutorContext.backgroundRegistry → buildForkedChildConfig.
-    // Sibling to the SubagentExecutor wiring above.
-    backgroundRegistry,
+    // Raw base prompt (pre-assembly): children and compose nodes stay task
+    // workers, without ROUTING_DIRECTIVE / TOOL_SYSTEM_PROMPT.
+    ...(basePrompt !== undefined ? { systemPrompt: basePrompt } : {}),
     ...(cliConfig.baseUrl !== undefined ? { baseUrl: cliConfig.baseUrl } : {}),
     ...(cliConfig.openaiBaseUrl !== undefined ? { openaiBaseUrl: cliConfig.openaiBaseUrl } : {}),
-    // Per-model credential resolver — mirrors SubagentExecutor wiring above.
-    resolveApiKeyForModel: getApiKeyForModel,
-    // Witness layer: without this, skill-forked subagents (every /review,
-    // /diagnose, /shadow-verify, etc.) emit zero trace events, making
-    // subagent failures undebuggable from disk.
-    ...(trace?.writer !== undefined ? { traceWriter: trace.writer } : {}),
-    // Worktree isolation: skills invoked via the `skill` tool spawn their
-    // subagents through a per-call SubagentManager constructed inside the
-    // executor. Without forwarding cwd here, every `/diagnose`, `/mint`,
-    // etc. runs its first-tier subagents against the host repo even when
-    // `--worktree` was set.
-    ...(effectiveCwd !== undefined ? { cwd: effectiveCwd } : {}),
-    // Read-scope inheritance (#547): skill-forked children inherit the parent
-    // session's read scope via the root manager — symmetric with the `agent`
-    // tool (subagentManager: rootManager above). Read fresh so mid-session
-    // setCwd re-anchors are reflected.
-    getReadScopeInputs: () => rootManager.getReadScopeInputs(),
+    // Worktree cwd (`afk i --worktree`, or a resumed session's restored cwd)
+    // propagates to every depth so subagents' resolveBase + readRoots anchor
+    // to the worktree, not the Node host's process.cwd().
+    ...(effectiveCwd !== undefined ? { cwd: effectiveCwd, nestedCwd: effectiveCwd } : {}),
+    ...(trace?.writer !== undefined
+      ? { traceWriter: trace.writer, skillTraceWriter: trace.writer }
+      : {}),
+    // Background dispatch (`agent` with mode:"background") is REPL-only; the
+    // registry must reach every depth of the skill/agent fork chain.
+    backgroundRegistry,
+    // `warn` routes into bootWarnings rather than stderr: the built-in-shadow
+    // warning is a safety signal and the startup screen clear eats stderr.
+    agentRegistryWarn: (message: string) => bootWarnings.push(message),
   });
 
-  // Pass the raw base prompt (pre-assembly) so compose subagents do not
-  // inherit ROUTING_DIRECTIVE or TOOL_SYSTEM_PROMPT — keeping them as
-  // task workers that cannot spawn nested DAGs or recurse into skills.
-  // Mirrors the SubagentExecutor defaultConfig.systemPrompt convention.
-  const composeExecutor = new ComposeExecutor({
-    parentSession: deferredParent,
-    defaultModel: sessionModel,
-    defaultSubagentModel: getDefaultSubagentModel(sessionModel),
-    apiKey,
-    // Per-model credential resolver — mirrors #640 for the compose fork-path.
-    resolveApiKeyForModel: getApiKeyForModel,
-    // Read-scope inheritance (#547): DAG nodes inherit the parent session's
-    // read scope via the root manager, symmetric with the `agent`/`skill` tools.
-    getReadScopeInputs: () => rootManager.getReadScopeInputs(),
-    ...(cliConfig.baseUrl !== undefined ? { baseUrl: cliConfig.baseUrl } : {}),
-    // Anchor DAG nodes to the worktree (re-anchored via composeExecutor.setCwd).
-    ...(effectiveCwd !== undefined ? { cwd: effectiveCwd } : {}),
-    systemPrompt: basePrompt ?? '',
-    // Session identity for routing-decision rows (REPL → cli).
-    surface: 'cli',
-    depth: 0,
-    // Witness layer: DAG nodes emit subagent_lifecycle into the session trace.
-    ...(trace?.writer !== undefined ? { traceWriter: trace.writer } : {}),
-  });
 
   const sharedMemoryStore = new MemoryStore();
 

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -47,13 +47,7 @@ import { resolveModelId } from './agent/session/model-resolution.js';
 import { getDefaultSubagentModel, getMaxOutputTokens, getMaxToolUseIterations, getApiKeyForModel, loadSystemPrompt, composeSystemPrompt } from './cli/shared-helpers.js';
 import { topLevelSurfaceAllowedTools } from './agent/tools/top-level-allowlist.js';
 import type { AgentConfig, AgentModelInput } from './agent/types.js';
-import { SubagentManager } from './agent/subagent.js';
-import { SubagentExecutor } from './agent/tools/subagent-executor.js';
-import { SkillExecutor } from './agent/tools/skill-executor.js';
-import { ComposeExecutor } from './agent/tools/compose-executor.js';
-import { createChildProviderFactory, createChildSkillExecutorFactory } from './agent/tools/nesting.js';
-import { loadAgentRegistry } from './agent/agents/index.js';
-import { discoverPluginAgents } from './agent/tools/skill-bridge.js';
+import { wireExecutors } from './agent/session/wire-executors.js';
 import { attachMcpCleanup, loadTelegramMcpManager } from './telegram/mcp-session.js';
 
 // Capture version once at module load. Used by checkVersionDrift on each stats tick.
@@ -269,26 +263,8 @@ async function main() {
         // OpenAI-compatible endpoint (distinct from telegramBaseUrl, which is
         // Anthropic-only) — threaded for parity with chat.ts's cliConfig.openaiBaseUrl wiring.
         const telegramOpenaiBaseUrl = sessionConfig.openaiBaseUrl ?? config.openaiBaseUrl;
-        // Inherit configured-or-host cwd so forked subagents stay in the
-        // same working tree as the parent session — important when the
-        // bot is pointed at a worktree via AFK_TELEGRAM_CWD.
-        const rootManager = new SubagentManager({
-          apiKey: telegramApiKey,
-          // Parent model → provider, so the fork-time credential fallback never
-          // crosses the provider boundary (see SubagentManager.parentProvider).
-          parentModel: sessionConfig.model,
-          ...(telegramBaseUrl !== undefined ? { baseUrl: telegramBaseUrl } : {}),
-          ...(sessionCwd !== undefined && sessionCwd.length > 0 ? { cwd: sessionCwd } : {}),
-          // Witness layer: manager-level writer so `agent`-tool forks (which
-          // never set config.traceWriter) emit subagent_lifecycle events and
-          // hand the writer to their handles. Mirrors bootstrap.ts / chat.ts.
-          ...(telegramTraceWriter !== null ? { traceWriter: telegramTraceWriter } : {}),
-          // Origin attribution: thread the surface so forked `agent`-tool
-          // children inherit origin 'telegram' (not 'unknown') via
-          // forkSubagent's parentSurface fill. Mirrors farm.ts.
-          surface: 'telegram',
-        });
-
+        // The session is constructed after the executors, so the parent view
+        // they fork from reads through `boundSession` lazily.
         const deferredParent = {
           get sessionId() { return boundSession?.sessionId; },
           getInputStreamRef() { return boundSession?.getInputStreamRef?.() ?? { pushUserMessage: () => {} }; },
@@ -298,119 +274,36 @@ async function main() {
           get hookRegistry() { return boundSession?.hookRegistry; },
         };
 
-        // Pass openaiBaseUrl so OpenAI-routed children point at the configured
-        // local shim instead of the default api.openai.com (parity with chat.ts).
-        const childProviderFactory = createChildProviderFactory(
-          telegramOpenaiBaseUrl !== undefined ? { openaiBaseUrl: telegramOpenaiBaseUrl } : {},
-        );
-
-        // Named-agent registry: session-static scan enabling `agent_type`
-        // dispatch (builtin + user + project scopes, anchored at the bot cwd).
-        const agentRegistry = loadAgentRegistry({
-          ...(sessionCwd !== undefined && sessionCwd.length > 0 ? { cwd: sessionCwd } : {}),
-          pluginAgents: discoverPluginAgents(),
-        });
-
-        // Shared child-skill-executor factory — both SubagentExecutor and
-        // SkillExecutor need it for plugin skill children to nest properly.
-        // See skill-executor.ts:buildForkedChildConfig for the wiring rationale.
-        const childSkillExecutorFactory = createChildSkillExecutorFactory(
-          sessionConfig.model,
-          telegramApiKey,
-          childProviderFactory,
-          telegramBaseUrl,
-          undefined,
-          undefined,
-          sessionCwd !== undefined && sessionCwd.length > 0 ? sessionCwd : undefined,
-          // Per-model credential resolver — see bootstrap.ts for rationale.
-          getApiKeyForModel,
-          // Surface: Telegram skill executor children inherit origin 'telegram'.
-          'telegram',
-          // Resolved default-subagent model threaded into nested skill
-          // executors so skill→skill / skill→agent chains inherit the SAME
-          // policy as the top-level executors — closing the leak where a
-          // nested subagent silently defaulted to Anthropic `sonnet` under an
-          // OpenAI-routed parent.
-          getDefaultSubagentModel(sessionConfig.model),
-          // Named-agent registry propagates to nested skill executors.
-          agentRegistry,
-          // OpenAI endpoint → nested restricted/depth-cap provider builders.
-          telegramOpenaiBaseUrl,
-        );
-
-        // Pass `sessionConfig.model` to `getDefaultSubagentModel` for
-        // parity with the chat / interactive bootstraps. The current
-        // telegram wiring only reaches this branch for Anthropic parents
-        // (the `isCodex` gate above), so this is defensive — but it
-        // future-proofs the codex branch if/when it grows executor wiring.
-        const subagentExecutor = new SubagentExecutor({
-          subagentManager: rootManager,
-          parentSession: deferredParent,
-          // Session origin for routing-decision telemetry (Telegram → telegram).
+        // Invariant: ONE root manager per session, shared by all three
+        // executors. Inherit configured-or-host cwd so forked subagents stay
+        // in the same working tree as the parent session — important when the
+        // bot is pointed at a worktree via AFK_TELEGRAM_CWD.
+        const { subagentExecutor, skillExecutor, composeExecutor } = wireExecutors({
+          // Origin attribution: forked children inherit origin 'telegram'.
           surface: 'telegram',
-          defaultConfig: {
-            apiKey: telegramApiKey,
-            systemPrompt: layeredBasePrompt,
-            ...(telegramBaseUrl !== undefined ? { baseUrl: telegramBaseUrl } : {}),
-            ...(telegramOpenaiBaseUrl !== undefined ? { openaiBaseUrl: telegramOpenaiBaseUrl } : {}),
-          },
-          defaultSubagentModel: getDefaultSubagentModel(sessionConfig.model),
-          childProviderFactory,
-          childSkillExecutorFactory,
-          // Per-model credential resolver — see bootstrap.ts for rationale.
-          resolveApiKeyForModel: getApiKeyForModel,
-          // Top-level Telegram wiring → explicit depth 0. See SubagentExecutorContext.depth.
-          depth: 0,
-          // Named-agent dispatch: registry + `inherit` anchor.
-          agentRegistry,
-          parentModel: sessionConfig.model,
-          // Witness layer: thread the writer so depth ≥ 2 `agent` forks stay
-          // visible in the trace. Mirrors bootstrap.ts / chat.ts.
-          ...(telegramTraceWriter !== null ? { traceWriter: telegramTraceWriter } : {}),
-        });
-
-        const skillExecutor = new SkillExecutor({
           parentSession: deferredParent,
-          // Session origin for skill-invocation + routing telemetry (Telegram → telegram).
-          surface: 'telegram',
-          defaultModel: sessionConfig.model,
-          defaultSubagentModel: getDefaultSubagentModel(sessionConfig.model),
           apiKey: telegramApiKey,
-          childProviderFactory,
-          // Named-agent registry for skill-forked orchestrator children.
-          agentRegistry,
-          childSkillExecutorFactory,
-          // Per-model credential resolver — mirrors bootstrap.ts / chat.ts.
+          model: sessionConfig.model,
+          // The Telegram credential is resolved for the session model itself,
+          // so it is also the manager's credential-fallback anchor.
+          managerParentModel: sessionConfig.model,
+          defaultSubagentModel: getDefaultSubagentModel(sessionConfig.model),
           resolveApiKeyForModel: getApiKeyForModel,
+          // Framework base + operator overlay, but NOT ROUTING_DIRECTIVE /
+          // TOOL_SYSTEM_PROMPT — keeps children and DAG workers from recursing
+          // into skills or nested DAGs.
+          ...(layeredBasePrompt !== undefined ? { systemPrompt: layeredBasePrompt } : {}),
           ...(telegramBaseUrl !== undefined ? { baseUrl: telegramBaseUrl } : {}),
           ...(telegramOpenaiBaseUrl !== undefined ? { openaiBaseUrl: telegramOpenaiBaseUrl } : {}),
-          // Read-scope inheritance (#547): skill-forked children inherit the
-          // parent session's read scope via the root manager. See bootstrap.ts.
-          getReadScopeInputs: () => rootManager.getReadScopeInputs(),
-        });
-
-        // Compose subagents inherit the framework base + operator overlay
-        // (layeredBasePrompt) but NOT ROUTING_DIRECTIVE / TOOL_SYSTEM_PROMPT /
-        // end-of-turn — those are appended only by assembleSystemPrompt for the
-        // parent session. Keeps DAG workers from recursing into skills / nested DAGs.
-        const composeExecutor = new ComposeExecutor({
-          parentSession: deferredParent,
-          defaultModel: sessionConfig.model,
-          defaultSubagentModel: getDefaultSubagentModel(sessionConfig.model),
-          apiKey: telegramApiKey,
-          // Per-model credential resolver — mirrors #640 for the compose fork-path.
-          resolveApiKeyForModel: getApiKeyForModel,
-          // Read-scope inheritance (#547): DAG nodes inherit the parent session's
-          // read scope via the root manager. See bootstrap.ts.
-          getReadScopeInputs: () => rootManager.getReadScopeInputs(),
-          ...(telegramBaseUrl !== undefined ? { baseUrl: telegramBaseUrl } : {}),
-          // Anchor DAG nodes to the worktree (re-anchored via composeExecutor.setCwd).
+          // Behaviour-preserving asymmetry: cwd anchors the root manager, the
+          // named-agent scan and compose DAG nodes, but NOT the `agent`/`skill`
+          // executors (no `nestedCwd`) — matching the pre-refactor wiring.
+          // Widening it to nestedCwd would change depth ≥ 2 anchoring.
           ...(sessionCwd !== undefined && sessionCwd.length > 0 ? { cwd: sessionCwd } : {}),
-          systemPrompt: layeredBasePrompt ?? '',
-          // Session identity for routing-decision rows (Telegram → telegram).
-          surface: 'telegram',
-          depth: 0,
-          // Witness layer: DAG nodes emit subagent_lifecycle into the session trace.
+          // Behaviour-preserving asymmetry: the writer reaches the manager, the
+          // `agent` executor and compose nodes, but NOT the `skill` executor or
+          // the nested skill-executor factory (no `skillTraceWriter`) —
+          // matching the pre-refactor wiring.
           ...(telegramTraceWriter !== null ? { traceWriter: telegramTraceWriter } : {}),
         });
 


### PR DESCRIPTION
## Summary

The `SubagentManager` → `SubagentExecutor` → `SkillExecutor` → `ComposeExecutor` wiring block existed as four hand-synced copies, one per top-level surface (`bootstrap.ts`, `chat.ts`, `telegram.ts`, `daemon.ts`). The duplication was already acknowledged in-tree via comments pinned to hardcoded cross-file line numbers (`Mirrors bootstrap.ts:246`, etc.) that rot on the next edit to the file they point at.

This PR adds `src/agent/session/wire-executors.ts`: a single `wireExecutors()` factory that builds the executor trio plus the one root `SubagentManager` they share, in the same load-bearing construction order every call site used (manager → child provider factory → agent registry → child skill-executor factory → `agent` executor → `skill` executor → `compose` executor). Per-surface differences are explicit parameters on `WireExecutorsOptions` (e.g. `model` vs. `managerParentModel`, `cwd` vs. `nestedCwd`, `traceWriter` vs. `skillTraceWriter`), each documented at its declaration — the factory itself contains no `if (surface === ...)` branching.

Each of the four surfaces (`bootstrap.ts`, `chat.ts`, `telegram.ts`, `daemon.ts`) now calls `wireExecutors()` once instead of re-declaring the block. **`src/cli/commands/farm.ts:370` is intentionally NOT adopted** — see below.

Behavior-preserving only: every previously-asymmetric wiring detail is preserved via the factory's optional parameters rather than silently collapsed to a single behavior. Two examples called out in code comments:
- Telegram passes `cwd` but not `nestedCwd`, so its `agent`/`skill` executors stay unanchored at depth ≥ 2 (matches pre-refactor).
- Telegram passes `traceWriter` but not `skillTraceWriter`, so its `skill` executor and nested skill-executor factory stay untraced (matches pre-refactor).

Closes #822

## Measured LOC reclaim

| File | Before | After | Δ |
|---|---:|---:|---:|
| `src/cli/commands/chat.ts` | 944 | 806 | -138 |
| `src/cli/commands/daemon.ts` | 658 | 538 | -120 |
| `src/cli/commands/interactive/bootstrap.ts` | 1043 | 883 | -160 |
| `src/telegram.ts` | 745 | 638 | -107 |
| **4 call sites subtotal** | | | **-525** |
| `src/agent/session/wire-executors.ts` (new) | 0 | 286 | +286 |
| **True net reclaim** | | | **-239 LOC** |

(`git diff --stat` on the commit reports `405 insertions(+), 644 deletions(-)` across 5 files — insertions include the new file's 286 lines plus small comment/call-site additions at each site; net line-count delta measured via `wc -l` before/after per file, shown above, is the authoritative reclaim figure. The issue's own estimate was ~350-400 LOC; measured reclaim is smaller because the factory's JSDoc is more thorough than the original inline comments it replaces.)

## farm.ts: not adopted (deliberate)

`src/cli/commands/farm.ts:370` constructs its own bare `new SubagentManager(...)` — but it never builds a `SubagentExecutor`/`SkillExecutor`/`ComposeExecutor`. It forks plain DAG worker sessions directly via `runSubagentDAG` (`src/agent/dag-subagent.ts`), whose per-node fork config has no executor-wiring fields at all (model, systemPrompt, cwd, readRoots/writeRoots, apiKey — no tool executors). `wireExecutors()` returns the `agent`/`skill`/`compose` executor trio, which farm.ts has no use for. Folding farm.ts into this factory would require changing what farm.ts does (it would start wiring tools its workers don't call), not just how it's wired — out of scope for a behavior-preserving refactor. Left as its own minimal `SubagentManager` construction.

## How was this tested?

- `pnpm lint` (tsc --noEmit, strict) — **PASS**, no output.
- `pnpm build` — **PASS**.
- `pnpm audit:sdk:check` — **PASS**: "Lock matches current imports."
- `pnpm test:coverage` (`vitest run --coverage`, superset of `pnpm test`) — **PASS**: 733/733 test files, 14024 passed + 2 skipped (pre-existing skips, unrelated). Coverage: 87.61% stmts / 85.7% branches / 91.78% funcs / 87.61% lines — all above the CI gates (74/79/82/74).
- `pnpm audit:env:check` — **PASS**: 735 files scanned, 0 violations.
- `pnpm scan:env:check` — **PASS**: env-registry docs in sync.
- `pnpm audit:chalk:check` — **PASS**: 0 violations.
- `pnpm fix:pins:check` — **PASS**: all hash pins up to date.

Confirmed no `Mirrors bootstrap` comments remain anywhere in `src/` (`grep -rn "Mirrors bootstrap" src/` → no matches).

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes (ran the superset `pnpm test:coverage` instead, per this PR's verification scope)
- [x] Commits are signed off (`git commit -s`) per the DCO
- [x] No secrets, tokens, or private paths in the diff
