### PR TITLE
fix(permissions): reject newline/CR in rm-allowlist carve-out (#806 follow-up)

### DIFF
--- a/src/agent/afk-mode-gate.test.ts
+++ b/src/agent/afk-mode-gate.test.ts
@@ -111,6 +111,23 @@ describe('createAfkModeGate', () => {
     expect(result.decision).toBe('block');
   });
 
+  // ---- PR #806 follow-up review: embedded newline is a statement separator ---
+  // `spawn(cmd, { shell: true })` runs the command through a real `/bin/sh -c`,
+  // where a literal newline separates statements exactly like `;`. The
+  // tokenizer's `\s+` split treats `\n`/`\r` as ordinary whitespace, so without
+  // rejecting them at the metachar-check stage a command like
+  // `rm -rf node_modules\ndist` would flatten into a single token stream
+  // (`targets: ["node_modules", "dist"]`) instead of being recognized as two
+  // separate shell statements.
+  it.each([
+    ['rm -rf node_modules\ndist', 'embedded LF'],
+    ['rm -rf node_modules\r\ndist', 'embedded CRLF'],
+  ])('blocks rm -rf with an embedded newline statement separator (%s)', async (command) => {
+    const { gate } = makeGate('autonomous');
+    const result = await gate({ event: 'PreToolUse', toolName: 'bash', input: { command } });
+    expect(result.decision).toBe('block');
+  });
+
   // ---- PR #806 review: carve-out is recursive DIRECTORY deletes only ---------
   // Without a recursive flag the target is a regular file — a tracked script
   // named `build` is not a generated artifact and must still require approval.

--- a/src/agent/afk-mode-rm-allowlist.ts
+++ b/src/agent/afk-mode-rm-allowlist.ts
@@ -40,8 +40,15 @@ const RM_RF_SAFE_LEAF_DIRS: ReadonlySet<string> = new Set([
 ]);
 
 /** Shell metacharacters whose presence makes tokenization unreliable (glob
- *  expansion, variable interpolation, command substitution, chaining). */
-const SHELL_METACHAR = /[*?$`(){};|&<>'"\\]/;
+ *  expansion, variable interpolation, command substitution, chaining). `\r`
+ *  and `\n` are included too: the bash tool runs commands via
+ *  `spawn(cmd, { shell: true })`, a real `/bin/sh -c`, where a literal
+ *  embedded newline is a statement separator identical to `;`. Tokenization
+ *  below (`cmd.trim().split(/\s+/)`) treats `\n` as ordinary whitespace, so
+ *  without this a command like `rm -rf node_modules\ndist` — two shell
+ *  statements — would flatten into one token stream (`targets: ["node_modules",
+ *  "dist"]`) and be evaluated as if it were a single validated `rm` call. */
+const SHELL_METACHAR = /[*?$`(){};|&<>'"\\\r\n]/;
 
 /**
  * True for a recursive-delete flag: `-r`, `-R`, any clustered short-flag run


### PR DESCRIPTION
## What

Follow-up to a code review of the already-merged **#806** (`fix(permissions): allow curated in-workspace rm -rf in AFK autonomous mode (#579 O3)`).

`src/agent/afk-mode-rm-allowlist.ts` gates whether an AFK-autonomous-mode `rm -rf <dir>` bash command is auto-allowed without operator approval. Part of that gate rejects any command containing a shell metacharacter, via:

```ts
const SHELL_METACHAR = /[*?$`(){};|&<>'"\\]/;
```

The bash tool executes commands with `child_process.spawn(command, { shell: true })` — a real `/bin/sh -c`. A **literal embedded newline** in the command string is a shell statement separator, functionally identical to `;` — but the character class above did not include `\n` or `\r`. Meanwhile `parseRmCommand`'s tokenizer (`cmd.trim().split(/\s+/)`) treats a newline as ordinary whitespace (JS `\s` matches newline), so a two-statement command was silently flattened into one token stream.

**Concrete gap:** for `cmd = "rm -rf node_modules\ndist"` (a real embedded newline, not the two-character `\n` escape), tokenization yielded `targets: ["node_modules", "dist"]`, `recursive: true`. If `dist` happened to be a real, git-ignored directory in the workspace, `isSafeInWorkspaceRm` returned `true` — even though a real shell would execute this as **two statements** (`rm -rf node_modules`, then attempt to run `dist` as a command), not as a single validated `rm` call. That breaks the module's own documented contract: "Fails CLOSED on any ambiguity."

**Why it matters (impact, honestly scoped):** this is a soundness gap in a fail-closed security boundary and should be fixed regardless. That said, today's demonstrated impact is bounded — no working example in this PR (or found during review) causes deletion or command execution beyond what the carve-out already intentionally permits, since in the common case the shell would just fail trying to run the second "statement" (e.g. `dist`) as a command, not execute it as something harmful. The fix closes the gap before a more dangerous second statement becomes possible.

## What changed

Minimal, two-file diff:

1. **`src/agent/afk-mode-rm-allowlist.ts`** — added `\r` and `\n` to the `SHELL_METACHAR` character class, so a command containing either is rejected before tokenization ever runs (`parseRmCommand` returns `null` → `isSafeInWorkspaceRm` returns `false`). The command stays classified `high` and is gated exactly as every other metacharacter already was — same fail-closed behavior, no new code path. Updated the doc comment directly above the regex to explain the `spawn(..., { shell: true })` / statement-separator reasoning. No other parsing logic touched.

2. **`src/agent/afk-mode-gate.test.ts`** — new `it.each` regression block (matching the file's existing style) asserting:
   - `rm -rf node_modules\ndist` (embedded LF) → `result.decision === 'block'`
   - `rm -rf node_modules\r\ndist` (embedded CRLF) → `result.decision === 'block'`

   Both use a real newline character, not an escaped two-character string, and neither test constructs a `dist` directory on disk — the fix rejects at the metacharacter-check stage, before any per-target filesystem check runs, so the test is independent of whether `dist` exists.

No dedicated `afk-mode-rm-allowlist.test.ts` file exists — the allowlist module's behavior is exercised exclusively through `afk-mode-gate.test.ts`, consistent with prior PRs on this module.

## Verification

- `pnpm install` — clean (fresh worktree, no shared `node_modules`)
- `pnpm test src/agent/afk-mode-gate.test.ts` — **101/101 passed** (99 pre-existing + 2 new)
- `pnpm lint` (`tsc --noEmit`, strict) — clean, zero errors
- Manually confirmed the vulnerability and fix at the regex level:
  - old `SHELL_METACHAR.test("rm -rf node_modules\ndist")` → `false` (gap confirmed)
  - new `SHELL_METACHAR.test("rm -rf node_modules\ndist")` → `true` (fix confirmed)

## Scope

Touches only the two files above. No changes to `afk-mode-gate.ts`, no restructuring of the surrounding parsing logic, no changes to PR #806 itself.
