### PR TITLE
refactor(tui): split scrollback logic out of terminal-compositor.types.ts (#826)

### DIFF
--- a/src/cli/input/spinner.ts
+++ b/src/cli/input/spinner.ts
@@ -1,12 +1,8 @@
 import { palette } from '../palette.js';
 import { pickRandomVerb, pickRandomGoblinVerb } from '../constants.js';
 import { buildTipPool, selectTip } from '../loading-tips.js';
-import {
-  SPINNER_FRAMES,
-  formatElapsed,
-  formatTipRow,
-  type SpinnerState,
-} from '../terminal-compositor.types.js';
+import { SPINNER_FRAMES, type SpinnerState } from '../terminal-compositor.types.js';
+import { formatElapsed, formatTipRow } from '../terminal-compositor.scrollback.js';
 
 export interface SpinnerControllerOptions {
   /**

--- a/src/cli/loading-tips.test.ts
+++ b/src/cli/loading-tips.test.ts
@@ -23,7 +23,7 @@ import {
   _resetSeenTipsForTesting,
   type LoadingTip,
 } from './loading-tips.js';
-import { formatTipRow } from './terminal-compositor.types.js';
+import { formatTipRow } from './terminal-compositor.scrollback.js';
 
 // Harvest stubs — vi.mock has to be hoisted, so use the standard pattern.
 vi.mock('./slash/registry.js', () => ({

--- a/src/cli/terminal-compositor.committed-band-commit.ts
+++ b/src/cli/terminal-compositor.committed-band-commit.ts
@@ -20,7 +20,7 @@ import {
   scrollbackFlushLines,
   buildScrollbackArchiveEscape,
   snapFlushCountToLogicalBoundary,
-} from './terminal-compositor.types.js';
+} from './terminal-compositor.scrollback.js';
 import { hardWrapToWidth } from './wrap.js';
 import { decideCommitMode } from './commit-mode.js';
 import {

--- a/src/cli/terminal-compositor.committed-band-repin.ts
+++ b/src/cli/terminal-compositor.committed-band-repin.ts
@@ -6,7 +6,7 @@
  */
 
 import type { CommittedBandHost } from './terminal-compositor.committed-band-commit.js';
-import { eraseAndPaintRow } from './terminal-compositor.types.js';
+import { eraseAndPaintRow } from './terminal-compositor.scrollback.js';
 import { withAutowrapDisabled } from './terminal-compositor.band-reflow.js';
 
 /**

--- a/src/cli/terminal-compositor.format-elapsed.test.ts
+++ b/src/cli/terminal-compositor.format-elapsed.test.ts
@@ -13,11 +13,20 @@
  * and the padStart zero-padding on the seconds remainder.
  */
 
-import { describe, it, expect } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { formatElapsed, ELAPSED_GRACE_MS } from './terminal-compositor.scrollback.js';
 import { stripAnsi } from './display.js';
 
 describe('formatElapsed', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('returns empty string before the grace period elapses', () => {
     const startedAt = Date.now();
     expect(formatElapsed(startedAt)).toBe('');

--- a/src/cli/terminal-compositor.format-elapsed.test.ts
+++ b/src/cli/terminal-compositor.format-elapsed.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for `formatElapsed` (#826) — the only one of the 7 functions
+ * moved out of terminal-compositor.types.ts in this split that had no prior
+ * direct test coverage. The other 6 are exercised elsewhere:
+ * buildBandMeta/scrollbackFlushLines/snapFlushCountToLogicalBoundary/
+ * buildScrollbackArchiveEscape by terminal-compositor.logical-flush.test.ts,
+ * formatTipRow by loading-tips.test.ts, and eraseAndPaintRow by
+ * terminal-compositor.render-not-repin.test.ts +
+ * terminal-compositor.resize-stale-width.repro.test.ts.
+ *
+ * Covers the grace-period gate (nothing rendered before ELAPSED_GRACE_MS),
+ * the seconds-only vs. minutes+seconds format switch at the 60s boundary,
+ * and the padStart zero-padding on the seconds remainder.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { formatElapsed, ELAPSED_GRACE_MS } from './terminal-compositor.scrollback.js';
+import { stripAnsi } from './display.js';
+
+describe('formatElapsed', () => {
+  it('returns empty string before the grace period elapses', () => {
+    const startedAt = Date.now();
+    expect(formatElapsed(startedAt)).toBe('');
+  });
+
+  it('returns empty string right up to (but not including) ELAPSED_GRACE_MS', () => {
+    const startedAt = Date.now() - (ELAPSED_GRACE_MS - 1);
+    expect(formatElapsed(startedAt)).toBe('');
+  });
+
+  it('renders seconds-only once the grace period has elapsed', () => {
+    const startedAt = Date.now() - 5_000;
+    expect(stripAnsi(formatElapsed(startedAt))).toBe(' 5s');
+  });
+
+  it('renders seconds-only up to and including 59s', () => {
+    const startedAt = Date.now() - 59_000;
+    expect(stripAnsi(formatElapsed(startedAt))).toBe(' 59s');
+  });
+
+  it('switches to minutes+seconds at exactly 60s, zero-padding the seconds', () => {
+    const startedAt = Date.now() - 60_000;
+    expect(stripAnsi(formatElapsed(startedAt))).toBe(' 1m00s');
+  });
+
+  it('zero-pads a single-digit seconds remainder in the minutes form', () => {
+    const startedAt = Date.now() - 65_000; // 1m05s
+    expect(stripAnsi(formatElapsed(startedAt))).toBe(' 1m05s');
+  });
+
+  it('renders multi-minute durations without zero-padding the minutes', () => {
+    const startedAt = Date.now() - (12 * 60_000 + 34_000); // 12m34s
+    expect(stripAnsi(formatElapsed(startedAt))).toBe(' 12m34s');
+  });
+
+  it('applies a dim tint (non-empty ANSI wrapping) once past the grace period', () => {
+    const startedAt = Date.now() - 5_000;
+    const raw = formatElapsed(startedAt);
+    // Only assert tinting is present when the active chalk level actually
+    // emits escapes (NO_COLOR / non-TTY test runs strip it to plain text).
+    if (raw !== stripAnsi(raw)) {
+      expect(raw.length).toBeGreaterThan(stripAnsi(raw).length);
+    }
+    expect(stripAnsi(raw)).toBe(' 5s');
+  });
+});

--- a/src/cli/terminal-compositor.frame-preserve-archive.ts
+++ b/src/cli/terminal-compositor.frame-preserve-archive.ts
@@ -29,7 +29,7 @@ import {
   buildScrollbackArchiveEscape,
   eraseAndPaintRow,
   scrollbackFlushLines,
-} from './terminal-compositor.types.js';
+} from './terminal-compositor.scrollback.js';
 import { withAutowrapDisabled } from './terminal-compositor.band-reflow.js';
 
 /**

--- a/src/cli/terminal-compositor.lifecycle.ts
+++ b/src/cli/terminal-compositor.lifecycle.ts
@@ -20,7 +20,7 @@ import type {
   KeyInfo,
   LogUpdateFn,
 } from './terminal-compositor.types.js';
-import { scrollbackFlushLines, buildScrollbackArchiveEscape } from './terminal-compositor.types.js';
+import { scrollbackFlushLines, buildScrollbackArchiveEscape } from './terminal-compositor.scrollback.js';
 import * as InputDispatch from './terminal-compositor.input-dispatch.js';
 import type { KeyDispatchHost } from './terminal-compositor.input-dispatch.js';
 

--- a/src/cli/terminal-compositor.logical-flush.test.ts
+++ b/src/cli/terminal-compositor.logical-flush.test.ts
@@ -18,8 +18,8 @@ import {
   scrollbackFlushLines,
   snapFlushCountToLogicalBoundary,
   buildScrollbackArchiveEscape,
-  type BandRowMeta,
-} from './terminal-compositor.types.js';
+} from './terminal-compositor.scrollback.js';
+import type { BandRowMeta } from './terminal-compositor.types.js';
 import { reflowBandSplit } from './terminal-compositor.band-reflow.js';
 import { hardWrapToWidth } from './wrap.js';
 

--- a/src/cli/terminal-compositor.render-not-repin.test.ts
+++ b/src/cli/terminal-compositor.render-not-repin.test.ts
@@ -28,7 +28,7 @@ import { PassThrough } from 'node:stream';
 import { Terminal as HeadlessTerminal } from '@xterm/headless';
 import { repositionCommittedBand } from './terminal-compositor.committed-band-repin.js';
 import type { CommittedBandHost } from './terminal-compositor.committed-band-commit.js';
-import { eraseAndPaintRow } from './terminal-compositor.types.js';
+import { eraseAndPaintRow } from './terminal-compositor.scrollback.js';
 
 const COLS = 80;
 const ROWS = 24;

--- a/src/cli/terminal-compositor.scrollback.ts
+++ b/src/cli/terminal-compositor.scrollback.ts
@@ -1,0 +1,296 @@
+/**
+ * Scrollback / ANSI-write pure helpers extracted from terminal-compositor.types.ts
+ * (#826). These 7 functions carry the actual scrollback-flush algorithm and
+ * escape-sequence construction for the committed band — genuine runtime
+ * logic that a `.types.ts` name promised was absent. Split out so the file
+ * name matches its contents; `terminal-compositor.types.ts` keeps only
+ * interfaces/consts.
+ *
+ * Everything here is pure (no `self`/`this` — free functions, not
+ * free-functions-on-host) and import-side-effect-free, same as before the
+ * move. `BandRowMeta` stays defined in terminal-compositor.types.ts (several
+ * of these functions consume it, but terminal-compositor.ts also imports the
+ * type directly and is out of scope for this change), so it is imported
+ * back here as a type-only import.
+ */
+
+import { palette } from './palette.js';
+import { hardWrapToWidth } from './wrap.js';
+import { displayWidth, truncateDisplayWidth } from './display.js';
+import type { BandRowMeta } from './terminal-compositor.types.js';
+
+export const ELAPSED_GRACE_MS = 2_000;
+
+export function formatElapsed(startedAt: number): string {
+  const elapsed = Date.now() - startedAt;
+  if (elapsed < ELAPSED_GRACE_MS) return '';
+  const totalSec = Math.floor(elapsed / 1000);
+  if (totalSec < 60) return palette.dim(` ${totalSec}s`);
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  return palette.dim(` ${min}m${sec.toString().padStart(2, '0')}s`);
+}
+
+/**
+ * Absolute-position erase-and-paint of one terminal row, returned as a string
+ * for accumulation into a batched write (never written directly here).
+ *
+ * Emits CUP (`\x1b[{row};1H` — cursor to column 1 of `row`) then EL
+ * (`\x1b[2K` — erase entire line), then `line`. Omitting `line` (or passing
+ * `undefined`) erases the row and writes nothing — the bare-erase form.
+ *
+ * Invariant: emits NO `\n`, so callers that rely on CUP+EL writes never
+ * triggering the DECSTBM scroll region stay correct. Shared by the
+ * committed-band commit/repin and frame-preserve render paths, which batch
+ * these into one `out` string before a single `stdout.write`.
+ */
+export function eraseAndPaintRow(row: number, line?: string): string {
+  return `\x1b[${row};1H\x1b[2K${line ?? ''}`;
+}
+
+/**
+ * Build the {@link BandRowMeta} array for a list of LOGICAL lines hard-wrapped
+ * at `width` — the inverse-recording of the same
+ * `logicalLines.flatMap((l) => hardWrapToWidth(l, width).split('\n'))` that
+ * produces the physical `committedBand` rows, so the returned meta is
+ * index-aligned 1:1 with those rows. A logical line that fits in `width` is a
+ * single head row; one that overflows contributes a head row + N-1 continuation
+ * rows all carrying the same `logicalText`.
+ */
+export function buildBandMeta(logicalLines: readonly string[], width: number): BandRowMeta[] {
+  const meta: BandRowMeta[] = [];
+  for (const logical of logicalLines) {
+    const physicalCount = hardWrapToWidth(logical, width).split('\n').length;
+    for (let i = 0; i < physicalCount; i++) {
+      meta.push({ logicalText: logical, isHead: i === 0 });
+    }
+  }
+  return meta;
+}
+
+/**
+ * Translate the first `count` PHYSICAL rows of a band (the prefix being
+ * scrolled off into native scrollback) into the lines to WRITE to scrollback,
+ * emitting LOGICAL lines where a whole logical line lies within the prefix and
+ * PHYSICAL rows verbatim where a logical line straddles the flush boundary
+ * (#540 axis-2).
+ *
+ * Why: writing a raw logical line to the terminal with autowrap ON makes the
+ * terminal own the wrapping, so its continuation rows are soft-wrap
+ * continuations (isWrapped) that reflow cleanly on a later resize. Writing the
+ * pre-hard-wrapped physical rows instead lands N hard-newline rows the terminal
+ * can only reflow independently — the fragmentation bug.
+ *
+ * The straddle rule prevents both DUPLICATION and LOSS: if only some of a
+ * logical line's physical rows are in the flush prefix (the rest stay on
+ * screen), emitting the whole logical line would duplicate the on-screen tail
+ * in scrollback once it reflowed to full height. So a straddling line's
+ * in-prefix rows are emitted verbatim as physical rows (they stay
+ * hard-newlined — acceptable, since the surviving on-screen tail can never
+ * rejoin them anyway). A prefix whose first row is a continuation (`isHead:
+ * false` at index 0 — a logical line whose head was sliced away by an earlier
+ * eviction/cap) is likewise emitted verbatim. Every physical row in
+ * `[0, count)` is accounted for exactly once, so the physical-row COUNT the
+ * caller scrolls is unchanged whether a run emits as one logical line or as
+ * verbatim rows — the terminal re-derives the same number of physical rows from
+ * the logical line via its own autowrap (hardWrapToWidth is defined to match
+ * the terminal's char-level wrap).
+ *
+ * `meta` must be index-aligned 1:1 with `rows` (see {@link BandRowMeta}).
+ * Falls back to verbatim physical rows if `meta` is missing/short (defensive:
+ * never lose content to a meta desync).
+ */
+export function scrollbackFlushLines(
+  rows: readonly string[],
+  meta: readonly BandRowMeta[] | undefined,
+  count: number,
+): string[] {
+  const end = Math.max(0, Math.min(count, rows.length));
+  if (!meta || meta.length < rows.length) {
+    // No reliable provenance — emit the physical rows verbatim (pre-fix
+    // behavior); correctness (content present) over rejoinability.
+    return rows.slice(0, end);
+  }
+  const out: string[] = [];
+  let i = 0;
+  while (i < end) {
+    if (!meta[i]?.isHead) {
+      // A continuation row whose head is not in this prefix (sliced away
+      // earlier): emit verbatim — its logical line is already fragmented.
+      out.push(rows[i] ?? '');
+      i += 1;
+      continue;
+    }
+    // A logical-line head: find the extent of this logical line (until the
+    // next head or the end of the array — NOT bounded by `count`, so we can
+    // detect a straddle past the flush boundary).
+    let j = i + 1;
+    while (j < rows.length && !meta[j]?.isHead) j += 1;
+    if (j <= end) {
+      // The whole logical line is within the flush prefix → emit it ONCE as a
+      // logical line (the terminal soft-wraps it; reflows cleanly on resize).
+      out.push(meta[i]!.logicalText);
+    } else {
+      // Straddle: only rows [i, end) of this logical line are being flushed;
+      // its tail stays on screen. Emit the in-prefix physical rows verbatim so
+      // the on-screen tail is never duplicated in scrollback.
+      for (let k = i; k < end; k++) out.push(rows[k] ?? '');
+    }
+    i = j;
+  }
+  return out;
+}
+
+/**
+ * Snap a physical-row flush count DOWN to the nearest LOGICAL-line boundary
+ * (#540 axis-2) so a scrollback archive never splits one logical line across
+ * two archive events — which is what re-introduces the fragmentation even with
+ * logical-line emission (a line archived one physical row at a time is emitted
+ * verbatim each time, never as a whole soft-wrappable line).
+ *
+ * Given `meta` (per-physical-row provenance) and a desired `count` of leading
+ * physical rows to flush, returns the largest `n <= count` such that either
+ * `n === 0`, `n === meta.length`, or `meta[n]` is a logical-line head (i.e. the
+ * cut falls exactly between two logical lines, never mid-line). The caller
+ * archives `[0, n)` as whole logical lines and RETAINS the straddling line (and
+ * everything after it) in the band model until a later flush covers all of its
+ * rows. Returns `count` unchanged when `meta` is missing/short (the verbatim
+ * fallback in {@link scrollbackFlushLines} then applies).
+ */
+export function snapFlushCountToLogicalBoundary(
+  meta: readonly BandRowMeta[] | undefined,
+  count: number,
+  total: number,
+): number {
+  const c = Math.max(0, Math.min(count, total));
+  if (!meta || meta.length < total) return c;
+  if (c >= total) return total; // whole band flushes — always a clean boundary
+  // Walk DOWN from c to the nearest logical-line head (a clean cut point).
+  for (let n = c; n > 0; n--) {
+    if (meta[n]?.isHead) return n;
+  }
+  return 0;
+}
+
+/**
+ * Build the escape string that archives `lines` to native scrollback as
+ * SOFT-WRAPPABLE content (#540 axis-2).
+ *
+ * Mechanism (verified against @xterm/headless + real pty): paint the lines at
+ * the anchor floor as a normal top-of-screen text stream — each line CUP-less
+ * after the first, separated by `\r\n`, with autowrap ON so the terminal wraps
+ * an over-wide LOGICAL line itself (its continuation rows carry the terminal's
+ * soft-wrap flag → reflow-clean on a later resize) — then CUP to the physical
+ * bottom margin and emit `\n` × (total physical rows) to scroll the whole
+ * painted block up and OFF the top into native scrollback. Writing at the
+ * bottom-margin-only (the naive approach) leaves the content in the VIEWPORT,
+ * never scrollback; writing at the top then scrolling the resident painted
+ * height is what carries it into history. A line that fits the width is one physical
+ * row and contributes one scroll — byte-equivalent outcome to the pre-#540
+ * physical-row archive; a wide line contributes its wrapped height and rejoins
+ * cleanly.
+ *
+ * Chunked by the paintable height (`rows - anchorFloor + 1`) so a block taller
+ * than the terminal still archives every row: each chunk is painted top-aligned
+ * and scrolled off before the next chunk. A chunk is scrolled by its RESIDENT
+ * height — `min(chunkRows, chunkMax)` — not its full physical height: a SINGLE
+ * line taller than the region cannot be split across chunks, so its paint does
+ * overflow the bottom margin and the terminal auto-scrolls the excess itself.
+ * Adding a full-height explicit scroll on top of that auto-scroll double-counts
+ * and appends blank rows to history. `width` is needed to compute each line's
+ * physical (wrapped) height; it MUST equal the terminal's current column count
+ * so hardWrapToWidth's split matches what the terminal's autowrap will do.
+ *
+ * MUST run with autowrap ENABLED (the default) and inside the caller's
+ * full-screen scroll region — the opposite of the on-screen band paint, which
+ * runs inside `withAutowrapDisabled`. Autowrap is load-bearing HERE: it is what
+ * makes the terminal, not the app, own the wrap so scrollback can later reflow.
+ *
+ * Returns '' for an empty list (caller writes nothing).
+ */
+export function buildScrollbackArchiveEscape(
+  lines: readonly string[],
+  anchorFloor: number,
+  bottomRow: number,
+  width: number,
+): string {
+  if (lines.length === 0) return '';
+  const floor = Math.max(1, anchorFloor);
+  const bottom = Math.max(1, bottomRow);
+  const chunkMax = Math.max(1, bottom - floor + 1);
+  const physicalHeight = (line: string): number =>
+    Math.max(1, hardWrapToWidth(line, width).split('\n').length);
+  let out = '';
+  let chunk: string[] = [];
+  let chunkRows = 0;
+  const flushChunk = (): void => {
+    if (chunk.length === 0) return;
+    // External constraint (DECAWM autowrap owns the wrap): a chunk taller than
+    // the paint region auto-scrolls `chunkRows - chunkMax` rows into history
+    // DURING the paint, so only the rows still RESIDENT in the region may be
+    // scrolled explicitly afterwards. `residentRows` is that count, and is the
+    // single source of truth for both the pre-erase span and the scroll count.
+    const residentRows = Math.min(chunkRows, chunkMax);
+    // Erase every PHYSICAL row the paint will occupy, before painting it. The
+    // per-line `\x1b[2K` below erases only each logical line's HEAD row; a line
+    // that autowraps leaves its continuation rows unerased, so stale glyphs to
+    // the right of the wrapped tail scroll into scrollback verbatim. Restores
+    // the pre-#540 per-physical-row `eraseAndPaintRow` erase footprint exactly
+    // (same span, no rows below the painted block touched).
+    for (let r = 0; r < residentRows; r++) out += `\x1b[${floor + r};1H\x1b[2K`;
+    // Paint the chunk top-aligned at the floor, flowing with \r\n so each
+    // logical line starts on a fresh row and autowrap owns intra-line wrapping.
+    out += `\x1b[${floor};1H`;
+    out += chunk.map((l) => `\x1b[2K${l}`).join('\r\n');
+    // Scroll the RESIDENT rows off the top into scrollback — not `chunkRows`:
+    // for an over-height line the autowrap overflow already scrolled the
+    // difference, and counting it twice appends `chunkRows - chunkMax` blank
+    // rows to history.
+    out += `\x1b[${bottom};1H${'\n'.repeat(residentRows)}`;
+    chunk = [];
+    chunkRows = 0;
+  };
+  for (const line of lines) {
+    const h = physicalHeight(line);
+    // A single line taller than the whole paint region gets its own chunk: the
+    // terminal's autowrap scrolls the overflow beyond the region during the
+    // paint, and flushChunk explicitly scrolls only the resident remainder, so
+    // the two together carry exactly `h` rows into history.
+    if (chunkRows > 0 && chunkRows + h > chunkMax) flushChunk();
+    chunk.push(line);
+    chunkRows += h;
+  }
+  flushChunk();
+  return out;
+}
+
+/**
+ * Format a loading tip into the dim 💡 row that sits beneath the spinner.
+ *
+ * The literal `Tip:` label is load-bearing, not decoration: most tips are
+ * harvested skill hints shaped like `/agentify — Use when …`, and without
+ * the label a tip rendered mid-turn reads as the agent announcing it is
+ * routing to that skill (e.g. the user types `/automate` and immediately
+ * sees `💡 /agentify — Use when…`). `Tip:` marks the row as ambient
+ * guidance, decoupled from the in-flight turn. The {@link LoadingTip}
+ * contract has always promised this prefix; the implementation drifted.
+ *
+ * `cols` is the terminal width — we truncate to fit on one visual line so
+ * the tip never wraps and steals a viewport row that log-update can't
+ * cleanly reclaim on the next paint. The prefix budget is "  💡 Tip: "
+ * (10 visible cols); 1 more col is reserved for the trailing "…" when
+ * truncation kicks in. Budget and truncation are measured in DISPLAY
+ * columns (not JS chars) so wide glyphs (CJK, emoji) in a tip body cannot
+ * overflow the row — char-count truncation would under-truncate them 2:1.
+ */
+export function formatTipRow(text: string, cols: number): string {
+  const prefix = '  💡 Tip: ';
+  // Reserve the prefix chrome and 1 col for the truncation marker so the
+  // rendered line always fits in `cols` regardless of body length.
+  const bodyBudget = Math.max(8, cols - displayWidth(prefix) - 1);
+  const body =
+    displayWidth(text) > bodyBudget
+      ? truncateDisplayWidth(text, Math.max(0, bodyBudget - 1), '') + '…'
+      : text;
+  return palette.dim(prefix + body);
+}

--- a/src/cli/terminal-compositor.types.ts
+++ b/src/cli/terminal-compositor.types.ts
@@ -1,15 +1,19 @@
 /**
- * Types, constants, and pure helpers extracted from terminal-compositor.ts.
+ * Types and constants extracted from terminal-compositor.ts.
  *
- * Kept in a separate file so the ~2 KB of interface declarations and small
- * utility functions do not clutter the stateful TerminalCompositor class.
- * Everything here is import-side-effect-free and has no dependency on
- * `this` — pure module-level declarations only.
+ * Kept in a separate file so the ~2 KB of interface declarations do not
+ * clutter the stateful TerminalCompositor class. Everything here is
+ * import-side-effect-free and has no dependency on `this` — pure
+ * module-level declarations only, genuinely just types/consts (#826: the 7
+ * function declarations that used to live here — formatElapsed,
+ * eraseAndPaintRow, buildBandMeta, scrollbackFlushLines,
+ * snapFlushCountToLogicalBoundary, buildScrollbackArchiveEscape,
+ * formatTipRow — moved to terminal-compositor.scrollback.ts, which imports
+ * {@link BandRowMeta} back from here as a type-only import. BandRowMeta
+ * itself stays in this file because terminal-compositor.ts imports it
+ * directly).
  */
 
-import { palette } from './palette.js';
-import { hardWrapToWidth } from './wrap.js';
-import { displayWidth, truncateDisplayWidth } from './display.js';
 import type { LoadingTip } from './loading-tips.js';
 import type { ImageAttachment } from './input/attachments.js';
 import type { AutocompleteState } from './input/autocomplete-state.js';
@@ -64,35 +68,6 @@ export interface KeyInfo {
 // Braille spinner frames from ora's `dots` preset.
 export const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'] as const;
 
-export const ELAPSED_GRACE_MS = 2_000;
-
-export function formatElapsed(startedAt: number): string {
-  const elapsed = Date.now() - startedAt;
-  if (elapsed < ELAPSED_GRACE_MS) return '';
-  const totalSec = Math.floor(elapsed / 1000);
-  if (totalSec < 60) return palette.dim(` ${totalSec}s`);
-  const min = Math.floor(totalSec / 60);
-  const sec = totalSec % 60;
-  return palette.dim(` ${min}m${sec.toString().padStart(2, '0')}s`);
-}
-
-/**
- * Absolute-position erase-and-paint of one terminal row, returned as a string
- * for accumulation into a batched write (never written directly here).
- *
- * Emits CUP (`\x1b[{row};1H` — cursor to column 1 of `row`) then EL
- * (`\x1b[2K` — erase entire line), then `line`. Omitting `line` (or passing
- * `undefined`) erases the row and writes nothing — the bare-erase form.
- *
- * Invariant: emits NO `\n`, so callers that rely on CUP+EL writes never
- * triggering the DECSTBM scroll region stay correct. Shared by the
- * committed-band commit/repin and frame-preserve render paths, which batch
- * these into one `out` string before a single `stdout.write`.
- */
-export function eraseAndPaintRow(row: number, line?: string): string {
-  return `\x1b[${row};1H\x1b[2K${line ?? ''}`;
-}
-
 /**
  * Per-physical-row provenance for the committed band (#540 axis-2).
  *
@@ -127,253 +102,6 @@ export interface BandRowMeta {
   logicalText: string;
   /** True iff this is the FIRST physical row of its logical line. */
   isHead: boolean;
-}
-
-/**
- * Build the {@link BandRowMeta} array for a list of LOGICAL lines hard-wrapped
- * at `width` — the inverse-recording of the same
- * `logicalLines.flatMap((l) => hardWrapToWidth(l, width).split('\n'))` that
- * produces the physical `committedBand` rows, so the returned meta is
- * index-aligned 1:1 with those rows. A logical line that fits in `width` is a
- * single head row; one that overflows contributes a head row + N-1 continuation
- * rows all carrying the same `logicalText`.
- */
-export function buildBandMeta(logicalLines: readonly string[], width: number): BandRowMeta[] {
-  const meta: BandRowMeta[] = [];
-  for (const logical of logicalLines) {
-    const physicalCount = hardWrapToWidth(logical, width).split('\n').length;
-    for (let i = 0; i < physicalCount; i++) {
-      meta.push({ logicalText: logical, isHead: i === 0 });
-    }
-  }
-  return meta;
-}
-
-/**
- * Translate the first `count` PHYSICAL rows of a band (the prefix being
- * scrolled off into native scrollback) into the lines to WRITE to scrollback,
- * emitting LOGICAL lines where a whole logical line lies within the prefix and
- * PHYSICAL rows verbatim where a logical line straddles the flush boundary
- * (#540 axis-2).
- *
- * Why: writing a raw logical line to the terminal with autowrap ON makes the
- * terminal own the wrapping, so its continuation rows are soft-wrap
- * continuations (isWrapped) that reflow cleanly on a later resize. Writing the
- * pre-hard-wrapped physical rows instead lands N hard-newline rows the terminal
- * can only reflow independently — the fragmentation bug.
- *
- * The straddle rule prevents both DUPLICATION and LOSS: if only some of a
- * logical line's physical rows are in the flush prefix (the rest stay on
- * screen), emitting the whole logical line would duplicate the on-screen tail
- * in scrollback once it reflowed to full height. So a straddling line's
- * in-prefix rows are emitted verbatim as physical rows (they stay
- * hard-newlined — acceptable, since the surviving on-screen tail can never
- * rejoin them anyway). A prefix whose first row is a continuation (`isHead:
- * false` at index 0 — a logical line whose head was sliced away by an earlier
- * eviction/cap) is likewise emitted verbatim. Every physical row in
- * `[0, count)` is accounted for exactly once, so the physical-row COUNT the
- * caller scrolls is unchanged whether a run emits as one logical line or as
- * verbatim rows — the terminal re-derives the same number of physical rows from
- * the logical line via its own autowrap (hardWrapToWidth is defined to match
- * the terminal's char-level wrap).
- *
- * `meta` must be index-aligned 1:1 with `rows` (see {@link BandRowMeta}).
- * Falls back to verbatim physical rows if `meta` is missing/short (defensive:
- * never lose content to a meta desync).
- */
-export function scrollbackFlushLines(
-  rows: readonly string[],
-  meta: readonly BandRowMeta[] | undefined,
-  count: number,
-): string[] {
-  const end = Math.max(0, Math.min(count, rows.length));
-  if (!meta || meta.length < rows.length) {
-    // No reliable provenance — emit the physical rows verbatim (pre-fix
-    // behavior); correctness (content present) over rejoinability.
-    return rows.slice(0, end);
-  }
-  const out: string[] = [];
-  let i = 0;
-  while (i < end) {
-    if (!meta[i]?.isHead) {
-      // A continuation row whose head is not in this prefix (sliced away
-      // earlier): emit verbatim — its logical line is already fragmented.
-      out.push(rows[i] ?? '');
-      i += 1;
-      continue;
-    }
-    // A logical-line head: find the extent of this logical line (until the
-    // next head or the end of the array — NOT bounded by `count`, so we can
-    // detect a straddle past the flush boundary).
-    let j = i + 1;
-    while (j < rows.length && !meta[j]?.isHead) j += 1;
-    if (j <= end) {
-      // The whole logical line is within the flush prefix → emit it ONCE as a
-      // logical line (the terminal soft-wraps it; reflows cleanly on resize).
-      out.push(meta[i]!.logicalText);
-    } else {
-      // Straddle: only rows [i, end) of this logical line are being flushed;
-      // its tail stays on screen. Emit the in-prefix physical rows verbatim so
-      // the on-screen tail is never duplicated in scrollback.
-      for (let k = i; k < end; k++) out.push(rows[k] ?? '');
-    }
-    i = j;
-  }
-  return out;
-}
-
-/**
- * Snap a physical-row flush count DOWN to the nearest LOGICAL-line boundary
- * (#540 axis-2) so a scrollback archive never splits one logical line across
- * two archive events — which is what re-introduces the fragmentation even with
- * logical-line emission (a line archived one physical row at a time is emitted
- * verbatim each time, never as a whole soft-wrappable line).
- *
- * Given `meta` (per-physical-row provenance) and a desired `count` of leading
- * physical rows to flush, returns the largest `n <= count` such that either
- * `n === 0`, `n === meta.length`, or `meta[n]` is a logical-line head (i.e. the
- * cut falls exactly between two logical lines, never mid-line). The caller
- * archives `[0, n)` as whole logical lines and RETAINS the straddling line (and
- * everything after it) in the band model until a later flush covers all of its
- * rows. Returns `count` unchanged when `meta` is missing/short (the verbatim
- * fallback in {@link scrollbackFlushLines} then applies).
- */
-export function snapFlushCountToLogicalBoundary(
-  meta: readonly BandRowMeta[] | undefined,
-  count: number,
-  total: number,
-): number {
-  const c = Math.max(0, Math.min(count, total));
-  if (!meta || meta.length < total) return c;
-  if (c >= total) return total; // whole band flushes — always a clean boundary
-  // Walk DOWN from c to the nearest logical-line head (a clean cut point).
-  for (let n = c; n > 0; n--) {
-    if (meta[n]?.isHead) return n;
-  }
-  return 0;
-}
-
-/**
- * Build the escape string that archives `lines` to native scrollback as
- * SOFT-WRAPPABLE content (#540 axis-2).
- *
- * Mechanism (verified against @xterm/headless + real pty): paint the lines at
- * the anchor floor as a normal top-of-screen text stream — each line CUP-less
- * after the first, separated by `\r\n`, with autowrap ON so the terminal wraps
- * an over-wide LOGICAL line itself (its continuation rows carry the terminal's
- * soft-wrap flag → reflow-clean on a later resize) — then CUP to the physical
- * bottom margin and emit `\n` × (total physical rows) to scroll the whole
- * painted block up and OFF the top into native scrollback. Writing at the
- * bottom-margin-only (the naive approach) leaves the content in the VIEWPORT,
- * never scrollback; writing at the top then scrolling the resident painted
- * height is what carries it into history. A line that fits the width is one physical
- * row and contributes one scroll — byte-equivalent outcome to the pre-#540
- * physical-row archive; a wide line contributes its wrapped height and rejoins
- * cleanly.
- *
- * Chunked by the paintable height (`rows - anchorFloor + 1`) so a block taller
- * than the terminal still archives every row: each chunk is painted top-aligned
- * and scrolled off before the next chunk. A chunk is scrolled by its RESIDENT
- * height — `min(chunkRows, chunkMax)` — not its full physical height: a SINGLE
- * line taller than the region cannot be split across chunks, so its paint does
- * overflow the bottom margin and the terminal auto-scrolls the excess itself.
- * Adding a full-height explicit scroll on top of that auto-scroll double-counts
- * and appends blank rows to history. `width` is needed to compute each line's
- * physical (wrapped) height; it MUST equal the terminal's current column count
- * so hardWrapToWidth's split matches what the terminal's autowrap will do.
- *
- * MUST run with autowrap ENABLED (the default) and inside the caller's
- * full-screen scroll region — the opposite of the on-screen band paint, which
- * runs inside `withAutowrapDisabled`. Autowrap is load-bearing HERE: it is what
- * makes the terminal, not the app, own the wrap so scrollback can later reflow.
- *
- * Returns '' for an empty list (caller writes nothing).
- */
-export function buildScrollbackArchiveEscape(
-  lines: readonly string[],
-  anchorFloor: number,
-  bottomRow: number,
-  width: number,
-): string {
-  if (lines.length === 0) return '';
-  const floor = Math.max(1, anchorFloor);
-  const bottom = Math.max(1, bottomRow);
-  const chunkMax = Math.max(1, bottom - floor + 1);
-  const physicalHeight = (line: string): number =>
-    Math.max(1, hardWrapToWidth(line, width).split('\n').length);
-  let out = '';
-  let chunk: string[] = [];
-  let chunkRows = 0;
-  const flushChunk = (): void => {
-    if (chunk.length === 0) return;
-    // External constraint (DECAWM autowrap owns the wrap): a chunk taller than
-    // the paint region auto-scrolls `chunkRows - chunkMax` rows into history
-    // DURING the paint, so only the rows still RESIDENT in the region may be
-    // scrolled explicitly afterwards. `residentRows` is that count, and is the
-    // single source of truth for both the pre-erase span and the scroll count.
-    const residentRows = Math.min(chunkRows, chunkMax);
-    // Erase every PHYSICAL row the paint will occupy, before painting it. The
-    // per-line `\x1b[2K` below erases only each logical line's HEAD row; a line
-    // that autowraps leaves its continuation rows unerased, so stale glyphs to
-    // the right of the wrapped tail scroll into scrollback verbatim. Restores
-    // the pre-#540 per-physical-row `eraseAndPaintRow` erase footprint exactly
-    // (same span, no rows below the painted block touched).
-    for (let r = 0; r < residentRows; r++) out += `\x1b[${floor + r};1H\x1b[2K`;
-    // Paint the chunk top-aligned at the floor, flowing with \r\n so each
-    // logical line starts on a fresh row and autowrap owns intra-line wrapping.
-    out += `\x1b[${floor};1H`;
-    out += chunk.map((l) => `\x1b[2K${l}`).join('\r\n');
-    // Scroll the RESIDENT rows off the top into scrollback — not `chunkRows`:
-    // for an over-height line the autowrap overflow already scrolled the
-    // difference, and counting it twice appends `chunkRows - chunkMax` blank
-    // rows to history.
-    out += `\x1b[${bottom};1H${'\n'.repeat(residentRows)}`;
-    chunk = [];
-    chunkRows = 0;
-  };
-  for (const line of lines) {
-    const h = physicalHeight(line);
-    // A single line taller than the whole paint region gets its own chunk: the
-    // terminal's autowrap scrolls the overflow beyond the region during the
-    // paint, and flushChunk explicitly scrolls only the resident remainder, so
-    // the two together carry exactly `h` rows into history.
-    if (chunkRows > 0 && chunkRows + h > chunkMax) flushChunk();
-    chunk.push(line);
-    chunkRows += h;
-  }
-  flushChunk();
-  return out;
-}
-
-/**
- * Format a loading tip into the dim 💡 row that sits beneath the spinner.
- *
- * The literal `Tip:` label is load-bearing, not decoration: most tips are
- * harvested skill hints shaped like `/agentify — Use when …`, and without
- * the label a tip rendered mid-turn reads as the agent announcing it is
- * routing to that skill (e.g. the user types `/automate` and immediately
- * sees `💡 /agentify — Use when…`). `Tip:` marks the row as ambient
- * guidance, decoupled from the in-flight turn. The {@link LoadingTip}
- * contract has always promised this prefix; the implementation drifted.
- *
- * `cols` is the terminal width — we truncate to fit on one visual line so
- * the tip never wraps and steals a viewport row that log-update can't
- * cleanly reclaim on the next paint. The prefix budget is "  💡 Tip: "
- * (10 visible cols); 1 more col is reserved for the trailing "…" when
- * truncation kicks in. Budget and truncation are measured in DISPLAY
- * columns (not JS chars) so wide glyphs (CJK, emoji) in a tip body cannot
- * overflow the row — char-count truncation would under-truncate them 2:1.
- */
-export function formatTipRow(text: string, cols: number): string {
-  const prefix = '  💡 Tip: ';
-  // Reserve the prefix chrome and 1 col for the truncation marker so the
-  // rendered line always fits in `cols` regardless of body length.
-  const bodyBudget = Math.max(8, cols - displayWidth(prefix) - 1);
-  const body =
-    displayWidth(text) > bodyBudget
-      ? truncateDisplayWidth(text, Math.max(0, bodyBudget - 1), '') + '…'
-      : text;
-  return palette.dim(prefix + body);
 }
 
 export interface SpinnerState {


### PR DESCRIPTION
## Summary

`src/cli/terminal-compositor.types.ts` was named `.types.ts` but held 7 function declarations (~310 LOC) carrying real scrollback-flush and ANSI-escape-construction logic, most wrapped in dense `Invariant:`/`History:` commentary referencing past incident #540. A reviewer scanning for "the file with the scrollback algorithm" would not look in a file that promises zero logic.

This PR moves all 7 functions verbatim into a new `src/cli/terminal-compositor.scrollback.ts`, leaving `terminal-compositor.types.ts` with only interfaces/types/consts — finally honest about its name.

Moved: `formatElapsed`, `eraseAndPaintRow`, `buildBandMeta`, `scrollbackFlushLines`, `snapFlushCountToLogicalBoundary`, `buildScrollbackArchiveEscape`, `formatTipRow`, plus their sole constant dependency `ELAPSED_GRACE_MS`.

**Kept in `.types.ts`:** the `BandRowMeta` interface. It is consumed by several of the 7 moved functions, but `terminal-compositor.ts` (out of scope for this PR — see Hard constraints below) imports `BandRowMeta` directly, so moving it would have forced an edit there. `terminal-compositor.scrollback.ts` imports it back as a type-only import.

All 7 functions were confirmed **pure** by grep (`grep -n "self:"` — zero matches) before the move, matching the issue's claim: no `self: Host` parameter, unlike every stateful sibling module in the compositor cluster (these are free functions, not free-functions-on-host).

### Corrected premise (issue #826 is stale on this point)

The issue claims all 7 functions have **"ZERO tests"** and that adding tests "is most of the value here." **That claim is false as of this PR** — `terminal-compositor.logical-flush.test.ts` (added by PR #665, 2026-07-28, which pre-dates this issue) already covers 6 of the 7:

| Function | Existing test coverage |
|---|---|
| `buildBandMeta` | `terminal-compositor.logical-flush.test.ts` |
| `scrollbackFlushLines` | `terminal-compositor.logical-flush.test.ts` |
| `snapFlushCountToLogicalBoundary` | `terminal-compositor.logical-flush.test.ts` |
| `buildScrollbackArchiveEscape` | `terminal-compositor.logical-flush.test.ts` |
| `formatTipRow` | `loading-tips.test.ts` |
| `eraseAndPaintRow` | `terminal-compositor.render-not-repin.test.ts`, `terminal-compositor.resize-stale-width.repro.test.ts` |
| `formatElapsed` | **none — the only real gap** |

This PR adds exactly one new test file, `terminal-compositor.format-elapsed.test.ts` (8 cases), for that one real gap. It does **not** add redundant duplicate tests for the other 6 already-covered functions.

### Re-export vs. updated imports

**Chose: update the import sites directly, no re-export shim.** A re-export from the old `.types.ts` path would have left the exact stale-name import path issue #826 complains about fully reachable and idiomatic, defeating the discoverability fix this PR exists to make. The compiler verifies every updated site mechanically (`tsc --noEmit` fails loudly on any missed one, per the issue's own "Difficulty: low" reasoning). 8 files imported one of the 7 functions from the old path and were updated: `src/cli/input/spinner.ts`, `terminal-compositor.committed-band-commit.ts`, `terminal-compositor.committed-band-repin.ts`, `terminal-compositor.frame-preserve-archive.ts`, `terminal-compositor.lifecycle.ts`, and 3 test files (`terminal-compositor.logical-flush.test.ts`, `loading-tips.test.ts`, `terminal-compositor.render-not-repin.test.ts`). Files that only imported *types* from `terminal-compositor.types.js` (e.g. `terminal-compositor.ts`, `terminal-compositor.input-dispatch.ts`, `terminal-compositor.frame.ts`, `terminal-compositor.input-mode.ts`, `terminal-compositor.band-reflow.ts`, `terminal-compositor.autocomplete.ts`) needed no changes.

### LOC

| File | Before | After | Delta |
|---|---|---|---|
| `src/cli/terminal-compositor.types.ts` | 702 | 430 | −272 |
| `src/cli/terminal-compositor.scrollback.ts` | 0 | 296 | +296 |
| `src/cli/terminal-compositor.format-elapsed.test.ts` | 0 | 66 | +66 |

Both new/kept files are within the 350-LOC budget; no split needed.

### Coverage delta (measured empirically, not guessed)

The issue's premise raised a real question: does the `src/**/types.ts` coverage-exclude glob in `vitest.config.ts` match `terminal-compositor.types.ts` under picomatch basename semantics? Resolved empirically by running `pnpm test:coverage` before and after the change:

- **Before** (`git show dc56f8eb`, pristine main): `terminal-compositor.types.ts` **appears in the coverage table** at 94.49% stmts / 91.66% branches / 100% funcs / 94.49% lines (uncovered: lines 72-77, inside `formatElapsed`). This proves the glob does **not** match — `src/**/types.ts` requires the basename to be exactly `types.ts`, and `terminal-compositor.types.ts`'s basename is not `types.ts`. The file was never excluded.
- **After**: `terminal-compositor.types.ts` is now **100/100/100/100** (trivial — only types/consts remain, which don't execute). The new `terminal-compositor.scrollback.ts` shows **100% stmts / 94.11% branches / 100% funcs / 100% lines**.
- **Overall repo coverage, before → after**: stmts 87.69 → 87.70, branches 85.78 → 85.78, funcs 91.91 → 91.93, lines 87.69 → 87.70. Effectively flat (the move is coverage-neutral; the one new test nudges branches/funcs up marginally). Both before and after are comfortably above the CI floor (74/79/82/74).

### Behavior

No behavior change. Function bodies are byte-for-byte moves — diffed the new file's function bodies against `git show HEAD:src/cli/terminal-compositor.types.ts` and confirmed identical apart from the `BandRowMeta` interface staying behind.

Closes #826

## How was this tested?

All commands run for real in this session; output below is real, not assumed.

**`pnpm lint`** (tsc --noEmit, strict) — **PASS**, no output (clean).

**`pnpm build`** (tsc && copy-prompts) — **PASS**, no output (clean).

**`pnpm test:coverage`** (vitest run --coverage; superset of `pnpm test`, run once, not both) — **PASS**:
```
 Test Files  739 passed (739)
      Tests  14145 passed | 2 skipped (14147)
   Duration  49.41s (transform 12.75s, setup 17.83s, collect 215.16s, tests 158.97s, ...)

All files          |    87.7 |    85.78 |   91.93 |    87.7 |
```
Coverage thresholds (stmts 74 / branches 79 / funcs 82 / lines 74) all cleared; exit code 0.

**`pnpm audit:env:check`** — **PASS**: `744 files scanned, 150 legitimate process.env accesses inside allowlist, 0 violations.`

**`pnpm scan:env:check`** — **PASS**: `docs/env-registry.{json,md} in sync with src/config/env.ts (140 vars).`

**`pnpm audit:chalk:check`** — **PASS**: `744 files scanned, 73 legitimate raw-chalk sites inside allowlist, 0 violations.`

**`pnpm fix:pins:check`** — **PASS**: `All hash pins are up to date.`

Also individually re-ran the 3 edited test files plus the new one and `spinner.test.ts` scoped (each via `pnpm test <file>`, no `--`, to confirm imports resolved before the full-suite run):
- `terminal-compositor.format-elapsed.test.ts` — 8/8 passed
- `terminal-compositor.logical-flush.test.ts` — 33/33 passed
- `loading-tips.test.ts` — 22/22 passed
- `terminal-compositor.render-not-repin.test.ts` — 2/2 passed
- `input/spinner.test.ts` — 5/5 passed

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes (ran the coverage superset instead, `pnpm test:coverage`, per project convention — never run both)
- [x] Commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/) — see [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] No secrets, tokens, or private paths in the diff
