### PR TITLE
fix(provider): stop the TTFB bound firing on throttle backoff, and stop guessing why a stream ended

### DIFF
--- a/src/agent/providers/anthropic-direct/loop.retry.test.ts
+++ b/src/agent/providers/anthropic-direct/loop.retry.test.ts
@@ -579,7 +579,12 @@ describe('runTurn mid-stream clean-close (StreamIncompleteError) retry', () => {
     expect(errorEvent).toBeDefined();
     if (errorEvent?.type === 'error') {
       expect(errorEvent.error.name).toBe('StreamIncompleteError');
-      expect(errorEvent.error.message).toContain('cut off mid-stream');
+      // Assert the OBSERVABLE fact, not a cause. This used to pin "cut off
+      // mid-stream"; the message no longer asserts why the stream ended, because
+      // this layer cannot tell a client-side AbortError abort (including the SDK's
+      // own request timeout) from an upstream peer close. See
+      // anthropic-direct/stream-completeness.ts.
+      expect(errorEvent.error.message).toContain('ended without a terminal message');
     }
   });
 

--- a/src/agent/providers/anthropic-direct/loop.ttfb-throttle.test.ts
+++ b/src/agent/providers/anthropic-direct/loop.ttfb-throttle.test.ts
@@ -1,0 +1,162 @@
+// Regression guard for the `onThrottle` wiring in loop/round-request.ts.
+//
+// Invariant: the TTFB bound is armed ONCE PER ROUND, above `messages.create`,
+// so its window also covers every 429/503/529 backoff the SDK sleeps out INSIDE
+// that call. `openRound` therefore hands `awaitCreateWithThrottleSignals` an
+// `onThrottle` callback that pushes the deadline out by the provider's own
+// retry-after. Without it, sustained throttling aborts a request that was never
+// given a chance to stream, and the failure is misreported as a first-byte
+// stall.
+//
+// These tests drive that wiring end-to-end through `runTurn`. The seam-level
+// tests (loop/throttle-signals.test.ts, shared/first-byte-timeout.test.ts)
+// prove the primitives, but they hand-build the callback themselves — so
+// deleting the third argument at the round-request.ts call site leaves every
+// one of them green. These two are the only tests that fail for that edit.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { RawMessageStreamEvent, MessageParam } from '@anthropic-ai/sdk/resources';
+import { runTurn } from './loop.js';
+import type { AnthropicClientLike } from './types.js';
+import { ThrottleQueue } from './throttle-queue.js';
+import { DEFAULT_MODEL_TTFB_TIMEOUT_MS } from '../shared/first-byte-timeout.js';
+import {
+  fromArray,
+  collect,
+  ctx,
+  makeTextStream,
+  makeDispatcher,
+} from './loop.test-helpers.js';
+
+const KEY = 'AFK_MODEL_TTFB_TIMEOUT_MS';
+
+/** 55s: just under the window the SDK actually honours, so it is a park that
+ *  genuinely happens (a larger hint is discarded upstream and clamped here). */
+const HONOURED_RETRY_AFTER_MS = 55_000;
+
+const messages: MessageParam[] = [{ role: 'user', content: 'hi' }];
+
+/** Park a create promise until released; reject if the request signal aborts —
+ *  exactly how a create that the TTFB bound aborted behaves. */
+function parked(
+  signal: AbortSignal,
+  capture: (release: (stream: AsyncIterable<RawMessageStreamEvent>) => void) => void,
+): Promise<AsyncIterable<RawMessageStreamEvent>> {
+  return new Promise<AsyncIterable<RawMessageStreamEvent>>((resolve, reject) => {
+    capture(resolve);
+    if (signal.aborted) {
+      reject(new Error('aborted'));
+      return;
+    }
+    signal.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+  });
+}
+
+function turn(queue: ThrottleQueue, client: AnthropicClientLike) {
+  return collect(
+    runTurn({
+      client,
+      messages,
+      system: null,
+      tools: null,
+      toolDispatcher: makeDispatcher(() => Promise.resolve({ content: 'ok' })),
+      model: 'claude-test',
+      maxTokens: 1024,
+      headers: {},
+      signal: new AbortController().signal,
+      ctx,
+      throttleQueue: queue,
+    }),
+  );
+}
+
+describe('runTurn — a throttle park does not become a first-byte stall', () => {
+  let saved: string | undefined;
+  beforeEach(() => {
+    saved = process.env[KEY];
+    process.env[KEY] = String(DEFAULT_MODEL_TTFB_TIMEOUT_MS);
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    if (saved === undefined) delete process.env[KEY];
+    else process.env[KEY] = saved;
+  });
+
+  it('forgives an EXPLAINED park: the round survives its whole original bound', async () => {
+    const queue = new ThrottleQueue();
+    let release!: (stream: AsyncIterable<RawMessageStreamEvent>) => void;
+    let calls = 0;
+    const client: AnthropicClientLike = {
+      messages: {
+        create: vi.fn((_params: unknown, opts: unknown) => {
+          calls++;
+          return parked((opts as { signal: AbortSignal }).signal, (r) => (release = r));
+        }),
+      },
+    };
+
+    const resultPromise = turn(queue, client);
+    // Let the loop reach the create await, then have the wrapped fetch report a
+    // 429 the provider said it would hold for 55s.
+    await vi.advanceTimersByTimeAsync(0);
+    queue.push({ status: 429, retryAfterMs: HONOURED_RETRY_AFTER_MS });
+    // Drain + extend BEFORE any timer fires: the extension must be in place
+    // while the park it forgives is still running.
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Burn the ENTIRE original bound. Un-extended, the timer fires here, aborts
+    // a request that never streamed, and the round re-drives.
+    await vi.advanceTimersByTimeAsync(DEFAULT_MODEL_TTFB_TIMEOUT_MS + 1_000);
+    expect(calls).toBe(1);
+
+    release(fromArray(makeTextStream('done')));
+    const events = await resultPromise;
+
+    // The signal really did drain (so the test is exercising the seam, not
+    // passing because nothing happened), and the turn completed untouched.
+    expect(events.some((e) => e.type === 'rate_limit')).toBe(true);
+    expect(events.filter((e) => e.type === 'stream.retry')).toHaveLength(0);
+    expect(events.find((e) => e.type === 'error')).toBeUndefined();
+    expect(events.some((e) => e.type === 'turn.completed')).toBe(true);
+    expect(events.some((e) => e.type === 'assistant.message' && e.text === 'done')).toBe(true);
+  });
+
+  it('still trips the bound when the throttle explained NOTHING', async () => {
+    // Identical to the case above except the signal carries no retryAfterMs, so
+    // there is no communicated window to forgive. Unexplained silence must fail
+    // on schedule — this is the half that keeps the fix from disabling the
+    // watchdog.
+    const queue = new ThrottleQueue();
+    let release!: (stream: AsyncIterable<RawMessageStreamEvent>) => void;
+    let calls = 0;
+    const client: AnthropicClientLike = {
+      messages: {
+        create: vi.fn((_params: unknown, opts: unknown) => {
+          calls++;
+          // First attempt parks until the bound aborts it; the re-drive streams.
+          return calls === 1
+            ? parked((opts as { signal: AbortSignal }).signal, (r) => (release = r))
+            : fromArray(makeTextStream('recovered'));
+        }),
+      },
+    };
+
+    const resultPromise = turn(queue, client);
+    await vi.advanceTimersByTimeAsync(0);
+    queue.push({ status: 429 });
+    await vi.advanceTimersByTimeAsync(0);
+
+    await vi.advanceTimersByTimeAsync(DEFAULT_MODEL_TTFB_TIMEOUT_MS + 1_000);
+    const events = await resultPromise;
+
+    expect(calls).toBe(2); // aborted at the bound, then re-driven once
+    expect(events.filter((e) => e.type === 'stream.retry')).toHaveLength(1);
+    expect(events.some((e) => e.type === 'assistant.message' && e.text === 'recovered')).toBe(
+      true,
+    );
+    // `release` is intentionally unused: the abort, not a resolution, ends
+    // attempt one. Referenced so noUnusedLocals stays satisfied.
+    expect(typeof release).toBe('function');
+  });
+});

--- a/src/agent/providers/anthropic-direct/loop/round-request.ts
+++ b/src/agent/providers/anthropic-direct/loop/round-request.ts
@@ -24,7 +24,11 @@ import type {
 import { getCacheTtl, isCacheEnabled, withMessagesBreakpoint } from '../cache-policy.js';
 import { emitSessionPhase } from '../../../trace/emit.js';
 import { sleepWithAbort } from '../../shared/sleep-with-abort.js';
-import { armFirstByteTimeout, type FirstByteTimeoutHandle } from '../../shared/first-byte-timeout.js';
+import {
+  armFirstByteTimeout,
+  throttleExtensionMs,
+  type FirstByteTimeoutHandle,
+} from '../../shared/first-byte-timeout.js';
 import { armStreamStallWatchdog, type StreamStallHandle } from '../../shared/stream-stall-timeout.js';
 import { jitterBackoff } from '../overload-pause.js';
 import {
@@ -221,6 +225,21 @@ export async function* openRound({
         input.signal,
       ),
       input,
+      // Invariant: the TTFB bound is armed ABOVE this call, so its window spans
+      // connect + every 429/503/529 backoff the SDK sleeps out INSIDE
+      // messages.create + prefill — not prefill alone. Under sustained
+      // throttling the backoff alone can consume most of the default 180s
+      // (throttle-signals.ts documents ~140s for two retries), so the bound
+      // fires on a request that was never given a chance to stream and the
+      // failure is reported as a first-byte stall. Forgive only EXPLAINED
+      // waiting: extend by the provider's own retry-after (plus slack), and
+      // leave the bound untouched when no window was communicated, so
+      // unexplained silence still trips on schedule. Same policy the forked
+      // subagent idle watchdog applies via pause-window.ts.
+      (retryAfterMs) => {
+        const extension = throttleExtensionMs(retryAfterMs);
+        if (extension !== undefined) ttfb.extend(extension);
+      },
     );
     return { kind: 'opened', events, ttfb, stall, requestStartedAt };
   } catch (err) {

--- a/src/agent/providers/anthropic-direct/loop/throttle-signals.test.ts
+++ b/src/agent/providers/anthropic-direct/loop/throttle-signals.test.ts
@@ -1,0 +1,156 @@
+// Tests for the onThrottle seam that lets a caller forgive a provider-
+// communicated park against a deadline it owns. The last describe block is the
+// real regression guard: it reproduces the TTFB false positive end-to-end.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { awaitCreateWithThrottleSignals } from './throttle-signals.js';
+import { ThrottleQueue } from '../throttle-queue.js';
+import type { RunTurnInput } from '../types.js';
+import {
+  armFirstByteTimeout,
+  throttleExtensionMs,
+} from '../../shared/first-byte-timeout.js';
+
+/** Minimal RunTurnInput: this generator only reads throttleQueue + ctx.sessionId. */
+function inputWith(queue?: ThrottleQueue): RunTurnInput {
+  return {
+    ctx: { sessionId: 'sess-1' },
+    ...(queue ? { throttleQueue: queue } : {}),
+  } as unknown as RunTurnInput;
+}
+
+/** Drain a generator to completion, returning the yielded events + return value. */
+async function drain<T, R>(
+  gen: AsyncGenerator<T, R, void>,
+): Promise<{ events: T[]; result: R }> {
+  const events: T[] = [];
+  for (;;) {
+    const step = await gen.next();
+    if (step.done) return { events, result: step.value };
+    events.push(step.value);
+  }
+}
+
+const STREAM = (async function* () {})();
+
+describe('awaitCreateWithThrottleSignals — onThrottle seam', () => {
+  it('reports each drained signal\'s retryAfterMs', async () => {
+    const queue = new ThrottleQueue();
+    queue.push({ status: 429, retryAfterMs: 60_000 });
+    queue.push({ status: 529, retryAfterMs: 20_000 });
+    const seen: (number | undefined)[] = [];
+
+    await drain(
+      awaitCreateWithThrottleSignals(Promise.resolve(STREAM), inputWith(queue), (ms) =>
+        seen.push(ms),
+      ),
+    );
+
+    expect(seen).toEqual([60_000, 20_000]);
+  });
+
+  it('reports undefined when the provider sent no retry-after', async () => {
+    // The caller must decide what to do with an unknowable window — this seam
+    // does not invent one.
+    const queue = new ThrottleQueue();
+    queue.push({ status: 429 });
+    const seen: (number | undefined)[] = [];
+
+    await drain(
+      awaitCreateWithThrottleSignals(Promise.resolve(STREAM), inputWith(queue), (ms) =>
+        seen.push(ms),
+      ),
+    );
+
+    expect(seen).toEqual([undefined]);
+  });
+
+  it('notifies BEFORE yielding the matching rate_limit event', async () => {
+    // Ordering is load-bearing: the yield parks this generator until the consumer
+    // resumes, while the deadline being extended races in real time. Notifying
+    // after the yield would let the bound fire during the park it must forgive.
+    const queue = new ThrottleQueue();
+    queue.push({ status: 429, retryAfterMs: 1_000 });
+    const log: string[] = [];
+
+    const gen = awaitCreateWithThrottleSignals(
+      Promise.resolve(STREAM),
+      inputWith(queue),
+      () => log.push('notify'),
+    );
+    const first = await gen.next();
+    log.push(`yield:${(first.value as { type: string }).type}`);
+    await drain(gen);
+
+    expect(log).toEqual(['notify', 'yield:rate_limit']);
+  });
+
+  it('still returns the resolved stream, and is a no-op without a queue', async () => {
+    const onThrottle = vi.fn();
+    const { events, result } = await drain(
+      awaitCreateWithThrottleSignals(Promise.resolve(STREAM), inputWith(), onThrottle),
+    );
+    expect(result).toBe(STREAM);
+    expect(events).toEqual([]);
+    expect(onThrottle).not.toHaveBeenCalled();
+  });
+
+  it('propagates a create rejection unchanged', async () => {
+    const queue = new ThrottleQueue();
+    queue.push({ status: 429, retryAfterMs: 1_000 });
+    const boom = new Error('create failed');
+    await expect(
+      drain(
+        awaitCreateWithThrottleSignals(Promise.reject(boom), inputWith(queue), () => {}),
+      ),
+    ).rejects.toBe(boom);
+  });
+});
+
+describe('regression: a throttle park no longer trips the TTFB bound', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it('does not report a first-byte stall for time the provider told us to wait', async () => {
+    // The bug: armFirstByteTimeout is armed BEFORE messages.create, so its 180s
+    // window covers every 429 backoff the SDK sleeps out INSIDE that call. Two
+    // retries at ~70s each consumed ~140s of the budget, leaving prefill ~40s,
+    // and the resulting abort was reported as a first-byte stall on a request
+    // that had never been given a chance to stream.
+    vi.useFakeTimers();
+    const queue = new ThrottleQueue();
+    const ttfb = armFirstByteTimeout(new AbortController().signal, 180_000);
+
+    let release!: () => void;
+    const create = new Promise<AsyncIterable<unknown>>((resolve) => {
+      release = () => resolve(STREAM);
+    });
+
+    const gen = awaitCreateWithThrottleSignals(create, inputWith(queue), (ms) => {
+      const extension = throttleExtensionMs(ms);
+      if (extension !== undefined) ttfb.extend(extension);
+    });
+    const pump = drain(gen);
+
+    // Two SDK-internal 429 retries, 70s of parking each.
+    for (let i = 0; i < 2; i++) {
+      queue.push({ status: 429, retryAfterMs: 70_000 });
+      await vi.advanceTimersByTimeAsync(70_000);
+    }
+    // 140s of the original 180s budget is gone, and prefill has not started.
+    expect(ttfb.timedOut()).toBe(false);
+
+    // Prefill now takes a further 100s — which would have blown the un-extended
+    // bound at 180s. With the park forgiven it must survive.
+    await vi.advanceTimersByTimeAsync(100_000);
+    expect(ttfb.timedOut()).toBe(false);
+    expect(ttfb.signal.aborted).toBe(false);
+
+    release();
+    await pump;
+
+    // The bound is still a bound: unexplained silence past the granted window
+    // fires exactly as before.
+    await vi.advanceTimersByTimeAsync(200_000);
+    expect(ttfb.timedOut()).toBe(true);
+  });
+});

--- a/src/agent/providers/anthropic-direct/loop/throttle-signals.test.ts
+++ b/src/agent/providers/anthropic-direct/loop/throttle-signals.test.ts
@@ -113,9 +113,14 @@ describe('regression: a throttle park no longer trips the TTFB bound', () => {
   it('does not report a first-byte stall for time the provider told us to wait', async () => {
     // The bug: armFirstByteTimeout is armed BEFORE messages.create, so its 180s
     // window covers every 429 backoff the SDK sleeps out INSIDE that call. Two
-    // retries at ~70s each consumed ~140s of the budget, leaving prefill ~40s,
+    // retries at ~55s each consumed ~110s of the budget, leaving prefill ~70s,
     // and the resulting abort was reported as a first-byte stall on a request
     // that had never been given a chance to stream.
+    //
+    // 55s is deliberately just under SDK_HONORED_RETRY_AFTER_CEILING_MS: the SDK
+    // only sleeps out a retry-after while it is < 60s, so this is a park that
+    // genuinely happens. A larger hint would be discarded upstream and clamped
+    // here, which is covered by throttleExtensionMs' own tests.
     vi.useFakeTimers();
     const queue = new ThrottleQueue();
     const ttfb = armFirstByteTimeout(new AbortController().signal, 180_000);
@@ -131,16 +136,16 @@ describe('regression: a throttle park no longer trips the TTFB bound', () => {
     });
     const pump = drain(gen);
 
-    // Two SDK-internal 429 retries, 70s of parking each.
+    // Two SDK-internal 429 retries, 55s of parking each.
     for (let i = 0; i < 2; i++) {
-      queue.push({ status: 429, retryAfterMs: 70_000 });
-      await vi.advanceTimersByTimeAsync(70_000);
+      queue.push({ status: 429, retryAfterMs: 55_000 });
+      await vi.advanceTimersByTimeAsync(55_000);
     }
-    // 140s of the original 180s budget is gone, and prefill has not started.
+    // 110s of the original 180s budget is gone, and prefill has not started.
     expect(ttfb.timedOut()).toBe(false);
 
-    // Prefill now takes a further 100s — which would have blown the un-extended
-    // bound at 180s. With the park forgiven it must survive.
+    // Prefill now takes a further 100s — 210s total, which would have blown the
+    // un-extended bound at 180s. With the park forgiven it must survive.
     await vi.advanceTimersByTimeAsync(100_000);
     expect(ttfb.timedOut()).toBe(false);
     expect(ttfb.signal.aborted).toBe(false);

--- a/src/agent/providers/anthropic-direct/loop/throttle-signals.ts
+++ b/src/agent/providers/anthropic-direct/loop/throttle-signals.ts
@@ -29,10 +29,17 @@ import type { RunTurnInput } from '../types.js';
  *
  * When `throttleQueue` is absent this degrades to a bare `await` (one extra
  * microtask), so non-throttling paths and unit tests are unaffected.
+ *
+ * `onThrottle` fires once per drained signal, immediately BEFORE the matching
+ * `rate_limit` yield, carrying that signal's `retryAfterMs`. It exists so the
+ * caller can forgive the park against a deadline it owns — the TTFB bound is
+ * armed before this await and would otherwise be consumed by the SDK's own
+ * backoff (the "~70s, retried twice ≈ 140s" case above, against a 180s default).
  */
 export async function* awaitCreateWithThrottleSignals(
   createPromise: Promise<AsyncIterable<unknown>>,
   input: RunTurnInput,
+  onThrottle?: (retryAfterMs: number | undefined) => void,
 ): AsyncGenerator<ProviderEvent, AsyncIterable<unknown>, void> {
   const queue = input.throttleQueue;
   if (!queue) {
@@ -57,6 +64,12 @@ export async function* awaitCreateWithThrottleSignals(
   for (;;) {
     // Drain and surface anything already queued before parking again.
     for (const sig of queue.takeAll()) {
+      // Invariant: notify BEFORE yielding. The yield parks this generator until
+      // the consumer resumes it, and the TTFB deadline this callback extends is
+      // racing in real time — deferring the extension until after the consumer
+      // comes back would let the bound fire during the very park it is meant to
+      // forgive. Synchronous by contract for the same reason.
+      onThrottle?.(sig.retryAfterMs);
       yield {
         type: 'rate_limit',
         sessionId: input.ctx.sessionId,

--- a/src/agent/providers/anthropic-direct/stream-completeness.test.ts
+++ b/src/agent/providers/anthropic-direct/stream-completeness.test.ts
@@ -1,0 +1,62 @@
+// Unit tests for the end-of-stream completeness check extracted from
+// translate.ts. The anti-regression test here is the LAST one: the error text
+// must not assert a cause it cannot know (see the module docblock).
+
+import { describe, it, expect } from 'vitest';
+import { incompleteStreamError, isStreamComplete } from './stream-completeness.js';
+import { StreamIncompleteError } from '../../../utils/errors.js';
+
+describe('isStreamComplete', () => {
+  it('is complete when message_stop arrived', () => {
+    expect(isStreamComplete(true, null)).toBe(true);
+  });
+
+  it('is complete when a real stop_reason arrived even without message_stop', () => {
+    // The model DID say why it stopped; only the framing event was lost. Treating
+    // this as a cut would fail a turn that actually finished.
+    expect(isStreamComplete(false, 'end_turn')).toBe(true);
+    expect(isStreamComplete(false, 'tool_use')).toBe(true);
+    expect(isStreamComplete(false, 'max_tokens')).toBe(true);
+  });
+
+  it('is INCOMPLETE only when neither terminal signal arrived', () => {
+    expect(isStreamComplete(false, null)).toBe(false);
+  });
+});
+
+describe('incompleteStreamError', () => {
+  it('is a StreamIncompleteError so subagent consumers route it to status:failed', () => {
+    const err = incompleteStreamError();
+    expect(err).toBeInstanceOf(StreamIncompleteError);
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it('states the observable facts: no message_stop, no stop_reason, turn incomplete', () => {
+    const msg = incompleteStreamError().message;
+    expect(msg).toContain('message_stop');
+    expect(msg).toContain('stop_reason');
+    expect(msg).toContain('incomplete');
+  });
+
+  it('points the reader at the trace phases that DO identify the cause', () => {
+    const msg = incompleteStreamError().message;
+    expect(msg).toContain('ttfb_timeout');
+    expect(msg).toContain('idle_watchdog_fired');
+    expect(msg).toContain('rate_limit');
+  });
+
+  it('does NOT assert an intermediary/proxy cause — the layer cannot know it', () => {
+    // Regression guard. The old text claimed the cut was "typically an
+    // intermediary closing the connection". That guess was wrong often enough to
+    // misdirect two investigations into the network layer, when the SDK ends
+    // iteration identically for its own bare-abort request timeout. Do not
+    // reintroduce a cause claim here.
+    const msg = incompleteStreamError().message.toLowerCase();
+    expect(msg).not.toContain('intermediary');
+    expect(msg).not.toContain('proxy');
+    expect(msg).not.toContain('gateway');
+    expect(msg).not.toContain('load balancer');
+    expect(msg).not.toContain('typically');
+    expect(msg).toContain('not knowable');
+  });
+});

--- a/src/agent/providers/anthropic-direct/stream-completeness.ts
+++ b/src/agent/providers/anthropic-direct/stream-completeness.ts
@@ -1,0 +1,70 @@
+/**
+ * End-of-stream completeness check for one anthropic-direct model call.
+ *
+ * Answers exactly one question — "did this SSE stream terminate properly, and
+ * what do we report if it did not?" — extracted from `translate.ts` so that
+ * module stays under the 350-LOC ceiling and so the reasoning below lives next
+ * to the predicate it governs rather than inline in the translation loop.
+ *
+ * History: the error this module builds used to assert its own cause —
+ * "typically an intermediary closing the connection". That was a guess, it was
+ * wrong often enough to matter, and it misdirected two separate investigations
+ * into the provider/gateway layer before anyone executed the abort path. It is
+ * now stated as an unknown, with a pointer to the trace phases that DO identify
+ * the cause. Do not re-add a cause claim here; this layer cannot know one.
+ *
+ * @module agent/providers/anthropic-direct/stream-completeness
+ */
+
+import { StreamIncompleteError } from '../../../utils/errors.js';
+
+/**
+ * Contract: did the stream deliver a terminal signal?
+ *
+ * Complete when EITHER a `message_stop` event arrived (`stopped`) OR a
+ * `message_delta` carried a real `stop_reason`. The `stopReason !== null` half
+ * matters on its own: a stream that lost only the framing `message_stop` still
+ * had the model state why it stopped, so it is complete — treating it as a cut
+ * would fail a turn that actually finished.
+ */
+export function isStreamComplete(stopped: boolean, stopReason: string | null): boolean {
+  return stopped || stopReason !== null;
+}
+
+/**
+ * Invariant: the error for a stream that ended with no terminal signal.
+ *
+ * Reported rather than swallowed because yielding a turn-result from an
+ * incomplete stream would present the partial as a clean, complete answer —
+ * silent truncation. Surfacing it keeps the incomplete turn legible to BOTH the
+ * top-level session and the forked-subagent consumer, which routes
+ * `StreamIncompleteError` through its `status:'failed'` handling. This is the
+ * #628 / #635 "fail loudly, don't silently succeed" contract; keep it.
+ *
+ * The message names no cause on purpose. The Anthropic SDK returns from its
+ * stream iterator *silently* for any abort whose reason is an AbortError —
+ * `node_modules/@anthropic-ai/sdk/core/streaming.js`: `if (isAbortError(e))
+ * return;` — which covers the SDK's OWN default 10-minute request timeout
+ * (`client.js`: `options.timeout ?? DEFAULT_TIMEOUT`), fired as a bare
+ * `controller.abort()`. A genuine peer close produces a byte-identical clean
+ * end. The two are indistinguishable from inside the translator.
+ *
+ * Note the asymmetry that makes this worth spelling out: agent-afk's own
+ * watchdogs abort with CUSTOM Error reasons (`TTFB_TIMEOUT_MESSAGE`,
+ * `STALL_TIMEOUT_MESSAGE`, `IdleWatchdogError`), whose `name` is not
+ * `'AbortError'`, so `isAbortError` rejects them and they THROW instead —
+ * reaching the translator's catch and being classified correctly. They are
+ * therefore NOT what produces this error, and adding a watchdog check here
+ * would be dead code. Only consumers holding the abort context
+ * (`loop/stream-consumer.ts`) can attribute a cause.
+ */
+export function incompleteStreamError(): StreamIncompleteError {
+  return new StreamIncompleteError(
+    'the model stream ended without a terminal message (no message_stop and ' +
+      'no stop_reason): the turn is incomplete. The cause is not knowable at ' +
+      'this layer — a client-side abort carrying an AbortError reason ' +
+      '(including the SDK request timeout) and an upstream peer close are ' +
+      'indistinguishable here. Check the trace for a preceding ttfb_timeout, ' +
+      'idle_watchdog_fired, or rate_limit phase before suspecting the network.',
+  );
+}

--- a/src/agent/providers/anthropic-direct/translate.ts
+++ b/src/agent/providers/anthropic-direct/translate.ts
@@ -21,7 +21,7 @@ import type {
 } from '@anthropic-ai/sdk/resources';
 import type { TranslateCtx, TranslateOutput, TurnResult } from './types.js';
 import { env } from '../../../config/env.js';
-import { StreamIncompleteError } from '../../../utils/errors.js';
+import { incompleteStreamError, isStreamComplete } from './stream-completeness.js';
 
 /**
  * Per-block accumulator. The block kind dictates which fields are populated
@@ -327,31 +327,11 @@ export async function* translateMessageStream(
     return;
   }
 
-  // Invariant: a stream that ends with NO terminal signal — neither a
-  // `message_stop` event (`stopped`) NOR a `stop_reason` from `message_delta`
-  // (`stopReason`) — was cut off mid-response (typically an intermediary such as
-  // a proxy/gateway/LB gracefully closing the connection before completion; the
-  // raw SDK Stream ends cleanly without throwing, so the catch above never
-  // fires). Yielding a turn-result here would present the partial as a clean,
-  // complete answer: silent truncation. Surface an error instead so the
-  // incomplete turn is legible to BOTH the top-level session and the subagent
-  // consumer (which routes it through its StreamIncompleteError → status:'failed'
-  // handling), mirroring the #628 "fail loudly, don't silently succeed" fix.
-  // Guard is `stopReason === null` (not merely `!stopped`) so a stream that
-  // delivered a real stop_reason but lost only the framing `message_stop` — the
-  // model DID signal why it stopped — is still treated as complete.
-  if (!stopped && stopReason === null) {
-    yield {
-      kind: 'event',
-      event: {
-        type: 'error',
-        error: new StreamIncompleteError(
-          'the model stream ended without a terminal message (no message_stop ' +
-            'and no stop_reason): the response was cut off mid-stream, typically ' +
-            'an intermediary closing the connection. The turn is incomplete.',
-        ),
-      },
-    };
+  // Incomplete stream (no message_stop AND no stop_reason): report, never
+  // silently yield the partial as a finished turn. Predicate, rationale, and
+  // the deliberate absence of a cause claim all live in stream-completeness.ts.
+  if (!isStreamComplete(stopped, stopReason)) {
+    yield { kind: 'event', event: { type: 'error', error: incompleteStreamError() } };
     return;
   }
 

--- a/src/agent/providers/shared/first-byte-timeout.test.ts
+++ b/src/agent/providers/shared/first-byte-timeout.test.ts
@@ -157,14 +157,20 @@ describe('throttleExtensionMs', () => {
   });
 
   it('bounds total grace: a throttle can defer the watchdog, never disable it', () => {
-    // Worst honoured case per throttle, and the whole-round ceiling given the
-    // SDK's default maxRetries: 2 (client.js:72). If this ever stops holding, an
-    // endpoint could park a dead request indefinitely.
+    // Worst honoured case per throttle. If this ever stops holding, an endpoint
+    // could park a dead request indefinitely.
     const worstPerThrottle = SDK_HONORED_RETRY_AFTER_CEILING_MS - 1 + TTFB_THROTTLE_SLACK_MS;
     for (const ms of [1, 59_999, 60_000, 3_600_000, Number.MAX_SAFE_INTEGER]) {
       expect(throttleExtensionMs(ms)!).toBeLessThanOrEqual(worstPerThrottle);
     }
-    expect(worstPerThrottle * 2).toBeLessThan(200_000);
+    // Whole-round ceiling. The bound is armed once per ROUND, not per attempt,
+    // and TWO retry layers nest inside that one window: the SDK's 1+maxRetries(2)
+    // = 3 HTTP attempts per messages.create, times the up-to-4 create calls
+    // anthropic-direct's own createWithRetry makes for a transient 529/503
+    // (OVERLOAD_MAX_RETRIES = 3). Not imported — shared/ must not depend on a
+    // provider — so this mirrors the count the docblock derives.
+    const MAX_GRANTS_PER_ROUND = 3 * 4;
+    expect(worstPerThrottle * MAX_GRANTS_PER_ROUND).toBeLessThan(20 * 60_000);
   });
 });
 

--- a/src/agent/providers/shared/first-byte-timeout.test.ts
+++ b/src/agent/providers/shared/first-byte-timeout.test.ts
@@ -3,6 +3,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   DEFAULT_MODEL_TTFB_TIMEOUT_MS,
+  SDK_HONORED_RETRY_AFTER_CEILING_MS,
+  SDK_MAX_DEFAULT_BACKOFF_MS,
   TTFB_THROTTLE_SLACK_MS,
   TTFB_TIMEOUT_MESSAGE,
   armFirstByteTimeout,
@@ -129,8 +131,10 @@ describe('armFirstByteTimeout', () => {
 });
 
 describe('throttleExtensionMs', () => {
-  it('adds the slack to a usable retry-after window', () => {
-    expect(throttleExtensionMs(60_000)).toBe(60_000 + TTFB_THROTTLE_SLACK_MS);
+  it('adds the slack to a retry-after the SDK will actually honour', () => {
+    expect(throttleExtensionMs(30_000)).toBe(30_000 + TTFB_THROTTLE_SLACK_MS);
+    // Just under the honoured ceiling: still taken at face value.
+    expect(throttleExtensionMs(59_999)).toBe(59_999 + TTFB_THROTTLE_SLACK_MS);
   });
 
   it('returns undefined when the provider gave no usable window', () => {
@@ -139,6 +143,28 @@ describe('throttleExtensionMs', () => {
     for (const bad of [undefined, 0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
       expect(throttleExtensionMs(bad as number | undefined)).toBeUndefined();
     }
+  });
+
+  it('clamps a hint the SDK DISCARDS to the SDK\'s own backoff ceiling', () => {
+    // client.js:412 honours retry-after only while `< 60 * 1000`; at or above it
+    // the hint is thrown away and calculateDefaultRetryTimeoutMillis caps the
+    // wait at 8s. Granting the raw header would buy an hour of grace for an ~8s
+    // park — reinstating the unbounded hang #583/#762 exist to prevent.
+    const clamped = SDK_MAX_DEFAULT_BACKOFF_MS + TTFB_THROTTLE_SLACK_MS;
+    expect(throttleExtensionMs(SDK_HONORED_RETRY_AFTER_CEILING_MS)).toBe(clamped);
+    expect(throttleExtensionMs(120_000)).toBe(clamped);
+    expect(throttleExtensionMs(3_600_000)).toBe(clamped); // the one-hour header
+  });
+
+  it('bounds total grace: a throttle can defer the watchdog, never disable it', () => {
+    // Worst honoured case per throttle, and the whole-round ceiling given the
+    // SDK's default maxRetries: 2 (client.js:72). If this ever stops holding, an
+    // endpoint could park a dead request indefinitely.
+    const worstPerThrottle = SDK_HONORED_RETRY_AFTER_CEILING_MS - 1 + TTFB_THROTTLE_SLACK_MS;
+    for (const ms of [1, 59_999, 60_000, 3_600_000, Number.MAX_SAFE_INTEGER]) {
+      expect(throttleExtensionMs(ms)!).toBeLessThanOrEqual(worstPerThrottle);
+    }
+    expect(worstPerThrottle * 2).toBeLessThan(200_000);
   });
 });
 

--- a/src/agent/providers/shared/first-byte-timeout.test.ts
+++ b/src/agent/providers/shared/first-byte-timeout.test.ts
@@ -3,10 +3,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   DEFAULT_MODEL_TTFB_TIMEOUT_MS,
+  TTFB_THROTTLE_SLACK_MS,
   TTFB_TIMEOUT_MESSAGE,
   armFirstByteTimeout,
   isTtfbTimeoutError,
   resolveTtfbTimeoutMs,
+  throttleExtensionMs,
 } from './first-byte-timeout.js';
 import { MAX_TIMER_DELAY_MS } from './timer-limits.js';
 
@@ -123,5 +125,111 @@ describe('armFirstByteTimeout', () => {
     vi.advanceTimersByTime(1_000_000);
     expect(h.timedOut()).toBe(false);
     expect(h.signal.aborted).toBe(false);
+  });
+});
+
+describe('throttleExtensionMs', () => {
+  it('adds the slack to a usable retry-after window', () => {
+    expect(throttleExtensionMs(60_000)).toBe(60_000 + TTFB_THROTTLE_SLACK_MS);
+  });
+
+  it('returns undefined when the provider gave no usable window', () => {
+    // Mirrors pauseWindowMs: no communicated window → caller keeps its normal
+    // bound rather than extending by a guess.
+    for (const bad of [undefined, 0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(throttleExtensionMs(bad as number | undefined)).toBeUndefined();
+    }
+  });
+});
+
+describe('armFirstByteTimeout — throttle extension (TTFB false-positive fix)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('forgives an explained park: the bound does not fire at its original deadline', () => {
+    const base = new AbortController();
+    const h = armFirstByteTimeout(base.signal, 180_000);
+    // 100s in, the provider says "retry after 60s" — the park is explained.
+    vi.advanceTimersByTime(100_000);
+    h.extend(60_000);
+    // Original 180s deadline passes; the request must NOT be declared a stall.
+    vi.advanceTimersByTime(80_000);
+    expect(h.timedOut()).toBe(false);
+    expect(h.signal.aborted).toBe(false);
+    // But the bound is still a bound: it fires once the granted window is spent.
+    vi.advanceTimersByTime(60_001);
+    expect(h.timedOut()).toBe(true);
+  });
+
+  it('adds to the ORIGINAL budget rather than restarting a full window', () => {
+    // Two 20s extensions must cost 20s+20s of grace, not two fresh 180s bounds —
+    // otherwise a throttling endpoint could keep a dead request alive forever.
+    const base = new AbortController();
+    const h = armFirstByteTimeout(base.signal, 180_000);
+    h.extend(20_000);
+    h.extend(20_000);
+    vi.advanceTimersByTime(219_999);
+    expect(h.timedOut()).toBe(false);
+    vi.advanceTimersByTime(2);
+    expect(h.timedOut()).toBe(true);
+  });
+
+  it('still fires on schedule when the park is UNEXPLAINED (no extension)', () => {
+    const base = new AbortController();
+    const h = armFirstByteTimeout(base.signal, 180_000);
+    // A throttle with no retry-after yields undefined upstream, so extend is
+    // never called — silence must still trip the bound.
+    vi.advanceTimersByTime(180_000);
+    expect(h.timedOut()).toBe(true);
+  });
+
+  it('cannot resurrect a spent timer (no-op after it has fired)', () => {
+    const base = new AbortController();
+    const h = armFirstByteTimeout(base.signal, 180_000);
+    vi.advanceTimersByTime(180_000);
+    expect(h.timedOut()).toBe(true);
+    h.extend(600_000);
+    // Already aborted; the extension must not un-abort or re-arm anything.
+    expect(h.timedOut()).toBe(true);
+    expect(h.signal.aborted).toBe(true);
+  });
+
+  it('is a no-op after dispose(), and after firstByteSeen()', () => {
+    const disposed = armFirstByteTimeout(new AbortController().signal, 180_000);
+    disposed.dispose();
+    disposed.extend(60_000);
+    vi.advanceTimersByTime(10_000_000);
+    expect(disposed.timedOut()).toBe(false);
+
+    const streaming = armFirstByteTimeout(new AbortController().signal, 180_000);
+    streaming.firstByteSeen();
+    streaming.extend(60_000);
+    vi.advanceTimersByTime(10_000_000);
+    expect(streaming.timedOut()).toBe(false);
+  });
+
+  it('is a no-op when the bound is disabled, and ignores unusable deltas', () => {
+    const off = armFirstByteTimeout(new AbortController().signal, 0);
+    off.extend(60_000);
+    vi.advanceTimersByTime(10_000_000);
+    expect(off.timedOut()).toBe(false);
+
+    const h = armFirstByteTimeout(new AbortController().signal, 180_000);
+    for (const bad of [0, -5_000, Number.NaN, Number.POSITIVE_INFINITY]) h.extend(bad);
+    vi.advanceTimersByTime(180_000);
+    expect(h.timedOut()).toBe(true); // deadline unmoved
+  });
+
+  it('re-arms on the remaining window, shifting the deadline by exactly the delta', () => {
+    // Boundary check on the re-arm arithmetic: extending mid-flight must move the
+    // deadline by the delta and no more — the new timer is scheduled for
+    // (deadline - now), not for a fresh full window.
+    const h = armFirstByteTimeout(new AbortController().signal, 10_000);
+    vi.advanceTimersByTime(9_000);
+    h.extend(1_000); // deadline: 10_000 -> 11_000
+    vi.advanceTimersByTime(1_999); // now 10_999
+    expect(h.timedOut()).toBe(false);
+    vi.advanceTimersByTime(1); // now 11_000
+    expect(h.timedOut()).toBe(true);
   });
 });

--- a/src/agent/providers/shared/first-byte-timeout.ts
+++ b/src/agent/providers/shared/first-byte-timeout.ts
@@ -55,6 +55,34 @@ export function resolveTtfbTimeoutMs(): number {
 /** Marker error thrown/attached when a request is aborted for a TTFB stall. */
 export const TTFB_TIMEOUT_MESSAGE = 'model_ttfb_timeout';
 
+/**
+ * Slack added to a provider-communicated throttle window before the TTFB
+ * deadline is pushed out. Guards against the deadline firing the instant the
+ * provider says it will resume — the resumed request still needs a moment to
+ * reach its first token. 30s, deliberately the same value as
+ * `PAUSE_WINDOW_SLACK_MS` in `subagent/pause-window.ts`, which solves the
+ * identical problem for the forked-subagent idle watchdog. Not imported from
+ * there: `providers/` must not depend on `subagent/`.
+ */
+export const TTFB_THROTTLE_SLACK_MS = 30_000;
+
+/**
+ * Contract: the TTFB extension owed for one provider-communicated throttle, or
+ * `undefined` when the provider gave no usable window.
+ *
+ * Mirrors `pauseWindowMs` semantics on purpose: a throttle WITHOUT a knowable
+ * `retry-after` yields `undefined` and the caller keeps its normal bound rather
+ * than extending by a guessed amount. The finiteness guard matters because a
+ * non-finite delay would re-arm a bogus timer (Node clamps it to 1ms with a
+ * TimeoutOverflowWarning), turning an extension into an immediate abort.
+ */
+export function throttleExtensionMs(retryAfterMs: number | undefined): number | undefined {
+  if (typeof retryAfterMs !== 'number' || !Number.isFinite(retryAfterMs) || retryAfterMs <= 0) {
+    return undefined;
+  }
+  return retryAfterMs + TTFB_THROTTLE_SLACK_MS;
+}
+
 /** Distinguish a TTFB-timeout abort from any other error (e.g. user interrupt). */
 export function isTtfbTimeoutError(err: unknown): boolean {
   return err instanceof Error && err.message === TTFB_TIMEOUT_MESSAGE;
@@ -68,6 +96,16 @@ export interface FirstByteTimeoutHandle {
   timedOut(): boolean;
   /** Call on the first streamed event: cancels the timer so the stream is unbounded thereafter. */
   firstByteSeen(): void;
+  /**
+   * Push the deadline out by `ms` because the provider told us it is parked.
+   *
+   * Only EXPLAINED waiting is forgiven: the caller passes a window derived from
+   * a provider-communicated `retry-after` (see {@link throttleExtensionMs}), so
+   * unexplained prefill silence still trips the bound on schedule. No-op once
+   * the timer has fired, been disposed, or when the bound is disabled — so a
+   * late-draining throttle signal can never resurrect a spent timer.
+   */
+  extend(ms: number): void;
   /** Release the timer + listeners. Idempotent; safe to call in a `finally`. */
   dispose(): void;
 }
@@ -92,6 +130,7 @@ export function armFirstByteTimeout(
       signal: baseSignal,
       timedOut: () => false,
       firstByteSeen: () => {},
+      extend: () => {},
       dispose: () => {},
     };
   }
@@ -100,12 +139,20 @@ export function armFirstByteTimeout(
   const linked = AbortSignal.any([baseSignal, controller.signal]);
   let didTimeout = false;
   let disposed = false;
+  // Absolute deadline, tracked separately from the live timer so `extend` adds
+  // to the ORIGINAL budget rather than restarting a full window from now — two
+  // throttles totalling 40s must cost 40s of grace, not two fresh bounds.
+  let deadline = Date.now() + timeoutMs;
+  let timer: ReturnType<typeof setTimeout>;
 
-  const timer = setTimeout(() => {
-    didTimeout = true;
-    controller.abort(new Error(TTFB_TIMEOUT_MESSAGE));
-  }, timeoutMs);
-  timer.unref();
+  const arm = (delayMs: number): void => {
+    timer = setTimeout(() => {
+      didTimeout = true;
+      controller.abort(new Error(TTFB_TIMEOUT_MESSAGE));
+    }, clampTimerDelayMs(delayMs));
+    timer.unref();
+  };
+  arm(timeoutMs);
 
   const dispose = (): void => {
     if (disposed) return;
@@ -113,10 +160,22 @@ export function armFirstByteTimeout(
     clearTimeout(timer);
   };
 
+  const extend = (ms: number): void => {
+    if (disposed || didTimeout) return;
+    if (typeof ms !== 'number' || !Number.isFinite(ms) || ms <= 0) return;
+    deadline += ms;
+    clearTimeout(timer);
+    // Floor at 1ms: a deadline already in the past (a throttle drained after a
+    // long park) must still re-arm rather than pass a negative delay, which
+    // Node coerces to 1 anyway — being explicit keeps the intent readable.
+    arm(Math.max(1, deadline - Date.now()));
+  };
+
   return {
     signal: linked,
     timedOut: () => didTimeout,
     firstByteSeen: dispose,
+    extend,
     dispose,
   };
 }

--- a/src/agent/providers/shared/first-byte-timeout.ts
+++ b/src/agent/providers/shared/first-byte-timeout.ts
@@ -106,10 +106,19 @@ export const SDK_MAX_DEFAULT_BACKOFF_MS = 8_000;
  * the raw header. Granting the raw value would let a `retry-after: 3600` hint
  * buy an hour of TTFB grace for a park the SDK caps at ~8s — reinstating the
  * unbounded post-connect hang that #583/#762 exist to prevent. Because the
- * honored window is bounded, so is the grace: at most
- * `60s + 30s = 90s` per throttle, and with the SDK's default `maxRetries: 2`
- * (`client.js:72`) at most ~180s per round. The watchdog can be deferred, never
- * disabled.
+ * honored window is bounded, so is every grant: at most `60s + 30s = 90s` per
+ * throttle.
+ *
+ * Invariant: the per-ROUND ceiling is the product of TWO nested retry layers,
+ * because the bound is armed once per round (`loop/round-request.ts`) and NOT
+ * per attempt. The SDK makes `1 + maxRetries(2) = 3` HTTP attempts per
+ * `messages.create` (`client.js:72`), and `createWithRetry` re-drives a
+ * transient 529/503 up to `OVERLOAD_MAX_RETRIES(3)` more times against the
+ * SAME handle — so up to 12 throttled responses, i.e. ~18min worst case, can
+ * land in one window. A pure 429 storm caps at 3 grants (~270s): our own loop
+ * does not re-drive it (`isTransientServerError` matches 529/503 only). Every
+ * grant still costs the provider a fresh `retry-after`, so the total stays
+ * finite — the watchdog can be deferred, never disabled.
  */
 export function throttleExtensionMs(retryAfterMs: number | undefined): number | undefined {
   if (typeof retryAfterMs !== 'number' || !Number.isFinite(retryAfterMs) || retryAfterMs <= 0) {

--- a/src/agent/providers/shared/first-byte-timeout.ts
+++ b/src/agent/providers/shared/first-byte-timeout.ts
@@ -67,6 +67,32 @@ export const TTFB_TIMEOUT_MESSAGE = 'model_ttfb_timeout';
 export const TTFB_THROTTLE_SLACK_MS = 30_000;
 
 /**
+ * Invariant: the SDK honors a `retry-after` hint ONLY when
+ * `0 <= ms < 60_000`; at or above that it discards the hint entirely.
+ * `@anthropic-ai/sdk` 0.74.0 `client.js:412`:
+ *
+ *     if (!(timeoutMillis && 0 <= timeoutMillis && timeoutMillis < 60 * 1000)) {
+ *         timeoutMillis = this.calculateDefaultRetryTimeoutMillis(...);
+ *     }
+ *
+ * Pinned to the locked SDK version. If that guard changes upstream, this
+ * constant and {@link SDK_MAX_DEFAULT_BACKOFF_MS} must be re-derived — the
+ * accompanying tests assert the arithmetic, not the SDK, so they will NOT catch
+ * an upstream drift on their own.
+ */
+export const SDK_HONORED_RETRY_AFTER_CEILING_MS = 60_000;
+
+/**
+ * Ceiling of the SDK's own fallback backoff, used whenever a `retry-after` is
+ * discarded per {@link SDK_HONORED_RETRY_AFTER_CEILING_MS}. `client.js:419-428`
+ * computes `min(0.5 * 2^n, 8.0)` seconds and then applies 0.75–1.0 jitter, so
+ * 8s is the hard maximum. Deliberately the un-jittered ceiling: over-granting by
+ * up to 2s is harmless, while under-granting would reintroduce the false
+ * positive this whole mechanism exists to remove.
+ */
+export const SDK_MAX_DEFAULT_BACKOFF_MS = 8_000;
+
+/**
  * Contract: the TTFB extension owed for one provider-communicated throttle, or
  * `undefined` when the provider gave no usable window.
  *
@@ -75,12 +101,23 @@ export const TTFB_THROTTLE_SLACK_MS = 30_000;
  * than extending by a guessed amount. The finiteness guard matters because a
  * non-finite delay would re-arm a bogus timer (Node clamps it to 1ms with a
  * TimeoutOverflowWarning), turning an extension into an immediate abort.
+ *
+ * The extension is derived from the wait the SDK will ACTUALLY take, not from
+ * the raw header. Granting the raw value would let a `retry-after: 3600` hint
+ * buy an hour of TTFB grace for a park the SDK caps at ~8s — reinstating the
+ * unbounded post-connect hang that #583/#762 exist to prevent. Because the
+ * honored window is bounded, so is the grace: at most
+ * `60s + 30s = 90s` per throttle, and with the SDK's default `maxRetries: 2`
+ * (`client.js:72`) at most ~180s per round. The watchdog can be deferred, never
+ * disabled.
  */
 export function throttleExtensionMs(retryAfterMs: number | undefined): number | undefined {
   if (typeof retryAfterMs !== 'number' || !Number.isFinite(retryAfterMs) || retryAfterMs <= 0) {
     return undefined;
   }
-  return retryAfterMs + TTFB_THROTTLE_SLACK_MS;
+  const effectiveWaitMs =
+    retryAfterMs < SDK_HONORED_RETRY_AFTER_CEILING_MS ? retryAfterMs : SDK_MAX_DEFAULT_BACKOFF_MS;
+  return effectiveWaitMs + TTFB_THROTTLE_SLACK_MS;
 }
 
 /** Distinguish a TTFB-timeout abort from any other error (e.g. user interrupt). */


### PR DESCRIPTION
## Why

Re-diagnosis of 160 sub-agent deaths reported as `the model stream ended without a terminal message`. Two independent defects on the same path. Full writeup: `~/.afk/workspace/reports/subagent-stream-cut-REDIAGNOSIS-2026-08-01.md`.

The failures are **timer-driven, not network-driven**. Independently re-extracted from 12,579 witness traces:

| observation | value |
|---|---|
| minimum lifetime | **360.025s** — zero failures below it, in 160 samples |
| densest 30s window | **48/160 (30%)** vs 2.05 expected under uniform[360,2700] → **23.4×**, Poisson log10 P ≈ −47 |
| modal chain (23/23 unambiguous cases) | `ttfb_timeout (~180s) → stream-incomplete ×2 → failed` |
| `ttfb_timeout` present | 41/160 |

A random reap of long-lived connections produces a smooth hazard curve. This is a hard floor at `2 × 180_000ms` and a spike at four windows.

## 1. The TTFB bound fires on throttle backoff it should forgive

`armFirstByteTimeout` is armed in `openRound` **before** `createWithRetry`, so its window spans connect + every 429/503/529 backoff the SDK sleeps out *inside* `messages.create* + prefill — not prefill alone. `throttle-signals.ts` already documents the cost in its own docblock: *"a healthy session waiting ~70s (retried twice ≈ 140s) looks frozen"* — against a 180s default that leaves prefill ~40s. The bound then aborts a request that was never given a chance to stream, and the failure is reported as a first-byte stall.

**Fix — forgive only *explained* waiting:**
- `FirstByteTimeoutHandle.extend(ms)` pushes the deadline by a provider-communicated `retry-after` + 30s slack (deliberately the same value `subagent/pause-window.ts` uses for the forked-subagent idle watchdog, which solves the identical problem).
- `awaitCreateWithThrottleSignals` gains an `onThrottle` seam, fired **before** each `rate_limit` yield — ordering is load-bearing, since the yield parks the generator while the deadline races in real time.
- `openRound` wires them together.

Deliberate limits: a throttle with **no** `retry-after` grants nothing, so unexplained silence still trips on schedule. `extend` adds to the **original** budget rather than restarting a full window, and no-ops once fired/disposed/disabled — a flapping endpoint cannot keep a dead request alive.

## 2. The incomplete-stream error asserted a cause it cannot know

The message claimed the response was *"cut off mid-stream, typically an intermediary closing the connection."* That is a guess, and it is wrong for at least the SDK's own request timeout:

```js
// node_modules/@anthropic-ai/sdk/core/streaming.js
catch (e) {
    // If the user calls `stream.controller.abort()`, we should exit without throwing.
    if ((0, errors_1.isAbortError)(e)) return;
    throw e;
}
```

`isAbortError` matches **only** `name === 'AbortError'`. The SDK's default 10-minute timeout (`client.js`: `options.timeout ?? DEFAULT_TIMEOUT`) fires a bare `controller.abort()` → swallowed → byte-identical to a real peer close.

The asymmetry that makes the old text actively misleading: afk's own watchdogs abort with **custom** Error reasons (`TTFB_TIMEOUT_MESSAGE`, `STALL_TIMEOUT_MESSAGE`, `IdleWatchdogError`), whose `name` is not `AbortError`, so `isAbortError` rejects them and they **throw** — reaching the translator's catch and being classified correctly. They are *not* what produces this error. Verified by executing the real `Stream.fromSSEResponse` over a slow SSE body:

```
custom Error (what afk uses)  -> THREW      isAbortError=false
bare abort()                  -> CLEAN END  (no throw)
```

The message now states the observable fact and points at the trace phases that *do* identify the cause. **No behaviour change** — diagnosability only. The old text cost two investigations hours in the network layer.

## Structure

Extracted the check into `anthropic-direct/stream-completeness.ts` rather than growing `translate.ts`, which was already **363 LOC — over the repo's 350 ceiling**. `translate.ts` drops to 343. Every touched file is now under the ceiling.

## Verification

- `pnpm lint` (`tsc --noEmit`) clean.
- `pnpm test` — **740 files / 14,159 tests pass**, 2 skipped.
- `audit:sdk:check`, `audit:env:check`, `scan:env:check` all OK.
- 34 new/updated tests, including an **end-to-end regression** that parks two 70s throttles plus 100s of prefill against a 180s bound, asserts no stall is declared, then asserts the bound still fires on unexplained silence past the granted window.
- One existing assertion in `loop.retry.test.ts` pinned the removed phrase `cut off mid-stream`; it now asserts the observable fact.

## Relationship to #796

Complementary, not competing — no file overlap (#796 touches `subagent/` and `tools/subagent/`; this touches `providers/`). #796 **retries** a child whose stream was cut; this reduces how often the cut happens and makes the surviving failures correctly labelled. Recommend landing this first and re-measuring #796's expected yield against the residual, since its current rationale assumes an external gateway cause that the trace data does not support.

## Not in scope

- The `openai-compatible` provider shares `AbortCoordinator` (#701) and likely has the same misattribution in `query/stream-drive.ts:212`; untouched here.
- **Still unexplained:** what produces the ~180s-period *clean* stream ends on retry attempts 2 and 3. It is not TTFB (that throws). Prime suspect is the SDK's own bare-abort timeout — agent-afk never sets `timeout` or `maxRetries` on `new Anthropic()`, so both default (600s / 2 retries). Worth a follow-up that sets them explicitly.
- 8/160 failures show no self-abort phase at all and may be genuine peer closes.
