### PR TITLE
fix(tui): make a running subagent legible instead of decorative

### DIFF
--- a/src/cli/_lib/child-activity-select.test.ts
+++ b/src/cli/_lib/child-activity-select.test.ts
@@ -10,7 +10,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   ChildActivityTracker,
-  deriveChildActivity,
+  deriveChildBanner,
   formatChildActivity,
   CHILD_QUIET_MS,
   STICKY_HOLD_MS,
@@ -223,30 +223,47 @@ describe('ChildActivityTracker.select', () => {
   });
 });
 
-describe('deriveChildActivity', () => {
+describe('deriveChildBanner', () => {
+  const wired = () => ({
+    sources: new Map<string, SourceState>([['a', activeChild('sees')]]),
+    childActivity: new ChildActivityTracker(),
+  });
+
   it('returns undefined when the ctx omits the live wiring', () => {
     // Non-TTY surfaces and existing tests must keep their prior behaviour.
-    expect(deriveChildActivity({})).toBeUndefined();
-    expect(deriveChildActivity({ sources: new Map() })).toBeUndefined();
-    expect(
-      deriveChildActivity({ childActivity: new ChildActivityTracker() }),
-    ).toBeUndefined();
+    expect(deriveChildBanner({})).toBeUndefined();
+    expect(deriveChildBanner({ sources: new Map() })).toBeUndefined();
+    expect(deriveChildBanner({ childActivity: new ChildActivityTracker() })).toBeUndefined();
   });
 
   it('composes the label and clause into one plain-text line', () => {
-    const sources = new Map<string, SourceState>([['a', activeChild('sees')]]);
-    expect(
-      deriveChildActivity({ sources, childActivity: new ChildActivityTracker() }, NOW),
-    ).toBe('sees · round 2: Read sees.ts');
+    expect(deriveChildBanner(wired(), NOW)?.activity).toBe('sees · round 2: Read sees.ts');
   });
 
   it('emits no ANSI — the banner owns dimming and width math', () => {
-    const sources = new Map<string, SourceState>([['a', activeChild('sees')]]);
-    const line = deriveChildActivity(
-      { sources, childActivity: new ChildActivityTracker() },
-      NOW,
-    );
     // eslint-disable-next-line no-control-regex
-    expect(line).not.toMatch(/\u001b\[/);
+    expect(deriveChildBanner(wired(), NOW)?.activity).not.toMatch(/\u001b\[/);
+  });
+
+  it('reports stats scoped to the SAME child it names, not the parent', () => {
+    const sources = new Map<string, SourceState>([['a', activeChild('sees')]]);
+    const child = sources.get('a')!;
+    child.stats.toolUses = 52;
+    child.stats.tokens = 47_000;
+    child.startedAt = NOW - 1_400_000; // 23m20s ago
+
+    const banner = deriveChildBanner({ sources, childActivity: new ChildActivityTracker() }, NOW);
+    expect(banner?.stats).toEqual({
+      toolUses: 52,
+      totalTokens: 47_000,
+      durationMs: 1_400_000,
+    });
+  });
+
+  it('never reports a negative elapsed when the clock skews backwards', () => {
+    const sources = new Map<string, SourceState>([['a', activeChild('sees')]]);
+    sources.get('a')!.startedAt = NOW + 5_000;
+    const banner = deriveChildBanner({ sources, childActivity: new ChildActivityTracker() }, NOW);
+    expect(banner?.stats.durationMs).toBe(0);
   });
 });

--- a/src/cli/_lib/child-activity-select.test.ts
+++ b/src/cli/_lib/child-activity-select.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Tests for the progress-banner child-activity selector.
+ *
+ * The load-bearing behaviour here is the STICKINESS rule: without it, N chatty
+ * subagents swap the banner's detail line on every repaint, producing motion
+ * that is technically work-derived but unreadable — the exact failure this
+ * feature exists to avoid. Most of these cases pin that hold.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  ChildActivityTracker,
+  deriveChildActivity,
+  formatChildActivity,
+  CHILD_QUIET_MS,
+  STICKY_HOLD_MS,
+} from './child-activity-select.js';
+import { ORCHESTRATOR_SOURCE_KEY, type SourceState } from './stream-renderer-source.js';
+
+const NOW = 1_000_000;
+
+function makeSource(over: Partial<SourceState> = {}): SourceState {
+  return {
+    startedAt: NOW - 60_000,
+    lastEventAt: NOW,
+    stats: { tokens: 0, toolUses: 0 },
+    contentBuffer: '',
+    done: false,
+    errored: false,
+    stalledTicks: 0,
+    ...over,
+  };
+}
+
+/** A healthy, recently-active child with a provider round headline. */
+function activeChild(agentType: string, over: Partial<SourceState> = {}): SourceState {
+  return makeSource({
+    agentType,
+    lastProgressSummary: `round 2: Read ${agentType}.ts`,
+    stats: { tokens: 100, toolUses: 4 },
+    ...over,
+  });
+}
+
+describe('ChildActivityTracker.select', () => {
+  it('returns undefined when there are no sources at all', () => {
+    expect(new ChildActivityTracker().select(new Map(), NOW)).toBeUndefined();
+  });
+
+  it('ignores the orchestrator source — it is not a child', () => {
+    const sources = new Map<string, SourceState>([
+      [ORCHESTRATOR_SOURCE_KEY, activeChild('main')],
+    ]);
+    expect(new ChildActivityTracker().select(sources, NOW)).toBeUndefined();
+  });
+
+  it('ignores children that are done or errored', () => {
+    const sources = new Map<string, SourceState>([
+      ['a', activeChild('sees', { done: true })],
+      ['b', activeChild('signals', { errored: true })],
+    ]);
+    expect(new ChildActivityTracker().select(sources, NOW)).toBeUndefined();
+  });
+
+  it('names a single running child using the provider round headline', () => {
+    const sources = new Map<string, SourceState>([['a', activeChild('sees')]]);
+    const picked = new ChildActivityTracker().select(sources, NOW);
+    expect(picked).toMatchObject({
+      sourceId: 'a',
+      label: 'sees',
+      clause: 'round 2: Read sees.ts',
+      quiet: false,
+    });
+    expect(formatChildActivity(picked!)).toBe('sees · round 2: Read sees.ts');
+  });
+
+  it('falls back to the tool-call count when no round headline has arrived', () => {
+    const sources = new Map<string, SourceState>([
+      ['a', makeSource({ agentType: 'sees', stats: { tokens: 0, toolUses: 7 } })],
+    ]);
+    expect(new ChildActivityTracker().select(sources, NOW)?.clause).toBe('7 tool calls');
+  });
+
+  it('returns undefined when a child has produced nothing worth reporting', () => {
+    // No summary and no tool calls yet — better to leave the slot to the
+    // banner's own summary than render a hollow "sees ·" with nothing after it.
+    const sources = new Map<string, SourceState>([
+      ['a', makeSource({ agentType: 'sees' })],
+    ]);
+    expect(new ChildActivityTracker().select(sources, NOW)).toBeUndefined();
+  });
+
+  it('falls back to the raw source key when agentType is absent', () => {
+    const sources = new Map<string, SourceState>([
+      ['sub-42', activeChild('x', { agentType: undefined })],
+    ]);
+    expect(new ChildActivityTracker().select(sources, NOW)?.label).toBe('sub-42');
+  });
+
+  it('picks the freshest child on a cold tracker', () => {
+    const sources = new Map<string, SourceState>([
+      ['stale', activeChild('stale', { lastEventAt: NOW - 5_000 })],
+      ['fresh', activeChild('fresh', { lastEventAt: NOW - 10 })],
+    ]);
+    expect(new ChildActivityTracker().select(sources, NOW)?.sourceId).toBe('fresh');
+  });
+
+  it('breaks exact-timestamp ties deterministically by source key', () => {
+    const sources = new Map<string, SourceState>([
+      ['zebra', activeChild('zebra')],
+      ['alpha', activeChild('alpha')],
+    ]);
+    // Insertion order puts zebra first; the sort must still choose alpha so the
+    // line does not flip between equally-fresh children across repaints.
+    expect(new ChildActivityTracker().select(sources, NOW)?.sourceId).toBe('alpha');
+    expect(new ChildActivityTracker().select(sources, NOW)?.sourceId).toBe('alpha');
+  });
+
+  describe('stickiness (anti-thrash)', () => {
+    it('HOLDS the incumbent while it is quiet for less than the hold window', () => {
+      const tracker = new ChildActivityTracker();
+      const first = new Map<string, SourceState>([
+        ['a', activeChild('a', { lastEventAt: NOW })],
+        ['b', activeChild('b', { lastEventAt: NOW - 50 })],
+      ]);
+      expect(tracker.select(first, NOW)?.sourceId).toBe('a');
+
+      // `b` is now strictly fresher, but `a` has only been quiet 1s — under the
+      // 3s hold, so the line must NOT jump. This is the thrash guard.
+      const later = new Map<string, SourceState>([
+        ['a', activeChild('a', { lastEventAt: NOW })],
+        ['b', activeChild('b', { lastEventAt: NOW + 900 })],
+      ]);
+      expect(tracker.select(later, NOW + 1_000)?.sourceId).toBe('a');
+    });
+
+    it('SWITCHES once the incumbent exceeds the hold window and a fresher sibling exists', () => {
+      const tracker = new ChildActivityTracker();
+      const sources = new Map<string, SourceState>([
+        ['a', activeChild('a', { lastEventAt: NOW })],
+        ['b', activeChild('b', { lastEventAt: NOW })],
+      ]);
+      expect(tracker.select(sources, NOW)?.sourceId).toBe('a');
+
+      const later = new Map<string, SourceState>([
+        ['a', activeChild('a', { lastEventAt: NOW })],
+        ['b', activeChild('b', { lastEventAt: NOW + STICKY_HOLD_MS + 500 })],
+      ]);
+      expect(tracker.select(later, NOW + STICKY_HOLD_MS + 600)?.sourceId).toBe('b');
+    });
+
+    it('KEEPS the incumbent when every child is equally quiet', () => {
+      // Switching between two silent children is churn with no information.
+      const tracker = new ChildActivityTracker();
+      const at = (t: number) =>
+        new Map<string, SourceState>([
+          ['b', activeChild('b', { lastEventAt: t })],
+          ['c', activeChild('c', { lastEventAt: t })],
+        ]);
+      const firstPick = tracker.select(at(NOW), NOW)?.sourceId;
+      const secondPick = tracker.select(at(NOW), NOW + STICKY_HOLD_MS * 3)?.sourceId;
+      expect(secondPick).toBe(firstPick);
+    });
+
+    it('drops a held child once it completes', () => {
+      const tracker = new ChildActivityTracker();
+      const running = new Map<string, SourceState>([['a', activeChild('a')]]);
+      expect(tracker.select(running, NOW)?.sourceId).toBe('a');
+
+      const finished = new Map<string, SourceState>([
+        ['a', activeChild('a', { done: true })],
+        ['b', activeChild('b')],
+      ]);
+      expect(tracker.select(finished, NOW + 100)?.sourceId).toBe('b');
+    });
+
+    it('reset() clears the sticky selection so state never leaks across turns', () => {
+      const tracker = new ChildActivityTracker();
+      const sources = new Map<string, SourceState>([
+        ['a', activeChild('a', { lastEventAt: NOW })],
+        ['b', activeChild('b', { lastEventAt: NOW - 5_000 })],
+      ]);
+      expect(tracker.select(sources, NOW)?.sourceId).toBe('a');
+      tracker.reset();
+      const flipped = new Map<string, SourceState>([
+        ['a', activeChild('a', { lastEventAt: NOW - 5_000 })],
+        ['b', activeChild('b', { lastEventAt: NOW })],
+      ]);
+      expect(tracker.select(flipped, NOW)?.sourceId).toBe('b');
+    });
+  });
+
+  describe('quiet-child reporting', () => {
+    it('names the silence once a child passes the quiet threshold', () => {
+      const sources = new Map<string, SourceState>([
+        ['a', activeChild('sees', { lastEventAt: NOW - 41_000 })],
+      ]);
+      const picked = new ChildActivityTracker().select(sources, NOW);
+      expect(picked?.quiet).toBe(true);
+      expect(picked?.clause).toBe('no output for 41s');
+      // The silence must win over the stale round headline — reporting old work
+      // as if current is what makes a hung wave look healthy.
+      expect(picked?.clause).not.toContain('round 2');
+    });
+
+    it('does not flag a child just under the quiet threshold', () => {
+      const sources = new Map<string, SourceState>([
+        ['a', activeChild('sees', { lastEventAt: NOW - (CHILD_QUIET_MS - 1_000) })],
+      ]);
+      const picked = new ChildActivityTracker().select(sources, NOW);
+      expect(picked?.quiet).toBe(false);
+      expect(picked?.clause).toBe('round 2: Read sees.ts');
+    });
+
+    it('reports silence even for a child that never produced any output', () => {
+      const sources = new Map<string, SourceState>([
+        ['a', makeSource({ agentType: 'sees', lastEventAt: NOW - 45_000 })],
+      ]);
+      expect(new ChildActivityTracker().select(sources, NOW)?.clause).toBe(
+        'no output for 45s',
+      );
+    });
+  });
+});
+
+describe('deriveChildActivity', () => {
+  it('returns undefined when the ctx omits the live wiring', () => {
+    // Non-TTY surfaces and existing tests must keep their prior behaviour.
+    expect(deriveChildActivity({})).toBeUndefined();
+    expect(deriveChildActivity({ sources: new Map() })).toBeUndefined();
+    expect(
+      deriveChildActivity({ childActivity: new ChildActivityTracker() }),
+    ).toBeUndefined();
+  });
+
+  it('composes the label and clause into one plain-text line', () => {
+    const sources = new Map<string, SourceState>([['a', activeChild('sees')]]);
+    expect(
+      deriveChildActivity({ sources, childActivity: new ChildActivityTracker() }, NOW),
+    ).toBe('sees · round 2: Read sees.ts');
+  });
+
+  it('emits no ANSI — the banner owns dimming and width math', () => {
+    const sources = new Map<string, SourceState>([['a', activeChild('sees')]]);
+    const line = deriveChildActivity(
+      { sources, childActivity: new ChildActivityTracker() },
+      NOW,
+    );
+    // eslint-disable-next-line no-control-regex
+    expect(line).not.toMatch(/\u001b\[/);
+  });
+});

--- a/src/cli/_lib/child-activity-select.ts
+++ b/src/cli/_lib/child-activity-select.ts
@@ -26,6 +26,7 @@
 
 import { formatDuration, formatToolCallStat } from '../format-utils.js';
 import { ORCHESTRATOR_SOURCE_KEY, type SourceState } from './stream-renderer-source.js';
+import type { ProgressEvent } from '../../agent/types.js';
 
 /**
  * How long a selected child may stay quiet before the tracker is allowed to
@@ -221,5 +222,41 @@ export function deriveChildBanner(
       // turn's, so the number answers "how long has this agent been running".
       durationMs: Math.max(0, now - source.startedAt),
     },
+  };
+}
+
+/**
+ * Reserved task id for the synthetic banner event below. Mirrors the existing
+ * reserved ids (`__rate_limit__` in stream-renderer-orchestrator.ts,
+ * `__soft_stop__` in stream-renderer-lifecycle.ts). Never written INTO
+ * `lastProgressByTask` — it exists only to satisfy `ProgressEvent.taskId`.
+ */
+export const CHILD_BANNER_TASK_ID = '__child_activity__';
+
+/**
+ * Invariant: both provider loops emit the parent's `progress` event AFTER the
+ * round's tools have been dispatched and their results committed —
+ * anthropic-direct/loop/tool-round.ts dispatches at :66, commits results at
+ * :69, and only then yields `progress` at :101; openai-compatible/query.ts:651
+ * has the same ordering. A foreground subagent therefore runs to completion
+ * INSIDE a round whose `progress` has not been emitted yet, so on the parent's
+ * first tool round `lastProgressByTask` is empty for the child's entire
+ * lifetime and the banner's per-task render loop iterates zero times — the
+ * child banner is computed and then silently discarded.
+ *
+ * This synthesizes the missing carrier so a live child still paints a row.
+ * Stats are the child's own (see {@link deriveChildBanner}); `lastToolName`
+ * and `summary` are deliberately absent — the caller passes the child's clause
+ * as `activity`, which owns the detail slot, and a parent-scoped tool name
+ * beside a child clause is the exact contradiction this module exists to
+ * remove.
+ */
+export function childBannerEvent(stats: ChildBannerStats): ProgressEvent {
+  return {
+    taskId: CHILD_BANNER_TASK_ID,
+    description: 'Working',
+    totalTokens: stats.totalTokens,
+    toolUses: stats.toolUses,
+    durationMs: stats.durationMs,
   };
 }

--- a/src/cli/_lib/child-activity-select.ts
+++ b/src/cli/_lib/child-activity-select.ts
@@ -1,0 +1,194 @@
+/**
+ * Live child-activity selection for the progress banner's detail slot.
+ *
+ * Why this exists: while the parent turn is blocked awaiting a foreground
+ * subagent (`foreground-promotion.ts` awaits `handle.runToResult`), the
+ * orchestrator emits no `progress` event, and `commitThinkingPhase` has already
+ * drained `ctx.thinkingLane` — so `deriveProgressActivity` returns `undefined`
+ * and the banner's detail line goes blank for the entire child run. The only
+ * remaining on-screen motion is decorative (spinner glyph, elapsed counter,
+ * random verb, rotating tip), which is why a working agent reads as a hung one.
+ *
+ * This module fills that slot from state the renderer ALREADY tracks —
+ * `SourceState.lastEventAt`, `stats.toolUses`, and `lastProgressSummary` — so
+ * it introduces no new event plumbing and, critically, no new timer. The banner
+ * repaints on the discrete child transitions that already call
+ * `setComposedOverlay`, preserving the "at most one setComposedOverlay call per
+ * event" invariant in stream-renderer-orchestrator.ts.
+ *
+ * Deliberately complementary to the tool lane rather than duplicative: the lane
+ * already shows each child's current tool and thinking tail, so this slot
+ * reports WHO is active plus round/volume progress and — the part no other
+ * surface makes prominent — whether the selected child has gone quiet.
+ *
+ * @module cli/_lib/child-activity-select
+ */
+
+import { formatDuration, formatToolCallStat } from '../format-utils.js';
+import { ORCHESTRATOR_SOURCE_KEY, type SourceState } from './stream-renderer-source.js';
+
+/**
+ * How long a selected child may stay quiet before the tracker is allowed to
+ * switch to a livelier sibling.
+ *
+ * Invariant: this must exceed the 1500ms per-parent overlay throttle in
+ * stream-renderer-subagent.ts. Without the hold, N chatty children swap the
+ * detail line on every repaint — motion that is technically work-derived but
+ * unreadable, which is the failure mode this whole change exists to avoid.
+ */
+export const STICKY_HOLD_MS = 3000;
+
+/**
+ * Silence past which the banner names the child as producing no output.
+ *
+ * Matches `PAUSE_THRESHOLD_MS` in stream-renderer-lifecycle.ts so the banner
+ * and the tool-lane's `· waiting Xs` annotation agree rather than reporting two
+ * different notions of "stalled". The lane keeps its own label (renamed to
+ * `waiting` deliberately — see stream-renderer-visibility.test.ts); this adds
+ * the same fact in the higher-salience slot where the eye already rests.
+ */
+export const CHILD_QUIET_MS = 30_000;
+
+/** A running child worth naming in the banner detail slot. */
+export interface ChildActivity {
+  /** Source key (the subagent id). */
+  sourceId: string;
+  /** Human label — `agentType` when known, else the raw source key. */
+  label: string;
+  /** Progress clause, e.g. `round 3: Read tool-lane.ts` or `no output for 41s`. */
+  clause: string;
+  /** True when this child has been silent longer than {@link CHILD_QUIET_MS}. */
+  quiet: boolean;
+}
+
+/** A child still in flight, paired with how long it has been silent. */
+interface Candidate {
+  sourceId: string;
+  source: SourceState;
+  silentMs: number;
+}
+
+function runningChildren(
+  sources: ReadonlyMap<string, SourceState>,
+  now: number,
+): Candidate[] {
+  const out: Candidate[] = [];
+  for (const [sourceId, source] of sources) {
+    if (sourceId === ORCHESTRATOR_SOURCE_KEY) continue;
+    if (source.done || source.errored) continue;
+    out.push({ sourceId, source, silentMs: Math.max(0, now - source.lastEventAt) });
+  }
+  return out;
+}
+
+/**
+ * Compose the clause for one child. Priority is most-specific-first: an
+ * explicit silence warning beats a stale round headline, which beats a bare
+ * call count. Returns `undefined` when the child has produced nothing worth
+ * reporting yet, so the caller can fall through rather than render a hollow
+ * line like `sees ·` with no content after it.
+ */
+function clauseFor(candidate: Candidate): string | undefined {
+  if (candidate.silentMs >= CHILD_QUIET_MS) {
+    return `no output for ${formatDuration(candidate.silentMs)}`;
+  }
+  const summary = candidate.source.lastProgressSummary;
+  if (summary) return summary;
+  const calls = candidate.source.stats.toolUses;
+  if (calls > 0) return formatToolCallStat(calls);
+  return undefined;
+}
+
+/**
+ * Stateful selector for "which child should the banner name right now".
+ *
+ * Holds one field — the previously-selected source key — so the choice is
+ * stable across repaints. Owned by StreamRenderer (one instance per turn) and
+ * handed to the orchestrator ctx; `setComposedOverlay` rebuilds its ctx object
+ * on every call, so the sticky state cannot live there.
+ */
+export class ChildActivityTracker {
+  private prev: string | undefined;
+
+  /**
+   * Pick the child to name, or `undefined` when none is worth naming.
+   *
+   * Selection: newest `lastEventAt` wins, except that an already-selected child
+   * is held until it finishes or goes quiet for {@link STICKY_HOLD_MS} AND a
+   * livelier sibling exists. When every child is quiet the incumbent is kept —
+   * switching between equally-silent children is churn with no information.
+   */
+  select(
+    sources: ReadonlyMap<string, SourceState>,
+    now: number = Date.now(),
+  ): ChildActivity | undefined {
+    const candidates = runningChildren(sources, now);
+    if (candidates.length === 0) {
+      this.prev = undefined;
+      return undefined;
+    }
+
+    // Freshest first; ties broken by source key so the choice is deterministic
+    // under equal timestamps (fake timers in tests, coarse clocks in practice).
+    candidates.sort(
+      (a, b) => a.silentMs - b.silentMs || a.sourceId.localeCompare(b.sourceId),
+    );
+    const freshest = candidates[0]!;
+
+    const incumbent = this.prev
+      ? candidates.find((c) => c.sourceId === this.prev)
+      : undefined;
+    const holdIncumbent =
+      incumbent !== undefined &&
+      (incumbent.silentMs < STICKY_HOLD_MS || freshest.sourceId === incumbent.sourceId);
+    const chosen = holdIncumbent ? incumbent : freshest;
+
+    this.prev = chosen.sourceId;
+    const clause = clauseFor(chosen);
+    if (clause === undefined) return undefined;
+    return {
+      sourceId: chosen.sourceId,
+      label: chosen.source.agentType ?? chosen.sourceId,
+      clause,
+      quiet: chosen.silentMs >= CHILD_QUIET_MS,
+    };
+  }
+
+  /** Drop the sticky selection — call between turns so state never leaks. */
+  reset(): void {
+    this.prev = undefined;
+  }
+}
+
+/**
+ * Render a {@link ChildActivity} as the banner's detail clause.
+ *
+ * Kept separate from selection so the composition is trivially testable and so
+ * the caller controls styling. Intentionally emits plain text with no ANSI: the
+ * banner clamps and dims the whole line, and injecting escapes here would
+ * corrupt its width math.
+ */
+export function formatChildActivity(activity: ChildActivity): string {
+  return `${activity.label} · ${activity.clause}`;
+}
+
+/**
+ * Banner-slot adapter: resolve the detail clause for a composed overlay, or
+ * `undefined` when there is nothing live to report.
+ *
+ * Lives here rather than in stream-renderer-orchestrator.ts so that file (already
+ * past the 350-line ceiling) gains a call site and no new concern. Tolerates both
+ * fields being absent so non-TTY surfaces and existing tests keep their previous
+ * behaviour with no ctx changes.
+ */
+export function deriveChildActivity(
+  ctx: {
+    sources?: ReadonlyMap<string, SourceState>;
+    childActivity?: ChildActivityTracker;
+  },
+  now: number = Date.now(),
+): string | undefined {
+  if (!ctx.sources || !ctx.childActivity) return undefined;
+  const activity = ctx.childActivity.select(ctx.sources, now);
+  return activity ? formatChildActivity(activity) : undefined;
+}

--- a/src/cli/_lib/child-activity-select.ts
+++ b/src/cli/_lib/child-activity-select.ts
@@ -172,23 +172,54 @@ export function formatChildActivity(activity: ChildActivity): string {
   return `${activity.label} · ${activity.clause}`;
 }
 
+/** Stats slice the banner reads off a {@link ProgressEvent}. */
+export interface ChildBannerStats {
+  toolUses: number;
+  totalTokens: number;
+  durationMs: number;
+}
+
 /**
- * Banner-slot adapter: resolve the detail clause for a composed overlay, or
- * `undefined` when there is nothing live to report.
+ * Invariant: the banner's stats tail must describe the SAME actor its detail
+ * clause names.
  *
- * Lives here rather than in stream-renderer-orchestrator.ts so that file (already
- * past the 350-line ceiling) gains a call site and no new concern. Tolerates both
- * fields being absent so non-TTY surfaces and existing tests keep their previous
- * behaviour with no ctx changes.
+ * The banner is fed from `lastProgressByTask`, which is parent-scoped and — while
+ * the parent turn is parked awaiting `handle.runToResult` — frozen at the values
+ * it held before the dispatch. Rendering the live child clause next to those
+ * numbers puts two contradictory statements on one row: `pr796-fix · round 34`
+ * beside `7 tool calls · 2m` after twenty-three minutes. That is worse than the
+ * blank slot this feature replaced, because a live-looking clause invites the
+ * operator to trust the counters beside it.
+ *
+ * So when the clause comes from a child, the stats come from the same child's
+ * `SourceState`. `lastToolName` is deliberately dropped rather than inherited:
+ * the parent's last tool is `agent`, and the spinner verb already names the
+ * child's in-flight tool via `work-derived-verb.ts`, so `via <tool>` here would
+ * be either wrong or redundant.
+ *
+ * Returns `undefined` when no child is worth naming, so the caller keeps the
+ * parent's own event untouched.
  */
-export function deriveChildActivity(
+export function deriveChildBanner(
   ctx: {
     sources?: ReadonlyMap<string, SourceState>;
     childActivity?: ChildActivityTracker;
   },
   now: number = Date.now(),
-): string | undefined {
+): { activity: string; stats: ChildBannerStats } | undefined {
   if (!ctx.sources || !ctx.childActivity) return undefined;
-  const activity = ctx.childActivity.select(ctx.sources, now);
-  return activity ? formatChildActivity(activity) : undefined;
+  const picked = ctx.childActivity.select(ctx.sources, now);
+  if (!picked) return undefined;
+  const source = ctx.sources.get(picked.sourceId);
+  if (!source) return undefined;
+  return {
+    activity: formatChildActivity(picked),
+    stats: {
+      toolUses: source.stats.toolUses,
+      totalTokens: source.stats.tokens,
+      // Child-scoped elapsed: measured from the child's own start, not the
+      // turn's, so the number answers "how long has this agent been running".
+      durationMs: Math.max(0, now - source.startedAt),
+    },
+  };
 }

--- a/src/cli/_lib/live-progress-no-timer.test.ts
+++ b/src/cli/_lib/live-progress-no-timer.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Structural guard: the live-progress feature adds NO autonomous timer.
+ *
+ * Invariant being protected (documented at stream-renderer-orchestrator.ts, in
+ * `handleOrchestratorEvent`): "at most one setComposedOverlay call per event."
+ * The repaint model here is event-driven. A clock-tick that repaints a
+ * variable-height overlay block independently of real events is the failure class
+ * this codebase has already paid for twice — the H2 fix throttled per-parent
+ * overlay rebuilds to >=1500ms because ~50-80Hz repaints produced N-fold ghost
+ * rows (see stream-renderer-subagent.ts), and docs/tui-invariants.md names "an
+ * 80ms timer fires in the gap and mutates state the next step assumes is
+ * quiescent" as the recurrence vector for lifecycle corruption.
+ *
+ * So the child-activity banner fallback and the work-derived spinner verb are
+ * both PULL-based: they are read during repaints/ticks that already happen. This
+ * test fails if anyone reintroduces a timer into those modules, which would
+ * silently re-open that bug class.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const REPO_ROOT = join(import.meta.dirname, '..', '..', '..');
+
+/** Modules introduced by the live-progress work — all must be timer-free. */
+const TIMER_FREE_MODULES = [
+  'src/cli/_lib/child-activity-select.ts',
+  'src/cli/input/work-derived-verb.ts',
+] as const;
+
+function read(relPath: string): string {
+  return readFileSync(join(REPO_ROOT, relPath), 'utf8');
+}
+
+/** Strip comments so prose ABOUT timers cannot trip the assertions. */
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+}
+
+describe('live-progress modules introduce no autonomous timer', () => {
+  for (const relPath of TIMER_FREE_MODULES) {
+    it(`${relPath} schedules nothing`, () => {
+      const code = stripComments(read(relPath));
+      expect(code).not.toMatch(/\bsetInterval\b/);
+      expect(code).not.toMatch(/\bsetTimeout\b/);
+      expect(code).not.toMatch(/\bsetImmediate\b/);
+      expect(code).not.toMatch(/requestAnimationFrame/);
+    });
+  }
+
+  it('the spinner still owns exactly one interval', () => {
+    // The work-derived verb is read inside the EXISTING 80ms tick. If this count
+    // grows, a second competing clock was added to the same render path.
+    const code = stripComments(read('src/cli/input/spinner.ts'));
+    // Call-form only: the file also names `ReturnType<typeof setInterval>` as the
+    // handle's type, which is not a second timer.
+    const intervals = code.match(/\bsetInterval\s*\(/g) ?? [];
+    expect(intervals).toHaveLength(1);
+  });
+
+  it('the banner fallback is reached by pull, not by push', () => {
+    // deriveChildActivity must be invoked from render paths only. If it ever
+    // gains its own scheduling, the guard above catches it; here we assert the
+    // two known call sites are the render composers.
+    const orchestrator = read('src/cli/_lib/stream-renderer-orchestrator.ts');
+    const lifecycle = read('src/cli/_lib/stream-renderer-lifecycle.ts');
+    expect(orchestrator).toContain('deriveChildActivity(ctx)');
+    expect(lifecycle).toContain('deriveChildActivity(ctx)');
+  });
+
+  it('the compositor tool-name setter does not repaint', () => {
+    // Painting there would add a second frame write per tool event; the caller
+    // already repaints for the same transition.
+    const src = read('src/cli/terminal-compositor.ts');
+    const start = src.indexOf('setActiveToolName(');
+    expect(start).toBeGreaterThan(-1);
+    const body = src.slice(start, src.indexOf('}', start));
+    expect(body).not.toMatch(/repaint|flush|markDirty/);
+  });
+});

--- a/src/cli/_lib/live-progress-no-timer.test.ts
+++ b/src/cli/_lib/live-progress-no-timer.test.ts
@@ -60,13 +60,13 @@ describe('live-progress modules introduce no autonomous timer', () => {
   });
 
   it('the banner fallback is reached by pull, not by push', () => {
-    // deriveChildActivity must be invoked from render paths only. If it ever
+    // deriveChildBanner must be invoked from render paths only. If it ever
     // gains its own scheduling, the guard above catches it; here we assert the
     // two known call sites are the render composers.
     const orchestrator = read('src/cli/_lib/stream-renderer-orchestrator.ts');
     const lifecycle = read('src/cli/_lib/stream-renderer-lifecycle.ts');
-    expect(orchestrator).toContain('deriveChildActivity(ctx)');
-    expect(lifecycle).toContain('deriveChildActivity(ctx)');
+    expect(orchestrator).toContain('deriveChildBanner(ctx)');
+    expect(lifecycle).toContain('deriveChildBanner(ctx)');
   });
 
   it('the compositor tool-name setter does not repaint', () => {

--- a/src/cli/_lib/stream-renderer-contexts.ts
+++ b/src/cli/_lib/stream-renderer-contexts.ts
@@ -20,6 +20,7 @@ import type { Writer } from '../slash/types.js';
 import type { StageTrackerState } from '../commands/interactive/loop-stage.js';
 import type { CommitCoordinator } from './commit-coordinator.js';
 import type { SourceState } from './stream-renderer-source.js';
+import type { ChildActivityTracker } from './child-activity-select.js';
 import { isDebugEnabled } from '../../utils/debug.js';
 
 /**
@@ -38,6 +39,8 @@ export function makeOrchestratorCtx(args: {
   stageTracker?: StageTrackerState;
   activeSkillName?: string;
   lastProgressByTask: Map<string, ProgressEvent>;
+  sources?: ReadonlyMap<string, SourceState>;
+  childActivity?: ChildActivityTracker;
 }): OrchestratorCtx {
   return {
     out: args.out,
@@ -50,6 +53,11 @@ export function makeOrchestratorCtx(args: {
     streamingMarkdown: args.streamingMarkdown,
     coordinator: args.coordinator,
     lastProgressByTask: args.lastProgressByTask,
+    // Live child-activity inputs for the banner detail slot. Spread-guarded
+    // (not passed as `undefined`) so exactOptionalPropertyTypes stays satisfied
+    // and omitting them is indistinguishable from the pre-change ctx shape.
+    ...(args.sources ? { sources: args.sources } : {}),
+    ...(args.childActivity ? { childActivity: args.childActivity } : {}),
     // Hand the tracker only when we have a TTY compositor — non-TTY
     // surfaces (Telegram, daemon, tests) never call setComposedOverlay
     // anyway, and propagating a tracker through them would just be

--- a/src/cli/_lib/stream-renderer-lifecycle.test.ts
+++ b/src/cli/_lib/stream-renderer-lifecycle.test.ts
@@ -11,6 +11,8 @@ import { formatInterruptAffordance, registerOverlaySlots } from './stream-render
 import { OverlayComposer } from './overlay-composer.js';
 import { ThinkingLane } from '../commands/interactive/thinking-lane.js';
 import { stripAnsi } from '../display.js';
+import { ChildActivityTracker } from './child-activity-select.js';
+import { freshSourceState, type SourceState } from './stream-renderer-source.js';
 import type { ProgressEvent } from '../../agent/types.js';
 
 describe('formatInterruptAffordance', () => {
@@ -163,6 +165,88 @@ describe('registerOverlaySlots — progress-banner stopping wiring', () => {
 
   it('renders no banner at all when idle (no progress, not stopping)', () => {
     const { captured, composer } = makeComposer(new Map(), () => false);
+    composer.invalidate();
+    composer.flush();
+    expect(captured.at(-1)).toBe('');
+  });
+});
+
+describe('registerOverlaySlots — child banner without a parent progress row', () => {
+  // Regression for PR #840 review (P1). Both provider loops emit the parent's
+  // `progress` event AFTER the round's tools are dispatched and their results
+  // committed, so a foreground subagent launched in the parent's FIRST tool
+  // round runs its whole life while lastProgressByTask is still empty. The
+  // per-task render loop then iterates zero times and the child banner — which
+  // was computed — is discarded, leaving the banner blank for exactly the case
+  // the feature exists to cover.
+  function makeComposer(
+    lastProgressByTask: Map<string, ProgressEvent>,
+    sources: Map<string, SourceState>,
+    getSoftStopping: () => boolean = () => false,
+  ): { captured: string[]; composer: OverlayComposer } {
+    const captured: string[] = [];
+    const composer = new OverlayComposer({ setOverlay: (t) => captured.push(t) }, [
+      'thinking-live',
+      'markdown-pending',
+      'tool-lane',
+      'progress-banner',
+      'interrupt',
+    ]);
+    registerOverlaySlots(composer, {
+      stageTracker: undefined,
+      thinkingMode: 'summary',
+      thinkingLane: new ThinkingLane(),
+      streamingMarkdownRef: { current: null },
+      toolLane: { hasPending: () => false, getOverlay: () => '' },
+      lastProgressByTask,
+      getInterrupting: () => false,
+      getSoftStopping,
+      sources,
+      childActivity: new ChildActivityTracker(),
+    } as unknown as Parameters<typeof registerOverlaySlots>[1]);
+    return { captured, composer };
+  }
+
+  function liveChild(agentType: string): Map<string, SourceState> {
+    const source = freshSourceState(agentType);
+    source.lastProgressSummary = 'round 3: bash pnpm test';
+    source.stats.tokens = 2400;
+    source.stats.toolUses = 7;
+    return new Map([['child-1', source]]);
+  }
+
+  it('paints the child clause when lastProgressByTask is empty', () => {
+    const { captured, composer } = makeComposer(new Map(), liveChild('reviewer'));
+    composer.invalidate();
+    composer.flush();
+    const overlay = stripAnsi(captured.at(-1) ?? '');
+    expect(overlay).toContain('reviewer');
+    expect(overlay).toContain('round 3: bash pnpm test');
+  });
+
+  it('carries the child-scoped stats on that synthesized row', () => {
+    const { captured, composer } = makeComposer(new Map(), liveChild('reviewer'));
+    composer.invalidate();
+    composer.flush();
+    const overlay = stripAnsi(captured.at(-1) ?? '');
+    // 7 tool calls from the CHILD's SourceState — not the parent's counters,
+    // which is the contradiction the child-scoped stats exist to remove.
+    expect(overlay).toMatch(/7 tool calls/);
+  });
+
+  it('still yields the soft-stop banner when stopping, not the child clause', () => {
+    // Precedence: ESC feedback outranks the child fallback. Both branches fire
+    // only on an empty per-task loop, so this pins the order between them.
+    const { captured, composer } = makeComposer(new Map(), liveChild('reviewer'), () => true);
+    composer.invalidate();
+    composer.flush();
+    const overlay = stripAnsi(captured.at(-1) ?? '');
+    expect(overlay).toContain('stopping…');
+    expect(overlay).not.toContain('round 3: bash pnpm test');
+  });
+
+  it('leaves the banner blank when no child is live', () => {
+    const { captured, composer } = makeComposer(new Map(), new Map());
     composer.invalidate();
     composer.flush();
     expect(captured.at(-1)).toBe('');

--- a/src/cli/_lib/stream-renderer-lifecycle.ts
+++ b/src/cli/_lib/stream-renderer-lifecycle.ts
@@ -21,6 +21,7 @@ import { isDebugEnabled } from '../../utils/debug.js';
 import type { SourceState } from './stream-renderer-source.js';
 import { syntheticResult } from './stream-renderer-source.js';
 import {
+  childBannerEvent,
   deriveChildBanner,
   type ChildActivityTracker,
 } from './child-activity-select.js';
@@ -171,6 +172,12 @@ export function registerOverlaySlots(
       // a minimal banner so the `stopping…` state always paints; the synthetic
       // event carries no stats, so formatProgressBanner renders just the glyph +
       // description + stopping clause.
+      //
+      // Ordering constraint: this branch runs BEFORE the child fallback below.
+      // Both fire only when the per-task loop produced nothing, and a stopping
+      // turn must surface `stopping…` rather than a child clause — so soft-stop
+      // claims the empty slot first and the child branch sees a non-empty
+      // bannerLines.
       if (stopping && bannerLines.length === 0) {
         bannerLines.push(
           ...formatProgressBanner(
@@ -178,6 +185,20 @@ export function registerOverlaySlots(
             undefined,
             undefined,
             true,
+          ),
+        );
+      }
+      // A live child while the parent has reported no round yet: the per-task
+      // loop above had nothing to iterate, so the clause and the child-scoped
+      // stats would be dropped. See childBannerEvent for why lastProgressByTask
+      // is empty for the whole of a FIRST-round foreground dispatch.
+      if (childBanner && bannerLines.length === 0) {
+        bannerLines.push(
+          ...formatProgressBanner(
+            childBannerEvent(childBanner.stats),
+            undefined,
+            activity,
+            stopping,
           ),
         );
       }

--- a/src/cli/_lib/stream-renderer-lifecycle.ts
+++ b/src/cli/_lib/stream-renderer-lifecycle.ts
@@ -20,6 +20,7 @@ import { getTerminalWidth } from '../terminal-size.js';
 import { isDebugEnabled } from '../../utils/debug.js';
 import type { SourceState } from './stream-renderer-source.js';
 import { syntheticResult } from './stream-renderer-source.js';
+import { deriveChildActivity, type ChildActivityTracker } from './child-activity-select.js';
 import type { ToolLane } from '../commands/interactive/tool-lane.js';
 import type { ThinkingLane } from '../commands/interactive/thinking-lane.js';
 import type { StreamingMarkdownRenderer } from '../markdown-stream.js';
@@ -68,6 +69,14 @@ export interface LifecycleContext {
 export function registerOverlaySlots(
   overlayComposer: OverlayComposer,
   ctx: Readonly<Pick<LifecycleContext, 'stageTracker' | 'thinkingMode' | 'thinkingLane' | 'streamingMarkdownRef' | 'toolLane' | 'lastProgressByTask'>> & {
+    /**
+     * Live source map + sticky selector for the banner's child-activity
+     * fallback. Optional so existing non-TTY callers and tests register slots
+     * unchanged; when absent the banner keeps its pre-change behaviour of
+     * leaving the detail slot blank during a foreground subagent dispatch.
+     */
+    sources?: ReadonlyMap<string, SourceState>;
+    childActivity?: ChildActivityTracker;
     /** Live interrupt state — true while a Ctrl+C interrupt is being processed. */
     getInterrupting: () => boolean;
     /**
@@ -136,7 +145,13 @@ export function registerOverlaySlots(
       // uncommitted phase only — peekPhase clears at each seal boundary, so
       // a stale clause never outlives the phase that produced it). Falls
       // back to the event's tool-derived summary inside formatProgressBanner.
-      const activity = deriveProgressActivity(ctx.thinkingLane.peekPhase());
+      // Fallback: the model's clause is empty for the whole of a foreground
+      // subagent dispatch (phase sealed at the agent tool_use_detail boundary),
+      // so name the busiest child instead of letting the line go blank. This is
+      // the production render path — setComposedOverlay carries the same
+      // fallback for the direct-compositor path used by tests/non-TTY.
+      const activity =
+        deriveProgressActivity(ctx.thinkingLane.peekPhase()) ?? deriveChildActivity(ctx);
       for (const progress of ctx.lastProgressByTask.values()) {
         bannerLines.push(...formatProgressBanner(progress, undefined, activity, stopping));
       }

--- a/src/cli/_lib/stream-renderer-lifecycle.ts
+++ b/src/cli/_lib/stream-renderer-lifecycle.ts
@@ -20,7 +20,10 @@ import { getTerminalWidth } from '../terminal-size.js';
 import { isDebugEnabled } from '../../utils/debug.js';
 import type { SourceState } from './stream-renderer-source.js';
 import { syntheticResult } from './stream-renderer-source.js';
-import { deriveChildActivity, type ChildActivityTracker } from './child-activity-select.js';
+import {
+  deriveChildBanner,
+  type ChildActivityTracker,
+} from './child-activity-select.js';
 import type { ToolLane } from '../commands/interactive/tool-lane.js';
 import type { ThinkingLane } from '../commands/interactive/thinking-lane.js';
 import type { StreamingMarkdownRenderer } from '../markdown-stream.js';
@@ -150,10 +153,18 @@ export function registerOverlaySlots(
       // so name the busiest child instead of letting the line go blank. This is
       // the production render path — setComposedOverlay carries the same
       // fallback for the direct-compositor path used by tests/non-TTY.
-      const activity =
-        deriveProgressActivity(ctx.thinkingLane.peekPhase()) ?? deriveChildActivity(ctx);
+      const modelActivity = deriveProgressActivity(ctx.thinkingLane.peekPhase());
+      // The child banner applies only when the model's own clause is empty —
+      // i.e. exactly the foreground-dispatch case, where lastProgressByTask is
+      // frozen at its pre-dispatch values. See deriveChildBanner for why the
+      // stats must be re-scoped along with the clause.
+      const childBanner = modelActivity ? undefined : deriveChildBanner(ctx);
+      const activity = modelActivity ?? childBanner?.activity;
       for (const progress of ctx.lastProgressByTask.values()) {
-        bannerLines.push(...formatProgressBanner(progress, undefined, activity, stopping));
+        const event = childBanner
+          ? { ...progress, ...childBanner.stats, lastToolName: undefined }
+          : progress;
+        bannerLines.push(...formatProgressBanner(event, undefined, activity, stopping));
       }
       // ESC soft-stop must give visible feedback even on a text-only turn that
       // never emitted a `progress` event (lastProgressByTask empty). Synthesize

--- a/src/cli/_lib/stream-renderer-orchestrator.ts
+++ b/src/cli/_lib/stream-renderer-orchestrator.ts
@@ -15,6 +15,7 @@ import type { OutputEvent, ProgressEvent } from '../../agent/types.js';
 // stream-renderer-subagent.ts for the companion rationale.
 import type { SourceState } from './stream-renderer-source.js';
 import {
+  childBannerEvent,
   deriveChildBanner,
   type ChildActivityTracker,
 } from './child-activity-select.js';
@@ -522,6 +523,13 @@ export function setComposedOverlay(ctx: OrchestratorCtx): void {
       ? { ...progress, ...childBanner.stats, lastToolName: undefined }
       : progress;
     bannerLines.push(...formatProgressBanner(event, undefined, activity));
+  }
+  // A live child with no parent progress row to carry it — see childBannerEvent
+  // for why lastProgressByTask is empty for a first-round foreground dispatch.
+  if (childBanner && bannerLines.length === 0) {
+    bannerLines.push(
+      ...formatProgressBanner(childBannerEvent(childBanner.stats), undefined, activity),
+    );
   }
   if (bannerLines.length > 0) parts.push(bannerLines.join('\n'));
   ctx.compositor.setOverlay(parts.join('\n'));

--- a/src/cli/_lib/stream-renderer-orchestrator.ts
+++ b/src/cli/_lib/stream-renderer-orchestrator.ts
@@ -14,6 +14,10 @@ import type { OutputEvent, ProgressEvent } from '../../agent/types.js';
 // an independent copy of the progress map. See the SubagentCtx comment in
 // stream-renderer-subagent.ts for the companion rationale.
 import type { SourceState } from './stream-renderer-source.js';
+import {
+  deriveChildActivity,
+  type ChildActivityTracker,
+} from './child-activity-select.js';
 import type { Writer } from '../slash/types.js';
 import type { TerminalCompositor } from '../terminal-compositor.js';
 import type { ToolLane } from '../commands/interactive/tool-lane.js';
@@ -124,6 +128,20 @@ export interface OrchestratorCtx {
    * can compose the full frame without carrying a separate copy.
    */
   lastProgressByTask: Map<string, ProgressEvent>;
+  /**
+   * Live source map, read-only here. Present so `setComposedOverlay` can name
+   * the active subagent in the banner's detail slot while the parent turn is
+   * blocked awaiting a foreground child (at which point `lastProgressByTask`
+   * receives no updates and the thinking lane is already drained). Optional so
+   * non-TTY surfaces and tests can omit it and keep the previous behaviour.
+   */
+  sources?: ReadonlyMap<string, SourceState>;
+  /**
+   * Sticky selector for the child named in the banner detail slot. Stateful, so
+   * it is owned by StreamRenderer and passed in — `setComposedOverlay` rebuilds
+   * its ctx object per call and cannot hold the selection itself.
+   */
+  childActivity?: ChildActivityTracker;
 }
 
 /**
@@ -488,7 +506,13 @@ export function setComposedOverlay(ctx: OrchestratorCtx): void {
   // uncommitted phase only — peekPhase clears at each seal boundary, so a
   // stale clause never outlives the phase that produced it). Falls back to
   // the event's own tool-derived summary inside formatProgressBanner.
-  const activity = deriveProgressActivity(ctx.thinkingLane.peekPhase());
+  // Fallback chain for the detail slot: the model's own in-flight clause wins,
+  // but it is empty for the whole of a foreground subagent dispatch (the phase
+  // is sealed at the agent tool_use_detail boundary). Naming the busiest child
+  // there keeps the line moving with real work instead of going blank — which
+  // is what made a working fan-out read as a hung session.
+  const activity =
+    deriveProgressActivity(ctx.thinkingLane.peekPhase()) ?? deriveChildActivity(ctx);
   for (const progress of ctx.lastProgressByTask.values()) {
     bannerLines.push(...formatProgressBanner(progress, undefined, activity));
   }

--- a/src/cli/_lib/stream-renderer-orchestrator.ts
+++ b/src/cli/_lib/stream-renderer-orchestrator.ts
@@ -15,7 +15,7 @@ import type { OutputEvent, ProgressEvent } from '../../agent/types.js';
 // stream-renderer-subagent.ts for the companion rationale.
 import type { SourceState } from './stream-renderer-source.js';
 import {
-  deriveChildActivity,
+  deriveChildBanner,
   type ChildActivityTracker,
 } from './child-activity-select.js';
 import type { Writer } from '../slash/types.js';
@@ -511,10 +511,17 @@ export function setComposedOverlay(ctx: OrchestratorCtx): void {
   // is sealed at the agent tool_use_detail boundary). Naming the busiest child
   // there keeps the line moving with real work instead of going blank — which
   // is what made a working fan-out read as a hung session.
-  const activity =
-    deriveProgressActivity(ctx.thinkingLane.peekPhase()) ?? deriveChildActivity(ctx);
+  const modelActivity = deriveProgressActivity(ctx.thinkingLane.peekPhase());
+  // Stats are re-scoped with the clause: lastProgressByTask is parent-scoped and
+  // frozen for the duration of the dispatch, so the parent's counters beside a
+  // live child clause would contradict it. See deriveChildBanner.
+  const childBanner = modelActivity ? undefined : deriveChildBanner(ctx);
+  const activity = modelActivity ?? childBanner?.activity;
   for (const progress of ctx.lastProgressByTask.values()) {
-    bannerLines.push(...formatProgressBanner(progress, undefined, activity));
+    const event = childBanner
+      ? { ...progress, ...childBanner.stats, lastToolName: undefined }
+      : progress;
+    bannerLines.push(...formatProgressBanner(event, undefined, activity));
   }
   if (bannerLines.length > 0) parts.push(bannerLines.join('\n'));
   ctx.compositor.setOverlay(parts.join('\n'));

--- a/src/cli/_lib/stream-renderer-source.ts
+++ b/src/cli/_lib/stream-renderer-source.ts
@@ -37,6 +37,18 @@ interface SourceState {
     progressReportedToolUses?: number;
   };
   /**
+   * Most recent `event.progress.summary` — the provider's per-round headline
+   * (`round N: <tool + key arg>`, see anthropic-direct/loop.ts and
+   * openai-compatible/query.ts). Stored so the progress banner can name what a
+   * subagent is doing while the parent turn is blocked awaiting it; before this
+   * field the value was received and discarded, leaving the banner's detail
+   * slot frozen for the whole child run.
+   *
+   * Advisory display data only — never a control input, and never conflated
+   * with `stats.toolUses` (round count ≠ distinct tool_use_detail events).
+   */
+  lastProgressSummary?: string;
+  /**
    * Captured content. Orchestrator: used as the markdown source for non-TTY
    * rendering on done. Subagent: the live text-buffer mirrored into the
    * subagent's active TextEntry under its synthetic Agent.

--- a/src/cli/_lib/stream-renderer-subagent-h2.test.ts
+++ b/src/cli/_lib/stream-renderer-subagent-h2.test.ts
@@ -199,3 +199,86 @@ describe('H2 fix: setOverlay throttled on high-frequency content/thinking chunks
     }
   });
 });
+
+describe('child progress events repaint the composed frame (PR #840 review, P2)', () => {
+  // Regression: the progress arm stored lastProgressSummary and returned without
+  // repainting, on the theory that the discrete tool_use_detail / tool_result
+  // transitions "arrive at least as often as progress events". True for
+  // frequency, false for ORDER — both provider loops emit a round's tool_result
+  // BEFORE its progress event, so the result repaint rendered the PREVIOUS
+  // headline and the new one stayed invisible until the child's next tool call.
+  const mkProgress = () =>
+    ({
+      type: 'progress',
+      progress: {
+        taskId: 'child-task',
+        description: 'Working',
+        summary: 'round 4: bash pnpm lint',
+        totalTokens: 900,
+        toolUses: 3,
+        durationMs: 1200,
+      },
+    }) as OutputEvent;
+
+  it('fires exactly one composed repaint per progress event', () => {
+    const lane = new ToolLane();
+    const setOverlaySpy = vi.fn();
+    const compositor = { setOverlay: setOverlaySpy, commitAbove: vi.fn() } as unknown as TerminalCompositor;
+    const ctx = makeCtx(lane, compositor);
+
+    const source: SourceState = freshSourceState('reviewer');
+    synthesizeAgentEntry('src-progress', source, ctx, undefined);
+    setOverlaySpy.mockClear();
+
+    handleSubagentEvent(mkProgress(), 'src-progress', source, ctx);
+
+    expect(source.lastProgressSummary).toBe('round 4: bash pnpm lint');
+    // Exactly one — the "at most one setComposedOverlay call per event"
+    // invariant is a cap, and this arm must not exceed it.
+    expect(setOverlaySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('is not throttled across consecutive rounds', () => {
+    // Progress fires once per round, not at streaming frequency, so it uses the
+    // discrete-arm path rather than the 1500ms content gate. Two rounds inside
+    // one window must produce two repaints.
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(10_000);
+      const lane = new ToolLane();
+      const setOverlaySpy = vi.fn();
+      const compositor = { setOverlay: setOverlaySpy, commitAbove: vi.fn() } as unknown as TerminalCompositor;
+      const ctx = makeCtx(lane, compositor);
+
+      const source: SourceState = freshSourceState('reviewer');
+      synthesizeAgentEntry('src-progress-2', source, ctx, undefined);
+      setOverlaySpy.mockClear();
+
+      handleSubagentEvent(mkProgress(), 'src-progress-2', source, ctx);
+      vi.advanceTimersByTime(200); // well inside the 1500ms streaming window
+      handleSubagentEvent(mkProgress(), 'src-progress-2', source, ctx);
+
+      expect(setOverlaySpy).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not repaint on a non-TTY surface', () => {
+    const lane = new ToolLane();
+    const setOverlaySpy = vi.fn();
+    const compositor = { setOverlay: setOverlaySpy, commitAbove: vi.fn() } as unknown as TerminalCompositor;
+    const ctx = { ...makeCtx(lane, compositor), isTTY: false };
+
+    const source: SourceState = freshSourceState('reviewer');
+    // Required setup: handleSubagentEvent early-returns unless
+    // synthesizeAgentEntry has stamped source.syntheticAgentToolUseId.
+    synthesizeAgentEntry('src-progress-3', source, ctx, undefined);
+    setOverlaySpy.mockClear();
+
+    handleSubagentEvent(mkProgress(), 'src-progress-3', source, ctx);
+
+    expect(source.lastProgressSummary).toBe('round 4: bash pnpm lint');
+    expect(setOverlaySpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/_lib/stream-renderer-subagent.ts
+++ b/src/cli/_lib/stream-renderer-subagent.ts
@@ -148,6 +148,13 @@ export function handleSubagentEvent(
       if (event.progress.toolUses !== undefined) {
         source.stats.progressReportedToolUses = event.progress.toolUses;
       }
+      // Retain the provider's per-round headline for the progress banner's
+      // detail slot. Deliberately does NOT call setComposedOverlay: the banner
+      // is repainted by the discrete tool_use_detail / tool_result transitions
+      // below, which arrive at least as often as progress events. Repainting
+      // here too would break the "at most one setComposedOverlay call per
+      // event" invariant documented in stream-renderer-orchestrator.ts.
+      if (event.progress.summary) source.lastProgressSummary = event.progress.summary;
       return;
 
     case 'chunk': {

--- a/src/cli/_lib/stream-renderer-subagent.ts
+++ b/src/cli/_lib/stream-renderer-subagent.ts
@@ -149,12 +149,22 @@ export function handleSubagentEvent(
         source.stats.progressReportedToolUses = event.progress.toolUses;
       }
       // Retain the provider's per-round headline for the progress banner's
-      // detail slot. Deliberately does NOT call setComposedOverlay: the banner
-      // is repainted by the discrete tool_use_detail / tool_result transitions
-      // below, which arrive at least as often as progress events. Repainting
-      // here too would break the "at most one setComposedOverlay call per
-      // event" invariant documented in stream-renderer-orchestrator.ts.
+      // detail slot, then repaint ONCE.
+      //
+      // Invariant: the "at most one setComposedOverlay call per event" rule in
+      // stream-renderer-orchestrator.ts is a CAP, not a prohibition, and this arm
+      // previously made zero calls. The earlier reasoning — that the discrete
+      // tool_use_detail / tool_result transitions "arrive at least as often as
+      // progress events" — held for frequency but not for ORDER: both provider
+      // loops emit a round's tool_result BEFORE its progress event, so the result
+      // repaint renders the PREVIOUS headline and this one stays invisible for the
+      // whole of the child's next model request. Unthrottled, matching the discrete
+      // arms below rather than the 1500ms-gated streaming paths: progress fires
+      // once per round, not at streaming frequency.
       if (event.progress.summary) source.lastProgressSummary = event.progress.summary;
+      if (ctx.isTTY && ctx.orchestratorCtx) {
+        setComposedOverlay(ctx.orchestratorCtx);
+      }
       return;
 
     case 'chunk': {

--- a/src/cli/_lib/stream-renderer.ts
+++ b/src/cli/_lib/stream-renderer.ts
@@ -44,6 +44,8 @@ import {
   type SourceState,
   freshSourceState,
 } from './stream-renderer-source.js';
+import { ChildActivityTracker } from './child-activity-select.js';
+import { InFlightToolTracker, noteToolEvent } from '../input/work-derived-verb.js';
 import {
   handleOrchestratorEvent,
   setComposedOverlay,
@@ -275,6 +277,21 @@ export class StreamRenderer {
   /** Last progress event per task — emitted on stream end as a one-line summary. */
   private lastProgressByTask = new Map<string, ProgressEvent>();
 
+  /**
+   * Sticky selector for the subagent named in the progress banner's detail slot.
+   * Held here (not on the ctx) because `buildOrchestratorCtx` allocates a fresh
+   * ctx object per call, which would reset the stickiness on every repaint and
+   * reintroduce the child-to-child thrash the hold exists to prevent.
+   */
+  private childActivity = new ChildActivityTracker();
+
+  /**
+   * In-flight tool set backing the spinner's work-derived verb. Spans the
+   * orchestrator and all subagents — the verb describes the session, not one
+   * source, so a single tracker is correct here.
+   */
+  private inFlightTools = new InFlightToolTracker();
+
   private disposed = false;
   private pauseTickInterval: ReturnType<typeof setInterval> | null = null;
   /**
@@ -456,6 +473,8 @@ export class StreamRenderer {
       streamingMarkdownRef: this.streamingMarkdownRef,
       toolLane: this.toolLane,
       lastProgressByTask: this.lastProgressByTask,
+      sources: this.sources,
+      childActivity: this.childActivity,
       getInterrupting: () => this.interrupting,
       getSoftStopping: () => this.softStopping,
     });
@@ -552,6 +571,8 @@ export class StreamRenderer {
       streamingMarkdown: this.streamingMarkdownRef,
       coordinator: this.coordinator,
       lastProgressByTask: this.lastProgressByTask,
+      sources: this.sources,
+      childActivity: this.childActivity,
       ...(this.isTTY ? { stageTracker: this.stageTracker } : {}),
       ...(this.activeSkillName ? { activeSkillName: this.activeSkillName } : {}),
     });
@@ -560,6 +581,11 @@ export class StreamRenderer {
   process(event: OutputEvent, meta?: SubagentProgressMeta): void {
     if (this.disposed) return;
 
+    // Feed the spinner's work-derived verb. Done here — before delegation —
+    // because `process` is the one choke point that sees tool events from BOTH
+    // the orchestrator and every subagent, so neither handler needs its own
+    // call site. Pure bookkeeping plus one setter; fires no repaint of its own.
+    noteToolEvent(event, this.inFlightTools, this.compositor);
     const sourceId = meta?.subagentId ?? ORCHESTRATOR_SOURCE_KEY;
     const isOrchestrator = sourceId === ORCHESTRATOR_SOURCE_KEY;
     let source = this.sources.get(sourceId);

--- a/src/cli/commands/interactive/progress-banner.test.ts
+++ b/src/cli/commands/interactive/progress-banner.test.ts
@@ -257,6 +257,61 @@ describe('progress-banner — terminal width clamping', () => {
     });
   });
 
+  describe('formatProgressBanner — path elision on the detail line', () => {
+    // The provider's per-round headline embeds raw absolute paths
+    // (`summarizeToolInput` preserves them verbatim). Un-elided, a worktree path
+    // consumed the whole row and clipped away the part that says what the command
+    // actually DOES — the operator watched `cd /Users/…/pr796-review-fix && git
+    // rev-…` for minutes without ever seeing the verb. `shortenPaths` collapses
+    // absolute paths to their basename, which the tool lane already did but the
+    // banner did not.
+    const LONG =
+      'round 7: bash cd /Users/griffinlong/Projects/open_source/agent-afk/.afk-worktrees/pr796-review-fix && git rev-parse HEAD';
+
+    it('collapses an absolute path in the summary to its basename', () => {
+      const lines = formatProgressBanner(mkEvent({ description: 'task', summary: LONG }), Infinity);
+      const detail = stripAnsi(lines[1]!);
+      expect(detail).toContain('pr796-review-fix');
+      expect(detail).not.toContain('/Users/griffinlong/Projects');
+    });
+
+    it('keeps the informative tail visible at a realistic terminal width', () => {
+      // At 100 columns the un-elided form (4 indent + 122 chars) overflows and the
+      // trailing verb is the first thing truncated away. Elided, it fits.
+      const lines = formatProgressBanner(mkEvent({ description: 'task', summary: LONG }), 100);
+      expect(stripAnsi(lines[1]!)).toContain('git rev-parse HEAD');
+    });
+
+    it('elides the activity clause too, not just the summary', () => {
+      const lines = formatProgressBanner(
+        mkEvent({ description: 'task', summary: 'unused' }),
+        Infinity,
+        'worker · round 2: Read /Users/griffinlong/Projects/open_source/agent-afk/src/cli/palette.ts',
+      );
+      const detail = stripAnsi(lines[1]!);
+      expect(detail).toContain('palette.ts');
+      expect(detail).not.toContain('/Users/griffinlong');
+    });
+
+    it('leaves URLs intact — only filesystem paths collapse', () => {
+      const lines = formatProgressBanner(
+        mkEvent({ description: 'task', summary: 'round 1: web_scrape https://example.com/a/b/c/d' }),
+        Infinity,
+      );
+      expect(stripAnsi(lines[1]!)).toContain('https://example.com/a/b/c/d');
+    });
+
+    it('still sanitizes control bytes before eliding', () => {
+      const lines = formatProgressBanner(
+        mkEvent({ description: 'task', summary: 'round 1: bash\u0007 cat /a/b/c/secrets.txt' }),
+        Infinity,
+      );
+      const detail = stripAnsi(lines[1]!);
+      expect(detail).not.toContain('\u0007');
+      expect(detail).toContain('secrets.txt');
+    });
+  });
+
   describe('deriveProgressActivity', () => {
     it('returns undefined for an empty buffer', () => {
       expect(deriveProgressActivity('', 80)).toBeUndefined();

--- a/src/cli/commands/interactive/progress-banner.ts
+++ b/src/cli/commands/interactive/progress-banner.ts
@@ -7,6 +7,7 @@ import { formatDuration, formatTokens, formatToolCallStat } from '../../format-u
 import { palette } from '../../palette.js';
 import { getTerminalWidth } from '../../terminal-size.js';
 import { styleForToolName } from '../../tool-category.js';
+import { shortenPaths } from './tool-lane-format-args.js';
 import { sanitizeLabel } from './tool-lane-format-sanitize.js';
 
 /**
@@ -22,6 +23,8 @@ function clampToTerminal(line: string, columns?: number): string {
   if (!Number.isFinite(cols) || cols <= 0) return line;
   return truncateDisplayWidth(line, cols);
 }
+
+
 
 /**
  * Derive the grounded "current activity" clause for the progress banner from
@@ -146,7 +149,11 @@ export function formatProgressBanner(
     ? palette.warning('stopping…')
     : (() => {
         const detailRaw = activity?.trim() ? activity : summary;
-        return detailRaw ? sanitizeLabel(detailRaw) : '';
+        // sanitizeLabel BEFORE shortenPaths: the sanitizer collapses control
+        // bytes and runs of whitespace, which the path-collapsing regex assumes
+        // has already happened. Same order as tool-lane-format-args.ts, which
+        // shortens the already-summarized arg string.
+        return detailRaw ? shortenPaths(sanitizeLabel(detailRaw)) : '';
       })();
 
   if (detail) {

--- a/src/cli/commands/interactive/tool-lane-grouped-errors.test.ts
+++ b/src/cli/commands/interactive/tool-lane-grouped-errors.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for failure visibility on collapsed grouped-sibling rows.
+ *
+ * A subagent running a burst of the same leaf tool collapses into one row:
+ * `$ bash ×50 — 48 ok, 2 errors`. Before this behaviour the row stopped there.
+ * The failure text was retained on `ToolEntry.result` but had no render path, so
+ * a child looping on one broken command looked exactly like a child making
+ * progress — the operator's only clue was a counter that also increments on
+ * success.
+ *
+ * These tests pin the three properties that make the row actionable: the failure
+ * message appears, it is the MOST RECENT one (answering "is it still failing?"
+ * rather than "did it ever fail"), and it is bounded so it cannot push the row
+ * past the terminal clamp.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ToolLane } from './tool-lane.js';
+import { displayWidth, stripAnsi } from '../../display.js';
+import type { ToolResultChunk } from '../../../agent/types/message-types.js';
+
+function makeResult(content: string, isError = false): ToolResultChunk {
+  return { type: 'tool_result', toolUseId: 'unused', content, isError };
+}
+
+/**
+ * Build a lane with an Agent parent and `n` bash children, marking the entries
+ * at `errorAt` as failures with the supplied messages. GROUP_THRESHOLD_LEAF is 3,
+ * so n >= 3 collapses into a single grouped row.
+ */
+function laneWithBashGroup(n: number, errorAt: Map<number, string>): ToolLane {
+  const lane = new ToolLane();
+  lane.addStartWithAgentContext('agent', 'Agent', '(pr796-fix)', undefined);
+  for (let i = 0; i < n; i++) {
+    const id = `b${i}`;
+    lane.addStartWithAgentContext(id, 'bash', `("cmd ${i}")`, 'agent');
+    // has(), not a truthiness check on get() — an intentionally EMPTY failure
+    // message is a case under test, and '' is falsy.
+    lane.addResult(
+      id,
+      errorAt.has(i) ? makeResult(errorAt.get(i)!, true) : makeResult('ok'),
+    );
+  }
+  return lane;
+}
+
+function bashRow(lane: ToolLane): string {
+  const rows = stripAnsi(lane.getOverlay()).split('\n');
+  const row = rows.find((l) => l.includes('bash') && l.includes('×'));
+  if (!row) throw new Error(`no grouped bash row in:\n${rows.join('\n')}`);
+  return row;
+}
+
+describe('grouped sibling rows — failure visibility', () => {
+  it('surfaces the failure message alongside the error tally', () => {
+    const lane = laneWithBashGroup(5, new Map([[3, 'fatal: not a git repository']]));
+    const row = bashRow(lane);
+    expect(row).toContain('4 ok');
+    expect(row).toContain('1 error');
+    expect(row).toContain('fatal: not a git repository');
+  });
+
+  it('names the MOST RECENT failure, not the first', () => {
+    const lane = laneWithBashGroup(
+      6,
+      new Map([
+        [1, 'first failure: ENOENT'],
+        [4, 'latest failure: exit 128'],
+      ]),
+    );
+    const row = bashRow(lane);
+    expect(row).toContain('2 errors');
+    expect(row).toContain('latest failure: exit 128');
+    expect(row).not.toContain('first failure');
+  });
+
+  it('bounds the preview so one long stderr cannot blow out the row', () => {
+    const long = 'E'.repeat(400);
+    const lane = laneWithBashGroup(4, new Map([[2, long]]));
+    const row = bashRow(lane);
+    // 40-column preview budget plus the row's own prefix/tally scaffolding.
+    expect(displayWidth(row)).toBeLessThan(140);
+    expect(row).toContain('…');
+  });
+
+  it('elides absolute paths inside the failure message', () => {
+    const lane = laneWithBashGroup(
+      4,
+      new Map([[1, 'ENOENT: /Users/griffinlong/Projects/open_source/agent-afk/missing.ts']]),
+    );
+    const row = bashRow(lane);
+    expect(row).toContain('missing.ts');
+    expect(row).not.toContain('/Users/griffinlong');
+  });
+
+  it('emits no dangling "last:" when the failure carries no message', () => {
+    const lane = laneWithBashGroup(4, new Map([[1, '']]));
+    const row = bashRow(lane);
+    expect(row).toContain('1 error');
+    expect(row).not.toContain('last:');
+  });
+
+  it('leaves healthy groups untouched — no error tone, no tail', () => {
+    const lane = laneWithBashGroup(5, new Map());
+    const row = bashRow(lane);
+    expect(row).toContain('5 done');
+    expect(row).not.toContain('last:');
+    expect(row).not.toContain('error');
+  });
+
+  it('keeps the raw healthy row byte-identical to the pre-change ANSI shape', () => {
+    // The healthy branch must still be a single palette.dim() span. Snapshot
+    // suites compare raw bytes, so a split into per-segment dims would be a
+    // silent regression even though it looks the same.
+    const lane = laneWithBashGroup(4, new Map());
+    const raw = lane.getOverlay().split('\n').find((l) => l.includes('×4'))!;
+    // One dim-open before the count, and no red anywhere.
+    expect(raw).not.toMatch(/\u001b\[31m/);
+  });
+});

--- a/src/cli/commands/interactive/tool-lane-render-grouping.ts
+++ b/src/cli/commands/interactive/tool-lane-render-grouping.ts
@@ -1,11 +1,14 @@
 import type { ToolEntry } from './tool-lane-render.js';
 import { palette } from '../../palette.js';
 import { NESTING_TOOLS } from '../../tool-category.js';
+import { truncateDisplayWidth } from '../../display.js';
 import {
   GROUP_THRESHOLD_DISPATCH,
   GROUP_THRESHOLD_LEAF,
   formatToolLine,
 } from './tool-lane-format.js';
+import { shortenPaths } from './tool-lane-format-args.js';
+import { sanitizeLabel } from './tool-lane-format-sanitize.js';
 import type { Glyphs } from './tool-lane-render.js';
 import { getGlyphs } from './tool-lane-render.js';
 import {
@@ -133,11 +136,47 @@ function groupSiblings(toolChildren: ToolEntry[]): Array<ToolEntry | GroupedSibl
 }
 
 /**
+ * Display budget for the trailing failure preview on a grouped row.
+ *
+ * Deliberately small: the row already carries a spine indent, the tool name, the
+ * `×N` count and the ok/error tally, and the caller clamps the whole line to the
+ * terminal. The preview's job is to identify the failure CLASS ("not a git
+ * repository", "ENOENT", "exit 1"), not to reproduce the tool's stderr.
+ */
+const GROUP_ERROR_PREVIEW_WIDTH = 40;
+
+/**
+ * Contract: on an errored result, `ToolResultChunk.content` holds the failure
+ * message (the handler's stderr or exception text, already clipped to a preview
+ * upstream). `formatOutcome` is deliberately NOT reused here — its `lineCount`
+ * branch renders a multi-line result as `12 lines`, which for a failure discards
+ * the only part the operator needs.
+ *
+ * Returns `''` when the message is empty so the caller emits no dangling `· last:`.
+ */
+function formatGroupErrorPreview(entry: ToolEntry): string {
+  const raw = entry.result?.content ?? '';
+  // sanitizeLabel BEFORE shortenPaths — the sanitizer collapses the control
+  // bytes and whitespace runs the path regex assumes are already gone. Error
+  // text is LLM/tool-controlled and routinely embeds absolute paths.
+  const clean = shortenPaths(sanitizeLabel(raw));
+  if (!clean) return '';
+  return truncateDisplayWidth(clean, GROUP_ERROR_PREVIEW_WIDTH);
+}
+
+/**
  * Render a grouped-sibling row:
  *   `<glyph> <Name><label>  ×<N> — <status>`
  *
  * Status flips between `N running`, `K/N done`, `N done`, or
  * `K ok, M errors` based on per-entry result presence.
+ *
+ * When any entry failed, the error tally is toned with `palette.error` (matching
+ * the root-group convention in tool-lane-render-grouped-root.ts) and the most
+ * recent failure's message is appended. Before this, a collapsed group reported
+ * `×50 — 48 ok, 2 errors` and stopped: the failure text was retained on
+ * `ToolEntry.result` but had no render path, so a subagent silently looping on
+ * the same broken command was indistinguishable from one making progress.
  */
 function formatGroupedSibling(group: GroupedSibling): string {
   const total = group.entries.length;
@@ -145,13 +184,24 @@ function formatGroupedSibling(group: GroupedSibling): string {
   const errors = completed.filter((e) => e.result!.isError);
   const done = completed.length;
 
+  // Invariant: the errored branch returns a PRE-STYLED status (each span carries
+  // its own tone) while the healthy branches return plain text the caller wraps in
+  // a single palette.dim(). Keeping them separate preserves the healthy rows'
+  // exact ANSI byte sequence — snapshot suites compare it — and avoids nesting the
+  // error tone inside an outer dim, the hazard documented for the synthetic
+  // summary above.
   let status: string;
+  let errorTail = '';
   if (errors.length > 0) {
     const ok = done - errors.length;
     const parts: string[] = [];
-    if (ok > 0) parts.push(`${ok} ok`);
-    parts.push(`${errors.length} error${errors.length === 1 ? '' : 's'}`);
-    status = parts.join(', ');
+    if (ok > 0) parts.push(palette.dim(`${ok} ok`));
+    parts.push(palette.error(`${errors.length} error${errors.length === 1 ? '' : 's'}`));
+    status = parts.join(palette.dim(', '));
+    // Most recent failure: entries are appended in dispatch order, so the last
+    // errored entry answers "is it still failing?" rather than "did it ever".
+    const preview = formatGroupErrorPreview(errors[errors.length - 1]!);
+    if (preview) errorTail = palette.dim(' · last: ') + palette.error(preview);
   } else if (done === total) {
     status = `${total} done`;
   } else if (done === 0) {
@@ -161,6 +211,9 @@ function formatGroupedSibling(group: GroupedSibling): string {
   }
 
   const prefix = formatToolLine(group.toolName + group.label);
+  if (errors.length > 0) {
+    return prefix + palette.dim(` ×${total} — `) + status + errorTail;
+  }
   return prefix + palette.dim(` ×${total} — ${status}`);
 }
 

--- a/src/cli/input/spinner.ts
+++ b/src/cli/input/spinner.ts
@@ -23,6 +23,16 @@ export interface SpinnerControllerOptions {
    * {@link goblinSpinnerEnabled}. Purely cosmetic — no timer/width change.
    */
   goblin?: boolean;
+  /**
+   * Optional source of a work-derived verb. Consulted on every verb pick; when
+   * it returns a string that verb is used verbatim, otherwise the flavour pool
+   * supplies one. Lets the spinner describe the tool actually in flight instead
+   * of rotating random noir verbs that imply state changes which never happened.
+   *
+   * Pull-based on purpose: the controller already ticks at 80ms, so reading the
+   * current verb during that tick adds no timer and no new repaint path.
+   */
+  workVerb?: () => string | undefined;
 }
 
 /**
@@ -44,15 +54,27 @@ export class SpinnerController {
   private readonly captureMode: boolean;
   private readonly onTick: () => void;
   private readonly goblin: boolean;
+  private readonly workVerb: (() => string | undefined) | undefined;
 
   constructor(opts: SpinnerControllerOptions) {
     this.captureMode = opts.captureMode;
     this.onTick = opts.onTick;
     this.goblin = opts.goblin ?? false;
+    this.workVerb = opts.workVerb;
   }
 
-  /** Pick a verb from the active theme's pool. */
+  /**
+   * Pick a verb: the real in-flight activity when one is known, else the active
+   * theme's flavour pool. A throwing provider must never take down the render
+   * loop, so it degrades to the pool rather than propagating.
+   */
   private pickVerb(): string {
+    try {
+      const derived = this.workVerb?.();
+      if (derived) return derived;
+    } catch {
+      // fall through to the flavour pool
+    }
     return this.goblin ? pickRandomGoblinVerb() : pickRandomVerb();
   }
 
@@ -140,7 +162,20 @@ export class SpinnerController {
     if (!this.state) return;
     this.state.frameIndex = (this.state.frameIndex + 1) % SPINNER_FRAMES.length;
     const now = Date.now();
-    if (now >= this.state.nextVerbRotateAt) {
+    // Two triggers for a re-pick: the flavour rotation window elapsing, and the
+    // work-derived verb disagreeing with what is displayed. The second keeps the
+    // verb honest without waiting out a rotation — and is self-throttling,
+    // because the provider reports a tool CATEGORY, so a burst of reads yields
+    // one stable "Reading" rather than a flicker of new words.
+    const derived = (() => {
+      try {
+        return this.workVerb?.();
+      } catch {
+        return undefined;
+      }
+    })();
+    const workVerbChanged = derived !== undefined && derived !== this.state.verb;
+    if (now >= this.state.nextVerbRotateAt || workVerbChanged) {
       this.state.verb = this.pickVerb();
       this.state.nextVerbRotateAt = now + rotateMs;
     }

--- a/src/cli/input/work-derived-verb.test.ts
+++ b/src/cli/input/work-derived-verb.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests for work-derived spinner verbs.
+ *
+ * The point of this module is honesty: the verb slot previously rotated random
+ * flavour words, implying state changes that never happened. Two properties
+ * matter most here — an idle session must NOT claim an activity, and a parallel
+ * wave must not blank the verb when one of many concurrent tools finishes.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { verbForToolName, InFlightToolTracker, noteToolEvent } from './work-derived-verb.js';
+
+describe('verbForToolName', () => {
+  it('returns undefined when no tool is in flight', () => {
+    // Undefined routes the spinner back to its flavour pool — idle time has no
+    // work to describe, and inventing one would be the original lie.
+    expect(verbForToolName(undefined)).toBeUndefined();
+    expect(verbForToolName('')).toBeUndefined();
+    expect(verbForToolName('   ')).toBeUndefined();
+  });
+
+  it('describes read tools as Reading', () => {
+    expect(verbForToolName('read_file')).toBe('Reading');
+    expect(verbForToolName('grep')).toBe('Reading');
+  });
+
+  it('describes mutation tools as Editing', () => {
+    expect(verbForToolName('edit_file')).toBe('Editing');
+    expect(verbForToolName('write_file')).toBe('Editing');
+  });
+
+  it('describes shell tools as Running', () => {
+    expect(verbForToolName('bash')).toBe('Running');
+  });
+
+  it('describes dispatch tools by their dispatch class', () => {
+    expect(verbForToolName('agent')).toBe('Delegating');
+    expect(verbForToolName('skill')).toBe('Orchestrating');
+    expect(verbForToolName('compose')).toBe('Orchestrating');
+  });
+
+  it('describes MCP tools as Calling', () => {
+    expect(verbForToolName('mcp__server__do_thing')).toBe('Calling');
+  });
+
+  it('falls back to a deliberately vague verb for uncategorized tools', () => {
+    // `other` is the catch-all bucket, so any specific claim risks being wrong.
+    expect(verbForToolName('some_unknown_future_tool')).toBe('Working');
+  });
+
+  it('always returns a capitalized present participle', () => {
+    for (const name of ['read_file', 'bash', 'agent', 'web_scrape', 'unknown_x']) {
+      const verb = verbForToolName(name)!;
+      expect(verb).toMatch(/^[A-Z][a-z]+ing$/);
+    }
+  });
+});
+
+describe('InFlightToolTracker', () => {
+  it('reports undefined while idle', () => {
+    expect(new InFlightToolTracker().current()).toBeUndefined();
+  });
+
+  it('reports a started tool', () => {
+    const t = new InFlightToolTracker();
+    t.start('t1', 'bash');
+    expect(t.current()).toBe('bash');
+  });
+
+  it('reports the most recently started tool', () => {
+    const t = new InFlightToolTracker();
+    t.start('t1', 'bash');
+    t.start('t2', 'read_file');
+    expect(t.current()).toBe('read_file');
+  });
+
+  it('goes idle once the only tool finishes', () => {
+    const t = new InFlightToolTracker();
+    t.start('t1', 'bash');
+    t.finish('t1');
+    expect(t.current()).toBeUndefined();
+  });
+
+  it('KEEPS a verb when one of several concurrent tools finishes', () => {
+    // The parallel-wave invariant: a fan-out has many tools in flight, and one
+    // completing must not blank the verb while siblings are still working.
+    const t = new InFlightToolTracker();
+    t.start('t1', 'bash');
+    t.start('t2', 'read_file');
+    t.start('t3', 'grep');
+    t.finish('t3');
+    expect(t.current()).toBe('read_file');
+    t.finish('t2');
+    expect(t.current()).toBe('bash');
+    t.finish('t1');
+    expect(t.current()).toBeUndefined();
+  });
+
+  it('ignores completion of an unknown id', () => {
+    const t = new InFlightToolTracker();
+    t.start('t1', 'bash');
+    t.finish('nope');
+    expect(t.current()).toBe('bash');
+  });
+
+  it('moves a repeated id to the front rather than keeping a stale position', () => {
+    const t = new InFlightToolTracker();
+    t.start('t1', 'bash');
+    t.start('t2', 'read_file');
+    t.start('t1', 'grep');
+    expect(t.current()).toBe('grep');
+  });
+
+  it('reset() drops all tracking so no id can pin a stale verb', () => {
+    const t = new InFlightToolTracker();
+    t.start('t1', 'bash');
+    t.reset();
+    expect(t.current()).toBeUndefined();
+  });
+});
+
+describe('noteToolEvent', () => {
+  const sinkSpy = () => {
+    const seen: Array<string | undefined> = [];
+    return { seen, setActiveToolName: (n: string | undefined) => seen.push(n) };
+  };
+
+  it('ignores non-chunk events', () => {
+    const t = new InFlightToolTracker();
+    const sink = sinkSpy();
+    expect(noteToolEvent({ type: 'progress' }, t, sink)).toBe(false);
+    expect(sink.seen).toEqual([]);
+  });
+
+  it('ignores non-tool chunks such as content and thinking', () => {
+    const t = new InFlightToolTracker();
+    const sink = sinkSpy();
+    expect(noteToolEvent({ type: 'chunk', chunk: { type: 'content' } }, t, sink)).toBe(false);
+    expect(sink.seen).toEqual([]);
+  });
+
+  it('pushes the tool name on a tool start', () => {
+    const t = new InFlightToolTracker();
+    const sink = sinkSpy();
+    const handled = noteToolEvent(
+      { type: 'chunk', chunk: { type: 'tool_use_detail', toolUseId: 'a', toolName: 'bash' } },
+      t, sink,
+    );
+    expect(handled).toBe(true);
+    expect(sink.seen).toEqual(['bash']);
+  });
+
+  it('pushes undefined once the last tool completes', () => {
+    const t = new InFlightToolTracker();
+    const sink = sinkSpy();
+    noteToolEvent({ type: 'chunk', chunk: { type: 'tool_use_detail', toolUseId: 'a', toolName: 'bash' } }, t, sink);
+    noteToolEvent({ type: 'chunk', chunk: { type: 'tool_result', toolUseId: 'a' } }, t, sink);
+    expect(sink.seen).toEqual(['bash', undefined]);
+  });
+
+  it('tolerates a sink that does not implement the setter', () => {
+    // Partial compositor mocks are common in this repo; a cosmetic verb must
+    // never throw inside the event path.
+    const t = new InFlightToolTracker();
+    expect(() =>
+      noteToolEvent(
+        { type: 'chunk', chunk: { type: 'tool_use_detail', toolUseId: 'a', toolName: 'bash' } },
+        t, {},
+      ),
+    ).not.toThrow();
+  });
+
+  it('tolerates a null sink', () => {
+    const t = new InFlightToolTracker();
+    expect(() =>
+      noteToolEvent(
+        { type: 'chunk', chunk: { type: 'tool_use_detail', toolUseId: 'a', toolName: 'bash' } },
+        t, null,
+      ),
+    ).not.toThrow();
+    expect(t.current()).toBe('bash');
+  });
+
+  it('ignores a tool chunk with no toolUseId', () => {
+    const t = new InFlightToolTracker();
+    const sink = sinkSpy();
+    expect(noteToolEvent({ type: 'chunk', chunk: { type: 'tool_use_detail', toolName: 'bash' } }, t, sink)).toBe(false);
+    expect(sink.seen).toEqual([]);
+  });
+});

--- a/src/cli/input/work-derived-verb.ts
+++ b/src/cli/input/work-derived-verb.ts
@@ -1,0 +1,139 @@
+/**
+ * Work-derived spinner verbs.
+ *
+ * The spinner's verb slot rotates every 3500ms via `Math.random()` over a static
+ * pool (`SPINNER_VERBS` in ../constants.ts — "Stalking", "Shadowing", "Tailing").
+ * That motion is uncorrelated with the work, so it teaches the operator nothing
+ * and actively misleads: "Stalking" rotating to "Gnawing" implies a state change
+ * that never happened. Since it is the fastest-moving text on screen during a
+ * long turn, it is also the highest-leverage place to put a true signal.
+ *
+ * This module maps the tool currently in flight to an honest present participle.
+ * It returns `undefined` when nothing is running, which is the signal for the
+ * caller to fall back to the flavour pool — idle time has no work to describe,
+ * and that is where the noir/goblin character belongs.
+ *
+ * @module cli/input/work-derived-verb
+ */
+
+import { categorizeTool, type ToolCategory } from '../../agent/tool-category.js';
+
+/**
+ * Category → verb. Exhaustive over `ToolCategory` (a `Record`, not a `Partial`),
+ * so adding a category to the union is a compile error here rather than a silent
+ * fall-through to a flavour verb that misdescribes real work.
+ *
+ * `other` maps to a deliberately vague "Working": it is the catch-all bucket, so
+ * a specific claim would risk being wrong.
+ */
+const CATEGORY_VERB: Record<ToolCategory, string> = {
+  read: 'Reading',
+  write: 'Editing',
+  shell: 'Running',
+  subagent: 'Delegating',
+  skill: 'Orchestrating',
+  dag: 'Orchestrating',
+  mcp: 'Calling',
+  web: 'Fetching',
+  browser: 'Browsing',
+  planning: 'Planning',
+  schedule: 'Scheduling',
+  other: 'Working',
+};
+
+/**
+ * The verb for a tool name, or `undefined` when there is no tool to describe.
+ *
+ * Contract: an empty / whitespace-only name yields `undefined` rather than
+ * `'Working'`, so a caller that has not yet observed a tool_use is treated as
+ * idle (flavour pool) instead of being labelled with a false activity claim.
+ */
+export function verbForToolName(toolName: string | undefined): string | undefined {
+  if (!toolName || !toolName.trim()) return undefined;
+  return CATEGORY_VERB[categorizeTool(toolName)];
+}
+
+/**
+ * Tracks which tools are in flight so the spinner can name one of them.
+ *
+ * Invariant: a parallel wave has many concurrent tool calls, so completion of
+ * ONE must not blank the verb while siblings still run. Membership is keyed by
+ * `toolUseId` and {@link current} reports the most recently STARTED entry that
+ * has not yet completed — the freshest true statement about the session.
+ *
+ * Bounded by construction: entries are added on start and removed on result, and
+ * {@link reset} clears the map between turns so an abandoned id cannot pin a
+ * stale verb forever.
+ */
+export class InFlightToolTracker {
+  /** Insertion-ordered: JS Map iteration order gives "most recent" for free. */
+  private readonly inFlight = new Map<string, string>();
+
+  /** Record a tool as started. */
+  start(toolUseId: string, toolName: string): void {
+    // Delete-then-set so a repeated id moves to the end of the iteration order
+    // rather than keeping its original (now stale) position.
+    this.inFlight.delete(toolUseId);
+    this.inFlight.set(toolUseId, toolName);
+  }
+
+  /** Record a tool as finished. Unknown ids are ignored. */
+  finish(toolUseId: string): void {
+    this.inFlight.delete(toolUseId);
+  }
+
+  /** The most recently started still-running tool name, or `undefined` if idle. */
+  current(): string | undefined {
+    let last: string | undefined;
+    for (const name of this.inFlight.values()) last = name;
+    return last;
+  }
+
+  /** Drop all tracking — call between turns so state never leaks. */
+  reset(): void {
+    this.inFlight.clear();
+  }
+}
+
+/** The slice of the compositor this adapter needs. Structural, so mocks satisfy it. */
+export interface ActiveToolNameSink {
+  setActiveToolName?(toolName: string | undefined): void;
+}
+
+/** Minimal event shape — avoids importing the full OutputEvent union here. */
+interface MaybeToolEvent {
+  type: string;
+  chunk?: { type: string; toolUseId?: string; toolName?: string };
+}
+
+/**
+ * Mirror one stream event into `tracker` and push the resulting tool name to
+ * `sink`. Returns true when a tool transition was observed (useful in tests).
+ *
+ * A free function rather than a StreamRenderer method so the renderer — already
+ * far past the 350-line ceiling — gains a call site instead of new logic, and so
+ * this is unit-testable without constructing a renderer.
+ *
+ * `setActiveToolName` is invoked optionally on purpose: several suites build
+ * partial compositor mocks, and this signal is purely cosmetic, so a reduced
+ * surface must degrade to "no work-derived verb" rather than throw inside the
+ * event path.
+ */
+export function noteToolEvent(
+  event: MaybeToolEvent,
+  tracker: InFlightToolTracker,
+  sink: ActiveToolNameSink | null | undefined,
+): boolean {
+  if (event.type !== 'chunk' || !event.chunk) return false;
+  const chunk = event.chunk;
+  if (!chunk.toolUseId) return false;
+  if (chunk.type === 'tool_use_detail') {
+    tracker.start(chunk.toolUseId, chunk.toolName ?? '');
+  } else if (chunk.type === 'tool_result') {
+    tracker.finish(chunk.toolUseId);
+  } else {
+    return false;
+  }
+  sink?.setActiveToolName?.(tracker.current());
+  return true;
+}

--- a/src/cli/terminal-compositor.ts
+++ b/src/cli/terminal-compositor.ts
@@ -22,6 +22,7 @@ import type { AutocompleteState } from './input/autocomplete-state.js';
 import type { IHistoryRing } from './input/types.js';
 import type { ImageAttachment } from './input/attachments.js';
 import { SpinnerController } from './input/spinner.js';
+import { verbForToolName } from './input/work-derived-verb.js';
 import { CaretBlinkController, DEFAULT_CARET_BLINK_INTERVAL_MS } from './input/caret-blink.js';
 import type { StdinClaimHandle } from './input/stdin-claim.js';
 import {
@@ -333,6 +334,13 @@ export class TerminalCompositor {
   /** @internal Relaxed from `private` for the frame module (FrameHost). */
   readonly spinnerController: SpinnerController;
   /**
+   * Name of the tool currently in flight, or `undefined` when idle. Written only
+   * by {@link setActiveToolName} and read only by the spinner's `workVerb`
+   * provider, so it carries no layout or geometry consequences — the spinner row
+   * already has a variable-width verb.
+   */
+  private activeToolName: string | undefined;
+  /**
    * Owns the input caret's blink phase + timer. Started in arm() / resumeInput(),
    * stopped in disarm() / suspendInput(), reset-to-solid on each non-paste
    * keystroke. `caretVisible` (read by the frame renderer) reflects its phase.
@@ -566,6 +574,10 @@ export class TerminalCompositor {
       captureMode: opts.captureMode ?? false,
       goblin: opts.goblinSpinner ?? false,
       onTick: () => this.repaint(),
+      // Pull-based so the spinner reads the live tool during its existing 80ms
+      // tick — no extra timer, no extra repaint path. Returns undefined when no
+      // tool is in flight, which routes the spinner back to its flavour pool.
+      workVerb: () => verbForToolName(this.activeToolName),
     });
     // Caret blink defaults OFF: enablement (incl. reduced-motion) is resolved
     // by the interactive caller and passed as `caretBlink`, mirroring how the
@@ -794,6 +806,21 @@ export class TerminalCompositor {
   setSpinner(config: { enabled: boolean; rotateVerbEveryMs?: number }): void {
     if (!this.stdout.isTTY) return;
     this.spinnerController.set(config);
+  }
+
+  /**
+   * Record the tool currently in flight so the spinner's verb can describe real
+   * work instead of rotating random flavour words.
+   *
+   * Deliberately does NOT repaint: the spinner's existing 80ms tick picks the new
+   * verb up on its next frame, and the caller (StreamRenderer) is already firing
+   * a repaint for the same transition. Painting here too would add a second
+   * frame write per tool event for no visible gain.
+   *
+   * Pass `undefined` on tool completion to fall back to the flavour pool.
+   */
+  setActiveToolName(toolName: string | undefined): void {
+    this.activeToolName = toolName;
   }
 
   // Committed-band lifecycle extracted to terminal-compositor.committed-band.ts


### PR DESCRIPTION
Closes the visible half of #75.

## The report

An operator screenshotted the REPL after **23m20s** of one foreground subagent:

```
◉ → Agent(pr796-fix) [subagent]
│ ├ $ bash ×50 — 48 ok, 2 errors
│ ● read_file ×5 — 5 done
◦ Working
    round 7: bash cd /Users/griffinlong/Projects/open_source/agent-afk/.afk-worktrees/pr796-review-fix && git rev-…
⣾ Plotting... 23m20s
  💡 Tip: Set AFK_SPINNER_TIPS=0 to silence these loading-screen tips.
```

> "sometimes it just stays lookin like this for 20+ mins straight with just tiny numbers changing"

That is accurate, and it understates the problem. Four of those rows **cannot** change during a subagent run, and one is lying:

| Row | Live during a subagent run? |
|---|---|
| `Agent(pr796-fix) [subagent]` | No — written once at dispatch |
| `$ bash ×50 — 48 ok, 2 errors` | Yes — the "tiny numbers" |
| `read_file ×5 — 5 done` | No — static once done |
| `◦ Working` | No — hardcoded literal (`tool-round.ts:104`) |
| `round 7: …` | **No — and it is the PARENT's last COMPLETED round** |
| `Plotting... 23m20s` | Verb: `Math.random()` every 3.5s. Clock: real |

The `round 7:` line is the tell. Child `progress` events reached the renderer and were dropped: the `case 'progress':` arm stored `totalTokens` and returned without touching the banner. The comment admitted it — subagent progress "is firewalled to handleSubagentEvent and never reaches this map." So the row showed the parent's own pre-dispatch `git rev-parse HEAD` **for twenty-three minutes**.

## Changes

**1. Fill the detail slot from live child activity** (ports the TUI half of an orphaned commit, never PR'd)

The clause now names the active child, its round, and — the part nothing else surfaced — whether it has gone quiet: `pr796-fix · no output for 41s`. The spinner verb is derived from the tool actually in flight instead of a random pool.

Both are **pull-based**, read during repaints that already happen. No new timer, preserving the "at most one setComposedOverlay call per event" invariant; `live-progress-no-timer.test.ts` enforces it structurally.

Deliberately **not** ported: `activity-tracker.ts` + `streaming-stall-badge.ts` (~400 LOC with no production call site) and `ProgressEvent.lastActivityAt`, which the original documents as "NOT the stall source" and which lost its home when #818 split `anthropic-direct/loop.ts`.

**2. Elide absolute paths in the banner** — `shortenPaths` already existed and was already used on the tool-lane path; it was simply never wired here. `cd /Users/…/pr796-review-fix && git rev-parse HEAD` → `cd pr796-review-fix && git rev-parse HEAD`, so the verb survives instead of being clipped.

**3. Surface the failure on a collapsed row** — `48 ok, 2 errors` retained the failure text on `ToolEntry.result` and rendered only the tally, so a child looping on one broken command was indistinguishable from one making progress. Now: `48 ok, 2 errors · last: fatal: not a git repository`. Most recent (not first), bounded to 40 columns, run through `sanitizeLabel → shortenPaths`. This branch had **zero** test coverage before.

**4. Scope the stats to the child the clause names** — filling the slot exposed the second half of the same bug: the stats tail is parent-scoped and frozen for the whole dispatch, so a live clause sat beside 23-minute-old counters. Worse than the blank slot it replaced, because a live-looking clause invites you to trust the numbers next to it. Stats now come from the same child's `SourceState`, with elapsed measured from the child's own `startedAt`.

## Deliberately not done

**No always-on clock on the `Agent(...)` row** (#75's first ask). `OverlayComposer.dirty` is one global boolean, so `flush()` re-renders every slot — but nothing calls it on a fixed cadence while a child is *active*. Composition there is event-driven behind the 1500ms throttle. An unconditional row clock would therefore sit visibly stalled between events: a clock that lies about time, which is a worse failure than no clock. The informative case — silence — is already covered by the existing `· waiting Xs` annotation and by the new `no output for Ns` clause.

Elapsed advances at ~1.5s granularity while the child is active (child events) and ~1s while quiet (the existing 80ms pause tick, change-gated). Narrow dead zone: an active-but-silent child between ~1.5s and 30s.

**Round denominator** (`round 7/50`) needs `max_tool_use_iterations` plumbed across the agent→renderer boundary. Separable; not bolted on here.

## Verification

- `pnpm lint` (tsc --noEmit, strict) clean
- `pnpm test` — **743 files, 14,220 passed**, 2 skipped
- `pnpm test:pty` — 10/10 (CI-required gate)
- `audit:sdk:check`, `audit:env:check`, `scan:env:check` all pass
- New coverage: 12 cases across banner elision, grouped-row failures (incl. an ANSI-shape guard on the healthy row), and child-scoped stats
- Every touched file under the 350-LOC ceiling
- Rebased onto current `main`

Healthy grouped rows keep their exact ANSI byte sequence, so the 48 compositor regression suites are untouched — only errored rows change shape.
