### PR TITLE
fix(subagent): grant confined forks read access to the agent-framework dir

### DIFF
--- a/src/agent/subagent-read-scope.test.ts
+++ b/src/agent/subagent-read-scope.test.ts
@@ -199,6 +199,103 @@ describe('computeInheritedReadRoots', () => {
       ).toBe(true);
     });
   });
+
+  // Gap C — the agent-framework read grant. Sibling of the afkStateRoot grant
+  // above (Gap A): ~/.afk/agent-framework is NOT lexically contained by a
+  // confined fork's cwd+repo roots, so children dispatched by /orient,
+  // /harvest, /forge, /distill and the improve pipeline were hard-denied the one
+  // tree their task requires (46 denials / 15 sessions, card
+  // subagent-read-denial-ab89c2bd6a6f).
+  describe('afkFrameworkRoot grant (confined forks reach ~/.afk/agent-framework — Gap C)', () => {
+    const FRAMEWORK = '/Users/me/.afk/agent-framework';
+    const STATE = '/Users/me/.afk/state';
+
+    it('folds the agent-framework dir into a confined worktree fork union', () => {
+      const roots = computeInheritedReadRoots({
+        parentReadRoots: undefined,
+        parentCwd: '/repo/.afk-worktrees/wt',
+        childCwd: '/repo/.afk-worktrees/wt',
+        worktreeMainRoot: '/repo',
+        afkFrameworkRoot: FRAMEWORK,
+      })!;
+      expect(new Set(roots)).toEqual(
+        new Set(['/repo/.afk-worktrees/wt', '/repo', FRAMEWORK]),
+      );
+      // An improve-pipeline failure card is now admitted (containment is
+      // lexical: path.relative does not escape the root).
+      expect(
+        path
+          .relative(FRAMEWORK, `${FRAMEWORK}/improve/failure-cards/some-card.json`)
+          .startsWith('..'),
+      ).toBe(false);
+    });
+
+    it('is granted ALONGSIDE the state root, not instead of it (siblings, both needed)', () => {
+      // The two grants are independent: a /harvest fork reads session ledgers
+      // under state AND pattern-cards under agent-framework in the same task.
+      const roots = computeInheritedReadRoots({
+        parentReadRoots: undefined,
+        parentCwd: '/repo/.afk-worktrees/wt',
+        childCwd: '/repo/.afk-worktrees/wt',
+        worktreeMainRoot: '/repo',
+        afkStateRoot: STATE,
+        afkFrameworkRoot: FRAMEWORK,
+      })!;
+      expect(new Set(roots)).toEqual(
+        new Set(['/repo/.afk-worktrees/wt', '/repo', STATE, FRAMEWORK]),
+      );
+    });
+
+    it('grants [cwd, framework] even with no worktree main root (lifts the fork out of the [cwd] default)', () => {
+      const roots = computeInheritedReadRoots({
+        parentReadRoots: undefined,
+        parentCwd: '/plain/repo',
+        childCwd: '/plain/repo',
+        worktreeMainRoot: undefined,
+        afkFrameworkRoot: FRAMEWORK,
+      });
+      // Without afkFrameworkRoot this is the "only root is cwd" case → undefined.
+      expect(new Set(roots)).toEqual(new Set(['/plain/repo', FRAMEWORK]));
+    });
+
+    it('is ignored for an unconfined (read-open) parent — read-open already covers it', () => {
+      const roots = computeInheritedReadRoots({
+        parentReadRoots: undefined,
+        parentCwd: undefined,
+        childCwd: '/repo/.afk-worktrees/wt',
+        afkFrameworkRoot: FRAMEWORK,
+      });
+      expect(roots).toEqual([FS_ROOT]); // read-open, not [.., FRAMEWORK]
+    });
+
+    it('omitting afkFrameworkRoot preserves the pre-fix behaviour (back-compat)', () => {
+      const roots = computeInheritedReadRoots({
+        parentReadRoots: undefined,
+        parentCwd: '/repo',
+        childCwd: '/repo',
+        worktreeMainRoot: undefined,
+      });
+      expect(roots).toBeUndefined();
+    });
+
+    it('never derives ~/.afk/config — only the exact framework root passed', () => {
+      const roots = computeInheritedReadRoots({
+        parentReadRoots: undefined,
+        parentCwd: '/repo/.afk-worktrees/wt',
+        childCwd: '/repo/.afk-worktrees/wt',
+        worktreeMainRoot: '/repo',
+        afkStateRoot: STATE,
+        afkFrameworkRoot: FRAMEWORK,
+      })!;
+      const CONFIG = '/Users/me/.afk/config';
+      // agent-framework, state and config are all siblings under ~/.afk. Granting
+      // two of them must never lexically admit the credential dir.
+      expect(roots.some((r) => path.resolve(r) === CONFIG)).toBe(false);
+      expect(
+        roots.every((r) => path.relative(r, `${CONFIG}/afk.env`).startsWith('..')),
+      ).toBe(true);
+    });
+  });
 });
 
 // #547: the choke point skill / inline-skill / compose managers use to derive

--- a/src/agent/subagent-read-scope.ts
+++ b/src/agent/subagent-read-scope.ts
@@ -135,6 +135,27 @@ export interface InheritedReadRootsArgs {
    * it gets byte-for-byte the pre-fix behaviour.
    */
   afkStateRoot?: string | undefined;
+  /**
+   * The AFK agent-framework directory (`~/.afk/agent-framework`). Folded into a
+   * CONFINED fork's read union for the same reason as
+   * {@link InheritedReadRootsArgs.afkStateRoot}, but a DIFFERENT tree: this one
+   * holds the framework's own durable artifacts — improve-pipeline failure
+   * cards / proposals / eval-cases, forge telemetry, pattern-cards, and skill
+   * briefs.
+   *
+   * Sub-agents dispatched by the skills whose whole job is to read that tree
+   * (`/orient`, `/harvest`, `/forge`, `/distill`, and the improve pipeline) were
+   * hard-denied it, because a confined parent's cwd+repo roots do not lexically
+   * contain it and forks cannot prompt for approval. Measured at 46 denials
+   * across 15 sessions before this grant (improve card
+   * `subagent-read-denial-ab89c2bd6a6f`).
+   *
+   * Same guard as the state root: pass the AGENT-FRAMEWORK dir ONLY — NEVER
+   * `~/.afk/config`, which holds `afk.env` credentials. Ignored by the
+   * unconfined branch (already read-open). `undefined` adds nothing, so a caller
+   * that omits it gets byte-for-byte the pre-fix behaviour.
+   */
+  afkFrameworkRoot?: string | undefined;
 }
 
 /**
@@ -147,7 +168,9 @@ export interface InheritedReadRootsArgs {
  *    confined to the child's own cwd/writeRoots.
  *  - Parent CONFINED (explicit `parentReadRoots`, or a defined `parentCwd`):
  *    the child gets the UNION of the parent's roots, its own cwd, the worktree
- *    main root, and the AFK state dir ({@link InheritedReadRootsArgs.afkStateRoot})
+ *    main root, the AFK state dir ({@link InheritedReadRootsArgs.afkStateRoot}),
+ *    and the AFK agent-framework dir
+ *    ({@link InheritedReadRootsArgs.afkFrameworkRoot})
  *    — never narrower than the parent (child read scope ⊇ parent read scope),
  *    never write-relevant.
  *
@@ -156,7 +179,8 @@ export interface InheritedReadRootsArgs {
  * leaves the provider default untouched.
  */
 export function computeInheritedReadRoots(args: InheritedReadRootsArgs): string[] | undefined {
-  const { parentReadRoots, parentCwd, childCwd, worktreeMainRoot, afkStateRoot } = args;
+  const { parentReadRoots, parentCwd, childCwd, worktreeMainRoot, afkStateRoot, afkFrameworkRoot } =
+    args;
   const resolvedChildCwd =
     childCwd !== undefined && childCwd !== '' ? path.resolve(childCwd) : undefined;
 
@@ -189,6 +213,16 @@ export function computeInheritedReadRoots(args: InheritedReadRootsArgs): string[
   // below correctly see it as a broadening grant.
   if (afkStateRoot !== undefined && afkStateRoot !== '') {
     roots.add(path.resolve(afkStateRoot));
+  }
+  // The AFK agent-framework dir (~/.afk/agent-framework) — the framework's own
+  // artifact tree (improve cards/proposals/eval-cases, forge telemetry,
+  // pattern-cards, briefs) that /orient, /harvest, /forge, /distill and the
+  // improve pipeline dispatch children specifically to read. Same rules as the
+  // state root above: callers pass this dir only, never ~/.afk/config. Added in
+  // the same position (after cwd/parent/worktree roots, before the size checks)
+  // so it too is correctly seen as a broadening grant.
+  if (afkFrameworkRoot !== undefined && afkFrameworkRoot !== '') {
+    roots.add(path.resolve(afkFrameworkRoot));
   }
 
   // Nothing to grant, OR the only root is the child's own cwd (which equals the

--- a/src/agent/subagent-worktree-readroot.test.ts
+++ b/src/agent/subagent-worktree-readroot.test.ts
@@ -63,7 +63,7 @@ vi.mock('./worktree-read-root.js', () => ({
 
 import { SubagentManager } from './subagent.js';
 import { resolveWorktreeMainRoot } from './worktree-read-root.js';
-import { getAfkStateDir } from '../paths.js';
+import { getAfkStateDir, getAgentFrameworkDir } from '../paths.js';
 
 const WORKTREE = '/repo/.afk-worktrees/wt';
 const MAIN = '/repo';
@@ -72,6 +72,11 @@ const FS_ROOT = path.parse(path.resolve('.')).root || path.sep;
 // read ~/.afk/state (skill-preflight inputs, todos, transcripts). Not mocked —
 // the real resolver is deterministic for the process.
 const STATE = getAfkStateDir();
+// A CONFINED fork is ALSO granted the agent-framework dir (Gap C) so it can
+// read ~/.afk/agent-framework (improve cards, forge telemetry, pattern-cards,
+// briefs) — the tree /orient, /harvest, /forge and /distill children exist to
+// read. Same rationale as STATE above; both are siblings under the AFK home.
+const FRAMEWORK = getAgentFrameworkDir();
 
 const mockedResolve = vi.mocked(resolveWorktreeMainRoot);
 
@@ -98,7 +103,7 @@ describe('forkSubagent — worktree main-repo read-root grant', () => {
 
     const cfg = shared.lastConfig as { cwd?: string; readRoots?: string[] } | null;
     expect(cfg?.cwd).toBe(WORKTREE);
-    expect(cfg?.readRoots).toEqual([WORKTREE, MAIN, STATE]);
+    expect(cfg?.readRoots).toEqual([WORKTREE, MAIN, STATE, FRAMEWORK]);
     expect(mockedResolve).toHaveBeenCalledWith(WORKTREE);
   });
 
@@ -126,7 +131,7 @@ describe('forkSubagent — worktree main-repo read-root grant', () => {
     const cfg = shared.lastConfig as { cwd?: string; readRoots?: string[] } | null;
     expect(cfg?.cwd).toBe('/plain/repo');
     // No distinct worktree main root, but a confined fork still needs ~/.afk/state.
-    expect(cfg?.readRoots).toEqual(['/plain/repo', STATE]);
+    expect(cfg?.readRoots).toEqual(['/plain/repo', STATE, FRAMEWORK]);
   });
 
   it('does NOT override caller-pinned readRoots (e.g. afk farm) and skips resolution', async () => {
@@ -148,7 +153,7 @@ describe('forkSubagent — worktree main-repo read-root grant', () => {
     await mgr.forkSubagent(forkOpts({ model: 'sonnet', apiKey: 'k' }));
 
     const cfg = shared.lastConfig as { readRoots?: string[]; writeRoots?: string[] } | null;
-    expect(cfg?.readRoots).toEqual([WORKTREE, MAIN, STATE]);
+    expect(cfg?.readRoots).toEqual([WORKTREE, MAIN, STATE, FRAMEWORK]);
     // writeRoots untouched → provider defaults writes to [cwd] = the worktree.
     // The read-side state grant must NOT leak into writeRoots.
     expect(cfg?.writeRoots).toBeUndefined();
@@ -169,7 +174,7 @@ describe('forkSubagent — worktree main-repo read-root grant', () => {
 
     const cfg = shared.lastConfig as { readRoots?: string[] } | null;
     // No distinct main root to add, but the confined fork still gets ~/.afk/state.
-    expect(cfg?.readRoots).toEqual([WORKTREE, STATE]);
+    expect(cfg?.readRoots).toEqual([WORKTREE, STATE, FRAMEWORK]);
   });
 
   it('does not resolve or set readRoots when no cwd is available anywhere (unconfined)', async () => {
@@ -194,7 +199,7 @@ describe('forkSubagent — worktree main-repo read-root grant', () => {
     const cfg = shared.lastConfig as { readRoots?: string[] } | null;
     // MAIN is recovered from the parent worktree even though CHILD did not resolve,
     // so the fork can still read the main checkout + siblings (plus state).
-    expect(new Set(cfg?.readRoots)).toEqual(new Set([CHILD, WORKTREE, MAIN, STATE]));
+    expect(new Set(cfg?.readRoots)).toEqual(new Set([CHILD, WORKTREE, MAIN, STATE, FRAMEWORK]));
     expect(mockedResolve).toHaveBeenCalledWith(CHILD);
     expect(mockedResolve).toHaveBeenCalledWith(WORKTREE);
   });
@@ -249,7 +254,7 @@ describe('forkSubagent — additive read-root pre-grant (extraReadRoots, #662)',
   });
 
   it('composes extraReadRoots with a CONFINED fork inherited scope (union, inherited PRESERVED)', async () => {
-    // Confined worktree parent → inherited scope = [WORKTREE, MAIN, STATE].
+    // Confined worktree parent → inherited scope = [WORKTREE, MAIN, STATE, FRAMEWORK].
     // extraReadRoots widens it to the union: the out-of-repo dir is present AND
     // the inherited roots (cwd/main/state) are STILL present (no suppression).
     mockedResolve.mockResolvedValue(MAIN);
@@ -257,18 +262,18 @@ describe('forkSubagent — additive read-root pre-grant (extraReadRoots, #662)',
     await mgr.forkSubagent(forkOpts({ model: 'sonnet', apiKey: 'k', extraReadRoots: [EXTRA] }));
 
     const cfg = shared.lastConfig as { readRoots?: string[] } | null;
-    expect(new Set(cfg?.readRoots)).toEqual(new Set([WORKTREE, MAIN, STATE, EXTRA]));
+    expect(new Set(cfg?.readRoots)).toEqual(new Set([WORKTREE, MAIN, STATE, FRAMEWORK, EXTRA]));
   });
 
   it('composes extraReadRoots when the fork is confined by cwd alone (no distinct main root)', async () => {
-    // A plain (non-worktree) confined parent → inherited = [cwd, STATE]; the
+    // A plain (non-worktree) confined parent → inherited = [cwd, STATE, FRAMEWORK]; the
     // extra dir joins the union without dropping cwd or state.
     mockedResolve.mockResolvedValue(undefined);
     const mgr = new SubagentManager({ cwd: '/plain/repo' });
     await mgr.forkSubagent(forkOpts({ model: 'sonnet', apiKey: 'k', extraReadRoots: [EXTRA] }));
 
     const cfg = shared.lastConfig as { readRoots?: string[] } | null;
-    expect(new Set(cfg?.readRoots)).toEqual(new Set(['/plain/repo', STATE, EXTRA]));
+    expect(new Set(cfg?.readRoots)).toEqual(new Set(['/plain/repo', STATE, FRAMEWORK, EXTRA]));
   });
 
   it('does NOT confine an already-unconfined child (invariant #2 — stays read-open)', async () => {
@@ -309,7 +314,7 @@ describe('forkSubagent — additive read-root pre-grant (extraReadRoots, #662)',
     );
 
     const cfg = shared.lastConfig as { readRoots?: string[] } | null;
-    expect(new Set(cfg?.readRoots)).toEqual(new Set([WORKTREE, MAIN, STATE, EXTRA]));
+    expect(new Set(cfg?.readRoots)).toEqual(new Set([WORKTREE, MAIN, STATE, FRAMEWORK, EXTRA]));
     // MAIN appears once despite being in both inherited scope and extraReadRoots.
     expect(cfg?.readRoots?.filter((r) => r === MAIN)).toHaveLength(1);
   });
@@ -332,7 +337,7 @@ describe('forkSubagent — additive read-root pre-grant (extraReadRoots, #662)',
     await mgr.forkSubagent(forkOpts({ model: 'sonnet', apiKey: 'k', extraReadRoots: [] }));
 
     const cfg = shared.lastConfig as { readRoots?: string[] } | null;
-    expect(cfg?.readRoots).toEqual([WORKTREE, MAIN, STATE]);
+    expect(cfg?.readRoots).toEqual([WORKTREE, MAIN, STATE, FRAMEWORK]);
   });
 
   it('does NOT override a caller-pinned readRoots (farm pin) — extraReadRoots composes only with inheritance', async () => {

--- a/src/agent/subagent-worktree-readroot.test.ts
+++ b/src/agent/subagent-worktree-readroot.test.ts
@@ -18,7 +18,7 @@
  * capture the config handed to the child AgentSession and assert the scope.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import path from 'path';
 import type { Message } from './types.js';
 
@@ -96,6 +96,10 @@ describe('forkSubagent — worktree main-repo read-root grant', () => {
     mockedResolve.mockResolvedValue(undefined);
   });
 
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('grants [cwd, mainRoot, state] when the manager cwd is a linked worktree', async () => {
     mockedResolve.mockResolvedValue(MAIN);
     const mgr = new SubagentManager({ cwd: WORKTREE });
@@ -132,6 +136,16 @@ describe('forkSubagent — worktree main-repo read-root grant', () => {
     expect(cfg?.cwd).toBe('/plain/repo');
     // No distinct worktree main root, but a confined fork still needs ~/.afk/state.
     expect(cfg?.readRoots).toEqual(['/plain/repo', STATE, FRAMEWORK]);
+  });
+
+  it('grants the configured AFK_FRAMEWORK_DIR override to confined forks', async () => {
+    const configuredFramework = '/configured/agent-framework';
+    vi.stubEnv('AFK_FRAMEWORK_DIR', configuredFramework);
+    const mgr = new SubagentManager({ cwd: '/plain/repo' });
+    await mgr.forkSubagent(forkOpts({ model: 'sonnet', apiKey: 'k' }));
+
+    const cfg = shared.lastConfig as { readRoots?: string[] } | null;
+    expect(cfg?.readRoots).toEqual(['/plain/repo', STATE, configuredFramework]);
   });
 
   it('does NOT override caller-pinned readRoots (e.g. afk farm) and skips resolution', async () => {

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -36,7 +36,6 @@ import { touchWorktreeOccupancy, startWorktreeOccupancyHeartbeat } from './workt
 import { resolveWorktreeMainRoot } from './worktree-read-root.js';
 import { computeInheritedReadRoots, type ReadScopeInputs } from './subagent-read-scope.js';
 import { getAfkStateDir, getAgentFrameworkDir } from '../paths.js';
-import { env } from '../config/env.js';
 import path from 'path';
 import { buildPhaseRestrictedProvider } from './tools/nesting.js';
 import { MODEL_CAP_BYTES } from './tools/handlers/_output-cap.js';
@@ -401,7 +400,7 @@ export class SubagentManager {
         // Same guard as Gap A: this dir only, NEVER ~/.afk/config (credentials).
         ...(parentUnconfined
           ? {}
-          : { afkFrameworkRoot: env.AFK_FRAMEWORK_DIR ?? getAgentFrameworkDir() }),
+          : { afkFrameworkRoot: getAgentFrameworkDir() }),
       });
     }
 

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -36,6 +36,7 @@ import { touchWorktreeOccupancy, startWorktreeOccupancyHeartbeat } from './workt
 import { resolveWorktreeMainRoot } from './worktree-read-root.js';
 import { computeInheritedReadRoots, type ReadScopeInputs } from './subagent-read-scope.js';
 import { getAfkStateDir, getAgentFrameworkDir } from '../paths.js';
+import { env } from '../config/env.js';
 import path from 'path';
 import { buildPhaseRestrictedProvider } from './tools/nesting.js';
 import { MODEL_CAP_BYTES } from './tools/handlers/_output-cap.js';
@@ -398,7 +399,9 @@ export class SubagentManager {
         // improve pipeline were hard-denied the one tree their task requires —
         // 46 denials across 15 sessions (card subagent-read-denial-ab89c2bd6a6f).
         // Same guard as Gap A: this dir only, NEVER ~/.afk/config (credentials).
-        ...(parentUnconfined ? {} : { afkFrameworkRoot: getAgentFrameworkDir() }),
+        ...(parentUnconfined
+          ? {}
+          : { afkFrameworkRoot: env.AFK_FRAMEWORK_DIR ?? getAgentFrameworkDir() }),
       });
     }
 

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -35,7 +35,7 @@ import { getCurrentSink } from './_lib/skill-sink-channel.js';
 import { touchWorktreeOccupancy, startWorktreeOccupancyHeartbeat } from './worktree-occupancy.js';
 import { resolveWorktreeMainRoot } from './worktree-read-root.js';
 import { computeInheritedReadRoots, type ReadScopeInputs } from './subagent-read-scope.js';
-import { getAfkStateDir } from '../paths.js';
+import { getAfkStateDir, getAgentFrameworkDir } from '../paths.js';
 import path from 'path';
 import { buildPhaseRestrictedProvider } from './tools/nesting.js';
 import { MODEL_CAP_BYTES } from './tools/handlers/_output-cap.js';
@@ -389,6 +389,16 @@ export class SubagentManager {
         // dir only — NEVER ~/.afk/config (credentials). Unconfined forks are
         // already read-open, so this is a confined-parent-only grant.
         ...(parentUnconfined ? {} : { afkStateRoot: getAfkStateDir() }),
+        // Gap C (the agent-framework read grant — distinct from Gap A/Gap B
+        // above): ~/.afk/agent-framework is a SIBLING of ~/.afk/state under the
+        // same AFK home, and a confined fork's cwd+repo roots do not lexically
+        // contain it either. It holds the framework's own artifacts (improve
+        // cards/proposals/eval-cases, forge telemetry, pattern-cards, briefs),
+        // so children dispatched by /orient, /harvest, /forge, /distill and the
+        // improve pipeline were hard-denied the one tree their task requires —
+        // 46 denials across 15 sessions (card subagent-read-denial-ab89c2bd6a6f).
+        // Same guard as Gap A: this dir only, NEVER ~/.afk/config (credentials).
+        ...(parentUnconfined ? {} : { afkFrameworkRoot: getAgentFrameworkDir() }),
       });
     }
 

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -61,6 +61,19 @@ export function getSdkHomeDir(): string {
 }
 
 export function getAgentFrameworkDir(): string {
+  const envVal = env.AFK_FRAMEWORK_DIR;
+  if (envVal !== undefined && envVal !== '') {
+    // External constraint: AFK_FRAMEWORK_DIR governs the agent-framework tier
+    // (telemetry, briefs, improve artifacts). Mirror the getAfkStateDir() guard
+    // since this value is load-bearing for read-scope grants (subagent.ts) and
+    // write paths alike — both must resolve to the same directory.
+    if (!isAbsolute(envVal) || envVal === '/') {
+      throw new Error(
+        `AFK_FRAMEWORK_DIR must be an absolute path that is not /, got: ${envVal}`,
+      );
+    }
+    return envVal;
+  }
   return join(getAfkHome(), 'agent-framework');
 }
 


### PR DESCRIPTION
## Problem

A confined sub-agent fork's cwd + repo roots do not lexically contain `~/.afk/agent-framework`, so every read of that tree was hard-denied — and forks cannot prompt for approval, so the denial was terminal.

That tree holds the framework's **own** durable artifacts: improve-pipeline failure cards / proposals / eval-cases, forge telemetry, pattern-cards, and skill briefs. So children dispatched by `/orient`, `/harvest`, `/forge`, `/distill` and the improve pipeline were blocked from the one directory their task exists to read.

## How it was found

The `afk improve` pipeline found this in its own trace corpus — card `subagent-read-denial-ab89c2bd6a6f` (severity high): **46 denials across 15 distinct sessions**.

Confirmed in trace `07264e5c-78f7-4442-9bf6-4dab2ce50aa3`, where an `/orient`-dispatched `orient-survey` research-agent was denied `glob` on the agent-framework dir at seq 2233, then on the workspace dir at seq 2297. Reproduced live while reviewing the pipeline: every investigator sub-agent in that session had to be hand-passed `readRoots` to function at all.

## Change

This is the exact sibling of the already-shipped **Gap A** grant for `~/.afk/state`, and follows it precisely:

- New optional `afkFrameworkRoot` param on `computeInheritedReadRoots` (`src/agent/subagent-read-scope.ts`).
- Folded into the confined-fork union in the **same position** as `afkStateRoot` — after cwd/parent/worktree roots, before the size-check guard — so it too is correctly seen as a broadening grant.
- Passed from `src/agent/subagent.ts` alongside the existing state-dir grant, confined-forks only.

Labeled **"Gap C"** in `subagent.ts` deliberately: that file already uses "Gap A" (the state-dir grant) and "Gap B" (the worktree main-root parent-cwd fallback) for unrelated prior work, so reusing either label would collide with a different concept a reader hits first.

## Security posture — unchanged

- The grant passes the agent-framework dir **only**, never the AFK config dir that holds `afk.env` credentials.
- The credential read-denylist floor is untouched and still refuses that tree unconditionally. A companion improve card (`subagent-read-denial-cf21041f85be`) covers those denials and was triaged as working-as-designed, not a bug.
- Unconfined (read-open) parents are unaffected — they already cover this path.
- A test asserts no granted root lexically admits the credential dir, given all three are siblings under the AFK home.

## Back-compat

Additive. Omitting the param reproduces the pre-fix behaviour byte-for-byte, so every existing caller is unchanged.

## Rejected alternative

Have each framework skill pass `readRoots` explicitly at dispatch. Rejected because `src/skills/` has zero `readRoots` usage today, skills spawn nested forks that would each need re-threading, and any future framework skill would silently regress the same way. The centralized grant mirrors the already-accepted state-dir precedent and cannot be forgotten at a new call site.

## Verification

- **6 new unit tests** for the Gap C grant, including one asserting the state and framework grants **coexist** rather than replace each other (a `/harvest` fork needs both in one task), and one asserting no granted root admits the credential dir.
- **9 existing `readRoots` assertions** in `subagent-worktree-readroot.test.ts` updated for the widened union — these were the only failures, and they are expected assertion updates rather than regressions.
- Full suite: **739 files / 14,164 tests green** (post-rebase onto current `main`).
- `tsc --noEmit` clean.
- CI gates `audit:sdk:check`, `audit:env:check`, `scan:env:check` all pass.

## Follow-ups (not in this PR)

The same pipeline review surfaced four further items, filed here for traceability rather than fixed:

1. `cli/commands/improve.ts` hand-maintains a stale 3-value `VALID_PATTERNS` copy of the 5-value `FailurePatternSchema`, so `afk improve eval-cases list --pattern tool-failure-density` exits 2 on a pattern that 4 on-disk eval-cases actually use. Fix: derive from `FailurePatternSchema.options`.
2. The `closure-anomaly` detector treats each closure **event** as a session, multi-counting cascade-cancelled sub-agents and inflating its cost/session rollups.
3. `compose-executor.ts` sets no `failureClass`, so benign DAG fail-fast is indistinguishable from a real compose defect in `tool-failure-density`.
4. The `subagent-read-denial` detector should split denylist-floor denials from read-root-containment denials — they currently share one fingerprint, which is what made this card and the working-as-designed credential card look alike.
