### PR TITLE
fix(banner): stop pixel art sharing rows with text so resize cannot tear it

### DIFF
--- a/src/cli/render.test.ts
+++ b/src/cli/render.test.ts
@@ -212,8 +212,8 @@ describe('welcomeBanner', () => {
   });
 
   it('keeps the full tagline un-truncated in the mid-width band beside the sprite', () => {
-    // Regression guard for the 55–72-col "dead zone": the mascot still renders
-    // here (drops only below 55 cols), but the 42-col tagline used to live in
+    // Regression guard for the 56–72-col "dead zone": the mascot still renders
+    // here (drops only below 56 cols), but the 42-col tagline used to live in
     // the ~(cols−31) column beside the 27-col sprite — only ~33 cols at 64 — and
     // truncated to "Run coding agents without ba…". Hoisting it to a full-width
     // row fixed that; assert the whole thesis survives, un-ellipsized, WITH the
@@ -322,7 +322,7 @@ describe('welcomeBanner', () => {
     });
 
     it('drops the mascot and stacks info flush-left on a very narrow terminal', () => {
-      // Below the sprite budget (cols − 2 − 27 − 2 < 24, i.e. cols < 55) the
+      // Below the sprite budget (cols − 1 − 2 − 27 − 2 < 24, i.e. cols < 56) the
       // 27-col goblin would crush every info row into a one-char sliver. The
       // compact fallback drops the sprite and stacks the info full-width so the
       // identity signals stay legible instead of ellipsizing to nothing.
@@ -339,9 +339,29 @@ describe('welcomeBanner', () => {
       expect(hasSprite(out)).toBe(false);
       // …but every identity signal still survives, full-width.
       expect(out).toContain('Agent AFK');
-      expect(out).toContain('run coding agents without babysitting them');
       expect(out).toContain('opus_1m');
       expect(out).toContain('afk/polish-goblin-banner');
+      // Tagline present, though it ellipsizes by one char here — see the 45-col
+      // pin below for why 44 is one column short of holding it whole.
+      expect(out).toContain('run coding agents without babysitting');
+    });
+
+    it('holds the full tagline from 45 cols up in the compact fallback', () => {
+      // The 42-col tagline + 2-col LEFT_PAD needs 44 columns of glyphs, so it
+      // only used to fit at exactly cols=44 by occupying the terminal's FINAL
+      // column — which is the DECAWM deferred-wrap hazard that mangled the
+      // banner on resize (see welcome-banner.last-column.test.ts). Reserving
+      // that column moved the untruncated-tagline floor from 44 to 45. The
+      // tradeoff is deliberate: one ellipsized char at one narrow width, in
+      // exchange for sprite rows that survive a SIGWINCH intact.
+      Object.defineProperty(process.stdout, 'columns', { value: 45, configurable: true });
+      const out = strip(welcomeBanner({
+        mode: 'Interactive Mode',
+        model: 'opus_1m',
+        version: '5.11.0',
+        cwd: '/Users/example/projects/agent-afk',
+      }));
+      expect(out).toContain('run coding agents without babysitting them');
     });
 
     it('keeps every compact-banner row within the terminal width', () => {
@@ -355,23 +375,27 @@ describe('welcomeBanner', () => {
         hintLine: '/help · /model · /resume · Esc to interrupt · /exit to quit',
       }));
       const maxLine = Math.max(...out.split('\n').map((l) => stringWidth(l)));
-      expect(maxLine).toBeLessThanOrEqual(44);
+      // Strictly LESS than the width: a row landing exactly on column 44 puts a
+      // glyph in the final column, which sets the emulator's soft-wrap bit and
+      // re-splits the row on resize. This assertion used to be `<=`, which
+      // admitted precisely the corrupting case.
+      expect(maxLine).toBeLessThan(44);
     });
   });
 
-  describe('right-column vertical centering', () => {
+  describe('art-column vertical centering', () => {
     // The block-art hero is the ONLY source of full-block (█) glyphs — the
     // sprite is drawn with half-blocks (▀▄) only — so the first output line
-    // carrying a █ marks where the right column begins, i.e. its top pad.
+    // carrying a █ marks where the art column begins, i.e. its top pad.
     const heroTopRow = (s: string): number =>
       s.split('\n').findIndex((l) => /█/.test(l));
 
-    it('centers the right column onto the sprite, round-biased DOWN (not floor)', () => {
-      // A full column — model·mode + worktree + cwd + metaLine — is 12 rows
-      // against the 13-row sprite. (13−12)/2 = 0.5, so Math.round lands the top
-      // pad at 1, where Math.floor would strand the column at the cap tip (row
-      // 0). Pinning the exact top row is the direct guard for the round-not-floor
-      // bias the layout comment promises (welcome-banner.ts renderHybridBanner).
+    it('centers the 5-row hero onto the 13-row sprite, round-biased DOWN', () => {
+      // The hero is the only content sharing rows with the sprite (session text
+      // moved to full-width rows below — see welcome-banner.ts "Invariant (no row
+      // mixes pixel art with text)"). (13−5)/2 = 4, landing the logo beside the
+      // goblin's ear/eye band rather than the narrow cap tip. ROUND, not floor,
+      // is what the layout comment promises; this pins it.
       Object.defineProperty(process.stdout, 'columns', { value: 100, configurable: true });
       const out = strip(welcomeBanner({
         mode: 'Interactive Mode',
@@ -382,15 +406,19 @@ describe('welcomeBanner', () => {
         metaLine: 'Resuming abc123',
       }));
       expect(/[▀▄]/.test(out)).toBe(true); // sprite present → mascot layout
-      expect(heroTopRow(out)).toBe(1); // padded DOWN by one row (round, not floor)
+      expect(heroTopRow(out)).toBe(4);
     });
 
-    it('pushes the hero lower when the info column is shorter', () => {
-      // Centering responds to column height: a minimal column (model·mode only)
-      // is shorter than a full one, so it earns a larger top pad and its hero
-      // sits strictly lower. This exercises the round-biased centering across
-      // two different column heights without over-pinning either exact value.
+    it('holds the hero position invariant across session facts', () => {
+      // Regression guard for the mangling fix: the art block's geometry must not
+      // depend on how much session text there is. Previously the facts rode in
+      // the same column as the hero, so a /resume metaLine or a long branch name
+      // changed the sprite/hero pairing — and, worse, widened the art rows until
+      // a resize tore them. A fully-populated banner and a bare one must now
+      // produce byte-identical art rows.
       Object.defineProperty(process.stdout, 'columns', { value: 100, configurable: true });
+      const artRows = (s: string): string[] =>
+        s.split('\n').filter((l) => /[▀▄█]/.test(l));
       const fuller = strip(welcomeBanner({
         mode: 'Interactive Mode',
         model: 'opus_1m',
@@ -400,7 +428,8 @@ describe('welcomeBanner', () => {
         metaLine: 'Resuming abc123',
       }));
       const minimal = strip(welcomeBanner({ mode: 'Interactive Mode', model: 'opus_1m' }));
-      expect(heroTopRow(minimal)).toBeGreaterThan(heroTopRow(fuller));
+      expect(heroTopRow(minimal)).toBe(heroTopRow(fuller));
+      expect(artRows(minimal)).toEqual(artRows(fuller));
     });
   });
 

--- a/src/cli/render/welcome-banner.last-column.test.ts
+++ b/src/cli/render/welcome-banner.last-column.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import stringWidth from 'string-width';
+import { welcomeBanner } from './welcome-banner.js';
+
+/**
+ * Invariant (last-column safety): no welcome-banner row may end in the
+ * terminal's final column. This matches the reserve already enforced by
+ * `render/card.test.ts` and `input/echo.test.ts`, and it is what makes a
+ * one-column shrink non-destructive (see welcome-banner.resize.test.ts, which
+ * measures the actual reflow behaviour in a real emulator).
+ *
+ * Scope, stated plainly so this file is not mistaken for a resize fix: the
+ * reported "goblin / AFK gets mangled on resize" is overflow reflow of
+ * print-once scrollback rows, NOT a deferred-wrap/DECAWM effect. Reserving the
+ * final column buys exactly one column of shrink headroom. It was still worth
+ * doing — `render.test.ts` previously asserted rows were `<= cols`, which
+ * admitted rows sitting exactly ON the final column, so the banner was the one
+ * surface in `src/cli/` that violated a convention its siblings enforce.
+ *
+ * The trigger for exact-fill rows is that `truncateMiddle` / `truncateDisplay`
+ * truncate TO their budget rather than below it, and a mascot row is composed as
+ * 2-col pad + 27-col sprite + 2-col gutter + a right column budgeted at the
+ * remainder — so a filled right column made the row exactly `cols` wide.
+ */
+describe('welcomeBanner last-column safety', () => {
+  const prevCols = process.stdout.columns;
+
+  afterEach(() => {
+    Object.defineProperty(process.stdout, 'columns', {
+      value: prevCols,
+      configurable: true,
+    });
+  });
+
+  /** Widest banner row at `cols`, measured in display cells with ANSI stripped. */
+  const widestRow = (cols: number, cwd: string): number => {
+    Object.defineProperty(process.stdout, 'columns', { value: cols, configurable: true });
+    const out = welcomeBanner({
+      mode: 'Interactive Mode',
+      model: 'opus_1m',
+      worktree: 'afk/subagent-stream-cut-retry',
+      cwd,
+      version: '5.83.2',
+      hintLine: '/help · /model · /resume · Esc to interrupt · /exit to quit',
+    });
+    // eslint-disable-next-line no-control-regex
+    const strip = (s: string): string => s.replace(/\x1B\[[0-9;]*m/g, '');
+    return Math.max(...out.split('\n').map((l) => stringWidth(strip(l))));
+  };
+
+  // A deep path forces `truncateMiddle` to emit exactly `colMaxW` cells, which
+  // was the dominant real-world trigger (this operator's own worktree layout).
+  const DEEP_CWD =
+    '/Users/griffinlong/Projects/personal_projects/agent-workspace/agent-afk-private/deeply/nested';
+  const SHALLOW_CWD = '/tmp/x';
+
+  // Spans the mascot band (>= 56), the compact mascot-less fallback (< 56), and
+  // the natural-width band where nothing truncates at all (>= 110).
+  const WIDTHS = [40, 44, 48, 50, 55, 56, 60, 64, 70, 80, 90, 100, 107, 110, 120, 160];
+
+  for (const cwd of [DEEP_CWD, SHALLOW_CWD]) {
+    const label = cwd === DEEP_CWD ? 'deep cwd' : 'shallow cwd';
+    it(`never writes into the final column at any width (${label})`, () => {
+      for (const cols of WIDTHS) {
+        expect(widestRow(cols, cwd), `cols=${cols} (${label})`).toBeLessThan(cols);
+      }
+    });
+  }
+
+  it('reserves the final column even when every info row overflows its budget', () => {
+    // Every field oversized: each right-column row is truncated, so each one
+    // lands exactly on its budget — the worst case for the reserve.
+    Object.defineProperty(process.stdout, 'columns', { value: 80, configurable: true });
+    const out = welcomeBanner({
+      mode: 'Interactive Mode With An Absurdly Long Mode Label',
+      model: 'claude-opus-4-with-a-very-long-model-identifier',
+      worktree: 'afk/a-very-long-worktree-branch-name-that-definitely-overflows',
+      cwd: '/Users/example/projects/agent-afk/very/deep/nested/path/that/keeps/going',
+      version: '5.83.2',
+      metaLine: 'Resuming session 0199aa11-2b33-4c55-8d77-9e0011223344 from disk',
+      hintLine: '/help · /model · /resume · /clear · Esc to interrupt · /exit to quit',
+    });
+    // eslint-disable-next-line no-control-regex
+    const rows = out.split('\n').map((l) => stringWidth(l.replace(/\x1B\[[0-9;]*m/g, '')));
+    expect(Math.max(...rows)).toBeLessThan(80);
+  });
+});

--- a/src/cli/render/welcome-banner.resize.test.ts
+++ b/src/cli/render/welcome-banner.resize.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { Terminal as HeadlessTerminal } from '@xterm/headless';
+import { welcomeBanner } from './welcome-banner.js';
+
+/**
+ * History: root-cause record + regression guard for "sometimes the goblin / afk
+ * in the banner gets mangled on resize", measured rather than reasoned. Replays
+ * the REAL banner into `@xterm/headless` (a real emulator buffer + reflow engine)
+ * and resizes it.
+ *
+ * The mechanism was ordinary overflow reflow of print-once scrollback content:
+ *   - The banner is written once by `commands/interactive.ts` before the
+ *     compositor arms, and is never re-derived at a new width.
+ *   - No banner row carries the soft-wrap bit at print time — each is terminated
+ *     by CR/LF, which resets the last-column flag (DEC STD-070). The
+ *     deferred-wrap/DECAWM hazard behind the `card.ts`/`echo.ts` reserves does
+ *     NOT apply here; that one needs a printable byte or a CUP with no
+ *     intervening CR/LF. Pinned by the print-time assertion in `printBanner`.
+ *   - On a SHRINK the emulator hard-splits any stored row wider than the new
+ *     width. When session text rode BESIDE the sprite those rows were up to
+ *     `cols` wide while sprite-only rows were 29, so a shrink split some rows of
+ *     a fixed 13-row grid and injected text fragments into the goblin's face.
+ *
+ * The fix moved every readable string off the art rows (welcome-banner.ts,
+ * "Invariant (no row mixes pixel art with text)"), leaving the widest art row at
+ * LEFT_PAD + MASCOT_WIDTH + GUTTER + hero = 45 cols. The art therefore survives
+ * any resize down to 45 — below MIN_INFO_COLS (56) the mascot isn't rendered at
+ * all, so that covers its entire live range. Text rows below still reflow, which
+ * is intended: wrapped prose degrades gracefully, torn pixel art does not.
+ */
+describe('welcomeBanner resize reflow (real emulator)', () => {
+  const prevCols = process.stdout.columns;
+
+  afterEach(() => {
+    Object.defineProperty(process.stdout, 'columns', {
+      value: prevCols,
+      configurable: true,
+    });
+  });
+
+  const BANNER_OPTS = {
+    mode: 'Interactive Mode',
+    model: 'opus_1m',
+    worktree: 'afk/subagent-stream-cut-retry',
+    cwd: '/Users/griffinlong/Projects/personal_projects/agent-workspace/agent-afk-private/deeply/nested',
+    version: '5.83.2',
+    hintLine: '/help · /model · Ctrl+D to quit',
+  } as const;
+
+  /** Any row carrying mascot half-blocks or block-art hero glyphs. */
+  const isArtRow = (s: string): boolean => /[▀▄█]/.test(s);
+
+  const readRows = (term: HeadlessTerminal): { text: string; wrapped: boolean }[] => {
+    const buf = term.buffer.active;
+    const out: { text: string; wrapped: boolean }[] = [];
+    for (let i = 0; i < buf.length; i++) {
+      const line = buf.getLine(i);
+      if (!line) continue;
+      const text = line.translateToString(true);
+      if (text.trim() === '') continue;
+      out.push({ text, wrapped: line.isWrapped });
+    }
+    return out;
+  };
+
+  /** Print the banner rendered for `cols` into a fresh headless terminal. */
+  const printBanner = async (cols: number): Promise<HeadlessTerminal> => {
+    Object.defineProperty(process.stdout, 'columns', { value: cols, configurable: true });
+    const text = welcomeBanner({ ...BANNER_OPTS });
+    const term = new HeadlessTerminal({ cols, rows: 44, allowProposedApi: true });
+    // Real TTYs apply ONLCR (libuv keeps it set even in raw mode), so the
+    // emulator sees CRLF — which is what resets the last-column flag.
+    await new Promise<void>((resolve) => {
+      term.write(text.split('\n').join('\r\n') + '\r\n', resolve);
+    });
+    // Nothing may be wrapped at print time: rows fit the width they were built
+    // for. This rules out the deferred-wrap explanation for the mangling.
+    for (const row of readRows(term)) {
+      expect(row.wrapped, `wrapped at print time: |${row.text}|`).toBe(false);
+    }
+    return term;
+  };
+
+  const artAfterShrink = async (
+    fromCols: number,
+    toCols: number,
+  ): Promise<{ before: string[]; after: string[]; wrappedArt: string[] }> => {
+    const term = await printBanner(fromCols);
+    const before = readRows(term).map((r) => r.text).filter(isArtRow);
+    term.resize(toCols, 44);
+    await new Promise<void>((resolve) => term.write('', resolve));
+    const rowsAfter = readRows(term);
+    const after = rowsAfter.map((r) => r.text).filter(isArtRow);
+    const wrappedArt = rowsAfter.filter((r) => r.wrapped && isArtRow(r.text)).map((r) => r.text);
+    term.dispose();
+    return { before, after, wrappedArt };
+  };
+
+  it('keeps the goblin + AFK byte-identical through the shrink that used to mangle it', async () => {
+    // 100 -> 60 is the reported case. Before the fix this split rows 10 and 12
+    // (branch + cwd, both riding beside the sprite), inserting "ut-retry" and
+    // "rkspace/..." into the middle of the art and pushing the jaw row down 2.
+    const { before, after, wrappedArt } = await artAfterShrink(100, 60);
+    expect(before.length).toBeGreaterThan(10); // sanity: the sprite really rendered
+    expect(wrappedArt).toEqual([]);
+    expect(after).toEqual(before);
+  });
+
+  it('keeps the art intact down to the 45-col art-block width', async () => {
+    // The widest art row is 2 + 27 + 2 + 14 = 45. Shrinking to exactly that
+    // leaves every art row within the new width, so none can split.
+    const { before, after, wrappedArt } = await artAfterShrink(120, 45);
+    expect(wrappedArt).toEqual([]);
+    expect(after).toEqual(before);
+  });
+
+  it('holds across the whole live mascot range (mascot is dropped below 56)', async () => {
+    // MIN_INFO_COLS drops the sprite under 56 cols, so 56 is the narrowest width
+    // at which a freshly-rendered banner still contains art. Sweeping the band
+    // guards against a future right-column addition re-widening the art rows.
+    for (const to of [56, 64, 72, 80, 96]) {
+      const { before, after, wrappedArt } = await artAfterShrink(140, to);
+      expect(wrappedArt, `art split shrinking 140 -> ${to}`).toEqual([]);
+      expect(after, `art changed shrinking 140 -> ${to}`).toEqual(before);
+    }
+  });
+
+  it('still reflows the text rows below the art, by design', async () => {
+    // Not a defect: prose rewraps legibly. This pins the intended asymmetry so a
+    // future change that "fixes" it by re-widening art rows gets caught above.
+    const term = await printBanner(100);
+    term.resize(60, 44);
+    await new Promise<void>((resolve) => term.write('', resolve));
+    const wrappedText = readRows(term).filter((r) => r.wrapped && !isArtRow(r.text));
+    expect(wrappedText.length).toBeGreaterThan(0);
+    term.dispose();
+  });
+});

--- a/src/cli/render/welcome-banner.ts
+++ b/src/cli/render/welcome-banner.ts
@@ -253,90 +253,130 @@ function renderHybridBanner(opts: WelcomeBannerOpts): string {
   const LEFT_PAD = '  ';
   const GUTTER = '  ';
 
+  // Invariant (last-column safety): every composed banner row ends at column
+  // `cols - 1` at most — never the terminal's final column. Matches the reserve
+  // in render/card.ts (`rightEdge = cols - 1`) and input/echo.ts. Use `cols - 1`
+  // directly — NOT `Math.max(n, cols - 1)`: a floor would push the edge back UP
+  // into the physical last column on a 1–3 column terminal.
+  //
+  // Do NOT read this as a fix for "the goblin gets mangled on resize". That
+  // symptom is ordinary overflow reflow, measured in welcome-banner.resize.test.ts:
+  // the banner is printed ONCE into scrollback before the compositor arms
+  // (commands/interactive.ts) and never re-derived, so on a SHRINK the emulator
+  // hard-splits every stored row wider than the new width. Only the rows where
+  // right-column text rides beside the sprite are that wide, so they split while
+  // the sprite-only rows do not — the 13-row grid gains rows and text fragments
+  // land inside the art. Reserving one column makes a 1-column shrink safe and
+  // nothing more; a shrink of ≥2 columns below the widest row still mangles and
+  // is NOT addressed here. (The deferred-wrap/DECAWM hazard that motivates the
+  // card.ts and echo.ts reserves does not reach these rows: each is terminated
+  // by CR/LF, which resets the last-column flag per DEC STD-070. It applies to
+  // compositor-written rows, which are followed by a CUP instead.)
+  const usableCols = cols - 1;
+
   // Below this width the 27-col sprite would crush the right column into a
   // sliver; drop the mascot and stack the column full-width instead so the
   // banner stays legible at any narrow window size.
   const MIN_INFO_COLS = 24;
-  const spriteBudget = cols - LEFT_PAD.length - MASCOT_WIDTH - GUTTER.length;
+  const spriteBudget = usableCols - LEFT_PAD.length - MASCOT_WIDTH - GUTTER.length;
   const showMascot = spriteBudget >= MIN_INFO_COLS;
 
   // Right-column width: beside the sprite when shown, else the full terminal
-  // width (minus the left pad) in the compact, mascot-less fallback.
-  const headerMaxW = Math.max(1, cols - LEFT_PAD.length);
+  // width (minus the left pad and the reserved final column) in the compact,
+  // mascot-less fallback.
+  const headerMaxW = Math.max(1, usableCols - LEFT_PAD.length);
   const colMaxW = showMascot ? spriteBudget : headerMaxW;
 
   const versionText = opts.version !== undefined ? formatVersion(opts.version) : undefined;
 
-  // ── Right column, composed top → bottom. ──
-  const col: string[] = [];
+  // ── Art column beside the sprite. ──
+  // Invariant (no row mixes pixel art with text): the ONLY thing allowed to
+  // share a terminal row with the goblin is more art — the block-art hero. Every
+  // readable string (caption, model/mode, branch, cwd, metaLine) is emitted as a
+  // full-width row BELOW the composition instead.
+  //
+  // Why this is structural and not cosmetic: the banner is written once into
+  // scrollback and never re-derived, so on a SHRINK the emulator hard-splits any
+  // stored row wider than the new width. When text rode beside the sprite those
+  // rows were up to `cols` wide while sprite-only rows were 29, so a shrink split
+  // *some* rows of a fixed 13-row grid and injected text fragments into the
+  // goblin's face. With text moved off, the widest art row is
+  // LEFT_PAD + MASCOT_WIDTH + GUTTER + hero = 2+27+2+14 = 45 cols, so the whole
+  // sprite survives any resize down to 45 columns intact — and the mascot is
+  // already dropped below 56 (MIN_INFO_COLS), so the art is effectively
+  // resize-safe across its entire live range. Text rows below still reflow on a
+  // shrink, which is fine: wrapped prose degrades gracefully, torn pixel art does
+  // not. Measured in welcome-banner.resize.test.ts.
+  const artCol: string[] = [];
 
   // Hero: the gradient-shaded block-art "AFK" logo. Defensive text fallback
   // only on a pathologically narrow terminal that can't hold the 14-col mark.
   if (asciiWordmarkWidth(HERO_TEXT) <= colMaxW) {
-    col.push(...shadeWordmark(renderAsciiWordmark(HERO_TEXT)));
+    artCol.push(...shadeWordmark(renderAsciiWordmark(HERO_TEXT)));
   } else {
-    col.push(palette.brand('Agent ') + palette.bold(palette.brand('AFK')));
+    artCol.push(palette.brand('Agent ') + palette.bold(palette.brand('AFK')));
   }
 
-  // Readable name + version caption: keeps the full "Agent AFK" greppable and
-  // screen-reader-visible beneath the block-art acronym (tests assert this).
-  // The bold title anchors identity; the version rides dim beside it, sharing
-  // the same single-middot ( · ) rhythm as the mode/hint rows below rather than
-  // the airier double-middot it used to carry. The product tagline is NOT pushed
-  // here — it is emitted full-width below the whole composition (see the tagline
-  // row just above the footer) so the 42-col thesis can never truncate mid-word
-  // in the narrow ~(cols−31) column beside the 27-col sprite.
-  const nameChip =
-    palette.heading('Agent AFK') +
-    (versionText !== undefined ? palette.dim(' · ' + versionText) : '');
-  col.push('');
-  col.push(truncateDisplay(nameChip, colMaxW));
-
-  // Session-identity facts, each truncated to the column width.
-  const factRows: string[] = [];
-  const pushFact = (row: string): void => {
-    factRows.push(truncateDisplay(row, colMaxW));
-  };
-  const modeBits: string[] = [];
-  if (opts.model !== undefined) modeBits.push(palette.heading(opts.model));
-  if (opts.mode.length > 0) modeBits.push(palette.dim(opts.mode));
-  if (modeBits.length > 0) pushFact(modeBits.join(palette.dim(' · ')));
+  // ── Text block: full-width rows, emitted below the art. ──
+  // The caption folds identity + version + model + mode onto ONE row. Moving
+  // text off the sprite rows costs vertical space (the goblin's lower rows no
+  // longer carry facts for free), so the rows that CAN merge do, keeping the
+  // banner close to its previous height. "Agent AFK" stays a literal substring —
+  // greppable and screen-reader-visible beneath the block-art acronym, which
+  // render.test.ts asserts.
+  const infoRows: string[] = [];
+  const captionBits: string[] = [palette.heading('Agent AFK')];
+  if (versionText !== undefined) captionBits.push(palette.dim(versionText));
+  if (opts.model !== undefined) captionBits.push(palette.heading(opts.model));
+  if (opts.mode.length > 0) captionBits.push(palette.dim(opts.mode));
+  infoRows.push(truncateDisplay(captionBits.join(palette.dim(' · ')), headerMaxW));
   // worktree (only in a worktree session — an AFK-native signal).
-  if (opts.worktree !== undefined) pushFact(palette.dim('branch  ') + palette.goblin(opts.worktree));
+  if (opts.worktree !== undefined) {
+    infoRows.push(
+      truncateDisplay(palette.dim('branch  ') + palette.goblin(opts.worktree), headerMaxW),
+    );
+  }
   // cwd (home-tilde'd + middle-truncated to fit).
-  if (opts.cwd !== undefined) pushFact(palette.dim(truncateMiddle(tildifyHome(opts.cwd), colMaxW)));
+  if (opts.cwd !== undefined) {
+    infoRows.push(palette.dim(truncateMiddle(tildifyHome(opts.cwd), headerMaxW)));
+  }
   // metaLine (caller-supplied, e.g. a /resume "Resuming <id>" cue).
-  if (opts.metaLine !== undefined) pushFact(palette.dim(opts.metaLine));
-  if (factRows.length > 0) {
-    col.push('');
-    col.push(...factRows);
+  if (opts.metaLine !== undefined) {
+    infoRows.push(truncateDisplay(palette.dim(opts.metaLine), headerMaxW));
   }
 
   const lines: string[] = [];
 
   if (showMascot) {
-    // Compose sprite (left) + right column, the column vertically centered onto
-    // the goblin's widest rows. ROUND (not floor) the top pad so a column
-    // shorter than the 13-row sprite biases DOWN onto the ear/eye band. When
-    // the column is taller (e.g. a /resume metaLine) the pad collapses to 0 and
-    // the tail flows below the sprite.
+    // Compose sprite (left) + hero (right), the hero vertically centered onto the
+    // goblin's widest rows. ROUND (not floor) the top pad so the 5-row hero
+    // biases DOWN onto the ear/eye band rather than the narrow cap tip. The hero
+    // is now the ONLY right-column content, so this pad no longer varies with the
+    // session facts — the art block is geometrically identical every run.
     const sprite = renderMascotLines('idle');
-    const colTopPad = Math.max(0, Math.round((sprite.length - col.length) / 2));
-    const totalRows = Math.max(sprite.length, colTopPad + col.length);
+    const colTopPad = Math.max(0, Math.round((sprite.length - artCol.length) / 2));
+    const totalRows = Math.max(sprite.length, colTopPad + artCol.length);
     for (let i = 0; i < totalRows; i++) {
       const left = sprite[i] ?? ' '.repeat(MASCOT_WIDTH);
       const idx = i - colTopPad;
-      const right = idx >= 0 ? (col[idx] ?? '') : '';
+      const right = idx >= 0 ? (artCol[idx] ?? '') : '';
       // trimEnd drops the trailing gutter + transparent sprite columns on rows
-      // with no right-column text, leaving no selectable trailing whitespace.
+      // with no hero glyphs, leaving no selectable trailing whitespace.
       lines.push((LEFT_PAD + left + GUTTER + right).trimEnd());
     }
   } else {
-    // Compact fallback (terminal too narrow for the sprite): stack the column
+    // Compact fallback (terminal too narrow for the sprite): stack the hero
     // flush-left with no mascot. Rows are pre-truncated so nothing overflows.
-    for (const row of col) {
+    for (const row of artCol) {
       lines.push((LEFT_PAD + row).trimEnd());
     }
+  }
+
+  // Session identity, full-width below the art. Blank spacer keeps the art block
+  // reading as a distinct hero rather than crowding the caption.
+  lines.push('');
+  for (const row of infoRows) {
+    lines.push((LEFT_PAD + row).trimEnd());
   }
 
   // Blank spacer between the composition (goblin + info stack) and the tagline
@@ -364,10 +404,16 @@ function renderHybridBanner(opts: WelcomeBannerOpts): string {
     LEFT_PAD + truncateDisplay(palette.dim(`${DOCS_URL} · ${REPO_URL}`), headerMaxW),
   );
 
-  // Hint line sits flush-left below the whole composition.
+  // Hint line sits flush-left below the whole composition. Wrapped to
+  // `usableCols`, not `cols`: a wrap that lands exactly on the terminal width
+  // would put a glyph in the reserved final column and re-open the
+  // deferred-wrap hazard documented at the top of this function.
   if (opts.hintLine !== undefined) {
     lines.push(
-      ...wrapToWidth(palette.dim(LEFT_PAD + normalizeHintLine(opts.hintLine)), cols).split('\n'),
+      ...wrapToWidth(
+        palette.dim(LEFT_PAD + normalizeHintLine(opts.hintLine)),
+        usableCols,
+      ).split('\n'),
     );
   }
 


### PR DESCRIPTION
## Problem

Reported as: *"sometimes the goblin / afk in the banner gets mangled on resize."*

The welcome banner is written once into scrollback before the compositor arms, and is never re-derived at a new width. On a **shrink**, the emulator hard-splits any stored row wider than the new width. Session text (branch, cwd, mode) rode *beside* the goblin, so those rows were up to `cols` wide while sprite-only rows were 29 — a shrink therefore split **some** rows of a fixed 13-row grid and injected text fragments into the goblin's face.

Reproduced at 100 → 60 cols against a real emulator buffer (`@xterm/headless`):

```
[10] wrapped=n |     ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀       branch  afk/subagent-stream-c|
[11] wrapped=Y |ut-retry|                        <- fragment injected into the art
[12] wrapped=n |     ▀▀▀▀▀▀▼▀▀▀▀▀▀▀▀▀▀      ~/Projects/personal_projec…wo|
[13] wrapped=Y |rkspace/agent-afk-private/deeply/nested|
[14] wrapped=n |        ▀▀▀▀▀▀▀▀▀▀▀|             <- jaw row, pushed down 2
```

The *"sometimes"* is a shrink that crosses the widest row: a deep cwd makes almost any shrink tear it, a shallow cwd needs a large one.

## Fix

The only thing allowed to share a terminal row with the sprite is more art (the block-art hero). Every readable string moves to full-width rows below the composition.

Widest art row is now `LEFT_PAD + MASCOT_WIDTH + GUTTER + hero = 2+27+2+14 = 45` cols, so the art survives any resize down to 45 — and the mascot is already dropped below 56 (`MIN_INFO_COLS`), which covers its entire live range. Text rows below still reflow, which is intended: wrapped prose degrades gracefully, torn pixel art does not.

Also reserves the terminal's final column (`cols - 1`), matching the last-column-safety convention in `render/card.ts` and `input/echo.ts` that the banner alone violated.

## A correction worth recording

My first diagnosis was **wrong**, and the code now says so explicitly so nobody re-derives it. I attributed the tearing to the DECAWM deferred-wrap hazard — a row exactly `cols` wide acquiring the soft-wrap bit and being rejoined with its neighbour on resize. That mechanism does not reach these rows:

- Banner rows are CR/LF-terminated, and CR/LF resets the last-column flag (DEC STD-070).
- xterm.js sets `isWrapped` only when `print()` places a glyph *past* the last column, and `BufferReflow` only rejoins lines already flagged wrapped.

`welcome-banner.resize.test.ts` asserts **nothing is wrapped at print time**, which is the assertion that falsifies that theory. The `cols - 1` reserve is kept for convention consistency and one column of shrink headroom — not as the fix.

## Tradeoffs

- **+4 rows of height (17 → 21).** Inherent to the approach: the goblin's lower rows no longer carry facts for free. The caption folds identity + version + model + mode onto one row to limit it.
- The hero now centres on the 13-row sprite (`round((13-5)/2) = 4`), landing beside the ears/eyes rather than the cap tip — which is what the layout comment always said it wanted.
- Mascot drop boundary 55 → 56 cols. Untruncated-tagline floor 44 → 45 (the 42-col tagline previously fit at 44 *only* by occupying the final column, i.e. the thing being fixed).

## Verification

- `welcome-banner.resize.test.ts` — replays the **real** banner into `@xterm/headless` and asserts art rows stay byte-identical across shrinks (140→56/64/72/80/96, 120→45, and the reported 100→60), plus nothing wrapped at print time.
- `welcome-banner.last-column.test.ts` — pins the final-column reserve across widths and field lengths.
- `render.test.ts` — centering tests now assert the art block is invariant to session facts; width bound tightened from `<=` to `<`.
- Full suite: **741 files / 14,166 tests pass**. `tsc --noEmit` clean.

## Known unfixed

- The legacy boxed banner (`AFK_BANNER_PLAIN=1`) still lands on the final column at every width ≥28. Verified, deliberately out of scope: the fix routes through the shared `maxInnerBoxWidth()` helper that `statusPanel` and other boxes depend on.
- Found while investigating, untouched: resize → debounced `repaint()` (`terminal-compositor.lifecycle.ts:245-251`) → `evictRowsToScrollback` (`frame-preserve.ts:213-222`) can scroll banner rows on a shrink. It relocates rows intact so it is not the tearing, but it has had no independent review.
