### PR TITLE
feat(config): make AFK.md's user-scope fallback additive instead of exclusive

### DIFF
--- a/AFK.md
+++ b/AFK.md
@@ -112,10 +112,10 @@ The base system prompt is **layered**: the framework prompt (`prompts/system-pro
 |------|--------|----------------------|
 | 1 | `AFK_SYSTEM_PROMPT` env | `env:AFK_SYSTEM_PROMPT` |
 | 2 | `afk.config.json` (cwd → `~/.afk/config/` → legacy) | `file:<abs>` |
-| 3 | `AFK.md` (cwd → `$AFK_HOME/`) | `afk-md:<abs>` |
+| 3 | `AFK.md` (cwd **+** `$AFK_HOME/`, additive) | `afk-md:<abs>` or `afk-md:<user-abs>+afk-md:<project-abs>` |
 | — | None | `undefined` |
 
-`AFK.md` is plain markdown, no frontmatter. Empty/whitespace → treated as absent. The framework base is always present regardless of overlay tier (this file, `AFK.md`, is itself a tier-3 overlay appended to the framework base). `--dump-prompt` reports a composed `systemPromptSource` (`framework`, `framework+afk-md:<path>`, …); never forwarded to the SDK as a preset. Every overlay appends — no full-replace escape hatch yet (a future `AFK_BASE_PROMPT=0` would add one).
+`AFK.md` is plain markdown, no frontmatter. Empty/whitespace → treated as absent per-file (an accidental blank one still falls through to/combines with the other). The framework base is always present regardless of overlay tier (this file, `AFK.md`, is itself a tier-3 overlay appended to the framework base). Tier 3 itself is **additive, not exclusive**: `loadAfkMd()` (`src/cli/config/afk-md-tier.ts`) reads both `$AFK_HOME/AFK.md` (user-scope, default `~/.afk/AFK.md`) and `<cwd>/AFK.md` (project-scope) when both exist and are non-empty, and concatenates them — user-scope first, project-scope second under a `## Project configuration (...) — takes precedence on conflict` header — rather than the project file silently hiding the personal one. When only one tier resolves (the common case), the content and `afk-md:<path>` format are byte-identical to a single-tier read — no header, no behavior change. Delivery is still baked directly into the system prompt (not a separate synthetic user-turn message, unlike Claude Code's CLAUDE.md). `--dump-prompt` reports a composed `systemPromptSource` (`framework`, `framework+afk-md:<path>`, `framework+afk-md:<user-path>+afk-md:<project-path>`, …); never forwarded to the SDK as a preset. Every overlay appends — no full-replace escape hatch yet (a future `AFK_BASE_PROMPT=0` would add one).
 
 ## Conventions
 

--- a/src/agent/prompt-dump.test.ts
+++ b/src/agent/prompt-dump.test.ts
@@ -245,6 +245,29 @@ describe('dumpIfEnabled', () => {
     expect(obj.resolution).toBeDefined();
   });
 
+  it('renders a combined-tier systemPrompt source unmangled', () => {
+    process.env['AFK_DUMP_PROMPT'] = '1';
+    // `+`-joined provenance from both AFK.md tiers, composed with the
+    // framework base — the widest shape this field ever takes. The dump path
+    // must pass it through verbatim; it does no parsing of the value, and
+    // this locks that (a future "split on +" would corrupt the report the
+    // operator uses to debug which overlay actually loaded).
+    const source = 'framework+afk-md:/home/u/.afk/AFK.md+afk-md:/repo/AFK.md';
+    const payload: DumpPayload = {
+      prompt: { message: 'test' },
+      options: { model: 'claude-3-sonnet' },
+      provenance: { systemPrompt: { source } },
+    };
+    dumpIfEnabled(payload);
+
+    const jsonCall = stderrSpy.mock.calls
+      .map((c) => c[0] as string)
+      .find((s) => s.trimStart().startsWith('{'));
+    expect(jsonCall).toBeDefined();
+    const obj = JSON.parse(jsonCall!);
+    expect(obj.provenance.systemPrompt.source).toBe(source);
+  });
+
   it('writes to stderr when AFK_DUMP_PROMPT is "true" (case-insensitive)', () => {
     process.env['AFK_DUMP_PROMPT'] = 'True';
     const payload: DumpPayload = {

--- a/src/cli/config.test.ts
+++ b/src/cli/config.test.ts
@@ -467,22 +467,53 @@ describe('Config Loader', () => {
       expect(config.systemPromptSource).toBe(`afk-md:${homeAfkMd}`);
     });
 
-    it('prefers cwd/AFK.md over ~/.afk/AFK.md when both exist', () => {
+    it('combines ~/.afk/AFK.md and cwd/AFK.md when both exist, user-scope first and project-scope marked as the conflict winner', () => {
       const cwdAfkMd = join(process.cwd(), 'AFK.md');
+      const homeAfkMd = join(
+        process.env['AFK_HOME'] ??
+          join(process.env['HOME'] ?? process.env['USERPROFILE'] ?? '', '.afk'),
+        'AFK.md',
+      );
       mockedExistsSync().mockImplementation((p) => {
         if (String(p).endsWith('AFK.md')) return true; // both exist
         return realFsModule.__realExistsSync(p as fs.PathLike);
       });
       mockedReadFileSync().mockImplementation((p, ...args) => {
         if (String(p).endsWith('AFK.md')) {
-          return String(p) === cwdAfkMd ? 'cwd content wins' : 'user-scope content';
+          return String(p) === cwdAfkMd ? 'project content' : 'personal content';
         }
         return (realFsModule.__realReadFileSync as Function)(p, ...args);
       });
 
       const config = loadConfig();
-      expect(config.systemPrompt).toBe('cwd content wins');
-      expect(config.systemPromptSource).toBe(`afk-md:${cwdAfkMd}`);
+      expect(config.systemPrompt).toBe(
+        `## Personal configuration (${homeAfkMd})\n\npersonal content\n\n` +
+          `## Project configuration (${cwdAfkMd}) — takes precedence on conflict\n\nproject content`,
+      );
+      expect(config.systemPromptSource).toBe(`afk-md:${homeAfkMd}+afk-md:${cwdAfkMd}`);
+    });
+
+    it('does not duplicate content when $AFK_HOME/AFK.md and cwd/AFK.md resolve to the same file', () => {
+      const cwdAfkMd = join(process.cwd(), 'AFK.md');
+      const prevAfkHome = process.env['AFK_HOME'];
+      process.env['AFK_HOME'] = process.cwd(); // AFK_HOME relocated onto cwd — same file both ways
+      try {
+        mockedExistsSync().mockImplementation((p) => {
+          if (String(p).endsWith('AFK.md')) return String(p) === cwdAfkMd;
+          return realFsModule.__realExistsSync(p as fs.PathLike);
+        });
+        mockedReadFileSync().mockImplementation((p, ...args) => {
+          if (String(p) === cwdAfkMd) return 'single shared file';
+          return (realFsModule.__realReadFileSync as Function)(p, ...args);
+        });
+
+        const config = loadConfig();
+        expect(config.systemPrompt).toBe('single shared file');
+        expect(config.systemPromptSource).toBe(`afk-md:${cwdAfkMd}`);
+      } finally {
+        if (prevAfkHome === undefined) delete process.env['AFK_HOME'];
+        else process.env['AFK_HOME'] = prevAfkHome;
+      }
     });
 
     it('ignores AFK.md when AFK_SYSTEM_PROMPT env is set', () => {

--- a/src/cli/config.test.ts
+++ b/src/cli/config.test.ts
@@ -67,8 +67,10 @@ vi.mock('fs', async () => {
     // calling through the proxy (which would cause infinite recursion).
     __realExistsSync: real.existsSync,
     __realReadFileSync: real.readFileSync,
+    __realRealpathSync: real.realpathSync,
     existsSync: vi.fn(real.existsSync),
     readFileSync: vi.fn(real.readFileSync),
+    realpathSync: vi.fn(real.realpathSync),
   };
 });
 
@@ -78,6 +80,7 @@ import * as fs from 'fs';
 const realFsModule = fs as typeof fs & {
   __realExistsSync: typeof fs.existsSync;
   __realReadFileSync: typeof fs.readFileSync;
+  __realRealpathSync: typeof fs.realpathSync;
 };
 
 describe('Config Loader', () => {
@@ -401,6 +404,7 @@ describe('Config Loader', () => {
     // cannot redefine them per-test; the factory approach works instead.
     const mockedExistsSync = () => vi.mocked(fs.existsSync);
     const mockedReadFileSync = () => vi.mocked(fs.readFileSync);
+    const mockedRealpathSync = () => vi.mocked(fs.realpathSync);
 
     beforeEach(() => {
       // AFK.md cases mutate fs mocks per test — invalidate the disk-tier
@@ -409,6 +413,7 @@ describe('Config Loader', () => {
       // Reset to real implementations before each test.
       mockedExistsSync().mockImplementation(realFsModule.__realExistsSync);
       mockedReadFileSync().mockImplementation(realFsModule.__realReadFileSync);
+      mockedRealpathSync().mockImplementation(realFsModule.__realRealpathSync);
       // Wipe any prior model/prompt env that could bleed in from sibling tests.
       delete process.env['AFK_SYSTEM_PROMPT'];
       delete process.env.AFK_MODEL;
@@ -423,6 +428,7 @@ describe('Config Loader', () => {
       // Restore real implementations so other describe blocks are unaffected.
       mockedExistsSync().mockImplementation(realFsModule.__realExistsSync);
       mockedReadFileSync().mockImplementation(realFsModule.__realReadFileSync);
+      mockedRealpathSync().mockImplementation(realFsModule.__realRealpathSync);
       delete process.env['AFK_SYSTEM_PROMPT'];
     });
 
@@ -514,6 +520,111 @@ describe('Config Loader', () => {
         if (prevAfkHome === undefined) delete process.env['AFK_HOME'];
         else process.env['AFK_HOME'] = prevAfkHome;
       }
+    });
+
+    it('does not duplicate content when $AFK_HOME/AFK.md is a symlink to cwd/AFK.md', () => {
+      const cwdAfkMd = join(process.cwd(), 'AFK.md');
+      const prevAfkHome = process.env['AFK_HOME'];
+      // Lexically distinct from cwd — only realpath resolution can catch this.
+      process.env['AFK_HOME'] = join(process.cwd(), '.afk-home-link');
+      const homeAfkMd = join(process.env['AFK_HOME'], 'AFK.md');
+      try {
+        mockedExistsSync().mockImplementation((p) => {
+          if (String(p).endsWith('AFK.md')) return true; // both paths exist
+          return realFsModule.__realExistsSync(p as fs.PathLike);
+        });
+        // Both resolve to the same inode — the symlink case.
+        mockedRealpathSync().mockImplementation((p) => {
+          if (String(p).endsWith('AFK.md')) return cwdAfkMd;
+          return realFsModule.__realRealpathSync(p as fs.PathLike) as string;
+        });
+        mockedReadFileSync().mockImplementation((p, ...args) => {
+          if (String(p).endsWith('AFK.md')) return 'shared via symlink';
+          return (realFsModule.__realReadFileSync as Function)(p, ...args);
+        });
+
+        const config = loadConfig();
+        // Counted once, no headers, byte-identical to the single-tier contract.
+        expect(config.systemPrompt).toBe('shared via symlink');
+        expect(config.systemPromptSource).toBe(`afk-md:${homeAfkMd}`);
+      } finally {
+        if (prevAfkHome === undefined) delete process.env['AFK_HOME'];
+        else process.env['AFK_HOME'] = prevAfkHome;
+      }
+    });
+
+    it('still treats two distinct real files as two tiers when realpath resolves them apart', () => {
+      const cwdAfkMd = join(process.cwd(), 'AFK.md');
+      const homeAfkMd = join(
+        process.env['AFK_HOME'] ??
+          join(process.env['HOME'] ?? process.env['USERPROFILE'] ?? '', '.afk'),
+        'AFK.md',
+      );
+      mockedExistsSync().mockImplementation((p) => {
+        if (String(p).endsWith('AFK.md')) return true;
+        return realFsModule.__realExistsSync(p as fs.PathLike);
+      });
+      // Identity resolution — genuinely different files, must NOT over-merge.
+      mockedRealpathSync().mockImplementation((p) => {
+        if (String(p).endsWith('AFK.md')) return String(p);
+        return realFsModule.__realRealpathSync(p as fs.PathLike) as string;
+      });
+      mockedReadFileSync().mockImplementation((p, ...args) => {
+        if (String(p).endsWith('AFK.md')) {
+          return String(p) === cwdAfkMd ? 'project content' : 'personal content';
+        }
+        return (realFsModule.__realReadFileSync as Function)(p, ...args);
+      });
+
+      const config = loadConfig();
+      expect(config.systemPromptSource).toBe(`afk-md:${homeAfkMd}+afk-md:${cwdAfkMd}`);
+      expect(config.systemPrompt).toContain('personal content');
+      expect(config.systemPrompt).toContain('project content');
+    });
+
+    it('does not call realpathSync when only one AFK.md exists', () => {
+      const cwdAfkMd = join(process.cwd(), 'AFK.md');
+      mockedExistsSync().mockImplementation((p) => {
+        if (String(p).endsWith('AFK.md')) return String(p) === cwdAfkMd;
+        return realFsModule.__realExistsSync(p as fs.PathLike);
+      });
+      mockedReadFileSync().mockImplementation((p, ...args) => {
+        if (String(p) === cwdAfkMd) return 'project only';
+        return (realFsModule.__realReadFileSync as Function)(p, ...args);
+      });
+      // realpathSync THROWS on a missing path — an ungated call would take
+      // down loadConfig() for the majority single-tier install. Assert on the
+      // CALL, not the outcome: isSameFile catches throws, so an outcome-only
+      // assertion passes whether or not the existsSync gate is present.
+      mockedRealpathSync().mockClear();
+
+      expect(() => loadConfig()).not.toThrow();
+      expect(mockedRealpathSync()).not.toHaveBeenCalled();
+      const config = loadConfig();
+      expect(config.systemPrompt).toBe('project only');
+      expect(config.systemPromptSource).toBe(`afk-md:${cwdAfkMd}`);
+    });
+
+    it('falls back to treating paths as distinct when realpathSync fails', () => {
+      const cwdAfkMd = join(process.cwd(), 'AFK.md');
+      mockedExistsSync().mockImplementation((p) => {
+        if (String(p).endsWith('AFK.md')) return true;
+        return realFsModule.__realExistsSync(p as fs.PathLike);
+      });
+      mockedReadFileSync().mockImplementation((p, ...args) => {
+        if (String(p).endsWith('AFK.md')) {
+          return String(p) === cwdAfkMd ? 'project content' : 'personal content';
+        }
+        return (realFsModule.__realReadFileSync as Function)(p, ...args);
+      });
+      // A raced unlink / permission error must degrade to the pre-existing
+      // duplicate-content behavior, never wipe the overlay.
+      mockedRealpathSync().mockImplementation(() => {
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      });
+
+      expect(() => loadConfig()).not.toThrow();
+      expect(loadConfig().systemPrompt).toContain('project content');
     });
 
     it('ignores AFK.md when AFK_SYSTEM_PROMPT env is set', () => {
@@ -627,6 +738,32 @@ describe('Config Loader', () => {
       const config = loadConfig();
       expect(config.systemPrompt).toBeUndefined();
       expect(config.systemPromptSource).toBeUndefined();
+    });
+
+    it('surfaces the populated tier alone when the other tier is blank (no headers)', () => {
+      const cwdAfkMd = join(process.cwd(), 'AFK.md');
+      const homeAfkMd = join(
+        process.env['AFK_HOME'] ??
+          join(process.env['HOME'] ?? process.env['USERPROFILE'] ?? '', '.afk'),
+        'AFK.md',
+      );
+      mockedExistsSync().mockImplementation((p) => {
+        if (String(p).endsWith('AFK.md')) return true; // both files exist...
+        return realFsModule.__realExistsSync(p as fs.PathLike);
+      });
+      mockedReadFileSync().mockImplementation((p, ...args) => {
+        // ...but the personal one is blank, so only the project tier counts.
+        if (String(p) === homeAfkMd) return '  \n\t ';
+        if (String(p) === cwdAfkMd) return 'project content';
+        return (realFsModule.__realReadFileSync as Function)(p, ...args);
+      });
+
+      const config = loadConfig();
+      // Single-tier contract: verbatim content, no disambiguating headers.
+      expect(config.systemPrompt).toBe('project content');
+      expect(config.systemPrompt).not.toContain('## Personal configuration');
+      expect(config.systemPrompt).not.toContain('## Project configuration');
+      expect(config.systemPromptSource).toBe(`afk-md:${cwdAfkMd}`);
     });
 
     it('does not throw when no AFK.md exists anywhere', () => {

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -153,7 +153,11 @@ export function loadConfig(overrides?: Partial<CliConfig>): CliConfig {
     const afkMd = loadAfkMd();
     if (afkMd !== null) {
       merged.systemPrompt = afkMd.content;
-      systemPromptSource = `afk-md:${afkMd.path}`;
+      // Each contributing path gets its own `afk-md:` prefix, joined with the
+      // same `+` convention resolveBaseSystemPrompt() uses for framework+overlay
+      // layering: `afk-md:<path>` when one tier resolved (unchanged format),
+      // `afk-md:<user>+afk-md:<project>` when both combined.
+      systemPromptSource = afkMd.paths.map((p) => `afk-md:${p}`).join('+');
     }
   }
 

--- a/src/cli/config/afk-md-tier.ts
+++ b/src/cli/config/afk-md-tier.ts
@@ -5,7 +5,7 @@
 // reassign an imported binding (same pattern as `setState()` in the #366
 // plugin-skills split).
 
-import { readFileSync, existsSync } from 'fs';
+import { readFileSync, existsSync, realpathSync } from 'fs';
 import { join } from 'path';
 import { getAfkHome } from '../../paths.js';
 
@@ -15,7 +15,8 @@ export interface AfkMdResult {
    * Absolute path(s) that contributed content, in the order they were
    * concatenated into `content` (user-scope first, project-scope second).
    * Length 1 in the common case — only one tier resolved, or both tiers
-   * point at the literal same file (e.g. `AFK_HOME` relocated to `cwd`) — in
+   * resolve to the same file, whether lexically (`AFK_HOME` relocated to
+   * `cwd`) or through a symlink (see `isSameFile`) — in
    * which case `content` is that single file's trimmed text verbatim, with
    * no added headers, byte-identical to the pre-hybrid single-tier result.
    * Length 2 only when `$AFK_HOME/AFK.md` and `<cwd>/AFK.md` are distinct
@@ -48,6 +49,34 @@ function readAfkMdCandidate(path: string): string | null {
     return content.length > 0 ? content : null;
   } catch {
     return null;
+  }
+}
+
+/**
+ * Contract: true when both paths denote the same file on disk.
+ *
+ * Ordering here is load-bearing, not stylistic. Lexical equality is tested
+ * first as a pure-string fast path, so the overwhelmingly common shapes (no
+ * AFK.md anywhere, or exactly one) never touch the filesystem. Only when the
+ * paths differ lexically AND both exist do we resolve symlinks: `realpathSync`
+ * THROWS on a missing path, so an ungated call would fail `loadAfkMd()` — and
+ * therefore `loadConfig()` — for nearly every caller. When either path is
+ * absent the dedup question is moot (a file that isn't there cannot be
+ * double-counted), so we report `false` and let `readAfkMdCandidate()`'s own
+ * existence check short-circuit as before.
+ *
+ * Returns `false` rather than throwing on any realpath failure (races,
+ * permissions, broken links): a false negative degrades to the pre-existing
+ * duplicate-content behavior, whereas a throw would wipe the operator's
+ * entire system-prompt overlay.
+ */
+function isSameFile(a: string, b: string): boolean {
+  if (a === b) return true;
+  if (!existsSync(a) || !existsSync(b)) return false;
+  try {
+    return realpathSync(a) === realpathSync(b);
+  } catch {
+    return false;
   }
 }
 
@@ -91,9 +120,13 @@ export function loadAfkMd(): AfkMdResult | null {
   const projectPath = join(process.cwd(), 'AFK.md');
 
   const userContent = readAfkMdCandidate(userPath);
-  // Skip re-reading the same file twice (e.g. AFK_HOME relocated to cwd) —
-  // treat it as a single tier rather than duplicating its content.
-  const projectContent = projectPath === userPath ? null : readAfkMdCandidate(projectPath);
+  // Skip re-reading the same file twice — treat it as a single tier rather
+  // than duplicating its content. Covers both the lexical case (AFK_HOME
+  // relocated to cwd) and the resolved case (either path a symlink to the
+  // other); see `isSameFile` for why realpath is gated on existence.
+  const projectContent = isSameFile(projectPath, userPath)
+    ? null
+    : readAfkMdCandidate(projectPath);
 
   let result: AfkMdResult | null;
   if (userContent !== null && projectContent !== null) {

--- a/src/cli/config/afk-md-tier.ts
+++ b/src/cli/config/afk-md-tier.ts
@@ -9,7 +9,22 @@ import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { getAfkHome } from '../../paths.js';
 
-let afkMdCache: { value: { content: string; path: string } | null } | undefined;
+export interface AfkMdResult {
+  content: string;
+  /**
+   * Absolute path(s) that contributed content, in the order they were
+   * concatenated into `content` (user-scope first, project-scope second).
+   * Length 1 in the common case — only one tier resolved, or both tiers
+   * point at the literal same file (e.g. `AFK_HOME` relocated to `cwd`) — in
+   * which case `content` is that single file's trimmed text verbatim, with
+   * no added headers, byte-identical to the pre-hybrid single-tier result.
+   * Length 2 only when `$AFK_HOME/AFK.md` and `<cwd>/AFK.md` are distinct
+   * files and both are non-empty.
+   */
+  paths: string[];
+}
+
+let afkMdCache: { value: AfkMdResult | null } | undefined;
 
 /**
  * Clear this tier's memoized AFK.md read. Called (only) by
@@ -21,38 +36,81 @@ export function resetAfkMdCache(): void {
 }
 
 /**
- * Try to load a system prompt from `AFK.md`.
- *
- * Search order (first non-empty file wins):
- *   1. `<cwd>/AFK.md`   — project-scope
- *   2. `$AFK_HOME/AFK.md` (default `~/.afk/AFK.md`) — user-scope
- *
- * Returns `{ content, path }` with trimmed content, or `null` when no
- * readable non-empty `AFK.md` exists. Empty / whitespace-only files are
- * treated as absent so an accidental blank file doesn't silently wipe the
- * system prompt.
- *
- * Memoized via `afkMdCache` — see the cache block above `loadJsonConfig`
- * for the invalidation contract.
+ * Read one AFK.md candidate. Returns `null` when the file is missing,
+ * unreadable, or empty/whitespace-only — each tier is checked independently
+ * so an accidental blank file at one tier still falls through to (or
+ * combines with) the other, rather than silently wiping the prompt.
  */
-export function loadAfkMd(): { content: string; path: string } | null {
-  if (afkMdCache !== undefined) return afkMdCache.value;
-  const candidates = [
-    join(process.cwd(), 'AFK.md'),
-    join(getAfkHome(), 'AFK.md'),
-  ];
-  for (const p of candidates) {
-    if (!existsSync(p)) continue;
-    try {
-      const content = readFileSync(p, 'utf-8').trim();
-      if (content.length > 0) {
-        afkMdCache = { value: { content, path: p } };
-        return afkMdCache.value;
-      }
-    } catch {
-      // skip unreadable files
-    }
+function readAfkMdCandidate(path: string): string | null {
+  if (!existsSync(path)) return null;
+  try {
+    const content = readFileSync(path, 'utf-8').trim();
+    return content.length > 0 ? content : null;
+  } catch {
+    return null;
   }
-  afkMdCache = { value: null };
+}
+
+const userScopeHeader = (path: string): string => `## Personal configuration (${path})`;
+const projectScopeHeader = (path: string): string =>
+  `## Project configuration (${path}) — takes precedence on conflict`;
+
+/**
+ * Load a system-prompt overlay from AFK.md.
+ *
+ * Additive hybrid — checks BOTH:
+ *   1. `$AFK_HOME/AFK.md` (default `~/.afk/AFK.md`) — user-scope, broadest
+ *   2. `<cwd>/AFK.md` — project-scope, most specific
+ * and concatenates whichever are present and non-empty, user-scope first —
+ * mirroring Claude Code's CLAUDE.md load order (broadest first, most
+ * specific last, so the more specific instructions land closest to the
+ * actual conversation). This replaces the previous "first non-empty wins"
+ * exclusive fallback, where a project AFK.md fully hid a personal one.
+ *
+ * When only one tier resolves — by far the common case, since most repos
+ * either have their own AFK.md or don't — the result is that file's trimmed
+ * content verbatim, with NO added headers: byte-identical to the pre-hybrid
+ * single-tier behavior, so nothing changes for a repo with only a project
+ * AFK.md or a machine with only a personal one. Headers are injected only
+ * when there are genuinely two distinct sources to disambiguate, and the
+ * project section is explicitly marked as the conflict-precedence winner
+ * rather than relying on positional/recency bias alone.
+ *
+ * Delivery is unchanged: the returned `content` is still folded directly
+ * into the system prompt by `composeSystemPrompt()` under the one outer
+ * `# Operator configuration` header — never delivered as a separate
+ * synthetic user-turn message the way Claude Code delivers CLAUDE.md.
+ *
+ * Memoized via `afkMdCache` — see the cache block above for the
+ * invalidation contract.
+ */
+export function loadAfkMd(): AfkMdResult | null {
+  if (afkMdCache !== undefined) return afkMdCache.value;
+
+  const userPath = join(getAfkHome(), 'AFK.md');
+  const projectPath = join(process.cwd(), 'AFK.md');
+
+  const userContent = readAfkMdCandidate(userPath);
+  // Skip re-reading the same file twice (e.g. AFK_HOME relocated to cwd) —
+  // treat it as a single tier rather than duplicating its content.
+  const projectContent = projectPath === userPath ? null : readAfkMdCandidate(projectPath);
+
+  let result: AfkMdResult | null;
+  if (userContent !== null && projectContent !== null) {
+    result = {
+      content:
+        `${userScopeHeader(userPath)}\n\n${userContent}\n\n` +
+        `${projectScopeHeader(projectPath)}\n\n${projectContent}`,
+      paths: [userPath, projectPath],
+    };
+  } else if (projectContent !== null) {
+    result = { content: projectContent, paths: [projectPath] };
+  } else if (userContent !== null) {
+    result = { content: userContent, paths: [userPath] };
+  } else {
+    result = null;
+  }
+
+  afkMdCache = { value: result };
   return afkMdCache.value;
 }

--- a/src/cli/shared-helpers.test.ts
+++ b/src/cli/shared-helpers.test.ts
@@ -164,6 +164,24 @@ describe('resolveBaseSystemPrompt', () => {
     const { source } = resolveBaseSystemPrompt();
     expect(source).toBe('framework+env:AFK_SYSTEM_PROMPT');
   });
+
+  // Invariant: the `+` join is a flat list of contributing sources, not a
+  // two-field "framework plus one overlay" shape. When both AFK.md tiers
+  // resolve, loadConfig() already hands up a `+`-joined pair, so the composed
+  // string carries three segments. Locking this guards against a refactor
+  // that "simplifies" the join back to a single overlay path and silently
+  // drops the personal tier from provenance while still loading its content.
+  it('preserves every segment when both AFK.md tiers contributed', () => {
+    vi.mocked(loadConfig).mockReturnValue(
+      fakeConfig(
+        'personal + project overlay',
+        'afk-md:/home/user/.afk/AFK.md+afk-md:/repo/AFK.md',
+      ),
+    );
+    const { source } = resolveBaseSystemPrompt();
+    expect(source).toBe('framework+afk-md:/home/user/.afk/AFK.md+afk-md:/repo/AFK.md');
+    expect(source.split('+')).toHaveLength(3);
+  });
 });
 
 describe('isGrantManager', () => {

--- a/src/cli/shared-helpers.ts
+++ b/src/cli/shared-helpers.ts
@@ -40,7 +40,9 @@ export function loadSystemPrompt(): string | undefined {
  * Load systemPrompt from env or afk.config.json, if set.
  * Precedence: AFK_SYSTEM_PROMPT env > cwd/afk.config.json >
  *   ~/.afk/config/afk.config.json > legacy ~/.afk.config.json >
- *   cwd/AFK.md > $AFK_HOME/AFK.md.
+ *   AFK.md (cwd + $AFK_HOME/, combined additively when both exist —
+ *   project-scope text is appended after personal-scope text and wins on
+ *   conflict; see `loadAfkMd()` in `config/afk-md-tier.ts`).
  * Mirrors the telegram entrypoint so CLI and bot read the same config surface.
  *
  * Delegates to `loadConfig()` to share the same 3-tier walk and disk-cache.

--- a/website/content/docs/configuration/afk-md.mdx
+++ b/website/content/docs/configuration/afk-md.mdx
@@ -21,15 +21,30 @@ is parsed.
 
 ## Resolution order
 
-`loadConfig()` searches for `AFK.md` in this order (first found wins):
+`loadConfig()` checks **both** locations and loads whichever are present — the
+tiers are additive, not first-found-wins:
 
-1. `<cwd>/AFK.md` — **project-scope**: loaded when you run `afk` from inside
-   the project directory.
-2. `$AFK_HOME/AFK.md` (default `~/.afk/AFK.md`) — **user-scope global**:
-   loaded when no project-level file is found.
+1. `$AFK_HOME/AFK.md` (default `~/.afk/AFK.md`) — **user-scope global**:
+   cross-project preferences that apply on every run.
+2. `<cwd>/AFK.md` — **project-scope**: loaded when you run `afk` from inside a
+   directory that contains one.
 
-If neither file exists, the framework prompt runs alone with no overlay.
-An empty or whitespace-only `AFK.md` is treated as absent.
+When both exist they are concatenated **user-scope first, project-scope
+second**, each under a heading naming its source path, with the project
+section explicitly marked as taking precedence on conflict. Broadest context
+lands first; the most specific instructions land closest to the conversation.
+
+When only one exists — by far the common case — its content is used verbatim
+with **no added headings**, byte-identical to the previous single-tier
+behavior.
+
+If both paths resolve to the same file (for example `AFK_HOME` pointed at your
+project directory, whether directly or through a symlink) it is loaded once,
+not twice.
+
+If neither file exists, the framework prompt runs alone with no overlay. An
+empty or whitespace-only `AFK.md` is treated as absent — evaluated per file, so
+a blank project file still lets a populated personal one through.
 
 ## How it layers with the framework prompt
 

--- a/website/content/docs/configuration/overview.mdx
+++ b/website/content/docs/configuration/overview.mdx
@@ -38,7 +38,7 @@ Configuration is layered. Higher tiers win over lower ones.
 |------|--------|-----------|
 | 1 (highest) | `AFK_SYSTEM_PROMPT` env var | everything |
 | 2 | `afk.config.json` — searched in order: `<cwd>/afk.config.json` → `~/.afk/config/afk.config.json` → legacy `~/.afk.config.json` | AFK.md |
-| 3 (lowest) | `AFK.md` — searched in order: `<cwd>/AFK.md` → `~/.afk/AFK.md` | nothing |
+| 3 (lowest) | `AFK.md` — **additive**: `~/.afk/AFK.md` and `<cwd>/AFK.md` are both loaded when both exist, user-scope first | nothing |
 
 The built-in prompt is always present. Any overlay you set is appended after it
 under an `# Operator configuration` header — it adds to the base, never overwrites it.

--- a/website/content/docs/how-it-works.mdx
+++ b/website/content/docs/how-it-works.mdx
@@ -87,7 +87,9 @@ The system prompt is always composed of two parts:
    priority order:
    - `AFK_SYSTEM_PROMPT` env var (highest)
    - `afk.config.json` (`systemPrompt` field)
-   - `AFK.md` at the project root (lowest)
+   - `AFK.md` (lowest) — additive across two locations: `~/.afk/AFK.md`
+     (user-scope) and `<cwd>/AFK.md` (project-scope), both loaded and
+     concatenated when both exist
 
 An absent overlay means the model gets the framework base alone. Overlays append — they never
 replace the base. Use `--dump-prompt` to inspect the fully composed prompt and provenance.


### PR DESCRIPTION
## Summary

`AFK.md`'s user-scope fallback (`$AFK_HOME/AFK.md`, default `~/.afk/AFK.md`) was previously an **exclusive** fallback: `loadAfkMd()` returned the first non-empty file it found, checking `<cwd>/AFK.md` before `$AFK_HOME/AFK.md`. In practice this meant a personal `~/.afk/AFK.md` was dead weight in any repo that already shipped its own `AFK.md` — it would never be read at all, since the project file fully hid it.

This PR makes Tier 3 **additive** instead: when both `$AFK_HOME/AFK.md` (personal) and `<cwd>/AFK.md` (project) exist and are non-empty, they're concatenated — personal first, project second, mirroring Claude Code's CLAUDE.md broadest-to-most-specific load order — with the project section explicitly marked as the conflict-precedence winner. Delivery is unchanged: the combined text is still baked directly into the system prompt under the existing `# Operator configuration` header, never a separate synthetic user-turn message.

**Backward compatible by construction:** when only one tier resolves (the common case — most repos either have their own `AFK.md` or don't), the output is byte-identical to the pre-hybrid format: no added header, same single-path `afk-md:<path>` provenance string.

### What changed

- `src/cli/config/afk-md-tier.ts` — `loadAfkMd()` now returns `{ content, paths: string[] }` (was `{ content, path }`). Reads both tiers independently (each still treats empty/whitespace-only as absent); when both resolve, concatenates under `## Personal configuration (...)` / `## Project configuration (...) — takes precedence on conflict` sub-headers. A same-file dedup guard prevents double-reading when `AFK_HOME` is relocated onto `cwd`.
- `src/cli/config.ts` — `systemPromptSource` now maps each contributing path through its own `afk-md:` prefix and joins with `+` (same convention `resolveBaseSystemPrompt()` already uses for `framework+afk-md:<path>`): unchanged `afk-md:<path>` when one tier resolves, `afk-md:<user>+afk-md:<project>` when both combine.
- `src/cli/config.test.ts` — rewrote the old exclusive-fallback assertion (`prefers cwd/AFK.md over ~/.afk/AFK.md`) into the new additive contract, and added a same-file dedup-guard test. The other 8 pre-existing AFK.md auto-discovery cases (env/json precedence, empty-file handling, no-file case) are unchanged and still pass.
- `AFK.md`, `src/cli/shared-helpers.ts` — doc-comment updates so the operator-overlay docs describe the additive tier instead of the old exclusive fallback.

**Unchanged:** the outer 3-tier precedence (`AFK_SYSTEM_PROMPT` env → `afk.config.json` → `AFK.md`) stays exclusive — first tier that resolves still wins outright. Only Tier 3's *internal* personal/project resolution became additive.

## How was this tested?

- `pnpm lint` (`tsc --noEmit`) — clean.
- `pnpm test src/cli/config.test.ts` — 88/88 passing, including the rewritten and new cases.
- `pnpm test src/cli/shared-helpers.test.ts` — 16/16 passing (unaffected, confirms no collateral breakage).
- Full regression sweep, `pnpm test src/cli/` — **286 test files / 5082 tests, all passing**, zero regressions.
- Live, non-mocked, real-filesystem repro via `tsx` against the actual installed toolchain, covering all three shapes:
  - both tiers present → concatenated with headers, `afk-md:<user>+afk-md:<project>`
  - project-only → verbatim, unchanged single-path format
  - user-only (the original fallback case) → verbatim, unchanged single-path format

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] No secrets, tokens, or private paths in the diff
