### PR TITLE
fix(improve): make the pipeline's own instruments tell the truth

### DIFF
--- a/src/cli/commands/improve.pattern-options.test.ts
+++ b/src/cli/commands/improve.pattern-options.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Regression guard for `afk improve ... --pattern` validation.
+ *
+ * History: the CLI hand-maintained a copy of the failure-pattern list. Sprint 2
+ * added `tool-failure-density` and `subagent-read-denial` to
+ * `FailurePatternSchema` but not to the copy, so
+ * `afk improve eval-cases list --pattern tool-failure-density` exited 2 with
+ * "Invalid --pattern" while four eval-cases on disk used exactly that pattern.
+ *
+ * The fix derives the list from the schema, making the drift structurally
+ * impossible. These tests fail if anyone reintroduces a hand-maintained literal.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { VALID_PATTERNS } from './improve.js';
+import { FailurePatternSchema } from '../../improve/schemas.js';
+
+describe('improve --pattern accepted values', () => {
+  it('accepts every pattern the canonical schema defines', () => {
+    expect([...VALID_PATTERNS].sort()).toEqual([...FailurePatternSchema.options].sort());
+  });
+
+  it('accepts the two patterns that the drifted hand-copy rejected', () => {
+    // Named explicitly: these are the exact values that produced the live
+    // exit-2 bug, so a future truncation of the list cannot pass silently.
+    expect(VALID_PATTERNS).toContain('tool-failure-density');
+    expect(VALID_PATTERNS).toContain('subagent-read-denial');
+  });
+
+  it('is not a truncated subset of the schema', () => {
+    expect(VALID_PATTERNS.length).toBe(FailurePatternSchema.options.length);
+    expect(VALID_PATTERNS.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('contains only values the schema will parse', () => {
+    for (const pattern of VALID_PATTERNS) {
+      expect(() => FailurePatternSchema.parse(pattern)).not.toThrow();
+    }
+  });
+});

--- a/src/cli/commands/improve.ts
+++ b/src/cli/commands/improve.ts
@@ -115,6 +115,7 @@ import {
 } from '../../improve/eval-run/runner.js';
 import { knownContractIds } from '../../improve/eval-run/contracts.js';
 import type { EvalCase, EvalCaseStatus, EvalRun, FailurePattern } from '../../improve/schemas.js';
+import { FailurePatternSchema } from '../../improve/schemas.js';
 
 const VALID_STATUSES: readonly CardStatus[] = ['open', 'deferred', 'resolved'];
 const VALID_EVAL_STATUSES: readonly EvalCaseStatus[] = [
@@ -123,11 +124,10 @@ const VALID_EVAL_STATUSES: readonly EvalCaseStatus[] = [
   'rejected',
   'superseded',
 ];
-const VALID_PATTERNS: readonly FailurePattern[] = [
-  'repeated-tool-use',
-  'subagent-block',
-  'closure-anomaly',
-];
+// Invariant: DERIVED from the canonical schema, never hand-maintained. A
+// hand-copied duplicate drifted two sprints behind `FailurePatternSchema`, so
+// `--pattern tool-failure-density` was rejected while cards on disk used it.
+export const VALID_PATTERNS: readonly FailurePattern[] = FailurePatternSchema.options;
 
 export function registerImproveCommand(program: Command): void {
   const improve = program

--- a/src/improve/scan/card-writer.test.ts
+++ b/src/improve/scan/card-writer.test.ts
@@ -156,6 +156,56 @@ describe('mergeCard (pure)', () => {
     expect(escalated.severity).toBe('medium');
   });
 
+  // Integration counterpart to severity-merge.test.ts: those tests exercise
+  // reconcileSeverity directly, these prove mergeCard actually routes through
+  // it — the wiring that makes de-escalation reachable at all.
+  it('de-escalates through mergeCard across a detector version change', () => {
+    const v1Card = mergeCard(
+      undefined,
+      makeDetection({ severity: 'high', detail: { detector: 'closure-anomaly@v1' } }),
+    );
+    expect(v1Card.severity).toBe('high');
+
+    const merged = mergeCard(
+      v1Card,
+      makeDetection({ severity: 'low', detail: { detector: 'closure-anomaly@v2' } }),
+    );
+    // A v1 `high` computed by superseded arithmetic must yield to v2's verdict.
+    expect(merged.severity).toBe('low');
+    // …and the merged card carries the new tag, so the next merge is
+    // escalate-only again rather than re-firing the version-change path.
+    expect(merged.detail['detector']).toBe('closure-anomaly@v2');
+  });
+
+  it('stays escalate-only through mergeCard when the detector tag matches', () => {
+    const existing = mergeCard(
+      undefined,
+      makeDetection({ severity: 'high', detail: { detector: 'closure-anomaly@v2' } }),
+    );
+    const merged = mergeCard(
+      existing,
+      makeDetection({ severity: 'low', detail: { detector: 'closure-anomaly@v2' } }),
+    );
+    expect(merged.severity).toBe('high');
+  });
+
+  it('replaces detail wholesale on merge, including closureEventCount', () => {
+    // Contract pinned deliberately: `detail` is REPLACED, not merged, so a
+    // narrower scan window lowers closureEventCount rather than accumulating
+    // it. Reads as "this window saw 2 events", never as "the cascade shrank".
+    const existing = mergeCard(
+      undefined,
+      makeDetection({ detail: { detector: 'closure-anomaly@v2', closureEventCount: 9 } }),
+    );
+    expect(existing.detail['closureEventCount']).toBe(9);
+
+    const merged = mergeCard(
+      existing,
+      makeDetection({ detail: { detector: 'closure-anomaly@v2', closureEventCount: 2 } }),
+    );
+    expect(merged.detail['closureEventCount']).toBe(2);
+  });
+
   it('dedupes evidence by (sessionId, first event seq)', () => {
     const first = mergeCard(undefined, makeDetection());
     const merged = mergeCard(first, makeDetection()); // identical evidence

--- a/src/improve/scan/card-writer.ts
+++ b/src/improve/scan/card-writer.ts
@@ -50,6 +50,7 @@ import {
   FailureCardSchema,
   type FailureEvidence,
 } from '../schemas.js';
+import { reconcileSeverity } from './severity-merge.js';
 import {
   getFailureCardJsonPath,
   getFailureCardMarkdownPath,
@@ -174,7 +175,10 @@ export function mergeCard(
   const mergedEvidence = mergeEvidence(existing.evidence, detection.evidence);
   const firstSeen = minIso(existing.firstSeen, detection.observedAt);
   const lastSeen = maxIso(existing.lastSeen, detection.observedAt);
-  const severity = maxSeverity(existing.severity, detection.severity);
+  // Escalate-only, EXCEPT across a detector version change — see
+  // reconcileSeverity. A v1 card's severity was computed by different
+  // arithmetic and must not pin the v2 detection's verdict.
+  const severity = reconcileSeverity(existing, detection);
 
   return {
     schemaVersion: 1,
@@ -317,16 +321,6 @@ function minIso(a: string, b: string): string {
 
 function maxIso(a: string, b: string): string {
   return a >= b ? a : b;
-}
-
-const SEVERITY_RANK: Record<FailureCard['severity'], number> = {
-  low: 0,
-  medium: 1,
-  high: 2,
-};
-
-function maxSeverity(a: FailureCard['severity'], b: FailureCard['severity']): FailureCard['severity'] {
-  return SEVERITY_RANK[a] >= SEVERITY_RANK[b] ? a : b;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/improve/scan/detectors/closure-anomaly.test.ts
+++ b/src/improve/scan/detectors/closure-anomaly.test.ts
@@ -245,3 +245,106 @@ describe('default min occurrences', () => {
     expect(DEFAULT_CLOSURE_ANOMALY_MIN_OCCURRENCES).toBe(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Cascade dedupe — one parent timeout must not read as N sessions.
+//
+// History: a single parent timeout cascade-cancels every in-flight child and
+// each cancellation writes its own closure event into the SAME trace. The
+// event-keyed rollup reported affectedSessions=37 / totalCostUsd=$114.47 for
+// what was a much smaller set of sessions, and emitted duplicate sessionIds.
+// finalCostUsd is CUMULATIVE, so summing per-event multi-counted spend.
+// ---------------------------------------------------------------------------
+
+describe('detectClosureAnomaly — cascade dedupe (per-session rollup)', () => {
+  it('collapses four cascade closures in one session into a single row', () => {
+    resetSeq();
+    // Four children cascade-killed by one parent timeout; cost is cumulative
+    // and monotonically non-decreasing across the four events.
+    const sessions = [
+      makeSession('parent-1', [
+        closureLine('timeout', 10, 3),
+        closureLine('timeout', 20, 4),
+        closureLine('timeout', 30, 5),
+        closureLine('timeout', 40, 6),
+      ]),
+    ];
+    const results = detectClosureAnomaly(sessions);
+    expect(results).toHaveLength(1);
+    const r = results[0]!;
+
+    // One session, not four.
+    expect(r.detail['affectedSessions']).toBe(1);
+    expect(r.detail['sessionIds']).toEqual(['parent-1']);
+    expect(r.evidence).toHaveLength(1);
+
+    // Cost is the session's true final figure, NOT 10+20+30+40=100.
+    expect(r.detail['totalCostUsd']).toBe(40);
+    expect(r.detail['maxCostUsd']).toBe(40);
+
+    // The raw event count survives as its own signal.
+    expect(r.detail['closureEventCount']).toBe(4);
+
+    // Turn count comes from the surviving (highest-cost) sighting.
+    expect(r.detail['avgTurnCount']).toBe(6);
+  });
+
+  it('never emits duplicate session ids', () => {
+    resetSeq();
+    const sessions = [
+      makeSession('a', [closureLine('timeout', 5), closureLine('timeout', 9)]),
+      makeSession('b', [closureLine('timeout', 7)]),
+    ];
+    const r = detectClosureAnomaly(sessions)[0]!;
+    const ids = r.detail['sessionIds'] as string[];
+    expect(ids).toEqual(['a', 'b']);
+    expect(new Set(ids).size).toBe(ids.length);
+    // Per-session maxima summed: 9 + 7, not 5+9+7.
+    expect(r.detail['totalCostUsd']).toBe(16);
+    expect(r.detail['closureEventCount']).toBe(3);
+  });
+
+  it('counts sessions, not events, against minOccurrences', () => {
+    resetSeq();
+    // Three closure events but only ONE session — must not clear a 2-session bar.
+    const sessions = [
+      makeSession('solo', [
+        closureLine('timeout', 1),
+        closureLine('timeout', 2),
+        closureLine('timeout', 3),
+      ]),
+    ];
+    expect(detectClosureAnomaly(sessions, { minOccurrences: 2 })).toHaveLength(0);
+    expect(detectClosureAnomaly(sessions, { minOccurrences: 1 })).toHaveLength(1);
+  });
+
+  it('reports the deduped session count in the title', () => {
+    resetSeq();
+    const sessions = [
+      makeSession('p', [closureLine('timeout', 1), closureLine('timeout', 2)]),
+    ];
+    const r = detectClosureAnomaly(sessions)[0]!;
+    expect(r.title).toContain('1 session');
+    expect(r.title).not.toContain('2 sessions');
+  });
+
+  it('keeps the highest-cost sighting regardless of event order', () => {
+    resetSeq();
+    // Descending cost order — the survivor is still the max, not the last seen.
+    const sessions = [
+      makeSession('p', [closureLine('timeout', 99, 12), closureLine('timeout', 4, 2)]),
+    ];
+    const r = detectClosureAnomaly(sessions)[0]!;
+    expect(r.detail['totalCostUsd']).toBe(99);
+    expect(r.detail['avgTurnCount']).toBe(12);
+  });
+
+  it('still parses against DetectorResultSchema after dedupe', () => {
+    resetSeq();
+    const sessions = [
+      makeSession('p', [closureLine('timeout', 3), closureLine('timeout', 8)]),
+    ];
+    const r = detectClosureAnomaly(sessions)[0]!;
+    expect(DetectorResultSchema.safeParse(r).success).toBe(true);
+  });
+});

--- a/src/improve/scan/detectors/closure-anomaly.test.ts
+++ b/src/improve/scan/detectors/closure-anomaly.test.ts
@@ -371,4 +371,36 @@ describe('detectClosureAnomaly — cascade dedupe (per-session rollup)', () => {
     const r = detectClosureAnomaly(sessions)[0]!;
     expect(DetectorResultSchema.safeParse(r).success).toBe(true);
   });
+
+  it('caps seqs with evidence but leaves sessionIds whole', () => {
+    resetSeq();
+    // A wide cascade: 20 children killed by one parent timeout. Evidence and
+    // seqs index each other, so both cap at 8; the aggregates and sessionIds
+    // must still describe every event/session, uncapped.
+    const sessions = [
+      makeSession('wide', Array.from({ length: 20 }, () => closureLine('timeout', 1, 2))),
+    ];
+    const r = detectClosureAnomaly(sessions)[0]!;
+    expect(r.evidence).toHaveLength(8);
+    expect((r.detail['seqs'] as number[]).length).toBe(8);
+    // Uncapped: the honest event count, the true summed spend, and the session
+    // list whose length IS affectedSessions.
+    expect(r.detail['closureEventCount']).toBe(20);
+    expect(r.detail['totalCostUsd']).toBe(20);
+    expect(r.detail['sessionIds']).toEqual(['wide']);
+    expect(r.detail['affectedSessions']).toBe(1);
+  });
+
+  it('caps seqs across many sessions without truncating sessionIds', () => {
+    resetSeq();
+    // 12 distinct sessions — sessionIds.length must stay equal to
+    // affectedSessions even though seqs is clamped to the evidence cap.
+    const sessions = Array.from({ length: 12 }, (_, i) =>
+      makeSession(`s${i}`, [closureLine('timeout', 1, 2)]),
+    );
+    const r = detectClosureAnomaly(sessions)[0]!;
+    expect((r.detail['seqs'] as number[]).length).toBe(8);
+    expect((r.detail['sessionIds'] as string[]).length).toBe(12);
+    expect(r.detail['affectedSessions']).toBe(12);
+  });
 });

--- a/src/improve/scan/detectors/closure-anomaly.test.ts
+++ b/src/improve/scan/detectors/closure-anomaly.test.ts
@@ -276,17 +276,23 @@ describe('detectClosureAnomaly — cascade dedupe (per-session rollup)', () => {
     // One session, not four.
     expect(r.detail['affectedSessions']).toBe(1);
     expect(r.detail['sessionIds']).toEqual(['parent-1']);
-    expect(r.evidence).toHaveLength(1);
 
-    // Cost is the session's true final figure, NOT 10+20+30+40=100.
-    expect(r.detail['totalCostUsd']).toBe(40);
+    // Evidence is per EVENT: a cascade's distinct child closures are the
+    // evidence, so all four survive (codex review, PR #847).
+    expect(r.evidence).toHaveLength(4);
+
+    // Cost sums across instances. The four accumulators are disjoint — a
+    // child's spend never reaches the parent's `sessionRunningCostUsd` — so
+    // 10+20+30+40 IS this trace file's true spend, and the old max-based 40
+    // under-reported it.
+    expect(r.detail['totalCostUsd']).toBe(100);
     expect(r.detail['maxCostUsd']).toBe(40);
 
     // The raw event count survives as its own signal.
     expect(r.detail['closureEventCount']).toBe(4);
 
-    // Turn count comes from the surviving (highest-cost) sighting.
-    expect(r.detail['avgTurnCount']).toBe(6);
+    // Turns average over every instance: (3+4+5+6)/4.
+    expect(r.detail['avgTurnCount']).toBe(4.5);
   });
 
   it('never emits duplicate session ids', () => {
@@ -299,8 +305,9 @@ describe('detectClosureAnomaly — cascade dedupe (per-session rollup)', () => {
     const ids = r.detail['sessionIds'] as string[];
     expect(ids).toEqual(['a', 'b']);
     expect(new Set(ids).size).toBe(ids.length);
-    // Per-session maxima summed: 9 + 7, not 5+9+7.
-    expect(r.detail['totalCostUsd']).toBe(16);
+    // Every instance's disjoint segment summed: 5+9+7, not the per-session
+    // maxima 9+7 — session ids stay deduped, cost does not.
+    expect(r.detail['totalCostUsd']).toBe(21);
     expect(r.detail['closureEventCount']).toBe(3);
   });
 
@@ -328,15 +335,32 @@ describe('detectClosureAnomaly — cascade dedupe (per-session rollup)', () => {
     expect(r.title).not.toContain('2 sessions');
   });
 
-  it('keeps the highest-cost sighting regardless of event order', () => {
+  it('aggregates every instance regardless of event order', () => {
     resetSeq();
-    // Descending cost order — the survivor is still the max, not the last seen.
+    // Descending cost order — nothing is discarded, so the totals are
+    // order-independent and no sighting "wins".
     const sessions = [
       makeSession('p', [closureLine('timeout', 99, 12), closureLine('timeout', 4, 2)]),
     ];
     const r = detectClosureAnomaly(sessions)[0]!;
-    expect(r.detail['totalCostUsd']).toBe(99);
-    expect(r.detail['avgTurnCount']).toBe(12);
+    expect(r.detail['totalCostUsd']).toBe(103);
+    expect(r.detail['maxCostUsd']).toBe(99);
+    expect(r.detail['avgTurnCount']).toBe(7);
+    expect(r.detail['affectedSessions']).toBe(1);
+  });
+
+  it('is order-independent: reversed input yields identical aggregates', () => {
+    resetSeq();
+    const ascending = detectClosureAnomaly([
+      makeSession('p', [closureLine('timeout', 4, 2), closureLine('timeout', 99, 12)]),
+    ])[0]!;
+    resetSeq();
+    const descending = detectClosureAnomaly([
+      makeSession('p', [closureLine('timeout', 99, 12), closureLine('timeout', 4, 2)]),
+    ])[0]!;
+    expect(ascending.detail['totalCostUsd']).toBe(descending.detail['totalCostUsd']);
+    expect(ascending.detail['avgTurnCount']).toBe(descending.detail['avgTurnCount']);
+    expect(ascending.detail['maxCostUsd']).toBe(descending.detail['maxCostUsd']);
   });
 
   it('still parses against DetectorResultSchema after dedupe', () => {

--- a/src/improve/scan/detectors/closure-anomaly.ts
+++ b/src/improve/scan/detectors/closure-anomaly.ts
@@ -37,11 +37,15 @@
  *   - A single anomalous closure is meaningful but noisy. Default
  *     threshold is 1 — every anomalous closure is flagged — but
  *     `minOccurrences` lifts the bar when desired.
- *   - Every count and cost in `detail` is PER SESSION, not per closure event.
- *     One parent timeout cascade-cancels its children and each writes its own
- *     `closure` event into the same trace, so an event-keyed rollup reported a
- *     single session as several and multi-counted its cumulative cost. The raw
- *     event total survives as `detail.closureEventCount`.
+ *   - `detail` reports TWO granularities on purpose, because a witness trace
+ *     file is not one agent. `affectedSessions` / `sessionIds` count WITNESS
+ *     TRACE FILES (`SessionRead.sessionId`, the witness directory name);
+ *     `closureEventCount`, `totalCostUsd`, `maxCostUsd` and `avgTurnCount`
+ *     aggregate every closure EVENT, i.e. every AgentSession instance. A
+ *     parent and each child it forked write into the SAME trace file and each
+ *     owns a DISJOINT cost accumulator, so summing events recovers that trace
+ *     file's true spend while counting them would invent phantom sessions —
+ *     see {@link distinctSessionIds}.
  *
  * @module improve/scan/detectors/closure-anomaly
  */
@@ -118,66 +122,74 @@ export function detectClosureAnomaly(
 
   const results: DetectorResult[] = [];
   for (const [reason, sightings] of byReason.entries()) {
-    // Contract: the threshold, the rollup arithmetic, and the evidence rows all
-    // count SESSIONS, not closure events. See collapseBySession.
-    const perSession = collapseBySession(sightings);
-    if (perSession.length < minOccurrences) continue;
-    results.push(buildResult(reason, perSession, sightings.length));
+    // Contract: the THRESHOLD counts sessions — one noisy trace file must not
+    // clear a multi-session bar — while the cost/turn aggregates and the
+    // evidence rows count EVENTS. See distinctSessionIds and buildResult.
+    const sessionIds = distinctSessionIds(sightings);
+    if (sessionIds.length < minOccurrences) continue;
+    results.push(buildResult(reason, sessionIds, sightings));
   }
   return results;
 }
 
 /**
- * Invariant: one row per session per reason — a session that emitted N closure
- * events sharing a reason contributes exactly ONE sighting downstream.
+ * Invariant: one entry per WITNESS TRACE FILE per reason — a `sessionId` that
+ * emitted N closure events sharing a reason contributes exactly ONE id here.
  *
- * A single parent timeout cascade-cancels every in-flight child, and each
- * cancellation writes its own `closure{reason:'timeout'}` event into the SAME
- * trace. Rolling those up per-event made one parent look like N independent
- * sessions: `affectedSessions` counted events, `sessionIds` carried duplicate
- * ids, and `finalCostUsd` — a CUMULATIVE figure, not an increment — was summed
- * once per child, inflating reported spend severalfold.
+ * `sessionId` is the witness trace file's directory name (`reader.ts`'s
+ * `parseTraceContent` stamps it onto every event parsed from that one
+ * `trace.jsonl`), NOT a per-`AgentSession`-instance identity. A parent timeout
+ * cascade-cancels every in-flight child and each cancellation writes its own
+ * `closure{reason}` event into the SAME trace, because forked subagents share
+ * the parent's `TraceWriter` by reference (`subagent.ts`'s
+ * `effectiveTraceWriter` resolution). Counting those events as sessions made
+ * one trace look like N independent ones and emitted duplicate ids; counting
+ * distinct ids fixes that.
  *
- * The survivor is the highest-cost sighting: `finalCostUsd` is monotonically
- * non-decreasing across a session's life, so the maximum is that session's true
- * final cost. `seq` breaks ties toward the later event. Map insertion order is
- * preserved on overwrite, so first-seen session ordering is stable.
+ * This governs the session COUNT ONLY. Cost and turn aggregates deliberately do
+ * NOT collapse: each instance owns a DISJOINT accumulator, so summing events is
+ * the trace file's true spend. `sessionRunningCostUsd` is written in exactly
+ * two places (re-zeroed in `initSdkLifecycle()`, and `+= m.totalCostUsd` from
+ * that instance's OWN response metadata); a child's spend lands in a SEPARATE
+ * accumulator via `recordSubagentCompletion` (`subagentRunningTokens`) and
+ * never reaches the parent's. An earlier revision kept only the highest-cost
+ * sighting per session, which discarded every other instance's spend and
+ * under-reported the card (codex review, PR #847).
+ *
+ * Returned in first-seen order; `Set` preserves insertion order, so ordering is
+ * stable across runs.
  */
-function collapseBySession(sightings: ClosureSighting[]): ClosureSighting[] {
-  const bySession = new Map<string, ClosureSighting>();
-  for (const s of sightings) {
-    const incumbent = bySession.get(s.sessionId);
-    if (
-      incumbent === undefined ||
-      s.finalCostUsd > incumbent.finalCostUsd ||
-      (s.finalCostUsd === incumbent.finalCostUsd && s.seq > incumbent.seq)
-    ) {
-      bySession.set(s.sessionId, s);
-    }
-  }
-  return [...bySession.values()];
+function distinctSessionIds(sightings: ClosureSighting[]): string[] {
+  return [...new Set(sightings.map((s) => s.sessionId))];
 }
 
 /** Hard cap on evidence rows per card. Same convention as repeated-tool-use. */
 const MAX_EVIDENCE_PER_CARD = 8;
 
 /**
- * Contract: `sightings` MUST already be collapsed to one entry per session
- * (see {@link collapseBySession}); every figure in `detail` is per-session.
- * `closureEventCount` is the RAW pre-collapse event total, preserved because a
- * session emitting many closures for one reason is itself real signal (cascade
- * fan-out width) that the collapse would otherwise discard.
+ * Contract: `sessionIds` is the deduped id list — one entry per witness trace
+ * file (see {@link distinctSessionIds}) — and drives the SESSION-scoped
+ * figures: `affectedSessions`, `sessionIds`, the title, and the severity
+ * ladder. `allSightings` is the raw event list and drives the
+ * INSTANCE-scoped figures: `closureEventCount`, `totalCostUsd`, `maxCostUsd`,
+ * `avgTurnCount`, and the evidence rows.
+ *
+ * The two granularities are reported side by side rather than folded together,
+ * because a trace file is not one agent: collapsing events would under-report
+ * spend and hide a cascade's fan-out, while counting them as sessions would
+ * invent sessions that never existed.
  */
 function buildResult(
   reason: string,
-  sightings: ClosureSighting[],
-  closureEventCount: number,
+  sessionIds: string[],
+  allSightings: ClosureSighting[],
 ): DetectorResult {
   const slug = makeSlug(reason);
   const observedAt = new Date().toISOString();
 
-  // One evidence row per session, capped.
-  const capped = sightings.slice(0, MAX_EVIDENCE_PER_CARD);
+  // One evidence row per closure EVENT, capped — a cascade's distinct child
+  // closures ARE the evidence, so collapsing them here would hide the fan-out.
+  const capped = allSightings.slice(0, MAX_EVIDENCE_PER_CARD);
   const evidence: FailureEvidence[] = capped.map((s) => ({
     sessionId: s.sessionId,
     tracePath: s.relativeTracePath,
@@ -186,26 +198,30 @@ function buildResult(
     annotation: `closure.reason='${s.reason}' · cost=${formatUsd(s.finalCostUsd)} · turns=${s.finalTurnCount}`,
   }));
 
-  const totalCost = sightings.reduce((acc, s) => acc + s.finalCostUsd, 0);
-  const avgTurns = sightings.reduce((acc, s) => acc + s.finalTurnCount, 0) / sightings.length;
+  const totalCost = allSightings.reduce((acc, s) => acc + s.finalCostUsd, 0);
+  const avgTurns =
+    allSightings.reduce((acc, s) => acc + s.finalTurnCount, 0) / allSightings.length;
 
   return {
     slug,
-    title: `Session closure reason '${reason}' across ${sightings.length} session${sightings.length === 1 ? '' : 's'}`,
+    title: `Session closure reason '${reason}' across ${sessionIds.length} session${sessionIds.length === 1 ? '' : 's'}`,
     pattern: 'closure-anomaly',
-    severity: severityFor(reason, sightings.length),
+    severity: severityFor(reason, sessionIds.length),
     observedAt,
     evidence,
     detail: {
-      detector: 'closure-anomaly@v1',
+      // @v2: cost/turn aggregates moved from per-session-survivor to per-event
+      // after the accumulators were confirmed disjoint. The version bump lets a
+      // consumer tell v1's under-reported figures from v2's true totals.
+      detector: 'closure-anomaly@v2',
       closureReason: reason,
-      affectedSessions: sightings.length,
-      closureEventCount,
+      affectedSessions: sessionIds.length,
+      closureEventCount: allSightings.length,
       totalCostUsd: round4(totalCost),
       avgTurnCount: round2(avgTurns),
-      maxCostUsd: round4(Math.max(...sightings.map((s) => s.finalCostUsd))),
-      sessionIds: sightings.map((s) => s.sessionId),
-      seqs: sightings.map((s) => s.seq),
+      maxCostUsd: round4(Math.max(...allSightings.map((s) => s.finalCostUsd))),
+      sessionIds,
+      seqs: allSightings.map((s) => s.seq),
     },
   };
 }

--- a/src/improve/scan/detectors/closure-anomaly.ts
+++ b/src/improve/scan/detectors/closure-anomaly.ts
@@ -220,8 +220,14 @@ function buildResult(
       totalCostUsd: round4(totalCost),
       avgTurnCount: round2(avgTurns),
       maxCostUsd: round4(Math.max(...allSightings.map((s) => s.finalCostUsd))),
+      // Contract: `sessionIds` is deliberately UNCAPPED — its length IS
+      // `affectedSessions`, so truncating it would break that equality. `seqs`
+      // carries no such invariant: it indexes the evidence rows, so it is
+      // capped to the same slice. A wide cascade emits one closure event per
+      // cancelled child and would otherwise write an unbounded array into the
+      // persisted card (a live card on disk already carries 386 entries).
       sessionIds,
-      seqs: allSightings.map((s) => s.seq),
+      seqs: capped.map((s) => s.seq),
     },
   };
 }

--- a/src/improve/scan/detectors/closure-anomaly.ts
+++ b/src/improve/scan/detectors/closure-anomaly.ts
@@ -37,6 +37,11 @@
  *   - A single anomalous closure is meaningful but noisy. Default
  *     threshold is 1 — every anomalous closure is flagged — but
  *     `minOccurrences` lifts the bar when desired.
+ *   - Every count and cost in `detail` is PER SESSION, not per closure event.
+ *     One parent timeout cascade-cancels its children and each writes its own
+ *     `closure` event into the same trace, so an event-keyed rollup reported a
+ *     single session as several and multi-counted its cumulative cost. The raw
+ *     event total survives as `detail.closureEventCount`.
  *
  * @module improve/scan/detectors/closure-anomaly
  */
@@ -113,16 +118,61 @@ export function detectClosureAnomaly(
 
   const results: DetectorResult[] = [];
   for (const [reason, sightings] of byReason.entries()) {
-    if (sightings.length < minOccurrences) continue;
-    results.push(buildResult(reason, sightings));
+    // Contract: the threshold, the rollup arithmetic, and the evidence rows all
+    // count SESSIONS, not closure events. See collapseBySession.
+    const perSession = collapseBySession(sightings);
+    if (perSession.length < minOccurrences) continue;
+    results.push(buildResult(reason, perSession, sightings.length));
   }
   return results;
+}
+
+/**
+ * Invariant: one row per session per reason — a session that emitted N closure
+ * events sharing a reason contributes exactly ONE sighting downstream.
+ *
+ * A single parent timeout cascade-cancels every in-flight child, and each
+ * cancellation writes its own `closure{reason:'timeout'}` event into the SAME
+ * trace. Rolling those up per-event made one parent look like N independent
+ * sessions: `affectedSessions` counted events, `sessionIds` carried duplicate
+ * ids, and `finalCostUsd` — a CUMULATIVE figure, not an increment — was summed
+ * once per child, inflating reported spend severalfold.
+ *
+ * The survivor is the highest-cost sighting: `finalCostUsd` is monotonically
+ * non-decreasing across a session's life, so the maximum is that session's true
+ * final cost. `seq` breaks ties toward the later event. Map insertion order is
+ * preserved on overwrite, so first-seen session ordering is stable.
+ */
+function collapseBySession(sightings: ClosureSighting[]): ClosureSighting[] {
+  const bySession = new Map<string, ClosureSighting>();
+  for (const s of sightings) {
+    const incumbent = bySession.get(s.sessionId);
+    if (
+      incumbent === undefined ||
+      s.finalCostUsd > incumbent.finalCostUsd ||
+      (s.finalCostUsd === incumbent.finalCostUsd && s.seq > incumbent.seq)
+    ) {
+      bySession.set(s.sessionId, s);
+    }
+  }
+  return [...bySession.values()];
 }
 
 /** Hard cap on evidence rows per card. Same convention as repeated-tool-use. */
 const MAX_EVIDENCE_PER_CARD = 8;
 
-function buildResult(reason: string, sightings: ClosureSighting[]): DetectorResult {
+/**
+ * Contract: `sightings` MUST already be collapsed to one entry per session
+ * (see {@link collapseBySession}); every figure in `detail` is per-session.
+ * `closureEventCount` is the RAW pre-collapse event total, preserved because a
+ * session emitting many closures for one reason is itself real signal (cascade
+ * fan-out width) that the collapse would otherwise discard.
+ */
+function buildResult(
+  reason: string,
+  sightings: ClosureSighting[],
+  closureEventCount: number,
+): DetectorResult {
   const slug = makeSlug(reason);
   const observedAt = new Date().toISOString();
 
@@ -150,6 +200,7 @@ function buildResult(reason: string, sightings: ClosureSighting[]): DetectorResu
       detector: 'closure-anomaly@v1',
       closureReason: reason,
       affectedSessions: sightings.length,
+      closureEventCount,
       totalCostUsd: round4(totalCost),
       avgTurnCount: round2(avgTurns),
       maxCostUsd: round4(Math.max(...sightings.map((s) => s.finalCostUsd))),

--- a/src/improve/scan/detectors/subagent-read-denial.test.ts
+++ b/src/improve/scan/detectors/subagent-read-denial.test.ts
@@ -21,6 +21,7 @@ import { parseTraceContent, type SessionRead } from '../reader.js';
 import {
   detectSubagentReadDenial,
   computeFingerprint,
+  classifyDenialMechanism,
   makeSlug,
   normalizeReason,
   DEFAULT_SUBAGENT_READ_DENIAL_MIN_OCCURRENCES,
@@ -296,5 +297,126 @@ describe('detectSubagentReadDenial — fingerprint, slug, schema', () => {
       notes: [],
     };
     expect(FailureCardSchema.safeParse(card).success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mechanism split — the credential floor is by-design, never a card.
+//
+// History: card `subagent-read-denial-cf21041f85be` was open/high with N=9 and
+// every evidence row was the unconditional read-denylist floor refusing
+// mcp.json / schedules.json / afk.env. That is the guardrail working as
+// designed; no read-scope widening should ever make it stop firing. Worse, it
+// was indistinguishable from the genuine agent-framework containment gap
+// sitting next to it.
+// ---------------------------------------------------------------------------
+
+/** The credential-floor denial the path-approval hook emits verbatim. */
+function floorDenial(path: string, matched = '~/.afk/config'): string {
+  return (
+    `Access denied: ${path} is a protected credential/secret path ` +
+    `(read-denylist entry: ${matched}). This path is never readable — ` +
+    `it holds credentials, not task data; do not retry.`
+  );
+}
+
+const CRED_PATH = '/Users/x/.afk/config/afk.env';
+
+describe('classifyDenialMechanism', () => {
+  it('classifies the credential-floor message as credential-floor', () => {
+    expect(classifyDenialMechanism(floorDenial(CRED_PATH))).toBe('credential-floor');
+  });
+
+  it('classifies a containment message as read-root-containment', () => {
+    expect(classifyDenialMechanism(denial(PATH_A))).toBe('read-root-containment');
+  });
+
+  it('matches on the marker even if the path text varies', () => {
+    expect(classifyDenialMechanism(floorDenial('/tmp/whatever', '~/.ssh'))).toBe(
+      'credential-floor',
+    );
+  });
+
+  it('treats an empty reason as containment (fail-open to the real signal)', () => {
+    expect(classifyDenialMechanism('')).toBe('read-root-containment');
+  });
+});
+
+describe('detectSubagentReadDenial — credential floor produces no card', () => {
+  it('emits nothing when every denial is the credential floor', () => {
+    resetSeq();
+    const sessions = [
+      makeSession('s1', [
+        hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: floorDenial(CRED_PATH), blockedTool: 'read_file' }),
+        hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: floorDenial(CRED_PATH), blockedTool: 'grep' }),
+        hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: floorDenial(CRED_PATH), blockedTool: 'glob' }),
+      ]),
+    ];
+    expect(detectSubagentReadDenial(sessions, { minOccurrences: 1 })).toHaveLength(0);
+  });
+
+  it('counts only containment denials when the two are mixed', () => {
+    resetSeq();
+    const sessions = [
+      makeSession('s1', [
+        hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: floorDenial(CRED_PATH), blockedTool: 'read_file' }),
+        hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: denial(PATH_A), blockedTool: 'read_file' }),
+        hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: denial(PATH_B), blockedTool: 'grep' }),
+      ]),
+    ];
+    const results = detectSubagentReadDenial(sessions, { minOccurrences: 1 });
+    expect(results).toHaveLength(1);
+    const r = results[0]!;
+    // The floor denial must not inflate the count.
+    expect(r.detail['denialCount']).toBe(2);
+    expect(r.evidence).toHaveLength(2);
+    for (const e of r.evidence) {
+      expect(e.excerpt).not.toContain('read-denylist entry');
+    }
+  });
+
+  it('does not let floor denials clear the occurrence threshold', () => {
+    resetSeq();
+    // One genuine containment denial + two floor denials. With a bar of 2, the
+    // pre-fix detector would have fired on the padded count.
+    const sessions = [
+      makeSession('s1', [
+        hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: denial(PATH_A), blockedTool: 'read_file' }),
+        hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: floorDenial(CRED_PATH), blockedTool: 'read_file' }),
+        hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: floorDenial(CRED_PATH), blockedTool: 'grep' }),
+      ]),
+    ];
+    expect(detectSubagentReadDenial(sessions, { minOccurrences: 2 })).toHaveLength(0);
+  });
+
+  it('labels every emitted card as a containment gap', () => {
+    resetSeq();
+    const sessions = [
+      makeSession('s1', [
+        hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: denial(PATH_A), blockedTool: 'read_file' }),
+      ]),
+    ];
+    const r = detectSubagentReadDenial(sessions, { minOccurrences: 1 })[0]!;
+    expect(r.detail['denialMechanism']).toBe('read-root-containment');
+  });
+
+  it('keeps containment fingerprints stable across the split', () => {
+    resetSeq();
+    // The fingerprint tuple is unchanged, so a pre-existing containment card
+    // keeps its slug identity and merges rather than forking a new card.
+    const expected = makeSlug(
+      computeFingerprint({
+        hookEvent: 'PreToolUse',
+        normalizedReason: normalizeReason(denial(PATH_A)),
+      }),
+    );
+    const sessions = [
+      makeSession('s1', [
+        hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: floorDenial(CRED_PATH), blockedTool: 'grep' }),
+        hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: denial(PATH_A), blockedTool: 'read_file' }),
+      ]),
+    ];
+    const r = detectSubagentReadDenial(sessions, { minOccurrences: 1 })[0]!;
+    expect(r.slug).toBe(expected);
   });
 });

--- a/src/improve/scan/detectors/subagent-read-denial.test.ts
+++ b/src/improve/scan/detectors/subagent-read-denial.test.ts
@@ -322,6 +322,14 @@ function floorDenial(path: string, matched = '~/.afk/config'): string {
 
 const CRED_PATH = '/Users/x/.afk/config/afk.env';
 
+/**
+ * A THIRD mechanism, neither floor nor containment: the tool-allowlist refusal
+ * `permissions.ts` emits, which reaches this detector because `list_directory`
+ * is in READ_TOOL_NAMES. A live open card on disk
+ * (`subagent-read-denial-62cbd769c977`) carries exactly this reason.
+ */
+const TOOL_ALLOWLIST_DENIAL = 'Tool "list_directory" is not in the configured allowlist';
+
 describe('classifyDenialMechanism', () => {
   it('classifies the credential-floor message as credential-floor', () => {
     expect(classifyDenialMechanism(floorDenial(CRED_PATH))).toBe('credential-floor');
@@ -337,8 +345,32 @@ describe('classifyDenialMechanism', () => {
     );
   });
 
-  it('treats an empty reason as containment (fail-open to the real signal)', () => {
-    expect(classifyDenialMechanism('')).toBe('read-root-containment');
+  it('treats an empty reason as unclassified, never as containment', () => {
+    // Fail-open to the real signal — the denial is still kept and counted —
+    // but "we could not tell" is recorded as itself, not as a containment gap
+    // the classifier never actually observed.
+    expect(classifyDenialMechanism('')).toBe('unclassified');
+  });
+
+  it('classifies the legacy containment wording as read-root-containment', () => {
+    expect(
+      classifyDenialMechanism(
+        "Sub-agents cannot access paths outside the session's granted roots (/x/y)",
+      ),
+    ).toBe('read-root-containment');
+  });
+
+  // A denial that is neither the floor nor a read-root gap must NOT be
+  // asserted as containment: its remedy is not "widen read roots", so the
+  // label would send a triager toward a fix that cannot work.
+  it('classifies a tool-allowlist refusal as unclassified', () => {
+    expect(classifyDenialMechanism(TOOL_ALLOWLIST_DENIAL)).toBe('unclassified');
+  });
+
+  it('classifies a human prompt-denial as unclassified', () => {
+    expect(classifyDenialMechanism('User denied access to /Users/x/proj/src/a.ts')).toBe(
+      'unclassified',
+    );
   });
 });
 
@@ -389,7 +421,7 @@ describe('detectSubagentReadDenial — credential floor produces no card', () =>
     expect(detectSubagentReadDenial(sessions, { minOccurrences: 2 })).toHaveLength(0);
   });
 
-  it('labels every emitted card as a containment gap', () => {
+  it('labels a genuine containment card as a containment gap', () => {
     resetSeq();
     const sessions = [
       makeSession('s1', [
@@ -398,6 +430,37 @@ describe('detectSubagentReadDenial — credential floor produces no card', () =>
     ];
     const r = detectSubagentReadDenial(sessions, { minOccurrences: 1 })[0]!;
     expect(r.detail['denialMechanism']).toBe('read-root-containment');
+    expect(r.detail['detector']).toBe('subagent-read-denial@v2');
+  });
+
+  it('does NOT label a tool-allowlist card as a containment gap', () => {
+    resetSeq();
+    // The regression this fix exists for: pre-fix this card asserted
+    // denialMechanism='read-root-containment', sending a triager to widen read
+    // roots for a block that widening read roots cannot possibly fix.
+    const sessions = [
+      makeSession('s1', [
+        hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: TOOL_ALLOWLIST_DENIAL, blockedTool: 'list_directory' }),
+      ]),
+    ];
+    const r = detectSubagentReadDenial(sessions, { minOccurrences: 1 })[0]!;
+    expect(r.detail['denialMechanism']).toBe('unclassified');
+  });
+
+  it('still emits and counts unclassified denials — only the label changed', () => {
+    resetSeq();
+    // Dropping is reserved for the credential floor. An unrecognised mechanism
+    // is still a real block worth surfacing; it just is not asserted to be
+    // something the classifier never observed.
+    const sessions = [
+      makeSession('s1', [
+        hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: TOOL_ALLOWLIST_DENIAL, blockedTool: 'list_directory' }),
+        hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: TOOL_ALLOWLIST_DENIAL, blockedTool: 'list_directory' }),
+      ]),
+    ];
+    const r = detectSubagentReadDenial(sessions, { minOccurrences: 2 })[0]!;
+    expect(r.detail['denialCount']).toBe(2);
+    expect(r.evidence).toHaveLength(2);
   });
 
   it('keeps containment fingerprints stable across the split', () => {

--- a/src/improve/scan/detectors/subagent-read-denial.ts
+++ b/src/improve/scan/detectors/subagent-read-denial.ts
@@ -61,7 +61,7 @@ const READ_TOOL_NAMES: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Invariant: two DIFFERENT mechanisms both surface as `PreToolUse` read blocks,
+ * Invariant: several DIFFERENT mechanisms surface as `PreToolUse` read blocks,
  * and only one of them is ever a defect.
  *
  *   - `read-root-containment` — the resolved path fell outside the fork's
@@ -73,28 +73,53 @@ const READ_TOOL_NAMES: ReadonlySet<string> = new Set([
  *     `isReadDenied` / `BUILTIN_READ_DENYLIST`. This is the guardrail working
  *     exactly as designed and no read-scope widening should ever make it stop
  *     firing.
+ *   - `unclassified` — a real PreToolUse/block on a read-family tool whose
+ *     reason matches neither positive marker below. A human declining an
+ *     interactive prompt (`path-approval-hook.ts`'s `User denied access to
+ *     <path>`) and a tool-allowlist refusal (`permissions.ts`'s `Tool "<x>" is
+ *     not in the configured allowlist`) both land here — neither's remedy is
+ *     "widen read roots", so mislabeling either as containment sends a triager
+ *     toward a fix that cannot work.
  *
- * Conflating them manufactured a card (`subagent-read-denial-cf21041f85be`,
- * open/high, N=9) whose every evidence row was the credential floor doing its
- * job — and, worse, made that noise indistinguishable from the genuine
- * agent-framework scope gap it sat next to. Floor denials are therefore dropped
- * before fingerprinting: they never reach a bucket, so they can never merge into
- * or inflate a containment card.
+ * Conflating the floor with containment manufactured a card
+ * (`subagent-read-denial-cf21041f85be`, open/high, N=9) whose every evidence
+ * row was the credential floor doing its job — and, worse, made that noise
+ * indistinguishable from the genuine agent-framework scope gap it sat next to.
+ * Floor denials are therefore dropped before fingerprinting: they never reach
+ * a bucket, so they can never merge into or inflate a containment card.
+ * `unclassified` denials are NOT dropped — they still fingerprint and count
+ * exactly as containment did before this split; only the label changes, from
+ * a false positive assertion to an honest "don't know".
  */
-export type DenialMechanism = 'read-root-containment' | 'credential-floor';
+export type DenialMechanism = 'read-root-containment' | 'credential-floor' | 'unclassified';
 
 /**
  * Contract: classify from the deny reason alone — the trace carries no explicit
- * mechanism field. The floor's message is machine-generated in one place and
- * embeds the literal marker `read-denylist entry:` plus a protected-path phrase;
- * matching the marker is stable against the path itself varying (and against
- * path normalization, which rewrites paths but not this prose).
+ * mechanism field. Detection is POSITIVE for both non-default outcomes; a
+ * reason matching neither marker is `unclassified` rather than assumed to be
+ * containment.
+ *
+ * The floor's message is machine-generated in one place and embeds the literal
+ * marker `read-denylist entry:` plus a protected-path phrase. Containment is
+ * matched on two wordings: `Sub-agent path access denied:` — the current
+ * prefix, documented load-bearing at `path-approval-hook.ts:301` — and the
+ * legacy `Sub-agents cannot access paths outside the session's granted roots`,
+ * which still appears on cards written before the reword. Matching markers is
+ * stable against the path itself varying (and against path normalization,
+ * which rewrites paths but not this prose).
  */
 export function classifyDenialMechanism(reason: string): DenialMechanism {
   const isFloor =
     reason.includes('read-denylist entry:') ||
     reason.includes('is a protected credential/secret path');
-  return isFloor ? 'credential-floor' : 'read-root-containment';
+  if (isFloor) return 'credential-floor';
+
+  const isContainment =
+    reason.includes('Sub-agent path access denied:') ||
+    reason.includes("Sub-agents cannot access paths outside the session's granted roots");
+  if (isContainment) return 'read-root-containment';
+
+  return 'unclassified';
 }
 
 export interface SubagentReadDenialOptions {
@@ -109,6 +134,7 @@ interface DenialSighting {
   reason: string;
   normalizedReason: string;
   blockedTool: string;
+  mechanism: DenialMechanism;
 }
 
 /**
@@ -149,8 +175,10 @@ export function detectSubagentReadDenial(
 
       const reason = ev.payload.reason ?? '';
       // The credential floor is by-design, never a defect — drop it before it
-      // can reach a fingerprint bucket. See DenialMechanism.
-      if (classifyDenialMechanism(reason) === 'credential-floor') continue;
+      // can reach a fingerprint bucket. See DenialMechanism. Every other
+      // mechanism, `unclassified` included, is kept and labelled honestly.
+      const mechanism = classifyDenialMechanism(reason);
+      if (mechanism === 'credential-floor') continue;
       const normalizedReason = normalizeReason(reason);
       const fingerprint = computeFingerprint({ hookEvent: ev.payload.hookEvent, normalizedReason });
 
@@ -162,6 +190,7 @@ export function detectSubagentReadDenial(
         reason,
         normalizedReason,
         blockedTool,
+        mechanism,
       };
 
       const bucket = byFingerprint.get(fingerprint);
@@ -223,15 +252,23 @@ function buildResult(fingerprint: string, sightings: DenialSighting[]): Detector
     observedAt,
     evidence,
     detail: {
-      detector: 'subagent-read-denial@v1',
+      // @v2: credential-floor denials are dropped before fingerprinting, so
+      // `denialCount` / `distinctSessions` no longer include them, and
+      // `denialMechanism` is now observed per sighting rather than assumed. The
+      // version bump lets `reconcileSeverity` re-derive a card whose v1 severity
+      // was computed from floor-inflated counts — under escalate-only it could
+      // never come back down.
+      detector: 'subagent-read-denial@v2',
       fingerprintAlgorithm: FINGERPRINT_ALGORITHM,
       fingerprint,
       hookEvent: 'PreToolUse',
-      // Positive assertion, not an inference: credential-floor denials are
-      // dropped upstream, so every card this detector emits is a containment gap
-      // by construction. The fingerprint tuple is unchanged, so pre-existing
-      // containment card slugs keep their identity across this change.
-      denialMechanism: 'read-root-containment' satisfies DenialMechanism,
+      // Contract: read from the first sighting, not asserted as a literal. The
+      // fingerprint tuple is (hookEvent, normalizedReason) and the mechanism is
+      // a pure function of the reason, so every sighting in this bucket
+      // classifies identically — the first is representative of all of them.
+      // The tuple itself is unchanged, so pre-existing containment card slugs
+      // keep their identity across this change.
+      denialMechanism: first.mechanism,
       normalizedReason: first.normalizedReason,
       reason: first.reason,
       blockedTools,

--- a/src/improve/scan/detectors/subagent-read-denial.ts
+++ b/src/improve/scan/detectors/subagent-read-denial.ts
@@ -60,6 +60,43 @@ const READ_TOOL_NAMES: ReadonlySet<string> = new Set([
   'NotebookRead',
 ]);
 
+/**
+ * Invariant: two DIFFERENT mechanisms both surface as `PreToolUse` read blocks,
+ * and only one of them is ever a defect.
+ *
+ *   - `read-root-containment` — the resolved path fell outside the fork's
+ *     granted read roots. A fork cannot prompt a human, so the hook hard-blocks
+ *     (`path-approval-hook.ts`, the confinement branch). This CAN be a real
+ *     scope gap worth a card.
+ *   - `credential-floor` — the unconditional read-denylist floor refusing a
+ *     credential path (`~/.afk/config/afk.env`, `mcp.json`, `~/.ssh`, …) via
+ *     `isReadDenied` / `BUILTIN_READ_DENYLIST`. This is the guardrail working
+ *     exactly as designed and no read-scope widening should ever make it stop
+ *     firing.
+ *
+ * Conflating them manufactured a card (`subagent-read-denial-cf21041f85be`,
+ * open/high, N=9) whose every evidence row was the credential floor doing its
+ * job — and, worse, made that noise indistinguishable from the genuine
+ * agent-framework scope gap it sat next to. Floor denials are therefore dropped
+ * before fingerprinting: they never reach a bucket, so they can never merge into
+ * or inflate a containment card.
+ */
+export type DenialMechanism = 'read-root-containment' | 'credential-floor';
+
+/**
+ * Contract: classify from the deny reason alone — the trace carries no explicit
+ * mechanism field. The floor's message is machine-generated in one place and
+ * embeds the literal marker `read-denylist entry:` plus a protected-path phrase;
+ * matching the marker is stable against the path itself varying (and against
+ * path normalization, which rewrites paths but not this prose).
+ */
+export function classifyDenialMechanism(reason: string): DenialMechanism {
+  const isFloor =
+    reason.includes('read-denylist entry:') ||
+    reason.includes('is a protected credential/secret path');
+  return isFloor ? 'credential-floor' : 'read-root-containment';
+}
+
 export interface SubagentReadDenialOptions {
   minOccurrences?: number;
 }
@@ -111,6 +148,9 @@ export function detectSubagentReadDenial(
       if (blockedTool === undefined || !READ_TOOL_NAMES.has(blockedTool)) continue;
 
       const reason = ev.payload.reason ?? '';
+      // The credential floor is by-design, never a defect — drop it before it
+      // can reach a fingerprint bucket. See DenialMechanism.
+      if (classifyDenialMechanism(reason) === 'credential-floor') continue;
       const normalizedReason = normalizeReason(reason);
       const fingerprint = computeFingerprint({ hookEvent: ev.payload.hookEvent, normalizedReason });
 
@@ -187,6 +227,11 @@ function buildResult(fingerprint: string, sightings: DenialSighting[]): Detector
       fingerprintAlgorithm: FINGERPRINT_ALGORITHM,
       fingerprint,
       hookEvent: 'PreToolUse',
+      // Positive assertion, not an inference: credential-floor denials are
+      // dropped upstream, so every card this detector emits is a containment gap
+      // by construction. The fingerprint tuple is unchanged, so pre-existing
+      // containment card slugs keep their identity across this change.
+      denialMechanism: 'read-root-containment' satisfies DenialMechanism,
       normalizedReason: first.normalizedReason,
       reason: first.reason,
       blockedTools,

--- a/src/improve/scan/severity-merge.test.ts
+++ b/src/improve/scan/severity-merge.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for severity reconciliation across a detector version change.
+ *
+ * The rule under test: severity ratchets UP by default, but a detector version
+ * change makes the fresh detection authoritative in BOTH directions — otherwise
+ * a card whose `high` came from superseded arithmetic could never come back
+ * down, and correcting the numbers would leave the headline verdict wrong.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { maxSeverity, detectorTag, reconcileSeverity } from './severity-merge.js';
+import type { FailureCard, DetectorResult } from '../schemas.js';
+
+function card(severity: FailureCard['severity'], detector?: string): FailureCard {
+  return {
+    schemaVersion: 1,
+    slug: 'closure-anomaly-abort',
+    title: 'existing',
+    pattern: 'closure-anomaly',
+    severity,
+    status: 'open',
+    firstSeen: '2026-01-01T00:00:00.000Z',
+    lastSeen: '2026-01-01T00:00:00.000Z',
+    occurrenceCount: 1,
+    evidence: [],
+    detail: detector === undefined ? {} : { detector },
+    notes: [],
+  };
+}
+
+function detection(severity: DetectorResult['severity'], detector?: string): DetectorResult {
+  return {
+    slug: 'closure-anomaly-abort',
+    title: 'fresh',
+    pattern: 'closure-anomaly',
+    severity,
+    observedAt: '2026-02-01T00:00:00.000Z',
+    evidence: [],
+    detail: detector === undefined ? {} : { detector },
+  };
+}
+
+describe('maxSeverity', () => {
+  it('returns the higher rank', () => {
+    expect(maxSeverity('low', 'high')).toBe('high');
+    expect(maxSeverity('high', 'low')).toBe('high');
+    expect(maxSeverity('medium', 'medium')).toBe('medium');
+  });
+});
+
+describe('detectorTag', () => {
+  it('reads a non-empty string tag', () => {
+    expect(detectorTag({ detector: 'closure-anomaly@v2' })).toBe('closure-anomaly@v2');
+  });
+
+  it('treats missing, empty, and non-string tags as undefined', () => {
+    expect(detectorTag(undefined)).toBeUndefined();
+    expect(detectorTag({})).toBeUndefined();
+    expect(detectorTag({ detector: '' })).toBeUndefined();
+    expect(detectorTag({ detector: 42 })).toBeUndefined();
+  });
+});
+
+describe('reconcileSeverity', () => {
+  it('escalates when the detector version is unchanged', () => {
+    const s = reconcileSeverity(card('low', 'closure-anomaly@v2'), detection('high', 'closure-anomaly@v2'));
+    expect(s).toBe('high');
+  });
+
+  it('does NOT de-escalate when the detector version is unchanged', () => {
+    // The deliberate default: a quiet window must not downgrade a real incident.
+    const s = reconcileSeverity(card('high', 'closure-anomaly@v2'), detection('low', 'closure-anomaly@v2'));
+    expect(s).toBe('high');
+  });
+
+  it('DE-ESCALATES across a detector version change', () => {
+    // The regression this fix exists for: a v1 `high` computed from
+    // event-as-session counting must yield to v2's corrected verdict.
+    const s = reconcileSeverity(card('high', 'closure-anomaly@v1'), detection('low', 'closure-anomaly@v2'));
+    expect(s).toBe('low');
+  });
+
+  it('also escalates across a version change (fresh detection is authoritative both ways)', () => {
+    const s = reconcileSeverity(card('low', 'closure-anomaly@v1'), detection('high', 'closure-anomaly@v2'));
+    expect(s).toBe('high');
+  });
+
+  it('stays escalate-only when the existing card is untagged', () => {
+    // An untagged legacy card is not evidence of a version CHANGE, so the safe
+    // default applies and its severity is preserved.
+    expect(reconcileSeverity(card('high'), detection('low', 'closure-anomaly@v2'))).toBe('high');
+  });
+
+  it('stays escalate-only when the detection is untagged', () => {
+    expect(reconcileSeverity(card('high', 'closure-anomaly@v1'), detection('low'))).toBe('high');
+  });
+
+  it('leaves every other detector on escalate-only semantics', () => {
+    // A detector that never versions itself keeps identical behaviour.
+    expect(
+      reconcileSeverity(card('high', 'repeated-tool-use@v1'), detection('low', 'repeated-tool-use@v1')),
+    ).toBe('high');
+  });
+});

--- a/src/improve/scan/severity-merge.ts
+++ b/src/improve/scan/severity-merge.ts
@@ -1,0 +1,68 @@
+/**
+ * Severity reconciliation for card merges.
+ *
+ * Split out of `card-writer.ts` (already at its size ceiling) so the decision
+ * has one obvious home and its own tests.
+ *
+ * @module improve/scan/severity-merge
+ */
+
+import type { FailureCard, DetectorResult } from '../schemas.js';
+
+type Severity = FailureCard['severity'];
+
+const SEVERITY_RANK: Record<Severity, number> = {
+  low: 0,
+  medium: 1,
+  high: 2,
+};
+
+/** Escalate-only: the higher of the two ranks wins. */
+export function maxSeverity(a: Severity, b: Severity): Severity {
+  return SEVERITY_RANK[a] >= SEVERITY_RANK[b] ? a : b;
+}
+
+/**
+ * Read the `detector` version tag out of a card/detection `detail` bag.
+ *
+ * Contract: `detail` is an open `z.record(z.string(), z.unknown())`, so the tag
+ * is optional and may be any type. Anything that is not a non-empty string
+ * reads as `undefined` — an untagged card can then never be mistaken for a
+ * version CHANGE (see {@link reconcileSeverity}), which keeps the default path
+ * escalate-only for every detector that does not version itself.
+ */
+export function detectorTag(detail: Record<string, unknown> | undefined): string | undefined {
+  const raw = detail?.['detector'];
+  return typeof raw === 'string' && raw.length > 0 ? raw : undefined;
+}
+
+/**
+ * Invariant: severity only ever RATCHETS UP — except across a detector version
+ * change, where the fresh detection's severity is authoritative.
+ *
+ * Escalate-only is deliberate: a card that was once high stays high even if a
+ * later quieter scan would rate it lower, so a real incident cannot be silently
+ * downgraded by a quiet window.
+ *
+ * That rule breaks when the detector's own ARITHMETIC changes. `closure-anomaly`
+ * shipped a v1 that counted one closure EVENT as one session and reported only
+ * the largest instance's cost; v2 counts sessions and sums the disjoint
+ * per-instance costs. A card whose `high` was computed from v1's inflated
+ * session count could never come back down under escalate-only, so the fix
+ * would correct every number on the card while leaving the headline severity
+ * wrong — the exact failure the fix set out to remove.
+ *
+ * A version change is therefore treated as "these two severities are not
+ * comparable, trust the newer one". Both directions are allowed: a version bump
+ * can lower a severity as well as raise it. When the tags match, or either side
+ * is untagged, this is exactly `maxSeverity`.
+ */
+export function reconcileSeverity(existing: FailureCard, detection: DetectorResult): Severity {
+  const existingTag = detectorTag(existing.detail);
+  const detectionTag = detectorTag(detection.detail);
+
+  const versionChanged =
+    existingTag !== undefined && detectionTag !== undefined && existingTag !== detectionTag;
+
+  return versionChanged ? detection.severity : maxSeverity(existing.severity, detection.severity);
+}


### PR DESCRIPTION
Step 3 of the post-review plan: the improve pipeline's **measurement layer**, not the agent it measures.

Context: a full audit of `afk improve` produced 6 findings, and 4 of them were defects in the pipeline's own instruments rather than in the agent. Item 1 already shipped as #841. This PR lands items **3, 2, and 6** — the three that live in the measurement layer and share a single theme: the instrument was lying. Items 4 and 5 are deliberately separate (see below).

## 1. `--pattern` rejected two valid patterns

The CLI hand-maintained a copy of the failure-pattern list. It drifted two sprints behind `FailurePatternSchema` — 3 values against the schema's 5 — so this failed while four eval-cases on disk used exactly that pattern:

```
$ afk improve eval-cases list --pattern tool-failure-density
Invalid --pattern: 'tool-failure-density'. Must be one of: repeated-tool-use, subagent-block, closure-anomaly
exit=2
```

Now derived from `FailurePatternSchema.options`. This kills the drift **class** rather than the instance: there is no longer a second list that can fall behind.

## 2. `closure-anomaly` counted closure EVENTS as sessions

A single parent timeout cascade-cancels every in-flight child, and each cancellation writes its own `closure` event into the *same* trace. The rollup was event-keyed, so one parent read as N independent sessions:

- `affectedSessions` counted events, not sessions
- `sessionIds` carried duplicate ids
- `affectedSessions` and `sessionIds` therefore both over-reported

The **session count** is now deduped: `affectedSessions`, `sessionIds`, the title, and the severity ladder all count distinct witness trace files, so one cascade reads as one session.

The **cost and turn aggregates deliberately do not collapse.** An earlier revision of this PR kept only the highest-cost sighting per session; codex review caught that this under-reports, and it was reverted. Each `AgentSession` instance owns a *disjoint* cost accumulator — `sessionRunningCostUsd` is written in exactly two places (re-zeroed in `initSdkLifecycle()`, and `+= m.totalCostUsd` from that instance's own response metadata), and a child's spend lands in a separate `subagentRunningCostUsd` via `recordSubagentCompletion` that never reaches the parent's. Summing per-event is therefore the trace file's *true* spend, not a multi-count.

So `detail` reports two granularities on purpose: `affectedSessions` / `sessionIds` count trace files; `closureEventCount`, `totalCostUsd`, `maxCostUsd`, `avgTurnCount` and the evidence rows count events. A trace file is not one agent, and collapsing the two would either invent sessions that never existed or discard spend that really happened.

Worth noting the pre-fix code already *documented* the correct behavior: `DEFAULT_CLOSURE_ANOMALY_MIN_OCCURRENCES` was described as a count of "sessions", and the evidence-mapping comment said "one evidence row per session". The implementation just never matched. This makes the code agree with its own contract.

## 3. `subagent-read-denial` conflated two mechanisms

Two different things surface as `PreToolUse` read blocks, and only one is ever a defect:

| Mechanism | Meaning |
|---|---|
| `read-root-containment` | path outside the fork's granted read roots — **can be a real gap** (this is what #841 fixed) |
| `credential-floor` | the unconditional read-denylist floor refusing a credential path — **the guardrail working as designed** |

No read-scope widening should ever make the floor stop firing. Yet it manufactured an open/high card (`subagent-read-denial-cf21041f85be`, N=9) whose every evidence row was the floor doing its job — and, worse, made that noise indistinguishable from the genuine agent-framework scope gap sitting next to it.

Floor denials are now classified and dropped **before** fingerprinting, so no standalone floor card is manufactured. (They could never have *merged into* a containment card in the first place — the fingerprint is `hash(hookEvent, normalizedReason)` and the two wordings differ, so they always landed in separate buckets. The noise was a whole card of its own, not a contaminated one.) The fingerprint tuple is unchanged, so pre-existing containment cards keep their slug identity and continue to merge rather than forking a duplicate.

## 4. Severity could not come back down after a detector version bump

Not in the original plan — a consequence of §2 that surfaced while writing it, and load-bearing enough to belong in this PR rather than a follow-up.

Card severity ratchets **up** only: a card that was once `high` stays `high` even if a later, quieter scan would rate it lower, so a real incident cannot be silently downgraded by a quiet window. That rule breaks when the detector's own *arithmetic* changes. A `closure-anomaly@v1` card whose `high` was computed from event-as-session counting could never come back down under escalate-only — §2 would correct every number on the card while leaving the headline verdict wrong, which is the exact failure this PR exists to remove.

`reconcileSeverity` (new `src/improve/scan/severity-merge.ts`, split out because `card-writer.ts` is at its size ceiling) treats a detector version change as "these two severities are not comparable, trust the newer one" — in **both** directions. When the tags match, or either side is untagged, it is exactly the old `maxSeverity`, so every detector that does not version itself keeps identical behaviour.

Scope note for reviewers: on the failure cards currently on disk this changes no severity. `severityFor` returns `high` for `timeout`/`budget_exceeded` regardless of count, and the `iteration_cap` (66 → 40 sessions) and `abort` (386 → 176) cards both stay above their `>= 3` thresholds. It is a correctness guard for the general case, not a fix with visible effect today.

## 5. Review feedback (commit `746c7758`)

- **`denialMechanism` asserted a mechanism it never observed.** `classifyDenialMechanism` was binary with `read-root-containment` as the unconditional `else`, and the card stamped that as a hardcoded literal described as a "positive assertion". At least two other mechanisms reach this detector — `User denied access to <path>` (a human declining a prompt) and `Tool "<x>" is not in the configured allowlist` — and both were affirmatively mislabelled as read-root gaps. Neither is fixed by widening read roots, and `card-writer` dumps `detail` verbatim into the operator-facing markdown, so the label sent a triager toward a remedy that cannot work. A live open card on disk (`subagent-read-denial-62cbd769c977`, `blockedTools: ["list_directory"]`) carries exactly that shape. Containment is now detected **positively**; anything matching neither marker is `unclassified`. The drop filter is byte-identical, so which cards get emitted does not change — only the label.
- **`subagent-read-denial@v1` → `@v2`.** Its counting semantics changed when floor denials stopped contributing, but the tag never moved, so §4's reconciliation could not fire for the one detector whose counts this PR shrinks. Now symmetric with `closure-anomaly`.
- **`seqs` capped to the evidence slice.** `evidence` capped at 8 while `seqs` — which indexes it — did not, so a wide cascade wrote an unbounded array into the persisted card (a live card already carries 386 entries). `sessionIds` is left uncapped deliberately: its length *is* `affectedSessions`.
- **Integration coverage** for `reconcileSeverity` through `mergeCard`, plus a test pinning the wholesale `detail` replace for `closureEventCount`.

## Verification

**Every new test was confirmed to fail against the pre-fix code before being kept.** Tests that pass both before and after a change are restatements, not regression guards — and given this PR is specifically about instruments telling the truth, shipping unproven guards would have been self-defeating. The source was reverted, the suite re-run, and all 17 discriminating assertions failed with the predicted values:

- `expected 4 to be 1` — four cascade events counted as four sessions
- `expected [ 'a', 'a', 'b' ] to deeply equal [ 'a', 'b' ]` — duplicate session ids
- `expected 99 to be 103` — only the largest instance's cost kept, instead of the summed disjoint total
- `expected 3 to be 5` — the truncated pattern list
- floor-only denials produced a card where none should exist

And for the review-feedback commit (see §5):

- `expected 'read-root-containment' to be 'unclassified'` ×4 — the binary fallback asserting containment for a tool-allowlist refusal, a human prompt-denial, an empty reason, and at card level
- `expected 'subagent-read-denial@v1' to be 'subagent-read-denial@v2'` — the missing version bump
- `expected 20 to be 8` / `expected 12 to be 8` — uncapped `seqs`
- `expected 'high' to be 'low'` — `mergeCard` de-escalation, against pre-PR `card-writer.ts`

Gates, at `746c7758`:

- `pnpm test` — **750 files / 14,308 passed, 2 skipped, 0 failed**
- `pnpm lint` (`tsc --noEmit`, strict) — clean
- `audit:sdk:check`, `audit:env:check`, `scan:env:check` — all green
- Both touched detectors stay under the 350-LOC ceiling (`subagent-read-denial.ts` 308, `closure-anomaly.ts` 293)

## Consequence

This unblocks `afk improve scan --write`, which was deliberately frozen pending items 2 and 3. Running it earlier would have persisted known false-positive cards and overwritten existing card `detail` with a narrower 7-day window (`card-writer.ts` replaces `detail` rather than merging it).

## Deliberately out of scope

- **Item 4** (compose `failureClass`) crosses out of `src/improve/` into `src/agent/tools/compose-executor.ts` with its own test surface — separate PR, so this diff stays reviewable as one concern.
- **Item 5** (graduating `closure-anomaly` + `subagent-read-denial` to default-on) is gated on items 4 and this one landing, plus a noise-floor check. Flipping blind is how the noise got normalized in the first place; `tool-failure-density` graduated via a two-week evaluation and these should follow the same path.
- **`src/cli/commands/improve.ts` is 1023 LOC**, well over the 350-LOC ceiling. That is pre-existing. This PR is deliberately **net-neutral** on that file's length rather than growing it further; the split is a follow-up refactor with its own blast radius.

Two findings from review are deferred on the same criterion — both cross out of `src/improve/scan/` into a subsystem with its own test surface:

- **The `detectorVersion` staleness guard does not exist** — filed as #860. `schemas.ts` documents that "a version bump on the detector invalidates the eval-case (which the runner detects and reports rather than silently passing)", but there is no comparison anywhere in `src/improve/eval-run/` — the field is written at generation time and never read back. Correcting an earlier draft of this bullet: these bumps are **not** the first to exercise it. `tool-failure-density` bumped to `@v2` before this PR and already carries a stale `@v1` eval-case on disk today. What this PR adds is the first case to reach the *replay* surface — `closure-anomaly-abort-eval-*` now replays through v2 under a v1 provenance label with nothing reporting the mismatch. The assertion outcome is unchanged (`pattern-absent` at the default threshold), so this is a stale label rather than a wrong verdict.
- **The credential-floor markers are duplicated literals** — filed as #861, a sibling of #853 (same producer, different consumer: #853 covers slug rotation via the fingerprint, #861 covers misclassification via the classifier). `classifyDenialMechanism` matches strings that four separate producers hand-roll (`path-approval-hook.ts`, `_cwd-utils.ts`, `read-denylist.ts`, `input-parse.ts`) with no shared constant and no test cross-referencing them. All four match today — verified — but a wording edit in the hook would silently reclassify floor denials as containment and pipe credential paths back into cards. The fix is to export the marker from `read-denylist.ts`; that touches the hook layer and belongs with its own tests.


