### PR TITLE
fix(subagent): tell a denied fork the remedy that actually works

### DIFF
--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -396,7 +396,11 @@ export class SubagentManager {
         // cards/proposals/eval-cases, forge telemetry, pattern-cards, briefs),
         // so children dispatched by /orient, /harvest, /forge, /distill and the
         // improve pipeline were hard-denied the one tree their task requires —
-        // 46 denials across 15 sessions (card subagent-read-denial-ab89c2bd6a6f).
+        // 46 denials across 15 sessions (card subagent-read-denial-ab89c2bd6a6f,
+        // now HISTORICAL: that slug is a hash of the denial reason string, which
+        // was reworded when the read remedy moved to
+        // `tools/hooks/fork-denial-remedy.ts`. Post-rewording denials accumulate
+        // under a new slug; this card no longer accrues sightings).
         // Same guard as Gap A: this dir only, NEVER ~/.afk/config (credentials).
         ...(parentUnconfined
           ? {}

--- a/src/agent/tools/hooks/fork-denial-remedy.test.ts
+++ b/src/agent/tools/hooks/fork-denial-remedy.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Locks the fork-denial remedy wording contract.
+ *
+ * Invariant under test: the READ branch must name a re-dispatch with a concrete
+ * `readRoots: [<path>]` literal, and must NOT suggest that a parent-side grant
+ * made after dispatch can reach the running fork. A fork's roots are fixed at
+ * dispatch (see `fork-denial-remedy.ts`), so grant-widening advice is
+ * unactionable and drives the retry-until-timeout failure #544 fixed.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildForkDenialRemedy } from './fork-denial-remedy.js';
+
+const P = '/tmp/scratch/data.json';
+
+describe('buildForkDenialRemedy', () => {
+  describe('read mode', () => {
+    const remedy = buildForkDenialRemedy({ mode: 'read', resolvedPath: P });
+
+    it('names the agent tool as the recovery vector', () => {
+      expect(remedy).toContain('`agent` tool');
+      expect(remedy).toContain('re-dispatch');
+    });
+
+    it('emits a copy-pasteable readRoots literal containing the resolved path', () => {
+      expect(remedy).toContain(`readRoots: ["${P}"]`);
+    });
+
+    it('never mentions writeRoots (asserted by path-approval-hook.test.ts too)', () => {
+      expect(remedy).not.toContain('writeRoots');
+    });
+
+    it('states that a post-dispatch grant cannot reach the fork', () => {
+      // Guards against reintroducing "ask the operator to /allow-dir" as an
+      // in-flight remedy: grants are snapshot at fork, so that advice is wrong.
+      expect(remedy).toMatch(/fixed at dispatch/);
+      expect(remedy).not.toContain('/allow-dir');
+    });
+
+    it('tells the fork to report the requirement upward', () => {
+      expect(remedy).toContain('Return this exact path requirement to your parent.');
+    });
+  });
+
+  describe('write mode', () => {
+    const remedy = buildForkDenialRemedy({ mode: 'write', resolvedPath: P });
+
+    it('keeps the pre-existing writeRoots remedy shape', () => {
+      expect(remedy).toContain('`agent` tool');
+      expect(remedy).toContain(`writeRoots: ["${P}"]`);
+      expect(remedy).toContain('worktree isolation');
+      expect(remedy).toContain('Return this exact path requirement to your parent.');
+    });
+
+    it('does not offer readRoots for a write denial', () => {
+      expect(remedy).not.toContain('readRoots');
+    });
+  });
+
+  it('JSON-quotes the path so a space-bearing path stays copy-pasteable', () => {
+    const spaced = '/tmp/my scratch/a.txt';
+    expect(buildForkDenialRemedy({ mode: 'read', resolvedPath: spaced })).toContain(
+      `readRoots: ["${spaced}"]`,
+    );
+  });
+});

--- a/src/agent/tools/hooks/fork-denial-remedy.ts
+++ b/src/agent/tools/hooks/fork-denial-remedy.ts
@@ -1,0 +1,55 @@
+/**
+ * The recovery text a forked sub-agent sees when a path falls outside its
+ * granted roots. Extracted from `path-approval-hook.ts` so the wording and the
+ * two downstream consumers that key on it live in one documented place.
+ */
+
+/** Which containment check produced the denial. */
+export type ForkDenialMode = 'read' | 'write';
+
+/**
+ * Invariant: a fork's grant roots are FIXED AT DISPATCH. `computeInheritedReadRoots`
+ * and the additive-`readRoots` union both build NEW arrays for the child
+ * (`src/agent/subagent.ts`), and the child resolves containment against its own
+ * grant manager — so a parent-side widening performed AFTER the fork started
+ * (`/allow-dir`, an elicitation approval, `revokeRoot`) CANNOT reach a running
+ * child. Re-dispatch is therefore the ONLY remedy that works on an in-flight
+ * fork, which is why both branches below name it explicitly and neither offers
+ * "ask the operator to grant it" as an in-flight option. Do not reintroduce
+ * grant-widening as the suggested read remedy: it reads as actionable, is not,
+ * and sends the fork into retry-until-timeout — the exact failure #544 was
+ * opened to stop.
+ *
+ * Contract: the CALLER prefixes this body with the byte-stable
+ * `Sub-agent path access denied:` string — see `SUBAGENT_PATH_DENIAL_REASON_PREFIX`
+ * in `../denial-circuit-breaker.ts`, matched by substring, not by prefix
+ * position. The remedy body returned here is NOT byte-stable, but it IS
+ * fingerprinted: `src/improve/scan/detectors/subagent-read-denial.ts` hashes the
+ * ENTIRE normalized reason (`normalizeReason` collapses path-shaped tokens to
+ * `<path>`, then `computeFingerprint` SHA-256s it), so any reword here rotates
+ * the failure-card slug and restarts that card's severity ladder. That rotation
+ * is silent — every detector test builds its own fixture string rather than
+ * importing this module — so a reword must be a deliberate decision, not a
+ * drive-by edit.
+ */
+export function buildForkDenialRemedy(args: { mode: ForkDenialMode; resolvedPath: string }): string {
+  const { mode, resolvedPath } = args;
+  const grant = JSON.stringify(resolvedPath);
+
+  if (mode === 'write') {
+    return (
+      `Writes are confined to this fork's granted write roots by design ` +
+      `(worktree isolation). To allow it, the parent must re-dispatch you via ` +
+      `the \`agent\` tool with \`writeRoots: [${grant}]\`, or perform the write ` +
+      `itself. Return this exact path requirement to your parent.`
+    );
+  }
+
+  return (
+    `Reads are confined to this fork's granted read roots. To allow it, the parent ` +
+    `must re-dispatch you via the \`agent\` tool with \`readRoots: [${grant}]\`, or ` +
+    `read the path itself and pass the content to you in the prompt. A grant made ` +
+    `after you were dispatched cannot reach you — your roots were fixed at dispatch. ` +
+    `Return this exact path requirement to your parent.`
+  );
+}

--- a/src/agent/tools/hooks/path-approval-hook.test.ts
+++ b/src/agent/tools/hooks/path-approval-hook.test.ts
@@ -306,6 +306,14 @@ describe('createPathApprovalHook — sub-agent auto-deny (PR1)', () => {
     expect(decision.reason).toContain('read');
     // Read-mode remedy should NOT mention writeRoots.
     expect(decision.reason).not.toContain('writeRoots');
+    // The read remedy must name the same concrete recovery vector the write
+    // branch does — a re-dispatch carrying an explicit readRoots grant — rather
+    // than vague "the parent can widen access" prose. A fork's roots are fixed
+    // at dispatch, so a post-dispatch grant cannot reach it; wording contract
+    // and rationale live in `fork-denial-remedy.ts`.
+    expect(decision.reason).toContain('`agent` tool');
+    expect(decision.reason).toContain('readRoots: ["/etc/hosts"]');
+    expect(decision.reason).toContain('fixed at dispatch');
   });
 
   it('leaves inherited in-root access untouched for a sub-agent (no prompt, no block)', async () => {

--- a/src/agent/tools/hooks/path-approval-hook.ts
+++ b/src/agent/tools/hooks/path-approval-hook.ts
@@ -60,6 +60,7 @@ import type { GrantManager } from '../../../cli/slash/commands/allow-dir.js';
 import { wouldBeRestricted, realpathSafe } from '../handlers/_cwd-utils.js';
 import { isReadDenied } from '../handlers/read-denylist.js';
 import { appendGrant } from '../../permissions-store.js';
+import { buildForkDenialRemedy } from './fork-denial-remedy.js';
 import type { HookContext, HookDecision, HookHandler } from '../../hooks.js';
 
 /** Tools subject to per-call path approval. Bash is gated separately. */
@@ -286,18 +287,10 @@ async function preToolUseImpl(
     );
     // #435: name the concrete remedy rather than implying a grant mechanism the
     // fork does not have. A fork cannot elicit, so the recovery actor is always
-    // the PARENT: for writes it can re-dispatch with an explicit writeRoots
-    // grant on the `agent` tool (or do the write itself); for reads it owns the
-    // operator surface and can widen readRoots or re-dispatch with the path in cwd.
-    const remedy =
-      mode === 'write'
-        ? `Writes are confined to this fork's granted write roots by design ` +
-          `(worktree isolation). To allow it, the parent must re-dispatch you via ` +
-          `the \`agent\` tool with \`writeRoots: [${JSON.stringify(result.resolved)}]\`, ` +
-          `or perform the write itself. Return this exact path requirement to your parent.`
-        : `Reads are confined to this fork's granted read roots. Return this exact ` +
-          `path requirement to your parent, which owns the operator surface and can ` +
-          `grant access (widen readRoots or re-dispatch with the path inside cwd).`;
+    // the PARENT — and because a fork's roots are fixed at dispatch, the only
+    // remedy that reaches an in-flight fork is a re-dispatch. Wording + the
+    // downstream byte/fingerprint contracts live in `./fork-denial-remedy.ts`.
+    const remedy = buildForkDenialRemedy({ mode, resolvedPath: result.resolved });
     // Contract: the "Sub-agent path access denied:" prefix is load-bearing —
     // the `subagent-read-denial` telemetry detector (improve/scan/detectors)
     // and the denial circuit breaker (tools/denial-circuit-breaker.ts,


### PR DESCRIPTION
## What

A forked sub-agent denied an out-of-root **read** was handed advice it could not act on. The write branch of the denial named a concrete recovery vector; the read branch did not — and what it did say was subtly wrong.

Before:

> Reads are confined to this fork's granted read roots. Return this exact path requirement to your parent, which owns the operator surface and can grant access (widen readRoots or re-dispatch with the path inside cwd).

After:

> Reads are confined to this fork's granted read roots. To allow it, the parent must re-dispatch you via the `agent` tool with `readRoots: ["/path"]`, or read the path itself and pass the content to you in the prompt. A grant made after you were dispatched cannot reach you — your roots were fixed at dispatch. Return this exact path requirement to your parent.

## Why "widen readRoots" was the wrong advice

A fork's grant roots are **fixed at dispatch**. `computeInheritedReadRoots` and the additive-`readRoots` union both build *new* arrays for the child, and the child resolves containment against its own grant manager. So a parent-side widening performed after the fork started — `/allow-dir`, an elicitation approval, `revokeRoot` — **cannot reach a running child.** Re-dispatch is the only remedy.

Telling the fork otherwise is worse than saying nothing: it reads as actionable, isn't, and drives retry-until-timeout — the exact failure #544 was opened to stop.

Note the capability was never missing. `agent(prompt, readRoots: [...])` has worked since #662, and `/allow-dir` works for *subsequent* dispatches. The fork was simply never told to ask.

## Changes

- **New `src/agent/tools/hooks/fork-denial-remedy.ts`** owns both remedy strings. `path-approval-hook.ts` is 661 LOC — pre-existing, ~1.9x the 350-LOC convention — so this extracts a concern rather than growing it further. Net effect on that file: -9 lines.
- The read branch now names the `agent` tool, emits a copy-pasteable `readRoots: ["<path>"]` literal (JSON-quoted, so space-bearing paths survive), and states the fixed-at-dispatch fact.
- **The `Sub-agent path access denied:` prefix is unchanged.** It stays byte-stable: matched by *substring* (not prefix position) at `denial-circuit-breaker.ts:102`, and keyed by the `subagent-read-denial` detector. Both suites pass untouched.
- `fork-denial-remedy.test.ts` locks the contract — including a negative assertion that the read remedy never suggests `/allow-dir`, which is the specific regression this PR exists to prevent.
- The write branch is byte-identical to before; only its home moved.

Consistency bonus: `buildDenialBreakerMessage` already said "re-dispatch ... or pass explicit readRoots". The hook now agrees with the breaker instead of contradicting it.

## Deliberate consequence: rotated failure-card slug

The improve detector SHA-256s the **entire** normalized denial reason (`normalizeReason` → `computeFingerprint` → `makeSlug`), so any reword rotates the card fingerprint and restarts its severity ladder.

Accepted rather than worked around. The old card `subagent-read-denial-ab89c2bd6a6f` (46 denials / 15 sessions) counted **Gap C** agent-framework denials, whose root cause #841 closed two commits ago. Post-fix denials are a genuinely different population and should accumulate under a fresh slug rather than inflate a card whose cause is fixed. Re-keying is semantically correct here, not lossy. The stale slug cited in `subagent.ts` is annotated as historical.

The rotation is nonetheless **invisible to CI** — every detector test builds its own fixture string rather than importing the producer. Filed as #853.

## Verification

- `pnpm lint` clean (tsc --noEmit, strict)
- `audit:env:check`, `scan:env:check`, `audit:sdk:check` all pass
- Full suite: **751 files / 14,305 tests green**
- Targeted: `fork-denial-remedy` (8 new), `path-approval-hook` (40), `denial-circuit-breaker` (19), `subagent-read-denial` (18)

## Provenance

This started as a question — "why can't subagents read /tmp?" — and the answer turned out to be that nothing denies `/tmp`; it is default-deny-by-allowlist and `/tmp` is simply never in the union. A `/devils-advocate` wave then killed my first two proposed fixes: routing scratch to `$AFK_STATE_DIR` (which is on the **write** denylist, so a model cannot write there — and agent scratch already lands in `$AFK_STATE_DIR/skill-preflight/`), and tightening `isTooBroadRoot` against bare `/tmp` (a regression: that guard is shared by `cwd`/`writeRoots`/`readRoots`, and on macOS `os.tmpdir()` is `/var/folders/...`, not `/tmp`). What survived was this — the smallest change that makes the existing capability discoverable.

Not included, deliberately: no new read root is granted, and compose nodes still do not accept per-node `readRoots`.

## Related

- #852 — model-supplied `readRoots` can silently lift the bash credential floor for a child (found during this investigation; needs design, not a quick fix)
- #853 — this reword's fingerprint rotation is invisible to CI; wants a golden-fingerprint test
