### PR TITLE
fix(cli): render round denominator in progress banner (#857)

### DIFF
--- a/src/agent/providers/anthropic-direct.test.ts
+++ b/src/agent/providers/anthropic-direct.test.ts
@@ -979,6 +979,76 @@ describe('AnthropicDirectProvider', () => {
     expect(second.progress.taskId).toBe(first.progress.taskId);
   });
 
+  // Issue #857: the progress banner named the round but never its cap
+  // ("round 7" said nothing about how close the child was to winding down).
+  // With no configured cap the loop is unlimited, so the summary must keep the
+  // bare "round N" form — never "round N/0" or "round N/Infinity".
+  it('progress.summary has no denominator when maxToolUseIterations is unset', async () => {
+    let callIdx = 0;
+    messagesCreateMock.mockImplementation(() => {
+      callIdx += 1;
+      if (callIdx === 1) return fromArray(makeToolUseStream('toolu_1', 'read_file', '{}'));
+      return fromArray(makeTextStream('Done.'));
+    });
+
+    const dispatcher: ToolDispatcher = {
+      async execute(): Promise<ToolResult> {
+        return { content: 'ok' };
+      },
+    };
+
+    const provider = new AnthropicDirectProvider({ tools: dispatcher });
+    const query = provider.query({
+      prompt: singleInput('do stuff'),
+      config: { model: 'claude-sonnet-5', apiKey: 'sk-ant-api03-test' },
+    });
+    const events = await collect(query);
+
+    const progressEvents = events.filter((e) => e.type === 'progress') as Array<
+      Extract<ProviderEvent, { type: 'progress' }>
+    >;
+    expect(progressEvents.length).toBe(1);
+    expect(progressEvents[0]!.progress.summary).toBe('round 1: read_file');
+  });
+
+  // Issue #857 companion: when a real cap IS configured, the same summary
+  // string must carry it as a denominator (`round N/cap`) so the banner shows
+  // how close the child is to its tool-round ceiling.
+  it('progress.summary carries the resolved cap as a denominator', async () => {
+    let callIdx = 0;
+    messagesCreateMock.mockImplementation(() => {
+      callIdx += 1;
+      if (callIdx >= 3) return fromArray(makeTextStream('Summary of findings.'));
+      return fromArray(makeToolUseStream(`toolu_${callIdx}`, 'get_weather', '{"city":"SF"}'));
+    });
+
+    const dispatcher: ToolDispatcher = {
+      async execute(): Promise<ToolResult> {
+        return { content: 'sunny' };
+      },
+    };
+
+    const provider = new AnthropicDirectProvider({ tools: dispatcher });
+    const query = provider.query({
+      prompt: singleInput('weather?'),
+      config: {
+        model: 'claude-sonnet-5',
+        apiKey: 'sk-ant-api03-test',
+        maxToolUseIterations: 2,
+      },
+    });
+    const events = await collect(query);
+
+    const progressEvents = events.filter((e) => e.type === 'progress') as Array<
+      Extract<ProviderEvent, { type: 'progress' }>
+    >;
+    expect(progressEvents.length).toBe(2);
+    // get_weather's `city` arg isn't a recognized summarizeToolInput key
+    // (path/command/query), so the headline is the bare tool name.
+    expect(progressEvents[0]!.progress.summary).toBe('round 1/2: get_weather');
+    expect(progressEvents[1]!.progress.summary).toBe('round 2/2: get_weather');
+  });
+
   // Regression (PR 508 codex review, P2): a single round that batches multiple
   // parallel tool_use blocks must report `toolUses` as the actual number of
   // tool CALLS — not "1" (the round/iteration count). Before the fix `toolUses`

--- a/src/agent/providers/anthropic-direct/loop/tool-round.ts
+++ b/src/agent/providers/anthropic-direct/loop/tool-round.ts
@@ -24,6 +24,7 @@ import { summarizeToolInput } from '../../shared/tool-input-summary.js';
 import {
   TOOL_USE_LOOP_CAPPED,
   WIND_DOWN_NOTE,
+  formatRoundLabel,
   shouldWindDown,
 } from '../../shared/tool-loop-cap.js';
 import { dispatchToolCalls } from './tool-dispatch.js';
@@ -102,7 +103,7 @@ export async function* runToolRound(
     progress: {
       taskId: turn.taskId,
       description: 'Working',
-      summary: `round ${turn.iterations}: ${lastToolHeadline}`,
+      summary: `${formatRoundLabel(turn.iterations, maxIterations)}: ${lastToolHeadline}`,
       lastToolName: lastTool?.name,
       totalTokens: turn.usage.totalTokens ?? 0,
       // Contract: `toolUses` is the cumulative COUNT OF TOOL CALLS so far in

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -116,6 +116,7 @@ import { dispatchAndAppendToolCalls } from './query/dispatch-append.js';
 import {
   TOOL_USE_LOOP_CAPPED,
   WIND_DOWN_NOTE,
+  formatRoundLabel,
   resolveMaxToolIterations,
   shouldWindDown,
 } from '../shared/tool-loop-cap.js';
@@ -652,7 +653,7 @@ export class OpenAICompatibleQuery implements ProviderQuery {
           progress: {
             taskId,
             description: 'Working',
-            summary: `round ${round}: ${lastToolHeadline}`,
+            summary: `${formatRoundLabel(round, maxIterations)}: ${lastToolHeadline}`,
             lastToolName,
             totalTokens: accumulatedUsage.totalTokens ?? 0,
             // Contract: `toolUses` is the cumulative COUNT OF TOOL CALLS so far

--- a/src/agent/providers/openai-compatible/tool-dispatch.test.ts
+++ b/src/agent/providers/openai-compatible/tool-dispatch.test.ts
@@ -818,6 +818,15 @@ describe('OpenAICompatibleQuery — tool dispatch (slice 3)', () => {
     if (completed?.type === 'turn.completed') {
       expect(completed.usage.stopReason).toBe('tool_use_loop_capped');
     }
+
+    // Issue #857: each tool-round progress event's summary carries the
+    // resolved cap as a denominator (`round N/3`) — mirrors anthropic-direct.
+    const progressEvents = events.filter((e) => e.type === 'progress');
+    expect(progressEvents).toHaveLength(3);
+    const summaries = progressEvents.map((e) =>
+      e.type === 'progress' ? e.progress.summary : undefined,
+    );
+    expect(summaries).toEqual(['round 1/3: echo', 'round 2/3: echo', 'round 3/3: echo']);
   });
 
   it('runs uncapped at top level — past the former hard-coded 50-round limit (no maxToolUseIterations)', async () => {
@@ -852,6 +861,16 @@ describe('OpenAICompatibleQuery — tool dispatch (slice 3)', () => {
     if (completed?.type === 'turn.completed') {
       expect(completed.usage.stopReason).not.toBe('tool_use_loop_capped');
     }
+
+    // Issue #857: unlimited (no configured cap) keeps the bare "round N" form
+    // — never a "round N/0" or "round N/Infinity" denominator.
+    const progressEvents = events.filter((e) => e.type === 'progress');
+    expect(progressEvents).toHaveLength(52);
+    expect(progressEvents[0]!.type === 'progress' ? progressEvents[0].progress.summary : undefined).toBe(
+      'round 1: echo',
+    );
+    const last = progressEvents.at(-1);
+    expect(last?.type === 'progress' ? last.progress.summary : undefined).toBe('round 52: echo');
   });
 });
 

--- a/src/agent/providers/shared/tool-loop-cap.test.ts
+++ b/src/agent/providers/shared/tool-loop-cap.test.ts
@@ -3,6 +3,7 @@ import {
   TOOL_USE_LOOP_CAPPED,
   DEFAULT_MAX_TOOL_USE_ITERATIONS,
   WIND_DOWN_NOTE,
+  formatRoundLabel,
   resolveMaxToolIterations,
   shouldWindDown,
 } from './tool-loop-cap.js';
@@ -41,6 +42,28 @@ describe('shared/tool-loop-cap', () => {
       expect(shouldWindDown(2, 3)).toBe(false);
       expect(shouldWindDown(3, 3)).toBe(true);
       expect(shouldWindDown(4, 3)).toBe(true);
+    });
+  });
+
+  describe('formatRoundLabel', () => {
+    // Issue #857: the progress banner named the round but never its cap, so
+    // "round 7" said nothing about how close the child was to winding down.
+    it('renders the bare round number when the cap is unlimited (0)', () => {
+      expect(formatRoundLabel(7, 0)).toBe('round 7');
+    });
+
+    it('treats a negative resolved cap the same as unlimited', () => {
+      // resolveMaxToolIterations never actually returns a negative value, but
+      // formatRoundLabel guards independently rather than trusting the caller.
+      expect(formatRoundLabel(7, -5)).toBe('round 7');
+    });
+
+    it('renders round/cap when a real cap is in effect', () => {
+      expect(formatRoundLabel(7, 50)).toBe('round 7/50');
+    });
+
+    it('renders round/cap even once the round number reaches the cap', () => {
+      expect(formatRoundLabel(50, 50)).toBe('round 50/50');
     });
   });
 });

--- a/src/agent/providers/shared/tool-loop-cap.ts
+++ b/src/agent/providers/shared/tool-loop-cap.ts
@@ -74,3 +74,18 @@ export function resolveMaxToolIterations(configured: number | undefined): number
 export function shouldWindDown(completedRounds: number, maxIterations: number): boolean {
   return maxIterations > 0 && completedRounds >= maxIterations;
 }
+
+/**
+ * Render the round-number label both providers embed in the progress-banner
+ * `summary` string (`round ${label}: ${toolHeadline}`).
+ *
+ * `maxIterations` must already be a RESOLVED cap (the output of {@link
+ * resolveMaxToolIterations}, not raw config) — same contract as {@link
+ * shouldWindDown}. A positive cap renders the denominator (`round 7/50`) so
+ * the banner shows how close the child is to its tool-round ceiling;
+ * `maxIterations <= 0` means unlimited, so the bare `round 7` is kept as-is
+ * rather than rendering the meaningless `round 7/0` or `round 7/Infinity`.
+ */
+export function formatRoundLabel(round: number, maxIterations: number): string {
+  return maxIterations > 0 ? `round ${round}/${maxIterations}` : `round ${round}`;
+}


### PR DESCRIPTION
## Summary

Closes the "round denominator" half of #857: the interactive progress banner names a running subagent's round number (`round 7: <tool headline>`) but never its tool-round cap, so the banner said nothing about how close the child was to winding down. This renders `round 7/50` when a real cap is configured, and keeps the bare `round 7` when the cap is `0`/unset (unlimited).

The stall-machinery half of #857 (the 1.5s–30s dead zone) is untouched — out of scope for this change.

## Design: provider-side string formatting, not the `{round, cap}` fields the issue proposed

#857 proposed adding structured `round?` / `cap?` fields to `ProviderProgress`, reasoning that `progress.summary` is an opaque preformatted string and "the renderer cannot parse a denominator back out of it."

That premise is correct but doesn't require structured fields, because this change never parses the string — it formats it correctly at the one place it's assembled. I verified before implementing (see below) that `progress.summary` is built at exactly two provider emit sites and reaches the banner **completely unmodified**: `clauseFor()` in `src/cli/_lib/child-activity-select.ts` returns `candidate.source.lastProgressSummary` verbatim, with no parsing or reconstruction anywhere downstream. Since the resolved cap (`resolveMaxToolIterations()`'s output) is already an in-scope local at both emit sites — no threading through new parameters — the denominator can be baked into the string at the source, with zero renderer changes.

Adding `{ round, cap }` fields instead would create a second source of truth: the fields would sit next to a `summary` string that already encodes the same round number as human-readable text, and the two would need to be kept in sync by convention rather than by construction. Formatting once, at the single place the string is built, avoids that.

### Assumptions verified before writing code

- **A — cap in scope at both emit sites:** Confirmed. `anthropic-direct/loop/tool-round.ts`'s `runToolRound()` already takes `maxIterations` as a direct parameter (`src/agent/providers/anthropic-direct/loop.ts:86` resolves it via `resolveMaxToolIterations`, passed at `loop.ts:277`). `openai-compatible/query.ts` resolves it once at `query.ts:542` as a local `const` used later in the very same method body (`shouldWindDown(round, maxIterations)` at `query.ts:676`) — no threading needed at all.
- **B — `summary` reaches the banner verbatim:** Confirmed. `event.progress.summary` → `stream-renderer-subagent.ts:164` (`source.lastProgressSummary = event.progress.summary`) → `child-activity-select.ts:96-97` (`clauseFor()` returns it unmodified) → `formatChildActivity()` wraps it as `` `${label} · ${clause}` `` with no rewriting of the clause content. Also checked that the new literal `/` in `round 7/50` can't be mis-collapsed by `shortenPaths()`'s path-collapse regex (requires 2+ `/`-separated segments; a bare `7/50` never matches).

Both held, so this implements the 2-site change per the issue's own "no renderer plumbing" framing, via a small shared formatter rather than duplicating the same ternary in both providers.

## Changes

- `src/agent/providers/shared/tool-loop-cap.ts` — new `formatRoundLabel(round, maxIterations)`: returns `` `round ${round}/${maxIterations}` `` when `maxIterations > 0`, else the bare `` `round ${round}` ``. Lives alongside `resolveMaxToolIterations`/`shouldWindDown`, the module's existing single source of truth for cap policy shared by both providers.
- `src/agent/providers/anthropic-direct/loop/tool-round.ts` — emit site now calls `formatRoundLabel(turn.iterations, maxIterations)`.
- `src/agent/providers/openai-compatible/query.ts` — emit site now calls `formatRoundLabel(round, maxIterations)`.
- Test coverage: `tool-loop-cap.test.ts` (pure formatter: unlimited, negative-guard, real-cap, at-cap-boundary) plus end-to-end regression tests in both providers' existing test suites covering the uncapped case (bare `round N`) and a real-cap case (`round N/cap`, and confirming the same real-cap scenario used in each provider's existing wind-down test).

Nothing else about the summary string changed — the `: <lastToolHeadline>` tail is untouched.

## Verification

- `pnpm lint` (tsc --noEmit, strict): clean.
- `pnpm test`: full suite green — 757 files, 14400 passed, 2 skipped, 0 failed. Includes `src/cli/_lib/live-progress-no-timer.test.ts` (no-autonomous-timer invariant, untouched by this change) and all pre-existing progress-banner/child-activity-select tests that assert on the `round N` literal.

Refs #857.
