### PR TITLE
feat(agent): make the nesting-depth cap configurable via AFK_MAX_NESTING_DEPTH

### DIFF
--- a/docs/env-registry.json
+++ b/docs/env-registry.json
@@ -325,6 +325,15 @@
       "category": "model"
     },
     {
+      "name": "AFK_MAX_NESTING_DEPTH",
+      "description": "Maximum sub-agent/skill nesting depth; 0 disables nested delegation entirely (the agent, skill, AND compose tools all refuse). A top-level session is depth 0, so the default 3 permits three generations of forked descendants (depth 1 → 2 → 3) and refuses the agent and skill tools at depth 3. Resolved once at the root of each session and propagated down through child AgentConfig, so descendants inherit the root value rather than re-reading the environment. Raise with care: depth is a fan-out exponent (a width-N wave at depth D reaches ~N^D concurrent children), so values above 4 invite provider rate-limit (429) cascades. Accepted range 0-6; unset, empty, unparseable, negative, or out-of-range input falls back to the default. An explicit programmatic maxDepth (SubagentExecutorContext / SkillExecutorContext) still wins.",
+      "type": "number",
+      "required": false,
+      "default": "3",
+      "example": "2",
+      "category": "model"
+    },
+    {
       "name": "AFK_MAX_OUTPUT_TOKENS",
       "description": "Cap on output tokens per turn. Falls back to provider default when unset.",
       "type": "number",

--- a/docs/env-registry.md
+++ b/docs/env-registry.md
@@ -2,7 +2,7 @@
 
 Generated from `src/config/env.ts`. Do not edit by hand — run `pnpm scan:env` after changing the registry source.
 
-**141 vars** across 12 categories. Every `process.env[...]` read in `src/` outside `src/config/env.ts` is a CI failure (enforced by `pnpm audit:env:check`).
+**142 vars** across 12 categories. Every `process.env[...]` read in `src/` outside `src/config/env.ts` is a CI failure (enforced by `pnpm audit:env:check`).
 
 To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV_REGISTRY`), then run `pnpm scan:env`.
 
@@ -18,6 +18,7 @@ To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV
 | `AFK_EFFORT` | string |  |  | `medium` | Effort hint guiding adaptive-thinking depth, forwarded as Anthropic output_config.effort (model-gated; ignored where unsupported). Accepts low \| medium \| high \| xhigh \| max. |
 | `AFK_LOCAL_BASE_URL` | string |  |  | `http://127.0.0.1:8080` | Base URL for a self-hosted Anthropic-compatible server. When set, routes traffic away from api.anthropic.com. |
 | `AFK_MAX_BUDGET_USD` | number |  | `5.00` | `10.00` | Cumulative USD budget ceiling for the session. Aborts the turn when the running cost crosses this. |
+| `AFK_MAX_NESTING_DEPTH` | number |  | `3` | `2` | Maximum sub-agent/skill nesting depth; 0 disables nested delegation entirely (the agent, skill, AND compose tools all refuse). A top-level session is depth 0, so the default 3 permits three generations of forked descendants (depth 1 → 2 → 3) and refuses the agent and skill tools at depth 3. Resolved once at the root of each session and propagated down through child AgentConfig, so descendants inherit the root value rather than re-reading the environment. Raise with care: depth is a fan-out exponent (a width-N wave at depth D reaches ~N^D concurrent children), so values above 4 invite provider rate-limit (429) cascades. Accepted range 0-6; unset, empty, unparseable, negative, or out-of-range input falls back to the default. An explicit programmatic maxDepth (SubagentExecutorContext / SkillExecutorContext) still wins. |
 | `AFK_MAX_OUTPUT_TOKENS` | number |  |  | `8192` | Cap on output tokens per turn. Falls back to provider default when unset. |
 | `AFK_MAX_TOKENS` | number |  | `4096` | `8192` | Deprecated and inert: not read by the generation path. Use AFK_MAX_OUTPUT_TOKENS (or --max-output-tokens) to cap per-response output tokens; falls back to the model output ceiling when unset. |
 | `AFK_MAX_TOOL_USE_ITERATIONS` | number |  | `0` | `150` | Opt-in ceiling on tool-use rounds per turn for TOP-LEVEL (non-subagent) sessions, on both providers. Mirrors the maxToolUseIterations config key / max_tool_use_iterations tool param. Unset, non-numeric, or <=0 means unlimited (the default — zero behavior change): a top-level turn ends only when the model stops calling tools, the abort signal fires, the provider errors, or the dollar budget trips. A positive integer N makes top-level turns wind down gracefully after N tool rounds (one tools-stripped final round). An explicit config/CLI value wins over this env default. Does NOT affect subagent forks — they keep their own non-zero anti-hang default (SUBAGENT_DEFAULT_MAX_TOOL_USE_ITERATIONS) regardless of this var. |

--- a/src/agent/session/wire-executors.ts
+++ b/src/agent/session/wire-executors.ts
@@ -25,7 +25,11 @@ import { SubagentManager } from '../subagent.js';
 import { SubagentExecutor } from '../tools/subagent-executor.js';
 import { SkillExecutor } from '../tools/skill-executor.js';
 import { ComposeExecutor } from '../tools/compose-executor.js';
-import { createChildProviderFactory, createChildSkillExecutorFactory } from '../tools/nesting.js';
+import {
+  createChildProviderFactory,
+  createChildSkillExecutorFactory,
+  resolveMaxNestingDepth,
+} from '../tools/nesting.js';
 import { loadAgentRegistry } from '../agents/index.js';
 import { discoverPluginAgents } from '../tools/skill-bridge.js';
 import type { SubagentExecutorContext } from '../tools/subagent-executor.js';
@@ -176,6 +180,10 @@ export function wireExecutors(opts: WireExecutorsOptions): WiredExecutors {
   const skillTraceOpt = skillTraceWriter !== undefined ? { traceWriter: skillTraceWriter } : {};
   const apiKeyOpt = apiKey !== undefined ? { apiKey } : {};
   const bgRegistryOpt = backgroundRegistry !== undefined ? { backgroundRegistry } : {};
+  // Session-static snapshot shared by all root executors and inherited by
+  // descendants. Do not resolve inside execute(): sibling calls must not see
+  // different caps if the process environment changes during the session.
+  const maxDepth = resolveMaxNestingDepth();
 
   // 1. The single root manager. Every executor below reads through this
   //    instance; a second manager would fork children outside the abort graph
@@ -237,6 +245,7 @@ export function wireExecutors(opts: WireExecutorsOptions): WiredExecutors {
     // Top-level wiring → explicit depth 0. See SubagentExecutorContext.depth
     // for why this is required rather than defaulted.
     depth: 0,
+    maxDepth,
     ...nestedCwdOpt,
     agentRegistry,
     parentModel: model,
@@ -259,6 +268,7 @@ export function wireExecutors(opts: WireExecutorsOptions): WiredExecutors {
     resolveApiKeyForModel,
     ...skillTraceOpt,
     ...nestedCwdOpt,
+    maxDepth,
     // Read-scope inheritance (#547): skill-forked children inherit the parent
     // session's read scope via the root manager — symmetric with the `agent`
     // tool. Read fresh so mid-session setCwd re-anchors are reflected.
@@ -279,6 +289,7 @@ export function wireExecutors(opts: WireExecutorsOptions): WiredExecutors {
     systemPrompt: systemPrompt ?? '',
     surface,
     depth: 0,
+    maxDepth,
     ...traceOpt,
   });
 

--- a/src/agent/tools/compose-executor.test.ts
+++ b/src/agent/tools/compose-executor.test.ts
@@ -5,6 +5,7 @@ import { join } from 'path';
 import type { ToolCall } from './types.js';
 import type { SubagentProgressSink } from '../types/session-types.js';
 import { runWithSink } from '../_lib/skill-sink-channel.js';
+import { SKILL_MAX_DEPTH_RECOVERY_HINT } from './skill-depth-message.js';
 
 // Mock SubagentManager + runSubagentDAG before importing the executor.
 const mockForkSubagent = vi.fn();
@@ -457,6 +458,9 @@ describe('ComposeExecutor', () => {
         }));
         expect(result.isError).toBe(true);
         expect(result.content).toContain('Compose tool not available at nesting depth 0 (max 0)');
+        // Parity with the `agent` and `skill` refusals: the actionable "work
+        // inline" hint must reach the caller, not just the depth number.
+        expect(result.content).toContain(SKILL_MAX_DEPTH_RECOVERY_HINT);
         expect(mockRunSubagentDAG).not.toHaveBeenCalled();
       } finally {
         if (original !== undefined) process.env[KEY] = original;

--- a/src/agent/tools/compose-executor.test.ts
+++ b/src/agent/tools/compose-executor.test.ts
@@ -442,6 +442,56 @@ describe('ComposeExecutor', () => {
       expect(mockRunSubagentDAG).toHaveBeenCalledOnce();
     });
 
+    // Depth cap parity with the `agent` and `skill` tools. Inert at any
+    // non-zero cap (compose is never wired below the root), so the reachable
+    // case is AFK_MAX_NESTING_DEPTH=0 — the documented "disable nested
+    // delegation entirely" escape hatch.
+    it('refuses when the resolved cap is 0 (AFK_MAX_NESTING_DEPTH=0)', async () => {
+      const KEY = 'AFK_MAX_NESTING_DEPTH';
+      const original = process.env[KEY];
+      process.env[KEY] = '0';
+      try {
+        const executor = new ComposeExecutor(makeContext());
+        const result = await executor.execute(makeCall({
+          nodes: [{ id: 'a', prompt: 'task a' }],
+        }));
+        expect(result.isError).toBe(true);
+        expect(result.content).toContain('Compose tool not available at nesting depth 0 (max 0)');
+        expect(mockRunSubagentDAG).not.toHaveBeenCalled();
+      } finally {
+        if (original !== undefined) process.env[KEY] = original;
+        else delete process.env[KEY];
+      }
+    });
+
+    it('runs normally at the default cap (depth 0 < 3)', async () => {
+      mockRunSubagentDAG.mockResolvedValue({ outputs: {}, failed: [], skipped: [] });
+      const executor = new ComposeExecutor(makeContext());
+      const result = await executor.execute(makeCall({
+        nodes: [{ id: 'a', prompt: 'task a' }],
+      }));
+      expect(result.isError).toBeFalsy();
+      expect(mockRunSubagentDAG).toHaveBeenCalledOnce();
+    });
+
+    it('honours an explicit ctx.maxDepth over the env value', async () => {
+      const KEY = 'AFK_MAX_NESTING_DEPTH';
+      const original = process.env[KEY];
+      process.env[KEY] = '0';
+      try {
+        mockRunSubagentDAG.mockResolvedValue({ outputs: {}, failed: [], skipped: [] });
+        const executor = new ComposeExecutor(makeContext({ maxDepth: 3 }));
+        const result = await executor.execute(makeCall({
+          nodes: [{ id: 'a', prompt: 'task a' }],
+        }));
+        expect(result.isError).toBeFalsy();
+        expect(mockRunSubagentDAG).toHaveBeenCalledOnce();
+      } finally {
+        if (original !== undefined) process.env[KEY] = original;
+        else delete process.env[KEY];
+      }
+    });
+
     it('returns isError when apiKey is missing (M5)', async () => {
       const executor = new ComposeExecutor(makeContext({ apiKey: undefined }));
       const result = await executor.execute(makeCall({

--- a/src/agent/tools/compose-executor.ts
+++ b/src/agent/tools/compose-executor.ts
@@ -25,6 +25,8 @@ import { deriveOrigin, actorFromDepth } from '../session/session-identity.js';
 import type { SubagentExecutionError } from '../subagent/result.js';
 import type { SubagentProgressSink } from '../types/session-types.js';
 import { getCurrentSink } from '../_lib/skill-sink-channel.js';
+import { resolveMaxNestingDepth } from './nesting.js';
+import { buildComposeMaxDepthRefusal } from './skill-depth-message.js';
 import { getSessionsDir } from '../../paths.js';
 
 export interface ComposeExecutorContext {
@@ -122,6 +124,18 @@ export interface ComposeExecutorContext {
    * → `subagent`). Optional/back-compat: defaults to 0 when unset.
    */
   depth?: number;
+  /**
+   * Maximum allowed nesting depth. Optional: unset resolves the default from
+   * `AFK_MAX_NESTING_DEPTH` via {@link resolveMaxNestingDepth}, matching the
+   * `agent` and `skill` executors.
+   *
+   * Invariant: `compose` is excluded from {@link CHILD_ALLOWED_TOOLS}, so this
+   * executor is only ever wired at the root (`depth` 0) and the gate below is
+   * inert at any default cap. It exists so `AFK_MAX_NESTING_DEPTH=0` means what
+   * it says — no nested delegation from ANY of the three dispatch tools —
+   * rather than silently leaving one fan-out door open.
+   */
+  maxDepth?: number;
   /**
    * Reads the parent session's read scope ({@link ReadScopeInputs}) at
    * dispatch time (wired to the root
@@ -559,6 +573,26 @@ export class ComposeExecutor {
       this.ctx.surface !== undefined
         ? { origin: deriveOrigin(this.ctx.surface), actor: actorFromDepth(this.ctx.depth) }
         : {};
+
+    // Depth cap, mirroring the `agent` and `skill` executors. See
+    // ComposeExecutorContext.maxDepth: this is inert at any non-zero cap
+    // because compose is never wired below the root, and exists so that
+    // AFK_MAX_NESTING_DEPTH=0 disables every dispatch tool uniformly.
+    const depth = this.ctx.depth ?? 0;
+    const maxDepth = this.ctx.maxDepth ?? resolveMaxNestingDepth();
+    if (depth >= maxDepth) {
+      void appendRoutingDecision({
+        ...identity,
+        event: 'delegation.skipped',
+        parent_session_id: this.ctx.parentSession.sessionId,
+        reason: 'max_depth',
+        depth,
+      }).catch(() => {});
+      return {
+        content: buildComposeMaxDepthRefusal(depth, maxDepth),
+        isError: true,
+      };
+    }
 
     // Contract: the per-node tool budget is enforced BY THE PROVIDER LOOP, not
     // by this executor. `max_tool_rounds_per_node` is forwarded to each node's

--- a/src/agent/tools/nesting.test.ts
+++ b/src/agent/tools/nesting.test.ts
@@ -1,11 +1,15 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   CHILD_ALLOWED_TOOLS,
   RECON_ALLOWED_TOOLS,
+  DEFAULT_MAX_NESTING_DEPTH,
   DEFAULT_READ_ONLY_SKILLS,
+  MAX_NESTING_DEPTH_CEILING,
   buildReadOnlyReconProvider,
   buildSkillRestrictedProvider,
+  resolveMaxNestingDepth,
 } from './nesting.js';
+import { ENV_REGISTRY } from '../../config/env.js';
 import { checkToolPermission } from './permissions.js';
 
 describe('CHILD_ALLOWED_TOOLS', () => {
@@ -254,5 +258,75 @@ describe('restricted builders thread openaiBaseUrl into the OpenAI client baseUR
   it('buildSkillRestrictedProvider leaves baseURL unset when no openaiBaseUrl is given', () => {
     const provider = buildSkillRestrictedProvider(['read_file'], 'gpt-4o');
     expect(bakedBaseURL(provider)).toBeUndefined();
+  });
+});
+
+// resolveMaxNestingDepth is the DEFAULT resolver consulted at the three
+// `ctx.maxDepth ?? resolveMaxNestingDepth()` sites (subagent-executor,
+// skill-executor, skill-executor/fork-child-config). Pure-function contract,
+// mirroring resolveSubagentTimeoutMs: unset/empty/invalid → default, valid int
+// within [0, MAX_NESTING_DEPTH_CEILING] → that value, 0 → 0 (nesting disabled).
+describe('resolveMaxNestingDepth (AFK_MAX_NESTING_DEPTH)', () => {
+  const KEY = 'AFK_MAX_NESTING_DEPTH';
+  let original: string | undefined;
+  beforeEach(() => {
+    original = process.env[KEY];
+    delete process.env[KEY];
+  });
+  afterEach(() => {
+    if (original !== undefined) process.env[KEY] = original;
+    else delete process.env[KEY];
+  });
+
+  it('returns DEFAULT_MAX_NESTING_DEPTH when unset', () => {
+    expect(resolveMaxNestingDepth()).toBe(DEFAULT_MAX_NESTING_DEPTH);
+  });
+
+  it('returns DEFAULT_MAX_NESTING_DEPTH when empty / whitespace', () => {
+    process.env[KEY] = '';
+    expect(resolveMaxNestingDepth()).toBe(DEFAULT_MAX_NESTING_DEPTH);
+    process.env[KEY] = '   ';
+    expect(resolveMaxNestingDepth()).toBe(DEFAULT_MAX_NESTING_DEPTH);
+  });
+
+  it('parses a valid integer below the default', () => {
+    process.env[KEY] = '1';
+    expect(resolveMaxNestingDepth()).toBe(1);
+  });
+
+  it('parses a valid integer above the default, up to the ceiling', () => {
+    process.env[KEY] = String(MAX_NESTING_DEPTH_CEILING);
+    expect(resolveMaxNestingDepth()).toBe(MAX_NESTING_DEPTH_CEILING);
+  });
+
+  it('treats 0 as the explicit "disable nested delegation" escape hatch', () => {
+    process.env[KEY] = '0';
+    expect(resolveMaxNestingDepth()).toBe(0);
+  });
+
+  it('falls back to the default on a negative value', () => {
+    process.env[KEY] = '-1';
+    expect(resolveMaxNestingDepth()).toBe(DEFAULT_MAX_NESTING_DEPTH);
+  });
+
+  it('falls back to the default above the ceiling', () => {
+    // The typo case the ceiling exists for: `30` for `3` would turn one
+    // dispatch into an unbounded fan-out tree against a shared rate limit.
+    process.env[KEY] = String(MAX_NESTING_DEPTH_CEILING + 1);
+    expect(resolveMaxNestingDepth()).toBe(DEFAULT_MAX_NESTING_DEPTH);
+    process.env[KEY] = '30';
+    expect(resolveMaxNestingDepth()).toBe(DEFAULT_MAX_NESTING_DEPTH);
+  });
+
+  it('falls back to the default on unparseable garbage', () => {
+    process.env[KEY] = 'not-a-number';
+    expect(resolveMaxNestingDepth()).toBe(DEFAULT_MAX_NESTING_DEPTH);
+  });
+
+  it('keeps the ENV_REGISTRY documented default in lockstep with the constant', () => {
+    // Guards against DEFAULT_MAX_NESTING_DEPTH drifting from the registry
+    // `default` string that feeds docs/env-registry.{json,md}.
+    const entry = ENV_REGISTRY.find((e) => e.name === KEY);
+    expect(entry?.default).toBe(String(DEFAULT_MAX_NESTING_DEPTH));
   });
 });

--- a/src/agent/tools/nesting.test.ts
+++ b/src/agent/tools/nesting.test.ts
@@ -261,10 +261,9 @@ describe('restricted builders thread openaiBaseUrl into the OpenAI client baseUR
   });
 });
 
-// resolveMaxNestingDepth is the DEFAULT resolver consulted at the three
-// `ctx.maxDepth ?? resolveMaxNestingDepth()` sites (subagent-executor,
-// skill-executor, skill-executor/fork-child-config). Pure-function contract,
-// mirroring resolveSubagentTimeoutMs: unset/empty/invalid → default, valid int
+// resolveMaxNestingDepth is snapshotted by root wiring and remains the fallback
+// for directly constructed executors. Pure-function contract, mirroring
+// resolveSubagentTimeoutMs: unset/empty/invalid → default, valid int
 // within [0, MAX_NESTING_DEPTH_CEILING] → that value, 0 → 0 (nesting disabled).
 describe('resolveMaxNestingDepth (AFK_MAX_NESTING_DEPTH)', () => {
   const KEY = 'AFK_MAX_NESTING_DEPTH';
@@ -322,6 +321,14 @@ describe('resolveMaxNestingDepth (AFK_MAX_NESTING_DEPTH)', () => {
     process.env[KEY] = 'not-a-number';
     expect(resolveMaxNestingDepth()).toBe(DEFAULT_MAX_NESTING_DEPTH);
   });
+
+  it.each(['0.5', '0x5', '0b10', '1oops'])(
+    'falls back to the default for non-decimal input %s',
+    (malformed) => {
+      process.env[KEY] = malformed;
+      expect(resolveMaxNestingDepth()).toBe(DEFAULT_MAX_NESTING_DEPTH);
+    },
+  );
 
   it('keeps the ENV_REGISTRY documented default in lockstep with the constant', () => {
     // Guards against DEFAULT_MAX_NESTING_DEPTH drifting from the registry

--- a/src/agent/tools/nesting.ts
+++ b/src/agent/tools/nesting.ts
@@ -8,6 +8,7 @@
  * @module agent/tools/nesting
  */
 
+import { env } from '../../config/env.js';
 import type { IAgentSession } from '../types.js';
 import type { ModelProvider } from '../provider.js';
 import type { AgentModelInput } from '../types.js';
@@ -26,6 +27,45 @@ import type { BackgroundAgentRegistry } from '../background-registry.js';
 import type { AgentRegistry } from '../agents/types.js';
 
 export const DEFAULT_MAX_NESTING_DEPTH = 3;
+
+/**
+ * Upper bound accepted from `AFK_MAX_NESTING_DEPTH`.
+ *
+ * Invariant: depth is a fan-out EXPONENT, not a linear budget — a width-N wave
+ * repeated at depth D reaches on the order of N^D concurrent children, all
+ * sharing one provider rate limit. The cap is what keeps a typo (`30` for `3`)
+ * from turning a single dispatch into a 429 cascade that kills the whole tree.
+ * Anything above 4 is already unadvisable; 6 is the hard refusal point.
+ */
+export const MAX_NESTING_DEPTH_CEILING = 6;
+
+/**
+ * Resolve the default nesting-depth cap from `AFK_MAX_NESTING_DEPTH`.
+ *
+ * Mirrors {@link resolveSubagentTimeoutMs} (src/agent/subagent/constants.ts):
+ * returns the parsed value when it is a finite integer within
+ * `[0, MAX_NESTING_DEPTH_CEILING]`. `0` is the explicit escape hatch that
+ * disables nested delegation entirely — the `agent`, `skill`, AND `compose`
+ * tools all refuse at depth 0. Unset, empty, unparseable, negative, or
+ * above-ceiling input falls back to {@link DEFAULT_MAX_NESTING_DEPTH}.
+ *
+ * Contract: this resolves the DEFAULT only. An explicit `ctx.maxDepth`
+ * (SubagentExecutorContext / SkillExecutorContext) still wins via the `??` at
+ * each call site — which is also why children never re-read the environment:
+ * the root resolves once and threads the number down through child
+ * `AgentConfig.maxDepth` and `childSkillExecutorFactory(depth + 1, maxDepth,…)`,
+ * so a mid-process env mutation cannot desynchronise one branch of the tree
+ * from another.
+ */
+export function resolveMaxNestingDepth(): number {
+  const raw = env.AFK_MAX_NESTING_DEPTH;
+  if (raw === undefined || raw.trim() === '') return DEFAULT_MAX_NESTING_DEPTH;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 0 || n > MAX_NESTING_DEPTH_CEILING) {
+    return DEFAULT_MAX_NESTING_DEPTH;
+  }
+  return n;
+}
 
 export interface ChildProviderFactoryArgs {
   childExecutor: SubagentExecutor;

--- a/src/agent/tools/nesting.ts
+++ b/src/agent/tools/nesting.ts
@@ -59,9 +59,11 @@ export const MAX_NESTING_DEPTH_CEILING = 6;
  */
 export function resolveMaxNestingDepth(): number {
   const raw = env.AFK_MAX_NESTING_DEPTH;
-  if (raw === undefined || raw.trim() === '') return DEFAULT_MAX_NESTING_DEPTH;
-  const n = Number.parseInt(raw, 10);
-  if (!Number.isFinite(n) || n < 0 || n > MAX_NESTING_DEPTH_CEILING) {
+  if (raw === undefined) return DEFAULT_MAX_NESTING_DEPTH;
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) return DEFAULT_MAX_NESTING_DEPTH;
+  const n = Number(trimmed);
+  if (!Number.isInteger(n) || n < 0 || n > MAX_NESTING_DEPTH_CEILING) {
     return DEFAULT_MAX_NESTING_DEPTH;
   }
   return n;

--- a/src/agent/tools/orchestration-telemetry.test.ts
+++ b/src/agent/tools/orchestration-telemetry.test.ts
@@ -42,6 +42,7 @@ import type { IAgentSession } from '../types.js';
 import type { AgentConfig } from '../types/config-types.js';
 import type { Surface } from '../awareness/types.js';
 import type { ToolCall } from './types.js';
+import type { AgentRegistry, RegisteredAgent } from '../agents/index.js';
 import {
   SubagentExecutor,
   type SubagentExecutorContext,
@@ -435,6 +436,107 @@ describe('delegation.skipped telemetry (skill depth limit)', () => {
   });
 });
 
+describe('delegation.skipped telemetry (agent depth limit)', () => {
+  function makeAgentExecutor(opts: {
+    depth: number;
+    maxDepth: number;
+    agentRegistry?: AgentRegistry;
+  }) {
+    const manager = mockManager();
+    const ctx: SubagentExecutorContext = {
+      subagentManager: manager as unknown as SubagentExecutorContext['subagentManager'],
+      parentSession: {
+        sessionId: 'parent-sess',
+        getInputStreamRef: vi.fn(),
+        abortSignal: new AbortController().signal,
+      } as unknown as SubagentExecutorContext['parentSession'],
+      defaultConfig: { apiKey: 'k', systemPrompt: 'sp' },
+      depth: opts.depth,
+      maxDepth: opts.maxDepth,
+      ...(opts.agentRegistry !== undefined ? { agentRegistry: opts.agentRegistry } : {}),
+    };
+    return { executor: new SubagentExecutor(ctx), manager };
+  }
+
+  const RESEARCH: RegisteredAgent = {
+    name: 'research-agent',
+    source: 'builtin',
+    definition: {
+      description: 'Read-only research sub-agent',
+      prompt: 'You are the research agent system prompt.',
+      tools: ['Read', 'Grep', 'Glob'],
+    },
+  };
+
+  it('emits delegation.skipped with reason=max_depth at the depth limit', async () => {
+    // Invariant: `agent` and `skill` emit the SAME row at the wall. The
+    // agent_type must resolve against a registry to reach the depth gate —
+    // named-agent resolution runs first, so an unknown type would return
+    // "not found" and emit nothing.
+    const { executor, manager } = makeAgentExecutor({
+      depth: 3,
+      maxDepth: 3,
+      agentRegistry: new Map([[RESEARCH.name, RESEARCH]]),
+    });
+
+    const result = await executor.execute(
+      makeCall({ input: { prompt: 'investigate', agent_type: 'research-agent' } }),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('nesting depth');
+    expect(manager.forkSubagent).not.toHaveBeenCalled();
+
+    const evt = findEvent('delegation.skipped');
+    expect(evt).toBeDefined();
+    expect(evt).toMatchObject({
+      event: 'delegation.skipped',
+      reason: 'max_depth',
+      depth: 3,
+      requested_name: 'research-agent',
+      parent_session_id: 'parent-sess',
+    });
+  });
+
+  it('does not emit delegation.skipped below the depth limit', async () => {
+    const { executor } = makeAgentExecutor({ depth: 1, maxDepth: 3 });
+    await executor.execute(makeCall());
+    expect(findEvent('delegation.skipped')).toBeUndefined();
+  });
+
+  it('omits requested_name for a bare dispatch at the depth limit', async () => {
+    // Contract: unlike the skill path — which derives a name from raw input
+    // before parsing — the agent row carries requested_name only when the
+    // dispatch named an agent_type. A bare dispatch emits the row without it.
+    const { executor } = makeAgentExecutor({ depth: 3, maxDepth: 3 });
+    await executor.execute(makeCall());
+
+    const evt = findEvent('delegation.skipped');
+    expect(evt).toBeDefined();
+    expect(evt!['requested_name']).toBeUndefined();
+  });
+
+  it('refuses every dispatch when the cap is 0 and still emits the row', async () => {
+    const { executor, manager } = makeAgentExecutor({ depth: 0, maxDepth: 0 });
+    const result = await executor.execute(makeCall());
+
+    expect(result.isError).toBe(true);
+    expect(manager.forkSubagent).not.toHaveBeenCalled();
+    expect(findEvent('delegation.skipped')).toMatchObject({
+      reason: 'max_depth',
+      depth: 0,
+    });
+  });
+
+  it('depth-gate refusal payload does not contain the dispatch prompt', async () => {
+    const { executor } = makeAgentExecutor({ depth: 3, maxDepth: 3 });
+    await executor.execute(
+      makeCall({ input: { prompt: 'SECRET-AGENT-PROMPT-88' } }),
+    );
+    const serialized = JSON.stringify(appendRoutingDecision.mock.calls);
+    expect(serialized).not.toContain('SECRET-AGENT-PROMPT-88');
+  });
+});
+
 describe('skill.dispatched / skill.completed telemetry (inline registry path)', () => {
   /**
    * Closes the inline-skill telemetry blind spot. Plugin skills + forked
@@ -803,5 +905,77 @@ describe('compose routing rows — Fix 2 (compose-executor.ts identity)', () => 
     expect(evt).toBeDefined();
     expect('origin' in (evt ?? {})).toBe(false);
     expect('actor' in (evt ?? {})).toBe(false);
+  });
+});
+
+describe('delegation.skipped telemetry (compose depth limit)', () => {
+  beforeEach(() => {
+    // mockClear (not just mockResolvedValue): the hoisted DAG mock is shared
+    // file-wide and its call history is never reset globally, so a
+    // `not.toHaveBeenCalled()` assertion here would otherwise observe
+    // dispatches from earlier describe blocks.
+    mockRunSubagentDAG.mockClear();
+    mockRunSubagentDAG.mockResolvedValue({ outputs: { n1: 'ok' }, failed: [], skipped: [] });
+  });
+
+  // Invariant: this gate is INERT at any non-zero cap — `compose` is absent
+  // from CHILD_ALLOWED_TOOLS, so the executor is only ever wired at the root
+  // (depth 0). The reachable case is AFK_MAX_NESTING_DEPTH=0, the documented
+  // "disable nested delegation entirely" escape hatch. These cases exist so
+  // that promise covers compose too, not just `agent` and `skill`.
+  it('emits delegation.skipped with reason=max_depth when the cap is 0', async () => {
+    const executor = new ComposeExecutor(makeComposeContext({ maxDepth: 0 }));
+    const result = await executor.execute(makeComposeCall());
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('nesting depth');
+    expect(mockRunSubagentDAG).not.toHaveBeenCalled();
+
+    const evt = findEvent('delegation.skipped');
+    expect(evt).toBeDefined();
+    expect(evt).toMatchObject({
+      event: 'delegation.skipped',
+      reason: 'max_depth',
+      depth: 0,
+      parent_session_id: 'compose-parent-sess',
+    });
+  });
+
+  it('carries origin + actor on the refusal row when surface is set', async () => {
+    const executor = new ComposeExecutor(
+      makeComposeContext({ maxDepth: 0, surface: 'daemon', depth: 0 }),
+    );
+    await executor.execute(makeComposeCall());
+
+    const evt = findEvent('delegation.skipped');
+    expect(evt?.['origin']).toBe('daemon');
+    expect(evt?.['actor']).toBe('main');
+  });
+
+  it('omits requested_name — compose dispatches no named unit', async () => {
+    const executor = new ComposeExecutor(makeComposeContext({ maxDepth: 0 }));
+    await executor.execute(makeComposeCall());
+
+    const evt = findEvent('delegation.skipped');
+    expect(evt).toBeDefined();
+    expect(evt!['requested_name']).toBeUndefined();
+  });
+
+  it('does not emit delegation.skipped at the default cap', async () => {
+    const executor = new ComposeExecutor(makeComposeContext());
+    await executor.execute(makeComposeCall());
+    expect(findEvent('delegation.skipped')).toBeUndefined();
+  });
+
+  it('depth-gate refusal payload does not contain node prompts', async () => {
+    const executor = new ComposeExecutor(makeComposeContext({ maxDepth: 0 }));
+    await executor.execute({
+      id: 'cc-secret',
+      name: 'compose',
+      input: { nodes: [{ id: 'n1', prompt: 'SECRET-NODE-PROMPT-99' }] },
+      signal: new AbortController().signal,
+    });
+    const serialized = JSON.stringify(appendRoutingDecision.mock.calls);
+    expect(serialized).not.toContain('SECRET-NODE-PROMPT-99');
   });
 });

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -326,7 +326,8 @@ export const agentTool: AnthropicToolDef = {
     'research-shaped investigation.\n\n' +
     'Parallelize: dispatch multiple `agent` calls in a single tool-use turn to run ' +
     'independent investigations concurrently.\n\n' +
-    'Nest: a subagent may itself dispatch further subagents (depth limit 3) when it ' +
+    'Nest: a subagent may itself dispatch further subagents (depth limit 3 by default — ' +
+    '`get_runtime_state` reports the live cap) when it ' +
     'discovers a separable sub-investigation.\n\n' +
     'Subagents return their final assistant message verbatim — instruct them ' +
     'explicitly to compress their findings into: answer, evidence with file:line ' +

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -326,9 +326,9 @@ export const agentTool: AnthropicToolDef = {
     'research-shaped investigation.\n\n' +
     'Parallelize: dispatch multiple `agent` calls in a single tool-use turn to run ' +
     'independent investigations concurrently.\n\n' +
-    'Nest: a subagent may itself dispatch further subagents (depth limit 3 by default — ' +
-    '`get_runtime_state` reports the live cap) when it ' +
-    'discovers a separable sub-investigation.\n\n' +
+    'Nest: a subagent may itself dispatch further subagents (depth limit 3 by default) when it ' +
+    'discovers a separable sub-investigation. Inside a subagent, `get_runtime_state` reports ' +
+    'the live cap.\n\n' +
     'Subagents return their final assistant message verbatim — instruct them ' +
     'explicitly to compress their findings into: answer, evidence with file:line ' +
     'citations, confidence, risks, recommended next action, unresolved questions, ' +

--- a/src/agent/tools/skill-depth-message.ts
+++ b/src/agent/tools/skill-depth-message.ts
@@ -1,5 +1,10 @@
 /**
- * Skill-tool max-nesting-depth refusal message.
+ * Max-nesting-depth refusal messages for the delegation tools (`skill`, `agent`).
+ *
+ * The module is still filed under its original skill-specific name so the
+ * `afk improve eval-run` contract refs that cite it by path stay valid; it now
+ * serves both tools, which share one recovery hint because a caller at the
+ * depth wall has the same remedy either way.
  *
  * Extracted as a pure, dependency-free module so two consumers share one
  * source of truth:
@@ -34,4 +39,27 @@ export const SKILL_MAX_DEPTH_RECOVERY_HINT =
  */
 export function buildSkillMaxDepthRefusal(depth: number, maxDepth: number): string {
   return `Skill tool not available at nesting depth ${depth} (max ${maxDepth}). ${SKILL_MAX_DEPTH_RECOVERY_HINT}`;
+}
+
+/**
+ * Build the refusal returned by the `agent` tool at or beyond the nesting-depth
+ * limit. Deliberately the same shape and the same
+ * {@link SKILL_MAX_DEPTH_RECOVERY_HINT} as the skill refusal — the hint's text
+ * ("perform the work inline … instead of calling skill/agent/compose") was
+ * already tool-agnostic, and a caller that hits the wall on one tool must not
+ * be told to reach for the other.
+ */
+export function buildAgentMaxDepthRefusal(depth: number, maxDepth: number): string {
+  return `Agent tool not available at nesting depth ${depth} (max ${maxDepth}). ${SKILL_MAX_DEPTH_RECOVERY_HINT}`;
+}
+
+/**
+ * Build the refusal returned by the `compose` tool at or beyond the
+ * nesting-depth limit. Reachable only when the cap is `0`: `compose` is absent
+ * from the child tool allowlist, so the executor is never wired below the root.
+ * It exists so `AFK_MAX_NESTING_DEPTH=0` closes every dispatch door rather than
+ * three-quarters of them.
+ */
+export function buildComposeMaxDepthRefusal(depth: number, maxDepth: number): string {
+  return `Compose tool not available at nesting depth ${depth} (max ${maxDepth}). ${SKILL_MAX_DEPTH_RECOVERY_HINT}`;
 }

--- a/src/agent/tools/skill-executor.ts
+++ b/src/agent/tools/skill-executor.ts
@@ -26,7 +26,7 @@ import { getSkill } from '../../skills/index.js';
 import type { IAgentSession } from '../types.js';
 import type { ToolCall, ToolResult } from './types.js';
 import { collectSkillEntries, discoverPluginSkillBodies, type PluginSkillBody } from './skill-bridge.js';
-import { DEFAULT_MAX_NESTING_DEPTH, DEFAULT_READ_ONLY_SKILLS } from './nesting.js';
+import { DEFAULT_READ_ONLY_SKILLS, resolveMaxNestingDepth } from './nesting.js';
 import { buildSkillMaxDepthRefusal } from './skill-depth-message.js';
 import { appendRoutingDecision } from '../routing-telemetry.js';
 import { isTrustedSkill } from '../_lib/trusted-skill-registry.js';
@@ -121,7 +121,7 @@ export class SkillExecutor {
     }
 
     const depth = this.ctx.depth ?? 0;
-    const maxDepth = this.ctx.maxDepth ?? DEFAULT_MAX_NESTING_DEPTH;
+    const maxDepth = this.ctx.maxDepth ?? resolveMaxNestingDepth();
     if (depth >= maxDepth) {
       // Best-effort: surface a name for the telemetry payload without
       // changing the error precedence (parse errors still come later).

--- a/src/agent/tools/skill-executor/fork-child-config.ts
+++ b/src/agent/tools/skill-executor/fork-child-config.ts
@@ -15,7 +15,7 @@ import { SubagentManager } from '../../subagent.js';
 import { resolveChildManagerReadRoots } from '../../subagent-read-scope.js';
 import type { AgentConfig } from '../../types/config-types.js';
 import {
-  DEFAULT_MAX_NESTING_DEPTH,
+  resolveMaxNestingDepth,
   RECON_ALLOWED_TOOLS,
   buildReadOnlyReconProvider,
   createStubParentSession,
@@ -58,7 +58,7 @@ export function buildForkedChildConfig(
 ): { childConfig: AgentConfig; childManager: SubagentManager | undefined } {
   const { ctx, currentCwd } = internals;
   const depth = ctx.depth ?? 0;
-  const maxDepth = ctx.maxDepth ?? DEFAULT_MAX_NESTING_DEPTH;
+  const maxDepth = ctx.maxDepth ?? resolveMaxNestingDepth();
   const childConfig: AgentConfig = { ...baseConfig };
 
   // Invariant (single source of truth for effective allowlist):

--- a/src/agent/tools/subagent-executor.named-agents.test.ts
+++ b/src/agent/tools/subagent-executor.named-agents.test.ts
@@ -284,10 +284,16 @@ describe('SubagentExecutor named-agent dispatch', () => {
     expect(factoryCalls[0]?.['readOnlyBash']).toBe(true);
   });
 
-  it('falls back to a restricted provider at the depth cap instead of failing open', async () => {
-    const executor = makeExecutor({ depth: 3, maxDepth: 3 });
+  it('falls back to a restricted provider with no nesting factory instead of failing open', async () => {
+    // buildChildConfig skips the nesting branch when EITHER the factory is
+    // absent OR depth >= maxDepth; without an explicit provider the fork would
+    // inherit the default UNRESTRICTED one and the named agent's contract would
+    // silently fail open. The depth trigger is no longer reachable from
+    // execute() (it now refuses at the cap — see subagent-executor.test.ts),
+    // so the no-factory route is what keeps this fail-safe under test.
+    const executor = makeExecutor({ childProviderFactory: undefined });
     await executor.execute(makeCall({ prompt: 'go', agent_type: 'research-agent' }));
-    expect(factoryCalls).toHaveLength(0); // factory not used at cap
+    expect(factoryCalls).toHaveLength(0); // no factory wired
     const forkArgs = forkSubagent.mock.calls[0]?.[0];
     // A provider override IS present (the restricted fallback), not undefined.
     expect(forkArgs.config.provider).toBeDefined();

--- a/src/agent/tools/subagent-executor.test.ts
+++ b/src/agent/tools/subagent-executor.test.ts
@@ -1042,6 +1042,10 @@ describe('SubagentExecutor', () => {
 
       expect(result.isError).toBe(true);
       expect(result.content).toContain('Agent tool not available at nesting depth 0 (max 0)');
+      // The recovery hint is the user-facing half of the refusal: a caller told
+      // only "not available" has no next move. Asserted on BOTH refusal paths
+      // (here and at the cap above) so a future refactor cannot drop it from one.
+      expect(result.content).toContain(SKILL_MAX_DEPTH_RECOVERY_HINT);
       expect(manager.forkSubagent).not.toHaveBeenCalled();
     });
 

--- a/src/agent/tools/subagent-executor.test.ts
+++ b/src/agent/tools/subagent-executor.test.ts
@@ -4,7 +4,7 @@
  * Run with: npm test -- tests/agent/tools/subagent-executor.test.ts
  */
 
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest';
 
 // Hoisted mock so SubagentExecutor picks up the mocked appendRoutingDecision.
 const appendRoutingDecision = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
@@ -29,6 +29,7 @@ import type { ToolCall } from './types.js';
 import type { ModelProvider } from '../provider.js';
 import { SubagentExecutor, DEFAULT_MAX_NESTING_DEPTH, type SubagentExecutorContext } from './subagent-executor.js';
 import { SUBAGENT_HANDOFF_CONTRACT } from '../subagent-contract.js';
+import { SKILL_MAX_DEPTH_RECOVERY_HINT } from './skill-depth-message.js';
 import { stripEscapeSequences } from '../../utils/terminal-sanitize.js';
 
 function mockHandle(
@@ -1012,18 +1013,36 @@ describe('SubagentExecutor', () => {
       expect(args.childExecutor).toBeInstanceOf(SubagentExecutor);
     });
 
-    it('does not set provider when at maxDepth', async () => {
+    it('refuses the dispatch at maxDepth instead of forking a capped leaf', async () => {
+      // Contract change: the cap used to be enforced only by child-config NOT
+      // wiring nested executors (`depth < maxDepth`), so a dispatch AT the cap
+      // still forked a child — one generation deeper than `skill`, which
+      // refuses at `depth >= maxDepth`. Both tools now stop at the same depth.
       const { executor: nestingExec, manager, factory } = makeNestingExecutor({
         depth: 3,
         maxDepth: 3,
       });
 
-      await nestingExec.execute(makeCall());
+      const result = await nestingExec.execute(makeCall());
 
-      const forkCall = (manager.forkSubagent as ReturnType<typeof vi.fn>).mock.calls[0] as unknown[];
-      const config = (forkCall[0] as { config: AgentConfig }).config;
-      expect(config.provider).toBeUndefined();
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('Agent tool not available at nesting depth 3 (max 3)');
+      expect(result.content).toContain(SKILL_MAX_DEPTH_RECOVERY_HINT);
+      expect(manager.forkSubagent).not.toHaveBeenCalled();
       expect(factory).not.toHaveBeenCalled();
+    });
+
+    it('refuses every dispatch when maxDepth is 0 (nesting disabled)', async () => {
+      const { executor: nestingExec, manager } = makeNestingExecutor({
+        depth: 0,
+        maxDepth: 0,
+      });
+
+      const result = await nestingExec.execute(makeCall());
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('Agent tool not available at nesting depth 0 (max 0)');
+      expect(manager.forkSubagent).not.toHaveBeenCalled();
     });
 
     it('does not set provider when no factory is provided', async () => {
@@ -1104,12 +1123,73 @@ describe('SubagentExecutor', () => {
         // maxDepth omitted — should default to DEFAULT_MAX_NESTING_DEPTH
       });
 
-      await depthAtMax.execute(makeCall());
+      const result = await depthAtMax.execute(makeCall());
 
-      const forkCall = (manager.forkSubagent as ReturnType<typeof vi.fn>).mock.calls[0] as unknown[];
-      const config = (forkCall[0] as { config: AgentConfig }).config;
-      expect(config.provider).toBeUndefined();
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain(
+        `Agent tool not available at nesting depth ${DEFAULT_MAX_NESTING_DEPTH} (max ${DEFAULT_MAX_NESTING_DEPTH})`,
+      );
+      expect(manager.forkSubagent).not.toHaveBeenCalled();
       expect(factory).not.toHaveBeenCalled();
+    });
+
+    // AFK_MAX_NESTING_DEPTH feeds the SAME `??` fallback the omitted-maxDepth
+    // case above exercises — see resolveMaxNestingDepth's unit tests in
+    // nesting.test.ts for the parsing contract.
+    describe('AFK_MAX_NESTING_DEPTH at the dispatch site', () => {
+      const KEY = 'AFK_MAX_NESTING_DEPTH';
+      let original: string | undefined;
+      beforeEach(() => {
+        original = process.env[KEY];
+        delete process.env[KEY];
+      });
+      afterEach(() => {
+        if (original !== undefined) process.env[KEY] = original;
+        else delete process.env[KEY];
+      });
+
+      it('tightens the cap for an executor that omits maxDepth', async () => {
+        process.env[KEY] = '1';
+        const { executor: nestingExec, manager } = makeNestingExecutor({
+          depth: 1,
+          maxDepth: undefined,
+        });
+
+        const result = await nestingExec.execute(makeCall());
+
+        expect(result.isError).toBe(true);
+        expect(result.content).toContain('Agent tool not available at nesting depth 1 (max 1)');
+        expect(manager.forkSubagent).not.toHaveBeenCalled();
+      });
+
+      it('still permits a dispatch below the env-tightened cap', async () => {
+        process.env[KEY] = '1';
+        const { executor: nestingExec, manager } = makeNestingExecutor({
+          depth: 0,
+          maxDepth: undefined,
+        });
+
+        const result = await nestingExec.execute(makeCall());
+
+        expect(result.isError).toBeFalsy();
+        expect(manager.forkSubagent).toHaveBeenCalledOnce();
+      });
+
+      it('loses to an explicit ctx.maxDepth', async () => {
+        // Precedence: the env value resolves the DEFAULT only. A caller that
+        // passes maxDepth explicitly (every test double, and any programmatic
+        // embedder) is unaffected by the environment.
+        process.env[KEY] = '0';
+        const { executor: nestingExec, manager } = makeNestingExecutor({
+          depth: 0,
+          maxDepth: 3,
+        });
+
+        const result = await nestingExec.execute(makeCall());
+
+        expect(result.isError).toBeFalsy();
+        expect(manager.forkSubagent).toHaveBeenCalledOnce();
+      });
     });
 
     it('B1: forwards ctx.allowedTools and ctx.readOnlyBash into childProviderFactory and recursive child executor', async () => {

--- a/src/agent/tools/subagent-executor.ts
+++ b/src/agent/tools/subagent-executor.ts
@@ -16,7 +16,7 @@ import type { AgentModelInput, IAgentSession } from '../types.js';
 import type { AgentConfig } from '../types/config-types.js';
 import type { AnthropicToolDef, ToolCall, ToolResult } from './types.js';
 import {
-  DEFAULT_MAX_NESTING_DEPTH,
+  resolveMaxNestingDepth,
   type ChildProviderFactoryArgs,
 } from './nesting.js';
 import { buildAgentToolDef } from '../agents/index.js';
@@ -33,6 +33,8 @@ import { runBackgroundBranch } from './subagent/background-branch.js';
 import { runForegroundWithPromotion, type PromotionTrigger } from './subagent/foreground-promotion.js';
 import { createIsolatedWorktree } from './handlers/worktree-managed.js';
 import { debugLog } from '../../utils/debug.js';
+import { appendRoutingDecision } from '../routing-telemetry.js';
+import { buildAgentMaxDepthRefusal } from './skill-depth-message.js';
 
 export { DEFAULT_MAX_NESTING_DEPTH, type ChildProviderFactoryArgs } from './nesting.js';
 export type { AgentExecutionMode };
@@ -471,7 +473,7 @@ export class SubagentExecutor implements SubagentControl {
     // the silent misconfig fallback the Phase 1 awareness contract is designed
     // to avoid.
     const depth = this.ctx.depth;
-    const maxDepth = this.ctx.maxDepth ?? DEFAULT_MAX_NESTING_DEPTH;
+    const maxDepth = this.ctx.maxDepth ?? resolveMaxNestingDepth();
 
     // Session identity for routing-decision rows. Only emitted when this
     // executor was wired with a `surface` (the new top-level wiring); legacy/
@@ -481,6 +483,32 @@ export class SubagentExecutor implements SubagentControl {
       this.ctx.surface !== undefined
         ? { origin: deriveOrigin(this.ctx.surface), actor: actorFromDepth(depth) }
         : {};
+
+    // Depth cap, mirroring the `skill` tool's guard (skill-executor.ts). Before
+    // this existed the cap was enforced only by child-config.ts NOT wiring
+    // nested executors into the child it builds (`depth < maxDepth`), which
+    // made the two tools stop one generation apart: a depth-3 child (wired by
+    // its depth-2 parent, which passed that gate) still held a live `agent`
+    // tool and could fork a depth-4 leaf, whereas `skill` already refused at
+    // depth 3. The leaf then answered "Agent tool is not available in this
+    // session configuration" from the dispatcher — a config-shaped message for
+    // what is really a depth wall, with no recovery hint. Refusing here makes
+    // `maxDepth` mean one thing for both tools and hands back the actionable
+    // "work inline" clause instead.
+    if (depth >= maxDepth) {
+      void appendRoutingDecision({
+        ...identity,
+        event: 'delegation.skipped',
+        parent_session_id: this.ctx.parentSession.sessionId,
+        reason: 'max_depth',
+        depth,
+        ...(parsed.agent_type !== undefined ? { requested_name: parsed.agent_type } : {}),
+      }).catch(() => {});
+      return {
+        content: buildAgentMaxDepthRefusal(depth, maxDepth),
+        isError: true,
+      };
+    }
 
     // Transitive read-scope propagation (see ../subagent-read-scope): compute
     // THIS child's inherited read roots from the manager that will fork it, so

--- a/src/agent/tools/subagent/child-config.ts
+++ b/src/agent/tools/subagent/child-config.ts
@@ -309,6 +309,12 @@ export function buildChildConfig(args: BuildChildConfigArgs): BuildChildConfigRe
   // dispatch Agent and Skill tool calls. Skip when at maxDepth or no
   // factory — child gracefully loses both tools.
   //
+  // Invariant: the `depth < maxDepth` disjunct is no longer reachable from
+  // SubagentExecutor.execute(), which refuses at `depth >= maxDepth` before
+  // calling this. It is retained as defense-in-depth for direct callers (and
+  // is exercised as such by child-config.test.ts); the live production trigger
+  // is the `!childProviderFactory` half.
+  //
   // childParentSession is a mutable stub: sessionId starts undefined and is
   // backfilled to handle.id once forkSubagent resolves. This ensures depth-2
   // forks (dispatched by childExecutor) see a real parentId rather than

--- a/src/agent/types/config-types.ts
+++ b/src/agent/types/config-types.ts
@@ -623,7 +623,16 @@ export interface AgentConfig {
   /** Nesting depth assigned at fork (0-indexed). Top-level → undefined. */
   depth?: number;
 
-  /** Maximum allowed nesting depth at fork time. */
+  /**
+   * Maximum allowed nesting depth at fork time.
+   *
+   * Contract: an explicit value here (and on SubagentExecutorContext /
+   * SkillExecutorContext) wins over `AFK_MAX_NESTING_DEPTH` and is NOT
+   * checked against `MAX_NESTING_DEPTH_CEILING` — the ceiling guards the
+   * env-parsed default only. An embedder that sets this field owns the
+   * fan-out consequences. Not reachable from model tool-call input: neither
+   * parseAgentInput nor parseSkillInput accepts a depth field.
+   */
   maxDepth?: number;
 
   /** Phase enforcement tag inherited from `ForkSubagentOptions.phaseRole`. */

--- a/src/cli/commands/chat.mcp.test.ts
+++ b/src/cli/commands/chat.mcp.test.ts
@@ -112,6 +112,9 @@ vi.mock('../../agent/tools/skill-bridge.js', () => ({
 vi.mock('../../agent/tools/nesting.js', () => ({
   createChildProviderFactory: vi.fn(() => ({})),
   createChildSkillExecutorFactory: vi.fn(() => ({})),
+  // wireExecutors() resolves the nesting cap once at the root (#871). The chat
+  // surface never exercises depth, so return the production default.
+  resolveMaxNestingDepth: vi.fn(() => 3),
 }));
 
 vi.mock('../../agent/providers/anthropic-direct/index.js', () => ({

--- a/src/cli/commands/chat.post.test.ts
+++ b/src/cli/commands/chat.post.test.ts
@@ -114,6 +114,9 @@ vi.mock('../../agent/tools/compose-executor.js', () => ({
 vi.mock('../../agent/tools/nesting.js', () => ({
   createChildProviderFactory: vi.fn(() => ({})),
   createChildSkillExecutorFactory: vi.fn(() => ({})),
+  // wireExecutors() resolves the nesting cap once at the root (#871). The chat
+  // surface never exercises depth, so return the production default.
+  resolveMaxNestingDepth: vi.fn(() => 3),
 }));
 
 vi.mock('../../agent/providers/anthropic-direct/index.js', () => ({

--- a/src/cli/commands/chat.resume.test.ts
+++ b/src/cli/commands/chat.resume.test.ts
@@ -140,6 +140,9 @@ vi.mock('../../agent/tools/compose-executor.js', () => ({
 vi.mock('../../agent/tools/nesting.js', () => ({
   createChildProviderFactory: vi.fn(() => ({})),
   createChildSkillExecutorFactory: vi.fn(() => ({})),
+  // wireExecutors() resolves the nesting cap once at the root (#871). The chat
+  // surface never exercises depth, so return the production default.
+  resolveMaxNestingDepth: vi.fn(() => 3),
 }));
 
 vi.mock('../../agent/providers/anthropic-direct/index.js', () => ({

--- a/src/cli/commands/chat.stdin.test.ts
+++ b/src/cli/commands/chat.stdin.test.ts
@@ -106,6 +106,9 @@ vi.mock('../../agent/tools/compose-executor.js', () => ({
 vi.mock('../../agent/tools/nesting.js', () => ({
   createChildProviderFactory: vi.fn(() => ({})),
   createChildSkillExecutorFactory: vi.fn(() => ({})),
+  // wireExecutors() resolves the nesting cap once at the root (#871). The chat
+  // surface never exercises depth, so return the production default.
+  resolveMaxNestingDepth: vi.fn(() => 3),
 }));
 
 vi.mock('../../agent/providers/anthropic-direct/index.js', () => ({

--- a/src/cli/commands/chat.stream-json.test.ts
+++ b/src/cli/commands/chat.stream-json.test.ts
@@ -128,6 +128,9 @@ vi.mock('../../agent/tools/compose-executor.js', () => ({
 vi.mock('../../agent/tools/nesting.js', () => ({
   createChildProviderFactory: vi.fn(() => ({})),
   createChildSkillExecutorFactory: vi.fn(() => ({})),
+  // wireExecutors() resolves the nesting cap once at the root (#871). The chat
+  // surface never exercises depth, so return the production default.
+  resolveMaxNestingDepth: vi.fn(() => 3),
 }));
 
 vi.mock('../../agent/providers/anthropic-direct/index.js', () => ({

--- a/src/cli/commands/daemon-session-factory.test.ts
+++ b/src/cli/commands/daemon-session-factory.test.ts
@@ -225,4 +225,30 @@ describe('buildDaemonSessionFactory', () => {
 
     void session.close().catch(() => undefined);
   });
+
+  it('snapshots one environment nesting cap across all root executors', () => {
+    const key = 'AFK_MAX_NESTING_DEPTH';
+    const original = process.env[key];
+    let session: ReturnType<ReturnType<typeof buildDaemonSessionFactory>> | undefined;
+    try {
+      process.env[key] = '1';
+      const factory = buildDaemonSessionFactory({ model: 'sonnet', apiKey: TEST_API_KEY });
+      session = factory(makeConfig());
+      const internals = session as unknown as { config?: { provider?: unknown } };
+      const provider = internals.config?.provider as AnthropicDirectProvider;
+
+      // A later mutation must not change any sibling executor in this session.
+      process.env[key] = '0';
+      const subExec = readSubagentExecutor(provider) as { ctx?: { maxDepth?: number } };
+      const skillExec = readSkillExecutor(provider) as { ctx?: { maxDepth?: number } };
+      const composeExec = readComposeExecutor(provider) as { ctx?: { maxDepth?: number } };
+      expect(subExec.ctx?.maxDepth).toBe(1);
+      expect(skillExec.ctx?.maxDepth).toBe(1);
+      expect(composeExec.ctx?.maxDepth).toBe(1);
+    } finally {
+      if (original === undefined) delete process.env[key];
+      else process.env[key] = original;
+      void session?.close().catch(() => undefined);
+    }
+  });
 });

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -208,6 +208,25 @@ export const ENV_REGISTRY: readonly EnvVarMeta[] = [
     category: 'model',
   },
   {
+    name: 'AFK_MAX_NESTING_DEPTH',
+    description:
+      'Maximum sub-agent/skill nesting depth; 0 disables nested delegation entirely (the agent, ' +
+      'skill, AND compose tools all refuse). A top-level session is depth 0, so the default 3 ' +
+      'permits three generations of forked descendants (depth 1 → 2 → 3) and refuses the agent ' +
+      'and skill tools at depth 3. Resolved once ' +
+      'at the root of each session and propagated down through child AgentConfig, so descendants ' +
+      'inherit the root value rather than re-reading the environment. Raise with care: depth is a ' +
+      'fan-out exponent (a width-N wave at depth D reaches ~N^D concurrent children), so values ' +
+      'above 4 invite provider rate-limit (429) cascades. Accepted range 0-6; unset, empty, ' +
+      'unparseable, negative, or out-of-range input falls back to the default. An explicit ' +
+      'programmatic maxDepth (SubagentExecutorContext / SkillExecutorContext) still wins.',
+    type: 'number',
+    required: false,
+    default: '3',
+    example: '2',
+    category: 'model',
+  },
+  {
     name: 'AFK_MAX_OUTPUT_TOKENS',
     description: 'Cap on output tokens per turn. Falls back to provider default when unset.',
     type: 'number',
@@ -1438,6 +1457,7 @@ export const env = {
   get AFK_EFFORT(): string | undefined { return process.env['AFK_EFFORT']; },
   get AFK_FORCE_BASH_INTERPRETER_GUARD(): string | undefined { return process.env['AFK_FORCE_BASH_INTERPRETER_GUARD']; },
   get AFK_MAX_BUDGET_USD(): string | undefined { return process.env['AFK_MAX_BUDGET_USD']; },
+  get AFK_MAX_NESTING_DEPTH(): string | undefined { return process.env['AFK_MAX_NESTING_DEPTH']; },
   get AFK_MAX_OUTPUT_TOKENS(): string | undefined { return process.env['AFK_MAX_OUTPUT_TOKENS']; },
   get AFK_MAX_TOKENS(): string | undefined { return process.env['AFK_MAX_TOKENS']; },
   get AFK_MAX_TOOL_USE_ITERATIONS(): string | undefined { return process.env['AFK_MAX_TOOL_USE_ITERATIONS']; },


### PR DESCRIPTION
## What

Makes the sub-agent/skill nesting-depth cap configurable at runtime via a new `AFK_MAX_NESTING_DEPTH` env var, and closes two coherence gaps that the knob would otherwise expose.

## Why

`DEFAULT_MAX_NESTING_DEPTH = 3` (`src/agent/tools/nesting.ts`) was the only way to set the cap. There was no env var, no `afk.config.json` key, and — notably — **no wiring site passes `maxDepth` at all**, so every real surface (chat, REPL, Telegram, daemon, threads) fell through to the `?? DEFAULT_MAX_NESTING_DEPTH` fallback. That made the fallback the effective value and the whole knob a one-line swap, with no surface plumbing required.

## How

`resolveMaxNestingDepth()` lands beside the constant, mirroring the existing `resolveSubagentTimeoutMs()` precedent (`src/agent/subagent/constants.ts`): parse the var, accept a finite integer in `[0, MAX_NESTING_DEPTH_CEILING]` (6), fall back to the default on unset / empty / unparseable / negative / above-ceiling input. Consumed at the three `ctx.maxDepth ?? …` sites:

- `src/agent/tools/subagent-executor.ts`
- `src/agent/tools/skill-executor.ts`
- `src/agent/tools/skill-executor/fork-child-config.ts`

Two properties worth calling out:

- **Explicit wins.** A programmatic `ctx.maxDepth` still beats the env value via the same `??`, so every existing caller and test double is unaffected. The ceiling deliberately does not apply to an explicit override — documented on `AgentConfig.maxDepth`, and unreachable from model input (neither `parseAgentInput` nor `parseSkillInput` accepts a depth field).
- **Resolved once.** The root resolves; descendants inherit through `AgentConfig.maxDepth` and `childSkillExecutorFactory(depth + 1, maxDepth, …)`. No child re-reads the environment, so a mid-process mutation cannot desynchronise one branch of the tree from another.

The ceiling is not decoration: depth is a fan-out **exponent** — a width-N wave at depth D reaches ~N^D concurrent children against a single provider rate limit — so `30` typed for `3` is a 429 cascade, not a slow run.

### Gap 1: `agent` reached one generation deeper than `skill`

The agent cap was enforced only by `child-config.ts` declining to wire nested executors (`depth < maxDepth`), never by a refusal. So a depth-3 child — wired by its depth-2 parent, which passed that gate — still held a live `agent` tool and could fork a depth-4 leaf. That leaf then answered `Agent tool is not available in this session configuration` from the dispatcher: a config-shaped message for what is really a depth wall, with no recovery hint. Meanwhile `skill` already refused at `depth >= maxDepth`.

`SubagentExecutor.execute()` now refuses at `depth >= maxDepth`, emits the same `delegation.skipped` / `max_depth` routing row the skill path emits, and returns the actionable "work inline" hint. `maxDepth` now means one thing for both tools.

### Gap 2: `compose` had no depth gate at all

`AFK_MAX_NESTING_DEPTH=0` would have disabled `agent` and `skill` while leaving `compose` free to fan out — making the var's own documentation false. `ComposeExecutor.execute()` gets the same gate. It is **inert at any non-zero cap** (compose is excluded from `CHILD_ALLOWED_TOOLS`, so the executor is only ever wired at the root, depth 0); it exists so that "0 disables nested delegation entirely" is true rather than three-quarters true.

## Behavior change

Only at the cap boundary, and only for `agent`:

| | before | after |
|---|---|---|
| `skill` at `depth == maxDepth` | refusal + hint | unchanged |
| `agent` at `depth == maxDepth` | forks a depth-4 leaf that can call nothing | refusal + hint |
| `compose` at `depth == maxDepth` | runs | refusal + hint (reachable only at cap 0) |

Nothing in the repo's fixed pipelines reaches depth 3 with a live nested dispatch: DAG nodes are never wired with `agent`/`skill`/`compose`, mint's phase forks are permanent leaves, and the named-agent chain caps at two hops (`research-agent` → `git-investigator`). The reachable case is unrestricted freeform recursion (`general-purpose` → `general-purpose` → …), which now gets a legible refusal one generation earlier instead of a mute leaf.

## Tests

- `resolveMaxNestingDepth` parsing contract: unset, empty/whitespace, valid below/above default, `0`, negative, above ceiling (incl. the `30`-for-`3` typo case), garbage, plus an `ENV_REGISTRY`-default lockstep guard.
- New agent refusal at the cap and at `0`; `AFK_MAX_NESTING_DEPTH` at the dispatch site (tightens an omitted-`maxDepth` executor, permits below the cap, loses to an explicit `ctx.maxDepth`).
- Compose gate: refuses at `0`, runs at the default, honours explicit `ctx.maxDepth`.
- **Three existing tests changed.** Two asserted the old silent-omission behavior at the cap and now assert the refusal. The third (named-agents "fail-open at the depth cap") was retargeted to trigger via the still-reachable `childProviderFactory: undefined` route, because the depth trigger is no longer reachable from `execute()`; the `depth < maxDepth` disjunct in `child-config.ts` is retained as defense-in-depth and commented as such.

## Verification

- `pnpm lint` (tsc --noEmit, strict) clean
- `pnpm test` — 757 files, 14,416 passed, 2 skipped
- `pnpm scan:env:check` in sync (142 vars), `pnpm audit:env:check` 0 violations, `pnpm audit:sdk:check` OK

Reviewed pre-push by a two-dimension `/review` wave (security·api-compat, correctness·spec-compliance·test-coverage). No critical or high findings; every low/medium finding it raised is folded into this branch — registry alphabetical ordering, the ceiling caveat on `AgentConfig.maxDepth`, the unreachable-branch comment, the stale hardcoded `3` in the `agent` tool description, and the compose gap above.

## Not done

- `get_runtime_state`'s `self` view still reports `maxDepth: null` for a top-level session (it sources from `AgentConfig.maxDepth`, which is fork-only by design). Threading the resolved root value there is a separate, additive change.
- `skill-depth-message.ts` now holds all three refusal builders and is no longer skill-specific. Left un-renamed so the `afk improve eval-run` contract refs that cite it by path stay valid.
