### PR TITLE
fix(tui): close the 1.5s–30s live-progress dead zone (#857)

### DIFF
--- a/src/cli/_lib/child-activity-select.test.ts
+++ b/src/cli/_lib/child-activity-select.test.ts
@@ -197,7 +197,7 @@ describe('ChildActivityTracker.select', () => {
       ]);
       const picked = new ChildActivityTracker().select(sources, NOW);
       expect(picked?.quiet).toBe(true);
-      expect(picked?.clause).toBe('no output for 41s');
+      expect(picked?.clause).toBe('no output (waiting)');
       // The silence must win over the stale round headline — reporting old work
       // as if current is what makes a hung wave look healthy.
       expect(picked?.clause).not.toContain('round 2');
@@ -217,7 +217,7 @@ describe('ChildActivityTracker.select', () => {
         ['a', makeSource({ agentType: 'sees', lastEventAt: NOW - 45_000 })],
       ]);
       expect(new ChildActivityTracker().select(sources, NOW)?.clause).toBe(
-        'no output for 45s',
+        'no output (waiting)',
       );
     });
   });

--- a/src/cli/_lib/child-activity-select.ts
+++ b/src/cli/_lib/child-activity-select.ts
@@ -24,7 +24,7 @@
  * @module cli/_lib/child-activity-select
  */
 
-import { formatDuration, formatToolCallStat } from '../format-utils.js';
+import { formatToolCallStat } from '../format-utils.js';
 import { ORCHESTRATOR_SOURCE_KEY, type SourceState } from './stream-renderer-source.js';
 import type { ProgressEvent } from '../../agent/types.js';
 
@@ -42,13 +42,21 @@ export const STICKY_HOLD_MS = 3000;
 /**
  * Silence past which the banner names the child as producing no output.
  *
- * Matches `PAUSE_THRESHOLD_MS` in stream-renderer-lifecycle.ts so the banner
- * and the tool-lane's `· waiting Xs` annotation agree rather than reporting two
- * different notions of "stalled". The lane keeps its own label (renamed to
- * `waiting` deliberately — see stream-renderer-visibility.test.ts); this adds
- * the same fact in the higher-salience slot where the eye already rests.
+ * Deliberately decoupled from `PAUSE_THRESHOLD_MS` in stream-renderer-lifecycle.ts
+ * (which stays at 30s): the banner reports "no output (waiting)" earlier so the
+ * operator sees a quiet child during the 8s–30s dead zone that the tool-lane's
+ * `· waiting Xs` annotation (armed only past 30s) does not cover. The static
+ * clause avoids a live-ticking counter that would change the composed string on
+ * every recompose (breaking setOverlay's identical-string dedup), so the banner
+ * flips once at this threshold and then stays byte-stable —
+ * `checkProgressBannerStaleness` rides the existing 80ms pause tick to trigger
+ * that one flip without adding a new timer (see live-progress-no-timer.test.ts).
+ *
+ * Invariant: must exceed `STICKY_HOLD_MS` (3s) so the sticky selector has settled
+ * before the silence clause appears, and must exceed the 1500ms per-parent
+ * overlay throttle in stream-renderer-subagent.ts.
  */
-export const CHILD_QUIET_MS = 30_000;
+export const CHILD_QUIET_MS = 8_000;
 
 /** A running child worth naming in the banner detail slot. */
 export interface ChildActivity {
@@ -56,7 +64,7 @@ export interface ChildActivity {
   sourceId: string;
   /** Human label — `agentType` when known, else the raw source key. */
   label: string;
-  /** Progress clause, e.g. `round 3: Read tool-lane.ts` or `no output for 41s`. */
+  /** Progress clause, e.g. `round 3: Read tool-lane.ts` or `no output (waiting)`. */
   clause: string;
   /** True when this child has been silent longer than {@link CHILD_QUIET_MS}. */
   quiet: boolean;
@@ -91,7 +99,15 @@ function runningChildren(
  */
 function clauseFor(candidate: Candidate): string | undefined {
   if (candidate.silentMs >= CHILD_QUIET_MS) {
-    return `no output for ${formatDuration(candidate.silentMs)}`;
+    // Static clause: intentionally NOT a live-ticking "no output for Xs" counter.
+    // A live counter would change the composed string on every recompose,
+    // breaking setOverlay's identical-string dedup (terminal-compositor.ts:794)
+    // and re-introducing the ghost-row/flicker class the 1500ms H2 throttle
+    // (stream-renderer-subagent.ts) exists to prevent. The tool-lane's
+    // `· waiting Xs` annotation already shows elapsed silence past 30s
+    // (PAUSE_THRESHOLD_MS); the banner just needs to signal the child went
+    // quiet, which one static string does.
+    return 'no output (waiting)';
   }
   const summary = candidate.source.lastProgressSummary;
   if (summary) return summary;

--- a/src/cli/_lib/live-progress-no-timer.test.ts
+++ b/src/cli/_lib/live-progress-no-timer.test.ts
@@ -47,10 +47,13 @@ describe('live-progress modules introduce no autonomous timer', () => {
   for (const relPath of TIMER_FREE_MODULES) {
     it(`${relPath} schedules nothing`, () => {
       const code = stripComments(read(relPath));
-      expect(code).not.toMatch(/\bsetInterval\b/);
-      expect(code).not.toMatch(/\bsetTimeout\b/);
-      expect(code).not.toMatch(/\bsetImmediate\b/);
-      expect(code).not.toMatch(/requestAnimationFrame/);
+      // Call-form regexes (not bare-word) so type annotations like
+      // `ReturnType<typeof setInterval>` do not false-positive — a real
+      // timer call always has parens. Matches the spinner test's approach.
+      expect(code).not.toMatch(/\bsetInterval\s*\(/);
+      expect(code).not.toMatch(/\bsetTimeout\s*\(/);
+      expect(code).not.toMatch(/\bsetImmediate\s*\(/);
+      expect(code).not.toMatch(/requestAnimationFrame\s*\(/);
     });
   }
 

--- a/src/cli/_lib/live-progress-no-timer.test.ts
+++ b/src/cli/_lib/live-progress-no-timer.test.ts
@@ -27,6 +27,11 @@ const REPO_ROOT = join(import.meta.dirname, '..', '..', '..');
 const TIMER_FREE_MODULES = [
   'src/cli/_lib/child-activity-select.ts',
   'src/cli/input/work-derived-verb.ts',
+  // stream-renderer-lifecycle.ts hosts checkProgressBannerStaleness, which
+  // rides the EXISTING 80ms pause tick (stream-renderer.ts:485) — it must not
+  // introduce its own setInterval/setTimeout. Guard this so a future refactor
+  // cannot silently add one to the dead-zone path.
+  'src/cli/_lib/stream-renderer-lifecycle.ts',
 ] as const;
 
 function read(relPath: string): string {

--- a/src/cli/_lib/stream-renderer-lifecycle.test.ts
+++ b/src/cli/_lib/stream-renderer-lifecycle.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { formatInterruptAffordance, registerOverlaySlots } from './stream-renderer-lifecycle.js';
+import { formatInterruptAffordance, registerOverlaySlots, checkProgressBannerStaleness } from './stream-renderer-lifecycle.js';
 import { OverlayComposer } from './overlay-composer.js';
 import { ThinkingLane } from '../commands/interactive/thinking-lane.js';
 import { stripAnsi } from '../display.js';
@@ -250,5 +250,121 @@ describe('registerOverlaySlots — child banner without a parent progress row', 
     composer.invalidate();
     composer.flush();
     expect(captured.at(-1)).toBe('');
+  });
+});
+
+describe('checkProgressBannerStaleness', () => {
+  function makeCtx(over: Partial<Parameters<typeof checkProgressBannerStaleness>[0]> = {}) {
+    const marks: string[] = [];
+    const flushes: number[] = [];
+    const overlayComposer = {
+      markDirty: (key: string) => marks.push(key),
+      flush: () => flushes.push(flushes.length),
+    };
+    return {
+      ctx: {
+        disposed: false,
+        isTTY: true,
+        sources: new Map<string, SourceState>(),
+        overlayComposer,
+        compositor: null,
+        stageTracker: undefined,
+        thinkingLane: new ThinkingLane(),
+        toolLane: { hasPending: () => false, getOverlay: () => '' },
+        streamingMarkdownRef: { current: null },
+        lastProgressByTask: new Map(),
+        thinkingMode: 'summary' as const,
+        out: { write: () => {} },
+        pauseTickInterval: null,
+        resizeUnsub: null,
+        ...over,
+      },
+      marks,
+      flushes,
+    };
+  }
+
+  it('marks progress-banner dirty when a running child is silent past CHILD_QUIET_MS', () => {
+    const { ctx, marks, flushes } = makeCtx({
+      sources: new Map([
+        ['child-1', freshSourceState('reviewer')],
+      ]),
+    });
+    // Set child to be silent for 10s (> CHILD_QUIET_MS = 8s)
+    ctx.sources.get('child-1')!.lastEventAt = Date.now() - 10_000;
+    const changed = checkProgressBannerStaleness(ctx);
+    expect(changed).toBe(true);
+    expect(marks).toContain('progress-banner');
+    expect(flushes.length).toBe(1);
+  });
+
+  it('does NOT mark dirty when all children are fresh (under CHILD_QUIET_MS)', () => {
+    const { ctx, marks, flushes } = makeCtx({
+      sources: new Map([
+        ['child-1', freshSourceState('reviewer')],
+      ]),
+    });
+    ctx.sources.get('child-1')!.lastEventAt = Date.now() - 3_000;
+    const changed = checkProgressBannerStaleness(ctx);
+    expect(changed).toBe(false);
+    expect(marks.length).toBe(0);
+    expect(flushes.length).toBe(0);
+  });
+
+  it('skips the orchestrator source', () => {
+    const { ctx, marks } = makeCtx({
+      sources: new Map([
+        ['__main__', freshSourceState(undefined)],
+      ]),
+    });
+    ctx.sources.get('__main__')!.lastEventAt = Date.now() - 50_000;
+    const changed = checkProgressBannerStaleness(ctx);
+    expect(changed).toBe(false);
+    expect(marks.length).toBe(0);
+  });
+
+  it('skips done and errored sources', () => {
+    const { ctx, marks } = makeCtx({
+      sources: new Map([
+        ['child-1', { ...freshSourceState('reviewer'), done: true }],
+        ['child-2', { ...freshSourceState('reviewer'), errored: true }],
+      ]),
+    });
+    ctx.sources.get('child-1')!.lastEventAt = Date.now() - 50_000;
+    ctx.sources.get('child-2')!.lastEventAt = Date.now() - 50_000;
+    const changed = checkProgressBannerStaleness(ctx);
+    expect(changed).toBe(false);
+    expect(marks.length).toBe(0);
+  });
+
+  it('returns false when disposed', () => {
+    const { ctx, marks } = makeCtx({ disposed: true });
+    ctx.sources.set('child-1', freshSourceState('reviewer'));
+    ctx.sources.get('child-1')!.lastEventAt = Date.now() - 50_000;
+    expect(checkProgressBannerStaleness(ctx)).toBe(false);
+    expect(marks.length).toBe(0);
+  });
+
+  it('returns false on non-TTY surfaces', () => {
+    const { ctx, marks } = makeCtx({ isTTY: false });
+    ctx.sources.set('child-1', freshSourceState('reviewer'));
+    ctx.sources.get('child-1')!.lastEventAt = Date.now() - 50_000;
+    expect(checkProgressBannerStaleness(ctx)).toBe(false);
+    expect(marks.length).toBe(0);
+  });
+
+  it('marks dirty for ANY silent child in a multi-child fleet', () => {
+    const { ctx, marks } = makeCtx({
+      sources: new Map([
+        ['child-1', freshSourceState('reviewer')],
+        ['child-2', freshSourceState('pragmatist')],
+      ]),
+    });
+    // child-1 is fresh, child-2 is silent
+    ctx.sources.get('child-1')!.lastEventAt = Date.now() - 1_000;
+    ctx.sources.get('child-2')!.lastEventAt = Date.now() - 12_000;
+    const changed = checkProgressBannerStaleness(ctx);
+    expect(changed).toBe(true);
+    expect(marks).toContain('progress-banner');
   });
 });

--- a/src/cli/_lib/stream-renderer-lifecycle.ts
+++ b/src/cli/_lib/stream-renderer-lifecycle.ts
@@ -18,11 +18,11 @@ import { deriveProgressActivity, formatProgressBanner } from '../commands/intera
 import { palette } from '../palette.js';
 import { getTerminalWidth } from '../terminal-size.js';
 import { isDebugEnabled } from '../../utils/debug.js';
-import type { SourceState } from './stream-renderer-source.js';
-import { syntheticResult } from './stream-renderer-source.js';
+import { ORCHESTRATOR_SOURCE_KEY, syntheticResult, type SourceState } from './stream-renderer-source.js';
 import {
   childBannerEvent,
   deriveChildBanner,
+  CHILD_QUIET_MS,
   type ChildActivityTracker,
 } from './child-activity-select.js';
 import type { ToolLane } from '../commands/interactive/tool-lane.js';
@@ -299,4 +299,45 @@ export function checkPauseAnnotations(ctx: LifecycleContext): boolean {
     ctx.overlayComposer.flush();
   }
   return changed;
+}
+
+/**
+ * Dead-zone checker for the progress-banner slot. Called every 80ms by the same
+ * pause tick interval that drives {@link checkPauseAnnotations}.
+ *
+ * The problem: the progress banner only recomposes when *something* marks the
+ * OverlayComposer dirty, and a genuinely-silent child emits no events to drive
+ * that recompose. So between roughly 1.5s and 30s (the tool-lane mqtt threshold)
+ * the banner's "no output for Xs" clause never appears — the dead zone.
+ *
+ * This function closes that gap by marking the `progress-banner` slot dirty when
+ * any running child has been silent past `CHILD_QUIET_MS`. The resulting recompose
+ * re-reads the child-activity selector, which now produces a *static* clause
+ * (`no output (waiting)`, not a live-ticking counter) — so once the clause flips,
+ * subsequent flushes produce a byte-identical composed string and setOverlay's
+ * identical-string dedup (terminal-compositor.ts:794) makes them free no-ops.
+ * No cadence gate is needed.
+ *
+ * Sibling of {@link checkPauseAnnotations} by design: two separate functions
+ * on the same tick, each owning one concern. The stall state machine stays in
+ * its own function; this function only marks the banner dirty. Adding no new
+ * timer satisfies the no-autonomous-timer invariant
+ * (live-progress-no-timer.test.ts) by letter and intent.
+ *
+ * Returns true if the overlay was changed and needs a flush.
+ */
+export function checkProgressBannerStaleness(ctx: LifecycleContext): boolean {
+  if (ctx.disposed || !ctx.isTTY || !ctx.overlayComposer) return false;
+  const now = Date.now();
+  for (const [sourceId, source] of ctx.sources) {
+    if (sourceId === ORCHESTRATOR_SOURCE_KEY) continue;
+    if (source.done || source.errored) continue;
+    const silentMs = Math.max(0, now - source.lastEventAt);
+    if (silentMs >= CHILD_QUIET_MS) {
+      ctx.overlayComposer.markDirty('progress-banner');
+      ctx.overlayComposer.flush();
+      return true;
+    }
+  }
+  return false;
 }

--- a/src/cli/_lib/stream-renderer.ts
+++ b/src/cli/_lib/stream-renderer.ts
@@ -58,7 +58,7 @@ import { OverlayComposer } from './overlay-composer.js';
 import { createStageTracker, type StageTrackerState } from '../commands/interactive/loop-stage.js';
 import { detectCaptureMode, detectReducedMotion, detectGoblinSpinner } from './capture-mode.js';
 import { makeDedupingLineWriter, type DedupingLineWriter } from './dedup-line-writer.js';
-import { registerOverlaySlots, checkPauseAnnotations, subscribeToResize } from './stream-renderer-lifecycle.js';
+import { registerOverlaySlots, checkPauseAnnotations, checkProgressBannerStaleness, subscribeToResize } from './stream-renderer-lifecycle.js';
 import { makeOrchestratorCtx, makeSubagentCtx, resolveParentSyntheticId } from './stream-renderer-contexts.js';
 
 export interface StreamRendererOptions {
@@ -948,10 +948,13 @@ export class StreamRenderer {
 
   /**
    * Bounded stalled-entry lifecycle checker. Called every 80ms by the pause tick interval.
-   * Delegates to the lifecycle module to keep core class compact.
+   * Delegates to the lifecycle module — checkProgressBannerStaleness closes the
+   * 1.5s–30s dead zone by marking the progress-banner slot dirty when a child
+   * goes quiet, then checkPauseAnnotations handles the post-30s stall state
+   * machine. Both ride the same tick; neither adds a new timer.
    */
   private checkPauseAnnotations(): void {
-    checkPauseAnnotations({
+    const lifecycleCtx = {
       compositor: this.compositor,
       disposed: this.disposed,
       sources: this.sources,
@@ -966,7 +969,9 @@ export class StreamRenderer {
       out: this.out,
       pauseTickInterval: this.pauseTickInterval,
       resizeUnsub: this.resizeUnsub,
-    });
+    };
+    checkProgressBannerStaleness(lifecycleCtx);
+    checkPauseAnnotations(lifecycleCtx);
   }
 
 }


### PR DESCRIPTION
## Summary

Closes the "dead zone" (piece #2 of #857) where an active-but-silent subagent child showed nothing in the TUI progress banner between ~1.5s and 30s of silence.

The banner only recomposed on events, and a silent child emits none — so the "no output" clause never appeared. An autonomous timer was previously rejected ("a clock that lies") and structurally forbidden by `live-progress-no-timer.test.ts`.

## Approach

This implements the **static-clause + pause-tick piggyback** approach recommended by the devils-advocate critique. Three changes:

### 1. Lower `CHILD_QUIET_MS`: 30s → 8s
Decoupled from `PAUSE_THRESHOLD_MS` (30s, unchanged). The banner names a quiet child at 8s instead of 30s. 8s exceeds `STICKY_HOLD_MS` (3s) and the 1500ms streaming throttle.

### 2. Static silent clause: `'no output (waiting)'`
Previously `no output for ${formatDuration(silentMs)}` — a live-ticking counter. The counter changes the composed string on every recompose, breaking `setOverlay`'s identical-string dedup (`terminal-compositor.ts:794`). With a static clause, the string flips once at 8s, then stays byte-stable. The tool-lane's `· waiting Xs` annotation already shows elapsed silence past 30s.

### 3. `checkProgressBannerStaleness` — sibling of `checkPauseAnnotations`
New function in `stream-renderer-lifecycle.ts`, called from the same 80ms `pauseTickInterval` — **no new `setInterval`**. When any running child is silent past `CHILD_QUIET_MS`, it marks the `progress-banner` slot dirty and flushes, triggering the one clause flip. Subsequent flushes are free (dedup).

`live-progress-no-timer.test.ts` is strengthened to also guard `stream-renderer-lifecycle.ts` against future timer additions.

## Why not the original Option A?

The original scoping report proposed piggybacking on the pause-tick with a >=1500ms cadence gate and a live counter. A devils-advocate critique (3 parallel critics) found that **the dedup-rely assumption was invalid**: because `clauseFor` emitted a live-ticking counter, the banner string changed on every recompose, so `setOverlay`'s dedup never fired. Every 1500ms the full slot tree would re-render with a changed string — potentially re-introducing the ghost-row/flicker class the H2 throttle was designed to prevent. The static-clause approach eliminates this flaw *and* removes the cadence gate entirely.

## Test results

- lint (tsc --noEmit, maximally strict) — clean
- pnpm test — 760 files / 14,448 tests passed, 0 failures
- audit:sdk:check — OK
- audit:env:check — 0 violations
- scan:env:check — in sync

## Files changed

| File | Change |
|------|--------|
| `src/cli/_lib/child-activity-select.ts` | `CHILD_QUIET_MS` 30s to 8s, static clause, remove `formatDuration` import |
| `src/cli/_lib/stream-renderer-lifecycle.ts` | New `checkProgressBannerStaleness` function |
| `src/cli/_lib/stream-renderer.ts` | Wire `checkProgressBannerStaleness` into the pause tick |
| `src/cli/_lib/live-progress-no-timer.test.ts` | Strengthen guard to include `stream-renderer-lifecycle.ts` |
| `src/cli/_lib/child-activity-select.test.ts` | Update tests for static clause |
| `src/cli/_lib/stream-renderer-lifecycle.test.ts` | 7 new tests for `checkProgressBannerStaleness` |

Closes #857.