### PR TITLE
fix(subagent): resolve an omitted named-agent model to the policy default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ auto-release workflow to deduplicate commits across successive runs.
 
 ## [Unreleased]
 
+### Changed
+- a named subagent dispatched without an explicit model now resolves to the
+  policy default (`AFK_DEFAULT_SUBAGENT_MODEL`, else the `medium` tier) instead
+  of silently inheriting the dispatching session's model. Inheritance is now
+  opt-in via `model: inherit` in the agent definition. Behaviour change on
+  upgrade: named agents that declare no model — including the built-in
+  `research-agent` — drop from the parent's tier to the policy default under a
+  high-tier parent (e.g. `opus`). Pin `model: inherit` to restore the old
+  behaviour per agent.
+
 ## [5.85.5] - 2026-08-02
 
 ### Fixed

--- a/src/agent/tools/subagent-executor.named-agents.test.ts
+++ b/src/agent/tools/subagent-executor.named-agents.test.ts
@@ -237,10 +237,16 @@ describe('SubagentExecutor named-agent dispatch', () => {
     expect(forkSubagent.mock.calls[0]?.[0].config.model).toBe('opus');
   });
 
-  it('named dispatch with omitted model inherits the parent model (CC parity)', async () => {
+  // `research-agent` declares no model, so it takes the policy default rather
+  // than the dispatching session's model. Regression guard: this previously
+  // resolved to 'opus' (parent), which silently voided
+  // `AFK_DEFAULT_SUBAGENT_MODEL` for every named dispatch and let a high-tier
+  // parent auto-spawn high-tier read-only children. Inheritance is now opt-in
+  // via `model: 'inherit'` — see the 'inheritor' case above.
+  it('named dispatch with omitted model takes the policy default, not the parent model', async () => {
     const executor = makeExecutor({ defaultSubagentModel: 'haiku' });
     await executor.execute(makeCall({ prompt: 'go', agent_type: 'research-agent' }));
-    expect(forkSubagent.mock.calls[0]?.[0].config.model).toBe('opus');
+    expect(forkSubagent.mock.calls[0]?.[0].config.model).toBe('haiku');
   });
 
   it('unnamed dispatch keeps the policy default chain', async () => {

--- a/src/agent/tools/subagent/child-config.test.ts
+++ b/src/agent/tools/subagent/child-config.test.ts
@@ -284,14 +284,30 @@ describe('buildChildConfig', () => {
       expect(childConfig.model).toBe('haiku');
     });
 
-    it('treats an omitted named model as inherit (uses parentModel)', () => {
+    // An omitted model resolves to the POLICY default, not the parent's model.
+    // Inheritance is opt-in via an explicit `model: 'inherit'` (covered above).
+    // Guards the cost contract of `AFK_DEFAULT_SUBAGENT_MODEL`: a high-tier
+    // parent must not silently auto-spawn high-tier named children.
+    it('resolves an omitted named model to the policy default, NOT parentModel', () => {
       const { childConfig } = buildChildConfig(
         baseArgs({
           namedAgent: namedAgent({}), // no model field
           parentModel: 'opus',
+          defaultSubagentModel: 'sonnet',
         }),
       );
-      expect(childConfig.model).toBe('opus');
+      expect(childConfig.model).toBe('sonnet');
+    });
+
+    it('resolves an omitted named model to sonnet when no policy default is wired', () => {
+      const { childConfig } = buildChildConfig(
+        baseArgs({
+          namedAgent: namedAgent({}), // no model field
+          parentModel: 'opus',
+          defaultSubagentModel: undefined,
+        }),
+      );
+      expect(childConfig.model).toBe('sonnet');
     });
   });
 

--- a/src/agent/tools/subagent/child-config.ts
+++ b/src/agent/tools/subagent/child-config.ts
@@ -148,20 +148,27 @@ export function buildChildConfig(args: BuildChildConfigArgs): BuildChildConfigRe
   // `resolveOpenAIAuth()` to return the Anthropic key as if it were a config
   // OpenAI key (tier 1 wins) — the OpenAI API then 401s. Clearing them lets
   // the OpenAI auth resolver walk its env / codex precedence cleanly.
-  // Model resolution.
-  //   Unnamed dispatch (legacy, unchanged): call-site > policy default > 'sonnet'.
-  //   Named dispatch (Claude Code parity): call-site > definition model
-  //   ('inherit' → dispatching session's model) > inherit-by-default
-  //   (omitted model also means inherit) > policy default > 'sonnet'.
-  // `parentModel` is optional ctx wiring; when absent, inherit falls
-  // through to the policy chain rather than guessing.
+  // Invariant: an OMITTED definition model means "policy default", never
+  // "inherit the parent". Both dispatch shapes therefore share one chain:
+  //   call-site > definition model > policy default (`defaultSubagentModel`) > 'sonnet'
+  // with exactly one escape hatch: an explicit `model: 'inherit'` resolves to
+  // the dispatching session's model.
+  //
+  // This is load-bearing for cost. `AFK_DEFAULT_SUBAGENT_MODEL` is documented
+  // (src/config/env.ts) as "the default model used when a subagent is
+  // dispatched without an explicit model", and `getDefaultSubagentModel`
+  // (src/cli/shared-helpers.ts) exists so a high-tier parent does not
+  // auto-spawn high-tier children. Treating an omitted model as inherit
+  // silently voided both for every NAMED dispatch — i.e. nearly all of them,
+  // since `agent_type` is the common call shape. An agent that genuinely needs
+  // parent-tier capability must now say so with `model: 'inherit'`.
+  //
+  // `parentModel` is optional ctx wiring; when absent, an explicit 'inherit'
+  // falls through to the policy chain rather than guessing.
   let namedDefaultModel: string | undefined;
   if (namedAgent !== undefined) {
     const defModel = namedAgent.definition.model;
-    namedDefaultModel =
-      defModel !== undefined && defModel !== 'inherit'
-        ? defModel
-        : args.parentModel;
+    namedDefaultModel = defModel === 'inherit' ? args.parentModel : defModel;
   }
   const childModel: string =
     parsed.model ?? namedDefaultModel ?? args.defaultSubagentModel ?? 'sonnet';


### PR DESCRIPTION
## Summary

A named subagent dispatch whose definition declared no model silently inherited the dispatching session's model. That voided two documented contracts at once:

- **`AFK_DEFAULT_SUBAGENT_MODEL`** is described in `src/config/env.ts` as *"the default model used when a subagent is dispatched without an explicit model"* — and was ignored for every named dispatch.
- **`getDefaultSubagentModel`** (`src/cli/shared-helpers.ts:222-229`) exists, per its own doc comment, so that *"a high-tier parent (e.g. opus) shouldn't auto-spawn high-tier children"*. Named dispatch routed around it.

Because `agent_type` is the common call shape, the cost guard only ever applied to the rare unnamed path. Under an `opus` parent, every `research-agent` dispatch ran on opus.

The old behaviour was pinned by a test that stated the problem plainly — the operator sets the policy default to `haiku` and the child resolves to `opus` anyway:

```ts
it('named dispatch with omitted model inherits the parent model (CC parity)', async () => {
  const executor = makeExecutor({ defaultSubagentModel: 'haiku' });
  await executor.execute(makeCall({ prompt: 'go', agent_type: 'research-agent' }));
  expect(forkSubagent.mock.calls[0]?.[0].config.model).toBe('opus');
});
```

### The change

One line at `src/agent/tools/subagent/child-config.ts`:

```diff
-    namedDefaultModel =
-      defModel !== undefined && defModel !== 'inherit'
-        ? defModel
-        : args.parentModel;
+    namedDefaultModel = defModel === 'inherit' ? args.parentModel : defModel;
```

Both dispatch shapes now share one chain — *call-site > definition model > policy default > `'sonnet'`* — with a single explicit escape hatch: `model: 'inherit'` resolves to the dispatching session's model. No expressiveness is lost, because `'inherit'` was already a supported value; inheritance simply becomes opt-in rather than silent.

### Why this is safe for non-Anthropic setups

The cross-provider guard is untouched. `getDefaultSubagentModel` returns the parent's model for `openai-compatible` parents *before* the Claude-bound `medium` tier is ever reached, so a local-only or GPT session still cannot be routed to `api.anthropic.com` by this path.

### Blast radius

Small. Named definitions declaring no model: 4 built-ins and 3 plugin definitions, 0 user agents. Of the built-ins, `Explore` (`model: 'haiku'`) and `git-investigator` (pinned via its definition) already declare one — **only `research-agent` moves**, and it is a read-only search role for which the policy default is sufficient.

Any agent that genuinely needs parent-tier capability declares `model: inherit`.

### Behaviour change on upgrade

Named agents that declare no model drop from the parent's tier to the policy default. This is user-visible and is called out under `### Changed` in the changelog.

## How was this tested?

- `pnpm lint` — clean (`tsc --noEmit`)
- `pnpm test` — **760 files, 14,449 passed, 2 skipped**

Test changes: two assertions that encoded the old inherit-by-default behaviour are inverted, and one is added covering the case where no policy default is wired (terminates at `'sonnet'`). The two existing `model: 'inherit'` legs are unchanged and now document the opt-in path.

## Follow-ups (not in this PR)

1. `'inherit'` is now load-bearing but is still a magic string — it appears only in a comment and a comparison, with no type union and no frontmatter documentation. Worth typing and documenting.
2. Tier names bypass the cross-provider child-model fallback: `isClaudeFamilyModel` (`openai-compatible/responses-config.ts:43-49`) matches `claude-*`, `local-*`, and `^(opus|sonnet|haiku)`, but not `small`/`medium`/`large`. An agent explicitly pinned `model: medium` under `AFK_PROVIDER=openai-compatible` therefore resolves to `claude-sonnet-5` and is *not* rescued by `coerceCrossProviderChildModel`, while one pinned `sonnet` is. Pre-existing and independent of this change; filed separately.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] No secrets, tokens, or private paths in the diff
