### PR TITLE
docs(mcp): document optional Parallel Search setup

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -155,6 +155,28 @@ than crashing.
 - **No shell in `${VAR}` expansion.** Expansion reads `process.env` directly;
   it never invokes a shell or evaluates expressions.
 
+## Worked example: Parallel Search MCP over HTTP
+
+Parallel Search MCP adds current web search and clean page fetching as optional
+companion tools. Its default endpoint requires no account, API key, or OAuth.
+Add it to your user-global config:
+
+```json
+{
+  "mcpServers": {
+    "parallel-search": {
+      "type": "streamable-http",
+      "url": "https://search.parallel.ai/mcp"
+    }
+  }
+}
+```
+
+Start a new AFK session and run `/mcp` to confirm the server is connected. Its
+tools appear as `mcp__parallel-search__web_search` and
+`mcp__parallel-search__web_fetch`. These are separate MCP tools; this config
+does not replace or reconfigure AFK's built-in Exa-backed web search.
+
 ## Worked example: Brave Search over stdio
 
 ```jsonc


### PR DESCRIPTION
## Summary

AFK already supports remote Streamable HTTP MCP servers on every execution surface. This adds a pasteable user-global example for connecting Parallel Search MCP without an account or API key, and names the resulting `web_search` and `web_fetch` MCP tools.

The example is optional and documentation-only. It does not change AFK's default configuration, MCP runtime, or built-in Exa-backed web search.

## How was this tested?

- Extracted the new fenced JSON from `docs/mcp.md`, parsed it with Node, and asserted the server type and endpoint.
- Ran `git diff --check`.
- Did not run `pnpm lint` or `pnpm test` because no TypeScript or runtime files changed.
- Did not perform a live model-backed MCP connection test.

## Checklist

- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes
- [x] Commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/) — see [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] No secrets, tokens, or private paths in the diff

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.