### PR TITLE
fix(agent): address configurable nesting-depth review feedback

### DIFF
--- a/src/agent/session/wire-executors.ts
+++ b/src/agent/session/wire-executors.ts
@@ -25,7 +25,11 @@ import { SubagentManager } from '../subagent.js';
 import { SubagentExecutor } from '../tools/subagent-executor.js';
 import { SkillExecutor } from '../tools/skill-executor.js';
 import { ComposeExecutor } from '../tools/compose-executor.js';
-import { createChildProviderFactory, createChildSkillExecutorFactory } from '../tools/nesting.js';
+import {
+  createChildProviderFactory,
+  createChildSkillExecutorFactory,
+  resolveMaxNestingDepth,
+} from '../tools/nesting.js';
 import { loadAgentRegistry } from '../agents/index.js';
 import { discoverPluginAgents } from '../tools/skill-bridge.js';
 import type { SubagentExecutorContext } from '../tools/subagent-executor.js';
@@ -176,6 +180,10 @@ export function wireExecutors(opts: WireExecutorsOptions): WiredExecutors {
   const skillTraceOpt = skillTraceWriter !== undefined ? { traceWriter: skillTraceWriter } : {};
   const apiKeyOpt = apiKey !== undefined ? { apiKey } : {};
   const bgRegistryOpt = backgroundRegistry !== undefined ? { backgroundRegistry } : {};
+  // Session-static snapshot shared by all root executors and inherited by
+  // descendants. Do not resolve inside execute(): sibling calls must not see
+  // different caps if the process environment changes during the session.
+  const maxDepth = resolveMaxNestingDepth();
 
   // 1. The single root manager. Every executor below reads through this
   //    instance; a second manager would fork children outside the abort graph
@@ -237,6 +245,7 @@ export function wireExecutors(opts: WireExecutorsOptions): WiredExecutors {
     // Top-level wiring → explicit depth 0. See SubagentExecutorContext.depth
     // for why this is required rather than defaulted.
     depth: 0,
+    maxDepth,
     ...nestedCwdOpt,
     agentRegistry,
     parentModel: model,
@@ -259,6 +268,7 @@ export function wireExecutors(opts: WireExecutorsOptions): WiredExecutors {
     resolveApiKeyForModel,
     ...skillTraceOpt,
     ...nestedCwdOpt,
+    maxDepth,
     // Read-scope inheritance (#547): skill-forked children inherit the parent
     // session's read scope via the root manager — symmetric with the `agent`
     // tool. Read fresh so mid-session setCwd re-anchors are reflected.
@@ -279,6 +289,7 @@ export function wireExecutors(opts: WireExecutorsOptions): WiredExecutors {
     systemPrompt: systemPrompt ?? '',
     surface,
     depth: 0,
+    maxDepth,
     ...traceOpt,
   });
 

--- a/src/agent/tools/nesting.test.ts
+++ b/src/agent/tools/nesting.test.ts
@@ -322,12 +322,13 @@ describe('resolveMaxNestingDepth (AFK_MAX_NESTING_DEPTH)', () => {
     expect(resolveMaxNestingDepth()).toBe(DEFAULT_MAX_NESTING_DEPTH);
   });
 
-  it('falls back to the default when only a numeric prefix is valid', () => {
-    for (const malformed of ['0.5', '0x3', '3oops']) {
+  it.each(['0.5', '0x5', '0b10', '1oops'])(
+    'falls back to the default for non-decimal input %s',
+    (malformed) => {
       process.env[KEY] = malformed;
       expect(resolveMaxNestingDepth()).toBe(DEFAULT_MAX_NESTING_DEPTH);
-    }
-  });
+    },
+  );
 
   it('keeps the ENV_REGISTRY documented default in lockstep with the constant', () => {
     // Guards against DEFAULT_MAX_NESTING_DEPTH drifting from the registry

--- a/src/agent/tools/nesting.test.ts
+++ b/src/agent/tools/nesting.test.ts
@@ -261,10 +261,9 @@ describe('restricted builders thread openaiBaseUrl into the OpenAI client baseUR
   });
 });
 
-// resolveMaxNestingDepth is the DEFAULT resolver consulted at the three
-// `ctx.maxDepth ?? resolveMaxNestingDepth()` sites (subagent-executor,
-// skill-executor, skill-executor/fork-child-config). Pure-function contract,
-// mirroring resolveSubagentTimeoutMs: unset/empty/invalid → default, valid int
+// resolveMaxNestingDepth is snapshotted by root wiring and remains the fallback
+// for directly constructed executors. Pure-function contract, mirroring
+// resolveSubagentTimeoutMs: unset/empty/invalid → default, valid int
 // within [0, MAX_NESTING_DEPTH_CEILING] → that value, 0 → 0 (nesting disabled).
 describe('resolveMaxNestingDepth (AFK_MAX_NESTING_DEPTH)', () => {
   const KEY = 'AFK_MAX_NESTING_DEPTH';
@@ -321,6 +320,13 @@ describe('resolveMaxNestingDepth (AFK_MAX_NESTING_DEPTH)', () => {
   it('falls back to the default on unparseable garbage', () => {
     process.env[KEY] = 'not-a-number';
     expect(resolveMaxNestingDepth()).toBe(DEFAULT_MAX_NESTING_DEPTH);
+  });
+
+  it('falls back to the default when only a numeric prefix is valid', () => {
+    for (const malformed of ['0.5', '0x3', '3oops']) {
+      process.env[KEY] = malformed;
+      expect(resolveMaxNestingDepth()).toBe(DEFAULT_MAX_NESTING_DEPTH);
+    }
   });
 
   it('keeps the ENV_REGISTRY documented default in lockstep with the constant', () => {

--- a/src/agent/tools/nesting.ts
+++ b/src/agent/tools/nesting.ts
@@ -60,8 +60,8 @@ export const MAX_NESTING_DEPTH_CEILING = 6;
 export function resolveMaxNestingDepth(): number {
   const raw = env.AFK_MAX_NESTING_DEPTH;
   if (raw === undefined || raw.trim() === '') return DEFAULT_MAX_NESTING_DEPTH;
-  const n = Number.parseInt(raw, 10);
-  if (!Number.isFinite(n) || n < 0 || n > MAX_NESTING_DEPTH_CEILING) {
+  const n = Number(raw.trim());
+  if (!Number.isInteger(n) || n < 0 || n > MAX_NESTING_DEPTH_CEILING) {
     return DEFAULT_MAX_NESTING_DEPTH;
   }
   return n;

--- a/src/agent/tools/nesting.ts
+++ b/src/agent/tools/nesting.ts
@@ -59,8 +59,10 @@ export const MAX_NESTING_DEPTH_CEILING = 6;
  */
 export function resolveMaxNestingDepth(): number {
   const raw = env.AFK_MAX_NESTING_DEPTH;
-  if (raw === undefined || raw.trim() === '') return DEFAULT_MAX_NESTING_DEPTH;
-  const n = Number(raw.trim());
+  if (raw === undefined) return DEFAULT_MAX_NESTING_DEPTH;
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) return DEFAULT_MAX_NESTING_DEPTH;
+  const n = Number(trimmed);
   if (!Number.isInteger(n) || n < 0 || n > MAX_NESTING_DEPTH_CEILING) {
     return DEFAULT_MAX_NESTING_DEPTH;
   }

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -327,7 +327,8 @@ export const agentTool: AnthropicToolDef = {
     'Parallelize: dispatch multiple `agent` calls in a single tool-use turn to run ' +
     'independent investigations concurrently.\n\n' +
     'Nest: a subagent may itself dispatch further subagents (depth limit 3 by default) when it ' +
-    'discovers a separable sub-investigation.\n\n' +
+    'discovers a separable sub-investigation. Inside a subagent, `get_runtime_state` reports ' +
+    'the live cap.\n\n' +
     'Subagents return their final assistant message verbatim — instruct them ' +
     'explicitly to compress their findings into: answer, evidence with file:line ' +
     'citations, confidence, risks, recommended next action, unresolved questions, ' +

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -326,8 +326,7 @@ export const agentTool: AnthropicToolDef = {
     'research-shaped investigation.\n\n' +
     'Parallelize: dispatch multiple `agent` calls in a single tool-use turn to run ' +
     'independent investigations concurrently.\n\n' +
-    'Nest: a subagent may itself dispatch further subagents (depth limit 3 by default — ' +
-    '`get_runtime_state` reports the live cap) when it ' +
+    'Nest: a subagent may itself dispatch further subagents (depth limit 3 by default) when it ' +
     'discovers a separable sub-investigation.\n\n' +
     'Subagents return their final assistant message verbatim — instruct them ' +
     'explicitly to compress their findings into: answer, evidence with file:line ' +

--- a/src/cli/commands/daemon-session-factory.test.ts
+++ b/src/cli/commands/daemon-session-factory.test.ts
@@ -225,4 +225,30 @@ describe('buildDaemonSessionFactory', () => {
 
     void session.close().catch(() => undefined);
   });
+
+  it('snapshots one environment nesting cap across all root executors', () => {
+    const key = 'AFK_MAX_NESTING_DEPTH';
+    const original = process.env[key];
+    let session: ReturnType<ReturnType<typeof buildDaemonSessionFactory>> | undefined;
+    try {
+      process.env[key] = '1';
+      const factory = buildDaemonSessionFactory({ model: 'sonnet', apiKey: TEST_API_KEY });
+      session = factory(makeConfig());
+      const internals = session as unknown as { config?: { provider?: unknown } };
+      const provider = internals.config?.provider as AnthropicDirectProvider;
+
+      // A later mutation must not change any sibling executor in this session.
+      process.env[key] = '0';
+      const subExec = readSubagentExecutor(provider) as { ctx?: { maxDepth?: number } };
+      const skillExec = readSkillExecutor(provider) as { ctx?: { maxDepth?: number } };
+      const composeExec = readComposeExecutor(provider) as { ctx?: { maxDepth?: number } };
+      expect(subExec.ctx?.maxDepth).toBe(1);
+      expect(skillExec.ctx?.maxDepth).toBe(1);
+      expect(composeExec.ctx?.maxDepth).toBe(1);
+    } finally {
+      if (original === undefined) delete process.env[key];
+      else process.env[key] = original;
+      void session?.close().catch(() => undefined);
+    }
+  });
 });


### PR DESCRIPTION
### Motivation

- Prevent partially-numeric, fractional, and hex env values from being accepted as valid nesting caps because `Number.parseInt` accepted numeric prefixes and could silently disable delegation or set wrong caps.
- Ensure the environment-sourced cap is consistent across all root executors in a long-lived session so sibling executors cannot observe different caps after a mid-process env mutation.
- Remove an inaccurate documentation claim that `get_runtime_state` reports the live root cap which is not wired into runtime state today.

### Description

- Tighten `resolveMaxNestingDepth()` to parse the trimmed value via `Number(...)` and require `Number.isInteger(n)` within `[0, MAX_NESTING_DEPTH_CEILING]`, falling back to `DEFAULT_MAX_NESTING_DEPTH` for all malformed inputs. (`src/agent/tools/nesting.ts`)
- Snapshot the env cap once in `wireExecutors()` with `const maxDepth = resolveMaxNestingDepth()` and pass that `maxDepth` into the `SubagentExecutor`, `SkillExecutor`, and `ComposeExecutor` root wiring so all root executors share the same session-static value. (`src/agent/session/wire-executors.ts`)
- Remove the unsupported claim about live-cap discovery from the `agent` tool description so docs no longer promise `get_runtime_state` will report the live root cap. (`src/agent/tools/schemas.ts`)
- Add regression tests for malformed env inputs and for session-static snapshot behavior by extending `resolveMaxNestingDepth` tests and adding a daemon session factory test asserting all three executors observe the same captured `maxDepth`. (`src/agent/tools/nesting.test.ts`, `src/cli/commands/daemon-session-factory.test.ts`)

### Testing

- Ran `pnpm vitest run src/agent/tools/nesting.test.ts src/cli/commands/daemon-session-factory.test.ts` and all tests passed (49 tests across the two files).
- Ran `pnpm lint` (`tsc --noEmit`) and it completed without errors.
- The new tests specifically cover malformed `AFK_MAX_NESTING_DEPTH` inputs like `0.5`, `0x3`, and `3oops` and the session-static snapshot behavior for root executors, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fa1305d80832bba55a407876e1d74)