### PR TITLE
fix(tool-lane): stop fabricating filenames from relative paths

### DIFF
--- a/src/cli/commands/interactive/tool-lane-format-args.ts
+++ b/src/cli/commands/interactive/tool-lane-format-args.ts
@@ -56,7 +56,21 @@ export function shortenPaths(text: string): string {
  */
 function collapseFsPaths(text: string): string {
   const linkify = hyperlinksEnabled();
-  return text.replace(/\/(?:[^/\s,)]+\/){2,}([^/\s,)]+)/g, (fullPath, basename: string) =>
+  // Invariant: the leading `/` must OPEN an absolute path — it may not be an
+  // interior separator of a longer token. The lookbehind rejects a preceding
+  // path-ish character (word char, `.`, `~`, `-`, `/`), which is what confines
+  // this to absolute paths as documented.
+  //
+  // Without it the regex matched from the FIRST interior slash of a relative
+  // path and spliced the surviving head onto the basename, fabricating a path
+  // that never existed: `src/cli/_lib/child-activity-select.test.ts` rendered
+  // as `srcchild-activity-select.test.ts` (head `src` + basename, separator and
+  // middle segments deleted), and `./src/cli/_lib/x.ts` as `.x.ts`. A tool-lane
+  // label that invents a filename is worse than a long one — a reader cannot
+  // tell the shown path from a real sibling file. Relative and `~/`-rooted
+  // paths are therefore left intact; the lane's own width truncation shortens
+  // them honestly with a trailing ellipsis.
+  return text.replace(/(?<![\w./~-])\/(?:[^/\s,)]+\/){2,}([^/\s,)]+)/g, (fullPath, basename: string) =>
     linkify ? fileHyperlink(basename, fullPath) : basename,
   );
 }

--- a/src/cli/commands/interactive/tool-lane-format-args.ts
+++ b/src/cli/commands/interactive/tool-lane-format-args.ts
@@ -56,10 +56,11 @@ export function shortenPaths(text: string): string {
  */
 function collapseFsPaths(text: string): string {
   const linkify = hyperlinksEnabled();
-  // Invariant: the leading `/` must OPEN an absolute path — it may not be an
-  // interior separator of a longer token. The lookbehind rejects a preceding
-  // path-ish character (word char, `.`, `~`, `-`, `/`), which is what confines
-  // this to absolute paths as documented.
+  // Invariant: the leading `/` must OPEN an absolute-path token — it may not be
+  // an interior separator of a longer token. Match the token boundary itself
+  // instead of trying to enumerate every character that a relative path may
+  // contain. Besides the start of the string, accepted boundaries are shell /
+  // prose whitespace, assignment (`=`), quotes, and opening delimiters.
   //
   // Without it the regex matched from the FIRST interior slash of a relative
   // path and spliced the surviving head onto the basename, fabricating a path
@@ -70,8 +71,10 @@ function collapseFsPaths(text: string): string {
   // tell the shown path from a real sibling file. Relative and `~/`-rooted
   // paths are therefore left intact; the lane's own width truncation shortens
   // them honestly with a trailing ellipsis.
-  return text.replace(/(?<![\w./~-])\/(?:[^/\s,)]+\/){2,}([^/\s,)]+)/g, (fullPath, basename: string) =>
-    linkify ? fileHyperlink(basename, fullPath) : basename,
+  return text.replace(
+    /(^|[\s='"([{])(\/(?:[^/\s,)]+\/){2,}([^/\s,)]+))/g,
+    (_match, boundary: string, fullPath: string, basename: string) =>
+      boundary + (linkify ? fileHyperlink(basename, fullPath) : basename),
   );
 }
 

--- a/src/cli/commands/interactive/tool-lane-format.test.ts
+++ b/src/cli/commands/interactive/tool-lane-format.test.ts
@@ -747,6 +747,8 @@ describe('shortenPaths — URL-safety + fs-path collapsing', () => {
   it('does not fabricate a basename from a relative path head', () => {
     expect(shortenPaths('src/a/b/c.ts')).toBe('src/a/b/c.ts');
     expect(shortenPaths('a/b/c/d.ts')).toBe('a/b/c/d.ts');
+    expect(shortenPaths('資料/src/cli/x.ts')).toBe('資料/src/cli/x.ts');
+    expect(shortenPaths('foo@/src/cli/x.ts')).toBe('foo@/src/cli/x.ts');
   });
 
   it('leaves a dot-relative path intact (regression: ./src/cli/_lib/x.ts was .x.ts)', () => {

--- a/src/cli/commands/interactive/tool-lane-format.test.ts
+++ b/src/cli/commands/interactive/tool-lane-format.test.ts
@@ -734,6 +734,38 @@ describe('shortenPaths — URL-safety + fs-path collapsing', () => {
       'see https://x.com/a/b/c then y.ts',
     );
   });
+
+  // Regression: the leading `/` was unanchored, so the regex matched from the
+  // first INTERIOR slash of a relative path and spliced the surviving head onto
+  // the basename — fabricating a filename that never existed on disk.
+  it('leaves a relative path intact (regression: src/cli/_lib/x.ts was srcx.ts)', () => {
+    expect(shortenPaths('pnpm test:file src/cli/_lib/child-activity-select.test.ts')).toBe(
+      'pnpm test:file src/cli/_lib/child-activity-select.test.ts',
+    );
+  });
+
+  it('does not fabricate a basename from a relative path head', () => {
+    expect(shortenPaths('src/a/b/c.ts')).toBe('src/a/b/c.ts');
+    expect(shortenPaths('a/b/c/d.ts')).toBe('a/b/c/d.ts');
+  });
+
+  it('leaves a dot-relative path intact (regression: ./src/cli/_lib/x.ts was .x.ts)', () => {
+    expect(shortenPaths('./src/cli/_lib/x.ts')).toBe('./src/cli/_lib/x.ts');
+  });
+
+  it('leaves a ~-rooted path intact rather than emitting ~basename', () => {
+    expect(shortenPaths('~/proj/a/b/c.ts')).toBe('~/proj/a/b/c.ts');
+  });
+
+  it('still collapses an absolute path after a flag separator', () => {
+    expect(shortenPaths('--out=/Users/me/proj/src/x.ts')).toBe('--out=x.ts');
+  });
+
+  it('collapses an absolute path in a cd command (real tool-lane case)', () => {
+    expect(shortenPaths('cd /Users/me/proj/agent-afk/.afk-worktrees/wt && pwd')).toBe(
+      'cd wt && pwd',
+    );
+  });
 });
 
 describe('shortenPaths — OSC 8 hyperlink emission', () => {

--- a/src/cli/terminal-compositor.space-fusion.repro.test.ts
+++ b/src/cli/terminal-compositor.space-fusion.repro.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Space-fusion hunt (#thinking-spacing): can agent-afk's PAINT layer emit two
+ * words fused into one ("relevant tests" -> "relevanttests") when a committed
+ * block is re-wrapped across a WIDTH-CHANGE resize?
+ *
+ * Symptom under investigation: rendered terminal text intermittently loses a
+ * single space between two words. afk's formatters (formatThinkingParagraph,
+ * renderMarkdownToTerminal, wrapToWidth, hardWrapToWidth) and tmux reflow are
+ * already proven clean; persisted transcripts hold the CORRECT spaced text.
+ * The residual in-process suspect is the compositor paint layer:
+ * terminal-compositor.band-reflow.ts (re-wrap at current width),
+ * terminal-compositor.committed-band-commit.ts (hard-wrap at commit width),
+ * terminal-compositor.scrollback.ts (logical-line rejoin into native history).
+ *
+ * TRIGGER CONDITION HUNTED: a wrap landing EXACTLY on the space between two
+ * words. At that width the space is the boundary character — the row ends
+ * with it (and any right-trim eats it) or it leads the next row. If any paint
+ * site later REJOINS those rows without re-inserting the separator, the words
+ * fuse. This sweeps every width where that boundary lands on each space in
+ * the sentence, at commit width W1 then repaint width W2 (narrower AND wider).
+ *
+ * DETECTION MODEL (what counts as a real fusion): two words are fused only if
+ * a SINGLE physical row — or a single archived scrollback LOGICAL line —
+ * contains "relevanttests". A hard-wrap that puts "relevant" at the end of one
+ * row and "tests" at the start of the next is NOT fusion: the terminal renders
+ * them on separate lines. Concatenating right-trimmed rows would therefore
+ * produce a false positive, so rows are checked individually.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { PassThrough } from 'node:stream';
+import { TerminalCompositor } from './terminal-compositor.js';
+import { StatusLine } from './status-line.js';
+import { stripAnsi } from './display.js';
+import { VirtualScreen } from './_lib/testing/virtual-screen.js';
+import { hardWrapToWidth } from './wrap.js';
+import { reflowBandSplit } from './terminal-compositor.band-reflow.js';
+import { buildBandMeta, scrollbackFlushLines } from './terminal-compositor.scrollback.js';
+
+type MockStdout = NodeJS.WriteStream & { isTTY: boolean; columns: number; rows: number };
+type MockStdin = NodeJS.ReadStream & {
+  isTTY: boolean;
+  isRaw: boolean;
+  setRawMode: ReturnType<typeof vi.fn>;
+};
+
+function makeStdout(cols: number, rows: number): MockStdout {
+  const s = new PassThrough() as unknown as MockStdout;
+  s.isTTY = true;
+  s.columns = cols;
+  s.rows = rows;
+  return s;
+}
+function makeStdin(): MockStdin {
+  const s = new PassThrough() as unknown as MockStdin;
+  s.isTTY = true;
+  s.isRaw = false;
+  s.setRawMode = vi.fn((raw: boolean) => {
+    s.isRaw = raw;
+    return s;
+  });
+  return s;
+}
+
+interface Internals {
+  repaint(): void;
+  committedBand: string[];
+  committedBandPaintedRows: number;
+}
+
+/** The sentence from the live symptom report, with the witness pair in it. */
+const SENTENCE = 'I edited the relevant tests and ran the tests again to confirm';
+/** Every fusion witness: the two words with their separating space removed. */
+const FUSIONS = ['Iedited', 'thetests', 'relevanttests', 'andran', 'theirrelevant'] as const;
+
+/** Column widths that place a hard-wrap boundary EXACTLY on each space. */
+function widthsBreakingOnEachSpace(s: string): number[] {
+  const out = new Set<number>();
+  for (let i = 0; i < s.length; i++) {
+    if (s[i] !== ' ') continue;
+    // Row of width i ends right before the space; width i+1 ends ON it.
+    out.add(i);
+    out.add(i + 1);
+    out.add(i + 2);
+  }
+  return [...out].filter((w) => w >= 4).sort((a, b) => a - b);
+}
+
+/** Assert no single row/line fuses a word pair. Returns the offending line. */
+function findFusedLine(lines: readonly string[]): { line: string; token: string } | null {
+  for (const raw of lines) {
+    const line = stripAnsi(raw);
+    for (const token of FUSIONS) {
+      if (line.includes(token)) return { line, token };
+    }
+  }
+  return null;
+}
+
+describe('paint layer — word/space fusion under width-change reflow', () => {
+  const armed: TerminalCompositor[] = [];
+
+  afterEach(() => {
+    while (armed.length > 0) {
+      try {
+        armed.pop()?.disarm();
+      } catch {
+        /* idempotent */
+      }
+    }
+    vi.useRealTimers();
+  });
+
+  it('PURE: hardWrapToWidth never drops the space at any width (incl. exact-on-space breaks)', () => {
+    for (let w = 4; w <= 120; w++) {
+      const rows = hardWrapToWidth(SENTENCE, w).split('\n');
+      const fused = findFusedLine(rows);
+      expect(fused, `width ${w} fused: ${JSON.stringify(fused)}`).toBeNull();
+      // Content preservation: rejoining rows reproduces the sentence exactly.
+      expect(rows.join(''), `width ${w} lost characters`).toBe(SENTENCE);
+    }
+  });
+
+  it('PURE: reflowBandSplit (commit W1 -> repaint W2) preserves every space across all width pairs', () => {
+    const interesting = widthsBreakingOnEachSpace(SENTENCE);
+    const widths = [...new Set([...interesting, 8, 20, 40, 64, 80, 100, 160])].filter((w) => w >= 4);
+    for (const w1 of widths) {
+      const band = hardWrapToWidth(SENTENCE, w1).split('\n');
+      const meta = buildBandMeta([SENTENCE], w1);
+      for (const w2 of widths) {
+        const r = reflowBandSplit(band, band.length, w2, meta);
+        const fused = findFusedLine(r.rows);
+        expect(fused, `W1=${w1} -> W2=${w2} fused: ${JSON.stringify(fused)}`).toBeNull();
+        expect(r.rows.join(''), `W1=${w1} -> W2=${w2} lost characters`).toBe(SENTENCE);
+        // The logical provenance that scrollback rejoin depends on must also
+        // still carry the spaced text — this is the rejoin-fusion surface.
+        for (const m of r.meta) {
+          expect(findFusedLine([m.logicalText]), `W1=${w1}->W2=${w2} meta fused`).toBeNull();
+        }
+      }
+    }
+  });
+
+  it('PURE: scrollbackFlushLines rejoin (physical rows -> logical line) never fuses', () => {
+    for (const w1 of widthsBreakingOnEachSpace(SENTENCE)) {
+      const band = hardWrapToWidth(SENTENCE, w1).split('\n');
+      const meta = buildBandMeta([SENTENCE], w1);
+      for (let count = 0; count <= band.length; count++) {
+        const flushed = scrollbackFlushLines(band, meta, count);
+        const fused = findFusedLine(flushed);
+        expect(fused, `W1=${w1} count=${count} fused: ${JSON.stringify(fused)}`).toBeNull();
+      }
+      // Reflow to a WIDER width first (the rejoin-relevant case), then flush.
+      const wide = reflowBandSplit(band, band.length, 200, meta);
+      const flushedWide = scrollbackFlushLines(wide.rows, wide.meta, wide.rows.length);
+      expect(findFusedLine(flushedWide), `W1=${w1} wide-reflow flush fused`).toBeNull();
+      expect(flushedWide.join('\n')).toContain('relevant tests');
+    }
+  });
+
+  it('E2E: real compositor — commit at W1, resize to W2, repaint; no painted row fuses words', async () => {
+    // Sweep the exact-on-space widths as the POST-resize width (that is where
+    // the re-wrap boundary lands on a space), against both a wider and a
+    // narrower commit width.
+    const targets = widthsBreakingOnEachSpace(SENTENCE).filter((w) => w >= 12 && w <= 70);
+    const pairs: [number, number][] = [];
+    for (const w2 of targets) {
+      pairs.push([120, w2]); // shrink onto the space boundary
+      pairs.push([w2, 120]); // grow off the space boundary
+    }
+
+    for (const [w1, w2] of pairs) {
+      vi.useFakeTimers();
+      const stdout = makeStdout(w1, 24);
+      const stdin = makeStdin();
+      const vscreen = new VirtualScreen(Math.max(w1, w2), 24);
+      stdout.on('data', (chunk: unknown) => {
+        if (Buffer.isBuffer(chunk)) vscreen.write(chunk as Buffer);
+        else if (typeof chunk === 'string') vscreen.write(Buffer.from(chunk, 'utf-8'));
+      });
+      const statusLine = new StatusLine({ stream: stdout, force: true, throttleMs: 0 });
+      statusLine.start();
+      statusLine.repaint({ model: 'M', cost: 0, tokens: 0, contextPct: 0 });
+      const c = new TerminalCompositor({
+        stdout,
+        stdin,
+        onCancel: vi.fn(),
+        scrollRegion: statusLine,
+        anchorRow: 1,
+      });
+      armed.push(c);
+      await c.arm();
+      statusLine.setExtraRows(2);
+      c.setSpinner({ enabled: true });
+      const internals = c as unknown as Internals;
+
+      // Tall overlay -> band-hold, so the commit is retained in the model and
+      // materialized only after the resize (the reflow-at-paint path).
+      c.setOverlay(
+        Array.from({ length: 22 }, (_, i) => `thinking ${i} — held overlay row`).join('\n'),
+      );
+
+      c.commitAbove(`${SENTENCE}\n\n`);
+
+      // Pure-width SIGWINCH: immediate channel + debounced channel.
+      stdout.columns = w2;
+      process.stdout.emit('resize');
+      vi.advanceTimersByTime(150);
+
+      // Collapse the overlay -> band materializes and repaints at w2.
+      c.setSpinner({ enabled: false });
+      c.setOverlay('');
+      internals.repaint();
+      internals.repaint();
+
+      const rows = [...vscreen.scrollbackLines(), ...vscreen.visibleLines()];
+      const fused = findFusedLine(rows);
+      expect(
+        fused,
+        `W1=${w1} -> W2=${w2} produced a fused row: ${JSON.stringify(fused)}`,
+      ).toBeNull();
+
+      // The in-memory band model must also stay unfused and space-preserving.
+      expect(findFusedLine(internals.committedBand), `W1=${w1}->W2=${w2} band fused`).toBeNull();
+      const bandText = internals.committedBand.map((l) => stripAnsi(l)).join('');
+      expect(bandText.replace(/\s+/g, ' ').trim(), `W1=${w1}->W2=${w2} band lost content`).toContain(
+        'relevant tests',
+      );
+
+      c.disarm();
+      armed.pop();
+      statusLine.stop?.();
+      vi.useRealTimers();
+    }
+  }, 120_000);
+});

--- a/src/cli/terminal-compositor.space-fusion.repro.test.ts
+++ b/src/cli/terminal-compositor.space-fusion.repro.test.ts
@@ -71,7 +71,8 @@ interface Internals {
 /** The sentence from the live symptom report, with the witness pair in it. */
 const SENTENCE = 'I edited the relevant tests and ran the tests again to confirm';
 /** Every fusion witness: the two words with their separating space removed. */
-const FUSIONS = ['Iedited', 'thetests', 'relevanttests', 'andran', 'theirrelevant'] as const;
+const SENTENCE_WORDS = SENTENCE.split(' ');
+const FUSIONS = SENTENCE_WORDS.slice(1).map((word, i) => SENTENCE_WORDS[i] + word);
 
 /** Column widths that place a hard-wrap boundary EXACTLY on each space. */
 function widthsBreakingOnEachSpace(s: string): number[] {
@@ -223,8 +224,8 @@ describe('paint layer — word/space fusion under width-change reflow', () => {
       // The in-memory band model must also stay unfused and space-preserving.
       expect(findFusedLine(internals.committedBand), `W1=${w1}->W2=${w2} band fused`).toBeNull();
       const bandText = internals.committedBand.map((l) => stripAnsi(l)).join('');
-      expect(bandText.replace(/\s+/g, ' ').trim(), `W1=${w1}->W2=${w2} band lost content`).toContain(
-        'relevant tests',
+      expect(bandText.replace(/\s+/g, ' ').trim(), `W1=${w1}->W2=${w2} band lost content`).toBe(
+        SENTENCE,
       );
 
       c.disarm();


### PR DESCRIPTION
## Summary

The tool lane was rendering filenames that do not exist on disk.

`collapseFsPaths` is documented as collapsing **absolute** paths to their basename, but the leading `/` in its regex was unanchored. It therefore matched from the first *interior* slash of a **relative** path and spliced the surviving head straight onto the basename, deleting the separator and every middle segment:

| input | rendered before | rendered now |
|---|---|---|
| `src/cli/_lib/child-activity-select.test.ts` | `srcchild-activity-select.test.ts` | unchanged |
| `./src/cli/_lib/x.ts` | `.x.ts` | unchanged |
| `a/b/c/d.ts` | `ad.ts` | unchanged |
| `/Users/me/proj/src/x.ts` | `x.ts` | `x.ts` (unchanged behaviour) |

A label naming a file that does not exist is worse than a long one: a reader cannot distinguish it from a real sibling file, and it silently misreports which test or source file a command touched. This was spotted in a real session where `pnpm test:file src/cli/_lib/child-activity-select.test.ts` displayed as `srcchild-activity-select.test.ts`.

The fix anchors the match with a lookbehind rejecting a preceding path-ish character (`[\w./~-]`), which confines the collapse to genuinely absolute paths as the doc comment already claimed. Relative and `~/`-rooted paths are now left intact and shortened honestly by the lane's own width truncation. Absolute-path collapsing, URL safety, and OSC 8 hyperlink emission are all unchanged.

### Also included

`src/cli/terminal-compositor.space-fusion.repro.test.ts` — a width-sweep regression guard asserting the compositor paint layer never fuses two words when a wrap lands exactly on the space between them. This came out of investigating a *separate* reported symptom (streamed prose intermittently losing a single space, e.g. `relevant tests` rendering as `relevanttests`). That symptom was **not** reproduced in agent-afk: the provider delta translation, stream consumer, session accumulation, markdown/thinking formatters, wrap helpers, and compositor reflow were each measured lossless, and the persisted transcripts carry correctly spaced text. The test is kept as a standing guard on the one layer that could plausibly regress into it.

## How was this tested?

- `pnpm lint` — clean (`tsc --noEmit`, strict).
- `pnpm test` — **761 files, 14458 tests passed, 2 skipped, 0 failures.**
- `pnpm test:file src/cli/commands/interactive/tool-lane-format.test.ts` — 149 passed, including 6 new regression assertions covering relative paths, dot-relative paths, `~/`-rooted paths, and the two absolute-path cases that must keep collapsing (`--out=/abs/...` and `cd /abs/...`).
- The pre-existing `shortenPaths` suite (URL safety, OSC 8 hyperlinks, embedded bash commands) passes unmodified, which is what pins the absolute-path and URL behaviour as unchanged.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/) — see [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] No secrets, tokens, or private paths in the diff
