### PR TITLE
refactor(repl): split bootstrap.ts into 9 phase modules (#823)

### DIFF
--- a/src/cli/commands/interactive/bootstrap-config.ts
+++ b/src/cli/commands/interactive/bootstrap-config.ts
@@ -1,0 +1,101 @@
+import { unconfiguredSlotError } from '../../../agent/session/model-slots.js';
+import type { ThinkingConfig, EffortLevel, AgentConfig } from '../../../agent/types.js';
+import {
+  parseThinking, parseEffort, parseMaxOutputTokens, getThinking, getEffort,
+  getMaxOutputTokens, getMaxToolUseIterations, resolveBaseSystemPrompt,
+} from '../../shared-helpers.js';
+import { loadConfig, type CliConfig } from '../../config.js';
+import { assembleSystemPrompt } from '../../../agent/routing-directive.js';
+import type { CliOptions } from './shared.js';
+import { resolveResumeCwd } from './shared.js';
+import { resolveResumeTarget, resumeConfigFor } from '../../resume-session.js';
+import type { ResolvedResumeTarget } from '../../resume-session.js';
+
+/** Resolved bootstrap configuration — output of {@link resolveBootstrapConfig}. */
+export interface BootstrapConfig {
+  resumeTarget: ResolvedResumeTarget | undefined;
+  resumeConfig: Partial<AgentConfig>;
+  effectiveCwd: string | undefined;
+  sessionModel: string;
+  thinking: ThinkingConfig | undefined;
+  effort: EffortLevel | undefined;
+  maxOutputTokens: number | undefined;
+  maxToolUseIterations: number | undefined;
+  basePrompt: string | undefined;
+  systemPrompt: string | undefined;
+  systemPromptSource: string | undefined;
+  cliConfig: CliConfig;
+}
+
+/**
+ * Resolve the resume target, effective cwd, session model, thinking/effort/
+ * token knobs, and the layered system prompt from CLI options. Extracted
+ * from `bootstrapSession` so option-parsing failures (the unconfigured-slot
+ * throw below) are testable without constructing the heavy session/executor
+ * graph.
+ *
+ * Throws when the resolved session model names an unconfigured capability
+ * tier (e.g. `afk i -m local` with no `AFK_MODEL_LOCAL`) — callers must let
+ * this propagate before building the REPL session, exactly as the inlined
+ * code did.
+ */
+export function resolveBootstrapConfig(
+  options: CliOptions,
+  extras?: { cwd?: string },
+): BootstrapConfig {
+  const resumeTarget = resolveResumeTarget(options);
+  const resumeConfig = resumeConfigFor(resumeTarget);
+  // Resume cwd restoration: a resumed session should run in the directory it
+  // was saved in (e.g. an `afk --worktree` session that was later /fork'd or
+  // --resume'd), not wherever the shell happens to be. Precedence: an explicit
+  // --worktree override (extras.cwd) always wins; otherwise fall back to the
+  // stored cwd IFF it still exists on disk as a directory — a cleaned-up
+  // worktree degrades safely to process.cwd(). `effectiveCwd` is threaded
+  // through every cwd-purpose usage below (stats stamp, hook/session cwd,
+  // subagent/skill/compose/MCP cwd) so resumed worktree sessions AND their
+  // children anchor correctly. Defaults to `extras?.cwd` when there is no
+  // resume override, so this is a safe drop-in: behavior only changes for a
+  // resume whose stored cwd still exists.
+  const effectiveCwd = resolveResumeCwd(extras?.cwd, resumeTarget?.stored?.cwd);
+  const sessionModel = resumeTarget?.stored?.model ?? options.model;
+  // Fail fast on an unconfigured capability tier (e.g. `afk i -m local` with no
+  // AFK_MODEL_LOCAL) before building the REPL session — an empty id would
+  // otherwise reach the provider as an opaque error or a silent cloud call.
+  const unconfiguredModel = unconfiguredSlotError(sessionModel);
+  if (unconfiguredModel) {
+    throw new Error(unconfiguredModel);
+  }
+
+  const thinking: ThinkingConfig | undefined = parseThinking(options.thinking) ?? getThinking();
+  const effort: EffortLevel | undefined = parseEffort(options.effort) ?? getEffort();
+  const maxOutputTokens: number | undefined =
+    parseMaxOutputTokens(options.maxOutputTokens) ?? getMaxOutputTokens();
+  // Opt-in top-level tool-use-round ceiling. No CLI flag exists, so this is the
+  // env default only (unset/<=0 → undefined → unlimited; no behavior change).
+  const maxToolUseIterations = getMaxToolUseIterations();
+
+  // System-prompt layering: the framework base (`prompts/system-prompt.md`)
+  // is unconditional; the operator overlay (env → afk.config.json → AFK.md)
+  // is appended on top via resolveBaseSystemPrompt(), never substituted for
+  // the base. `source` is the layered provenance string surfaced by
+  // --dump-prompt (`framework`, `framework+afk-md:/path`, …).
+  const { prompt: basePrompt, source: systemPromptSource } = resolveBaseSystemPrompt();
+  const cliConfig = loadConfig();
+  const autoRouting = cliConfig.autoRouting?.interactive ?? true;
+  const systemPrompt = assembleSystemPrompt(basePrompt, autoRouting, 'repl');
+
+  return {
+    resumeTarget,
+    resumeConfig,
+    effectiveCwd,
+    sessionModel,
+    thinking,
+    effort,
+    maxOutputTokens,
+    maxToolUseIterations,
+    basePrompt,
+    systemPrompt,
+    systemPromptSource,
+    cliConfig,
+  };
+}

--- a/src/cli/commands/interactive/bootstrap-hooks.ts
+++ b/src/cli/commands/interactive/bootstrap-hooks.ts
@@ -1,0 +1,61 @@
+import { createDefaultHookRegistry } from '../../../agent/default-hook-registry.js';
+import { loadHooksConfig } from '../../../agent/hooks/config-loader.js';
+import type { HookRegistry } from '../../../agent/hooks.js';
+import type { MemoryStore } from '../../../agent/memory/index.js';
+import type { TraceWriter } from '../../../agent/trace/index.js';
+import type { SessionStats } from '../../slash/types.js';
+import type { CompletionWriter } from './shared.js';
+import { emitSubagentCompletion } from './progress-banner.js';
+import { createTerminalStateGate } from './terminal-state-gate.js';
+import { loadConfig } from '../../config.js';
+
+/**
+ * Build the stable hook registry shared across sessions (including
+ * mid-session `/resume` swaps) and register the terminal-state Stop gate on
+ * top of it.
+ *
+ * The hook callbacks close over `stats` and `completionWriter`, which are
+ * also stable, so a rebuilt session gets the same routing without re-wiring.
+ * `pathApprovalGrantRef` is populated by the caller once the provider
+ * exists — the path-approval hook fails open until then (mirroring
+ * `setAllowDirDispatcher` wiring order).
+ *
+ * The terminal-state gate (issue #237) is a post-turn `Stop` hook that
+ * bounces a self-certified `Done` with no corroborating evidence back into
+ * the next turn via the Stop injectContext primitive (wired in
+ * loop-iteration.ts). Registered here rather than in
+ * `createDefaultHookRegistry` because it reads cli-layer config
+ * (`enforceDoneEvidence`, fresh each turn) and the live permission mode;
+ * opt-in + autonomous-only, so it is inert unless the operator enabled it.
+ * REPL surface only — the Stop injectContext delivery it depends on lives in
+ * the REPL loop.
+ */
+export function createReplHookRegistry(a: {
+  completionWriter: CompletionWriter;
+  memoryStore: MemoryStore;
+  stats: SessionStats;
+  effectiveCwd: string | undefined;
+  traceWriter: TraceWriter | undefined;
+}): { hookRegistry: HookRegistry; pathApprovalGrantRef: { current: unknown } } {
+  const hookRegistryBundle = createDefaultHookRegistry(
+    (info) => { emitSubagentCompletion(a.completionWriter, info); },
+    'cli',
+    a.memoryStore,
+    () => a.stats.permissionMode,
+    loadHooksConfig({ cwd: a.effectiveCwd }),
+    { cwd: a.effectiveCwd, ...(a.traceWriter !== undefined ? { traceWriter: a.traceWriter } : {}) },
+    () => a.effectiveCwd ?? process.cwd(),
+  );
+  const hookRegistry = hookRegistryBundle.registry;
+  const pathApprovalGrantRef = hookRegistryBundle.pathApprovalGrantRef;
+
+  hookRegistry.register(
+    'Stop',
+    createTerminalStateGate({
+      getPermissionMode: () => a.stats.permissionMode,
+      isEnabled: () => loadConfig().enforceDoneEvidence === true,
+    }),
+  );
+
+  return { hookRegistry, pathApprovalGrantRef };
+}

--- a/src/cli/commands/interactive/bootstrap-infra.ts
+++ b/src/cli/commands/interactive/bootstrap-infra.ts
@@ -1,0 +1,171 @@
+import type { SessionRef } from '../../../agent/session-ref.js';
+import { getApiKey, getApiKeyForModel, getModel, getDefaultSubagentModel } from '../../shared-helpers.js';
+import type { CliConfig } from '../../config.js';
+import { wireExecutors } from '../../../agent/session/wire-executors.js';
+import type { SubagentExecutor } from '../../../agent/tools/subagent-executor.js';
+import type { SkillExecutor } from '../../../agent/tools/skill-executor.js';
+import type { ComposeExecutor } from '../../../agent/tools/compose-executor.js';
+import type { SubagentManager } from '../../../agent/subagent.js';
+import { BackgroundAgentRegistry } from '../../../agent/background-registry.js';
+import { BackgroundSummarizer } from '../../../agent/background-summarizer.js';
+import { setBgsubRegistry, setBgsubSummarizer } from '../../slash/commands/bgsub.js';
+import { createDefaultTraceWriter } from '../../../agent/trace/factory.js';
+import { emitSessionPhase } from '../../../agent/trace/emit.js';
+import type { ResolvedResumeTarget } from '../../resume-session.js';
+import type { CliOptions } from './shared.js';
+
+/** Wired infra bundle returned by {@link createBootstrapInfra}. */
+export interface BootstrapInfra {
+  trace: ReturnType<typeof createDefaultTraceWriter>;
+  apiKey: string | undefined;
+  backgroundRegistry: BackgroundAgentRegistry;
+  bgSummarizer: BackgroundSummarizer | undefined;
+  rootManager: SubagentManager;
+  subagentExecutor: SubagentExecutor;
+  skillExecutor: SkillExecutor;
+  composeExecutor: ComposeExecutor;
+}
+
+/**
+ * Construct the witness trace writer, the background-agent registry (+
+ * optional summarizer), the deferred-parent proxy, and the `agent`/`skill`/
+ * `compose` executor trio (via {@link wireExecutors}).
+ *
+ * Ordering invariants preserved from the original inline sequence:
+ *   1. `trace` is opened BEFORE `BackgroundAgentRegistry` and BEFORE
+ *      `wireExecutors` — the root manager inherits the writer (fork lifecycle
+ *      events depend on that inheritance), and `bootstrap_start` fires only
+ *      once the writer exists.
+ *   2. `deferredParent` reads through `a.sessionRef.current` (never captures
+ *      `session` by value) so a mid-session `/resume` swap — which mutates
+ *      `sessionRef.current` — stays transparent to every child executor that
+ *      holds this proxy.
+ *   3. `bootWarnings` is the SAME array instance the caller owns — never
+ *      copied — so `agentRegistryWarn` pushes are visible to the caller after
+ *      this function returns (and even if a later phase throws).
+ */
+export function createBootstrapInfra(a: {
+  sessionRef: SessionRef;
+  // Unused in this phase's own body today — kept on the signature to match
+  // the extraction contract (every phase receives the full options bag) and
+  // to avoid a signature change if a future option needs to reach this phase.
+  options: CliOptions;
+  cliConfig: CliConfig;
+  sessionModel: string;
+  basePrompt: string | undefined;
+  effectiveCwd: string | undefined;
+  resumeTarget: ResolvedResumeTarget | undefined;
+  bootWarnings: string[];
+}): BootstrapInfra {
+  // Witness layer: open trace BEFORE the root SubagentManager and the
+  // executor so (a) the manager inherits the writer — the `agent`-tool path
+  // relies on manager-level inheritance for its forks' lifecycle events
+  // (see forkSubagent's effectiveTraceWriter) — and (b) the
+  // BackgroundAgentRegistry can be constructed with the writer in hand.
+  // The trace path is logged after `bootstrapSession` returns (caller-side
+  // banner), so we open the file here but defer the log line until later
+  // to preserve startup-message ordering.
+  const traceSessionLabel = a.resumeTarget?.stored?.sessionId;
+  const trace = createDefaultTraceWriter(
+    traceSessionLabel ? { sessionLabel: traceSessionLabel } : {},
+  );
+
+  const apiKey = getApiKey();
+  // Witness layer: trace writer is now live — emit the bootstrap_start marker.
+  // (Total bootstrap span is reported by bootstrap_done, measured from the
+  // function-entry timestamp captured in bootstrap.ts.)
+  void emitSessionPhase(trace?.writer, { phase: 'bootstrap_start' });
+
+  // BackgroundAgentRegistry — owns the lifecycle of every job spawned by
+  // `agent` tool with mode="background". Constructed before the executor
+  // so we can pass it via SubagentExecutorContext. Cancel-all is invoked
+  // by the interactive teardown path so detached jobs do not outlive
+  // their parent process.
+  const backgroundRegistry = new BackgroundAgentRegistry(
+    trace ? { traceWriter: trace.writer } : {},
+  );
+  setBgsubRegistry(backgroundRegistry);
+
+  // Opt-in background summarizer — only constructed when bgSummaries: true.
+  const bgSummariesEnabled = a.cliConfig.bgSummaries === true;
+  const bgSummarizer = bgSummariesEnabled && apiKey
+    ? new BackgroundSummarizer({
+        registry: backgroundRegistry,
+        apiKey,
+        maxCallsPerSession: a.cliConfig.maxSummaryCallsPerSession ?? 200,
+      })
+    : undefined;
+  bgSummarizer?.start();
+  setBgsubSummarizer(bgSummarizer);
+
+  // External constraint: deferredParent reads through sessionRef.current so
+  // a mid-session swap (mutating sessionRef.current) is transparent to all
+  // child executors — they hold a reference to this proxy object, which
+  // always delegates to the currently-active session.
+  const deferredParent = {
+    get sessionId() { return a.sessionRef.current?.sessionId; },
+    getInputStreamRef() { return a.sessionRef.current?.getInputStreamRef?.() ?? { pushUserMessage: () => {} }; },
+    get abortSignal() {
+      return a.sessionRef.current?.abortSignal ?? new AbortController().signal;
+    },
+    // Expose the live session's registry so forked subagents resolve it via
+    // SubagentManager.forkSubagent's parent fallback — the production path for
+    // SubagentStart/Stop (incl. the shadow-verify nudge) and child-config
+    // inheritance. The registry is constructed after this proxy, so reading
+    // it lazily through sessionRef.current is required.
+    get hookRegistry() { return a.sessionRef.current?.hookRegistry; },
+  };
+
+  // Invariant: ONE root manager per session, shared by all three executors.
+  // Constructed here (not earlier) so it can be created together with the
+  // executors that close over it; the SubagentManager constructor is pure —
+  // it emits no trace events — so this placement does not reorder the
+  // witness trace relative to `bootstrap_start` above.
+  const { rootManager, subagentExecutor, skillExecutor, composeExecutor } = wireExecutors({
+    // Origin attribution: the REPL is a `cli` entrypoint, so forked children
+    // inherit origin 'cli' (not 'unknown'). See session-identity.ts.
+    surface: 'cli',
+    parentSession: deferredParent,
+    apiKey,
+    model: a.sessionModel,
+    // `apiKey` is getApiKey(), which keys off getModel() (AFK_MODEL), so the
+    // manager's credential-fallback provider must be derived from THAT model —
+    // not the possibly-resumed session model — or the fallback can cross the
+    // provider boundary.
+    managerParentModel: getModel(),
+    // OpenAI-routed parents default dispatched subagents to the parent model
+    // rather than the legacy `'sonnet'` literal, which would silently route
+    // local-only sessions to api.anthropic.com. Claude parents still get 'sonnet'.
+    defaultSubagentModel: getDefaultSubagentModel(a.sessionModel),
+    resolveApiKeyForModel: getApiKeyForModel,
+    // Raw base prompt (pre-assembly): children and compose nodes stay task
+    // workers, without ROUTING_DIRECTIVE / TOOL_SYSTEM_PROMPT.
+    ...(a.basePrompt !== undefined ? { systemPrompt: a.basePrompt } : {}),
+    ...(a.cliConfig.baseUrl !== undefined ? { baseUrl: a.cliConfig.baseUrl } : {}),
+    ...(a.cliConfig.openaiBaseUrl !== undefined ? { openaiBaseUrl: a.cliConfig.openaiBaseUrl } : {}),
+    // Worktree cwd (`afk i --worktree`, or a resumed session's restored cwd)
+    // propagates to every depth so subagents' resolveBase + readRoots anchor
+    // to the worktree, not the Node host's process.cwd().
+    ...(a.effectiveCwd !== undefined ? { cwd: a.effectiveCwd, nestedCwd: a.effectiveCwd } : {}),
+    ...(trace?.writer !== undefined
+      ? { traceWriter: trace.writer, skillTraceWriter: trace.writer }
+      : {}),
+    // Background dispatch (`agent` with mode:"background") is REPL-only; the
+    // registry must reach every depth of the skill/agent fork chain.
+    backgroundRegistry,
+    // `warn` routes into bootWarnings rather than stderr: the built-in-shadow
+    // warning is a safety signal and the startup screen clear eats stderr.
+    agentRegistryWarn: (message: string) => a.bootWarnings.push(message),
+  });
+
+  return {
+    trace,
+    apiKey,
+    backgroundRegistry,
+    bgSummarizer,
+    rootManager,
+    subagentExecutor,
+    skillExecutor,
+    composeExecutor,
+  };
+}

--- a/src/cli/commands/interactive/bootstrap-mcp.ts
+++ b/src/cli/commands/interactive/bootstrap-mcp.ts
@@ -1,0 +1,93 @@
+import { McpManager, loadMcpConfig, getMcpConfigPath } from '../../../agent/mcp/index.js';
+import { loadImportFromConfig, resolveImportedRoots } from '../../../config/import-sources.js';
+import type { TraceWriter } from '../../../agent/trace/index.js';
+import { emitSessionPhase } from '../../../agent/trace/emit.js';
+import { palette } from '../../palette.js';
+
+/**
+ * Load `~/.afk/config/mcp.json` (layered with project-local + imported
+ * sources) and connect every enabled server. Must run BEFORE provider
+ * construction so the provider sees the MCP-bridged tools in its initial
+ * schema set — `buildProvider` and `mcpToolWireNames` in
+ * `bootstrap-providers.ts` close over the returned manager.
+ *
+ * Failure model: `loadMcpConfig()` returns warnings, never throws. The
+ * manager itself throws when an `alwaysLoad: true` server fails or when
+ * there's a wire-name collision — both are user-facing config errors and
+ * should abort bootstrap with the error message intact (propagated, not
+ * caught here).
+ *
+ * Prints the `mcp: N server(s) from …` startup line directly (preserved
+ * console-output ordering: `mcp:` → `trace:` → `↪ resuming in`, the latter
+ * two owned by `bootstrap-surface.ts`). Pushes config-loader warnings into
+ * the SAME `bootWarnings` array instance the caller owns — never a copy.
+ */
+export async function connectReplMcp(a: {
+  effectiveCwd: string | undefined;
+  mcpConfigOverride: string | undefined;
+  traceWriter: TraceWriter | undefined;
+  bootWarnings: string[];
+}): Promise<McpManager | undefined> {
+  // Use the worktree cwd for project-local `.mcp.json` resolution so each
+  // worktree can carry its own MCP config (matching how the worktree
+  // already isolates everything else under `worktreeCwd`).
+  const projectCwd = a.effectiveCwd ?? process.cwd();
+  // Imported MCP servers from trusted source binaries (`importFrom`). Only
+  // JSON-format configs (Claude Code) are loadable today; they enter as the
+  // lowest-priority layer so AFK's own config always wins. MCP import is
+  // off by default even for a trusted binary (it auto-runs commands on
+  // connect) — this only fires when the user set `mcp: true` for a binary.
+  const importedMcpConfigs = resolveImportedRoots(loadImportFromConfig())
+    .mcpConfigs.filter((c) => c.format === 'json')
+    .map((c) => c.source);
+  const loaded = loadMcpConfig({
+    cwd: projectCwd,
+    ...(importedMcpConfigs.length > 0 ? { importedMcpConfigs } : {}),
+    ...(a.mcpConfigOverride !== undefined ? { cliOverride: a.mcpConfigOverride } : {}),
+  });
+  const enabledCount = Object.values(loaded.mcpServers).filter((s) => !s.disabled).length;
+  // Config-loader warnings ("your mcp.json had X") reach the operator on both
+  // branches — servers enabled or not — via the post-clear drain. Collected
+  // once here so the two paths cannot diverge: previously the enabled path
+  // printed inside McpManager.fromConfig and the disabled path printed here,
+  // and the clear erased both.
+  for (const w of loaded.warnings) a.bootWarnings.push(`[mcp] ${w}`);
+
+  let mcpManager: McpManager | undefined;
+  if (enabledCount > 0) {
+    const sourcesLabel = loaded.sources.length === 1
+      ? loaded.sources[0]
+      : `${loaded.sources.length} source(s)`;
+    console.log(palette.dim(`  mcp: ${enabledCount} server(s) from ${sourcesLabel ?? getMcpConfigPath()}`));
+    // Witness layer: bracket the whole-fleet MCP connect. try/finally so
+    // mcp_connect_done fires even when an alwaysLoad server makes fromConfig
+    // throw. Per-server mcp_server_* pairs are emitted inside fromConfig via
+    // the traceWriter passed below. Fire-and-forget; never gates connect.
+    const mcpStartedAt = Date.now();
+    void emitSessionPhase(a.traceWriter, {
+      phase: 'mcp_connect_start',
+      metadata: { serverCount: enabledCount },
+    });
+    try {
+      // `warnings` is deliberately NOT forwarded: fromConfig would
+      // `console.warn` them (mcp/manager.ts) mid-bootstrap, where the startup
+      // clear erases them. They ride bootWarnings instead and are drained
+      // after the clear. `chat` still forwards them — it never clears — so
+      // this does not change any other surface, and nothing double-prints.
+      mcpManager = await McpManager.fromConfig(loaded.mcpServers, {
+        ...(a.traceWriter !== undefined ? { traceWriter: a.traceWriter } : {}),
+      });
+    } finally {
+      void emitSessionPhase(a.traceWriter, {
+        phase: 'mcp_connect_done',
+        durationMs: Date.now() - mcpStartedAt,
+        metadata: { serverCount: enabledCount },
+      });
+    }
+  }
+  // No `else` branch for warnings: the no-enabled-servers case used to
+  // console.warn here, and both branches are now covered by the single
+  // bootWarnings collection above.
+
+  return mcpManager;
+}

--- a/src/cli/commands/interactive/bootstrap-providers.ts
+++ b/src/cli/commands/interactive/bootstrap-providers.ts
@@ -1,0 +1,97 @@
+import type { ModelProvider } from '../../../agent/provider.js';
+import type { MemoryStore } from '../../../agent/memory/index.js';
+import type { SubagentExecutor } from '../../../agent/tools/subagent-executor.js';
+import type { SkillExecutor } from '../../../agent/tools/skill-executor.js';
+import type { ComposeExecutor } from '../../../agent/tools/compose-executor.js';
+import type { McpManager } from '../../../agent/mcp/index.js';
+import { parseProvider } from '../../shared-helpers.js';
+import { topLevelSurfaceAllowedTools } from '../../../agent/tools/top-level-allowlist.js';
+import { AnthropicDirectProvider } from '../../../agent/providers/anthropic-direct/index.js';
+import { providerForModel } from '../../../agent/providers/index.js';
+import { createMemoizedProviderFactory } from './provider-factory.js';
+import type { CliConfig } from '../../config.js';
+import type { CliOptions } from './shared.js';
+
+/**
+ * Build a fully-wired, per-family-memoized provider factory the
+ * ProviderRouter calls to resolve the active provider — at session init and
+ * again on each cross-family `/model` swap (NOT every turn; the router
+ * reuses the active inner across turns of the same family). The builder
+ * closes over the executors, memoryStore, mcpManager, and openaiBaseUrl so
+ * every provider it builds (regardless of family) carries the full tool
+ * surface — agent/skill/compose tools, MCP bridges, and the shared
+ * MemoryStore. This is what allows mid-session `/model` cross-family
+ * switches (e.g. Claude → GPT) without losing any tool wiring.
+ *
+ * When `--provider` is explicit (`options.provider` is set), `parseProvider`
+ * returns a single fixed provider, so the builder always yields the same
+ * family. This preserves the AFK_PROVIDER / --provider escape-hatch behavior.
+ *
+ * Memoization invariant: `startupProvider` (returned here) MUST be the same
+ * instance the router's `buildInner` reuses for turn 1, or `/allow-dir`
+ * grants land on a dead instance and are silently dropped. The cache key
+ * mirrors `parseProvider`'s own routing: the `--provider` override first (a
+ * fixed family), otherwise `providerForModel` with the same `openaiBaseUrl`
+ * hint — so a key never aliases two different provider families.
+ *
+ * Call this AFTER MCP connect (`bootstrap-mcp.ts`) — `buildProvider` and
+ * `mcpToolWireNames` close over `a.mcpManager`.
+ */
+export function createReplProviders(a: {
+  options: CliOptions;
+  cliConfig: CliConfig;
+  sessionModel: string;
+  subagentExecutor: SubagentExecutor;
+  skillExecutor: SkillExecutor;
+  composeExecutor: ComposeExecutor;
+  memoryStore: MemoryStore;
+  mcpManager: McpManager | undefined;
+}): { providerFactory: (m: string | undefined) => ModelProvider; startupProvider: ModelProvider } {
+  // The MCP tool wire names are stable for the manager lifetime, so they can be
+  // captured once in the closure without re-querying on every build.
+  const mcpToolWireNames = a.mcpManager?.getMcpToolWireNames() ?? [];
+  const buildProvider = (model: string | undefined): ModelProvider =>
+    parseProvider(a.options.provider, {
+      subagentExecutor: a.subagentExecutor,
+      skillExecutor: a.skillExecutor,
+      composeExecutor: a.composeExecutor,
+      memoryStore: a.memoryStore,
+      model: model !== undefined ? model : String(a.sessionModel),
+      ...(a.cliConfig.openaiBaseUrl !== undefined ? { openaiBaseUrl: a.cliConfig.openaiBaseUrl } : {}),
+      ...(a.mcpManager !== undefined ? { mcpManager: a.mcpManager } : {}),
+    })
+    ?? new AnthropicDirectProvider({
+      permissions: {
+        allowedTools: topLevelSurfaceAllowedTools(mcpToolWireNames),
+      },
+      subagentExecutor: a.subagentExecutor,
+      skillExecutor: a.skillExecutor,
+      composeExecutor: a.composeExecutor,
+      memoryStore: a.memoryStore,
+      surface: 'cli',
+      ...(a.mcpManager !== undefined ? { mcpManager: a.mcpManager } : {}),
+    });
+
+  // Memoize by provider family so the `startupProvider` built below for /allow-dir
+  // wiring is the SAME instance the router's buildInner reuses for turn 1.
+  // Without this, the two call sites mint separate instances with independent
+  // read/write grant roots, and /allow-dir grants are silently dropped (they land
+  // on the startup instance, never on the query runner). The cache key mirrors
+  // parseProvider's own routing: the --provider override first (a fixed family),
+  // otherwise providerForModel with the same openaiBaseUrl hint — so a key never
+  // aliases two different provider families.
+  const providerFactory = createMemoizedProviderFactory(buildProvider, (model) =>
+    a.options.provider ??
+    providerForModel(
+      model !== undefined ? model : String(a.sessionModel),
+      a.cliConfig.openaiBaseUrl !== undefined ? { openaiBaseUrl: a.cliConfig.openaiBaseUrl } : undefined,
+    ),
+  );
+
+  // Build the startup provider (for /allow-dir wiring). Because the factory
+  // memoizes by family, this returns the SAME instance the router reuses for
+  // turn 1, so grants added via setAllowDirDispatcher reach the query runner.
+  const startupProvider = providerFactory(String(a.sessionModel));
+
+  return { providerFactory, startupProvider };
+}

--- a/src/cli/commands/interactive/bootstrap-session-builder.ts
+++ b/src/cli/commands/interactive/bootstrap-session-builder.ts
@@ -1,0 +1,129 @@
+import { AgentSession } from '../../../agent/session.js';
+import type { PermissionMode } from '../../../agent/types/sdk-types.js';
+import { injectHotMemory } from '../../../agent/memory/index.js';
+import { injectCompanionPrimer } from '../../../agent/companion/index.js';
+import type { ThinkingConfig, EffortLevel } from '../../../agent/types.js';
+import type { AgentConfig } from '../../../agent/types.js';
+import type { ModelProvider } from '../../../agent/provider.js';
+import type { HookRegistry } from '../../../agent/hooks.js';
+import type { TraceWriter } from '../../../agent/trace/index.js';
+import { getApiKeyForModel } from '../../shared-helpers.js';
+import type { CliConfig } from '../../config.js';
+
+/**
+ * Dependencies for constructing a fresh `AgentSession`. Captures everything
+ * the constructor block reads so `buildAgentSession` can be called both from
+ * `bootstrapSession` (initial) and from the mid-session swap path.
+ */
+export interface BuildAgentSessionDeps {
+  model: string;
+  resumeConfig: Partial<AgentConfig>;
+  systemPrompt: string | undefined;
+  systemPromptSource: string | undefined;
+  thinking: ThinkingConfig | undefined;
+  effort: EffortLevel | undefined;
+  maxOutputTokens: number | undefined;
+  /**
+   * Opt-in top-level tool-use-round ceiling (from AFK_MAX_TOOL_USE_ITERATIONS).
+   * `undefined` = unlimited (no behavior change). Flows to
+   * `AgentConfig.maxToolUseIterations` and hits both providers via
+   * `resolveMaxToolIterations()`. Top-level only — subagent forks set their own.
+   */
+  maxToolUseIterations: number | undefined;
+  /**
+   * Fully-wired provider factory. Passed as `config.providerFactory` so the
+   * ProviderRouter builds a wired provider (with executors, memoryStore,
+   * mcpManager) on every turn — enabling cross-family /model swaps without
+   * losing the agent/skill/compose tools or MCP bridges.
+   */
+  providerFactory: (model: string | undefined) => ModelProvider;
+  hookRegistry: HookRegistry;
+  traceWriter: TraceWriter | undefined;
+  cwd: string | undefined;
+  maxTurns: number;
+  autoResumeOnUsageLimit: boolean | undefined;
+  /** Initial session permission mode (e.g. 'bypassPermissions'). Omit for 'default'. */
+  permissionMode?: PermissionMode;
+  baseUrl?: string;
+}
+
+/**
+ * Construct a fresh `AgentSession` from the supplied deps. Extracted so the
+ * mid-session swap path can build a new session with a different `resumeConfig`
+ * without duplicating the constructor argument list.
+ */
+export function buildAgentSession(deps: BuildAgentSessionDeps): AgentSession {
+  return new AgentSession(injectCompanionPrimer(injectHotMemory({
+    model: deps.model,
+    // User-facing surface for trace `origin` attribution. The REPL is a CLI
+    // entrypoint → 'cli'. (Mid-session swap reuses this helper, also 'cli'.)
+    surface: 'cli',
+    // Resolve the credential for the ACTUAL session model, not the env-derived
+    // default. `getApiKey()` keys off AFK_MODEL/CLAUDE_MODEL, so launching
+    // `afk -m gpt-5.5` while CLAUDE_MODEL is a Claude id would inject the
+    // Anthropic OAuth token into the OpenAI provider — leaking sk-ant-… to
+    // OpenAI and shadowing Codex ChatGPT OAuth. getApiKeyForModel routes via
+    // providerForModel → the correct family (anti-leak invariant).
+    apiKey: getApiKeyForModel(deps.model),
+    maxTurns: deps.maxTurns,
+    hookRegistry: deps.hookRegistry,
+    ...(deps.permissionMode !== undefined ? { permissionMode: deps.permissionMode } : {}),
+    ...(deps.systemPrompt !== undefined ? { systemPrompt: deps.systemPrompt } : {}),
+    ...(deps.systemPromptSource !== undefined ? { systemPromptSource: deps.systemPromptSource } : {}),
+    ...(deps.thinking !== undefined ? { thinking: deps.thinking } : {}),
+    ...(deps.effort !== undefined ? { effort: deps.effort } : {}),
+    ...(deps.maxOutputTokens !== undefined ? { maxOutputTokens: deps.maxOutputTokens } : {}),
+    ...(deps.maxToolUseIterations !== undefined ? { maxToolUseIterations: deps.maxToolUseIterations } : {}),
+    ...deps.resumeConfig,
+    ...(deps.cwd !== undefined ? { cwd: deps.cwd } : {}),
+    ...(deps.traceWriter !== undefined ? { traceWriter: deps.traceWriter } : {}),
+    ...(deps.autoResumeOnUsageLimit !== undefined
+      ? { autoResumeOnUsageLimit: deps.autoResumeOnUsageLimit }
+      : {}),
+    ...(deps.baseUrl !== undefined ? { baseUrl: deps.baseUrl } : {}),
+    providerFactory: deps.providerFactory,
+  })));
+}
+
+/**
+ * Assemble the {@link BuildAgentSessionDeps} bundle shared by the initial
+ * session build and the mid-session `/resume` swap closure. Extracted from
+ * `bootstrapSession` so the argument list constructed once there is testable
+ * in isolation from the heavy session/executor/provider wiring above it.
+ */
+export function buildSharedDeps(a: {
+  sessionModel: string;
+  resumeConfig: Partial<AgentConfig>;
+  systemPrompt: string | undefined;
+  systemPromptSource: string | undefined;
+  thinking: ThinkingConfig | undefined;
+  effort: EffortLevel | undefined;
+  maxOutputTokens: number | undefined;
+  maxToolUseIterations: number | undefined;
+  cliConfig: CliConfig;
+  providerFactory: (m: string | undefined) => ModelProvider;
+  hookRegistry: HookRegistry;
+  traceWriter: TraceWriter | undefined;
+  effectiveCwd: string | undefined;
+  maxTurns: string;
+  initialPermissionMode: PermissionMode | undefined;
+}): BuildAgentSessionDeps {
+  return {
+    model: a.sessionModel,
+    resumeConfig: a.resumeConfig,
+    systemPrompt: a.systemPrompt,
+    systemPromptSource: a.systemPromptSource,
+    thinking: a.thinking,
+    effort: a.effort,
+    maxOutputTokens: a.maxOutputTokens,
+    maxToolUseIterations: a.maxToolUseIterations,
+    ...(a.cliConfig.baseUrl !== undefined ? { baseUrl: a.cliConfig.baseUrl } : {}),
+    providerFactory: a.providerFactory,
+    hookRegistry: a.hookRegistry,
+    traceWriter: a.traceWriter,
+    cwd: a.effectiveCwd,
+    maxTurns: parseInt(a.maxTurns, 10),
+    autoResumeOnUsageLimit: a.cliConfig.autoResumeOnUsageLimit,
+    ...(a.initialPermissionMode !== undefined ? { permissionMode: a.initialPermissionMode } : {}),
+  };
+}

--- a/src/cli/commands/interactive/bootstrap-slash-context.ts
+++ b/src/cli/commands/interactive/bootstrap-slash-context.ts
@@ -1,0 +1,80 @@
+import type { SlashContext } from '../../slash/types.js';
+import type { SessionRef } from '../../../agent/session-ref.js';
+import type { SessionStats } from '../../slash/types.js';
+import type { StatusLine } from '../../status-line.js';
+import type { ContextSampler } from '../../context-sampler.js';
+import type { GitStatusSampler } from '../../git-status-sampler.js';
+import type { TrustedSkillLedger } from '../../trusted-skill-ledger.js';
+import type { McpManager } from '../../../agent/mcp/index.js';
+import type { createConsoleWriter } from '../../slash/writer.js';
+import { formatStatusFields } from './shared.js';
+
+/**
+ * Assemble the `SlashContext` every slash command dispatches through.
+ *
+ * Ordered-operation invariant (governed comment moved verbatim): `ui.clearScreen`
+ * resets the persistent compositor's overlay AND committed band BEFORE the
+ * physical clear. At idle the overlay still holds the prior turn's composed
+ * slots (stage-rail / progress-banner / live-thinking) because borrow-dispose
+ * re-composes via overlayComposer.flush() rather than setOverlay('') (see
+ * stream-renderer.ts), and the committed band still retains the prior turn's
+ * last above-frame block. Without zeroing both here, the post-clear repaint
+ * re-paints stale overlay/band rows onto the freshly-cleared screen — the
+ * band leak resurrects the prior transcript when a slash menu opens then
+ * collapses (a shrink repaint firing repositionCommittedBand). getCompositor
+ * is wired by repl-loop.ts after armCompositor and is reached late-bound at
+ * call time; undefined on non-TTY surfaces (daemon/tests) → no-op.
+ * setOverlay('') early-returns when the overlay is already empty.
+ */
+export function createReplSlashContext(a: {
+  sessionRef: SessionRef;
+  stats: SessionStats;
+  writer: ReturnType<typeof createConsoleWriter>;
+  statusLine: StatusLine;
+  contextSampler: ContextSampler;
+  gitStatusSampler: GitStatusSampler;
+  ledger: TrustedSkillLedger;
+  mcpManager: McpManager | undefined;
+}): SlashContext {
+  const slashCtx: SlashContext = {
+    session: a.sessionRef,
+    stats: a.stats,
+    out: a.writer,
+    ui: {
+      clearScreen: () => {
+        // Ordered-operation invariant: reset the persistent compositor's
+        // overlay AND committed band BEFORE the physical clear. At idle the
+        // overlay still holds the prior turn's composed slots (stage-rail /
+        // progress-banner / live-thinking) because borrow-dispose re-composes
+        // via overlayComposer.flush() rather than setOverlay('') (see
+        // stream-renderer.ts), and the committed band still retains the prior
+        // turn's last above-frame block. Without zeroing both here, the
+        // post-clear repaint re-paints stale overlay/band rows onto the
+        // freshly-cleared screen — the band leak resurrects the prior
+        // transcript when a slash menu opens then collapses (a shrink repaint
+        // firing repositionCommittedBand). getCompositor is wired by
+        // repl-loop.ts after armCompositor and is reached late-bound at call
+        // time; undefined on non-TTY surfaces (daemon/tests) → no-op.
+        // setOverlay('') early-returns when the overlay is already empty.
+        const compositor = slashCtx.getCompositor?.();
+        compositor?.setOverlay('');
+        compositor?.resetCommittedBand();
+        a.statusLine.stop();
+        a.contextSampler.reset();
+        // CSI 3J clears scrollback, 2J clears viewport, H homes cursor.
+        process.stdout.write('\x1b[3J\x1b[2J\x1b[H');
+        a.statusLine.start();
+        // Read contextSampler at call time so any swap-replaced sampler is used.
+        a.statusLine.repaint(formatStatusFields(a.stats, a.contextSampler, a.gitStatusSampler));
+      },
+      // Read contextSampler at call time (not at closure-capture time) so
+      // a mid-session swap that calls contextSampler.attach(newSession) is
+      // reflected on the next repaint.
+      repaintStatusLine: () => a.statusLine.repaint(formatStatusFields(a.stats, a.contextSampler, a.gitStatusSampler)),
+    },
+    ledger: a.ledger,
+    // Expose mcpManager so `/mcp auth complete` can call completeAuth().
+    ...(a.mcpManager !== undefined ? { mcpManager: a.mcpManager } : {}),
+  };
+  return slashCtx;
+}

--- a/src/cli/commands/interactive/bootstrap-surface.ts
+++ b/src/cli/commands/interactive/bootstrap-surface.ts
@@ -1,0 +1,151 @@
+import { resolve } from 'node:path';
+import { StatusLine } from '../../status-line.js';
+import { GitStatusSampler } from '../../git-status-sampler.js';
+import { createConsoleWriter } from '../../slash/writer.js';
+import { createSessionStats } from '../../slash/session-stats.js';
+import type { SessionStats } from '../../slash/types.js';
+import type { PermissionMode } from '../../../agent/types/sdk-types.js';
+import type { CompletionWriter } from './shared.js';
+import { reseedStatsFromStored } from './shared.js';
+import { createReplRenderer } from './repl-renderer.js';
+import { TrustedSkillLedger } from '../../trusted-skill-ledger.js';
+import type { CliConfig } from '../../config.js';
+import type { CliOptions } from './shared.js';
+import type { ResolvedResumeTarget } from '../../resume-session.js';
+import { createDefaultTraceWriter } from '../../../agent/trace/factory.js';
+import { palette } from '../../palette.js';
+
+/**
+ * Seed session stats + permission/thinking-UI mode, print the `trace:` and
+ * `↪ resuming in` startup lines, and construct the status line, REPL
+ * renderer, console writer, trusted-skill ledger, and git-status sampler.
+ *
+ * Console output order is fixed: `mcp:` (bootstrap-mcp.ts) → `trace:` →
+ * `↪ resuming in` — preserved by calling this phase strictly after MCP
+ * connect in `bootstrap.ts`.
+ *
+ * NOTE: `contextSampler` stays in `bootstrap.ts` — it needs `session`, which
+ * is only built after this phase returns.
+ */
+export function createReplSurface(a: {
+  options: CliOptions;
+  cliConfig: CliConfig;
+  sessionModel: string;
+  resumeTarget: ResolvedResumeTarget | undefined;
+  effectiveCwd: string | undefined;
+  extrasCwd: string | undefined;
+  trace: ReturnType<typeof createDefaultTraceWriter>;
+}): {
+  stats: SessionStats;
+  initialPermissionMode: PermissionMode | undefined;
+  completionWriter: CompletionWriter;
+  statusLine: StatusLine;
+  replRenderer: ReturnType<typeof createReplRenderer>;
+  writer: ReturnType<typeof createConsoleWriter>;
+  trustedSkillLedger: TrustedSkillLedger;
+  gitStatusSampler: GitStatusSampler;
+} {
+  // Create stats before session so the plan-mode gate getter can close over it.
+  const stats = createSessionStats(a.sessionModel);
+  if (a.resumeTarget?.stored) {
+    reseedStatsFromStored(stats, a.resumeTarget.stored, a.resumeTarget.resumeId);
+  }
+  // Initial permission mode: --dangerously-skip-permissions wins, else the
+  // resolved afk.config.json `permissionMode` (loadConfig now always returns one
+  // — DEFAULT_CLI_PERMISSION_MODE = bypass for new installs, overridable by the
+  // config key). Stamped on stats so the status-line badge + the plan/AFK/bypass
+  // gate getters reflect it from turn 1; the session is constructed with the same
+  // value via sharedDeps. The `!== undefined` guard is retained defensively.
+  const initialPermissionMode = a.options.dangerouslySkipPermissions
+    ? ('bypassPermissions' as const)
+    : a.cliConfig.permissionMode;
+  if (initialPermissionMode !== undefined) {
+    stats.permissionMode = initialPermissionMode;
+  }
+  // Seed thinking-UI mode so `/thinking` has a live value to mutate.
+  // `options.thinkingUi` was already resolved by the interactive action handler
+  // via `resolveThinkingUi` (--thinking-ui flag > AFK_THINKING_UI env >
+  // interactive.thinkingUi config > 'live'), so this seeds the persistent
+  // default. `createSessionStats()` pre-seeds 'live' for any path that reaches
+  // bootstrap without that resolution (e.g. tests constructing options directly).
+  if (a.options.thinkingUi !== undefined) {
+    stats.thinkingUi = a.options.thinkingUi;
+  }
+  // Stamp the effective working directory on stats so the status line can
+  // render it. We capture the same cwd the provider will see: `effectiveCwd`
+  // (the explicit `--worktree` override when present, else a resumed session's
+  // restored cwd — see resolveResumeCwd above), falling back to
+  // `process.cwd()`. Captured once at bootstrap — sessions don't `chdir`
+  // mid-run, and the status line treats this as a fixed identity field.
+  stats.cwd = a.effectiveCwd ?? process.cwd();
+
+  // Trace was opened earlier (before the executor) so the
+  // BackgroundAgentRegistry could be constructed with the writer. Surface
+  // the path here so the startup banner ordering is preserved.
+  if (a.trace) {
+    console.log(palette.dim(`  trace: ${a.trace.tracePath}`));
+  }
+  // Make a restored resume cwd legible: only when the cwd came from the stored
+  // session (not an explicit --worktree, which the banner already implies) and
+  // differs from where the shell launched. Printed in the same dim-log style
+  // as the trace line above, before the compositor is armed.
+  if (
+    a.extrasCwd === undefined &&
+    a.effectiveCwd !== undefined &&
+    resolve(a.effectiveCwd) !== resolve(process.cwd())
+  ) {
+    console.log(palette.dim(`  ↪ resuming in ${a.effectiveCwd}`));
+  }
+
+  // Both slots default to `console.log` here; `runReplLoop` mutates them
+  // after `armCompositor` resolves (when a borrowed compositor is available)
+  // so between-turn slash output commits above the live overlay instead of
+  // overlaying onto the input row. See CompletionWriter docs in shared.ts.
+  const completionWriter: CompletionWriter = {
+    fn: (line) => console.log(line),
+    idleFn: (line) => console.log(line),
+  };
+  // Construct StatusLine BEFORE createReplRenderer so the renderer can route
+  // its inter-turn raw writes through statusLine.withFullScrollRegion(...) —
+  // see repl-renderer.ts for the DECSTBM sub-region scroll-loss contract this
+  // wiring is defending against.
+  // `tickMs` is resolved caller-side (StatusLine defaults it off, like the
+  // compositor's caret blink) so only the REPL gets a recurring timer. 30s is
+  // half the quota countdown's minute granularity, which is the finest
+  // clock-derived value the row renders.
+  const statusLine = new StatusLine({ tickMs: 30_000 });
+  const replRenderer = createReplRenderer(process.stdout, { statusLine });
+
+  const trustedSkillLedger = new TrustedSkillLedger();
+  // Slash-command writer routes through `completionWriter` so when Stage 3's
+  // persistent compositor swaps `completionWriter.fn` to `compositor.commitAbove`
+  // between turns (it currently only swaps mid-turn — see turn-handler.ts:124),
+  // slash output commits above the live overlay instead of tearing it. No
+  // behavior change today: completionWriter.fn === console.log when slash
+  // commands run (always between turns under the current arm/disarm cycle).
+  const writer = createConsoleWriter(completionWriter);
+  // GitStatusSampler resolves the current branch (fast, local) + open PR
+  // (network, detached) for the status line. Bound to the session's effective
+  // cwd — under `--worktree` that differs from process.cwd(). Construction is
+  // side-effect-free (no process spawn): the initial sample + the on-update
+  // repaint wiring are kicked by setupSurface (REPL Phase 1), so bootstrap-only
+  // unit tests never shell out to git/gh.
+  const gitStatusSampler = new GitStatusSampler({
+    cwd: stats.cwd ?? process.cwd(),
+    // Suppress the per-turn git subprocess if the branch was checked < 1 s
+    // ago — human turns are seconds apart so this is imperceptible, and it
+    // bounds overhead on slow filesystems (network mounts, Docker volumes).
+    branchTtlMs: 1_000,
+  });
+
+  return {
+    stats,
+    initialPermissionMode,
+    completionWriter,
+    statusLine,
+    replRenderer,
+    writer,
+    trustedSkillLedger,
+    gitStatusSampler,
+  };
+}

--- a/src/cli/commands/interactive/bootstrap-wiring.ts
+++ b/src/cli/commands/interactive/bootstrap-wiring.ts
@@ -1,0 +1,148 @@
+import * as readline from 'node:readline';
+import { elicitationRouter } from '../../../agent/elicitation-router.js';
+import { makeReplElicitationHandler } from '../../elicitation-repl.js';
+import type { ModelProvider } from '../../../agent/provider.js';
+import { setAllowDirDispatcher } from '../../slash/commands/allow-dir.js';
+import { seedPersistedGrants } from '../../../agent/permissions-store.js';
+import { isGrantManager } from '../../shared-helpers.js';
+import { env } from '../../../config/env.js';
+import type { CompletionWriter } from './shared.js';
+import { TrustedSkillLedger } from '../../trusted-skill-ledger.js';
+import {
+  onTrustedSkillComplete, offTrustedSkillComplete,
+  onTrustedSkillStart, offTrustedSkillStart,
+} from '../../../agent/_lib/trusted-skill-events.js';
+import { formatTrustedSkillCompletion, formatTrustedSkillInFlight } from '../../trusted-skill-badge.js';
+import type { TrustedSkillResult } from '../../../agent/trusted-skill-result.js';
+import type { InputSurface } from '../../input/input-surface.js';
+
+/**
+ * Subscribe to trusted-skill start/completion events, emitting in-flight +
+ * completion badges inline at the invocation point via `completionWriter`
+ * (routed to `compositor.commitAbove` during a live turn; falls back to
+ * `console.log` outside a turn). Completions are recorded in `ledger`. Each
+ * event is its own scrollback line, so overlapping skills no longer need
+ * Set-based tracking the way the status-line approach did.
+ *
+ * @returns a teardown function — assign it to `ctx.teardownTrustedSkillEvents`.
+ */
+export function wireTrustedSkillEvents(
+  completionWriter: CompletionWriter,
+  ledger: TrustedSkillLedger,
+): () => void {
+  const onStart = (skillName: string) => {
+    completionWriter.fn(
+      formatTrustedSkillInFlight(skillName, {
+        isTTY: process.stdout.isTTY,
+        columns: process.stdout.columns,
+      }),
+    );
+  };
+
+  const onComplete = (result: TrustedSkillResult) => {
+    completionWriter.fn(
+      formatTrustedSkillCompletion(result, {
+        isTTY: process.stdout.isTTY,
+        columns: process.stdout.columns,
+      }),
+    );
+    ledger.record(result);
+  };
+
+  onTrustedSkillStart(onStart);
+  onTrustedSkillComplete(onComplete);
+
+  return () => {
+    offTrustedSkillStart(onStart);
+    offTrustedSkillComplete(onComplete);
+  };
+}
+
+/**
+ * Wire `/allow-dir` to the startup provider's grant API so the slash command
+ * can mutate read/write roots across turns.
+ *
+ * Invariant: `startupProvider` MUST be the same instance the ProviderRouter
+ * uses to run queries, or grants land on a dead instance and are silently
+ * dropped. The per-family memoization in `bootstrap-providers.ts`'s
+ * `providerFactory` guarantees this — the router's `buildInner` calls the
+ * same factory with a same-family model and gets the cached instance back.
+ * Do not remove that cache without rewiring this dispatcher to the router's
+ * active inner.
+ *
+ * We wire once here and do not rewire on `/model` swaps: directory grants
+ * are a session-level concept (not per-model), and a Claude→GPT→Claude swap
+ * reuses the cached instance with its grants intact. The duck-type guard
+ * (`isGrantManager`) covers both AnthropicDirectProvider and
+ * OpenAICompatibleProvider — and any future provider that exposes the
+ * GrantManager surface — without naming each.
+ *
+ * Call AFTER `registerAll()` (ordering hazard #12) and after the hook bundle
+ * exists — `pathApprovalGrantRef` is populated here.
+ */
+export function wireProviderGrants(
+  startupProvider: ModelProvider,
+  pathApprovalGrantRef: { current: unknown },
+): void {
+  if (isGrantManager(startupProvider)) {
+    setAllowDirDispatcher(startupProvider);
+    // Wire the same provider into the path-approval + bash-restriction hooks so
+    // they can mutate grants when the user picks Session / Always (persist) on
+    // the elicitation prompt.
+    pathApprovalGrantRef.current = startupProvider;
+    // Seed read/write roots from persisted `persist` grants so the prompt's
+    // "future sessions inherit it" promise actually holds. No-op when none.
+    seedPersistedGrants(startupProvider);
+  } else if (env.AFK_DISABLE_PATH_APPROVAL !== '1') {
+    // Emit a one-time advisory when path-approval is enabled but the active
+    // provider does not expose the GrantManager API. This makes fail-open
+    // explicit rather than silent — the bash interpreter denylist still fires,
+    // but the elicitation prompt and bash restricted-path check will not.
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[path-approval] active provider does not implement GrantManager — ' +
+        'path-approval elicitation and bash restricted-path checks will not fire.',
+    );
+  }
+}
+
+/**
+ * Create the REPL's non-terminal readline interface and install the REPL
+ * elicitation handler so `ask_question` calls from the agent are routed to
+ * the interactive readline surface.
+ *
+ * Returns the late-bound `inputSurfaceRef` too — populated by `runReplLoop`
+ * after `armCompositor`. The elicitation handler closes over this ref so
+ * suspend/resume works at invocation time even though the surface isn't
+ * armed yet at install time.
+ */
+export function createReplInput(): {
+  rl: readline.Interface;
+  inputSurfaceRef: { current: InputSurface | null };
+} {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    terminal: false,
+  });
+
+  // Late-bound InputSurface ref — populated by runReplLoop after armCompositor.
+  // The elicitation handler closes over this so suspend/resume works at
+  // invocation time even though the surface isn't armed yet at install time.
+  const inputSurfaceRef: { current: InputSurface | null } = { current: null };
+
+  // Install the REPL elicitation handler so ask_question calls from the
+  // agent are routed to the interactive readline surface.
+  elicitationRouter.install(makeReplElicitationHandler({
+    readLine: (prompt) => new Promise((resolve, reject) => {
+      rl.question(prompt, resolve);
+      rl.once('close', () => reject(new Error('readline closed')));
+    }),
+    writer: { line: (text = '') => process.stdout.write(text + '\n') },
+    pendingCount: () => elicitationRouter.pendingCount(),
+    suspendInput: () => inputSurfaceRef.current?.suspendForElicitation(),
+    resumeInput: () => inputSurfaceRef.current?.resumeAfterElicitation(),
+  }));
+
+  return { rl, inputSurfaceRef };
+}

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -1,141 +1,27 @@
-import * as readline from 'node:readline';
-import { resolve } from 'node:path';
-import { elicitationRouter } from '../../../agent/elicitation-router.js';
-import { makeReplElicitationHandler } from '../../elicitation-repl.js';
-import { AgentSession } from '../../../agent/session.js';
-import type { PermissionMode } from '../../../agent/types/sdk-types.js';
-import { unconfiguredSlotError } from '../../../agent/session/model-slots.js';
-import { createDefaultHookRegistry } from '../../../agent/default-hook-registry.js';
-import { loadHooksConfig } from '../../../agent/hooks/config-loader.js';
-import { MemoryStore, injectHotMemory } from '../../../agent/memory/index.js';
-import { injectCompanionPrimer } from '../../../agent/companion/index.js';
-import type { ThinkingConfig, EffortLevel } from '../../../agent/types.js';
-import type { AgentConfig } from '../../../agent/types.js';
-import type { ModelProvider } from '../../../agent/provider.js';
-import type { HookRegistry } from '../../../agent/hooks.js';
-import type { TraceWriter } from '../../../agent/trace/index.js';
-import {
-  parseThinking, parseEffort, parseMaxOutputTokens, parseProvider, getApiKey, getApiKeyForModel, getModel, getThinking, getEffort,
-  getMaxOutputTokens, getMaxToolUseIterations, getDefaultSubagentModel, resolveBaseSystemPrompt, isGrantManager,
-} from '../../shared-helpers.js';
-import { topLevelSurfaceAllowedTools } from '../../../agent/tools/top-level-allowlist.js';
-import { loadConfig } from '../../config.js';
-import { assembleSystemPrompt } from '../../../agent/routing-directive.js';
-import { StatusLine } from '../../status-line.js';
-import { GitStatusSampler } from '../../git-status-sampler.js';
-import { registerAll } from '../../slash/index.js';
-import { setAllowDirDispatcher } from '../../slash/commands/allow-dir.js';
-import { createConsoleWriter } from '../../slash/writer.js';
-import { createSessionStats } from '../../slash/session-stats.js';
+import { MemoryStore } from '../../../agent/memory/index.js';
 import type { SlashContext } from '../../slash/types.js';
 import type { SessionRef } from '../../../agent/session-ref.js';
-import type { CliOptions, CompletionWriter, InteractiveCtx } from './shared.js';
-import { formatStatusFields } from './shared.js';
-import { createReplRenderer } from './repl-renderer.js';
-import { createTerminalStateGate } from './terminal-state-gate.js';
-import { TrustedSkillLedger } from '../../trusted-skill-ledger.js';
-import {
-  onTrustedSkillComplete, offTrustedSkillComplete,
-  onTrustedSkillStart, offTrustedSkillStart,
-} from '../../../agent/_lib/trusted-skill-events.js';
-import { formatTrustedSkillCompletion, formatTrustedSkillInFlight } from '../../trusted-skill-badge.js';
-import type { TrustedSkillResult } from '../../../agent/trusted-skill-result.js';
-import { emitSubagentCompletion } from './progress-banner.js';
+import type { CliOptions, InteractiveCtx } from './shared.js';
 import { ContextSampler } from '../../context-sampler.js';
-import { wireExecutors } from '../../../agent/session/wire-executors.js';
-import { BackgroundAgentRegistry } from '../../../agent/background-registry.js';
-import { BackgroundSummarizer } from '../../../agent/background-summarizer.js';
-import { setBgsubRegistry, setBgsubSummarizer } from '../../slash/commands/bgsub.js';
-import { AnthropicDirectProvider } from '../../../agent/providers/anthropic-direct/index.js';
-import { seedPersistedGrants } from '../../../agent/permissions-store.js';
-import { providerForModel } from '../../../agent/providers/index.js';
-import { createMemoizedProviderFactory } from './provider-factory.js';
 import { ensurePluginEntrypointsLoaded } from '../../../agent/tools/skill-bridge.js';
-import { McpManager, loadMcpConfig, getMcpConfigPath } from '../../../agent/mcp/index.js';
-import { loadImportFromConfig, resolveImportedRoots } from '../../../config/import-sources.js';
-import { env } from '../../../config/env.js';
-import { resolveResumeTarget } from '../../resume-session.js';
 import type { ResolvedResumeTarget } from '../../resume-session.js';
-import { createDefaultTraceWriter } from '../../../agent/trace/factory.js';
 import { emitSessionPhase } from '../../../agent/trace/emit.js';
-import { palette } from '../../palette.js';
 import { performResumeSwap, resumeConfigFor } from './resume-swap.js';
-import { reseedStatsFromStored, resolveResumeCwd } from './shared.js';
+import { resolveBootstrapConfig } from './bootstrap-config.js';
+import { createBootstrapInfra } from './bootstrap-infra.js';
+import { connectReplMcp } from './bootstrap-mcp.js';
+import { createReplProviders } from './bootstrap-providers.js';
+import { createReplSurface } from './bootstrap-surface.js';
+import { createReplHookRegistry } from './bootstrap-hooks.js';
+import { createReplSlashContext } from './bootstrap-slash-context.js';
+import { wireTrustedSkillEvents, wireProviderGrants, createReplInput } from './bootstrap-wiring.js';
+import { buildAgentSession, buildSharedDeps } from './bootstrap-session-builder.js';
+import { registerAll } from '../../slash/index.js';
 
-/**
- * Dependencies for constructing a fresh `AgentSession`. Captures everything
- * the constructor block reads so `buildAgentSession` can be called both from
- * `bootstrapSession` (initial) and from the mid-session swap path.
- */
-interface BuildAgentSessionDeps {
-  model: string;
-  resumeConfig: Partial<AgentConfig>;
-  systemPrompt: string | undefined;
-  systemPromptSource: string | undefined;
-  thinking: ThinkingConfig | undefined;
-  effort: EffortLevel | undefined;
-  maxOutputTokens: number | undefined;
-  /**
-   * Opt-in top-level tool-use-round ceiling (from AFK_MAX_TOOL_USE_ITERATIONS).
-   * `undefined` = unlimited (no behavior change). Flows to
-   * `AgentConfig.maxToolUseIterations` and hits both providers via
-   * `resolveMaxToolIterations()`. Top-level only — subagent forks set their own.
-   */
-  maxToolUseIterations: number | undefined;
-  /**
-   * Fully-wired provider factory. Passed as `config.providerFactory` so the
-   * ProviderRouter builds a wired provider (with executors, memoryStore,
-   * mcpManager) on every turn — enabling cross-family /model swaps without
-   * losing the agent/skill/compose tools or MCP bridges.
-   */
-  providerFactory: (model: string | undefined) => ModelProvider;
-  hookRegistry: HookRegistry;
-  traceWriter: TraceWriter | undefined;
-  cwd: string | undefined;
-  maxTurns: number;
-  autoResumeOnUsageLimit: boolean | undefined;
-  /** Initial session permission mode (e.g. 'bypassPermissions'). Omit for 'default'. */
-  permissionMode?: PermissionMode;
-  baseUrl?: string;
-}
-
-/**
- * Construct a fresh `AgentSession` from the supplied deps. Extracted so the
- * mid-session swap path can build a new session with a different `resumeConfig`
- * without duplicating the constructor argument list.
- */
-export function buildAgentSession(deps: BuildAgentSessionDeps): AgentSession {
-  return new AgentSession(injectCompanionPrimer(injectHotMemory({
-    model: deps.model,
-    // User-facing surface for trace `origin` attribution. The REPL is a CLI
-    // entrypoint → 'cli'. (Mid-session swap reuses this helper, also 'cli'.)
-    surface: 'cli',
-    // Resolve the credential for the ACTUAL session model, not the env-derived
-    // default. `getApiKey()` keys off AFK_MODEL/CLAUDE_MODEL, so launching
-    // `afk -m gpt-5.5` while CLAUDE_MODEL is a Claude id would inject the
-    // Anthropic OAuth token into the OpenAI provider — leaking sk-ant-… to
-    // OpenAI and shadowing Codex ChatGPT OAuth. getApiKeyForModel routes via
-    // providerForModel → the correct family (anti-leak invariant).
-    apiKey: getApiKeyForModel(deps.model),
-    maxTurns: deps.maxTurns,
-    hookRegistry: deps.hookRegistry,
-    ...(deps.permissionMode !== undefined ? { permissionMode: deps.permissionMode } : {}),
-    ...(deps.systemPrompt !== undefined ? { systemPrompt: deps.systemPrompt } : {}),
-    ...(deps.systemPromptSource !== undefined ? { systemPromptSource: deps.systemPromptSource } : {}),
-    ...(deps.thinking !== undefined ? { thinking: deps.thinking } : {}),
-    ...(deps.effort !== undefined ? { effort: deps.effort } : {}),
-    ...(deps.maxOutputTokens !== undefined ? { maxOutputTokens: deps.maxOutputTokens } : {}),
-    ...(deps.maxToolUseIterations !== undefined ? { maxToolUseIterations: deps.maxToolUseIterations } : {}),
-    ...deps.resumeConfig,
-    ...(deps.cwd !== undefined ? { cwd: deps.cwd } : {}),
-    ...(deps.traceWriter !== undefined ? { traceWriter: deps.traceWriter } : {}),
-    ...(deps.autoResumeOnUsageLimit !== undefined
-      ? { autoResumeOnUsageLimit: deps.autoResumeOnUsageLimit }
-      : {}),
-    ...(deps.baseUrl !== undefined ? { baseUrl: deps.baseUrl } : {}),
-    providerFactory: deps.providerFactory,
-  })));
-}
+// Re-exported so `resume-swap.test.ts` (and the mid-session swap closure
+// below) can resolve `buildAgentSession` from this module — the historical
+// import path every existing caller uses.
+export { buildAgentSession } from './bootstrap-session-builder.js';
 
 /**
  * Build the session context from CLI options. Throws with a user-facing
@@ -156,48 +42,12 @@ export async function bootstrapSession(
   // created a few lines below, so bootstrap_start (writer-ready marker) and
   // bootstrap_done (full span, measured from here) are emitted once it exists.
   const bootstrapStartedAt = Date.now();
-  const resumeTarget = resolveResumeTarget(options);
-  const resumeConfig = resumeConfigFor(resumeTarget);
-  // Resume cwd restoration: a resumed session should run in the directory it
-  // was saved in (e.g. an `afk --worktree` session that was later /fork'd or
-  // --resume'd), not wherever the shell happens to be. Precedence: an explicit
-  // --worktree override (extras.cwd) always wins; otherwise fall back to the
-  // stored cwd IFF it still exists on disk as a directory — a cleaned-up
-  // worktree degrades safely to process.cwd(). `effectiveCwd` is threaded
-  // through every cwd-purpose usage below (stats stamp, hook/session cwd,
-  // subagent/skill/compose/MCP cwd) so resumed worktree sessions AND their
-  // children anchor correctly. Defaults to `extras?.cwd` when there is no
-  // resume override, so this is a safe drop-in: behavior only changes for a
-  // resume whose stored cwd still exists.
-  const effectiveCwd = resolveResumeCwd(extras?.cwd, resumeTarget?.stored?.cwd);
-  const sessionModel = resumeTarget?.stored?.model ?? options.model;
-  // Fail fast on an unconfigured capability tier (e.g. `afk i -m local` with no
-  // AFK_MODEL_LOCAL) before building the REPL session — an empty id would
-  // otherwise reach the provider as an opaque error or a silent cloud call.
-  const unconfiguredModel = unconfiguredSlotError(sessionModel);
-  if (unconfiguredModel) {
-    throw new Error(unconfiguredModel);
-  }
 
-  let thinking: ThinkingConfig | undefined;
-  let effort: EffortLevel | undefined;
-  let maxOutputTokens: number | undefined;
-  thinking = parseThinking(options.thinking) ?? getThinking();
-  effort = parseEffort(options.effort) ?? getEffort();
-  maxOutputTokens = parseMaxOutputTokens(options.maxOutputTokens) ?? getMaxOutputTokens();
-  // Opt-in top-level tool-use-round ceiling. No CLI flag exists, so this is the
-  // env default only (unset/<=0 → undefined → unlimited; no behavior change).
-  const maxToolUseIterations = getMaxToolUseIterations();
-
-  // System-prompt layering: the framework base (`prompts/system-prompt.md`)
-  // is unconditional; the operator overlay (env → afk.config.json → AFK.md)
-  // is appended on top via resolveBaseSystemPrompt(), never substituted for
-  // the base. `source` is the layered provenance string surfaced by
-  // --dump-prompt (`framework`, `framework+afk-md:/path`, …).
-  const { prompt: basePrompt, source: systemPromptSource } = resolveBaseSystemPrompt();
-  const cliConfig = loadConfig();
-  const autoRouting = cliConfig.autoRouting?.interactive ?? true;
-  const systemPrompt = assembleSystemPrompt(basePrompt, autoRouting, 'repl');
+  const {
+    resumeTarget, resumeConfig, effectiveCwd, sessionModel,
+    thinking, effort, maxOutputTokens, maxToolUseIterations,
+    basePrompt, systemPrompt, systemPromptSource, cliConfig,
+  } = resolveBootstrapConfig(options, extras);
 
   // Wire Agent tool by creating SubagentExecutor first.
   // The executor needs the session's methods, so we use a deferred parent proxy
@@ -205,65 +55,6 @@ export async function bootstrapSession(
   // child executors without re-wiring.
   // sessionRef is populated after the session is constructed below.
   const sessionRef: SessionRef = { current: null! };
-
-  // Witness layer: open trace BEFORE the root SubagentManager and the
-  // executor so (a) the manager inherits the writer — the `agent`-tool path
-  // relies on manager-level inheritance for its forks' lifecycle events
-  // (see forkSubagent's effectiveTraceWriter) — and (b) the
-  // BackgroundAgentRegistry can be constructed with the writer in hand.
-  // The trace path is logged after `bootstrapSession` returns (caller-side
-  // banner), so we open the file here but defer the log line until later
-  // to preserve startup-message ordering.
-  const traceSessionLabel = resumeTarget?.stored?.sessionId;
-  const trace = createDefaultTraceWriter(
-    traceSessionLabel ? { sessionLabel: traceSessionLabel } : {},
-  );
-
-  const apiKey = getApiKey();
-  // Witness layer: trace writer is now live — emit the bootstrap_start marker.
-  // (Total bootstrap span is reported by bootstrap_done, measured from the
-  // function-entry timestamp captured above.)
-  void emitSessionPhase(trace?.writer, { phase: 'bootstrap_start' });
-
-  // BackgroundAgentRegistry — owns the lifecycle of every job spawned by
-  // `agent` tool with mode="background". Constructed before the executor
-  // so we can pass it via SubagentExecutorContext. Cancel-all is invoked
-  // by the interactive teardown path so detached jobs do not outlive
-  // their parent process.
-  const backgroundRegistry = new BackgroundAgentRegistry(
-    trace ? { traceWriter: trace.writer } : {},
-  );
-  setBgsubRegistry(backgroundRegistry);
-
-  // Opt-in background summarizer — only constructed when bgSummaries: true.
-  const bgSummariesEnabled = cliConfig.bgSummaries === true;
-  const bgSummarizer = bgSummariesEnabled && apiKey
-    ? new BackgroundSummarizer({
-        registry: backgroundRegistry,
-        apiKey,
-        maxCallsPerSession: cliConfig.maxSummaryCallsPerSession ?? 200,
-      })
-    : undefined;
-  bgSummarizer?.start();
-  setBgsubSummarizer(bgSummarizer);
-
-  // External constraint: deferredParent reads through sessionRef.current so
-  // a mid-session swap (mutating sessionRef.current) is transparent to all
-  // child executors — they hold a reference to this proxy object, which
-  // always delegates to the currently-active session.
-  const deferredParent = {
-    get sessionId() { return sessionRef.current?.sessionId; },
-    getInputStreamRef() { return sessionRef.current?.getInputStreamRef?.() ?? { pushUserMessage: () => {} }; },
-    get abortSignal() {
-      return sessionRef.current?.abortSignal ?? new AbortController().signal;
-    },
-    // Expose the live session's registry so forked subagents resolve it via
-    // SubagentManager.forkSubagent's parent fallback — the production path for
-    // SubagentStart/Stop (incl. the shadow-verify nudge) and child-config
-    // inheritance. The registry is constructed after this proxy, so reading
-    // it lazily through sessionRef.current is required.
-    get hookRegistry() { return sessionRef.current?.hookRegistry; },
-  };
 
   // Bootstrap warnings that must outlive the startup screen clear. Everything
   // written to stdout/stderr from here until `interactive.ts` finishes clearing
@@ -279,48 +70,12 @@ export async function bootstrapSession(
   // care get a local bucket and the prior behaviour.
   const bootWarnings: string[] = extras?.bootWarnings ?? [];
 
-  // Invariant: ONE root manager per session, shared by all three executors.
-  // Constructed here (not earlier) so it can be created together with the
-  // executors that close over it; the SubagentManager constructor is pure —
-  // it emits no trace events — so this placement does not reorder the
-  // witness trace relative to `bootstrap_start` above.
-  const { rootManager, subagentExecutor, skillExecutor, composeExecutor } = wireExecutors({
-    // Origin attribution: the REPL is a `cli` entrypoint, so forked children
-    // inherit origin 'cli' (not 'unknown'). See session-identity.ts.
-    surface: 'cli',
-    parentSession: deferredParent,
-    apiKey,
-    model: sessionModel,
-    // `apiKey` is getApiKey(), which keys off getModel() (AFK_MODEL), so the
-    // manager's credential-fallback provider must be derived from THAT model —
-    // not the possibly-resumed session model — or the fallback can cross the
-    // provider boundary.
-    managerParentModel: getModel(),
-    // OpenAI-routed parents default dispatched subagents to the parent model
-    // rather than the legacy `'sonnet'` literal, which would silently route
-    // local-only sessions to api.anthropic.com. Claude parents still get 'sonnet'.
-    defaultSubagentModel: getDefaultSubagentModel(sessionModel),
-    resolveApiKeyForModel: getApiKeyForModel,
-    // Raw base prompt (pre-assembly): children and compose nodes stay task
-    // workers, without ROUTING_DIRECTIVE / TOOL_SYSTEM_PROMPT.
-    ...(basePrompt !== undefined ? { systemPrompt: basePrompt } : {}),
-    ...(cliConfig.baseUrl !== undefined ? { baseUrl: cliConfig.baseUrl } : {}),
-    ...(cliConfig.openaiBaseUrl !== undefined ? { openaiBaseUrl: cliConfig.openaiBaseUrl } : {}),
-    // Worktree cwd (`afk i --worktree`, or a resumed session's restored cwd)
-    // propagates to every depth so subagents' resolveBase + readRoots anchor
-    // to the worktree, not the Node host's process.cwd().
-    ...(effectiveCwd !== undefined ? { cwd: effectiveCwd, nestedCwd: effectiveCwd } : {}),
-    ...(trace?.writer !== undefined
-      ? { traceWriter: trace.writer, skillTraceWriter: trace.writer }
-      : {}),
-    // Background dispatch (`agent` with mode:"background") is REPL-only; the
-    // registry must reach every depth of the skill/agent fork chain.
-    backgroundRegistry,
-    // `warn` routes into bootWarnings rather than stderr: the built-in-shadow
-    // warning is a safety signal and the startup screen clear eats stderr.
-    agentRegistryWarn: (message: string) => bootWarnings.push(message),
+  const {
+    trace, apiKey, backgroundRegistry, bgSummarizer,
+    rootManager, subagentExecutor, skillExecutor, composeExecutor,
+  } = createBootstrapInfra({
+    sessionRef, options, cliConfig, sessionModel, basePrompt, effectiveCwd, resumeTarget, bootWarnings,
   });
-
 
   const sharedMemoryStore = new MemoryStore();
 
@@ -329,257 +84,45 @@ export async function bootstrapSession(
   // tools in its initial schema set. The manager is also persisted on
   // `InteractiveCtx` so `interactive.ts` can call `disconnectAll()` during
   // teardown (ordered: subagents → session → mcpManager → memory → worktree).
-  //
-  // Failure model: `loadMcpConfig()` returns warnings, never throws. The
-  // manager itself throws when an `alwaysLoad: true` server fails or when
-  // there's a wire-name collision — both are user-facing config errors and
-  // should abort bootstrap with the error message intact.
-  let mcpManager: McpManager | undefined;
-  {
-    // Use the worktree cwd for project-local `.mcp.json` resolution so each
-    // worktree can carry its own MCP config (matching how the worktree
-    // already isolates everything else under `worktreeCwd`).
-    const projectCwd = effectiveCwd ?? process.cwd();
-    // Imported MCP servers from trusted source binaries (`importFrom`). Only
-    // JSON-format configs (Claude Code) are loadable today; they enter as the
-    // lowest-priority layer so AFK's own config always wins. MCP import is
-    // off by default even for a trusted binary (it auto-runs commands on
-    // connect) — this only fires when the user set `mcp: true` for a binary.
-    const importedMcpConfigs = resolveImportedRoots(loadImportFromConfig())
-      .mcpConfigs.filter((c) => c.format === 'json')
-      .map((c) => c.source);
-    const loaded = loadMcpConfig({
-      cwd: projectCwd,
-      ...(importedMcpConfigs.length > 0 ? { importedMcpConfigs } : {}),
-      ...(options.mcpConfig !== undefined ? { cliOverride: options.mcpConfig } : {}),
-    });
-    const enabledCount = Object.values(loaded.mcpServers).filter((s) => !s.disabled).length;
-    // Config-loader warnings ("your mcp.json had X") reach the operator on both
-    // branches — servers enabled or not — via the post-clear drain. Collected
-    // once here so the two paths cannot diverge: previously the enabled path
-    // printed inside McpManager.fromConfig and the disabled path printed here,
-    // and the clear erased both.
-    for (const w of loaded.warnings) bootWarnings.push(`[mcp] ${w}`);
-    if (enabledCount > 0) {
-      const sourcesLabel = loaded.sources.length === 1
-        ? loaded.sources[0]
-        : `${loaded.sources.length} source(s)`;
-      console.log(palette.dim(`  mcp: ${enabledCount} server(s) from ${sourcesLabel ?? getMcpConfigPath()}`));
-      // Witness layer: bracket the whole-fleet MCP connect. try/finally so
-      // mcp_connect_done fires even when an alwaysLoad server makes fromConfig
-      // throw. Per-server mcp_server_* pairs are emitted inside fromConfig via
-      // the traceWriter passed below. Fire-and-forget; never gates connect.
-      const mcpStartedAt = Date.now();
-      void emitSessionPhase(trace?.writer, {
-        phase: 'mcp_connect_start',
-        metadata: { serverCount: enabledCount },
-      });
-      try {
-        // `warnings` is deliberately NOT forwarded: fromConfig would
-        // `console.warn` them (mcp/manager.ts) mid-bootstrap, where the startup
-        // clear erases them. They ride bootWarnings instead and are drained
-        // after the clear. `chat` still forwards them — it never clears — so
-        // this does not change any other surface, and nothing double-prints.
-        mcpManager = await McpManager.fromConfig(loaded.mcpServers, {
-          ...(trace?.writer !== undefined ? { traceWriter: trace.writer } : {}),
-        });
-      } finally {
-        void emitSessionPhase(trace?.writer, {
-          phase: 'mcp_connect_done',
-          durationMs: Date.now() - mcpStartedAt,
-          metadata: { serverCount: enabledCount },
-        });
-      }
-    }
-    // No `else` branch for warnings: the no-enabled-servers case used to
-    // console.warn here, and both branches are now covered by the single
-    // bootWarnings collection above.
-  }
+  const mcpManager = await connectReplMcp({
+    effectiveCwd,
+    mcpConfigOverride: options.mcpConfig,
+    traceWriter: trace?.writer,
+    bootWarnings,
+  });
 
   // Build a fully-wired provider factory that the ProviderRouter calls to
-  // resolve the active provider — at session init and again on each cross-family
-  // /model swap (NOT every turn; the router reuses the active inner across turns
-  // of the same family). The builder closes over the executors, memoryStore,
-  // mcpManager, and openaiBaseUrl captured above so every provider it builds
-  // (regardless of family) carries the full tool surface — agent/skill/compose
-  // tools, MCP bridges, and the shared MemoryStore. This is what allows
-  // mid-session /model cross-family switches (e.g. Claude → GPT) without losing
-  // any tool wiring.
-  //
-  // When --provider is explicit (options.provider is set), parseProvider returns
-  // a single fixed provider, so the builder always yields the same family. This
-  // preserves the AFK_PROVIDER / --provider escape-hatch behavior.
-  //
-  // The MCP tool wire names are stable for the manager lifetime, so they can be
-  // captured once in the closure without re-querying on every build.
-  const mcpToolWireNames = mcpManager?.getMcpToolWireNames() ?? [];
-  const buildProvider = (model: string | undefined): ModelProvider =>
-    parseProvider(options.provider, {
-      subagentExecutor,
-      skillExecutor,
-      composeExecutor,
-      memoryStore: sharedMemoryStore,
-      model: model !== undefined ? model : String(sessionModel),
-      ...(cliConfig.openaiBaseUrl !== undefined ? { openaiBaseUrl: cliConfig.openaiBaseUrl } : {}),
-      ...(mcpManager !== undefined ? { mcpManager } : {}),
-    })
-    ?? new AnthropicDirectProvider({
-      permissions: {
-        allowedTools: topLevelSurfaceAllowedTools(mcpToolWireNames),
-      },
-      subagentExecutor,
-      skillExecutor,
-      composeExecutor,
-      memoryStore: sharedMemoryStore,
-      surface: 'cli',
-      ...(mcpManager !== undefined ? { mcpManager } : {}),
-    });
+  // resolve the active provider. Must run AFTER MCP connect — the factory's
+  // builder closes over `mcpManager`.
+  const { providerFactory, startupProvider } = createReplProviders({
+    options, cliConfig, sessionModel, subagentExecutor, skillExecutor, composeExecutor,
+    memoryStore: sharedMemoryStore, mcpManager,
+  });
 
-  // Memoize by provider family so the `startupProvider` built below for /allow-dir
-  // wiring is the SAME instance the router's buildInner reuses for turn 1.
-  // Without this, the two call sites mint separate instances with independent
-  // read/write grant roots, and /allow-dir grants are silently dropped (they land
-  // on the startup instance, never on the query runner). The cache key mirrors
-  // parseProvider's own routing: the --provider override first (a fixed family),
-  // otherwise providerForModel with the same openaiBaseUrl hint — so a key never
-  // aliases two different provider families.
-  const providerFactory = createMemoizedProviderFactory(buildProvider, (model) =>
-    options.provider ??
-    providerForModel(
-      model !== undefined ? model : String(sessionModel),
-      cliConfig.openaiBaseUrl !== undefined ? { openaiBaseUrl: cliConfig.openaiBaseUrl } : undefined,
-    ),
-  );
+  // Stats, permission/thinking-UI seeding, startup banners (`trace:` /
+  // `↪ resuming in` — preserving the `mcp:` → `trace:` → `↪ resuming in`
+  // console-output order), StatusLine/renderer/writer, trusted-skill ledger,
+  // and git-status sampler.
+  const {
+    stats, initialPermissionMode, completionWriter, statusLine, replRenderer,
+    writer, trustedSkillLedger, gitStatusSampler,
+  } = createReplSurface({
+    options, cliConfig, sessionModel, resumeTarget, effectiveCwd, extrasCwd: extras?.cwd, trace,
+  });
 
-  // Build the startup provider (for /allow-dir wiring below). Because the factory
-  // memoizes by family, this returns the SAME instance the router reuses for
-  // turn 1, so grants added via setAllowDirDispatcher reach the query runner.
-  const startupProvider = providerFactory(String(sessionModel));
-
-  // Create stats before session so the plan-mode gate getter can close over it.
-  const stats = createSessionStats(sessionModel);
-  if (resumeTarget?.stored) {
-    reseedStatsFromStored(stats, resumeTarget.stored, resumeTarget.resumeId);
-  }
-  // Initial permission mode: --dangerously-skip-permissions wins, else the
-  // resolved afk.config.json `permissionMode` (loadConfig now always returns one
-  // — DEFAULT_CLI_PERMISSION_MODE = bypass for new installs, overridable by the
-  // config key). Stamped on stats so the status-line badge + the plan/AFK/bypass
-  // gate getters reflect it from turn 1; the session is constructed with the same
-  // value via sharedDeps. The `!== undefined` guard is retained defensively.
-  const initialPermissionMode = options.dangerouslySkipPermissions
-    ? ('bypassPermissions' as const)
-    : cliConfig.permissionMode;
-  if (initialPermissionMode !== undefined) {
-    stats.permissionMode = initialPermissionMode;
-  }
-  // Seed thinking-UI mode so `/thinking` has a live value to mutate.
-  // `options.thinkingUi` was already resolved by the interactive action handler
-  // via `resolveThinkingUi` (--thinking-ui flag > AFK_THINKING_UI env >
-  // interactive.thinkingUi config > 'live'), so this seeds the persistent
-  // default. `createSessionStats()` pre-seeds 'live' for any path that reaches
-  // bootstrap without that resolution (e.g. tests constructing options directly).
-  if (options.thinkingUi !== undefined) {
-    stats.thinkingUi = options.thinkingUi;
-  }
-  // Stamp the effective working directory on stats so the status line can
-  // render it. We capture the same cwd the provider will see: `effectiveCwd`
-  // (the explicit `--worktree` override when present, else a resumed session's
-  // restored cwd — see resolveResumeCwd above), falling back to
-  // `process.cwd()`. Captured once at bootstrap — sessions don't `chdir`
-  // mid-run, and the status line treats this as a fixed identity field.
-  stats.cwd = effectiveCwd ?? process.cwd();
-
-  // Trace was opened earlier (before the executor) so the
-  // BackgroundAgentRegistry could be constructed with the writer. Surface
-  // the path here so the startup banner ordering is preserved.
-  if (trace) {
-    console.log(palette.dim(`  trace: ${trace.tracePath}`));
-  }
-  // Make a restored resume cwd legible: only when the cwd came from the stored
-  // session (not an explicit --worktree, which the banner already implies) and
-  // differs from where the shell launched. Printed in the same dim-log style
-  // as the trace line above, before the compositor is armed.
-  if (
-    extras?.cwd === undefined &&
-    effectiveCwd !== undefined &&
-    resolve(effectiveCwd) !== resolve(process.cwd())
-  ) {
-    console.log(palette.dim(`  ↪ resuming in ${effectiveCwd}`));
-  }
-
-  // Both slots default to `console.log` here; `runReplLoop` mutates them
-  // after `armCompositor` resolves (when a borrowed compositor is available)
-  // so between-turn slash output commits above the live overlay instead of
-  // overlaying onto the input row. See CompletionWriter docs in shared.ts.
-  const completionWriter: CompletionWriter = {
-    fn: (line) => console.log(line),
-    idleFn: (line) => console.log(line),
-  };
-  // Construct StatusLine BEFORE createReplRenderer so the renderer can route
-  // its inter-turn raw writes through statusLine.withFullScrollRegion(...) —
-  // see repl-renderer.ts for the DECSTBM sub-region scroll-loss contract this
-  // wiring is defending against.
-  // `tickMs` is resolved caller-side (StatusLine defaults it off, like the
-  // compositor's caret blink) so only the REPL gets a recurring timer. 30s is
-  // half the quota countdown's minute granularity, which is the finest
-  // clock-derived value the row renders.
-  const statusLine = new StatusLine({ tickMs: 30_000 });
-  const replRenderer = createReplRenderer(process.stdout, { statusLine });
-
-  // Stable hookRegistry shared across sessions (including swaps).
-  // The hook callbacks close over `stats` and `completionWriter` which are
-  // also stable, so the new session gets the same routing without re-wiring.
-  // `pathApprovalGrantRef` is populated below once the provider exists; the
-  // path-approval hook fails open until then (mirroring `setAllowDirDispatcher`
-  // wiring order).
-  const hookRegistryBundle = createDefaultHookRegistry(
-    (info) => { emitSubagentCompletion(completionWriter, info); },
-    'cli',
-    sharedMemoryStore,
-    () => stats.permissionMode,
-    loadHooksConfig({ cwd: effectiveCwd }),
-    { cwd: effectiveCwd, ...(trace?.writer !== undefined ? { traceWriter: trace.writer } : {}) },
-    () => effectiveCwd ?? process.cwd(),
-  );
-  const hookRegistry = hookRegistryBundle.registry;
-  const pathApprovalGrantRef = hookRegistryBundle.pathApprovalGrantRef;
-
-  // Terminal-state gate (issue #237): a post-turn `Stop` hook that bounces a
-  // self-certified `Done` with no corroborating evidence back into the next turn
-  // via the Stop injectContext primitive (wired in loop-iteration.ts). Registered
-  // here rather than in createDefaultHookRegistry because it reads cli-layer
-  // config (`enforceDoneEvidence`, fresh each turn) and the live permission mode;
-  // opt-in + autonomous-only, so it is inert unless the operator enabled it. REPL
-  // surface only — the Stop injectContext delivery it depends on lives in the
-  // REPL loop.
-  hookRegistry.register(
-    'Stop',
-    createTerminalStateGate({
-      getPermissionMode: () => stats.permissionMode,
-      isEnabled: () => loadConfig().enforceDoneEvidence === true,
-    }),
-  );
+  // Stable hookRegistry shared across sessions (including swaps), plus the
+  // terminal-state Stop gate registered on top of it. `pathApprovalGrantRef`
+  // is populated later (wireProviderGrants) once the provider exists.
+  const { hookRegistry, pathApprovalGrantRef } = createReplHookRegistry({
+    completionWriter, memoryStore: sharedMemoryStore, stats, effectiveCwd, traceWriter: trace?.writer,
+  });
 
   // Capture deps needed by both the initial build and the swap closure.
-  const sharedDeps: BuildAgentSessionDeps = {
-    model: sessionModel,
-    resumeConfig,
-    systemPrompt,
-    systemPromptSource,
-    thinking,
-    effort,
-    maxOutputTokens,
-    maxToolUseIterations,
-    ...(cliConfig.baseUrl !== undefined ? { baseUrl: cliConfig.baseUrl } : {}),
-    providerFactory,
-    hookRegistry,
-    traceWriter: trace?.writer,
-    cwd: effectiveCwd,
-    maxTurns: parseInt(options.maxTurns, 10),
-    autoResumeOnUsageLimit: cliConfig.autoResumeOnUsageLimit,
-    ...(initialPermissionMode !== undefined ? { permissionMode: initialPermissionMode } : {}),
-  };
+  const sharedDeps = buildSharedDeps({
+    sessionModel, resumeConfig, systemPrompt, systemPromptSource, thinking, effort,
+    maxOutputTokens, maxToolUseIterations, cliConfig, providerFactory, hookRegistry,
+    traceWriter: trace?.writer, effectiveCwd, maxTurns: options.maxTurns, initialPermissionMode,
+  });
 
   // Import any plugin JS entrypoints (manifest `main`) before constructing the
   // session: the skill manifest is assembled synchronously in the constructor,
@@ -606,72 +149,15 @@ export async function bootstrapSession(
     sessionRef.current?.recordSubagentCompletion(usage, costUsd);
   });
 
-  const trustedSkillLedger = new TrustedSkillLedger();
-  // Slash-command writer routes through `completionWriter` so when Stage 3's
-  // persistent compositor swaps `completionWriter.fn` to `compositor.commitAbove`
-  // between turns (it currently only swaps mid-turn — see turn-handler.ts:124),
-  // slash output commits above the live overlay instead of tearing it. No
-  // behavior change today: completionWriter.fn === console.log when slash
-  // commands run (always between turns under the current arm/disarm cycle).
-  const writer = createConsoleWriter(completionWriter);
   // ContextSampler constructor assigns `session` as the source.  attach() is
   // called by performResumeSwap (resume-swap.ts step 8) on every mid-session
   // swap to rebind the source and reset the cache; no call needed here.
   const contextSampler = new ContextSampler(session);
-  // GitStatusSampler resolves the current branch (fast, local) + open PR
-  // (network, detached) for the status line. Bound to the session's effective
-  // cwd — under `--worktree` that differs from process.cwd(). Construction is
-  // side-effect-free (no process spawn): the initial sample + the on-update
-  // repaint wiring are kicked by setupSurface (REPL Phase 1), so bootstrap-only
-  // unit tests never shell out to git/gh.
-  const gitStatusSampler = new GitStatusSampler({
-    cwd: stats.cwd ?? process.cwd(),
-    // Suppress the per-turn git subprocess if the branch was checked < 1 s
-    // ago — human turns are seconds apart so this is imperceptible, and it
-    // bounds overhead on slow filesystems (network mounts, Docker volumes).
-    branchTtlMs: 1_000,
-  });
 
-  const slashCtx: SlashContext = {
-    session: sessionRef,
-    stats,
-    out: writer,
-    ui: {
-      clearScreen: () => {
-        // Ordered-operation invariant: reset the persistent compositor's
-        // overlay AND committed band BEFORE the physical clear. At idle the
-        // overlay still holds the prior turn's composed slots (stage-rail /
-        // progress-banner / live-thinking) because borrow-dispose re-composes
-        // via overlayComposer.flush() rather than setOverlay('') (see
-        // stream-renderer.ts), and the committed band still retains the prior
-        // turn's last above-frame block. Without zeroing both here, the
-        // post-clear repaint re-paints stale overlay/band rows onto the
-        // freshly-cleared screen — the band leak resurrects the prior
-        // transcript when a slash menu opens then collapses (a shrink repaint
-        // firing repositionCommittedBand). getCompositor is wired by
-        // repl-loop.ts after armCompositor and is reached late-bound at call
-        // time; undefined on non-TTY surfaces (daemon/tests) → no-op.
-        // setOverlay('') early-returns when the overlay is already empty.
-        const compositor = slashCtx.getCompositor?.();
-        compositor?.setOverlay('');
-        compositor?.resetCommittedBand();
-        statusLine.stop();
-        contextSampler.reset();
-        // CSI 3J clears scrollback, 2J clears viewport, H homes cursor.
-        process.stdout.write('\x1b[3J\x1b[2J\x1b[H');
-        statusLine.start();
-        // Read contextSampler at call time so any swap-replaced sampler is used.
-        statusLine.repaint(formatStatusFields(stats, contextSampler, gitStatusSampler));
-      },
-      // Read contextSampler at call time (not at closure-capture time) so
-      // a mid-session swap that calls contextSampler.attach(newSession) is
-      // reflected on the next repaint.
-      repaintStatusLine: () => statusLine.repaint(formatStatusFields(stats, contextSampler, gitStatusSampler)),
-    },
-    ledger: trustedSkillLedger,
-    // Expose mcpManager so `/mcp auth complete` can call completeAuth().
-    ...(mcpManager !== undefined ? { mcpManager } : {}),
-  };
+  const slashCtx: SlashContext = createReplSlashContext({
+    sessionRef, stats, writer, statusLine, contextSampler, gitStatusSampler,
+    ledger: trustedSkillLedger, mcpManager,
+  });
 
   // requestResume delegates to performResumeSwap (resume-swap.ts).
   // The sharedDeps + model-precedence resolution lives here; the swap
@@ -769,104 +255,27 @@ export async function bootstrapSession(
     ...(cliConfig.interactive?.suggestGhost !== undefined
       ? { suggestGhostConfig: cliConfig.interactive.suggestGhost }
       : {}),
-    hookRegistry: hookRegistryBundle.registry,
+    hookRegistry,
   };
 
   // Trusted-skill event subscriptions — emit in-flight + completion badges
   // inline at the invocation point via completionWriter (routed to
   // compositor.commitAbove during a live turn; falls back to console.log
-  // outside a turn). Recorded in the ledger on completion. Each event is
-  // its own scrollback line, so overlapping skills no longer need Set-based
-  // tracking the way the status-line approach did.
-  const onStart = (skillName: string) => {
-    completionWriter.fn(
-      formatTrustedSkillInFlight(skillName, {
-        isTTY: process.stdout.isTTY,
-        columns: process.stdout.columns,
-      }),
-    );
-  };
-
-  const onComplete = (result: TrustedSkillResult) => {
-    completionWriter.fn(
-      formatTrustedSkillCompletion(result, {
-        isTTY: process.stdout.isTTY,
-        columns: process.stdout.columns,
-      }),
-    );
-    trustedSkillLedger.record(result);
-  };
-
-  onTrustedSkillStart(onStart);
-  onTrustedSkillComplete(onComplete);
-  ctx.teardownTrustedSkillEvents = () => {
-    offTrustedSkillStart(onStart);
-    offTrustedSkillComplete(onComplete);
-  };
+  // outside a turn). Recorded in the ledger on completion.
+  ctx.teardownTrustedSkillEvents = wireTrustedSkillEvents(completionWriter, trustedSkillLedger);
 
   registerAll();
 
   // Wire /allow-dir to the startup provider's grant API so the slash command
-  // can mutate read/write roots across turns.
-  //
-  // Invariant: `startupProvider` MUST be the same instance the ProviderRouter
-  // uses to run queries, or grants land on a dead instance and are silently
-  // dropped. The per-family memoization in `providerFactory` above guarantees
-  // this — the router's `buildInner` calls the same factory with a same-family
-  // model and gets the cached instance back. Do not remove that cache without
-  // rewiring this dispatcher to the router's active inner.
-  //
-  // We wire once here and do not rewire on /model swaps: directory grants are a
-  // session-level concept (not per-model), and a Claude→GPT→Claude swap reuses
-  // the cached instance with its grants intact. The duck-type guard (isGrantManager)
-  // covers both AnthropicDirectProvider and OpenAICompatibleProvider — and any
-  // future provider that exposes the GrantManager surface — without naming each.
-  if (isGrantManager(startupProvider)) {
-    setAllowDirDispatcher(startupProvider);
-    // Wire the same provider into the path-approval + bash-restriction hooks so
-    // they can mutate grants when the user picks Session / Always (persist) on
-    // the elicitation prompt.
-    pathApprovalGrantRef.current = startupProvider;
-    // Seed read/write roots from persisted `persist` grants so the prompt's
-    // "future sessions inherit it" promise actually holds. No-op when none.
-    seedPersistedGrants(startupProvider);
-  } else if (env.AFK_DISABLE_PATH_APPROVAL !== '1') {
-    // Emit a one-time advisory when path-approval is enabled but the active
-    // provider does not expose the GrantManager API. This makes fail-open
-    // explicit rather than silent — the bash interpreter denylist still fires,
-    // but the elicitation prompt and bash restricted-path check will not.
-    // eslint-disable-next-line no-console
-    console.warn(
-      '[path-approval] active provider does not implement GrantManager — ' +
-        'path-approval elicitation and bash restricted-path checks will not fire.',
-    );
-  }
+  // can mutate read/write roots across turns. Must run AFTER registerAll()
+  // (ordering hazard: the dispatcher setter is itself a slash-command module
+  // side effect target) and reads `pathApprovalGrantRef` populated by the
+  // hook bundle above.
+  wireProviderGrants(startupProvider, pathApprovalGrantRef);
 
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
-    terminal: false,
-  });
+  const { rl, inputSurfaceRef } = createReplInput();
   ctx.rl = rl;
-
-  // Late-bound InputSurface ref — populated by runReplLoop after armCompositor.
-  // The elicitation handler closes over this so suspend/resume works at
-  // invocation time even though the surface isn't armed yet at install time.
-  const inputSurfaceRef: { current: import('../../input/input-surface.js').InputSurface | null } = { current: null };
   ctx.inputSurfaceRef = inputSurfaceRef;
-
-  // Install the REPL elicitation handler so ask_question calls from the
-  // agent are routed to the interactive readline surface.
-  elicitationRouter.install(makeReplElicitationHandler({
-    readLine: (prompt) => new Promise((resolve, reject) => {
-      rl.question(prompt, resolve);
-      rl.once('close', () => reject(new Error('readline closed')));
-    }),
-    writer: { line: (text = '') => process.stdout.write(text + '\n') },
-    pendingCount: () => elicitationRouter.pendingCount(),
-    suspendInput: () => inputSurfaceRef.current?.suspendForElicitation(),
-    resumeInput: () => inputSurfaceRef.current?.resumeAfterElicitation(),
-  }));
 
   // Wire requestResume into slashCtx so slash commands can call it.
   slashCtx.requestResume = requestResume;


### PR DESCRIPTION
## What

Splits `src/cli/commands/interactive/bootstrap.ts` (883 LOC, one function scope, zero adjacent tests) into 9 flat, single-concern modules under `src/cli/commands/interactive/`, matching the existing `tool-lane-*.ts` convention. Pure structural move — same exports, same call order, same runtime semantics. No behavior change.

## Why

Per #823: the file had 45 commits in 6 months (2nd-highest churn in the repo) with everything fused into one 887-line function via shared closure locals, making nothing independently invocable or testable. This splits it into named, narrowly-scoped phase functions with explicit parameter/return contracts.

## New files

| File | Concern | LOC |
|---|---|---|
| `bootstrap-session-builder.ts` | `buildAgentSession` + `buildSharedDeps` — constructing an `AgentSession` and its dep bundle | 129 |
| `bootstrap-config.ts` | `resolveBootstrapConfig` — resume target, cwd, model, thinking/effort/tokens, system prompt | 101 |
| `bootstrap-infra.ts` | `createBootstrapInfra` — trace writer, apiKey, background registry/summarizer, deferred-parent proxy, `wireExecutors` call-site | 171 |
| `bootstrap-mcp.ts` | `connectReplMcp` — loading + connecting the MCP fleet with trace bracketing | 93 |
| `bootstrap-providers.ts` | `createReplProviders` — memoized, fully-wired provider factory + startup provider | 97 |
| `bootstrap-surface.ts` | `createReplSurface` — stats seeding, startup banners, StatusLine/renderer/writer, git sampler | 151 |
| `bootstrap-hooks.ts` | `createReplHookRegistry` — hook registry bundle + terminal-state Stop gate registration | 61 |
| `bootstrap-slash-context.ts` | `createReplSlashContext` — assembling `SlashContext` incl. the clear-screen ordered-operation invariant | 80 |
| `bootstrap-wiring.ts` | `wireTrustedSkillEvents`, `wireProviderGrants`, `createReplInput` — post-ctx wiring | 148 |

## Before/after LOC

| File | Before | After |
|---|---|---|
| `bootstrap.ts` | 883 | 292 |
| 9 new files (sum) | — | 1031 |
| **Total** | **883** | **1323** |

`bootstrap.ts` retains: trimmed imports, the `bootstrapSession` doc block, `bootstrapStartedAt`, `sessionRef`, `bootWarnings` decl, `sharedMemoryStore`, the nine phase call-sites, `ensurePluginEntrypointsLoaded()` + `buildAgentSession(sharedDeps)` + `sessionRef.current = session` + `setOnSubagentSucceeded` (verbatim), `requestResume` (verbatim — it's the ctx/closure knot; extracting it would need a `ctxRef` indirection, so it stays per the plan), the `ctx` literal (verbatim), `registerAll()`, the tail, and the re-export `export { buildAgentSession } from './bootstrap-session-builder.js'`.

No release-valve extraction (`bootstrap-resume-request.ts`) was needed — `bootstrap.ts` landed at 292 LOC, under the 350 ceiling.

## Gates run

- `pnpm lint` (`tsc --noEmit`, full project): clean, 0 errors
- `pnpm test src/cli/interactive-lifecycle.test.ts`: **19/19 passing** (matches pre-change baseline, confirmed before any edits)
- `pnpm test src/cli/commands/interactive/resume-swap.test.ts`: **46/46 passing**, including the `buildAgentSession` re-export smoke test (`vi.importActual` assertion at resume-swap.test.ts:397-399) that gates the mandatory re-export line
- `pnpm test src/cli/commands/interactive.boot-warnings.test.ts src/cli/commands/interactive.resume.test.ts`: **13/13 passing**

Full `pnpm test` suite was intentionally NOT run here — left to CI/the centrally-run suite per the task's scoping.

## Ordering hazards handled

All preserved by keeping `bootstrap.ts` as the single sequencing point calling each phase in original order:
- `trace` opened before `BackgroundAgentRegistry`/`wireExecutors` (fork lifecycle writer inheritance) — both live inside `bootstrap-infra.ts`'s single call
- MCP connect before provider construction (`buildProvider`/`mcpToolWireNames` close over `mcpManager`) — `connectReplMcp` called strictly before `createReplProviders`
- `sessionRef` declared before `deferredParent` reads it — both inside `bootstrap-infra.ts`
- `stats` before hook registry construction, before `sharedDeps`
- `StatusLine` before `createReplRenderer` (DECSTBM contract) — both inside `bootstrap-surface.ts`'s single call
- `await ensurePluginEntrypointsLoaded()` before `buildAgentSession` — kept inline in `bootstrap.ts`
- `bgSummarizer?.start()` before `setBgsubSummarizer` — both inside `bootstrap-infra.ts`
- Console output order `mcp:` → `trace:` → `↪ resuming in` — preserved by call order (`connectReplMcp` then `createReplSurface`)
- `registerAll()` before `wireProviderGrants` — preserved call order in `bootstrap.ts`
- Tail order (`ctx.rl` → `ctx.inputSurfaceRef` → `slashCtx.requestResume` → `bootstrap_done` → `return ctx`) — preserved verbatim

## Landmines handled

- `bootWarnings` identity: the same array instance is threaded by reference through `createBootstrapInfra`, `connectReplMcp`, and the `ctx` literal — never copied
- Exact-optional spreads (`...(x !== undefined ? { k: x } : {})`) preserved verbatim throughout
- `noUncheckedIndexedAccess`: `loaded.sources[0] ?? getMcpConfigPath()` fallback preserved in `bootstrap-mcp.ts`
- `noUnusedLocals`: pruned imports from the trimmed `bootstrap.ts` last, after all phase extractions, then ran `pnpm lint` clean
- The three ≥15-line `// Invariant:` governed comments (deferredParent proxy, clear-screen ordering, `/allow-dir` wiring) moved verbatim with their code into `bootstrap-infra.ts`, `bootstrap-slash-context.ts`, and `bootstrap-wiring.ts` respectively
- Mandatory re-export (`export { buildAgentSession } from './bootstrap-session-builder.js'`) present and covered by `resume-swap.test.ts`

## Plan items completed vs. skipped

All 9 files from the plan were created exactly as specified; no release-valve extraction was needed. Nothing skipped.

## Risks for reviewer

- This is a pure mechanical move verified by two test suites + a full-project `tsc --noEmit`, but the full `pnpm test` suite was not run locally (per task scope) — CI should catch anything outside the two files' coverage (e.g. daemon/Telegram bootstrap paths that don't touch this file, so low risk).
- `bootstrap-session-builder.ts`'s `buildSharedDeps` takes a `CliConfig` param rather than the two loose booleans implied by one plausible reading of the plan's signature block — this matches the actual shape needed (`cliConfig.baseUrl`, `cliConfig.autoResumeOnUsageLimit`) and is the minimal-diff choice; flagging in case the reviewer expected a narrower type.

## Not verified

- Full `pnpm test` suite (daemon, Telegram, other CLI commands) — left to CI per task instructions.
- Runtime behavior under `afk interactive` (manual smoke test) was not performed — only the automated test suites above.

Closes #823
