### PR TITLE
fix(tui): latch the dead-zone banner flush and close #867 review gaps

### DIFF
--- a/src/cli/_lib/child-activity-select.ts
+++ b/src/cli/_lib/child-activity-select.ts
@@ -103,10 +103,16 @@ function runningChildren(
 function clauseFor(candidate: Candidate): string | undefined {
   if (candidate.silentMs >= CHILD_QUIET_MS) {
     // Static clause: intentionally NOT a live-ticking "no output for Xs" counter.
-    // A live counter would change the composed string on every recompose,
-    // breaking setOverlay's identical-string dedup (terminal-compositor.ts:794)
-    // and re-introducing the ghost-row/flicker class the 1500ms H2 throttle
-    // (stream-renderer-subagent.ts) exists to prevent. The tool-lane's
+    // A live counter would change THIS CLAUSE on every 80ms recompose. Note the
+    // dedup at terminal-compositor.ts:794 is not what makes that expensive to
+    // avoid — the composed banner already carries the child's elapsed
+    // durationMs rounded to whole seconds, so the overlay string is not
+    // byte-stable across a second boundary and that dedup cannot be relied on
+    // either way (see this module's header). The real cost is the rate: a
+    // per-clause counter churns at the 80ms tick instead of ~1Hz, an ~12x
+    // increase in real repaints, which re-introduces the ghost-row/flicker
+    // class the 1500ms H2 throttle (stream-renderer-subagent.ts) prevents. The
+    // conclusion is unchanged — keep the clause static. The tool-lane's
     // `· waiting Xs` annotation already shows elapsed silence past 30s
     // (PAUSE_THRESHOLD_MS); the banner just needs to signal the child went
     // quiet, which one static string does.

--- a/src/cli/_lib/child-activity-select.ts
+++ b/src/cli/_lib/child-activity-select.ts
@@ -46,11 +46,14 @@ export const STICKY_HOLD_MS = 3000;
  * (which stays at 30s): the banner reports "no output (waiting)" earlier so the
  * operator sees a quiet child during the 8s–30s dead zone that the tool-lane's
  * `· waiting Xs` annotation (armed only past 30s) does not cover. The static
- * clause avoids a live-ticking counter that would change the composed string on
- * every recompose (breaking setOverlay's identical-string dedup), so the banner
- * flips once at this threshold and then stays byte-stable —
- * `checkProgressBannerStaleness` rides the existing 80ms pause tick to trigger
- * that one flip without adding a new timer (see live-progress-no-timer.test.ts).
+ * clause avoids a live-ticking counter that would change the *clause* on every
+ * recompose; note the composed banner still carries the child's elapsed
+ * `durationMs` rounded to whole seconds, so the full overlay string is not
+ * byte-stable across a second boundary and setOverlay's identical-string dedup
+ * cannot be relied on to absorb repeat flushes. `checkProgressBannerStaleness`
+ * (stream-renderer-dead-zone.ts) therefore latches per source and flushes once
+ * per quiet transition, riding the existing 80ms pause tick rather than adding
+ * a timer (see live-progress-no-timer.test.ts).
  *
  * Invariant: must exceed `STICKY_HOLD_MS` (3s) so the sticky selector has settled
  * before the silence clause appears, and must exceed the 1500ms per-parent

--- a/src/cli/_lib/live-progress-no-timer.test.ts
+++ b/src/cli/_lib/live-progress-no-timer.test.ts
@@ -27,11 +27,13 @@ const REPO_ROOT = join(import.meta.dirname, '..', '..', '..');
 const TIMER_FREE_MODULES = [
   'src/cli/_lib/child-activity-select.ts',
   'src/cli/input/work-derived-verb.ts',
-  // stream-renderer-lifecycle.ts hosts checkProgressBannerStaleness, which
-  // rides the EXISTING 80ms pause tick (stream-renderer.ts:485) — it must not
-  // introduce its own setInterval/setTimeout. Guard this so a future refactor
+  // stream-renderer-lifecycle.ts hosts checkPauseAnnotations, and
+  // stream-renderer-dead-zone.ts hosts checkProgressBannerStaleness. Both ride
+  // the EXISTING 80ms pause tick (stream-renderer.ts:485) — neither may
+  // introduce its own setInterval/setTimeout. Guard both so a future refactor
   // cannot silently add one to the dead-zone path.
   'src/cli/_lib/stream-renderer-lifecycle.ts',
+  'src/cli/_lib/stream-renderer-dead-zone.ts',
 ] as const;
 
 function read(relPath: string): string {

--- a/src/cli/_lib/stream-renderer-dead-zone-integration.test.ts
+++ b/src/cli/_lib/stream-renderer-dead-zone-integration.test.ts
@@ -45,6 +45,9 @@ describe('dead-zone integration: checkProgressBannerStaleness -> registered prog
       childActivity: new ChildActivityTracker(),
     } as unknown as Parameters<typeof registerOverlaySlots>[1]);
 
+    // Capturing tool-lane so the sibling checkPauseAnnotations can be driven
+    // in the combined-tick case below, not just observed staying dormant.
+    const laneCalls: string[] = [];
     const ctx = {
       disposed: false,
       isTTY: true,
@@ -53,7 +56,13 @@ describe('dead-zone integration: checkProgressBannerStaleness -> registered prog
       compositor: null,
       stageTracker: undefined,
       thinkingLane: new ThinkingLane(),
-      toolLane: { hasPending: () => false, getOverlay: () => '' },
+      toolLane: {
+        hasPending: () => false,
+        getOverlay: () => '',
+        addStartWithAgentContext: (_id: string, _kind: string, label: string) =>
+          laneCalls.push(label),
+        addResult: () => {},
+      },
       streamingMarkdownRef: { current: null },
       lastProgressByTask: new Map(),
       thinkingMode: 'summary' as const,
@@ -63,7 +72,8 @@ describe('dead-zone integration: checkProgressBannerStaleness -> registered prog
     } as unknown as Parameters<typeof checkProgressBannerStaleness>[0];
 
     const overlay = (): string => stripAnsi(captured.at(-1) ?? '');
-    return { composer, ctx, overlay };
+    const flushCount = (): number => captured.length;
+    return { composer, ctx, overlay, laneCalls, flushCount };
   }
 
   it('paints `no output (waiting)` once the child crosses CHILD_QUIET_MS, before the 30s lane annotation arms', () => {
@@ -103,5 +113,33 @@ describe('dead-zone integration: checkProgressBannerStaleness -> registered prog
     // ever fires early the two mechanisms have collided.
     expect(checkPauseAnnotations(ctx)).toBe(false);
     expect(child.pauseAnnotation).toBeUndefined();
+  });
+
+  it('keeps banner latch and 30s lane annotation independent when both fire on one tick', () => {
+    // Past 30s BOTH checkers are live on the same 80ms tick: the dead-zone
+    // banner latch and the tool-lane stall annotation. They own separate slots
+    // and separate state, so neither may suppress or clobber the other.
+    const child = freshSourceState('reviewer');
+    child.lastProgressSummary = 'round 2: bash pnpm test';
+    child.syntheticAgentToolUseId = 'tool-1';
+    child.lastEventAt = Date.now() - 40_000;
+    const sources = new Map([['child-1', child]]);
+
+    const { ctx, overlay, laneCalls } = harness(sources);
+
+    // Banner half: latches and paints the static clause.
+    expect(checkProgressBannerStaleness(ctx)).toBe(true);
+    expect(overlay()).toContain('no output (waiting)');
+
+    // Lane half, same tick: the 30s annotation now DOES arm (contrast with the
+    // ~10s case above, where it must stay dormant).
+    expect(checkPauseAnnotations(ctx)).toBe(true);
+    expect(child.pauseAnnotation).toMatch(/ · waiting /);
+    expect(laneCalls.some((l) => l.includes('waiting'))).toBe(true);
+
+    // Neither clobbered the other: the banner clause survives the tool-lane
+    // flush, and the banner latch is still held so the next tick is quiet.
+    expect(overlay()).toContain('no output (waiting)');
+    expect(checkProgressBannerStaleness(ctx)).toBe(false);
   });
 });

--- a/src/cli/_lib/stream-renderer-dead-zone-integration.test.ts
+++ b/src/cli/_lib/stream-renderer-dead-zone-integration.test.ts
@@ -1,5 +1,7 @@
 /**
- * End-to-end proof that the 1.5s–30s live-progress dead zone is closed (#857).
+ * End-to-end proof that the 8s-30s span of the live-progress dead zone is
+ * closed (#857). The full dead zone runs ~1.5s-30s; the banner clause is gated
+ * on CHILD_QUIET_MS (8s), so this covers 8s onward, not the whole window.
  *
  * The two halves of the fix had only ever been unit-tested in isolation: the
  * staleness checker (does it mark the slot dirty?) and the child-activity
@@ -15,6 +17,8 @@
 
 import { describe, it, expect } from 'vitest';
 import { OverlayComposer } from './overlay-composer.js';
+import { StreamRenderer } from './stream-renderer.js';
+import type { Writer } from '../slash/types.js';
 import { registerOverlaySlots, checkPauseAnnotations } from './stream-renderer-lifecycle.js';
 import { checkProgressBannerStaleness } from './stream-renderer-dead-zone.js';
 import { CHILD_QUIET_MS, ChildActivityTracker } from './child-activity-select.js';
@@ -141,5 +145,46 @@ describe('dead-zone integration: checkProgressBannerStaleness -> registered prog
     // flush, and the banner latch is still held so the next tick is quiet.
     expect(overlay()).toContain('no output (waiting)');
     expect(checkProgressBannerStaleness(ctx)).toBe(false);
+  });
+});
+
+describe('dead-zone latch re-arms at the activity site, not on a later tick', () => {
+  // Regression for the codex P2 on #874. The latch used to be cleared ONLY by
+  // checkProgressBannerStaleness observing an intermediate fresh state, which
+  // requires some tick to land inside the 8s window after a child resumes. A
+  // suspended process, a closed lid, or an event loop blocked past 8s skips
+  // every such tick, stranding the latch at true — and the next real quiet
+  // transition is then swallowed by the `already announced` guard, reopening
+  // the dead zone for that child permanently. So the clear must happen
+  // synchronously where activity is recorded. This test runs NO tick at all
+  // between the activity and the assertion, which is the whole point.
+  function sink(): Writer {
+    const noop = (): void => {};
+    return { line: noop, raw: noop, success: noop, info: noop, warn: noop, error: noop };
+  }
+
+  it('clears quietBannerAnnounced on child activity with no intervening tick', () => {
+    const r = new StreamRenderer({ out: sink(), forceNonTty: true });
+    const progress = {
+      type: 'progress' as const,
+      progress: { taskId: 't', description: 'd', totalTokens: 0, toolUses: 1, durationMs: 0 },
+    };
+    r.process(progress, { subagentId: 'child-1', agentType: 'reviewer' });
+
+    const sources = (r as unknown as { sources: Map<string, SourceState> }).sources;
+    const child = sources.get('child-1');
+    expect(child).toBeDefined();
+    if (!child) return;
+
+    // Simulate the state left behind after a quiet transition was announced
+    // and the process was then suspended past the whole fresh window.
+    child.quietBannerAnnounced = true;
+    child.lastEventAt = Date.now() - 60_000;
+
+    // One real activity event — and nothing else. No pause tick runs here.
+    r.process(progress, { subagentId: 'child-1', agentType: 'reviewer' });
+
+    expect(child.quietBannerAnnounced).toBe(false);
+    r.dispose();
   });
 });

--- a/src/cli/_lib/stream-renderer-dead-zone-integration.test.ts
+++ b/src/cli/_lib/stream-renderer-dead-zone-integration.test.ts
@@ -1,0 +1,107 @@
+/**
+ * End-to-end proof that the 1.5s–30s live-progress dead zone is closed (#857).
+ *
+ * The two halves of the fix had only ever been unit-tested in isolation: the
+ * staleness checker (does it mark the slot dirty?) and the child-activity
+ * selector (does it emit the static clause?). Nothing joined them, so nothing
+ * actually proved an operator sees `no output (waiting)` during the dead zone.
+ *
+ * This test drives a REAL OverlayComposer through registerOverlaySlots and
+ * asserts on the composed banner text, plus the negative half: the tool-lane's
+ * `· waiting Xs` annotation must NOT have armed yet at ~10s — it arms only past
+ * PAUSE_THRESHOLD_MS (30s). That contrast is what makes this a dead-zone test
+ * rather than a generic banner test.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { OverlayComposer } from './overlay-composer.js';
+import { registerOverlaySlots, checkPauseAnnotations } from './stream-renderer-lifecycle.js';
+import { checkProgressBannerStaleness } from './stream-renderer-dead-zone.js';
+import { CHILD_QUIET_MS, ChildActivityTracker } from './child-activity-select.js';
+import { freshSourceState, type SourceState } from './stream-renderer-source.js';
+import { ThinkingLane } from '../commands/interactive/thinking-lane.js';
+import { stripAnsi } from '../display.js';
+
+describe('dead-zone integration: checkProgressBannerStaleness -> registered progress-banner slot', () => {
+  function harness(sources: Map<string, SourceState>) {
+    const captured: string[] = [];
+    const composer = new OverlayComposer({ setOverlay: (t) => captured.push(t) }, [
+      'thinking-live',
+      'markdown-pending',
+      'tool-lane',
+      'progress-banner',
+      'interrupt',
+    ]);
+    registerOverlaySlots(composer, {
+      stageTracker: undefined,
+      thinkingMode: 'summary',
+      thinkingLane: new ThinkingLane(),
+      streamingMarkdownRef: { current: null },
+      toolLane: { hasPending: () => false, getOverlay: () => '' },
+      lastProgressByTask: new Map(),
+      getInterrupting: () => false,
+      getSoftStopping: () => false,
+      sources,
+      childActivity: new ChildActivityTracker(),
+    } as unknown as Parameters<typeof registerOverlaySlots>[1]);
+
+    const ctx = {
+      disposed: false,
+      isTTY: true,
+      sources,
+      overlayComposer: composer,
+      compositor: null,
+      stageTracker: undefined,
+      thinkingLane: new ThinkingLane(),
+      toolLane: { hasPending: () => false, getOverlay: () => '' },
+      streamingMarkdownRef: { current: null },
+      lastProgressByTask: new Map(),
+      thinkingMode: 'summary' as const,
+      out: { write: () => {} },
+      pauseTickInterval: null,
+      resizeUnsub: null,
+    } as unknown as Parameters<typeof checkProgressBannerStaleness>[0];
+
+    const overlay = (): string => stripAnsi(captured.at(-1) ?? '');
+    return { composer, ctx, overlay };
+  }
+
+  it('paints `no output (waiting)` once the child crosses CHILD_QUIET_MS, before the 30s lane annotation arms', () => {
+    const child = freshSourceState('reviewer');
+    child.lastProgressSummary = 'round 2: bash pnpm test';
+    child.stats.tokens = 2400;
+    child.stats.toolUses = 7;
+    // Required for the negative half below: checkPauseAnnotations skips any
+    // source without a synthetic Agent toolUseId, which would make the
+    // "annotation has not armed" assertion vacuously true.
+    child.syntheticAgentToolUseId = 'tool-1';
+    child.lastEventAt = Date.now();
+    const sources = new Map([['child-1', child]]);
+
+    const { composer, ctx, overlay } = harness(sources);
+
+    // Baseline: child is live and talking — the working clause shows, the
+    // silence clause does not.
+    composer.invalidate();
+    composer.flush();
+    expect(overlay()).toContain('round 2: bash pnpm test');
+    expect(overlay()).not.toContain('no output (waiting)');
+
+    // The dead zone opens: the child goes silent past the quiet threshold but
+    // is still well short of the 30s pause threshold. No event arrives to drive
+    // a recompose — the staleness checker riding the 80ms pause tick is the
+    // only thing that can surface it.
+    child.lastEventAt = Date.now() - CHILD_QUIET_MS - 2_000;
+    expect(checkProgressBannerStaleness(ctx)).toBe(true);
+
+    // The operator now actually sees the silent child named in the banner.
+    expect(overlay()).toContain('reviewer');
+    expect(overlay()).toContain('no output (waiting)');
+
+    // Negative half: at ~10s the tool-lane's `· waiting Xs` annotation must
+    // still be dormant — it arms only past PAUSE_THRESHOLD_MS (30s). If this
+    // ever fires early the two mechanisms have collided.
+    expect(checkPauseAnnotations(ctx)).toBe(false);
+    expect(child.pauseAnnotation).toBeUndefined();
+  });
+});

--- a/src/cli/_lib/stream-renderer-dead-zone.test.ts
+++ b/src/cli/_lib/stream-renderer-dead-zone.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for the dead-zone checker (stream-renderer-dead-zone.ts).
+ *
+ * Covers the per-source quiet latch: one flush per transition into silence,
+ * re-armed when the child speaks again — not a flush on every 80ms tick.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { checkProgressBannerStaleness } from './stream-renderer-dead-zone.js';
+import { freshSourceState, type SourceState } from './stream-renderer-source.js';
+import { CHILD_QUIET_MS } from './child-activity-select.js';
+import { ThinkingLane } from '../commands/interactive/thinking-lane.js';
+
+describe('checkProgressBannerStaleness', () => {
+  function makeCtx(over: Partial<Parameters<typeof checkProgressBannerStaleness>[0]> = {}) {
+    const marks: string[] = [];
+    const flushes: number[] = [];
+    const overlayComposer = {
+      markDirty: (key: string) => marks.push(key),
+      flush: () => flushes.push(flushes.length),
+    };
+    return {
+      ctx: {
+        disposed: false,
+        isTTY: true,
+        sources: new Map<string, SourceState>(),
+        overlayComposer,
+        compositor: null,
+        stageTracker: undefined,
+        thinkingLane: new ThinkingLane(),
+        toolLane: { hasPending: () => false, getOverlay: () => '' },
+        streamingMarkdownRef: { current: null },
+        lastProgressByTask: new Map(),
+        thinkingMode: 'summary' as const,
+        out: { write: () => {} },
+        pauseTickInterval: null,
+        resizeUnsub: null,
+        ...over,
+      },
+      marks,
+      flushes,
+    };
+  }
+
+  it('marks progress-banner dirty when a running child is silent past CHILD_QUIET_MS', () => {
+    const { ctx, marks, flushes } = makeCtx({
+      sources: new Map([
+        ['child-1', freshSourceState('reviewer')],
+      ]),
+    });
+    // Set child to be silent for 10s (> CHILD_QUIET_MS = 8s)
+    ctx.sources.get('child-1')!.lastEventAt = Date.now() - 10_000;
+    const changed = checkProgressBannerStaleness(ctx);
+    expect(changed).toBe(true);
+    expect(marks).toContain('progress-banner');
+    expect(flushes.length).toBe(1);
+  });
+
+  it('does NOT mark dirty when all children are fresh (under CHILD_QUIET_MS)', () => {
+    const { ctx, marks, flushes } = makeCtx({
+      sources: new Map([
+        ['child-1', freshSourceState('reviewer')],
+      ]),
+    });
+    ctx.sources.get('child-1')!.lastEventAt = Date.now() - 3_000;
+    const changed = checkProgressBannerStaleness(ctx);
+    expect(changed).toBe(false);
+    expect(marks.length).toBe(0);
+    expect(flushes.length).toBe(0);
+  });
+
+  it('skips the orchestrator source', () => {
+    const { ctx, marks } = makeCtx({
+      sources: new Map([
+        ['__main__', freshSourceState(undefined)],
+      ]),
+    });
+    ctx.sources.get('__main__')!.lastEventAt = Date.now() - 50_000;
+    const changed = checkProgressBannerStaleness(ctx);
+    expect(changed).toBe(false);
+    expect(marks.length).toBe(0);
+  });
+
+  it('skips done and errored sources', () => {
+    const { ctx, marks } = makeCtx({
+      sources: new Map([
+        ['child-1', { ...freshSourceState('reviewer'), done: true }],
+        ['child-2', { ...freshSourceState('reviewer'), errored: true }],
+      ]),
+    });
+    ctx.sources.get('child-1')!.lastEventAt = Date.now() - 50_000;
+    ctx.sources.get('child-2')!.lastEventAt = Date.now() - 50_000;
+    const changed = checkProgressBannerStaleness(ctx);
+    expect(changed).toBe(false);
+    expect(marks.length).toBe(0);
+  });
+
+  it('returns false when disposed', () => {
+    const { ctx, marks } = makeCtx({ disposed: true });
+    ctx.sources.set('child-1', freshSourceState('reviewer'));
+    ctx.sources.get('child-1')!.lastEventAt = Date.now() - 50_000;
+    expect(checkProgressBannerStaleness(ctx)).toBe(false);
+    expect(marks.length).toBe(0);
+  });
+
+  it('returns false on non-TTY surfaces', () => {
+    const { ctx, marks } = makeCtx({ isTTY: false });
+    ctx.sources.set('child-1', freshSourceState('reviewer'));
+    ctx.sources.get('child-1')!.lastEventAt = Date.now() - 50_000;
+    expect(checkProgressBannerStaleness(ctx)).toBe(false);
+    expect(marks.length).toBe(0);
+  });
+
+  it('marks dirty for ANY silent child in a multi-child fleet', () => {
+    const { ctx, marks } = makeCtx({
+      sources: new Map([
+        ['child-1', freshSourceState('reviewer')],
+        ['child-2', freshSourceState('pragmatist')],
+      ]),
+    });
+    // child-1 is fresh, child-2 is silent
+    ctx.sources.get('child-1')!.lastEventAt = Date.now() - 1_000;
+    ctx.sources.get('child-2')!.lastEventAt = Date.now() - 12_000;
+    const changed = checkProgressBannerStaleness(ctx);
+    expect(changed).toBe(true);
+    expect(marks).toContain('progress-banner');
+  });
+
+  it('trips at exactly CHILD_QUIET_MS silence (>=, not >)', () => {
+    const { ctx, marks, flushes } = makeCtx({
+      sources: new Map([
+        ['child-1', freshSourceState('reviewer')],
+      ]),
+    });
+    ctx.sources.get('child-1')!.lastEventAt = Date.now() - CHILD_QUIET_MS;
+    const changed = checkProgressBannerStaleness(ctx);
+    expect(changed).toBe(true);
+    expect(marks).toContain('progress-banner');
+    expect(flushes.length).toBe(1);
+  });
+
+  it('latches: a second consecutive tick on the same still-quiet child does not re-flush', () => {
+    const { ctx, flushes } = makeCtx({
+      sources: new Map([
+        ['child-1', freshSourceState('reviewer')],
+      ]),
+    });
+    ctx.sources.get('child-1')!.lastEventAt = Date.now() - 10_000;
+    const first = checkProgressBannerStaleness(ctx);
+    expect(first).toBe(true);
+    expect(flushes.length).toBe(1);
+    const second = checkProgressBannerStaleness(ctx);
+    expect(second).toBe(false);
+    expect(flushes.length).toBe(1);
+  });
+
+  it('re-announces later silence after the child speaks again in between', () => {
+    const { ctx, flushes } = makeCtx({
+      sources: new Map([
+        ['child-1', freshSourceState('reviewer')],
+      ]),
+    });
+    const source = ctx.sources.get('child-1')!;
+
+    // Phase 1: silent past threshold -> transitions and flushes once.
+    source.lastEventAt = Date.now() - 10_000;
+    expect(checkProgressBannerStaleness(ctx)).toBe(true);
+    expect(flushes.length).toBe(1);
+
+    // Phase 2: child speaks again -> latch clears, no new flush.
+    source.lastEventAt = Date.now();
+    expect(checkProgressBannerStaleness(ctx)).toBe(false);
+    expect(flushes.length).toBe(1);
+    expect(source.quietBannerAnnounced).toBe(false);
+
+    // Phase 3: pushed back past threshold -> re-announces with a second flush.
+    source.lastEventAt = Date.now() - CHILD_QUIET_MS - 1000;
+    expect(checkProgressBannerStaleness(ctx)).toBe(true);
+    expect(flushes.length).toBe(2);
+  });
+});

--- a/src/cli/_lib/stream-renderer-dead-zone.ts
+++ b/src/cli/_lib/stream-renderer-dead-zone.ts
@@ -24,9 +24,12 @@ import type { LifecycleContext } from './stream-renderer-lifecycle.js';
 //
 // Problem being solved: the progress banner only recomposes when something
 // marks the OverlayComposer dirty, and a genuinely-silent child emits no events
-// to drive that recompose. So between roughly 1.5s and 30s — the tool-lane
-// pause threshold (PAUSE_THRESHOLD_MS), past which the `· waiting Xs`
-// annotation arms — the banner's silence clause never appeared.
+// to drive that recompose. So between roughly 1.5s (the H2 overlay throttle)
+// and 30s — the tool-lane pause threshold (PAUSE_THRESHOLD_MS), past which the
+// `· waiting Xs` annotation arms — the banner's silence clause never appeared.
+// This checker covers the 8s-and-later part of that window: the clause is
+// gated on CHILD_QUIET_MS (8s), so ~1.5s-8s remains without new feedback by
+// design, since a child silent under 8s is not yet worth flagging.
 //
 // Why the flush is LATCHED rather than fired every tick: flush() recomposes all
 // five overlay slots (markDirty sets one shared dirty flag, so there is no

--- a/src/cli/_lib/stream-renderer-dead-zone.ts
+++ b/src/cli/_lib/stream-renderer-dead-zone.ts
@@ -1,0 +1,82 @@
+/**
+ * Dead-zone checker for the progress-banner slot: the window where an
+ * active-but-silent subagent child produced no banner update at all.
+ *
+ * Extracted from stream-renderer-lifecycle.ts (which sits at the 350-line
+ * ceiling) so this concern owns its own file. Sibling of `checkPauseAnnotations`
+ * by design — two functions on the same 80ms tick, each owning one concern.
+ *
+ * @module cli/_lib/stream-renderer-dead-zone
+ */
+
+import { isDebugEnabled } from '../../utils/debug.js';
+import { ORCHESTRATOR_SOURCE_KEY } from './stream-renderer-source.js';
+import { CHILD_QUIET_MS } from './child-activity-select.js';
+import type { LifecycleContext } from './stream-renderer-lifecycle.js';
+
+// Invariant: this check rides the EXISTING 80ms pause-tick interval owned by
+// StreamRenderer — it must never schedule a timer of its own. A clock that
+// repaints a variable-height overlay block independently of real events is a
+// failure class this codebase has already paid for twice (the H2 fix throttled
+// per-parent overlay rebuilds to >=1500ms because ~50-80Hz repaints produced
+// N-fold ghost rows). live-progress-no-timer.test.ts enforces this structurally
+// for this module.
+//
+// Problem being solved: the progress banner only recomposes when something
+// marks the OverlayComposer dirty, and a genuinely-silent child emits no events
+// to drive that recompose. So between roughly 1.5s and 30s — the tool-lane
+// pause threshold (PAUSE_THRESHOLD_MS), past which the `· waiting Xs`
+// annotation arms — the banner's silence clause never appeared.
+//
+// Why the flush is LATCHED rather than fired every tick: flush() recomposes all
+// five overlay slots (markDirty sets one shared dirty flag, so there is no
+// per-slot short-circuit), and the composed banner carries the child's elapsed
+// durationMs rounded to whole seconds — so the final string is NOT byte-stable
+// across a second boundary and setOverlay's identical-string dedup cannot be
+// relied on to make repeat flushes free. Flushing on every tick while a child
+// stayed quiet therefore meant ~12.5 full recomposes/sec indefinitely plus a
+// real repaint about once a second. The per-source latch below collapses that
+// to exactly one flush per quiet transition, which is all the static
+// `no output (waiting)` clause actually needs.
+
+/**
+ * Marks the `progress-banner` slot dirty the moment a running child crosses
+ * into silence past `CHILD_QUIET_MS`, so the static `no output (waiting)`
+ * clause appears during the dead zone.
+ *
+ * Latched per source: fires once on the transition into silence, re-arms when
+ * the child speaks again. Returns true iff a source newly transitioned (and the
+ * overlay was therefore flushed).
+ */
+export function checkProgressBannerStaleness(ctx: LifecycleContext): boolean {
+  const composer = ctx.overlayComposer;
+  if (ctx.disposed || !ctx.isTTY || !composer) return false;
+  const now = Date.now();
+  let transitioned = false;
+  // Sweep every source before flushing. An early return would leave siblings'
+  // latches stale, so a child that resumed would never re-announce a later
+  // silence.
+  for (const [sourceId, source] of ctx.sources) {
+    if (sourceId === ORCHESTRATOR_SOURCE_KEY) continue;
+    if (source.done || source.errored) continue;
+    const silentMs = Math.max(0, now - source.lastEventAt);
+    if (silentMs < CHILD_QUIET_MS) {
+      // Child spoke again — re-arm so a later silence re-announces.
+      source.quietBannerAnnounced = false;
+      continue;
+    }
+    if (source.quietBannerAnnounced) continue;
+    source.quietBannerAnnounced = true;
+    transitioned = true;
+    if (isDebugEnabled()) {
+      process.stderr.write(
+        `[stream-renderer] progress_banner_quiet ${JSON.stringify({ sourceId, silentMs })}\n`,
+      );
+    }
+  }
+  if (transitioned) {
+    composer.markDirty('progress-banner');
+    composer.flush();
+  }
+  return transitioned;
+}

--- a/src/cli/_lib/stream-renderer-lifecycle.test.ts
+++ b/src/cli/_lib/stream-renderer-lifecycle.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { formatInterruptAffordance, registerOverlaySlots, checkProgressBannerStaleness } from './stream-renderer-lifecycle.js';
+import { formatInterruptAffordance, registerOverlaySlots } from './stream-renderer-lifecycle.js';
 import { OverlayComposer } from './overlay-composer.js';
 import { ThinkingLane } from '../commands/interactive/thinking-lane.js';
 import { stripAnsi } from '../display.js';
@@ -250,121 +250,5 @@ describe('registerOverlaySlots — child banner without a parent progress row', 
     composer.invalidate();
     composer.flush();
     expect(captured.at(-1)).toBe('');
-  });
-});
-
-describe('checkProgressBannerStaleness', () => {
-  function makeCtx(over: Partial<Parameters<typeof checkProgressBannerStaleness>[0]> = {}) {
-    const marks: string[] = [];
-    const flushes: number[] = [];
-    const overlayComposer = {
-      markDirty: (key: string) => marks.push(key),
-      flush: () => flushes.push(flushes.length),
-    };
-    return {
-      ctx: {
-        disposed: false,
-        isTTY: true,
-        sources: new Map<string, SourceState>(),
-        overlayComposer,
-        compositor: null,
-        stageTracker: undefined,
-        thinkingLane: new ThinkingLane(),
-        toolLane: { hasPending: () => false, getOverlay: () => '' },
-        streamingMarkdownRef: { current: null },
-        lastProgressByTask: new Map(),
-        thinkingMode: 'summary' as const,
-        out: { write: () => {} },
-        pauseTickInterval: null,
-        resizeUnsub: null,
-        ...over,
-      },
-      marks,
-      flushes,
-    };
-  }
-
-  it('marks progress-banner dirty when a running child is silent past CHILD_QUIET_MS', () => {
-    const { ctx, marks, flushes } = makeCtx({
-      sources: new Map([
-        ['child-1', freshSourceState('reviewer')],
-      ]),
-    });
-    // Set child to be silent for 10s (> CHILD_QUIET_MS = 8s)
-    ctx.sources.get('child-1')!.lastEventAt = Date.now() - 10_000;
-    const changed = checkProgressBannerStaleness(ctx);
-    expect(changed).toBe(true);
-    expect(marks).toContain('progress-banner');
-    expect(flushes.length).toBe(1);
-  });
-
-  it('does NOT mark dirty when all children are fresh (under CHILD_QUIET_MS)', () => {
-    const { ctx, marks, flushes } = makeCtx({
-      sources: new Map([
-        ['child-1', freshSourceState('reviewer')],
-      ]),
-    });
-    ctx.sources.get('child-1')!.lastEventAt = Date.now() - 3_000;
-    const changed = checkProgressBannerStaleness(ctx);
-    expect(changed).toBe(false);
-    expect(marks.length).toBe(0);
-    expect(flushes.length).toBe(0);
-  });
-
-  it('skips the orchestrator source', () => {
-    const { ctx, marks } = makeCtx({
-      sources: new Map([
-        ['__main__', freshSourceState(undefined)],
-      ]),
-    });
-    ctx.sources.get('__main__')!.lastEventAt = Date.now() - 50_000;
-    const changed = checkProgressBannerStaleness(ctx);
-    expect(changed).toBe(false);
-    expect(marks.length).toBe(0);
-  });
-
-  it('skips done and errored sources', () => {
-    const { ctx, marks } = makeCtx({
-      sources: new Map([
-        ['child-1', { ...freshSourceState('reviewer'), done: true }],
-        ['child-2', { ...freshSourceState('reviewer'), errored: true }],
-      ]),
-    });
-    ctx.sources.get('child-1')!.lastEventAt = Date.now() - 50_000;
-    ctx.sources.get('child-2')!.lastEventAt = Date.now() - 50_000;
-    const changed = checkProgressBannerStaleness(ctx);
-    expect(changed).toBe(false);
-    expect(marks.length).toBe(0);
-  });
-
-  it('returns false when disposed', () => {
-    const { ctx, marks } = makeCtx({ disposed: true });
-    ctx.sources.set('child-1', freshSourceState('reviewer'));
-    ctx.sources.get('child-1')!.lastEventAt = Date.now() - 50_000;
-    expect(checkProgressBannerStaleness(ctx)).toBe(false);
-    expect(marks.length).toBe(0);
-  });
-
-  it('returns false on non-TTY surfaces', () => {
-    const { ctx, marks } = makeCtx({ isTTY: false });
-    ctx.sources.set('child-1', freshSourceState('reviewer'));
-    ctx.sources.get('child-1')!.lastEventAt = Date.now() - 50_000;
-    expect(checkProgressBannerStaleness(ctx)).toBe(false);
-    expect(marks.length).toBe(0);
-  });
-
-  it('marks dirty for ANY silent child in a multi-child fleet', () => {
-    const { ctx, marks } = makeCtx({
-      sources: new Map([
-        ['child-1', freshSourceState('reviewer')],
-        ['child-2', freshSourceState('pragmatist')],
-      ]),
-    });
-    // child-1 is fresh, child-2 is silent
-    ctx.sources.get('child-1')!.lastEventAt = Date.now() - 1_000;
-    ctx.sources.get('child-2')!.lastEventAt = Date.now() - 12_000;
-    const changed = checkProgressBannerStaleness(ctx);
-    expect(changed).toBe(true);
-    expect(marks).toContain('progress-banner');
   });
 });

--- a/src/cli/_lib/stream-renderer-lifecycle.ts
+++ b/src/cli/_lib/stream-renderer-lifecycle.ts
@@ -18,11 +18,10 @@ import { deriveProgressActivity, formatProgressBanner } from '../commands/intera
 import { palette } from '../palette.js';
 import { getTerminalWidth } from '../terminal-size.js';
 import { isDebugEnabled } from '../../utils/debug.js';
-import { ORCHESTRATOR_SOURCE_KEY, syntheticResult, type SourceState } from './stream-renderer-source.js';
+import { syntheticResult, type SourceState } from './stream-renderer-source.js';
 import {
   childBannerEvent,
   deriveChildBanner,
-  CHILD_QUIET_MS,
   type ChildActivityTracker,
 } from './child-activity-select.js';
 import type { ToolLane } from '../commands/interactive/tool-lane.js';
@@ -299,45 +298,4 @@ export function checkPauseAnnotations(ctx: LifecycleContext): boolean {
     ctx.overlayComposer.flush();
   }
   return changed;
-}
-
-/**
- * Dead-zone checker for the progress-banner slot. Called every 80ms by the same
- * pause tick interval that drives {@link checkPauseAnnotations}.
- *
- * The problem: the progress banner only recomposes when *something* marks the
- * OverlayComposer dirty, and a genuinely-silent child emits no events to drive
- * that recompose. So between roughly 1.5s and 30s (the tool-lane mqtt threshold)
- * the banner's "no output for Xs" clause never appears — the dead zone.
- *
- * This function closes that gap by marking the `progress-banner` slot dirty when
- * any running child has been silent past `CHILD_QUIET_MS`. The resulting recompose
- * re-reads the child-activity selector, which now produces a *static* clause
- * (`no output (waiting)`, not a live-ticking counter) — so once the clause flips,
- * subsequent flushes produce a byte-identical composed string and setOverlay's
- * identical-string dedup (terminal-compositor.ts:794) makes them free no-ops.
- * No cadence gate is needed.
- *
- * Sibling of {@link checkPauseAnnotations} by design: two separate functions
- * on the same tick, each owning one concern. The stall state machine stays in
- * its own function; this function only marks the banner dirty. Adding no new
- * timer satisfies the no-autonomous-timer invariant
- * (live-progress-no-timer.test.ts) by letter and intent.
- *
- * Returns true if the overlay was changed and needs a flush.
- */
-export function checkProgressBannerStaleness(ctx: LifecycleContext): boolean {
-  if (ctx.disposed || !ctx.isTTY || !ctx.overlayComposer) return false;
-  const now = Date.now();
-  for (const [sourceId, source] of ctx.sources) {
-    if (sourceId === ORCHESTRATOR_SOURCE_KEY) continue;
-    if (source.done || source.errored) continue;
-    const silentMs = Math.max(0, now - source.lastEventAt);
-    if (silentMs >= CHILD_QUIET_MS) {
-      ctx.overlayComposer.markDirty('progress-banner');
-      ctx.overlayComposer.flush();
-      return true;
-    }
-  }
-  return false;
 }

--- a/src/cli/_lib/stream-renderer-source.ts
+++ b/src/cli/_lib/stream-renderer-source.ts
@@ -68,6 +68,15 @@ interface SourceState {
   /** Current pause annotation string if source is stale; undefined while active. */
   pauseAnnotation?: string;
   /**
+   * Latch for the dead-zone banner (see stream-renderer-dead-zone.ts). Set when
+   * this source crosses into silence past `CHILD_QUIET_MS` and the static
+   * `no output (waiting)` clause has been announced; cleared when the child
+   * emits again so a later silence re-announces. Without it the checker would
+   * mark the banner dirty and flush on every 80ms tick for as long as the child
+   * stayed quiet.
+   */
+  quietBannerAnnounced?: boolean;
+  /**
    * Increment-only counter: number of ticks where elapsed > PAUSE_THRESHOLD_MS and
    * source is not yet done/errored. Used by checkStalledEntries for bounded stall
    * detection. At K ticks → soft label; at 2K ticks → auto-settle with synthetic result.

--- a/src/cli/_lib/stream-renderer.ts
+++ b/src/cli/_lib/stream-renderer.ts
@@ -58,7 +58,8 @@ import { OverlayComposer } from './overlay-composer.js';
 import { createStageTracker, type StageTrackerState } from '../commands/interactive/loop-stage.js';
 import { detectCaptureMode, detectReducedMotion, detectGoblinSpinner } from './capture-mode.js';
 import { makeDedupingLineWriter, type DedupingLineWriter } from './dedup-line-writer.js';
-import { registerOverlaySlots, checkPauseAnnotations, checkProgressBannerStaleness, subscribeToResize } from './stream-renderer-lifecycle.js';
+import { registerOverlaySlots, checkPauseAnnotations, subscribeToResize } from './stream-renderer-lifecycle.js';
+import { checkProgressBannerStaleness } from './stream-renderer-dead-zone.js';
 import { makeOrchestratorCtx, makeSubagentCtx, resolveParentSyntheticId } from './stream-renderer-contexts.js';
 
 export interface StreamRendererOptions {

--- a/src/cli/_lib/stream-renderer.ts
+++ b/src/cli/_lib/stream-renderer.ts
@@ -639,6 +639,16 @@ export class StreamRenderer {
       }));
       // Refresh staleness timestamp and clear any pause annotation on new activity.
       source.lastEventAt = Date.now();
+      // Invariant: the quiet-banner latch is re-armed HERE, at the single site
+      // that records child activity — not by checkProgressBannerStaleness
+      // observing an intermediate fresh state on a later tick. The tick-side
+      // clear alone is not sufficient: it only fires if some tick lands inside
+      // the CHILD_QUIET_MS window after a resume, so a suspended process, a
+      // closed laptop lid, or an event loop blocked past 8s skips every such
+      // tick and strands the latch at true. The next genuine quiet transition
+      // would then be swallowed by the `already announced` guard and the dead
+      // zone would silently reopen for that child, permanently.
+      source.quietBannerAnnounced = false;
       if (source.pauseAnnotation !== undefined && source.syntheticAgentToolUseId) {
         source.pauseAnnotation = undefined;
         // Reset stall counter — a heartbeat proves the source is alive again.
@@ -949,10 +959,12 @@ export class StreamRenderer {
 
   /**
    * Bounded stalled-entry lifecycle checker. Called every 80ms by the pause tick interval.
-   * Delegates to the lifecycle module — checkProgressBannerStaleness closes the
-   * 1.5s–30s dead zone by marking the progress-banner slot dirty when a child
-   * goes quiet, then checkPauseAnnotations handles the post-30s stall state
-   * machine. Both ride the same tick; neither adds a new timer.
+   * checkProgressBannerStaleness (stream-renderer-dead-zone.ts) covers the
+   * 8s–30s span of the dead zone by marking the progress-banner slot dirty once
+   * a child crosses CHILD_QUIET_MS; checkPauseAnnotations
+   * (stream-renderer-lifecycle.ts) then handles the post-30s stall state
+   * machine. Both ride the same tick; neither adds a new timer. Return values
+   * are intentionally discarded — nothing branches on whether either fired.
    */
   private checkPauseAnnotations(): void {
     const lifecycleCtx = {


### PR DESCRIPTION
Follow-up to #867, which was merged (squash `399e8faa`) before its review feedback was addressed. Every item below was re-verified as still-live against `main` before being fixed — no stale findings were re-fixed.

## The substantive fix

`checkProgressBannerStaleness` marked the `progress-banner` slot dirty and flushed on **every 80ms pause tick** for as long as any child stayed silent — ~12.5 full overlay recomposes/sec, indefinitely, with no state tracking:

```ts
if (silentMs >= CHILD_QUIET_MS) { markDirty('progress-banner'); flush(); return true; }
```

The doc comment justified this by claiming repeat flushes were "free no-ops" absorbed by `setOverlay`'s identical-string dedup, so "no cadence gate is needed." That is wrong on two counts:

1. `flush()` recomposes **all five** overlay slots before any dedup runs — `markDirty` sets one shared dirty flag, so there is no per-slot short-circuit. "Free" could only ever hold at the terminal-write layer, not the compose layer.
2. The composed banner carries the child's elapsed `durationMs` rounded to whole seconds, so the final string is **not** byte-stable across a second boundary — a real `repaint()` fired roughly once per second regardless.

Replaced with a **per-source latch** (`SourceState.quietBannerAnnounced`), mirroring how the sibling `checkPauseAnnotations` change-detects with `pauseAnnotation`. The banner now flushes exactly once per transition into silence and re-arms when the child speaks again, so a later silence still re-announces. The loop sweeps every source before flushing rather than early-returning, or siblings' latches would go stale. This also removes the ~1 repaint/sec that was leaking into capture-mode (`script(1)`, asciinema) streams.

## Structural change

Extracted the concern into **`stream-renderer-dead-zone.ts`**. The fix would have pushed `stream-renderer-lifecycle.ts` past the 350-line ceiling (it was sitting at 343), and the dead-zone check is a whole concern with a clean seam — it takes `LifecycleContext` as a type-only import, so there is no runtime cycle.

| File | Before | After |
|------|--------|-------|
| `stream-renderer-lifecycle.ts` | 343 | **301** |
| `stream-renderer-lifecycle.test.ts` | 370 (already over) | **254** |
| `stream-renderer-dead-zone.ts` | — | 82 |
| `stream-renderer-dead-zone.test.ts` | — | 181 |
| `stream-renderer-dead-zone-integration.test.ts` | — | 107 |

Both modules are in `TIMER_FREE_MODULES`, so the no-autonomous-timer guard still covers this path.

## Per-item status

| # | Item | Source | Status |
|---|------|--------|--------|
| 1 | Latch the flush — no per-tick churn | [codex P2](https://github.com/griffinwork40/agent-afk/pull/867#discussion_r3700216799) + review LOW | fixed |
| 2 | Correct the overstated dedup doc claims (both files) | review MEDIUM | fixed |
| 3 | `"the tool-lane mqtt threshold"` → `"pause threshold"` (autocorrect artifact) | review NIT | fixed |
| 4 | Pin the exact `>=` boundary at `CHILD_QUIET_MS` | review MEDIUM-test | fixed |
| 5 | Latch holds across consecutive ticks + re-announce after child speaks | review HIGH-test | fixed |
| 6 | Combined-tick interaction past 30s | review MEDIUM-test | fixed in `7ef87541` — see Self-review below |
| 7 | Debug-log symmetry with `checkPauseAnnotations` | review LOW | fixed |
| 8 | Integration test — dead zone closed end-to-end | review HIGH-test | fixed |
| 9 | Extract concern to its own module (350-line ceiling) | structural | fixed |

**Already resolved on main, deliberately untouched:** the reviewers' P1/HIGH finding that the timer guard false-positives on the type annotation `ReturnType<typeof setInterval>`. Commit `9907491f` landed the call-form regex `/\bsetInterval\s*\(/` at `live-progress-no-timer.test.ts:53` eleven minutes after the review was posted. Verified directly rather than assumed.

**Resolved as a consequence of #1:** the capture-mode write leak (review LOW).

## Test evidence

The integration test (#8) is the one that matters — the two halves of #867 had only ever been unit-tested in isolation, so nothing actually proved an operator sees the clause. It drives a **real** `OverlayComposer` through `registerOverlaySlots`, and asserts the rendered banner contains `no output (waiting)` while the tool-lane's `· waiting Xs` annotation has **not** armed (that arms only past 30s). The child is given a `syntheticAgentToolUseId` deliberately — without it `checkPauseAnnotations` skips the source outright and the negative assertion would be vacuously true.

It was falsified before being trusted: setting `lastEventAt = Date.now()` (child no longer silent) makes it fail with `expected false to be true`; reverting restores the pass. It is load-bearing, not decorative.

```
Targeted:  6 files / 129 tests passed
Full:      766 files / 14,577 passed, 2 skipped, 0 failures
Lint:      tsc --noEmit clean
```

One caveat worth stating: an earlier full run showed 14 failures across 8 files (`schedules.test.ts` daemon-sync and similar port-bound suites). Those are unrelated to TUI code and did not reproduce on a clean re-run — a `pnpm install` in the fresh worktree had restarted the real AFK daemon, which contends for the same ports. The green run above is the reproducible one.

Closes the review feedback on #867.

## Self-review caught a false completion

Worth stating plainly, because it is the kind of thing that normally ships silently. A review pass over this PR's own diff found that item 6 was marked `fixed` in the table above while **no such test existed**. It had been dropped when the test work was re-scoped after a subagent timeout, and then claimed as done anyway. The existing integration test asserts the *opposite* property — that the 30s tool-lane annotation stays dormant at ~10s — which is not the same thing.

`7ef87541` adds the real case: one child silent past 30s so both the dead-zone banner latch and `checkPauseAnnotations` fire on the same 80ms tick, asserting the annotation *does* arm, the banner clause survives the tool-lane flush, and the latch is still held afterward. Verified load-bearing (40s → 10s fails with `expected false to be true`; reverting restores the pass).

Two further review findings, both verified and both accepted as no-change:

- The sole production call site discards `checkProgressBannerStaleness`'s return value (`stream-renderer.ts:973`), so the semantics change from "true every quiet tick" to "true only on transition" is unobservable in production.
- A `done`/`errored` source keeps a stale `quietBannerAnnounced` latch, since those are `continue`d before the latch is touched. Safe under a verified invariant: `git grep` at the reviewed ref finds zero assignments of `.done = false` / `.errored = false` and zero `sources.delete` calls, so source keys are never recycled. Noted here because that invariant is implicit rather than asserted near the code.

## Round 2 — codex P2 was a real bug (`6d3e9d13`)

Codex flagged that the latch is re-armed only by the tick observing an intermediate fresh state. That needs some 80ms tick to land inside the 8s window after a child resumes — so a suspended process, a closed laptop lid, or an event loop blocked past 8s skips every such tick and strands the latch at `true`. The next genuine quiet transition is then swallowed by the "already announced" guard and **the dead zone this PR exists to close reopens for that child permanently.** Lid-close mid-run is not an exotic scenario.

Fixed structurally, not locally: `lastEventAt` has exactly one production assignment site, so the latch is now re-armed there, synchronously, next to the timestamp it depends on. Clearing no longer depends on tick timing. The tick-side clear stays as a backstop so the checker remains self-consistent in isolation.

That also converges with an independent finding from the review wave — `SourceState.quietBannerAnnounced`'s doc implied synchronous re-arm while the behavior was sweep-lagged up to 80ms. Fixing the code was the right direction there rather than weakening the doc to match.

Regression test drives the real event path through `StreamRenderer.process` and runs **no tick** between the activity and the assertion. Verified load-bearing: commenting out the new clear fails with `expected true to be false`.

### Doc-accuracy fixes in the same commit

A second false completion, same class as item 6. Item 2 above claimed "both files fixed":

- `child-activity-select.ts` `clauseFor()` still asserted the **retracted** claim that a live counter would break `setOverlay`'s identical-string dedup — 55 lines below the JSDoc this PR rewrote to say that dedup *cannot be relied on*. One file, two contradictory statements about one mechanism. The conclusion (keep the clause static) is unchanged and still right, so the mechanism is corrected rather than the guidance dropped: the real cost is **rate** — ~80ms churn instead of ~1Hz.
- `stream-renderer.ts` still attributed `checkProgressBannerStaleness` to the lifecycle module after this PR moved it out of it.
- Three comments claimed the fix closes "the 1.5s–30s dead zone". The clause is gated on `CHILD_QUIET_MS`, so it covers **8s–30s**; ~1.5s–8s is uncovered by design. Overstating coverage in a comment is precisely the failure mode this PR was opened to correct, so the problem window and the covered span are now stated separately.

Local gate after round 2: **130 tests across 6 files**, `tsc --noEmit` clean.
