### PR TITLE
fix(awareness): make the Workspace line follow a mid-session cwd re-anchor

### DIFF
--- a/src/agent/awareness/runtime-source.test.ts
+++ b/src/agent/awareness/runtime-source.test.ts
@@ -23,7 +23,7 @@ vi.mock('./workspace-source.js', () => ({
 function defaultDeps() {
   return {
     surface: 'cli',
-    cwd: '/work',
+    getCwd: () => '/work',
     modelName: 'sonnet',
     providerName: 'anthropic-direct',
     permissionMode: 'default',
@@ -278,10 +278,42 @@ describe('buildRuntimeStateSource.getWorkspace', () => {
     expect(vi.mocked(gatherWorkspace)).not.toHaveBeenCalled();
   });
 
-  it('passes deps.cwd through to gatherWorkspace on each read', () => {
+  it('passes deps.getCwd() through to gatherWorkspace on each read', () => {
     vi.mocked(gatherWorkspace).mockReturnValue(ws(0));
-    const src = buildRuntimeStateSource({ ...defaultDeps(), cwd: '/custom/work' });
+    const src = buildRuntimeStateSource({ ...defaultDeps(), getCwd: () => '/custom/work' });
     src.getWorkspace();
     expect(vi.mocked(gatherWorkspace)).toHaveBeenCalledWith('/custom/work');
+  });
+
+  it('re-reads getCwd per call so a mid-session setCwd re-anchors the repo', () => {
+    // Regression guard (worktree staleness): `cwd` used to be a captured
+    // string, so after an `afk -w` / `/cd` re-anchor the awareness layer kept
+    // gathering git state for the LAUNCH checkout. The symptom was a session
+    // whose `- Working directory:` line pointed at the new worktree while its
+    // `- Workspace:` line reported the original checkout's branch and HEAD.
+    vi.mocked(gatherWorkspace).mockReturnValue(ws(0));
+    let cwd = '/launch/checkout';
+    const src = buildRuntimeStateSource({ ...defaultDeps(), getCwd: () => cwd });
+
+    src.getWorkspace();
+    expect(vi.mocked(gatherWorkspace)).toHaveBeenLastCalledWith('/launch/checkout');
+
+    // Simulate cwdDependentsFactory's setCurrentCwd() on a worktree swap.
+    cwd = '/repo/.afk-worktrees/feature';
+
+    src.getWorkspace();
+    // The captured-string implementation would still pass '/launch/checkout'.
+    expect(vi.mocked(gatherWorkspace)).toHaveBeenLastCalledWith('/repo/.afk-worktrees/feature');
+  });
+
+  it('reports the re-anchored cwd on getSelf so the two never disagree', () => {
+    // `get_runtime_state` view 'self' and view 'workspace' must resolve the
+    // same cwd — a divergence there is what made the bug hard to see.
+    let cwd = '/launch/checkout';
+    const src = buildRuntimeStateSource({ ...defaultDeps(), getCwd: () => cwd });
+
+    expect(src.getSelf().cwd).toBe('/launch/checkout');
+    cwd = '/repo/.afk-worktrees/feature';
+    expect(src.getSelf().cwd).toBe('/repo/.afk-worktrees/feature');
   });
 });

--- a/src/agent/awareness/runtime-source.test.ts
+++ b/src/agent/awareness/runtime-source.test.ts
@@ -287,8 +287,9 @@ describe('buildRuntimeStateSource.getWorkspace', () => {
 
   it('re-reads getCwd per call so a mid-session setCwd re-anchors the repo', () => {
     // Regression guard (worktree staleness): `cwd` used to be a captured
-    // string, so after an `afk -w` / `/cd` re-anchor the awareness layer kept
-    // gathering git state for the LAUNCH checkout. The symptom was a session
+    // string, so after the deferred born-named `afk -w` worktree re-anchor the
+    // awareness layer kept gathering git state for the LAUNCH checkout. The
+    // symptom was a session
     // whose `- Working directory:` line pointed at the new worktree while its
     // `- Workspace:` line reported the original checkout's branch and HEAD.
     vi.mocked(gatherWorkspace).mockReturnValue(ws(0));

--- a/src/agent/awareness/runtime-source.ts
+++ b/src/agent/awareness/runtime-source.ts
@@ -2,9 +2,10 @@
  * Constructs a {@link RuntimeStateSource} from the provider's per-query state.
  *
  * Shared by both `anthropic-direct` and `openai-compatible` providers so the
- * resulting snapshot shape is provider-agnostic. The provider supplies live
- * accessors (lambdas), not snapshots, so subsequent `get_runtime_state` calls
- * see up-to-date subagent counts, MCP tool counts, and git workspace state.
+ * resulting snapshot shape is provider-agnostic. Providers supply callbacks so
+ * subsequent `get_runtime_state` calls can see up-to-date subagent counts, MCP
+ * tool counts, and git workspace state; openai-compatible's cwd callback is a
+ * known per-query snapshot until #876.
  *
  * @module agent/awareness/runtime-source
  */
@@ -30,13 +31,14 @@ export interface RuntimeSourceDeps {
   /**
    * Live accessor for the session working directory.
    *
-   * Invariant: this MUST be a callback, never a snapshot. `setCwd()` (the
-   * `afk -w` born-named worktree path, `/cd`, and worktree re-anchoring) can
-   * repoint the session mid-flight, and both `getSelf().cwd` and
-   * `getWorkspace()` have to follow it. A captured string silently pins the
-   * awareness layer to the launch directory, so `get_runtime_state` and the
-   * `- Workspace:` prompt line keep reporting the ORIGINAL checkout's branch
-   * and HEAD while the tools operate in the new one.
+   * Invariant: providers SHOULD supply a live callback, not a captured string.
+   * The deferred born-named `afk -w` worktree path can repoint an anthropic-direct
+   * session mid-flight, and both `getSelf().cwd` and `getWorkspace()` have to
+   * follow it. A captured string silently pins the awareness layer to the launch
+   * directory, so `get_runtime_state` and the `- Workspace:` prompt line keep
+   * reporting the ORIGINAL checkout's branch and HEAD while the tools operate in
+   * the new one. Known exception: openai-compatible currently freezes this value
+   * per query; fixing its mid-query `setCwd()` staleness is tracked in #876.
    */
   getCwd: () => string;
   /** Resolved model identifier the SDK will be called with. */
@@ -90,10 +92,11 @@ export interface RuntimeSourceDeps {
  * branch when it orients, not a frozen session-start snapshot that silently
  * goes stale as files change.
  *
- * `deps.getCwd` is likewise a callback rather than a string: a session can be
- * repointed mid-flight (`afk -w` born-named worktrees, `/cd`), and a captured
- * cwd would pin the awareness layer to the launch checkout — reporting the
- * wrong branch and HEAD for the entire remaining session.
+ * `deps.getCwd` is likewise a callback rather than a string: anthropic-direct
+ * sessions can be repointed mid-flight by the deferred born-named `afk -w`
+ * worktree path, and a captured cwd would pin the awareness layer to the launch
+ * checkout — reporting the wrong branch and HEAD for the remaining session.
+ * Known exception: openai-compatible freezes this value per query until #876.
  */
 export function buildRuntimeStateSource(deps: RuntimeSourceDeps): RuntimeStateSource {
   return {

--- a/src/agent/awareness/runtime-source.ts
+++ b/src/agent/awareness/runtime-source.ts
@@ -27,8 +27,18 @@ export interface RuntimeSourceDeps {
   sessionId?: string | undefined;
   /** Provider-level surface tag (e.g. 'cli', 'daemon', 'telegram'). */
   surface: string;
-  /** Working directory at query time. */
-  cwd: string;
+  /**
+   * Live accessor for the session working directory.
+   *
+   * Invariant: this MUST be a callback, never a snapshot. `setCwd()` (the
+   * `afk -w` born-named worktree path, `/cd`, and worktree re-anchoring) can
+   * repoint the session mid-flight, and both `getSelf().cwd` and
+   * `getWorkspace()` have to follow it. A captured string silently pins the
+   * awareness layer to the launch directory, so `get_runtime_state` and the
+   * `- Workspace:` prompt line keep reporting the ORIGINAL checkout's branch
+   * and HEAD while the tools operate in the new one.
+   */
+  getCwd: () => string;
   /** Resolved model identifier the SDK will be called with. */
   modelName: string;
   /** Provider name — e.g. 'anthropic-direct' or 'openai-compatible'. */
@@ -74,10 +84,16 @@ export interface RuntimeSourceDeps {
  * (`sessionId`, `depth`, `parentSessionId`, etc.) do not change mid-session.
  *
  * `getWorkspace()` recomputes git workspace state on every call via
- * `gatherWorkspace(deps.cwd)`, mirroring the live `getTools()`/`getSubagents()`
- * accessors. This costs 4 `spawnSync` git calls per invocation, but means the
- * model sees the *current* dirty-file count / HEAD / branch when it orients,
- * not a frozen session-start snapshot that silently goes stale as files change.
+ * `gatherWorkspace(deps.getCwd())`, mirroring the live `getTools()`/
+ * `getSubagents()` accessors. This costs 4 `spawnSync` git calls per
+ * invocation, but means the model sees the *current* dirty-file count / HEAD /
+ * branch when it orients, not a frozen session-start snapshot that silently
+ * goes stale as files change.
+ *
+ * `deps.getCwd` is likewise a callback rather than a string: a session can be
+ * repointed mid-flight (`afk -w` born-named worktrees, `/cd`), and a captured
+ * cwd would pin the awareness layer to the launch checkout — reporting the
+ * wrong branch and HEAD for the entire remaining session.
  */
 export function buildRuntimeStateSource(deps: RuntimeSourceDeps): RuntimeStateSource {
   return {
@@ -89,7 +105,7 @@ export function buildRuntimeStateSource(deps: RuntimeSourceDeps): RuntimeStateSo
         depth: deps.depth ?? null,
         maxDepth: deps.maxDepth ?? null,
         phaseRole: deps.phaseRole ?? null,
-        cwd: deps.cwd,
+        cwd: deps.getCwd(),
         model: {
           provider: deps.providerName,
           name: deps.modelName,
@@ -107,10 +123,12 @@ export function buildRuntimeStateSource(deps: RuntimeSourceDeps): RuntimeStateSo
       return deps.getSubagents();
     },
     getWorkspace(): RuntimeWorkspace {
-      // Live: recompute per call so the snapshot reflects edits made since
-      // session start — the agent's own writes AND concurrent external writers.
+      // Live on BOTH axes: the cwd is re-read per call (so a mid-session
+      // setCwd re-anchors which repo we report on) and git is re-run against
+      // it (so the snapshot reflects edits made since session start — the
+      // agent's own writes AND concurrent external writers).
       // Cost: 4 spawnSync git calls per call (see gatherWorkspace).
-      return gatherWorkspace(deps.cwd);
+      return gatherWorkspace(deps.getCwd());
     },
   };
 }

--- a/src/agent/awareness/types.ts
+++ b/src/agent/awareness/types.ts
@@ -137,7 +137,7 @@ export interface RuntimeSubagents {
  * Git workspace state for the session's CURRENT working directory (Phase 2).
  *
  * Re-gathered on every `getWorkspace()` call against the live cwd, so it
- * follows a mid-session `setCwd()` re-anchor (`afk -w`, `/cd`) instead of
+ * follows the deferred born-named `afk -w` worktree re-anchor instead of
  * pinning to the launch checkout.
  *
  * All fields are nullable — the object is returned with every field `null`

--- a/src/agent/awareness/types.ts
+++ b/src/agent/awareness/types.ts
@@ -134,7 +134,11 @@ export interface RuntimeSubagents {
 }
 
 /**
- * Git workspace state captured once at session start (Phase 2).
+ * Git workspace state for the session's CURRENT working directory (Phase 2).
+ *
+ * Re-gathered on every `getWorkspace()` call against the live cwd, so it
+ * follows a mid-session `setCwd()` re-anchor (`afk -w`, `/cd`) instead of
+ * pinning to the launch checkout.
  *
  * All fields are nullable — the object is returned with every field `null`
  * when the cwd is not a git repo, git is not installed, or any git command
@@ -177,6 +181,10 @@ export interface RuntimeStateSource {
   getSelf(): RuntimeSelf;
   getTools(): RuntimeTools;
   getSubagents(): RuntimeSubagents;
-  /** Returns the workspace baseline captured at session start. Always the same object. */
+  /**
+   * Returns git state for the session's current cwd, re-gathered per call.
+   * Follows mid-session `setCwd()` re-anchors — never a frozen session-start
+   * baseline.
+   */
   getWorkspace(): RuntimeWorkspace;
 }

--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -437,6 +437,14 @@ export class AnthropicDirectProvider implements ModelProvider {
     // Route through ensureSharedRoots so _initialResolveBase is captured for
     // the non-revocable guard in revokeRoot.
     this.ensureSharedRoots(config.cwd);
+    // Invariant: a cached provider instance is reused across `/model` swaps, and
+    // ProviderRouter.buildInner injects the router's live cwd into each new
+    // innerConfig — so `_currentCwd` left over from a PREVIOUS query can be older
+    // than THIS query's `config.cwd`. Re-seed from the incoming config so the
+    // awareness source never reports a checkout the rebuilt prompt and tools have
+    // already left. Later `setCwd()` calls still win: they overwrite `_currentCwd`
+    // after this point, and this only runs at query() entry.
+    if (config.cwd) this._currentCwd = config.cwd;
     // If the caller pre-supplied roots (e.g. forked subagent), prefer them on
     // the very first init only — ensureSharedRoots will have created defaults
     // we now overwrite with the explicit values.
@@ -463,10 +471,10 @@ export class AnthropicDirectProvider implements ModelProvider {
         externalTools: this.externalTools,
         sharedReadRoots: this._sharedReadRoots,
         sharedWriteRoots: this._sharedWriteRoots,
-        // Live cwd: `_currentCwd` wins because `cwdDependentsFactory` updates
-        // it on every setCwd (born-named `afk -w` worktree, `/cd`) before it
-        // re-reads the workspace, while `config.cwd` is the construction-time
-        // value. Same `||` fall-through as the `cwd` const below, so the
+        // Live cwd: `_currentCwd` is re-seeded from this query's config above,
+        // then `cwdDependentsFactory` updates it on every live-session re-anchor
+        // (the deferred born-named `afk -w` worktree path) before the workspace
+        // is re-read. Same `||` fall-through as the `cwd` const below, so the
         // `- Working directory:` and `- Workspace:` lines can never disagree.
         getCwd: () => this._currentCwd || config.cwd || process.cwd(),
         getMcpTools: () => this.mcpManager?.getMcpTools() ?? [],

--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -463,6 +463,12 @@ export class AnthropicDirectProvider implements ModelProvider {
         externalTools: this.externalTools,
         sharedReadRoots: this._sharedReadRoots,
         sharedWriteRoots: this._sharedWriteRoots,
+        // Live cwd: `_currentCwd` wins because `cwdDependentsFactory` updates
+        // it on every setCwd (born-named `afk -w` worktree, `/cd`) before it
+        // re-reads the workspace, while `config.cwd` is the construction-time
+        // value. Same `||` fall-through as the `cwd` const below, so the
+        // `- Working directory:` and `- Workspace:` lines can never disagree.
+        getCwd: () => this._currentCwd || config.cwd || process.cwd(),
         getMcpTools: () => this.mcpManager?.getMcpTools() ?? [],
         getSubagents: () =>
           this.subagentExecutor

--- a/src/agent/providers/anthropic-direct/query-wiring.characterization.test.ts
+++ b/src/agent/providers/anthropic-direct/query-wiring.characterization.test.ts
@@ -39,8 +39,19 @@ import type Anthropic from '@anthropic-ai/sdk';
 import type { RawMessageStreamEvent } from '@anthropic-ai/sdk/resources';
 import type { ProviderEvent } from '../../provider.js';
 import type { RuntimeSnapshot } from '../../awareness/index.js';
+import { gatherWorkspace } from '../../awareness/workspace-source.js';
 import { AnthropicDirectProvider, __setAnthropicClientFactory } from './index.js';
 import { tool } from '../../tools/custom-tool.js';
+
+vi.mock('../../awareness/workspace-source.js', () => ({
+  gatherWorkspace: vi.fn(() => ({
+    branch: null,
+    headSha: null,
+    dirty: null,
+    dirtyCount: null,
+    remoteUrl: null,
+  })),
+}));
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -546,5 +557,24 @@ describe('query() characterization (#824) — shared roots and grants', () => {
       provider.query({ prompt: singleInput('hi'), config: { ...BASE_CONFIG, cwd: '/work' } }),
     );
     expect(provider.getGrants().resolveBase).toBe('/work');
+  });
+
+  it('re-seeds awareness cwd from each query config on a cached provider', async () => {
+    const provider = new AnthropicDirectProvider();
+
+    scriptRuntimeStateCall('all');
+    const firstEvents = await collect(
+      provider.query({ prompt: singleInput('orient'), config: { ...BASE_CONFIG, cwd: '/checkout-a' } }),
+    );
+    expect(snapshotFrom(firstEvents).self?.cwd).toBe('/checkout-a');
+
+    scriptRuntimeStateCall('all');
+    const secondEvents = await collect(
+      provider.query({ prompt: singleInput('orient again'), config: { ...BASE_CONFIG, cwd: '/checkout-b' } }),
+    );
+    const second = snapshotFrom(secondEvents);
+
+    expect(second.self?.cwd).toBe('/checkout-b');
+    expect(vi.mocked(gatherWorkspace)).toHaveBeenLastCalledWith('/checkout-b');
   });
 });

--- a/src/agent/providers/anthropic-direct/query/cwd-dependents.ts
+++ b/src/agent/providers/anthropic-direct/query/cwd-dependents.ts
@@ -86,9 +86,17 @@ export function createCwdDependentsFactory(args: CwdDependentsFactoryArgs): CwdD
 
     // 2. Rebuild the system prompt with the new `# Environment` line via the
     //    SAME assembler the first-turn path uses (query/system-prompt.ts), so
-    //    the two can never drift. Awareness identity fields
-    //    (sessionId/surface/depth/maxDepth/workspace) are stable across cwd
-    //    swaps, so we reuse the config snapshot; only `newCwd` changes.
+    //    the two can never drift. Identity fields (sessionId/surface/depth/
+    //    maxDepth) are stable across cwd swaps, so we reuse the config
+    //    snapshot.
+    //
+    //    Invariant: `workspace` is NOT stable across a cwd swap — a different
+    //    worktree is a different branch and HEAD — so it MUST be re-read from
+    //    the live source, and `args.setCurrentCwd(newCwd)` above MUST have
+    //    already run. `getWorkspace()` resolves the cwd through the provider's
+    //    live `getCwd` accessor, so re-reading before that assignment would
+    //    re-gather git state for the OLD checkout and pin the `- Workspace:`
+    //    line to the launch directory for the rest of the session.
     const newUserSystem = assembleSystemPrompt(args.stableSystemPrefix, newCwd, {
       surface: args.surface,
       sessionId: args.config.sessionId,

--- a/src/agent/providers/anthropic-direct/query/cwd-dependents.ts
+++ b/src/agent/providers/anthropic-direct/query/cwd-dependents.ts
@@ -116,8 +116,8 @@ export function createCwdDependentsFactory(args: CwdDependentsFactoryArgs): CwdD
     //    accepted minor staleness window for Phase 1 (worktree rename
     //    rarely coincides with mid-session MCP tool refresh).
     // Use the LIVE permission mode (not the captured construction-time
-    // `permissionMode`) so a `/cd` after a `/bypass` toggle rebuilds the
-    // dispatcher with the current allowAll, never reverting the toggle.
+    // `permissionMode`) so a cwd re-anchor after a `/bypass` toggle rebuilds
+    // the dispatcher with the current allowAll, never reverting the toggle.
     const newDispatcher = args.buildDispatcher(args.getCurrentPermissionMode(), {
       cwd: newCwd,
       readRoots: args.sharedReadRoots,
@@ -129,7 +129,7 @@ export function createCwdDependentsFactory(args: CwdDependentsFactoryArgs): CwdD
       runtimeStateSource: args.runtimeStateSource,
       hookRegistry: args.config.hookRegistry,
       // Carry the resident plan-exit handler across a cwd rebuild — omitting
-      // this previously dropped `exit_plan_mode` after a `/cd` while planning.
+      // this previously dropped `exit_plan_mode` after a cwd re-anchor while planning.
       planExitControls: args.config.planExitControls,
     });
     return { userSystem: newUserSystem, dispatcher: newDispatcher };

--- a/src/agent/providers/anthropic-direct/query/cwd-dependents.workspace.test.ts
+++ b/src/agent/providers/anthropic-direct/query/cwd-dependents.workspace.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Composed-path regression test for worktree cwd staleness.
+ *
+ * The unit test in `awareness/runtime-source.test.ts` proves the awareness
+ * source re-reads its cwd accessor. This file proves the property that
+ * actually reached the model: after a `setCwd()` re-anchor, the REBUILT system
+ * prompt's `- Workspace:` line reports the NEW checkout's branch, not the
+ * launch directory's.
+ *
+ * Symptom this guards against: a session started in the main checkout and
+ * re-anchored into a worktree (`afk -w`, `/cd`) emitted an `# Environment`
+ * block whose `- Working directory:` line pointed at the worktree while its
+ * `- Workspace:` line still named the main checkout's branch and HEAD — so the
+ * model was told it was on a branch it was not on.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createCwdDependentsFactory } from './cwd-dependents.js';
+import { buildStableSystemPrefix } from './system-prompt.js';
+import { buildRuntimeStateSource } from '../../../awareness/index.js';
+import { gatherWorkspace } from '../../../awareness/workspace-source.js';
+import type { AgentConfig } from '../../../types/config-types.js';
+import type { ToolDispatcher } from '../tool-dispatcher.js';
+import type { AnthropicToolDef } from '../../../tools/types.js';
+
+// Mock git so the test asserts cwd->branch routing rather than a real repo.
+vi.mock('../../../awareness/workspace-source.js', () => ({
+  gatherWorkspace: vi.fn(),
+}));
+
+const LAUNCH_CWD = '/repo';
+const WORKTREE_CWD = '/repo/.afk-worktrees/feature';
+
+/** Branch is derived from cwd so a stale cwd is visible in the output. */
+function workspaceFor(cwd: string) {
+  return cwd === WORKTREE_CWD
+    ? {
+        branch: 'afk/feature',
+        headSha: 'fea7017',
+        dirty: false,
+        dirtyCount: 0,
+        remoteUrl: null,
+      }
+    : {
+        branch: 'main',
+        headSha: 'ma1n000',
+        dirty: false,
+        dirtyCount: 0,
+        remoteUrl: null,
+      };
+}
+
+function setup() {
+  // The provider's live cwd, mutated by setCurrentCwd exactly as
+  // AnthropicDirectProvider._currentCwd is.
+  let currentCwd: string | undefined = LAUNCH_CWD;
+
+  const runtimeStateSource = buildRuntimeStateSource({
+    surface: 'cli',
+    getCwd: () => currentCwd ?? LAUNCH_CWD,
+    modelName: 'sonnet',
+    providerName: 'anthropic-direct',
+    permissionMode: 'default',
+    getEnabledToolNames: () => [],
+    getMcpTools: () => [] as AnthropicToolDef[],
+    getSubagents: () => ({ active: [], backgroundJobs: [] }),
+  });
+
+  const factory = createCwdDependentsFactory({
+    stableSystemPrefix: buildStableSystemPrefix({
+      toolBase: 'TOOLBASE',
+      memoryPrompt: 'MEMORY',
+      hotMemory: '',
+      manifest: '',
+      userSystem: null,
+    }),
+    config: { cwd: LAUNCH_CWD } as AgentConfig,
+    surface: 'cli',
+    runtimeStateSource,
+    getCurrentCwd: () => currentCwd,
+    setCurrentCwd: (cwd: string) => {
+      currentCwd = cwd;
+    },
+    getCurrentPermissionMode: () => 'default',
+    sharedReadRoots: [LAUNCH_CWD],
+    sharedWriteRoots: [LAUNCH_CWD],
+    subagentExecutor: undefined,
+    skillExecutor: undefined,
+    composeExecutor: undefined,
+    buildDispatcher: () => ({}) as ToolDispatcher,
+  });
+
+  return { factory, runtimeStateSource };
+}
+
+describe('cwdDependentsFactory — workspace follows the re-anchored cwd', () => {
+  beforeEach(() => {
+    vi.mocked(gatherWorkspace).mockReset();
+    vi.mocked(gatherWorkspace).mockImplementation((cwd: string) => workspaceFor(cwd));
+  });
+
+  it('rebuilds the Workspace line for the new worktree, not the launch dir', () => {
+    const { factory } = setup();
+
+    const { userSystem } = factory(WORKTREE_CWD);
+
+    expect(userSystem).toContain(`- Working directory: ${WORKTREE_CWD}`);
+    // The captured-cwd implementation emitted `main @ ma1n000` here while the
+    // working-directory line already pointed at the worktree.
+    expect(userSystem).toContain('- Workspace: afk/feature @ fea7017 (clean)');
+    expect(userSystem).not.toContain('main @ ma1n000');
+  });
+
+  it('gathers git state against the new cwd', () => {
+    const { factory } = setup();
+
+    factory(WORKTREE_CWD);
+
+    expect(vi.mocked(gatherWorkspace)).toHaveBeenLastCalledWith(WORKTREE_CWD);
+  });
+
+  it('leaves get_runtime_state agreeing with the rebuilt prompt', () => {
+    // Invariant: the `self` view's cwd and the `workspace` view's branch must
+    // resolve through the same accessor — their disagreement is what made the
+    // original bug invisible from inside a session.
+    const { factory, runtimeStateSource } = setup();
+
+    factory(WORKTREE_CWD);
+
+    expect(runtimeStateSource.getSelf().cwd).toBe(WORKTREE_CWD);
+    expect(runtimeStateSource.getWorkspace().branch).toBe('afk/feature');
+  });
+});

--- a/src/agent/providers/anthropic-direct/query/cwd-dependents.workspace.test.ts
+++ b/src/agent/providers/anthropic-direct/query/cwd-dependents.workspace.test.ts
@@ -8,7 +8,7 @@
  * launch directory's.
  *
  * Symptom this guards against: a session started in the main checkout and
- * re-anchored into a worktree (`afk -w`, `/cd`) emitted an `# Environment`
+ * re-anchored into a worktree by the deferred born-named `afk -w` path emitted an `# Environment`
  * block whose `- Working directory:` line pointed at the worktree while its
  * `- Workspace:` line still named the main checkout's branch and HEAD — so the
  * model was told it was on a branch it was not on.
@@ -66,6 +66,10 @@ function setup() {
     getSubagents: () => ({ active: [], backgroundJobs: [] }),
   });
 
+  const setCurrentCwd = vi.fn((cwd: string) => {
+    currentCwd = cwd;
+  });
+
   const factory = createCwdDependentsFactory({
     stableSystemPrefix: buildStableSystemPrefix({
       toolBase: 'TOOLBASE',
@@ -78,9 +82,7 @@ function setup() {
     surface: 'cli',
     runtimeStateSource,
     getCurrentCwd: () => currentCwd,
-    setCurrentCwd: (cwd: string) => {
-      currentCwd = cwd;
-    },
+    setCurrentCwd,
     getCurrentPermissionMode: () => 'default',
     sharedReadRoots: [LAUNCH_CWD],
     sharedWriteRoots: [LAUNCH_CWD],
@@ -90,7 +92,7 @@ function setup() {
     buildDispatcher: () => ({}) as ToolDispatcher,
   });
 
-  return { factory, runtimeStateSource };
+  return { factory, runtimeStateSource, setCurrentCwd };
 }
 
 describe('cwdDependentsFactory — workspace follows the re-anchored cwd', () => {
@@ -117,6 +119,16 @@ describe('cwdDependentsFactory — workspace follows the re-anchored cwd', () =>
     factory(WORKTREE_CWD);
 
     expect(vi.mocked(gatherWorkspace)).toHaveBeenLastCalledWith(WORKTREE_CWD);
+  });
+
+  it('updates the live cwd before gathering workspace for the rebuilt prompt', () => {
+    const { factory, setCurrentCwd } = setup();
+
+    factory(WORKTREE_CWD);
+
+    expect(setCurrentCwd.mock.invocationCallOrder[0]!).toBeLessThan(
+      vi.mocked(gatherWorkspace).mock.invocationCallOrder[0]!,
+    );
   });
 
   it('leaves get_runtime_state agreeing with the rebuilt prompt', () => {

--- a/src/agent/providers/anthropic-direct/query/dispatcher-wiring.ts
+++ b/src/agent/providers/anthropic-direct/query/dispatcher-wiring.ts
@@ -65,6 +65,12 @@ export interface DispatcherWiringArgs {
   externalTools: ToolDispatcher | undefined;
   sharedReadRoots: string[] | undefined;
   sharedWriteRoots: string[] | undefined;
+  /**
+   * Live cwd accessor for the awareness source. Must reflect mid-session
+   * `setCwd()` re-anchors, not the construction-time `config.cwd` — see
+   * {@link RuntimeSourceDeps.getCwd}.
+   */
+  getCwd: () => string;
   /** Live MCP tool accessor for the awareness source. */
   getMcpTools: () => readonly AnthropicToolDef[];
   /** Live subagent accessor for the awareness source. */
@@ -107,7 +113,7 @@ export function wireQueryDispatcher(args: DispatcherWiringArgs): DispatcherWirin
   // STEP 2 — build the source, capturing the binding above.
   const runtimeStateSource: RuntimeStateSource = buildRuntimeStateSource({
     surface,
-    cwd: config.cwd ?? process.cwd(),
+    getCwd: args.getCwd,
     modelName: args.model,
     providerName: args.providerName,
     permissionMode: args.permissionMode,

--- a/src/agent/providers/anthropic-direct/query/dispatcher-wiring.ts
+++ b/src/agent/providers/anthropic-direct/query/dispatcher-wiring.ts
@@ -47,6 +47,7 @@ import {
   buildRuntimeStateSource,
   getRuntimeStateTool,
   wrapDispatcherWithRuntimeState,
+  type RuntimeSourceDeps,
   type RuntimeStateSource,
 } from '../../../awareness/index.js';
 import { builtinToolSchemas } from '../../../tools/schemas.js';

--- a/src/agent/providers/anthropic-direct/query/prompt-assembly.ts
+++ b/src/agent/providers/anthropic-direct/query/prompt-assembly.ts
@@ -83,7 +83,11 @@ export function assembleQueryPrompt(args: PromptAssemblyArgs): AssembledPrompt {
   const memoryPrompt = resolveMemorySystemPrompt(args.readOnlyMemory);
 
   // Awareness identity fields interleaved into the `# Environment` fragment
-  // (Phase 1 + 2). Stable across cwd swaps — only `cwd` changes on setCwd().
+  // (Phase 1 + 2). The identity fields (surface/sessionId/depth/maxDepth) are
+  // stable across cwd swaps; `workspace` is NOT — a different worktree is a
+  // different branch and HEAD. It is re-read from the live source here and
+  // again in `cwd-dependents.ts` on every setCwd, so it tracks the cwd rather
+  // than freezing at the launch checkout.
   const environmentIdentity = {
     surface: args.surface,
     sessionId: config.sessionId,

--- a/src/agent/providers/openai-compatible/index.ts
+++ b/src/agent/providers/openai-compatible/index.ts
@@ -216,10 +216,10 @@ export class OpenAICompatibleProvider implements ModelProvider {
 
     const runtimeStateSource: RuntimeStateSource = buildRuntimeStateSource({
       surface: this.providerOpts.surface ?? 'cli',
-      // Behaviour-preserving: this provider builds the source per query and
-      // its `setCwd` only re-bases the dispatcher (query.ts) without rebuilding
-      // the system prompt, so `config.cwd` IS the live value for the duration
-      // of a query. Kept as a callback to satisfy the live-accessor contract.
+      // Behaviour-preserving: this provider builds the source per query, so
+      // `config.cwd` is frozen at query construction. Its `setCwd` only re-bases
+      // the dispatcher (query.ts) without rebuilding this source or the system
+      // prompt, so mid-query `get_runtime_state` cwd is stale until #876.
       getCwd: () => config.cwd ?? process.cwd(),
       modelName,
       providerName: PROVIDER_NAME,

--- a/src/agent/providers/openai-compatible/index.ts
+++ b/src/agent/providers/openai-compatible/index.ts
@@ -216,7 +216,11 @@ export class OpenAICompatibleProvider implements ModelProvider {
 
     const runtimeStateSource: RuntimeStateSource = buildRuntimeStateSource({
       surface: this.providerOpts.surface ?? 'cli',
-      cwd: config.cwd ?? process.cwd(),
+      // Behaviour-preserving: this provider builds the source per query and
+      // its `setCwd` only re-bases the dispatcher (query.ts) without rebuilding
+      // the system prompt, so `config.cwd` IS the live value for the duration
+      // of a query. Kept as a callback to satisfy the live-accessor contract.
+      getCwd: () => config.cwd ?? process.cwd(),
       modelName,
       providerName: PROVIDER_NAME,
       permissionMode,

--- a/src/agent/providers/openai-compatible/query.test.ts
+++ b/src/agent/providers/openai-compatible/query.test.ts
@@ -1806,6 +1806,30 @@ describe('OpenAICompatibleQuery — ProviderQuery surface', () => {
     q.close();
   });
 
+  it('get_runtime_state cwd is frozen to the query config cwd (#876 characterization)', async () => {
+    const provider = new OpenAICompatibleProvider();
+    const q = provider.query({
+      prompt: makeControlledPromptStream().stream,
+      config: baseConfig({ cwd: '/query-cwd' }),
+    });
+
+    q.setCwd('/mid-query-cwd');
+    const dispatcher = (q as unknown as { toolDispatcher: SessionToolDispatcher }).toolDispatcher;
+    const result = await dispatcher.execute({
+      id: 'toolu_state',
+      name: 'get_runtime_state',
+      input: { view: 'self' },
+      signal: new AbortController().signal,
+    });
+
+    const snapshot = JSON.parse(result.content) as { self: { cwd: string } };
+    expect(snapshot.self.cwd).toBe('/query-cwd');
+    // #876 gap: unlike the dispatcher resolve base, awareness cwd does not follow
+    // a mid-query setCwd() on openai-compatible until that provider is fixed.
+    expect(snapshot.self.cwd).not.toBe('/mid-query-cwd');
+    q.close();
+  });
+
   it('setPermissionMode flips dispatcher allowAll: autonomous (AFK) + bypass ON, default/plan OFF', async () => {
     const hookRegistry = createHookRegistry();
     const dispatcher = new SessionToolDispatcher({


### PR DESCRIPTION
## What

A session re-anchored into a git worktree kept reporting the **launch** checkout's branch and HEAD for the rest of its life. The auto-injected `# Environment` block became self-contradictory:

```
- Working directory: /repo/.afk-worktrees/feature   <- correct
- Workspace: main @ ma1n000 (clean)                 <- the OTHER checkout
```

`get_runtime_state` split the same way — view `self` returned the launch cwd while the bash/file tools operated in the worktree.

This is not theoretical. It was found live, in a session running from a worktree:

| source | value |
|---|---|
| `- Working directory:` (prompt) | `.afk-worktrees/afk-remove-ground-state-endpoint` |
| bare `pwd` (bash tool) | `.afk-worktrees/afk-remove-ground-state-endpoint` |
| `- Workspace:` (prompt) | `afk/subagent-stream-cut-retry @ d35e0ee3` |
| `get_runtime_state` `self.cwd` | `/Users/.../agent-afk` (main checkout) |

The model was being told it was on a branch it was not on, by the very block meant to ground it.

**Trigger path — exactly one, and it is not `/cd`.** An earlier revision of this description claimed `/cd` as a second trigger; that is wrong. No REPL slash command calls `setCwd` (nothing under `src/cli/slash` does), and Telegram's `/cd` deliberately closes and rebuilds the session (`telegram/handlers/commands.ts:253,294`), so it never produces the stale state. `resume-swap` likewise constructs a fresh session. The only live-session re-anchor in the tree is the **deferred (born-named) `afk -w`** path:

1. `afk -w` with no explicit branch defers worktree creation (`interactive.ts:383`), so `worktreeCwd` stays `undefined` and bootstrap runs in the launch checkout.
2. The provider query — and with it the awareness source — is built at session *construction*: `initSdkLifecycle()` (`agent-session.ts:237`) → `ProviderRouter` (`:313`) → the first `pullInitialization` pull → `buildInner` → `provider.query()` → `buildRuntimeStateSource({ cwd: config.cwd ?? process.cwd() })` (`dispatcher-wiring.ts:110`). `config.cwd` is `undefined` here, so the snapshot is the **launch checkout**.
3. On the first message, `runFirstTurnAutoname` derives the slug from that message, creates the worktree, and calls `session.setCwd` (`worktree-autoname.ts:475`) — correctly awaited before `runTurn` (`loop-iteration.ts:443` vs `:606`). The rebuild re-threads the new cwd into the prompt, so `- Working directory:` is right, but hands the *same frozen* `runtimeStateSource` through.

Eager `-w <branch>` and `afk chat -w` await `setupWorktree` before the session is constructed, so the worktree is already in `config.cwd` and those paths were never affected.

## Root cause

`RuntimeSourceDeps.cwd` was a captured **string**, resolved once at source construction from `config.cwd ?? process.cwd()` (`dispatcher-wiring.ts:110`).

Every other live field on that interface is a `getX: () => T` accessor — `getEnabledToolNames`, `getMcpTools`, `getSubagents`. `cwd` was the lone snapshot. `dispatcher.setCwd` re-anchors the subagent, skill and compose executors (`dispatcher.ts:530-532`) but never the awareness source, so `gatherWorkspace()` kept being handed the outgoing directory.

Worth being precise: `cwd-dependents.ts` **already** re-read `getWorkspace()` on every rebuild. The call was live; its *input* was stale. That is why the bug survived a code path that looks correct on inspection.

Two comments had encoded the false premise and are corrected here — `prompt-assembly.ts:86` described the workspace as "stable across cwd swaps", and `cwd-dependents.ts` repeated it. A different worktree is a different branch and HEAD, so `workspace` is precisely the cwd-*dependent* field.

**Why this cannot be fixed by reordering instead.** The obvious alternative — snapshot the cwd later, after the worktree exists — is impossible on this path. The worktree's name is *derived from the first message*, and the query must already exist before that message can be streamed into it (`QueryInputStream` / prompt iterable, `router/provider-router.ts:261-272`). At construction time the worktree path is unknowable in principle, so the fix has to be late-binding. A live accessor is; an earlier snapshot cannot be.

This also matches the ownership model the router already implements: `ProviderRouter.setCwd` stores `this.currentCwd` (`router/provider-router.ts:459`) and re-injects it into every rebuilt inner (`innerConfig.cwd = this.currentCwd`, `:270`) — so a mid-session `/model` swap does *not* lose the re-anchor. cwd was already treated as live session state everywhere except this one field.

## Fix

`cwd: string` becomes `getCwd: () => string`, adopting the live-accessor convention already established in the same interface rather than introducing a new mechanism.

- **anthropic-direct** supplies `this._currentCwd || config.cwd || process.cwd()`. `_currentCwd` wins because `cwdDependentsFactory` updates it before re-reading the workspace; the `||` fall-through matches the sibling `cwd` const so the two Environment lines cannot disagree. `_currentCwd` is also re-seeded from each incoming `config.cwd` at `query()` entry — without that, a provider instance reused across a `/model` swap would let a *stale* `_currentCwd` outrank the newer per-query cwd the router injected (see the follow-up section below).
- **openai-compatible** is untouched in effect — its `setCwd` only re-bases the dispatcher (`openai-compatible/query.ts:1129-1131`) and its `# Environment` fragment is built once inside `query()` (`index.ts:327-335`), so that provider never re-emits the block at all. Kept as a callback to satisfy the contract.

  Stating the consequence plainly: on that provider this change is behaviour-neutral, and it neither creates nor closes a divergence. `getCwd()` and the `# Environment` fragment's `cwd` evaluate the *same* expression (`config.cwd ?? process.cwd()`) over a query-local `config` that is never reassigned, so after a re-anchor `- Working directory:`, `self.cwd`, and `- Workspace:` all stay pinned to the query's launch cwd and therefore agree with each other. The gap is that all three are frozen — not that they disagree. A `ProviderRouter` rebuild is the only thing that refreshes them, and it is gated on `modelChanged` (`router/provider-router.ts:336-339`), so an ordinary cwd-only `setCwd` never triggers one. Tracked in #876; deliberately not fixed here.

  (An earlier revision of this section claimed the change "makes `self.cwd` / `- Workspace:` live while the env block stays frozen — the divergence flips direction rather than closing." That was wrong, and is corrected above.)

An ordering invariant is now documented at the call site: `setCurrentCwd(newCwd)` must run before `getWorkspace()` in the rebuild, or git state is gathered for the outgoing checkout.

Four functional lines. The rest is tests and correcting the comments that made the bug invisible.

## Verification

- **5 tests added** — 2 unit (`runtime-source.test.ts`), 3 composed-path (`cwd-dependents.workspace.test.ts`, new file, asserts the rebuilt prompt string itself).
- **Mutation-checked.** With the accessor reverted to a captured string, all 5 fail with the exact stale value; with the fix, all 5 pass. They are not vacuous.
- Full suite: **766 files / 14,595 tests** green.
- `pnpm lint`, `audit:sdk:check`, `audit:env:check`, `scan:env:check` all pass.

## Scope

Deliberately narrow. This landed out of a wider audit of `/ground-state`, whose stated purpose is preventing exactly this class of stale-worktree error. The following follow-ons were considered and **excluded** from this PR because they are contested, higher-blast-radius, or not yet root-caused:

1. **A ~36x latency regression in skill forks** (median `/ground-state` duration went 0.28 min in 2026-05 to 10.78 min in 2026-07 across 294 traced dispatches). Cause not isolated, and evidence suggests it is *systemic fork latency* rather than skill-specific — an unrelated `general-purpose` subagent timed out at 45 min during this very investigation. Deserves its own diagnosis.
2. **Sub-agent forks receive neither the AFK.md overlay nor HOT.md**, so the actors doing most investigation work are the least grounded. Real, but a fork-briefing redesign.
3. **`ground-state`'s memory surveyor greps `~/.claude/projects/-<slug>/memory/`** — Claude Code's store, empty under AFK, whose real store is `~/.afk/state/memory/`. Correct for the Claude Code build of the same skill, so it needs a both-paths fix, not a swap.

Two same-bug-class siblings were found while auditing this fix's placement and are filed rather than folded in — both are captured-cwd defects on surfaces this PR does not touch:

4. **#876 — openai-compatible never rebuilds its `# Environment` block on `setCwd`**, so `- Working directory:` is stale there. See the Fix note above: this PR is behaviour-neutral on that provider — all three cwd-derived fields stay frozen together rather than disagreeing — and #876 is the close. A characterization test added in the follow-up commit pins that behaviour so #876 has a red/green signal.
5. **#877 — `GitStatusSampler` freezes its cwd at construction** (`git-status-sampler.ts:117` ← `bootstrap.ts:627`) with no re-point, so the status line's branch and open-PR fields are sampled from the launch checkout for the whole session after a deferred `-w` re-anchor.

None of those are prerequisites for this one, and this one makes the free grounding path trustworthy regardless of what is decided about the skill.

---

## Follow-up commit `73262f4` — review feedback

Addresses the Codex review comment and the automated review on this PR. One functional line; the rest is tests and comment corrections.

**1. Codex P2 (`index.ts` — reset the live cwd when reusing a cached provider).** Real defect, and it reintroduced this PR's own bug on a path the original fix missed. `_currentCwd` is an instance field that outlives a `query()`, but provider instances are cached across `/model` swaps and `ensureSharedRoots()` seeds it only once, while `ProviderRouter.setCwd` forwards a new cwd only to the *active* query. Sequence: Claude@A → swap to GPT → re-anchor to B → swap back to Claude reuses the cached provider with `config.cwd === B` but `_currentCwd === A`, so the stale value wins the `||` and `- Workspace:` / `get_runtime_state` report A while the prompt and tools use B. Fixed by re-seeding `_currentCwd` from the incoming config at `query()` entry (guarded on truthiness so an absent `config.cwd` cannot clobber it); later `setCwd()` calls still win. Regression test added — verified to fail without the fix (`expected '/checkout-a' to be '/checkout-b'`).

**2. Removed a false premise from 8 comment lines.** This PR's own description establishes that `/cd` is *not* a live-session re-anchor trigger — no REPL slash command calls `setCwd`, and Telegram's `/cd` closes and rebuilds the session (`telegram/session-manager.ts:564-571`) — yet six comment lines added here named `/cd` as exactly that, including inside an `Invariant:` block. Struck from all six, plus two pre-existing instances in `cwd-dependents.ts`. The only live-session re-anchor named in comments is now the deferred born-named `afk -w` path.

**3. The `getCwd` invariant no longer overstates.** It read `Invariant: this MUST be a callback, never a snapshot`, which is false for openai-compatible (a per-query snapshot by design, pending #876). Reworded to state the requirement and name the exception. The openai-compatible comment's "`config.cwd` IS the live value for the duration of a query" — which reads as a liveness guarantee but only describes staticness — now says plainly that it is frozen at query construction.

**4. The ordering invariant is now tested.** `setCurrentCwd(newCwd)` before `getWorkspace()` was comment-only, with no call-order assertion anywhere in the tree; the existing composed test observes only end state, so a reorder passed. Added an `invocationCallOrder` assertion — verified to fail when the statements are swapped (`expected 6 to be less than 5`).

**5. Characterization test for openai-compatible's `getCwd`** (previously untested), pinning the #876 behaviour.

**6. Fixed an unresolvable `{@link RuntimeSourceDeps.getCwd}`** in `dispatcher-wiring.ts` — the type was not imported.

**Verification:** `tsc --noEmit` clean; `audit:sdk:check` / `audit:env:check` / `scan:env:check` all pass; full suite 765/766 files green, 14,597 tests passing. The single failing file (`trace/writer.test.ts`, a test that spawns a real subprocess) fails identically at the pre-fix baseline in the same environment and passes 18/18 where dependencies are installed — a missing-deps artifact of the verification worktree, not a regression.


