### PR TITLE
fix(skills): ground-state memory surveyor calls memory_search, not a dead path (#862)

### DIFF
--- a/src/bundled-plugins/awa-bundled/bundled.test.ts
+++ b/src/bundled-plugins/awa-bundled/bundled.test.ts
@@ -80,7 +80,7 @@ const PINNED_HASHES = {
   // wave keeps dispatching). The upstream ground-state has neither layer, so
   // both lines are permanent bundled-only divergence.
   'ground-state':
-    'a9d6da1956a60dd4362eecb26321998b0e512db40d571671e9b4427bfb8e5d6e',
+    'b04da3abfa4f79d4599928f62896143b88fb9751f0d0d26ca0eb27134f9ba17a',
   // intent-lock is bundled-only (no upstream counterpart).
   // Hash bumps need no parallel PR — document the change in the
   // commit message instead.

--- a/src/bundled-plugins/awa-bundled/skills/ground-state/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/ground-state/SKILL.md
@@ -12,7 +12,7 @@ failure_modes:
 ## Sub-agent contract
 /contract
 
-**Constraint: read-only reconnaissance.** Surveyors and the synthesizer MUST NOT call `edit_file`, `write_file`, or any mutating bash command (no `git commit`, `git push`, `git checkout`, `mv`, `rm`, file redirection, package installs, etc.). Read-only tools only: `read_file`, `grep`, `glob`, `list_directory`, and read-only bash (`git status`, `git log`, `git diff`, `cat`, `ls`, `find`, etc.).
+**Constraint: read-only reconnaissance.** Surveyors and the synthesizer MUST NOT call `edit_file`, `write_file`, or any mutating bash command (no `git commit`, `git push`, `git checkout`, `mv`, `rm`, file redirection, package installs, etc.). Read-only tools only: `read_file`, `grep`, `glob`, `list_directory`, `memory_search`, and read-only bash (`git status`, `git log`, `git diff`, `cat`, `ls`, `find`, etc.). `memory_search` is non-mutating and is the **only** way to reach the cross-session fact archive — it is in scope for this skill, do not strip it from this list.
 
 If the survey reveals a fix that's tempting to apply, **return it as a recommendation in the snapshot** — the orchestrator decides whether to act. Even if the invoking brief sounds prescriptive ("draft the edit", "apply the change"), this skill stops at the snapshot and the preamble artifact. The orchestrator dispatches a separate implementation step afterward.
 
@@ -41,13 +41,17 @@ Before any multi-step implementation (not single-file fixes, not pure Q&A), disp
 When domain is unspecified, infer from the working directory contents.
 
 **Memory surveyor**
-Grep the user's auto-memory store (`~/.claude/projects/-<cwd-slug>/memory/`) + any project CLAUDE.md for keywords from the user's current request. Return relevant memory file pointers with 1-line summaries, or "no relevant memory found."
+Call the **`memory_search` tool** with keywords from the user's current request — FTS5 syntax, so `term1 AND term2`, `"exact phrase"`, and `prefix*` all work. Run 2–3 query variants (different keyword angles) before concluding nothing is there; a single miss is not evidence of absence. Then read hot memory at `~/.afk/state/memory/HOT.md` and the project overlay — `AFK.md`, or `CLAUDE.md` on a Claude Code surface — for conventions bearing on this task.
+
+**Invariant: do not grep a filesystem path for memory.** `~/.claude/projects/-<cwd-slug>/memory/` is vestigial — it is another product's state tree, its slug is not a literal cwd substitution (underscores hyphenate), and it holds zero files in every project on both the `~/.claude` and `~/.afk` trees. The archive is SQLite at `~/.afk/state/memory/memory.db` and is not greppable; `memory_search` is the only route in. Restoring a path-grep here silently zeroes this third of the recon wave.
+
+Return: relevant facts with 1-line summaries, **plus the stores actually consulted** — e.g. `memory_search: 3 queries, 0 hits; HOT.md: read; AFK.md: read` — so the orchestrator can tell "no relevant memory exists" from "the surveyor never looked." If `memory_search` is unavailable on this surface, say so explicitly instead of returning a bare "no relevant memory found."
 
 **Synthesize** into a 6-line ground-truth snapshot:
 - Branch: `<current>`, `<clean|diverged>`, upstream: `<fresh|stale>`
 - Recent work: last 3 commits or stash items
 - Infrastructure: CI present? package scripts? authoritative configs for this task
-- Memory hits: file refs or "none"
+- Memory hits: facts (1-line each) + which stores were consulted, or `none (consulted: …)`
 - Implementation risks: e.g. "branch is `main`, don't edit directly"; "CI runs on push"; "memory says prior attempt used approach X"
 - Epistemic confidence: `<high|medium|low>` — based on how much state could be verified. Flag if working directory is sparse, if domain is unfamiliar, or if key artifacts may be missing.
 


### PR DESCRIPTION
Closes #862.

## The bug

`/ground-state` dispatches three parallel recon sub-agents. The memory surveyor was told to grep `~/.claude/projects/-<cwd-slug>/memory/` — a path that is dead three ways over, exactly as the issue reports:

1. **Wrong product's state tree.** It points at Claude Code's directory; AFK keeps all state under `~/.afk/`.
2. **The slug is constructed wrong.** Underscores hyphenate during slugification, so a literal cwd substitution yields a nonexistent directory.
3. **The convention is vestigial.** Even where it resolves it is empty — zero files across every project, on *both* trees. So "repoint it at `~/.afk/`" is not the fix.

The archive is SQLite at `~/.afk/state/memory/memory.db` and is not greppable at any path. `memory_search` is the only route in — and it was missing from this skill's read-only allowlist (`SKILL.md:15`), so the surveyor was sent to a dead path *and* told the one tool for the job was out of scope, despite `CHILD_ALLOWED_TOOLS` (`src/agent/nesting.ts:90`) already permitting it for forked children.

## What changed

- Memory surveyor calls **`memory_search`** with 2-3 query variants before concluding absence, then reads `~/.afk/state/memory/HOT.md` and the project overlay (`AFK.md`, or `CLAUDE.md` on a Claude Code surface).
- `memory_search` added to the read-only tool allowlist, annotated as non-mutating so it does not get stripped back out by a future "hardening" pass.
- The surveyor must **report which stores it consulted**, and must declare the tool unavailable rather than silently emitting "no relevant memory found" — this is issue suggestion 4, and it is what makes the failure mode self-reporting next time.
- The snapshot's `Memory hits` line no longer asks for file refs, which `memory_search` does not return.
- An inline **invariant note** states why a path-grep cannot work here, so the next editor does not restore it.
- Pinned SHA-256 for `ground-state` recomputed in `bundled.test.ts` (`a9d6da19…` -> `b04da3ab…`) via `pnpm fix:pins`.

## Relationship to the canonical plugin

This repo's `src/bundled-plugins/awa-bundled/` is a **vendored copy**. Canon is the awa-private marketplace (`awa-dev` plugin), where the fix landed first as **griffinwork40/awa-private#79**. That PR also fixes two siblings the issue did not mention:

| Skill | Dead path | Fixed in |
|---|---|---|
| `ground-state` | `~/.claude/projects/-<cwd-slug>/memory/` | awa-private#79 **+ this PR** (bundled copy) |
| `orient` | `~/.claude/projects/-<cwd-slug>/memory/MEMORY.md` | awa-private#79 only — no bundled counterpart here |
| `thesis-lock` | `Grep ~/.claude/projects/ memory` | awa-private#79 only — no bundled counterpart here |

Before this change the bundled body was byte-identical to the canonical body; after it, it is byte-identical again. The only divergence remains the frontmatter (`read-only: true`, key order), unchanged by this PR.

## Verification

| Gate | Result |
|---|---|
| `pnpm test src/bundled-plugins/awa-bundled/bundled.test.ts` | 19 passed |
| `pnpm fix:pins:check` | All hash pins up to date |
| `pnpm test tests/copy-bundled-plugins.test.ts` | 4 passed |
| `pnpm lint` (`tsc --noEmit`) | clean |
| `grep -rn '\.claude/projects' src/ prompts/ docs/` | zero live references (only the new negated mentions) |
| Canonical-body diff | re-converged; frontmatter-only delta |

## Not claimed as fixed

Issue #862 notes that 2 of 4 `tool.overflow_kill` events on 2026-08-02 were attributed to `ground-state-memory` sub-agents, and explicitly hedges that link as inference from correlation rather than established fact. Carried through unmodified — a dead path plausibly invites a sub-agent to broaden its grep, but this PR does not claim to have fixed those kills.
