### PR TITLE
fix(subagent): resolve tier-name pins before the cross-provider Claude-family check

### DIFF
--- a/src/agent/subagent/child-model-fallback.test.ts
+++ b/src/agent/subagent/child-model-fallback.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { coerceCrossProviderChildModel } from './child-model-fallback.js';
+import {
+  CLAUDE_SONNET_ID,
+  DEFAULT_SLOT_BINDINGS,
+  resetSlotBindings,
+  setSlotBindings,
+} from '../session/model-slots.js';
 
 /**
  * `coerceCrossProviderChildModel` reads `AFK_PROVIDER` (and `AFK_OPENAI_BASE_URL`)
@@ -80,5 +86,63 @@ describe('coerceCrossProviderChildModel (#652)', () => {
 
   it('passes an undefined child through unchanged', () => {
     expect(coerceCrossProviderChildModel(undefined, 'gpt-5.5')).toEqual({ model: undefined });
+  });
+
+  /**
+   * #869: a bare capability-tier pin (`small`/`medium`/`large`/`local`, or a
+   * custom tier name — e.g. an agent definition's `model: medium`) must be
+   * resolved to its bound concrete id before the Claude-family check, not
+   * checked as a literal string. `resetSlotBindings()` in `afterEach` prevents
+   * the explicit `setSlotBindings` calls below from leaking into other tests.
+   */
+  describe('bare tier-name pins (#869)', () => {
+    afterEach(() => {
+      resetSlotBindings();
+    });
+
+    describe('no global force (normal Anthropic routing)', () => {
+      it.each(['small', 'medium', 'large'])(
+        'leaves tier %s untouched — its default binding routes anthropic-direct',
+        (tier) => {
+          expect(coerceCrossProviderChildModel(tier, 'gpt-5.5')).toEqual({ model: tier });
+        },
+      );
+    });
+
+    describe('AFK_PROVIDER=openai-compatible force', () => {
+      beforeEach(() => {
+        process.env['AFK_PROVIDER'] = 'openai-compatible';
+      });
+
+      it.each(['small', 'medium', 'large'])(
+        'coerces bare tier %s — default-bound to a Claude id, so it would otherwise hard-error',
+        (tier) => {
+          expect(coerceCrossProviderChildModel(tier, 'gpt-5.5')).toEqual({
+            model: 'gpt-5.5',
+            coercedFrom: tier,
+          });
+        },
+      );
+
+      it('does NOT coerce the bare "local" tier when unconfigured (empty id — nothing to protect)', () => {
+        expect(coerceCrossProviderChildModel('local', 'gpt-5.5')).toEqual({ model: 'local' });
+      });
+
+      it('does NOT coerce a tier explicitly rebound to a non-Claude id', () => {
+        setSlotBindings({ ...DEFAULT_SLOT_BINDINGS, small: { id: 'gpt-4o-mini' } });
+        expect(coerceCrossProviderChildModel('small', 'gpt-5.5')).toEqual({ model: 'small' });
+      });
+
+      it('coerces a custom tier NAME that resolves onto a Claude-bound slot', () => {
+        setSlotBindings({
+          ...DEFAULT_SLOT_BINDINGS,
+          medium: { id: CLAUDE_SONNET_ID, name: 'general' },
+        });
+        expect(coerceCrossProviderChildModel('general', 'gpt-5.5')).toEqual({
+          model: 'gpt-5.5',
+          coercedFrom: 'general',
+        });
+      });
+    });
   });
 });

--- a/src/agent/subagent/child-model-fallback.ts
+++ b/src/agent/subagent/child-model-fallback.ts
@@ -17,10 +17,15 @@
  * OpenAI/gpt target the session is already using — so the child runs instead of
  * dying. It is applied at `SubagentManager.forkSubagent`, the single choke point
  * through which every fork path converges.
+ *
+ * Issue #869: the Claude-family check must run on the TIER-RESOLVED id, not the
+ * raw pin — see {@link isClaudeFamilyAfterTierResolution}, the sole difference
+ * from the original #652 shape.
  */
 
 import { providerForModel } from '../providers/index.js';
 import { isClaudeFamilyModel } from '../providers/openai-compatible/responses-config.js';
+import { resolveModelInput } from '../session/model-slots.js';
 
 export interface ChildModelCoercion {
   /** The model the child should actually run — the substitute when coerced. */
@@ -34,11 +39,30 @@ export interface ChildModelCoercion {
 }
 
 /**
+ * True when `model`, once resolved past a bare capability-tier alias
+ * (`local`/`small`/`medium`/`large`, or a custom tier name — see
+ * `model-slots.ts`), is a Claude-family id.
+ *
+ * Issue #869: `isClaudeFamilyModel` pattern-matches the literal string and has
+ * no notion of tier indirection by design (it stays self-contained to avoid an
+ * import cycle through the provider registry). A child pinned to the bare tier
+ * name `medium` reads as "not Claude-family" even when that tier is BOUND to
+ * `claude-sonnet-5` — so the raw predicate misses exactly the case this module
+ * exists to catch. `resolveModelInput` is a no-op on an already-concrete id or
+ * a fixed identity alias (`sonnet`/`opus`/`haiku`/`claude-*`/`local-*`), so this
+ * changes nothing for those pre-#869 paths.
+ */
+function isClaudeFamilyAfterTierResolution(model: string | undefined): boolean {
+  return isClaudeFamilyModel(resolveModelInput(model));
+}
+
+/**
  * Decide the effective model for a forked child, substituting a Claude-family
  * model that would starve on this session's `openai-compatible` routing.
  *
  * Coerces iff ALL hold:
- *   1. `childModel` is a Claude-family id (`isClaudeFamilyModel`), AND
+ *   1. `childModel` is a Claude-family id once tier-resolved
+ *      (`isClaudeFamilyAfterTierResolution`), AND
  *   2. it currently ROUTES to `openai-compatible` — i.e. a global
  *      `AFK_PROVIDER` force (or a chatgpt-oauth/openai slot) has overridden the
  *      id's natural anthropic-direct routing, AND
@@ -66,14 +90,14 @@ export function coerceCrossProviderChildModel(
 ): ChildModelCoercion {
   if (
     childModel === undefined ||
-    !isClaudeFamilyModel(childModel) ||
+    !isClaudeFamilyAfterTierResolution(childModel) ||
     providerForModel(childModel) !== 'openai-compatible'
   ) {
     return { model: childModel };
   }
   if (
     parentModel === undefined ||
-    isClaudeFamilyModel(parentModel) ||
+    isClaudeFamilyAfterTierResolution(parentModel) ||
     providerForModel(parentModel) !== 'openai-compatible'
   ) {
     return { model: childModel };


### PR DESCRIPTION
## Summary

Fixes #869 — bare capability-tier model pins (`small` / `medium` / `large` / `local`, or a custom tier name) bypassed the cross-provider child-model fallback from #652.

`isClaudeFamilyModel` (`src/agent/providers/openai-compatible/responses-config.ts`) pattern-matches the literal model string and has no notion of tier indirection. `coerceCrossProviderChildModel` (`src/agent/subagent/child-model-fallback.ts`) called it directly on the caller-supplied model, so an agent definition pinned to `model: medium` read as "not Claude-family" even though the `medium` tier is bound to `claude-sonnet-5` by default. The #652 fallback was skipped, and the child still routed to the `openai-compatible` provider under an `AFK_PROVIDER=openai-compatible` force (or a `chatgpt-oauth`/`openai` model slot) and hard-errored there — the exact failure #652 exists to prevent, reached through tier indirection instead of a raw `sonnet`/`opus`/`haiku` pin.

The reported issue scopes this to an explicit tier pin on the **child**; the same predicate is also applied to the **parent** model inside the same function, so the fix resolves both sides symmetrically rather than leaving a mirrored gap.

## Fix

Resolve the model through `resolveModelInput` (`model-slots.ts`) before the Claude-family check, on both the `childModel` and `parentModel` branches — option 1 from the issue. `isClaudeFamilyModel` itself is untouched (it stays self-contained to avoid an import cycle through the provider registry, per its existing docstring) and is still exercised directly by `responses-config.test.ts`. `resolveModelInput` is a no-op on an already-concrete id or a fixed identity alias (`sonnet`/`opus`/`haiku`/`claude-*`/`local-*`), so every pre-existing case is unaffected.

Minimal diff: one new private helper (`isClaudeFamilyAfterTierResolution`) + swapping the two call sites in `coerceCrossProviderChildModel`. No change to `isClaudeFamilyModel`, `providerForModel`, or any downstream resolution path — those were already verified correct (`buildQueryFromConfig`/`setModel` in `openai-compatible/query.ts` already resolve tiers before the wire request, so this gap was isolated to this one pre-resolution check).

## Tests

Added a `bare tier-name pins (#869)` block to `child-model-fallback.test.ts` covering:
- default-Claude-bound `small`/`medium`/`large` tiers coercing under a provider force
- the unconfigured bare `local` tier correctly **not** coercing (empty id, nothing to protect)
- a tier explicitly rebound to a non-Claude id correctly **not** coercing
- a custom tier name that resolves onto a Claude-bound slot coercing correctly

## How was this tested?

```
pnpm lint                                                    # tsc --noEmit — pass
pnpm test src/agent/subagent/child-model-fallback.test.ts    # 20/20 pass (11 pre-existing + 9 new)
pnpm test                                                    # full suite: 770 files, 14670 passed, 2 skipped (pre-existing live/pty exclusions)
pnpm audit:sdk:check                                         # pass, no new SDK imports
pnpm audit:env:check                                         # pass, no new process.env reads
pnpm scan:env:check                                          # pass, env registry unaffected
```

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] No secrets, tokens, or private paths in the diff
