### PR TITLE
docs: correct stale provider claims in CLAUDE.md and sync with AFK.md

### DIFF
--- a/AFK.md
+++ b/AFK.md
@@ -14,25 +14,28 @@ pnpm test src/agent/session.test.ts                # single file (NO --; pnpm 10
 pnpm test src/agent/session.test.ts -t "sends a message"   # single test by name (scope to a file, then filter by -t)
 pnpm test:file src/agent/session.test.ts           # --proof alias for a scoped run (script: vitest run)
 pnpm test:watch                                    # vitest watch
+pnpm test:coverage                                 # CI gate: has coverage floors that `pnpm test` does not enforce
+pnpm test:pty                                      # PTY suite — separate config (vitest.pty.config.ts), own CI job
 pnpm lint                                          # tsc --noEmit (strict)
 
-pnpm audit:sdk                                     # regenerate docs/sdk-dependency.md
-pnpm audit:sdk:check                               # CI gate: fail on unlocked SDK symbols
+pnpm audit:sdk:check                               # CI gate: fail on unlocked SDK symbols (audit:sdk regenerates the doc)
 pnpm audit:sdk:update-lock                         # add new symbols → .sdk-dependency.lock.json (edit `reason` before commit)
-
 pnpm audit:env:check                               # CI gate: no raw process.env reads outside src/config/env.ts
 pnpm scan:env:check                                # CI gate: docs/env-registry.{json,md} in sync with src/config/env.ts
+pnpm audit:chalk:check                             # CI gate: no raw chalk.<color> outside src/cli/palette.ts (--list to find sites)
+pnpm fix:pins:check                                # CI gate: SHA-256 pins for vendored agents + bundled skills (pnpm fix:pins to rewrite)
+pnpm audit:deps                                    # CI gate: pnpm audit --audit-level=critical --prod
 pnpm release                                       # release pipeline (scripts/release.mjs; --dry via release:dry)
 ```
+
+Every gate above plus `pnpm lint` and `pnpm build` runs on each PR (`.github/workflows/ci.yml`) — run them locally before pushing, not after CI reddens.
 
 ### Running
 
 ```bash
-pnpm dev                  # tsx watch — live-reloads CLI
-afk chat "hello"          # one-shot
-afk interactive           # REPL (alias: afk i)
-afk daemon                # cron-based headless runner
-pnpm telegram:start       # Telegram bot
+pnpm dev                                     # tsx watch — live-reloads CLI
+afk chat "hi" / afk interactive / afk daemon # one-shot / REPL (alias: afk i) / cron headless runner
+pnpm telegram:start                          # Telegram bot
 ```
 
 ### Observability / tracing
@@ -40,21 +43,16 @@ pnpm telegram:start       # Telegram bot
 Every session writes a **witness trace** — the durable, chronological record of what the agent actually did (tool calls with timing + result bytes + ok/err, subagent lifecycle, session phases). This is the first thing to reach for when reconstructing "what happened" in a past run — not the transcript (prose only) and not the service logs (other processes).
 
 ```bash
-afk trace show              # pretty-print the latest session's trace (default: "latest")
-afk trace show <session>    # a specific session id
-afk trace show --all        # include low-signal events (latency phases, paired tool starts)
-afk trace show -n 40        # only the last N events
-afk trace show --json       # raw NDJSON, unchanged — pipe to jq
-afk trace list              # sessions that have a trace, most recent first (-n/--max <N>, default 20)
+afk trace show [<session>]  # pretty-print a trace (default "latest"). --all = include low-signal
+                            # events; -n 40 = last N; --json = raw NDJSON for jq
+afk trace list              # sessions having a trace, newest first (-n/--max <N>, default 20)
 ```
 
-Traces live at `~/.afk/state/witness/<session>/trace.jsonl` (`$AFK_HOME/state/witness/<sessionLabel>/trace.jsonl`). Writer + reader: `src/agent/trace/`; CLI: `src/cli/commands/trace.ts`. Known gaps (do not assume the trace answers these): tool **args** live in `~/.afk/state/sessions/<id>/events.jsonl`, not the witness trace — the trace carries only `inputBytes`; raw tool **output** is not recorded anywhere durable (only `resultBytes`).
+Traces live at `$AFK_HOME/state/witness/<sessionLabel>/trace.jsonl`. Writer + reader: `src/agent/trace/`; CLI: `src/cli/commands/trace.ts`. **Two things the trace does not answer**: tool *args* (those are in `~/.afk/state/sessions/<id>/events.jsonl`; the trace carries only `inputBytes`) and raw tool *output* (never recorded durably — only `resultBytes`).
 
 One slice of the args gap is now closable on demand: **subagent dispatch prompts**. Set `AFK_CAPTURE_SUBAGENT_PROMPTS=1` and every prompt a parent sends a child is written as a redacted markdown file (frontmatter + verbatim body) to `~/.afk/state/witness/<sessionLabel>/prompts/`. Because a fork resumes its parent's sessionId, one directory holds every prompt that session dispatched — across all six dispatch paths (agent fg/bg, worktree-isolated, compose/DAG, skill forks, in-process callers like mint phases), and across multi-turn children. **Off by default**, deliberately: nothing prunes the witness tree (12,596 dirs / 461 MB on this machine 2026-08-01) and redaction is regex-based, so connection strings, PEM blocks, and PII are *not* caught. Writer: `src/agent/session/subagent-prompt-capture.ts`; capture point is the child's own `sendMessageStreamInternal`, beside the ledger call that forks are gated out of. The trace itself still carries only `promptHead` (80 chars) on `subagent_lifecycle.started` — these files are not referenced by any trace event, so the directory is the index.
 
-Two gaps previously listed here are now closed — verified against 12,212 traces on disk 2026-07-27: a usage-limit **pause** does emit events (`usage_limit_pause` / `usage_limit_resume` session phases, #638); and a subagent `started` without a terminal is no longer the norm — sealing is owner-gated (#666, and `isSubagentFork` since), which took the rate of dispatched-children-with-no-recorded-fate from ~45% (through 2026-07-22) to ~3%.
-
-The residual ~3% is real and worth knowing about: a parent that ends while a wave is still in flight seals over its live children, so their terminal rows are silently dropped (`write()` throws on a sealed writer and `emitSubagentLifecycle` swallows it). It concentrates in daemon/cron sessions running parallel waves — stratified, interactive sessions sit near 1% while daemon labels sit near 8%. Symptom to recognise: `started` rows with no terminal in a trace that *does* contain `session_sealed`, where the children have attributed `tool_call` events right up to the seal. Detector: an unmatched `started` in a sealed trace — **not** "a `started` is the file's last line", which misses it because the seal is written afterward.
+One residual bug, worth recognizing: a parent ending mid-wave seals over live children and silently drops their terminal rows (`write()` throws on a sealed writer; `emitSubagentLifecycle` swallows it), so ~3% of dispatched subagents have no recorded fate — ~8% in daemon/cron parallel waves vs ~1% interactive. Detector: an **unmatched `started` in a trace that contains `session_sealed`** — not "a `started` is the last line", which misses it because the seal is written afterward.
 
 ## Architecture
 
@@ -71,9 +69,12 @@ Key layers under `src/`:
 | `src/skills/_agents/` | Vendored agent definitions. Drift detection: `vendored.test.ts`. |
 | `src/browser/` | Playwright-backed browser-control tools (open/observe/act/screenshot) + witness capture and domain-policy sanitization. |
 | `src/web/` | `web_scrape` pipeline: fetch → Readability → markdown extraction, with headless-render fallback and Exa search. |
-| `src/config/` | `env.ts` is the **sole** `process.env` read-point (typed lazy getters + `ENV_REGISTRY`); config mutation + settable-key gating. |
+| `src/config/` | `env.ts` is the **canonical** `process.env` read-point (typed lazy getters + `ENV_REGISTRY`); config mutation + settable-key gating. |
 | `src/service/` | macOS LaunchAgent install/manage for always-on telegram bot / daemon (`launchd.ts`). |
 | `src/improve/` | Self-improvement pipeline: telemetry scan → eval-gen → eval-run → propose. |
+| `src/insights/` | `afk insights` report: telemetry aggregators → recommendations → self-contained HTML → open-in-browser. Import via the `index.ts` barrel, not sub-paths. |
+| `src/utils/` | Cross-cutting leaf helpers (diff, errors + classifiers, terminal-sanitize, envFile, cleanupRegistry). No layer imports upward from here. |
+| `src/paths.ts` | Every AFK path helper. Two scopes: user (`$AFK_HOME/`) and project (`<cwd>/.afk/`). Never hand-join AFK paths — call these. |
 | `src/bundled-plugins/` | Plugins shipped with the package (copied at install; `tests/copy-bundled-plugins.test.ts`). |
 | `website/` | Next.js docs site (separate package, npm-locked; CI typechecks + builds it). |
 
@@ -90,34 +91,30 @@ Both providers emit a normalized `ProviderEvent` stream consumed by `src/agent/s
 
 ### User-scope state
 
-All AFK state under `~/.afk/` (never `~/.claude/`):
+All AFK state under `~/.afk/` (never `~/.claude/`), resolved exclusively through `src/paths.ts`:
 
 ```
-~/.afk/
+~/.afk/                          # user-scope ($AFK_HOME)
   config/    afk.env, afk.config.json, mcp.json
-  state/     sessions/  todos/  transcripts/  daemon/   ($AFK_STATE_DIR overrides this tier)
+  state/     sessions/  todos/  transcripts/  daemon/  witness/   ($AFK_STATE_DIR overrides this tier)
   plugins/   logs/  cache/
-  agent-framework/   # AFK telemetry + briefs (via paths.ts)
+  agent-framework/   # AFK telemetry + briefs
+<cwd>/.afk/                      # project-scope: per-project skills + plugins, auto-discovered
 ```
 
-`mcp.json` is the MCP server registry. Schema matches Claude Code's `mcpServers` block for portability — see `src/agent/mcp/types.ts` for fields. Loaded eagerly at session bootstrap from layered sources (plugin → user-global → project-local `<cwd>/.mcp.json` → `--mcp-config` flag, higher wins). Servers connect in parallel; failures are non-fatal unless `alwaysLoad: true`. Tools are exposed as `mcp__<server>__<tool>` and routed via the standard dispatcher (Pre/PostToolUse hooks fire automatically). `tools/list_changed` notifications trigger an in-place tool-list refresh — the next tool_use round sees the updated set without restart.
-
-The plugin surface writes to `~/.claude/agent-framework/` independently — no shared state.
+`mcp.json`'s schema matches Claude Code's `mcpServers` block for portability (fields: `src/agent/mcp/types.ts`). Servers connect in parallel at bootstrap; failures are non-fatal **unless** `alwaysLoad: true`. The plugin surface writes to `~/.claude/agent-framework/` independently — no shared state.
 
 ### System prompt discovery
 
-The base system prompt is **layered**: the framework prompt (`prompts/system-prompt.md`, inlined at publish-build) is the unconditional foundation; the resolved operator overlay is **appended** on top beneath an `# Operator configuration` header — never a replacement. `resolveBaseSystemPrompt()` (`src/cli/shared-helpers.ts`) layers them for every top-level surface (chat, REPL, Telegram, farm).
-
-`loadConfig()` resolves the **operator overlay** across three tiers (highest wins); `loadConfig().systemPrompt` is that overlay alone:
+The base system prompt is **layered**: the framework prompt (`prompts/system-prompt.md`, inlined at publish-build) is the unconditional foundation; the operator overlay is **appended** beneath an `# Operator configuration` header — never a replacement. `resolveBaseSystemPrompt()` (`src/cli/shared-helpers.ts`) layers them for every top-level surface (chat, REPL, Telegram, farm). `loadConfig()` resolves the overlay across three tiers (highest wins); `loadConfig().systemPrompt` is that overlay alone, and no tier resolving yields `undefined`:
 
 | Tier | Overlay source | `loadConfig().systemPromptSource` |
 |------|--------|----------------------|
 | 1 | `AFK_SYSTEM_PROMPT` env | `env:AFK_SYSTEM_PROMPT` |
 | 2 | `afk.config.json` (cwd → `~/.afk/config/` → legacy) | `file:<abs>` |
 | 3 | `AFK.md` (cwd **+** `$AFK_HOME/`, additive) | `afk-md:<abs>` or `afk-md:<user-abs>+afk-md:<project-abs>` |
-| — | None | `undefined` |
 
-`AFK.md` is plain markdown, no frontmatter. Empty/whitespace → treated as absent per-file (an accidental blank one still falls through to/combines with the other). The framework base is always present regardless of overlay tier (this file, `AFK.md`, is itself a tier-3 overlay appended to the framework base). Tier 3 itself is **additive, not exclusive**: `loadAfkMd()` (`src/cli/config/afk-md-tier.ts`) reads both `$AFK_HOME/AFK.md` (user-scope, default `~/.afk/AFK.md`) and `<cwd>/AFK.md` (project-scope) when both exist and are non-empty, and concatenates them — user-scope first, project-scope second under a `## Project configuration (...) — takes precedence on conflict` header — rather than the project file silently hiding the personal one. When only one tier resolves (the common case), the content and `afk-md:<path>` format are byte-identical to a single-tier read — no header, no behavior change. Delivery is still baked directly into the system prompt (not a separate synthetic user-turn message, unlike Claude Code's CLAUDE.md). `--dump-prompt` reports a composed `systemPromptSource` (`framework`, `framework+afk-md:<path>`, `framework+afk-md:<user-path>+afk-md:<project-path>`, …); never forwarded to the SDK as a preset. Every overlay appends — no full-replace escape hatch yet (a future `AFK_BASE_PROMPT=0` would add one).
+`AFK.md` is plain markdown, no frontmatter; empty/whitespace counts as absent per-file. The framework base is always present regardless of tier — this file is itself a tier-3 overlay. Tier 3 is **additive, not exclusive**: `loadAfkMd()` (`src/cli/config/afk-md-tier.ts`) reads *both* `$AFK_HOME/AFK.md` and `<cwd>/AFK.md` when both are non-empty and concatenates them (user-scope first, then project-scope under a `## Project configuration … takes precedence on conflict` header) rather than letting the project file hide the personal one; dedup runs through `realpath`. With one tier resolving — the common case — output is byte-identical to a single-tier read: no header, no behavior change. Delivery is baked into the system prompt, *not* a synthetic user-turn message (unlike Claude Code's CLAUDE.md), and is never forwarded to the SDK as a preset; `--dump-prompt` reports the composed source (`framework+afk-md:<user>+afk-md:<project>`, …). Every overlay appends — there is no full-replace escape hatch yet.
 
 ## Conventions
 
@@ -126,9 +123,10 @@ The base system prompt is **layered**: the framework prompt (`prompts/system-pro
 - `AgentSession` constructor is **synchronous**; SDK lifecycle runs async via `initSdkLifecycle()` and surfaces through the provider event stream.
 - DAG executor (`src/agent/dag.ts`, 266 LOC) is fully implemented: layer-by-layer Kahn execution, per-node `AbortController`s, fail-fast with transitive skip, node-level timeouts.
 - **SDK dependency tracking**: every import from `@anthropic-ai/sdk` is in `.sdk-dependency.lock.json`. CI fails on unlocked new symbols. After adding an SDK import, run `pnpm audit:sdk:update-lock` and edit the new entry's `reason` field before commit.
-- **Env-var access**: never read `process.env` directly — use the typed `env` object from `src/config/env.ts` and register new vars in `ENV_REGISTRY` there (CI-gated by `pnpm audit:env:check` + `pnpm scan:env:check`).
+- **Three mandatory indirections — each has exactly one read/write point, and CI enforces it.** Env vars: never `process.env`; use the typed `env` object and register new vars in `ENV_REGISTRY` (`src/config/env.ts`; `audit:env:check` + `scan:env:check`). Styling: never `chalk.<color>()`; use the semantic palette (`src/cli/palette.ts`; `audit:chalk:check` — ~180 raw sites had crept back before this gate). Paths: never hand-join anything under `~/.afk/`; use `src/paths.ts` (user- vs project-scope differ and `$AFK_HOME`/`$AFK_STATE_DIR` override).
 - Build copies `*.md` prompt files from `src/` into `dist/` via `scripts/copy-prompts.js` — required for built skills to find their prompts.
-- Vendored agents under `src/skills/_agents/` must stay byte-equal to upstream — drift detection enforces it.
+- Vendored agents under `src/skills/_agents/` must stay byte-equal to upstream, and bundled skills under `src/bundled-plugins/` are SHA-256 pinned in their test files. Editing either intentionally means running `pnpm fix:pins` to rewrite the pins (`pnpm fix:pins:check` is the CI gate); an unexplained pin failure means an edit you did not intend.
+- **Three agent-instruction files, different consumers**: this file is the AFK overlay; `CLAUDE.md` targets Claude Code and carries the same facts in longer form (incl. the long-comment audit recipe); `AGENTS.md` is generic operating protocol with no repo specifics. When architecture changes, `AFK.md` and `CLAUDE.md` both need the edit — they drifted apart once already on the provider layer.
 
 ### Long-comment prefix convention
 
@@ -138,7 +136,9 @@ Any source-comment block ≥15 contiguous lines must open with one of:
 - `// Contract:` — param/return/throws semantics, type-narrowing rationale. Stays inline.
 - `// History:` — root-cause, decision log, postmortem. Migrates to `docs/<area>.md` on next touch; leave a ≤5-line summary + link in place.
 
-Choose the prefix before writing the body. When in doubt between `Invariant:` and `History:`, use `Invariant:` — false-shrink is a regression.
+Choose the prefix before writing the body. When in doubt between `Invariant:` and `History:`, use `Invariant:` — false-shrink is a regression. JSDoc may carry the prefix in the body (`* Invariant: …`).
+
+**There is no linter gate for this** — `tsc` and CI will not catch a missing prefix, so it is review-enforced and self-checked. `CLAUDE.md` carries a ready-to-run grep+awk audit recipe for finding untagged ≥15-line blocks.
 
 ### Ordered-operation sequences
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-agent-afk is a standalone TypeScript CLI + daemon + Telegram bot that uses `@anthropic-ai/sdk` (and optionally `@openai/codex-sdk`). It runs **outside** Claude Code as its own process. The binary is `afk`.
+agent-afk is a standalone TypeScript CLI + daemon + Telegram bot built on `@anthropic-ai/sdk` (plus the `openai` package for OpenAI-compatible endpoints). It runs **outside** Claude Code as its own process. The binary is `afk`. Node ≥22, pnpm-only.
 
 ## Commands
 
@@ -12,15 +12,24 @@ agent-afk is a standalone TypeScript CLI + daemon + Telegram bot that uses `@ant
 pnpm install              # Use pnpm exclusively — lockfile is pnpm-specific
 pnpm build                # tsc + copies *.md prompt files into dist/
 pnpm test                 # vitest run (all tests)
-pnpm test src/agent/session.test.ts               # single test file (unit tests co-located with src)
-pnpm test -t "sends a message"                     # single test by name
+pnpm test src/agent/session.test.ts               # single file — NO `--`; pnpm 10 drops args after it and runs ALL files
+pnpm test src/agent/session.test.ts -t "sends a message"   # single test by name: scope to a file first, then filter
 pnpm test:watch           # vitest watch mode
+pnpm test:coverage        # CI gate — enforces coverage floors that plain `pnpm test` does not
+pnpm test:pty             # PTY suite, separate config (vitest.pty.config.ts) and its own CI job
 pnpm lint                 # tsc --noEmit (strict, no unused locals/params)
 
 pnpm audit:sdk            # regenerate SDK dependency snapshot (docs/sdk-dependency.md)
 pnpm audit:sdk:check      # CI gate — fails on unlocked new symbols or kind changes
 pnpm audit:sdk:update-lock  # add new symbols to .sdk-dependency.lock.json (edit reason field before committing)
+pnpm audit:env:check      # CI gate — no raw process.env reads outside src/config/env.ts
+pnpm scan:env:check       # CI gate — docs/env-registry.{json,md} in sync with src/config/env.ts
+pnpm audit:chalk:check    # CI gate — no raw chalk.<color> outside src/cli/palette.ts (--list locates sites)
+pnpm fix:pins:check       # CI gate — SHA-256 pins for vendored agents + bundled skills (pnpm fix:pins rewrites)
+pnpm audit:deps           # CI gate — pnpm audit --audit-level=critical --prod
 ```
+
+Every gate above, plus `pnpm lint` and `pnpm build`, runs on each PR (`.github/workflows/ci.yml`). Run them locally before pushing rather than after CI reddens.
 
 ### Running
 
@@ -38,13 +47,15 @@ pnpm telegram:start              # Telegram bot (managed via scripts/telegram-ma
 
 1. **`src/agent/`** — Provider-agnostic session harness. `AgentSession` is the single runtime entry point; it delegates to a `ModelProvider` selected by model family (`providerForModel()`). The two bundled providers live in `src/agent/providers/`:
    - `anthropic-direct/` — wraps `@anthropic-ai/sdk` Messages API directly (default for `claude-*`, `opus`, `sonnet`, `haiku`). `'anthropic'` is a silent alias for this provider.
-   - `openai-codex.ts` — wraps `@openai/codex-sdk` (for `gpt-*`, `o1*`, `o3*`, `o4*`, `codex-*`).
+   - `openai-compatible/` — talks directly to OpenAI's Chat Completions API, and to any compatible endpoint via `baseURL`. Default for `gpt-*`, `o1*`, `o3*`, `o4*`, `codex-*`, **and** HuggingFace-style `org/model` ids (`mlx-community/…`, `Qwen/…`) served by local OpenAI-shim runners (MLX, llama.cpp, vLLM, ollama-openai). It replaced a `@openai/codex-sdk`-backed `openai-codex` provider that no longer exists; `'openai-codex'` survives only as a deprecated alias, and the codex SDK is **not** a dependency.
 
-   Both emit a normalized `ProviderEvent` stream consumed by `src/agent/session/stream-consumer.ts`. Nothing outside `src/agent/providers/` imports from any model SDK directly.
+   Both emit a normalized `ProviderEvent` stream consumed by `src/agent/session/stream-consumer.ts`. No model SDK is imported for runtime use outside `src/agent/providers/` — the rest of the tree imports only the SDK's `ContentBlockParam` *type*.
 
 2. **`src/cli/`** — Terminal surface. Commander-based with commands under `src/cli/commands/`. The interactive REPL (`commands/interactive/`) has its own lifecycle: bootstrap → REPL loop → turn handler → markdown streaming → cleanup. Slash commands (`src/cli/slash/`) register via a Levenshtein-hint dispatcher.
 
 3. **`src/telegram/`** — Telegram surface. Telegraf-based bot with per-chat session management and an allowlist gate (`AFK_TELEGRAM_ALLOWED_CHAT_IDS`).
+
+Supporting modules outside those three layers: `src/config/` (`env.ts` is the **canonical** `process.env` read-point), `src/paths.ts` (all AFK path resolution), `src/browser/` (Playwright browser-control tools + witness capture + domain policy), `src/web/` (`web_scrape`: fetch → Readability → markdown, headless-render fallback, Exa search), `src/insights/` (`afk insights` report — import via the `index.ts` barrel, not sub-paths), `src/improve/` (telemetry scan → eval-gen → eval-run → propose), `src/service/` (macOS LaunchAgent install/manage), `src/bundled-plugins/` (plugins shipped with the package), `src/utils/` (leaf helpers; nothing here imports upward), and `website/` (Next.js docs site — separate package, npm-locked, typechecked and built in CI).
 
 ### Cross-Cutting Subsystems
 
@@ -52,7 +63,8 @@ pnpm telegram:start              # Telegram bot (managed via scripts/telegram-ma
 - **SubagentManager** (`src/agent/subagent.ts`) — Forks child `AgentSession` instances with permission bubbling, transitive abort via `AbortGraph`, and optional Zod output schemas.
 - **AbortGraph** (`src/agent/abort-graph.ts`) — Tree of `AbortController`s. Parent abort cascades down; child abort notifies up (never auto-aborts parent). Abort always takes precedence over hook decisions.
 - **Elicitation Router** (`src/agent/elicitation-router.ts`) — Module-scope handler for SDK elicitation requests, bridging to REPL/Telegram/iMessage surfaces.
-- **Plugins** (`src/agent/plugins-scanner.ts`, `src/agent/plugins/`) — Scans `~/.afk/plugins/` at session construction and passes discovered plugins as local entries to the SDK. Includes install, remove, update, and git-based source support.
+- **Plugins** (`src/agent/plugins-scanner.ts`, `src/agent/plugins/`) — `scanLocalPlugins()` scans `~/.afk/plugins/` at session construction; discovered skills are bridged into the tool surface by `src/agent/tools/skill-bridge.ts`. Plugins are never handed to a model SDK — there is no SDK-side plugin concept. Includes install, remove, update, and git-based source support.
+- **MCP client** (`src/agent/mcp/`) — Wraps `@modelcontextprotocol/sdk`. `McpManager.fromConfig()` connects every server from `loadMcpConfig()`, layered lowest→highest: plugin-contributed `<plugin>/.claude-plugin/mcp.json` → `~/.afk/config/mcp.json` → `<cwd>/.mcp.json` → `--mcp-config <path>`. Higher layer wins on name conflict, displaced source surfaced as a warning. Transports: stdio, streamable-HTTP, SSE fallback, OAuth. Tools bridge as `mcp__<server>__<tool>` and are read fresh per-query, so `notifications/tools/list_changed` refreshes land without a session restart. Sampling capability is deliberately not advertised — it removes the "stub or hang" footgun. `/mcp` lists servers; `/mcp auth` surfaces pending OAuth URLs.
 
 ### Skills System
 
@@ -62,22 +74,38 @@ Vendored agents (`src/skills/_agents/`) are byte-equal copies of agent definitio
 
 ### User-Scope State
 
-All AFK state lives under `~/.afk/` (never `~/.claude/`). AFK resolves user-scope state directly from that home. Layout:
+All AFK state lives under `~/.afk/` (never `~/.claude/`), and every path is resolved through `src/paths.ts` — never hand-join one. Two scopes:
 
 ```
-~/.afk/
-  config/     afk.env, afk.config.json
+~/.afk/                 # user-scope ($AFK_HOME)
+  config/     afk.env, afk.config.json, mcp.json
   state/                ($AFK_STATE_DIR overrides this tier)
-    sessions/    session-store sidecars
+    sessions/    session-store sidecars (tool ARGS live here, in events.jsonl)
     todos/       todo-panel data
     transcripts/ autosaved REPL session transcripts
     daemon/      per-instance daemon state
+    witness/     per-session trace.jsonl — see Observability below
   plugins/    local plugin installs
   logs/
   cache/
+<cwd>/.afk/             # project-scope: per-project skills + plugins, auto-discovered
 ```
 
 All AFK telemetry and briefs write to `~/.afk/agent-framework/` via `paths.ts`. The plugin surface writes to `~/.claude/agent-framework/` independently — no shared state between surfaces.
+
+### Observability / tracing
+
+Every session writes a **witness trace** — the durable chronological record of what the agent actually did (tool calls with timing, result bytes, ok/err; subagent lifecycle; session phases). Reach for this first when reconstructing a past run, not the transcript (prose only) and not the service logs (other processes).
+
+```bash
+afk trace show [<session>]  # pretty-print a trace (default "latest"); --all includes low-signal
+                            # events, -n 40 limits to last N, --json emits raw NDJSON for jq
+afk trace list              # sessions having a trace, newest first (-n/--max <N>, default 20)
+```
+
+Writer + reader live in `src/agent/trace/`; the CLI is `src/cli/commands/trace.ts`. **Two things the trace does not answer**: tool *args* (those are in `state/sessions/<id>/events.jsonl` — the trace carries only `inputBytes`) and raw tool *output* (never recorded durably, only `resultBytes`).
+
+One residual bug worth recognizing: a parent session ending mid-wave seals over live children and silently drops their terminal rows, so ~3% of dispatched subagents have no recorded fate (~8% in daemon/cron parallel waves vs ~1% interactive). Detector: an unmatched `started` in a trace that *contains* `session_sealed` — not "a `started` is the file's last line", which misses it because the seal is written afterward.
 
 ## SDK Dependency Tracking
 
@@ -86,9 +114,11 @@ Every import from `@anthropic-ai/sdk` is tracked. `.sdk-dependency.lock.json` is
 ## Key Conventions
 
 - `tsconfig.json` is maximally strict: `noUnusedLocals`, `noUnusedParameters`, `noUncheckedIndexedAccess`, `noPropertyAccessFromIndexSignature`. All code must pass `tsc --noEmit`.
-- The system prompt for agent-afk sessions is a raw string loaded from config or a file, sent to the Messages API as-is. No SDK preset (e.g. Agent SDK's `claude_code`) is loaded — agent-afk talks directly to `@anthropic-ai/sdk` / `@openai/codex-sdk`, not the Agent SDK.
+- The system prompt is the framework base (`prompts/system-prompt.md`) with the operator overlay appended, composed by `resolveBaseSystemPrompt()` and sent to the Messages API as a raw string. No SDK preset (e.g. Agent SDK's `claude_code`) is loaded — agent-afk talks directly to the Messages / Chat Completions APIs, not the Agent SDK.
 - The `AgentSession` constructor is synchronous; the SDK lifecycle (provider query setup, session init) runs asynchronously via `initSdkLifecycle()` and surfaces through the provider event stream.
 - DAG executor (`src/agent/dag.ts`) is a Kahn-layer parallel executor with per-node AbortControllers, fail-fast semantics, transitive skip propagation, node-level timeouts, and listener-leak prevention. ~266 LOC, fully implemented.
+- **Three mandatory indirections**, each with a canonical read/write point and a CI gate. Env vars: never read `process.env` in new code — use the typed `env` object and register new vars in `ENV_REGISTRY` (`src/config/env.ts`; `audit:env:check` + `scan:env:check`). A handful of files carry a documented whole-file exemption in `ALLOWED_FILES` (`scripts/audit-env-access.ts`); adding an entry there is a last resort, not the way around the gate. Styling: never call `chalk.<color>()` — use the semantic palette (`src/cli/palette.ts`; `audit:chalk:check`, which landed after ~180 raw sites crept back). Paths: never hand-join anything under `~/.afk/` — use `src/paths.ts`.
+- Vendored agents (`src/skills/_agents/`) and bundled skills (`src/bundled-plugins/`) are SHA-256 pinned in their test files. Editing either on purpose means running `pnpm fix:pins`; an unexplained pin failure means an edit you did not intend.
 
 ### Long-comment prefix convention
 
@@ -130,10 +160,14 @@ The base system prompt is **layered**: the framework prompt (`prompts/system-pro
 |------|--------|---------------------------|
 | 1 | `AFK_SYSTEM_PROMPT` env var | `"env:AFK_SYSTEM_PROMPT"` |
 | 2 | `afk.config.json` (`cwd` → `~/.afk/config/` → legacy) | `"file:<abs path>"` |
-| 3 | `AFK.md` (`cwd` → `$AFK_HOME/`) | `"afk-md:<abs path>"` |
+| 3 | `AFK.md` (`cwd` **+** `$AFK_HOME/`, additive) | `"afk-md:<abs>"` or `"afk-md:<user-abs>+afk-md:<project-abs>"` |
 | — | None | `systemPromptSource` is `undefined` |
 
-`AFK.md` is plain Markdown with no frontmatter. Empty or whitespace-only files are treated as absent. The framework base is always present regardless of overlay tier. `--dump-prompt` reports a composed `systemPromptSource` (`"framework"`, `"framework+afk-md:<path>"`, …) and the full text in `options.system`; the composed prompt is never forwarded to the SDK as a preset. Every overlay appends — there is currently no full-replace escape hatch (a future `AFK_BASE_PROMPT=0` would add one).
+`AFK.md` is plain Markdown with no frontmatter; empty or whitespace-only files count as absent per-file. The framework base is always present regardless of overlay tier.
+
+Tier 3 is **additive, not exclusive** — this is a recent change and the easiest thing to get wrong. `loadAfkMd()` (`src/cli/config/afk-md-tier.ts`) reads *both* `$AFK_HOME/AFK.md` (user-scope) and `<cwd>/AFK.md` (project-scope) when both are non-empty and concatenates them — user-scope first, then project-scope under a `## Project configuration … takes precedence on conflict` header — rather than letting the project file silently shadow the personal one. Dedup runs through `realpath`, so a symlinked pair is not double-counted. When only one tier resolves (the common case) the output is byte-identical to a single-tier read: no header, no behavior change.
+
+`--dump-prompt` reports the composed `systemPromptSource` (`"framework"`, `"framework+afk-md:<path>"`, `"framework+afk-md:<user>+afk-md:<project>"`, …) and the full text in `options.system`; the composed prompt is never forwarded to the SDK as a preset. Every overlay appends — there is currently no full-replace escape hatch (a future `AFK_BASE_PROMPT=0` would add one).
 
 ## Ordered-operation sequences
 


### PR DESCRIPTION
## Summary

`CLAUDE.md` documented a provider file that does not exist: `src/agent/providers/openai-codex.ts`, wrapping `@openai/codex-sdk`. The file was removed in the sibling-provider refactor and the package is not a dependency — an agent trusting the doc would go looking for deleted code. Three separate sites carried the claim.

While fixing that I audited every factual claim in the file against source. Corrections, each re-derived from code rather than inferred:

| Claim as written | Ground truth |
|---|---|
| `openai-codex.ts` wraps `@openai/codex-sdk` (×3 sites) | `openai-compatible/` is a **directory** talking to Chat Completions directly, and also serves HuggingFace-style `org/model` ids via local OpenAI-shim runners. `'openai-codex'` survives only as a deprecated alias — `providers/index.ts:218-221,285-289` |
| Plugins are "passed as local entries to the SDK" | Bridged into the tool surface by `tools/skill-bridge.ts:23,397-409`; the SDK-facing `plugins` fields are hardcoded `[]` (`providers/*/query.ts:340,363`) |
| Tier-3 `AFK.md` resolves `cwd` → `$AFK_HOME` (fallback) | **Additive** — `loadAfkMd()` reads both scopes and concatenates, realpath-deduped (`cli/config/afk-md-tier.ts:73-149`). Changed in #845; the doc still described the old semantics |
| `pnpm test -t "<name>"` | Needs a file scope first — pnpm 10 drops args after `--` and silently runs the entire suite |
| `env.ts` is the **sole** `process.env` read-point | **Canonical**, not sole: `scripts/audit-env-access.ts:43-85` maintains a documented exemption allowlist |

That last one was also present in `AFK.md`, so it is fixed in both files.

### Additions

Things a session working in this repo would otherwise miss:

- **8 CI gates that redden PRs** and were undocumented: `audit:chalk:check`, `fix:pins:check`, `audit:env:check`, `scan:env:check`, `audit:deps`, `test:coverage`, `test:pty`
- **The MCP subsystem** — absent entirely (`mcp/manager.ts:112`, `config-loader.ts:356-444`)
- **An Observability/tracing section** — witness traces are the primary tool for reconstructing a past run
- **10 `src/` modules** the "Three Layers" framing omitted (`browser/`, `web/`, `insights/`, `service/`, `improve/`, `paths.ts`, …)
- **Palette and hash-pin conventions** — both CI-gated, neither documented

`AFK.md` holds its 150-line budget: the additions are paid for by collapsing an MCP paragraph that duplicated the subsystems bullet almost verbatim and trimming the trace digression to its actionable detector. The note I had added claiming CLAUDE.md is stale is replaced with a lockstep-edit warning, since that drift is precisely what this PR repairs.

## How was this tested?

**The diff is markdown-only — two files, zero code changes**, so the compiled surface is untouched.

Verification actually performed:

- **Adversarial claim re-derivation.** A read-only agent independently re-derived 10 claims from source with no access to my reasoning: 9 CONFIRMED with `file:line` citations, **1 REFUTED** — the `sole` vs `canonical` overclaim above, which I then fixed in both files. That refutation is the reason this PR touches `AFK.md`'s config row at all.
- **No test reads either file.** `src/cli/config.test.ts` exercises AFK.md resolution against `vi.mock('fs')` (line 62), not the repo's real file, so content changes cannot move a test. Confirmed by grepping every `AFK.md`/`CLAUDE.md` reference under `src/`, `tests/`, `scripts/`.
- **Runtime load check.** `afk chat --dump-prompt stderr` reports `systemPromptSource=framework+afk-md:<user>+afk-md:<project>`, confirming the edited `AFK.md` still parses and loads as a tier-3 overlay.
- **Structural checks.** Balanced code fences (8 / 10), no YAML frontmatter in either file, and the new `see Observability below` forward reference resolves to a real section.

`pnpm lint` / `pnpm test` were **not** run locally: the diff contains no TypeScript, and this branch was cut fresh from `origin/main` into a worktree without installed dependencies. CI runs the full gate set on this PR, which is the meaningful check for a markdown-only change.

### A note on branch provenance

These edits were originally made in a checkout sitting on `afk/user-scoped-afk-config` — a branch **53 commits behind `main`** whose work had already squash-merged as #845, with its remote branch auto-deleted. Pushing from there would have produced a PR that appeared to delete ~14,950 lines across 208 files. This branch is instead cut fresh from `origin/main` with the doc changes re-applied via 3-way merge, which surfaced a real conflict: `main` had gained an `AFK_CAPTURE_SUBAGENT_PROMPTS` paragraph documenting a live feature that a naive copy would have silently deleted. **That paragraph is preserved** — verified present in the final file.

## Checklist

- [x] `pnpm lint` passes — n/a, no TypeScript in the diff; CI enforces
- [x] `pnpm test` passes — n/a, no code in the diff; no test reads either file (verified)
- [x] Commits are signed off (`git commit -s`) per the DCO
- [x] No secrets, tokens, or private paths in the diff — added lines scanned for `/Users/`, home paths, and key/token patterns
