### PR TITLE
fix(tools): make read-only bash refusals actionable and state the real shell dialect

### DIFF
--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -577,7 +577,11 @@ export class SessionToolDispatcher implements ToolDispatcher {
     const reason =
       `Bash command blocked: read-only skill may not run mutating commands ` +
       `(${verdict.reason ?? 'mutation detected'}). Allowed: read-only recon ` +
-      `(git status/log/diff, ls, cat, find, grep).`;
+      `(git status/log/diff/show/ls-remote, ls, cat, find, grep, gh pr view/diff). ` +
+      `For a remote ref you have not fetched, \`gh pr diff <n>\`, \`gh pr view <n>\` ` +
+      `and \`git ls-remote\` need no local ref — \`git fetch\` is blocked. ` +
+      `Do NOT retry variants of a blocked command: if the task genuinely requires a ` +
+      `mutation, stop and report that requirement to your caller instead.`;
     await this.emitPreToolUseBlock(call.name, reason);
     return { content: reason, isError: true, failureClass: 'permission-denied' };
   }

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -17,9 +17,10 @@ export const bashTool: AnthropicToolDef = {
   description:
     'Execute a shell command and return its stdout and stderr. ' +
     'Use for running programs, installing packages, git operations, and any task that requires a shell. ' +
-    'Commands run through /bin/sh in POSIX mode (Node spawn with shell:true) — NOT bash and NOT your $SHELL. '
-    + 'Bashisms are syntax errors that exit 2 WITHOUT running the command: process substitution <(...), [[ ]], arrays, {a,b} brace expansion. '
-    + 'Use a temp file or a POSIX equivalent instead. Long-running commands should use timeout_ms. ' +
+    'Commands run through /bin/sh (Node spawn with shell:true) — NOT bash and NOT your $SHELL; /bin/sh is bash-in-POSIX-mode on macOS but dash on Debian/Ubuntu. ' +
+    'Only process substitution <(...) reliably fails closed (exit 2, nothing runs). Other bashisms are nonportable and are NOT dependable refusals: ' +
+    '[[ ]] runs on macOS but is a not-found command on dash while the rest of the line still executes; {a,b} expands on macOS but passes through literally on dash (silently wrong argument); arrays run on macOS but are a syntax error on dash. ' +
+    'So never assume a bashism-containing command was side-effect-free — prefer a temp file or a POSIX equivalent. Long-running commands should use timeout_ms. ' +
     'Output is capped to a ~100KB head+tail view (the start and end are kept, the middle elided with a notice), so the command still runs to completion and you keep the real exit code and the tail (test/build summaries, final errors). For the full body of a verbose command, filter it (`| tail -n`, `--quiet`, narrower flags) or redirect to a file and read slices. Commands emitting extreme output (>8MB) are terminated. ' +
     'For reading or writing files — especially anything sensitive — prefer the typed file tools ' +
     '(read_file, write_file, edit_file): they support per-call user approval, and interpreter ' +

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -17,7 +17,9 @@ export const bashTool: AnthropicToolDef = {
   description:
     'Execute a shell command and return its stdout and stderr. ' +
     'Use for running programs, installing packages, git operations, and any task that requires a shell. ' +
-    'Commands run in the user\'s default shell. Long-running commands should use timeout_ms. ' +
+    'Commands run through /bin/sh in POSIX mode (Node spawn with shell:true) — NOT bash and NOT your $SHELL. '
+    + 'Bashisms are syntax errors that exit 2 WITHOUT running the command: process substitution <(...), [[ ]], arrays, {a,b} brace expansion. '
+    + 'Use a temp file or a POSIX equivalent instead. Long-running commands should use timeout_ms. ' +
     'Output is capped to a ~100KB head+tail view (the start and end are kept, the middle elided with a notice), so the command still runs to completion and you keep the real exit code and the tail (test/build summaries, final errors). For the full body of a verbose command, filter it (`| tail -n`, `--quiet`, narrower flags) or redirect to a file and read slices. Commands emitting extreme output (>8MB) are terminated. ' +
     'For reading or writing files — especially anything sensitive — prefer the typed file tools ' +
     '(read_file, write_file, edit_file): they support per-call user approval, and interpreter ' +


### PR DESCRIPTION
## Summary

Two model-facing string fixes. No logic changes, no behavior changes to the classifier or the spawn path.

**1. `src/agent/tools/dispatcher.ts` — make the read-only bash refusal actionable.**
The refusal named what was forbidden but never what to use instead. Now it names the no-local-ref alternatives and explicitly tells the child to stop rather than retry variants.

**2. `src/agent/tools/schemas.ts` — state the real shell dialect.**
The `bash` tool advertised "the user's default shell". It isn't: `handlers/bash.ts:224` spawns with `shell: true`, i.e. `/bin/sh` — which is bash-in-POSIX-mode on macOS but dash on Debian/Ubuntu. The description now names that split, marks only process substitution `<(...)` as reliably failing closed (exit 2, nothing runs), and describes the other bashisms as nonportable with per-dialect behavior rather than as dependable refusals.

### Why

Diagnosed from witness trace `2d56a189-2e27-43bb-a50d-c2deeb4cffa3`. A caged `git-investigator` asked to compare local work against a remote PR branch hit the `git fetch` block and retried variants **14 times**. One child in that wave burned to `stopReason: tool_use_loop_capped` after **12m55s and $3.52**, returning `incomplete: true` to its parent. The refusal it re-read on every attempt listed only prohibitions.

Separately, the session's root turn lost a round to `<(...)` failing under `/bin/sh` — a cost the tool description was actively causing.

The vendored `git-investigator.md` prompt is byte-locked by `vendored.test.ts:34`, so agent-file wording was never an available lever. The refusal string is the reachable one, and it has better properties anyway: it is read at the exact moment of failure, by every caged agent regardless of type, and costs zero context when nothing is blocked.

### Honest limitation

This reduces blast radius; it does not add capability. A task that genuinely needs a remote ref still needs the parent to fetch. The win is failing in one round with a clear escalation instead of 14 retries and a capped child.

## How was this tested?

- **Alternatives were verified before being advertised.** Naming a command in a refusal that is itself blocked would be worse than saying nothing, so each was checked against the classifier: `gh` is gated per-verb by `GH_NOUN_MUTATING` / `GH_API_*` (`readonly-bash.ts:104-115`), so `gh pr diff|view` pass; `ls-remote` is absent from `GIT_MUTATING_SUBCMDS` (`:566`), so it passes.
- **Typecheck:** pinned `tsc --noEmit` (5.9.3) — exit 0.
- **Targeted:** `dispatcher.test.ts` + `schemas.test.ts` — 124 passed, 1 skipped.
- **Full suite:** 770 of 771 files passed, 14682 tests passed. The single failure is `src/agent/trace/writer.test.ts > process-exit backstop seals a real crashed subprocess` (`expected null to be 1`). It is **pre-existing and unrelated**: it reproduces identically with this PR's two files reverted to their pre-change state, and fails deterministically 3/3 at HEAD. It spawns a real subprocess and this branch was tested from a git worktree without its own `node_modules`, which is the likely cause; a clean CI install should be green.
- **Wording safety:** no test or telemetry consumer depends on the changed text beyond `toContain('read-only skill may not run mutating commands')`, which is preserved. Called out because #714 deliberately kept this denial text byte-identical for telemetry parity — that substring is untouched.

## Deferred, filed rather than smuggled in

- **#881** — allow `>` redirection to `$TMPDIR` in the read-only classifier. This is the one place the two changes rub against each other: the new bash description tells the model to use a temp file, and the cage still blocks writing one. It widens a security-adjacent classifier, so it does not belong in a wording PR.
- **#882** — `/ground-state`'s memory surveyor path-greps a vestigial Claude Code project slug, producing a guaranteed `Path not found`. The skill already forbids this in prose and was ignored, so it needs a mechanical fix.
- **#883** — `/ground-state`'s memory surveyor is dispatched as an agent type whose allowlist excludes `memory_search`, silently zeroing a third of every recon wave. Surfaced by `/ground-state`'s own self-report while pre-flighting this PR.

## Review follow-ups

- **Codex P2 on `schemas.ts:21` — accepted and fixed in `ca313f64`.** The first version of this description claimed `[[ ]]`, arrays and `{a,b}` are syntax errors that "exit 2 WITHOUT running the command". They are not, and the error pointed the dangerous way: it invited a model to infer a bashism-containing command was side-effect-free when it had already run. Measured on both dialects before rewriting:

  | construct | macOS `/bin/sh` (bash 3.2 POSIX) | `dash` (Debian/Ubuntu `/bin/sh`) |
  |---|---|---|
  | `<(...)` | exit 2, nothing ran | exit 2, nothing ran |
  | `[[ ]]` | runs fine | `[[: not found` — rest of the line still executed |
  | `{a,b}` | expands to `xa xb` | passes through literally — silently wrong argument |
  | `arr=(1 2)` | runs fine | exit 2 |

  Only process substitution fails closed. `{a,b}` on dash is the worst case: nothing errors, the command simply receives a different path than intended.

## Checklist

- [x] `pnpm lint` passes — pinned `tsc --noEmit` 5.9.3, exit 0
- [x] `pnpm test` passes — full suite green except one pre-existing, unrelated failure proven independent of this diff (see above)
- [x] Commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/) — see [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] No secrets, tokens, or private paths in the diff
