### PR TITLE
feat(slash): add /afk-md to edit AFK.md overlays with live hot-reload

### DIFF
--- a/src/agent/provider.ts
+++ b/src/agent/provider.ts
@@ -382,6 +382,32 @@ export interface ProviderQuery extends AsyncIterable<ProviderEvent> {
    */
   setCwd?(cwd: string): void;
   /**
+   * Optional. Replace the composed base system prompt for all **subsequent**
+   * turns in this query's lifetime, without resetting the session or touching
+   * conversation history.
+   *
+   * Contract: `basePrompt` is the FULLY COMPOSED base prompt — the framework
+   * doctrine (`prompts/system-prompt.md`) plus the `# Operator configuration`
+   * overlay — i.e. exactly the shape of `AgentConfig.systemPrompt`, as produced
+   * by `resolveBaseSystemPrompt()`. It is NOT the bare AFK.md overlay text;
+   * passing only the overlay would silently drop the framework prompt from a
+   * live session.
+   *
+   * Returns `true` when the live prompt was actually rebuilt, `false` when the
+   * provider accepted the call but could not apply it (e.g. no rebuild factory
+   * was wired because the caller owns an external dispatcher). The return value
+   * is the honesty channel for `/afk-md`: a surface must never report a
+   * hot-reload it did not achieve, so a `false` here means "saved to disk,
+   * applies on next launch".
+   *
+   * Implemented by `AnthropicDirectQuery` and forwarded by `ProviderRouter`.
+   * `OpenAICompatibleQuery` deliberately leaves this undefined — it assembles
+   * its system parts as locals inside `query()` rather than retaining them on
+   * the instance, so a live swap there needs the #876 staleness rework first.
+   * `AgentSession.setSystemPrompt()` calls this only when present.
+   */
+  setSystemPrompt?(basePrompt: string | undefined): boolean;
+  /**
    * Optional. Force a fresh SDK client by re-reading whatever credential
    * source the provider uses (e.g. the macOS Keychain for OAuth tokens).
    *

--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -72,6 +72,7 @@ import { env } from '../../../config/env.js';
 import { resolveQueryToken } from './query/token-resolution.js';
 import { getRuntimeStateTool } from '../../awareness/index.js';
 import { createCwdDependentsFactory } from './query/cwd-dependents.js';
+import { createSystemPromptRebuildFactory } from './query/overlay-rebuild.js';
 import { wireQueryDispatcher } from './query/dispatcher-wiring.js';
 import { setUpQueryClient } from './query/client-setup.js';
 import { assembleQueryPrompt } from './query/prompt-assembly.js';
@@ -556,6 +557,24 @@ export class AnthropicDirectProvider implements ModelProvider {
           buildDispatcher: (mode, opts) => this.buildDispatcher(mode, opts),
         });
 
+    // Invariant: this factory MUST close over the SAME `stableSystemPrefix`
+    // object passed to `createCwdDependentsFactory` above — not a copy. The
+    // overlay rebuild writes the new base prompt back into that shared object
+    // so a later `setCwd()` re-assembly inherits it instead of resurrecting the
+    // launch-time prompt. See the Invariant block in query/overlay-rebuild.ts.
+    // Gated on `externalTools` for the same reason the cwd factory is: those
+    // callers own their own prompt/dispatcher lifecycle.
+    const systemPromptRebuildFactory = this.externalTools
+      ? undefined
+      : createSystemPromptRebuildFactory({
+          stableSystemPrefix,
+          config,
+          surface: this.surface,
+          runtimeStateSource,
+          getCurrentCwd: () => this._currentCwd,
+          fallbackCwd: cwd,
+        });
+
     const resolvedEffort = resolveEffort(config.effort, model);
     return new AnthropicDirectQuery({
       client,
@@ -609,6 +628,7 @@ export class AnthropicDirectProvider implements ModelProvider {
         ? { maxToolUseIterations: config.maxToolUseIterations }
         : {}),
       ...(cwdDependentsFactory !== undefined ? { cwdDependentsFactory } : {}),
+      ...(systemPromptRebuildFactory !== undefined ? { systemPromptRebuildFactory } : {}),
       // Path-approval half of the live `/bypass` toggle: keep the provider's
       // `_currentPermissionMode` (read by getGrants().allowAll) in sync with
       // the query handle's mode. The file-tool half is the dispatcher's

--- a/src/agent/providers/anthropic-direct/query.ts
+++ b/src/agent/providers/anthropic-direct/query.ts
@@ -180,6 +180,17 @@ export interface AnthropicDirectQueryOptions {
    */
   cwdDependentsFactory?: (cwd: string) => { userSystem: string; dispatcher: ToolDispatcher };
   /**
+   * Factory for re-assembling `userSystem` around a NEW composed base prompt
+   * when `setSystemPrompt()` is called mid-session (the `/afk-md` hot-reload
+   * path). When absent, `setSystemPrompt()` reports `false` and changes
+   * nothing — same degradation contract as `cwdDependentsFactory`.
+   *
+   * Supplied by `AnthropicDirectProvider.query()` as a closure over the same
+   * shared `stableSystemPrefix` the cwd factory uses, so the two rebuild paths
+   * compose rather than overwrite each other. See `query/overlay-rebuild.ts`.
+   */
+  systemPromptRebuildFactory?: (basePrompt: string | undefined) => string;
+  /**
    * Provider callback invoked by `setPermissionMode()` to update the
    * provider-level `_currentPermissionMode` — the field the path-approval hook
    * reads via the provider's `getGrants().allowAll`. This is the path-approval
@@ -283,6 +294,7 @@ export class AnthropicDirectQuery implements ProviderQuery {
    */
   private readonly retry: RetryLayer;
   private readonly cwdDependentsFactory?: (cwd: string) => { userSystem: string; dispatcher: ToolDispatcher };
+  private readonly systemPromptRebuildFactory?: (basePrompt: string | undefined) => string;
   private readonly onPermissionMode?: (mode: string) => void;
   private readonly mcpManager?: import('../../mcp/index.js').McpManager;
   private readonly hookRegistry?: HookRegistry;
@@ -303,6 +315,7 @@ export class AnthropicDirectQuery implements ProviderQuery {
     this.traceWriter = opts.traceWriter;
     if (opts.subagentId !== undefined) this.subagentId = opts.subagentId;
     this.cwdDependentsFactory = opts.cwdDependentsFactory;
+    this.systemPromptRebuildFactory = opts.systemPromptRebuildFactory;
     this.onPermissionMode = opts.onPermissionMode;
     this.mcpManager = opts.mcpManager;
     if (opts.hookRegistry !== undefined) this.hookRegistry = opts.hookRegistry;
@@ -733,6 +746,28 @@ export class AnthropicDirectQuery implements ProviderQuery {
     const { userSystem, dispatcher } = this.cwdDependentsFactory(cwd);
     this.state.userSystem = userSystem;
     this.state.toolDispatcher = dispatcher;
+  }
+
+  /**
+   * Swap the composed base system prompt for all subsequent turns.
+   *
+   * Contract: `basePrompt` is the FULL composed prompt (framework doctrine +
+   * `# Operator configuration` overlay), not the bare overlay — see the
+   * `ProviderQuery.setSystemPrompt` doc. Returns `true` when the live prompt
+   * was rebuilt, `false` when no rebuild factory is wired (external-dispatcher
+   * callers), so the caller can report honestly instead of claiming a reload
+   * that never happened.
+   *
+   * Safe between turns and idempotent: `composeSystem()` re-reads
+   * `state.userSystem` fresh on every turn (it already mutates it per-turn for
+   * date rollover), so writing a newly assembled string here is the same
+   * established mechanism `setCwd()` uses — no session reset, no history loss.
+   * Synchronous for the same reason `setCwd` is: it is called between turns.
+   */
+  setSystemPrompt(basePrompt: string | undefined): boolean {
+    if (!this.systemPromptRebuildFactory) return false;
+    this.state.userSystem = this.systemPromptRebuildFactory(basePrompt);
+    return true;
   }
 
   async supportedCommands(): Promise<ProviderCommandInfo[]> {

--- a/src/agent/providers/anthropic-direct/query/overlay-rebuild.test.ts
+++ b/src/agent/providers/anthropic-direct/query/overlay-rebuild.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for the live system-prompt rebuild factory.
+ *
+ * The load-bearing property is the SHARED-PREFIX mutation: the factory writes the
+ * new base prompt back into the same `StableSystemParts` object the cwd-rebuild
+ * factory closes over, so a later `setCwd()` inherits the operator's edit instead
+ * of resurrecting the launch-time prompt. A copy-then-assemble implementation
+ * would pass a naive "does the output contain the new text" check and still
+ * silently undo the hot-reload on the next `/cd`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createSystemPromptRebuildFactory } from './overlay-rebuild.js';
+import { assembleSystemPrompt, buildStableSystemPrefix } from './system-prompt.js';
+import type { AgentConfig } from '../../../types/config-types.js';
+import type { RuntimeStateSource } from '../../../awareness/index.js';
+
+function makeParts(userSystem: string | null): ReturnType<typeof buildStableSystemPrefix> {
+  return buildStableSystemPrefix({
+    toolBase: 'TOOL-BASE',
+    memoryPrompt: 'MEMORY',
+    hotMemory: '',
+    manifest: '',
+    userSystem,
+  });
+}
+
+const runtimeStateSource = {
+  getWorkspace: () => undefined,
+} as unknown as RuntimeStateSource;
+
+function makeFactory(
+  parts: ReturnType<typeof buildStableSystemPrefix>,
+  cwd: string | undefined,
+  fallbackCwd = '/fallback',
+) {
+  return createSystemPromptRebuildFactory({
+    stableSystemPrefix: parts,
+    config: { sessionId: 's1' } as AgentConfig,
+    surface: 'cli',
+    runtimeStateSource,
+    getCurrentCwd: () => cwd,
+    fallbackCwd,
+  });
+}
+
+describe('createSystemPromptRebuildFactory', () => {
+  it('returns a prompt containing the new base prompt', () => {
+    const parts = makeParts('OLD-PROMPT');
+    const rebuilt = makeFactory(parts, '/repo')('NEW-PROMPT');
+    expect(rebuilt).toContain('NEW-PROMPT');
+    expect(rebuilt).not.toContain('OLD-PROMPT');
+    expect(rebuilt).toContain('TOOL-BASE');
+  });
+
+  it('assembles against the LIVE cwd so an edit after /cd lands correctly', () => {
+    const parts = makeParts(null);
+    expect(makeFactory(parts, '/live/checkout')('P')).toContain('/live/checkout');
+  });
+
+  it('falls back to the query-entry cwd when the live accessor is unset', () => {
+    const parts = makeParts(null);
+    expect(makeFactory(parts, undefined, '/entry/cwd')('P')).toContain('/entry/cwd');
+  });
+
+  it('mutates the SHARED prefix so a later cwd rebuild inherits the new prompt', () => {
+    const parts = makeParts('OLD-PROMPT');
+    makeFactory(parts, '/repo')('NEW-PROMPT');
+
+    // The shared object itself must now carry the new text...
+    expect(parts.userSystem).toBe('NEW-PROMPT');
+
+    // ...so re-running the cwd-rebuild assembler over the same parts (exactly
+    // what createCwdDependentsFactory does on setCwd) keeps the operator's edit.
+    const afterCwdChange = assembleSystemPrompt(parts, '/other/worktree', {
+      surface: 'cli',
+      sessionId: 's1',
+      depth: undefined,
+      maxDepth: undefined,
+      workspace: undefined,
+    });
+    expect(afterCwdChange).toContain('NEW-PROMPT');
+    expect(afterCwdChange).not.toContain('OLD-PROMPT');
+    expect(afterCwdChange).toContain('/other/worktree');
+  });
+
+  it('normalizes a cleared overlay to null so no blank section is emitted', () => {
+    const parts = makeParts('OLD-PROMPT');
+    const rebuilt = makeFactory(parts, '/repo')(undefined);
+    expect(parts.userSystem).toBeNull();
+    expect(rebuilt).not.toContain('OLD-PROMPT');
+    expect(rebuilt).toContain('TOOL-BASE');
+    expect(rebuilt).not.toContain('\n\n\n');
+  });
+
+  it('treats an empty string the same as cleared', () => {
+    const parts = makeParts('OLD-PROMPT');
+    makeFactory(parts, '/repo')('');
+    expect(parts.userSystem).toBeNull();
+  });
+});

--- a/src/agent/providers/anthropic-direct/query/overlay-rebuild.ts
+++ b/src/agent/providers/anthropic-direct/query/overlay-rebuild.ts
@@ -1,0 +1,77 @@
+/**
+ * Live system-prompt rebuild helper for {@link AnthropicDirectProvider.query}.
+ *
+ * Sibling of `cwd-dependents.ts`: that module rebuilds the system prompt when
+ * the *cwd* changes, this one rebuilds it when the *operator overlay* changes
+ * (the `/afk-md` hot-reload path). Both funnel through the SAME
+ * `assembleSystemPrompt` assembler so the first-turn prompt, the cwd-rebuilt
+ * prompt, and the overlay-rebuilt prompt can never drift apart.
+ *
+ * @module agent/providers/anthropic-direct/query/overlay-rebuild
+ */
+
+import type { AgentConfig } from '../../../types/config-types.js';
+import type { RuntimeStateSource } from '../../../awareness/index.js';
+import { assembleSystemPrompt, type StableSystemParts } from './system-prompt.js';
+
+/**
+ * Rebuild the assembled system prompt around a new composed base prompt.
+ *
+ * Returns the full string to install into `SessionState.userSystem`.
+ */
+export type SystemPromptRebuildFactory = (basePrompt: string | undefined) => string;
+
+export interface SystemPromptRebuildFactoryArgs {
+  /**
+   * The SAME `StableSystemParts` instance handed to `createCwdDependentsFactory`.
+   * Sharing the object is load-bearing — see the Invariant in the factory body.
+   */
+  stableSystemPrefix: StableSystemParts;
+  config: AgentConfig;
+  surface: string;
+  runtimeStateSource: RuntimeStateSource;
+  /** Live cwd accessor — the provider's `_currentCwd`, which `setCwd()` updates. */
+  getCurrentCwd: () => string | undefined;
+  /** Session cwd captured at `query()` entry; used when the live accessor is unset. */
+  fallbackCwd: string;
+}
+
+/** Build the systemPromptRebuildFactory passed to AnthropicDirectQuery. */
+export function createSystemPromptRebuildFactory(
+  args: SystemPromptRebuildFactoryArgs,
+): SystemPromptRebuildFactory {
+  return (basePrompt: string | undefined): string => {
+    // Invariant: the new base prompt is written back into the SHARED
+    // `stableSystemPrefix` object, in place, BEFORE re-assembly — never into a
+    // local copy.
+    //
+    // `createCwdDependentsFactory` closes over this same instance by reference
+    // and re-runs `assembleSystemPrompt` over it on every `setCwd()`. If we
+    // assembled from a copy and left the shared object holding the old text,
+    // the next cwd change (a `/cd`, or the first-turn worktree autoname hook)
+    // would silently resurrect the pre-edit prompt and quietly undo the
+    // operator's hot-reload. Mutating the shared parts makes the two rebuild
+    // paths compose instead of fight: whichever runs last, both the current cwd
+    // and the current overlay survive.
+    //
+    // Normalizing empty-string to null matches `resolveUserSystem()` and the
+    // assembler's own `if (parts.userSystem)` skip, so "overlay cleared" drops
+    // the section entirely rather than emitting a stray blank block.
+    args.stableSystemPrefix.userSystem =
+      basePrompt !== undefined && basePrompt.length > 0 ? basePrompt : null;
+
+    // Ordering constraint (externally governed, same as cwd-dependents.ts step 2):
+    // `workspace` is NOT stable — it tracks the live checkout's branch and HEAD —
+    // so it must be re-read from the runtime source at rebuild time rather than
+    // reused from a construction-time snapshot. The cwd is read live for the same
+    // reason: an overlay edit may land after a `/cd` or a worktree re-anchor.
+    const cwd = args.getCurrentCwd() ?? args.fallbackCwd;
+    return assembleSystemPrompt(args.stableSystemPrefix, cwd, {
+      surface: args.surface,
+      sessionId: args.config.sessionId,
+      depth: args.config.depth,
+      maxDepth: args.config.maxDepth,
+      workspace: args.runtimeStateSource.getWorkspace(),
+    });
+  };
+}

--- a/src/agent/providers/router/provider-router.ts
+++ b/src/agent/providers/router/provider-router.ts
@@ -166,6 +166,14 @@ export class ProviderRouter implements ProviderQuery {
   /** Permission mode / cwd carried across inner swaps. */
   private currentPermissionMode: AgentConfig['permissionMode'];
   private currentCwd: string | undefined;
+  /**
+   * Composed base system prompt carried across inner swaps, set by
+   * `setSystemPrompt`. `undefined` is a MEANINGFUL value here (the operator
+   * cleared their overlay), so a separate flag — not a null check — records
+   * whether an override was ever applied.
+   */
+  private currentSystemPrompt: string | undefined;
+  private systemPromptOverridden = false;
   /** The provider family `config.apiKey` was resolved for (anti-leak gate). */
   private readonly startupFamily: string;
 
@@ -266,6 +274,9 @@ export class ProviderRouter implements ProviderQuery {
     // do not affect the routing signature (computed in resolveInner above).
     if (this.currentPermissionMode !== undefined) innerConfig.permissionMode = this.currentPermissionMode;
     if (this.currentCwd !== undefined) innerConfig.cwd = this.currentCwd;
+    // Flag-gated, not `!== undefined`: clearing the operator overlay is a
+    // legitimate override that must survive a model swap too.
+    if (this.systemPromptOverridden) innerConfig.systemPrompt = this.currentSystemPrompt;
 
     if (seed) innerConfig.resumeHistory = [...this.shadowHistory];
 
@@ -458,6 +469,24 @@ export class ProviderRouter implements ProviderQuery {
   setCwd(cwd: string): void {
     this.currentCwd = cwd;
     this.active?.query.setCwd?.(cwd);
+  }
+
+  /**
+   * Contract: returns the INNER query's honest result, not merely "the router
+   * accepted the call". The router always implements this method, so returning
+   * `true` unconditionally would tell `/afk-md` a hot-reload succeeded even when
+   * the active provider cannot apply one (openai-compatible leaves the hook
+   * undefined). `?? false` collapses both "no active inner yet" and "inner does
+   * not support live swaps" to an honest negative.
+   *
+   * The value is recorded either way so `buildInner()` carries it onto a fresh
+   * inner after a `/model` swap — otherwise switching models would silently
+   * revert to the launch-time prompt.
+   */
+  setSystemPrompt(basePrompt: string | undefined): boolean {
+    this.currentSystemPrompt = basePrompt;
+    this.systemPromptOverridden = true;
+    return this.active?.query.setSystemPrompt?.(basePrompt) ?? false;
   }
 
   async reauth(): Promise<{ accountId: string; swapped: boolean } | null> {

--- a/src/agent/session/agent-session.ts
+++ b/src/agent/session/agent-session.ts
@@ -995,6 +995,39 @@ export class AgentSession implements IAgentSession {
    * themselves AT a known safe site — `runFirstTurnAutoname` in the
    * interactive REPL is the only sanctioned caller today.
    */
+  /**
+   * Replace the composed base system prompt for all subsequent turns.
+   *
+   * Contract: `basePrompt` is the FULLY COMPOSED prompt — framework doctrine
+   * (`prompts/system-prompt.md`) + the `# Operator configuration` overlay —
+   * exactly what `resolveBaseSystemPrompt()` returns and what
+   * `AgentConfig.systemPrompt` holds. It is NOT the bare AFK.md overlay text:
+   * passing only the overlay would silently strip the framework prompt from a
+   * live session. The parameter is named `basePrompt`, not `overlay`, to make
+   * that misuse visibly wrong at the call site.
+   *
+   * Two things happen:
+   *   1. `config.systemPrompt` is updated, so a later `reset()` — which rebuilds
+   *      the provider query from config — starts from the new prompt.
+   *   2. `providerQuery.setSystemPrompt(...)` swaps the LIVE prompt when the
+   *      provider supports it. Conversation history is untouched; the change
+   *      lands on the next turn.
+   *
+   * Returns whether the live swap actually happened. `false` means the prompt is
+   * recorded in config but the running turn loop still holds the old text (the
+   * active provider does not implement the optional hook — openai-compatible
+   * today) so callers must report "applies on next launch" rather than claiming
+   * a hot-reload. Never claim a reload this returns `false` for.
+   *
+   * Cost note: replacing the stable system prefix invalidates the Anthropic
+   * prompt cache for the next request. That is accepted and expected — the
+   * caller surfaces it to the operator rather than silently eating a cache miss.
+   */
+  setSystemPrompt(basePrompt: string | undefined): boolean {
+    this.config = { ...this.config, systemPrompt: basePrompt };
+    return this.providerQuery.setSystemPrompt?.(basePrompt) ?? false;
+  }
+
   setCwd(cwd: string): void {
     this.config = { ...this.config, cwd };
     this.providerQuery.setCwd?.(cwd);

--- a/src/agent/session/set-system-prompt.test.ts
+++ b/src/agent/session/set-system-prompt.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Live AgentSession.setSystemPrompt() propagation test — the end-to-end proof
+ * for the `/afk-md` hot-reload feature.
+ *
+ * Verifies the full chain, not the wiring in isolation:
+ *   session.setSystemPrompt(newPrompt)
+ *     → ProviderQuery.setSystemPrompt(newPrompt)
+ *       → AnthropicDirectQuery.setSystemPrompt()   [re-assembles via the rebuild factory]
+ *         → next turn's messages.create() system carries the NEW prompt
+ *
+ * Structured as a deliberate sibling of the T19 setCwd test in
+ * `agent-session.test.ts` (same stubbed-client harness), because the two share a
+ * failure mode: a mid-session rebuild that mutates the wrong copy of the shared
+ * prompt parts looks correct in a unit test and silently reverts on the next
+ * turn. The composition case below (setSystemPrompt then setCwd) is the one a
+ * copy-based implementation fails.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type Anthropic from '@anthropic-ai/sdk';
+import type { ContentBlockParam, RawMessageStreamEvent } from '@anthropic-ai/sdk/resources';
+import { AgentSession } from './agent-session.js';
+import {
+  AnthropicDirectProvider,
+  __setAnthropicClientFactory,
+} from '../providers/anthropic-direct/index.js';
+
+vi.mock('../../utils/debug.js', () => ({ debugLog: vi.fn() }));
+
+const messagesCreateMock = vi.fn();
+
+class MockAnthropic {
+  public messages: { create: typeof messagesCreateMock };
+  constructor() {
+    this.messages = { create: messagesCreateMock };
+  }
+}
+
+async function* fromArray<T>(arr: T[]): AsyncIterable<T> {
+  for (const x of arr) yield x;
+}
+
+function makeTextStream(text: string): RawMessageStreamEvent[] {
+  return [
+    {
+      type: 'message_start',
+      message: {
+        id: 'msg_test',
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model: 'claude-haiku-4-5',
+        stop_reason: null,
+        stop_sequence: null,
+        usage: {
+          input_tokens: 5,
+          output_tokens: 1,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+      },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } } as unknown as RawMessageStreamEvent,
+    { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text } } as unknown as RawMessageStreamEvent,
+    { type: 'content_block_stop', index: 0 } as unknown as RawMessageStreamEvent,
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'end_turn', stop_sequence: null },
+      usage: { output_tokens: 1 },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'message_stop' } as unknown as RawMessageStreamEvent,
+  ];
+}
+
+function extractSystemText(systemArg: unknown): string {
+  if (typeof systemArg === 'string') return systemArg;
+  if (!Array.isArray(systemArg)) return '';
+  return (systemArg as ContentBlockParam[])
+    .map((b) => (b.type === 'text' && typeof b.text === 'string' ? b.text : ''))
+    .join('\n');
+}
+
+function systemOfCall(n: number): string {
+  return extractSystemText((messagesCreateMock.mock.calls[n]![0] as { system?: unknown }).system);
+}
+
+describe('AgentSession.setSystemPrompt() — live session propagation', () => {
+  const OLD_PROMPT = 'FRAMEWORK-BASE\n\n# Operator configuration\n\nOLD-OVERLAY-MARKER';
+  const NEW_PROMPT = 'FRAMEWORK-BASE\n\n# Operator configuration\n\nNEW-OVERLAY-MARKER';
+  const CWD = '/fixture/workspace';
+
+  beforeEach(() => {
+    messagesCreateMock.mockReset();
+    __setAnthropicClientFactory(null);
+    __setAnthropicClientFactory(() => new MockAnthropic() as unknown as Anthropic);
+  });
+
+  afterEach(() => {
+    __setAnthropicClientFactory(null);
+    vi.restoreAllMocks();
+  });
+
+  function makeSession(): AgentSession {
+    return new AgentSession({
+      model: 'claude-haiku-4-5',
+      apiKey: 'sk-ant-oat01-test',
+      cwd: CWD,
+      systemPrompt: OLD_PROMPT,
+      provider: new AnthropicDirectProvider(),
+    });
+  }
+
+  it('makes the NEXT turn send the new prompt, and reports that it applied', async () => {
+    messagesCreateMock
+      .mockImplementationOnce(() => fromArray(makeTextStream('one')))
+      .mockImplementationOnce(() => fromArray(makeTextStream('two')));
+    const session = makeSession();
+
+    try {
+      await session.sendMessage('first');
+      expect(systemOfCall(0)).toContain('OLD-OVERLAY-MARKER');
+
+      const applied = session.setSystemPrompt(NEW_PROMPT);
+      expect(applied).toBe(true);
+
+      await session.sendMessage('second');
+      const turn2 = systemOfCall(1);
+      expect(turn2).toContain('NEW-OVERLAY-MARKER');
+      expect(turn2).not.toContain('OLD-OVERLAY-MARKER');
+      // The framework doctrine must survive the swap — losing it is the
+      // catastrophic failure mode of passing a bare overlay.
+      expect(turn2).toContain('FRAMEWORK-BASE');
+      expect(turn2).toContain('Working directory');
+    } finally {
+      await session.close();
+    }
+  });
+
+  it('does not wipe conversation history (no implicit reset)', async () => {
+    messagesCreateMock
+      .mockImplementationOnce(() => fromArray(makeTextStream('one')))
+      .mockImplementationOnce(() => fromArray(makeTextStream('two')));
+    const session = makeSession();
+
+    try {
+      await session.sendMessage('first message');
+      session.setSystemPrompt(NEW_PROMPT);
+      await session.sendMessage('second message');
+
+      const turn2Messages = (messagesCreateMock.mock.calls[1]![0] as { messages: unknown[] }).messages;
+      // Turn 1's user text + assistant reply must still be in the payload.
+      expect(JSON.stringify(turn2Messages)).toContain('first message');
+      expect(turn2Messages.length).toBeGreaterThan(1);
+    } finally {
+      await session.close();
+    }
+  });
+
+  it('survives a subsequent setCwd() — the shared-prefix composition case', async () => {
+    messagesCreateMock
+      .mockImplementationOnce(() => fromArray(makeTextStream('one')))
+      .mockImplementationOnce(() => fromArray(makeTextStream('two')));
+    const session = makeSession();
+
+    try {
+      await session.sendMessage('first');
+      session.setSystemPrompt(NEW_PROMPT);
+      // A cwd re-anchor re-assembles the prompt from the shared stable parts. If
+      // setSystemPrompt had written to a copy, this would resurrect OLD_PROMPT.
+      session.setCwd('/moved/worktree');
+
+      await session.sendMessage('second');
+      const turn2 = systemOfCall(1);
+      expect(turn2).toContain('NEW-OVERLAY-MARKER');
+      expect(turn2).not.toContain('OLD-OVERLAY-MARKER');
+      expect(turn2).toContain('/moved/worktree');
+    } finally {
+      await session.close();
+    }
+  });
+
+  it('clearing the prompt drops the overlay but keeps the rest of the system payload', async () => {
+    messagesCreateMock
+      .mockImplementationOnce(() => fromArray(makeTextStream('one')))
+      .mockImplementationOnce(() => fromArray(makeTextStream('two')));
+    const session = makeSession();
+
+    try {
+      await session.sendMessage('first');
+      expect(session.setSystemPrompt(undefined)).toBe(true);
+
+      await session.sendMessage('second');
+      const turn2 = systemOfCall(1);
+      expect(turn2).not.toContain('OLD-OVERLAY-MARKER');
+      expect(turn2).toContain('Working directory');
+    } finally {
+      await session.close();
+    }
+  });
+});

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -122,7 +122,7 @@ export function resolveAutoResumeOnUsageLimit(): boolean {
   return loadJsonConfig().config.autoResumeOnUsageLimit ?? true;
 }
 
-export function loadConfig(overrides?: Partial<CliConfig>): CliConfig {
+export function loadConfig(overrides?: Partial<CliConfig>, cwd: string = process.cwd()): CliConfig {
   const envConfig = loadEnvConfig();
   const { config: jsonConfig, sourcePath: jsonSourcePath, modelsPartial } = loadJsonConfig();
 
@@ -150,7 +150,7 @@ export function loadConfig(overrides?: Partial<CliConfig>): CliConfig {
     // Strict `=== undefined`: an explicit empty-string override (`systemPrompt: ""`)
     // is treated as "unset" and falls through to AFK.md discovery. Callers that
     // truly want "no prompt" should omit the field rather than pass "".
-    const afkMd = loadAfkMd();
+    const afkMd = loadAfkMd(cwd);
     if (afkMd !== null) {
       merged.systemPrompt = afkMd.content;
       // Each contributing path gets its own `afk-md:` prefix, joined with the

--- a/src/cli/config/afk-md-tier.ts
+++ b/src/cli/config/afk-md-tier.ts
@@ -6,8 +6,7 @@
 // plugin-skills split).
 
 import { readFileSync, existsSync, realpathSync } from 'fs';
-import { join } from 'path';
-import { getAfkHome } from '../../paths.js';
+import { getUserAfkMdPath, getProjectAfkMdPath } from '../../paths.js';
 
 export interface AfkMdResult {
   content: string;
@@ -116,8 +115,8 @@ const projectScopeHeader = (path: string): string =>
 export function loadAfkMd(): AfkMdResult | null {
   if (afkMdCache !== undefined) return afkMdCache.value;
 
-  const userPath = join(getAfkHome(), 'AFK.md');
-  const projectPath = join(process.cwd(), 'AFK.md');
+  const userPath = getUserAfkMdPath();
+  const projectPath = getProjectAfkMdPath();
 
   const userContent = readAfkMdCandidate(userPath);
   // Skip re-reading the same file twice — treat it as a single tier rather

--- a/src/cli/config/afk-md-tier.ts
+++ b/src/cli/config/afk-md-tier.ts
@@ -24,7 +24,7 @@ export interface AfkMdResult {
   paths: string[];
 }
 
-let afkMdCache: { value: AfkMdResult | null } | undefined;
+let afkMdCache: { cwd: string; value: AfkMdResult | null } | undefined;
 
 /**
  * Clear this tier's memoized AFK.md read. Called (only) by
@@ -112,11 +112,11 @@ const projectScopeHeader = (path: string): string =>
  * Memoized via `afkMdCache` — see the cache block above for the
  * invalidation contract.
  */
-export function loadAfkMd(): AfkMdResult | null {
-  if (afkMdCache !== undefined) return afkMdCache.value;
+export function loadAfkMd(cwd: string = process.cwd()): AfkMdResult | null {
+  if (afkMdCache?.cwd === cwd) return afkMdCache.value;
 
   const userPath = getUserAfkMdPath();
-  const projectPath = getProjectAfkMdPath();
+  const projectPath = getProjectAfkMdPath(cwd);
 
   const userContent = readAfkMdCandidate(userPath);
   // Skip re-reading the same file twice — treat it as a single tier rather
@@ -143,6 +143,6 @@ export function loadAfkMd(): AfkMdResult | null {
     result = null;
   }
 
-  afkMdCache = { value: result };
+  afkMdCache = { cwd, value: result };
   return afkMdCache.value;
 }

--- a/src/cli/shared-helpers.ts
+++ b/src/cli/shared-helpers.ts
@@ -108,9 +108,9 @@ export function composeSystemPrompt(
  * overlay is (framework absent), or `none`. The plain overlay source remains
  * available unchanged via `loadConfig().systemPromptSource`.
  */
-export function resolveBaseSystemPrompt(): { prompt: string | undefined; source: string } {
+export function resolveBaseSystemPrompt(cwd: string = process.cwd()): { prompt: string | undefined; source: string } {
   const framework = loadSystemPrompt();
-  const cfg = loadConfig();
+  const cfg = loadConfig(undefined, cwd);
   const overlay = cfg.systemPrompt;
   const overlaySource = cfg.systemPromptSource;
   const hasFw = framework !== undefined && framework.trim().length > 0;

--- a/src/cli/slash/commands/afk-md.test.ts
+++ b/src/cli/slash/commands/afk-md.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Command-level tests for `/afk-md`.
+ *
+ * The load-bearing case is the hot-reload ordering invariant: the AFK.md cache
+ * MUST be busted before the prompt is re-derived, and the value handed to
+ * `setSystemPrompt` MUST be the fully composed base prompt from
+ * `resolveBaseSystemPrompt()` — never the bare `loadAfkMd().content`, which would
+ * silently strip the framework doctrine from a running session.
+ *
+ * `shared-helpers` and `afk-md-tier` are mocked so the assertion is exact and
+ * machine-independent (it does not depend on the operator's real config tiers).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let tmpRoot = '';
+const userDir = (): string => join(tmpRoot, 'home');
+const projectDir = (): string => join(tmpRoot, 'repo');
+
+/** Ordered log of the cache-bust / read / apply sequence. */
+let callLog: string[] = [];
+/** Overlay text the mocked loader reports. */
+let overlayContent: string | null = null;
+
+const COMPOSED_SENTINEL = 'FRAMEWORK-DOCTRINE\n\n# Operator configuration\n\nOVERLAY-TEXT';
+
+// Invariant: this specifier MUST resolve to `src/paths.ts` — from
+// `src/cli/slash/commands/` that is THREE levels up, not two. The global test
+// setup (`src/__test-utils__/redirect-paths-env.ts`) redirects AFK_HOME so the
+// USER tier is already safe, but nothing redirects `process.cwd()`, so the
+// PROJECT tier resolves to the real repo-root AFK.md. A wrong specifier here is
+// silently inert and the project-tier tests then read and APPEND to this
+// repository's own tracked AFK.md.
+vi.mock('../../../paths.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../paths.js')>();
+  return {
+    ...actual,
+    getUserAfkMdPath: (): string => join(userDir(), 'AFK.md'),
+    getProjectAfkMdPath: (): string => join(projectDir(), 'AFK.md'),
+  };
+});
+
+vi.mock('../../config/afk-md-tier.js', () => ({
+  resetAfkMdCache: (): void => { callLog.push('bust'); },
+  loadAfkMd: (): { content: string; paths: string[] } | null => {
+    callLog.push('read');
+    return overlayContent === null ? null : { content: overlayContent, paths: [] };
+  },
+}));
+
+vi.mock('../../config.js', () => ({
+  _resetConfigCache: (): void => { callLog.push('bust-composed'); },
+}));
+
+vi.mock('../../shared-helpers.js', () => ({
+  resolveBaseSystemPrompt: (): { prompt: string; source: string } => {
+    callLog.push('compose');
+    return { prompt: COMPOSED_SENTINEL, source: 'framework+afk-md:/fixture/AFK.md' };
+  },
+}));
+
+const spawnMock = vi.fn();
+vi.mock('./editor-spawn.js', () => ({
+  resolveEditor: (): { cmd: string; args: string[] } | null => ({ cmd: 'vim', args: [] }),
+  spawnEditorOnPath: (...args: unknown[]): unknown => spawnMock(...args),
+}));
+
+const { afkMdCmd } = await import('./afk-md.js');
+import type { SlashContext } from '../types.js';
+
+function plain(s: string): string {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/\u001B\[[0-9;]*m/g, '');
+}
+
+interface Harness {
+  ctx: SlashContext;
+  lines: string[];
+  setSystemPrompt: ReturnType<typeof vi.fn>;
+  text: () => string;
+}
+
+function makeCtx(opts: { tty?: boolean; applied?: boolean } = {}): Harness {
+  const lines: string[] = [];
+  const push = (s: string): void => { lines.push(plain(s)); };
+  const setSystemPrompt = vi.fn((_p: string | undefined) => {
+    callLog.push('apply');
+    return opts.applied ?? true;
+  });
+  const compositor = opts.tty === false ? null : ({} as unknown);
+  const ctx = {
+    session: { current: { setSystemPrompt } },
+    out: {
+      line: push,
+      raw: push,
+      success: (s: string) => push(`OK ${s}`),
+      info: (s: string) => push(`INFO ${s}`),
+      warn: (s: string) => push(`WARN ${s}`),
+      error: (s: string) => push(`ERR ${s}`),
+    },
+    ui: { clearScreen: vi.fn(), repaintStatusLine: vi.fn() },
+    stats: { model: 'test' },
+    getCompositor: () => compositor,
+  } as unknown as SlashContext;
+  return { ctx, lines, setSystemPrompt, text: () => lines.join('\n') };
+}
+
+beforeEach(() => {
+  tmpRoot = join(tmpdir(), `afk-md-cmd-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(userDir(), { recursive: true });
+  mkdirSync(projectDir(), { recursive: true });
+  callLog = [];
+  overlayContent = 'OVERLAY-TEXT';
+  spawnMock.mockReset();
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('/afk-md registration', () => {
+  it('is aliased to /memory for Claude Code muscle memory', () => {
+    expect(afkMdCmd.name).toBe('/afk-md');
+    expect(afkMdCmd.aliases).toContain('/memory');
+  });
+});
+
+describe('/afk-md overview', () => {
+  it('disambiguates the /memory alias from AFK cross-session memory', async () => {
+    const h = makeCtx();
+    await afkMdCmd.handler(h.ctx, '');
+    expect(h.text()).toContain('memory_update');
+    expect(h.text()).toContain('AFK.md prompt overlay');
+  });
+
+  it('names the resolved editor', async () => {
+    const h = makeCtx();
+    await afkMdCmd.handler(h.ctx, '');
+    expect(h.text()).toContain('editor: vim');
+  });
+});
+
+describe('/afk-md show', () => {
+  it('prints the composed overlay verbatim', async () => {
+    const h = makeCtx();
+    await afkMdCmd.handler(h.ctx, 'show');
+    expect(h.text()).toContain('OVERLAY-TEXT');
+  });
+
+  it('works on a non-TTY surface (no editor required)', async () => {
+    const h = makeCtx({ tty: false });
+    const result = await afkMdCmd.handler(h.ctx, 'show');
+    expect(result).toBe('continue');
+    expect(h.text()).toContain('OVERLAY-TEXT');
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('reports honestly when no overlay is active', async () => {
+    overlayContent = null;
+    const h = makeCtx();
+    await afkMdCmd.handler(h.ctx, 'show');
+    expect(h.text()).toContain('No AFK.md overlay is active');
+  });
+});
+
+describe('/afk-md reload — ordering invariant', () => {
+  it('busts the cache BEFORE re-deriving, and applies only after', async () => {
+    const h = makeCtx();
+    await afkMdCmd.handler(h.ctx, 'reload');
+
+    const bust = callLog.indexOf('bust');
+    const compose = callLog.indexOf('compose');
+    const apply = callLog.indexOf('apply');
+    expect(bust).toBeGreaterThanOrEqual(0);
+    expect(compose).toBeGreaterThan(bust);
+    expect(apply).toBeGreaterThan(compose);
+  });
+
+  it('applies the FULL composed prompt, not the bare AFK.md overlay', async () => {
+    const h = makeCtx();
+    await afkMdCmd.handler(h.ctx, 'reload');
+
+    expect(h.setSystemPrompt).toHaveBeenCalledTimes(1);
+    const applied = h.setSystemPrompt.mock.calls[0]?.[0] as string;
+    expect(applied).toBe(COMPOSED_SENTINEL);
+    // The regression this guards: passing loadAfkMd().content would lose the
+    // framework doctrine entirely.
+    expect(applied).toContain('FRAMEWORK-DOCTRINE');
+    expect(applied).toContain('# Operator configuration');
+    expect(applied).not.toBe('OVERLAY-TEXT');
+  });
+
+  it('claims a hot-reload only when the provider actually applied it', async () => {
+    const ok = makeCtx({ applied: true });
+    await afkMdCmd.handler(ok.ctx, 'reload');
+    expect(ok.text()).toContain('Takes effect on your next message');
+
+    callLog = [];
+    const no = makeCtx({ applied: false });
+    await afkMdCmd.handler(no.ctx, 'reload');
+    expect(no.text()).toContain('applies on next launch');
+    expect(no.text()).not.toContain('Takes effect on your next message');
+  });
+});
+
+describe('/afk-md add', () => {
+  it('appends a bullet to the project tier by default and names the destination', async () => {
+    const h = makeCtx();
+    await afkMdCmd.handler(h.ctx, 'add always use pnpm');
+    const written = readFileSync(join(projectDir(), 'AFK.md'), 'utf-8');
+    expect(written).toContain('- always use pnpm');
+    expect(h.text()).toContain(join(projectDir(), 'AFK.md'));
+  });
+
+  it('retargets to the personal tier with --user', async () => {
+    const h = makeCtx();
+    await afkMdCmd.handler(h.ctx, 'add --user be terse');
+    expect(readFileSync(join(userDir(), 'AFK.md'), 'utf-8')).toContain('- be terse');
+    expect(existsSync(join(projectDir(), 'AFK.md'))).toBe(false);
+  });
+
+  it('creates the file with a scaffold when absent', async () => {
+    const h = makeCtx();
+    await afkMdCmd.handler(h.ctx, 'add first rule');
+    const written = readFileSync(join(projectDir(), 'AFK.md'), 'utf-8');
+    expect(written).toContain('# Operator configuration');
+    expect(written).toContain('- first rule');
+    expect(h.text()).toContain('Created');
+  });
+
+  it('does not stack blank lines when appending to an existing file', async () => {
+    writeFileSync(join(projectDir(), 'AFK.md'), '- one', 'utf-8');
+    const h = makeCtx();
+    await afkMdCmd.handler(h.ctx, 'add two');
+    expect(readFileSync(join(projectDir(), 'AFK.md'), 'utf-8')).toBe('- one\n- two\n');
+  });
+
+  it('rejects an empty add without touching disk', async () => {
+    const h = makeCtx();
+    await afkMdCmd.handler(h.ctx, 'add   ');
+    expect(h.text()).toContain('Nothing to add');
+    expect(existsSync(join(projectDir(), 'AFK.md'))).toBe(false);
+  });
+
+  it('hot-reloads after appending', async () => {
+    const h = makeCtx();
+    await afkMdCmd.handler(h.ctx, 'add x');
+    expect(h.setSystemPrompt).toHaveBeenCalledWith(COMPOSED_SENTINEL);
+  });
+});
+
+describe('/afk-md edit', () => {
+  it('refuses on a non-TTY surface and points at the file instead', async () => {
+    spawnMock.mockResolvedValue({ outcome: 'no-tty', exitCode: null });
+    const h = makeCtx({ tty: false });
+    const result = await afkMdCmd.handler(h.ctx, 'project');
+    expect(result).toBe('continue');
+    expect(h.text()).toContain('Edit it directly');
+    expect(h.setSystemPrompt).not.toHaveBeenCalled();
+  });
+
+  it('does not reload when the editor made no changes', async () => {
+    writeFileSync(join(projectDir(), 'AFK.md'), '- unchanged\n', 'utf-8');
+    spawnMock.mockResolvedValue({ outcome: 'clean', exitCode: 0 });
+    const h = makeCtx();
+    await afkMdCmd.handler(h.ctx, 'project');
+    expect(h.text()).toContain('No changes');
+    expect(h.setSystemPrompt).not.toHaveBeenCalled();
+  });
+
+  it('diffs and reloads when the editor changed the file', async () => {
+    const path = join(projectDir(), 'AFK.md');
+    writeFileSync(path, '- old\n', 'utf-8');
+    spawnMock.mockImplementation(async () => {
+      writeFileSync(path, '- old\n- new\n', 'utf-8');
+      return { outcome: 'clean', exitCode: 0 };
+    });
+    const h = makeCtx();
+    await afkMdCmd.handler(h.ctx, 'project');
+    expect(h.text()).toContain('+1');
+    expect(h.text()).toContain('- new');
+    expect(h.setSystemPrompt).toHaveBeenCalledWith(COMPOSED_SENTINEL);
+  });
+
+  it('warns when an edit empties the tier', async () => {
+    const path = join(userDir(), 'AFK.md');
+    writeFileSync(path, '- something\n', 'utf-8');
+    spawnMock.mockImplementation(async () => {
+      writeFileSync(path, '\n', 'utf-8');
+      return { outcome: 'clean', exitCode: 0 };
+    });
+    const h = makeCtx();
+    await afkMdCmd.handler(h.ctx, 'user');
+    expect(h.text()).toContain('treated as ABSENT');
+  });
+
+  it('treats a nonzero editor exit as discard and reloads nothing', async () => {
+    writeFileSync(join(projectDir(), 'AFK.md'), '- keep\n', 'utf-8');
+    spawnMock.mockResolvedValue({ outcome: 'nonzero', exitCode: 1 });
+    const h = makeCtx();
+    await afkMdCmd.handler(h.ctx, 'project');
+    expect(h.text()).toContain('discard');
+    expect(h.setSystemPrompt).not.toHaveBeenCalled();
+  });
+
+  it('accepts the numeric row labels from the overview', async () => {
+    spawnMock.mockResolvedValue({ outcome: 'clean', exitCode: 0 });
+    const h = makeCtx();
+    await afkMdCmd.handler(h.ctx, '1');
+    expect(spawnMock).toHaveBeenCalled();
+    const arg = spawnMock.mock.calls[0]?.[0] as { filePath: string };
+    expect(arg.filePath).toBe(join(userDir(), 'AFK.md'));
+  });
+});
+
+describe('/afk-md unknown subcommand', () => {
+  it('prints usage and continues rather than throwing', async () => {
+    const h = makeCtx();
+    const result = await afkMdCmd.handler(h.ctx, 'frobnicate');
+    expect(result).toBe('continue');
+    expect(h.text()).toContain('Unknown subcommand');
+    expect(h.text()).toContain('/afk-md show');
+    expect(h.setSystemPrompt).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/slash/commands/afk-md.test.ts
+++ b/src/cli/slash/commands/afk-md.test.ts
@@ -24,6 +24,7 @@ const projectDir = (): string => join(tmpRoot, 'repo');
 let callLog: string[] = [];
 /** Overlay text the mocked loader reports. */
 let overlayContent: string | null = null;
+let promptSource = 'framework+afk-md:/fixture/AFK.md';
 
 const COMPOSED_SENTINEL = 'FRAMEWORK-DOCTRINE\n\n# Operator configuration\n\nOVERLAY-TEXT';
 
@@ -39,7 +40,7 @@ vi.mock('../../../paths.js', async (importOriginal) => {
   return {
     ...actual,
     getUserAfkMdPath: (): string => join(userDir(), 'AFK.md'),
-    getProjectAfkMdPath: (): string => join(projectDir(), 'AFK.md'),
+    getProjectAfkMdPath: (cwd?: string): string => join(cwd ?? projectDir(), 'AFK.md'),
   };
 });
 
@@ -53,12 +54,15 @@ vi.mock('../../config/afk-md-tier.js', () => ({
 
 vi.mock('../../config.js', () => ({
   _resetConfigCache: (): void => { callLog.push('bust-composed'); },
+  loadConfig: (): { autoRouting: { interactive: boolean } } => ({
+    autoRouting: { interactive: false },
+  }),
 }));
 
 vi.mock('../../shared-helpers.js', () => ({
   resolveBaseSystemPrompt: (): { prompt: string; source: string } => {
     callLog.push('compose');
-    return { prompt: COMPOSED_SENTINEL, source: 'framework+afk-md:/fixture/AFK.md' };
+    return { prompt: COMPOSED_SENTINEL, source: promptSource };
   },
 }));
 
@@ -83,7 +87,7 @@ interface Harness {
   text: () => string;
 }
 
-function makeCtx(opts: { tty?: boolean; applied?: boolean } = {}): Harness {
+function makeCtx(opts: { tty?: boolean; applied?: boolean; cwd?: string } = {}): Harness {
   const lines: string[] = [];
   const push = (s: string): void => { lines.push(plain(s)); };
   const setSystemPrompt = vi.fn((_p: string | undefined) => {
@@ -102,7 +106,7 @@ function makeCtx(opts: { tty?: boolean; applied?: boolean } = {}): Harness {
       error: (s: string) => push(`ERR ${s}`),
     },
     ui: { clearScreen: vi.fn(), repaintStatusLine: vi.fn() },
-    stats: { model: 'test' },
+    stats: { model: 'test', cwd: opts.cwd ?? projectDir() },
     getCompositor: () => compositor,
   } as unknown as SlashContext;
   return { ctx, lines, setSystemPrompt, text: () => lines.join('\n') };
@@ -114,6 +118,7 @@ beforeEach(() => {
   mkdirSync(projectDir(), { recursive: true });
   callLog = [];
   overlayContent = 'OVERLAY-TEXT';
+  promptSource = 'framework+afk-md:/fixture/AFK.md';
   spawnMock.mockReset();
 });
 
@@ -185,11 +190,12 @@ describe('/afk-md reload — ordering invariant', () => {
 
     expect(h.setSystemPrompt).toHaveBeenCalledTimes(1);
     const applied = h.setSystemPrompt.mock.calls[0]?.[0] as string;
-    expect(applied).toBe(COMPOSED_SENTINEL);
+    expect(applied).toContain(COMPOSED_SENTINEL);
     // The regression this guards: passing loadAfkMd().content would lose the
     // framework doctrine entirely.
     expect(applied).toContain('FRAMEWORK-DOCTRINE');
     expect(applied).toContain('# Operator configuration');
+    expect(applied).toContain('Every turn must end in one externally identifiable terminal state');
     expect(applied).not.toBe('OVERLAY-TEXT');
   });
 
@@ -203,6 +209,14 @@ describe('/afk-md reload — ordering invariant', () => {
     await afkMdCmd.handler(no.ctx, 'reload');
     expect(no.text()).toContain('applies on next launch');
     expect(no.text()).not.toContain('Takes effect on your next message');
+  });
+
+  it('reports AFK.md as shadowed by a higher-priority prompt override', async () => {
+    promptSource = 'framework+env:AFK_SYSTEM_PROMPT';
+    const h = makeCtx();
+    await afkMdCmd.handler(h.ctx, 'reload');
+    expect(h.text()).toContain('shadowed by a higher-priority system prompt override');
+    expect(h.text()).not.toContain('Takes effect on your next message');
   });
 });
 
@@ -219,6 +233,15 @@ describe('/afk-md add', () => {
     const h = makeCtx();
     await afkMdCmd.handler(h.ctx, 'add --user be terse');
     expect(readFileSync(join(userDir(), 'AFK.md'), 'utf-8')).toContain('- be terse');
+    expect(existsSync(join(projectDir(), 'AFK.md'))).toBe(false);
+  });
+
+  it('targets the active session cwd instead of the launch cwd', async () => {
+    const activeCwd = join(tmpRoot, 'active-worktree');
+    mkdirSync(activeCwd, { recursive: true });
+    const h = makeCtx({ cwd: activeCwd });
+    await afkMdCmd.handler(h.ctx, 'add worktree rule');
+    expect(readFileSync(join(activeCwd, 'AFK.md'), 'utf-8')).toContain('- worktree rule');
     expect(existsSync(join(projectDir(), 'AFK.md'))).toBe(false);
   });
 
@@ -248,7 +271,7 @@ describe('/afk-md add', () => {
   it('hot-reloads after appending', async () => {
     const h = makeCtx();
     await afkMdCmd.handler(h.ctx, 'add x');
-    expect(h.setSystemPrompt).toHaveBeenCalledWith(COMPOSED_SENTINEL);
+    expect(h.setSystemPrompt.mock.calls[0]?.[0]).toContain(COMPOSED_SENTINEL);
   });
 });
 
@@ -282,7 +305,7 @@ describe('/afk-md edit', () => {
     await afkMdCmd.handler(h.ctx, 'project');
     expect(h.text()).toContain('+1');
     expect(h.text()).toContain('- new');
-    expect(h.setSystemPrompt).toHaveBeenCalledWith(COMPOSED_SENTINEL);
+    expect(h.setSystemPrompt.mock.calls[0]?.[0]).toContain(COMPOSED_SENTINEL);
   });
 
   it('warns when an edit empties the tier', async () => {

--- a/src/cli/slash/commands/afk-md.ts
+++ b/src/cli/slash/commands/afk-md.ts
@@ -1,0 +1,173 @@
+/**
+ * `/afk-md` — inspect and edit the AFK.md system-prompt overlay, with a live
+ * hot-reload into the running session.
+ *
+ * Aliased to `/memory` for Claude Code muscle memory. That alias is deliberately
+ * disambiguated in the overview output, because AFK also has a SEPARATE
+ * cross-session memory system (HOT.md + the fact archive, written by the agent
+ * through `memory_update`) — a user typing `/memory` could reasonably mean
+ * either, so the overview names both and points at the right one.
+ *
+ * @module cli/slash/commands/afk-md
+ */
+
+import { loadAfkMd } from '../../config/afk-md-tier.js';
+import { resolveBaseSystemPrompt } from '../../shared-helpers.js';
+import { palette } from '../../palette.js';
+import type { SlashCommand, SlashContext, SlashResult } from '../types.js';
+import { resolveEditor } from './editor-spawn.js';
+import { appendToTarget, editTarget } from './afk-md/edit.js';
+import { applyReload, currentOverlayTokens, formatDelta } from './afk-md/reload.js';
+import {
+  OVERLAY_TOKEN_WARN_THRESHOLD,
+  contributes,
+  formatTokens,
+  renderTargetRows,
+  resolveTargets,
+  targetFor,
+  type AfkMdScope,
+} from './afk-md/targets.js';
+
+const USAGE = [
+  '  /afk-md                 overview of both tiers and what the model receives',
+  '  /afk-md user            edit your personal overlay in $EDITOR',
+  '  /afk-md project         edit this project\u2019s overlay in $EDITOR',
+  '  /afk-md show            print the composed overlay exactly as the model sees it',
+  '  /afk-md add <text>      append a bullet to the project overlay (--user for personal)',
+  '  /afk-md reload          re-read from disk into this live session',
+];
+
+function printUsage(ctx: SlashContext): void {
+  ctx.out.line(palette.heading('/afk-md — AFK.md prompt overlay'));
+  for (const line of USAGE) ctx.out.line(line);
+}
+
+/** Resolve a subcommand word to a tier, accepting the numeric row labels too. */
+function scopeFromWord(word: string): AfkMdScope | null {
+  if (word === 'user' || word === 'u' || word === '1' || word === 'personal') return 'user';
+  if (word === 'project' || word === 'p' || word === '2') return 'project';
+  return null;
+}
+
+function renderOverview(ctx: SlashContext): void {
+  const targets = resolveTargets();
+  const { source } = resolveBaseSystemPrompt();
+  const loaded = loadAfkMd();
+  const totalTokens = currentOverlayTokens();
+  const totalBytes = loaded ? Buffer.byteLength(loaded.content, 'utf8') : 0;
+
+  ctx.out.line(palette.heading('AFK.md prompt overlay'));
+  ctx.out.line('');
+  for (const line of renderTargetRows(targets)) ctx.out.line(line);
+  ctx.out.line('');
+
+  const active = targets.filter(contributes).length;
+  if (active === 0) {
+    ctx.out.line(palette.dim('  No overlay is active — the framework prompt is running bare.'));
+  } else {
+    ctx.out.line(
+      `  composed: ${totalBytes} B  ${formatTokens(totalTokens)} tokens across ${active} tier${active === 1 ? '' : 's'}`,
+    );
+  }
+  ctx.out.line(palette.dim(`  ${source}`));
+
+  if (totalTokens > OVERLAY_TOKEN_WARN_THRESHOLD) {
+    ctx.out.warn(
+      `That overlay is ${formatTokens(totalTokens)} tokens — it is prepended to every request in every session. Consider trimming it.`,
+    );
+  }
+
+  const editor = resolveEditor();
+  ctx.out.line('');
+  for (const line of USAGE) ctx.out.line(line);
+  ctx.out.line('');
+  ctx.out.line(
+    editor
+      ? palette.dim(`  editor: ${editor.cmd}`)
+      : palette.dim('  editor: none — set $VISUAL or $EDITOR to enable in-REPL editing'),
+  );
+  ctx.out.line(
+    palette.dim(
+      '  hot memory (HOT.md) + the fact archive are managed by the agent via memory_update —',
+    ),
+  );
+  ctx.out.line(palette.dim('  this command edits your AFK.md prompt overlay.'));
+}
+
+function renderShow(ctx: SlashContext): void {
+  const { source } = resolveBaseSystemPrompt();
+  const loaded = loadAfkMd();
+  if (!loaded) {
+    ctx.out.info('No AFK.md overlay is active — nothing to show.');
+    ctx.out.line(palette.dim(`  ${source}`));
+    return;
+  }
+  ctx.out.line(palette.heading('Composed overlay — exactly what the model receives'));
+  ctx.out.line(palette.dim(`  ${source}`));
+  ctx.out.line('');
+  ctx.out.raw(loaded.content);
+  ctx.out.line('');
+}
+
+export const afkMdCmd: SlashCommand = {
+  name: '/afk-md',
+  aliases: ['/memory', '/mem'],
+  summary: 'Inspect + edit your AFK.md prompt overlay, hot-reloaded into this session',
+  usage: '/afk-md [user|project|show|add <text>|reload]',
+  hint: 'When you want to change the standing instructions the agent runs under \u2014 opens the tier in $EDITOR, diffs what changed, and applies it to the RUNNING session (no restart).',
+  flags: ['--user'],
+  async handler(ctx: SlashContext, args: string): Promise<SlashResult> {
+    const trimmed = args.trim();
+
+    if (trimmed.length === 0) {
+      renderOverview(ctx);
+      return 'continue';
+    }
+
+    const [word = '', ...rest] = trimmed.split(/\s+/);
+
+    if (word === 'show') {
+      renderShow(ctx);
+      return 'continue';
+    }
+
+    if (word === 'reload') {
+      const baseline = currentOverlayTokens();
+      const { applied, tokens, delta, source } = applyReload(ctx, baseline);
+      if (applied) {
+        ctx.out.success(
+          `Re-read from disk — overlay now ${formatTokens(tokens)} tokens (${formatDelta(delta)}). Takes effect on your next message.`,
+        );
+      } else {
+        ctx.out.warn(
+          'Re-read from disk, but this provider cannot swap the prompt of a running session — it applies on next launch.',
+        );
+      }
+      ctx.out.line(palette.dim(`  ${source}`));
+      return 'continue';
+    }
+
+    if (word === 'add') {
+      // `--user` may appear anywhere in the remainder; strip it before treating
+      // the rest as literal bullet text.
+      const toUser = rest.includes('--user');
+      const text = rest.filter((w) => w !== '--user').join(' ').trim();
+      if (text.length === 0) {
+        ctx.out.error('Nothing to add. Usage: /afk-md add <text> [--user]');
+        return 'continue';
+      }
+      appendToTarget(ctx, targetFor(toUser ? 'user' : 'project'), text);
+      return 'continue';
+    }
+
+    const scope = scopeFromWord(word);
+    if (scope) {
+      await editTarget(ctx, targetFor(scope));
+      return 'continue';
+    }
+
+    ctx.out.error(`Unknown subcommand \`${word}\`.`);
+    printUsage(ctx);
+    return 'continue';
+  },
+};

--- a/src/cli/slash/commands/afk-md.ts
+++ b/src/cli/slash/commands/afk-md.ts
@@ -50,10 +50,11 @@ function scopeFromWord(word: string): AfkMdScope | null {
 }
 
 function renderOverview(ctx: SlashContext): void {
-  const targets = resolveTargets();
-  const { source } = resolveBaseSystemPrompt();
-  const loaded = loadAfkMd();
-  const totalTokens = currentOverlayTokens();
+  const cwd = ctx.stats.cwd ?? process.cwd();
+  const targets = resolveTargets(cwd);
+  const { source } = resolveBaseSystemPrompt(cwd);
+  const loaded = loadAfkMd(cwd);
+  const totalTokens = currentOverlayTokens(cwd);
   const totalBytes = loaded ? Buffer.byteLength(loaded.content, 'utf8') : 0;
 
   ctx.out.line(palette.heading('AFK.md prompt overlay'));
@@ -95,8 +96,9 @@ function renderOverview(ctx: SlashContext): void {
 }
 
 function renderShow(ctx: SlashContext): void {
-  const { source } = resolveBaseSystemPrompt();
-  const loaded = loadAfkMd();
+  const cwd = ctx.stats.cwd ?? process.cwd();
+  const { source } = resolveBaseSystemPrompt(cwd);
+  const loaded = loadAfkMd(cwd);
   if (!loaded) {
     ctx.out.info('No AFK.md overlay is active — nothing to show.');
     ctx.out.line(palette.dim(`  ${source}`));
@@ -132,9 +134,13 @@ export const afkMdCmd: SlashCommand = {
     }
 
     if (word === 'reload') {
-      const baseline = currentOverlayTokens();
-      const { applied, tokens, delta, source } = applyReload(ctx, baseline);
-      if (applied) {
+      const baseline = currentOverlayTokens(ctx.stats.cwd);
+      const { applied, tokens, delta, source, shadowed } = applyReload(ctx, baseline);
+      if (shadowed) {
+        ctx.out.warn(
+          'AFK.md is shadowed by a higher-priority system prompt override; the file is not part of what the model receives.',
+        );
+      } else if (applied) {
         ctx.out.success(
           `Re-read from disk — overlay now ${formatTokens(tokens)} tokens (${formatDelta(delta)}). Takes effect on your next message.`,
         );
@@ -156,13 +162,13 @@ export const afkMdCmd: SlashCommand = {
         ctx.out.error('Nothing to add. Usage: /afk-md add <text> [--user]');
         return 'continue';
       }
-      appendToTarget(ctx, targetFor(toUser ? 'user' : 'project'), text);
+      appendToTarget(ctx, targetFor(toUser ? 'user' : 'project', ctx.stats.cwd), text);
       return 'continue';
     }
 
     const scope = scopeFromWord(word);
     if (scope) {
-      await editTarget(ctx, targetFor(scope));
+      await editTarget(ctx, targetFor(scope, ctx.stats.cwd));
       return 'continue';
     }
 

--- a/src/cli/slash/commands/afk-md/edit.ts
+++ b/src/cli/slash/commands/afk-md/edit.ts
@@ -1,0 +1,172 @@
+/**
+ * Edit + append flows for `/afk-md`: create-if-absent with a seeded scaffold,
+ * hand the terminal to $EDITOR, then diff and hot-reload.
+ *
+ * @module cli/slash/commands/afk-md/edit
+ */
+
+import { mkdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { computeLineDiff, type DiffPayload } from '../../../../utils/diff.js';
+import { palette } from '../../../palette.js';
+import { spawnEditorOnPath } from '../editor-spawn.js';
+import type { SlashContext } from '../../types.js';
+import { applyReload, currentOverlayTokens, formatDelta } from './reload.js';
+import { formatTokens, type AfkMdTarget } from './targets.js';
+
+/** Max diff lines rendered before eliding — an AFK.md can be hundreds of lines. */
+const MAX_DIFF_LINES = 40;
+
+/**
+ * Seed text for a tier the operator has never created.
+ *
+ * Claude Code opens an empty buffer here; a scaffold that names the tier and its
+ * precedence is strictly more useful, and the comment survives as documentation
+ * because markdown comments are invisible to the rendered doc but ARE part of the
+ * prompt text — so it stays short.
+ */
+function scaffold(target: AfkMdTarget): string {
+  const scopeNote =
+    target.scope === 'user'
+      ? 'Applies to every project on this machine. Loaded first.'
+      : 'Applies to this project only. Loaded last, so it wins on conflict.';
+  return [
+    `# ${target.scope === 'user' ? 'Personal' : 'Project'} AFK configuration`,
+    '',
+    `<!-- ${scopeNote}`,
+    '     This file is appended to the system prompt under "# Operator configuration".',
+    '     Edit it with /afk-md; changes hot-reload into the running session. -->',
+    '',
+    '',
+  ].join('\n');
+}
+
+/** Create the file (and the user-scope parent dir) when absent. Returns true if created. */
+function ensureExists(target: AfkMdTarget): boolean {
+  if (existsSync(target.path)) return false;
+  mkdirSync(dirname(target.path), { recursive: true });
+  writeFileSync(target.path, scaffold(target), 'utf-8');
+  return true;
+}
+
+function readOrEmpty(path: string): string {
+  try {
+    return readFileSync(path, 'utf-8');
+  } catch {
+    return '';
+  }
+}
+
+/** Render a unified diff in the house style, capped and elided. */
+function renderDiff(ctx: SlashContext, diff: DiffPayload): void {
+  ctx.out.line(
+    `  ${palette.success(`+${diff.addedLines}`)} ${palette.error(`-${diff.removedLines}`)}`,
+  );
+  let printed = 0;
+  for (const hunk of diff.hunks) {
+    if (printed >= MAX_DIFF_LINES) break;
+    ctx.out.line(palette.dim(`  @@ -${hunk.oldStart},${hunk.oldLines} +${hunk.newStart},${hunk.newLines} @@`));
+    for (const line of hunk.lines) {
+      if (printed >= MAX_DIFF_LINES) break;
+      const text = `  ${line.kind}${line.text}`;
+      if (line.kind === '+') ctx.out.line(palette.success(text));
+      else if (line.kind === '-') ctx.out.line(palette.error(text));
+      else ctx.out.line(palette.dim(text));
+      printed++;
+    }
+  }
+  const total = diff.hunks.reduce((n, h) => n + h.lines.length, 0);
+  if (total > printed) {
+    ctx.out.line(palette.dim(`  … ${total - printed} more diff lines (see the file for the rest)`));
+  }
+}
+
+/**
+ * Report the result of a reload. Kept here so `edit` and `add` phrase the
+ * outcome identically.
+ *
+ * Contract (no optimistic rendering): this is called only AFTER `applyReload`
+ * has returned, and it branches on the real `applied` flag — a provider without
+ * live-swap support is told the truth rather than shown a success line.
+ */
+function reportReload(ctx: SlashContext, baseline: number): void {
+  const { applied, tokens, delta, source } = applyReload(ctx, baseline);
+  if (applied) {
+    ctx.out.success(
+      `Reloaded into this session — overlay now ${formatTokens(tokens)} tokens (${formatDelta(delta)}). Takes effect on your next message.`,
+    );
+  } else {
+    ctx.out.warn(
+      'Saved to disk, but this provider cannot swap the prompt of a running session — it applies on next launch.',
+    );
+  }
+  ctx.out.line(palette.dim(`  ${source}`));
+}
+
+/**
+ * Open a tier in $EDITOR, then diff + hot-reload on a clean exit.
+ *
+ * Ordering constraint: the pre-edit snapshot must be taken BEFORE the spawn (the
+ * editor writes in place, so there is no other chance to capture it), and the
+ * cache bust must happen AFTER the editor exits — see the Invariant in reload.ts.
+ */
+export async function editTarget(ctx: SlashContext, target: AfkMdTarget): Promise<void> {
+  const created = ensureExists(target);
+  if (created) ctx.out.info(`Created ${target.path}`);
+
+  const before = readOrEmpty(target.path);
+  const baseline = currentOverlayTokens();
+
+  const { outcome, exitCode } = await spawnEditorOnPath({
+    compositor: ctx.getCompositor?.() ?? null,
+    filePath: target.path,
+    notify: (kind, message) => {
+      if (kind === 'error') ctx.out.error(message);
+      else if (kind === 'warn') ctx.out.warn(message);
+      else ctx.out.info(message);
+    },
+  });
+
+  if (outcome === 'no-tty' || outcome === 'no-editor') {
+    ctx.out.line(palette.dim(`  Edit it directly: ${target.path}`));
+    return;
+  }
+  if (outcome === 'spawn-failed') {
+    ctx.out.warn('Could not launch your editor — the file is unchanged.');
+    return;
+  }
+  if (outcome === 'nonzero') {
+    ctx.out.warn(`Editor exited with status ${exitCode} — treating that as "discard", nothing reloaded.`);
+    return;
+  }
+
+  const after = readOrEmpty(target.path);
+  const diff = computeLineDiff(before, after);
+  if (!diff) {
+    ctx.out.info('No changes.');
+    return;
+  }
+
+  renderDiff(ctx, diff);
+  if (after.trim().length === 0) {
+    ctx.out.warn('This file is now empty — the tier is treated as ABSENT and contributes nothing.');
+  }
+  reportReload(ctx, baseline);
+}
+
+/** Append a bullet to a tier without opening an editor, then hot-reload. */
+export function appendToTarget(ctx: SlashContext, target: AfkMdTarget, text: string): void {
+  const created = ensureExists(target);
+  const baseline = currentOverlayTokens();
+
+  const existing = readOrEmpty(target.path);
+  // Guarantee the bullet starts on its own line without stacking blank lines on
+  // repeated appends.
+  const separator = existing.length === 0 || existing.endsWith('\n') ? '' : '\n';
+  writeFileSync(target.path, `${existing}${separator}- ${text}\n`, 'utf-8');
+
+  if (created) ctx.out.info(`Created ${target.path}`);
+  ctx.out.success(`Appended to ${target.path}`);
+  ctx.out.line(`  ${palette.success('+')} - ${text}`);
+  reportReload(ctx, baseline);
+}

--- a/src/cli/slash/commands/afk-md/edit.ts
+++ b/src/cli/slash/commands/afk-md/edit.ts
@@ -90,8 +90,12 @@ function renderDiff(ctx: SlashContext, diff: DiffPayload): void {
  * live-swap support is told the truth rather than shown a success line.
  */
 function reportReload(ctx: SlashContext, baseline: number): void {
-  const { applied, tokens, delta, source } = applyReload(ctx, baseline);
-  if (applied) {
+  const { applied, tokens, delta, source, shadowed } = applyReload(ctx, baseline);
+  if (shadowed) {
+    ctx.out.warn(
+      'Saved to disk, but AFK.md is shadowed by a higher-priority system prompt override and is not part of what the model receives.',
+    );
+  } else if (applied) {
     ctx.out.success(
       `Reloaded into this session — overlay now ${formatTokens(tokens)} tokens (${formatDelta(delta)}). Takes effect on your next message.`,
     );
@@ -115,7 +119,7 @@ export async function editTarget(ctx: SlashContext, target: AfkMdTarget): Promis
   if (created) ctx.out.info(`Created ${target.path}`);
 
   const before = readOrEmpty(target.path);
-  const baseline = currentOverlayTokens();
+  const baseline = currentOverlayTokens(ctx.stats.cwd);
 
   const { outcome, exitCode } = await spawnEditorOnPath({
     compositor: ctx.getCompositor?.() ?? null,
@@ -157,7 +161,7 @@ export async function editTarget(ctx: SlashContext, target: AfkMdTarget): Promis
 /** Append a bullet to a tier without opening an editor, then hot-reload. */
 export function appendToTarget(ctx: SlashContext, target: AfkMdTarget, text: string): void {
   const created = ensureExists(target);
-  const baseline = currentOverlayTokens();
+  const baseline = currentOverlayTokens(ctx.stats.cwd);
 
   const existing = readOrEmpty(target.path);
   // Guarantee the bullet starts on its own line without stacking blank lines on

--- a/src/cli/slash/commands/afk-md/reload.ts
+++ b/src/cli/slash/commands/afk-md/reload.ts
@@ -1,0 +1,88 @@
+/**
+ * Hot-reload engine for `/afk-md` — re-read AFK.md from disk and push the
+ * recomposed system prompt into the RUNNING session.
+ *
+ * This is the capability Claude Code's `/memory` does not have: there, an edited
+ * CLAUDE.md only applies to sessions started afterwards. Shared by the `edit`,
+ * `add`, and `reload` subcommands so all three apply changes identically.
+ *
+ * @module cli/slash/commands/afk-md/reload
+ */
+
+import { loadAfkMd } from '../../../config/afk-md-tier.js';
+import { resetAfkMdCache } from '../../../config/afk-md-tier.js';
+import { _resetConfigCache } from '../../../config.js';
+import { resolveBaseSystemPrompt } from '../../../shared-helpers.js';
+import { estimateTokens } from '../../../../agent/memory/index.js';
+import type { SlashContext } from '../../types.js';
+
+export interface ReloadOutcome {
+  /** True when the live session's prompt was actually swapped. */
+  applied: boolean;
+  /** Estimated tokens of the overlay now in effect. */
+  tokens: number;
+  /** Signed token delta vs. the overlay measured before the change. */
+  delta: number;
+  /** Provenance string, e.g. `framework+afk-md:/a/AFK.md+afk-md:/b/AFK.md`. */
+  source: string;
+}
+
+/**
+ * Estimated tokens of the currently-cached overlay. Call BEFORE mutating the
+ * file to capture the baseline for a delta.
+ */
+export function currentOverlayTokens(): number {
+  const loaded = loadAfkMd();
+  return loaded ? estimateTokens(loaded.content) : 0;
+}
+
+/**
+ * Re-read AFK.md and apply the recomposed prompt to the live session.
+ *
+ * Invariant (ordering is externally governed by the config-cache contract, and
+ * every step below depends on the previous one having already run):
+ *
+ *   1. BUST the cache. `loadAfkMd()` memoizes into a module-scope `afkMdCache`
+ *      that lives for the whole process, and nothing at runtime invalidates it —
+ *      it was previously reset only by tests. Skipping this step makes every
+ *      later read return the PRE-EDIT text, so the command would cheerfully
+ *      report a successful reload while applying nothing.
+ *   2. RE-DERIVE through `resolveBaseSystemPrompt()`, never by hand. That helper
+ *      returns the FULL composed prompt: the framework doctrine
+ *      (`prompts/system-prompt.md`) plus the operator overlay under the
+ *      `# Operator configuration` header. Passing the bare `loadAfkMd().content`
+ *      instead would replace the entire system prompt with just the AFK.md text
+ *      and silently delete the framework doctrine from the running session.
+ *   3. APPLY, and only then report. `setSystemPrompt` returns whether the live
+ *      swap actually happened; the caller must not print a success line before
+ *      this call returns, and must not claim a reload when it returns false.
+ *
+ * `resetAfkMdCache()` is the narrowest correct bust: only the AFK.md tier can
+ * have changed on disk, and the env/json tiers are strictly higher priority — if
+ * either of them supplies `systemPrompt`, the AFK.md tier is not consulted at
+ * all and this whole path is inert anyway. `_resetConfigCache()` is called as
+ * well because `loadConfig()` memoizes the COMPOSED result separately, and
+ * `resolveBaseSystemPrompt()` reads through it — busting only the leaf would
+ * leave the composed layer stale.
+ */
+export function applyReload(ctx: SlashContext, baselineTokens: number): ReloadOutcome {
+  // Step 1 — bust before any read.
+  resetAfkMdCache();
+  _resetConfigCache();
+
+  // Step 2 — re-derive the FULL composed prompt (framework + overlay).
+  const { prompt, source } = resolveBaseSystemPrompt();
+  const loaded = loadAfkMd();
+  const tokens = loaded ? estimateTokens(loaded.content) : 0;
+
+  // Step 3 — apply, then report what actually happened.
+  const applied = ctx.session.current.setSystemPrompt(prompt);
+
+  return { applied, tokens, delta: tokens - baselineTokens, source };
+}
+
+/** Format the signed delta for display: `+180`, `-42`, or `no size change`. */
+export function formatDelta(delta: number): string {
+  if (delta === 0) return 'no size change';
+  return delta > 0 ? `+${delta}` : `${delta}`;
+}

--- a/src/cli/slash/commands/afk-md/reload.ts
+++ b/src/cli/slash/commands/afk-md/reload.ts
@@ -12,7 +12,9 @@
 import { loadAfkMd } from '../../../config/afk-md-tier.js';
 import { resetAfkMdCache } from '../../../config/afk-md-tier.js';
 import { _resetConfigCache } from '../../../config.js';
+import { loadConfig } from '../../../config.js';
 import { resolveBaseSystemPrompt } from '../../../shared-helpers.js';
+import { assembleSystemPrompt } from '../../../../agent/routing-directive.js';
 import { estimateTokens } from '../../../../agent/memory/index.js';
 import type { SlashContext } from '../../types.js';
 
@@ -25,14 +27,16 @@ export interface ReloadOutcome {
   delta: number;
   /** Provenance string, e.g. `framework+afk-md:/a/AFK.md+afk-md:/b/AFK.md`. */
   source: string;
+  /** True when an env or JSON prompt override prevents AFK.md from contributing. */
+  shadowed: boolean;
 }
 
 /**
  * Estimated tokens of the currently-cached overlay. Call BEFORE mutating the
  * file to capture the baseline for a delta.
  */
-export function currentOverlayTokens(): number {
-  const loaded = loadAfkMd();
+export function currentOverlayTokens(cwd?: string): number {
+  const loaded = loadAfkMd(cwd);
   return loaded ? estimateTokens(loaded.content) : 0;
 }
 
@@ -71,14 +75,22 @@ export function applyReload(ctx: SlashContext, baselineTokens: number): ReloadOu
   _resetConfigCache();
 
   // Step 2 — re-derive the FULL composed prompt (framework + overlay).
-  const { prompt, source } = resolveBaseSystemPrompt();
-  const loaded = loadAfkMd();
+  const cwd = ctx.stats.cwd ?? process.cwd();
+  const { prompt: basePrompt, source } = resolveBaseSystemPrompt(cwd);
+  const config = loadConfig(undefined, cwd);
+  const shadowed = source.includes('env:AFK_SYSTEM_PROMPT') || source.includes('file:');
+  const loaded = shadowed ? null : loadAfkMd(cwd);
   const tokens = loaded ? estimateTokens(loaded.content) : 0;
+  const prompt = assembleSystemPrompt(
+    basePrompt,
+    config.autoRouting?.interactive ?? true,
+    'repl',
+  );
 
   // Step 3 — apply, then report what actually happened.
   const applied = ctx.session.current.setSystemPrompt(prompt);
 
-  return { applied, tokens, delta: tokens - baselineTokens, source };
+  return { applied, tokens, delta: tokens - baselineTokens, source, shadowed };
 }
 
 /** Format the signed delta for display: `+180`, `-42`, or `no size change`. */

--- a/src/cli/slash/commands/afk-md/targets.test.ts
+++ b/src/cli/slash/commands/afk-md/targets.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tier-inspection tests for `/afk-md`.
+ *
+ * Strategy: real temp files, with `src/paths.ts` mocked so the two AFK.md
+ * locations point into the fixture. Never touches the operator's real
+ * `$AFK_HOME/AFK.md`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let tmpRoot = '';
+const userDir = (): string => join(tmpRoot, 'home');
+const projectDir = (): string => join(tmpRoot, 'repo');
+
+vi.mock('../../../../paths.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../paths.js')>();
+  return {
+    ...actual,
+    getUserAfkMdPath: (): string => join(userDir(), 'AFK.md'),
+    getProjectAfkMdPath: (): string => join(projectDir(), 'AFK.md'),
+  };
+});
+
+const { contributes, resolveTargets, renderTargetRows, formatTokens } = await import('./targets.js');
+
+/** Strip ANSI so assertions do not depend on colour support. */
+function plain(s: string): string {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/\u001B\[[0-9;]*m/g, '');
+}
+
+beforeEach(() => {
+  tmpRoot = join(tmpdir(), `afk-md-targets-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(userDir(), { recursive: true });
+  mkdirSync(projectDir(), { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('resolveTargets', () => {
+  it('reports both tiers missing when neither file exists', () => {
+    const [user, project] = resolveTargets();
+    expect(user?.exists).toBe(false);
+    expect(project?.exists).toBe(false);
+    expect(resolveTargets().filter(contributes)).toHaveLength(0);
+  });
+
+  it('returns user-scope first, matching loader concatenation order', () => {
+    const targets = resolveTargets();
+    expect(targets.map((t) => t.scope)).toEqual(['user', 'project']);
+    expect(targets.map((t) => t.label)).toEqual(['personal', 'project']);
+  });
+
+  it('counts only the user tier when only it exists', () => {
+    writeFileSync(join(userDir(), 'AFK.md'), '- be terse\n', 'utf-8');
+    const active = resolveTargets().filter(contributes);
+    expect(active).toHaveLength(1);
+    expect(active[0]?.scope).toBe('user');
+    expect(active[0]?.tokens).toBeGreaterThan(0);
+  });
+
+  it('counts only the project tier when only it exists', () => {
+    writeFileSync(join(projectDir(), 'AFK.md'), '- use pnpm\n', 'utf-8');
+    const active = resolveTargets().filter(contributes);
+    expect(active).toHaveLength(1);
+    expect(active[0]?.scope).toBe('project');
+  });
+
+  it('counts both tiers when both are present and distinct', () => {
+    writeFileSync(join(userDir(), 'AFK.md'), '- be terse\n', 'utf-8');
+    writeFileSync(join(projectDir(), 'AFK.md'), '- use pnpm\n', 'utf-8');
+    expect(resolveTargets().filter(contributes)).toHaveLength(2);
+  });
+
+  it('treats a whitespace-only file as absent, matching the loader', () => {
+    writeFileSync(join(projectDir(), 'AFK.md'), '   \n\n\t\n', 'utf-8');
+    const project = resolveTargets().find((t) => t.scope === 'project');
+    expect(project?.exists).toBe(true);
+    expect(project?.blank).toBe(true);
+    expect(contributes(project!)).toBe(false);
+  });
+
+  it('de-duplicates a symlinked project tier instead of double-counting', () => {
+    writeFileSync(join(userDir(), 'AFK.md'), '- shared\n', 'utf-8');
+    symlinkSync(join(userDir(), 'AFK.md'), join(projectDir(), 'AFK.md'));
+    const targets = resolveTargets();
+    const project = targets.find((t) => t.scope === 'project');
+    expect(project?.duplicate).toBe(true);
+    expect(targets.filter(contributes)).toHaveLength(1);
+  });
+});
+
+describe('renderTargetRows', () => {
+  it('marks the project tier as the conflict winner when it contributes', () => {
+    writeFileSync(join(userDir(), 'AFK.md'), '- a\n', 'utf-8');
+    writeFileSync(join(projectDir(), 'AFK.md'), '- b\n', 'utf-8');
+    const out = plain(renderTargetRows(resolveTargets()).join('\n'));
+    expect(out).toContain('wins on conflict');
+    expect(out).toContain('loaded');
+  });
+
+  it('surfaces the empty-file footgun in the status column', () => {
+    writeFileSync(join(userDir(), 'AFK.md'), '\n\n', 'utf-8');
+    expect(plain(renderTargetRows(resolveTargets()).join('\n'))).toContain('treated as absent');
+  });
+
+  it('names the dedup rather than reporting the tier twice', () => {
+    writeFileSync(join(userDir(), 'AFK.md'), '- shared\n', 'utf-8');
+    symlinkSync(join(userDir(), 'AFK.md'), join(projectDir(), 'AFK.md'));
+    expect(plain(renderTargetRows(resolveTargets()).join('\n'))).toContain('counted once');
+  });
+});
+
+describe('formatTokens', () => {
+  it('renders sub-1k counts exactly and larger counts in k', () => {
+    expect(formatTokens(940)).toBe('~940');
+    expect(formatTokens(2432)).toBe('~2.4k');
+  });
+});

--- a/src/cli/slash/commands/afk-md/targets.ts
+++ b/src/cli/slash/commands/afk-md/targets.ts
@@ -1,0 +1,139 @@
+/**
+ * Tier resolution + overview rendering for `/afk-md`.
+ *
+ * Mirrors the discovery rules in `cli/config/afk-md-tier.ts` (the loader) so the
+ * overview reports exactly what the model will actually receive — including the
+ * two states that silently surprise operators: a tier that exists but is
+ * whitespace-only (the loader treats it as ABSENT) and two tiers that resolve to
+ * the same file (the loader de-duplicates rather than double-counting).
+ *
+ * @module cli/slash/commands/afk-md/targets
+ */
+
+import { existsSync, readFileSync, realpathSync, statSync } from 'node:fs';
+import { estimateTokens } from '../../../../agent/memory/index.js';
+import { getProjectAfkMdPath, getUserAfkMdPath } from '../../../../paths.js';
+import { palette } from '../../../palette.js';
+
+/** Which AFK.md tier a subcommand is aimed at. */
+export type AfkMdScope = 'user' | 'project';
+
+export interface AfkMdTarget {
+  scope: AfkMdScope;
+  /** `personal` / `project` — the label used in user-facing output. */
+  label: string;
+  path: string;
+  exists: boolean;
+  /** File size in bytes; 0 when absent. */
+  bytes: number;
+  /** Estimated tokens of the file's trimmed content; 0 when absent or blank. */
+  tokens: number;
+  /** True when the file exists but trims to nothing — the loader skips it. */
+  blank: boolean;
+  /**
+   * True when this tier resolves to the same file as the other one and the
+   * loader therefore ignores it as a duplicate. Only ever set on `project`,
+   * matching the loader's dedup direction.
+   */
+  duplicate: boolean;
+}
+
+/** Warn above this estimated token count for the composed overlay. */
+export const OVERLAY_TOKEN_WARN_THRESHOLD = 10_000;
+
+function isSameFile(a: string, b: string): boolean {
+  if (a === b) return true;
+  if (!existsSync(a) || !existsSync(b)) return false;
+  try {
+    return realpathSync(a) === realpathSync(b);
+  } catch {
+    return false;
+  }
+}
+
+function inspect(scope: AfkMdScope, path: string, duplicate: boolean): AfkMdTarget {
+  const label = scope === 'user' ? 'personal' : 'project';
+  if (!existsSync(path)) {
+    return { scope, label, path, exists: false, bytes: 0, tokens: 0, blank: false, duplicate };
+  }
+  let bytes = 0;
+  let trimmed = '';
+  try {
+    bytes = statSync(path).size;
+    trimmed = readFileSync(path, 'utf-8').trim();
+  } catch {
+    // Unreadable is indistinguishable from absent as far as the loader is
+    // concerned (readAfkMdCandidate swallows the same error), so report it as a
+    // present-but-blank tier rather than crashing the command.
+    return { scope, label, path, exists: true, bytes, tokens: 0, blank: true, duplicate };
+  }
+  return {
+    scope,
+    label,
+    path,
+    exists: true,
+    bytes,
+    tokens: trimmed.length > 0 ? estimateTokens(trimmed) : 0,
+    blank: trimmed.length === 0,
+    duplicate,
+  };
+}
+
+/** Resolve both tiers, in loader order (user-scope first). */
+export function resolveTargets(cwd: string = process.cwd()): AfkMdTarget[] {
+  const userPath = getUserAfkMdPath();
+  const projectPath = getProjectAfkMdPath(cwd);
+  return [
+    inspect('user', userPath, false),
+    inspect('project', projectPath, isSameFile(projectPath, userPath)),
+  ];
+}
+
+/** Pick one tier by scope. */
+export function targetFor(scope: AfkMdScope, cwd?: string): AfkMdTarget {
+  const found = resolveTargets(cwd).find((t) => t.scope === scope);
+  // resolveTargets always returns both scopes, so this is unreachable; the
+  // throw exists to satisfy noUncheckedIndexedAccess without a non-null assert.
+  if (!found) throw new Error(`unknown AFK.md scope: ${scope}`);
+  return found;
+}
+
+/** True when this tier actually contributes text to the composed overlay. */
+export function contributes(t: AfkMdTarget): boolean {
+  return t.exists && !t.blank && !t.duplicate;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  return `${(bytes / 1024).toFixed(1)} KB`;
+}
+
+/** Compact token rendering: 940 → `~940`, 2432 → `~2.4k`. */
+export function formatTokens(tokens: number): string {
+  return tokens < 1000 ? `~${tokens}` : `~${(tokens / 1000).toFixed(1)}k`;
+}
+
+/** One status word per tier, describing what the loader does with it. */
+function statusOf(t: AfkMdTarget): string {
+  if (!t.exists) return palette.dim('missing');
+  if (t.blank) return palette.warning('empty — treated as absent');
+  if (t.duplicate) return palette.warning('same file as personal — counted once');
+  return palette.success('loaded');
+}
+
+/**
+ * Render the per-tier table rows. Returns display lines; the caller owns the
+ * surrounding headings so this stays reusable by both the overview and the
+ * post-reload summary.
+ */
+export function renderTargetRows(targets: AfkMdTarget[]): string[] {
+  const lines: string[] = [];
+  for (const t of targets) {
+    const size = contributes(t) ? `${formatBytes(t.bytes)}  ${formatTokens(t.tokens)} tok` : '';
+    const precedence =
+      t.scope === 'project' && contributes(t) ? palette.dim('  ← wins on conflict') : '';
+    lines.push(`  ${t.label.padEnd(9)} ${palette.dim(t.path)}`);
+    lines.push(`  ${''.padEnd(9)} ${statusOf(t)}${size ? `  ${size}` : ''}${precedence}`);
+  }
+  return lines;
+}

--- a/src/cli/slash/commands/editor-open.ts
+++ b/src/cli/slash/commands/editor-open.ts
@@ -1,35 +1,40 @@
 /**
- * Shared $EDITOR handoff — the engine behind both the `/editor` slash command
- * and the Ctrl+O key chord.
+ * Buffer-flavoured $EDITOR handoff — the engine behind both the `/editor` slash
+ * command and the Ctrl+O key chord.
  *
- * Suspends the REPL's live input surface, spawns the user's external editor on
- * a temp file seeded with the current input-box buffer, and — on a clean exit —
- * loads the edited content back into the buffer (cursor at end) WITHOUT
+ * Seeds a temp file with the current input-box buffer, hands the terminal to the
+ * user's editor via the shared primitive in `editor-spawn.ts`, and — on a clean
+ * exit — loads the edited content back into the buffer (cursor at end) WITHOUT
  * submitting. The user reviews the loaded text and presses Enter themselves.
  *
- * Extracted to its own module so the slash command and the key chord share one
- * audited copy of the fragile TTY suspend/spawn/restore dance; each caller only
- * supplies a `notify` sink and the live compositor.
+ * The fragile TTY suspend/spawn/restore dance itself lives in
+ * `editor-spawn.ts`, so this module and `/afk-md` (which edits a real
+ * persistent file) share one audited copy. This module owns only the temp-file
+ * + input-buffer semantics layered on top.
  */
 
-import { spawn } from 'node:child_process';
 import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { env } from '../../../config/env.js';
 import { InputCore } from '../../input-core.js';
 import type { TerminalCompositor } from '../../terminal-compositor.js';
+import {
+  spawnEditorOnPath,
+  resolveEditor,
+  type EditorNotifyKind,
+} from './editor-spawn.js';
 
-/** Severity of a one-line notice surfaced to the user during the handoff. */
-export type EditorNotifyKind = 'info' | 'warn' | 'error';
+// Re-exported so existing importers of this module keep working unchanged.
+export { resolveEditor };
+export type { EditorNotifyKind };
 
 /** Dependencies the handoff needs — injected so both callers and tests can vary them. */
 export interface EditorHandoffDeps {
   /**
    * The REPL's persistent compositor — source of the input buffer and owner of
-   * the raw-mode stdin claim we must suspend/resume around the spawn. `null` on
-   * non-TTY surfaces (daemon, pipe, tests without a compositor); the handoff
-   * refuses politely in that case.
+   * the raw-mode stdin claim the primitive suspends/resumes around the spawn.
+   * `null` on non-TTY surfaces (daemon, pipe, tests without a compositor); the
+   * handoff refuses politely in that case.
    */
   compositor: TerminalCompositor | null;
   /** One-line notice sink. Slash command → `ctx.out`; chord → a `commitAbove` writer. */
@@ -45,69 +50,30 @@ export type EditorHandoffResult =
   | 'spawn-failed'; // spawn threw synchronously → original buffer preserved
 
 /**
- * Resolve the external editor command from the environment.
- *
- * Contract (resolution order): VISUAL first, then EDITOR — the standard POSIX
- * precedence (VISUAL names a full-screen editor; EDITOR is the line-editor
- * fallback, but modern setups point both at the same full-screen program). We
- * treat an EMPTY string as unset: the `env` getters return `''` for
- * `VISUAL=""`, and an empty command would spawn nothing useful, so the trim +
- * truthiness guard collapses both `unset` and `empty` to "not configured".
- *
- * Deliberately NO hardcoded `vi` fallback: guessing an editor the user did not
- * choose is worse than a one-line hint telling them to set VISUAL/EDITOR.
- * Returns null when neither is configured. The command string is split on
- * whitespace so `EDITOR="code --wait"` resolves to cmd=`code`, args=`--wait`.
- */
-export function resolveEditor(): { cmd: string; args: string[] } | null {
-  const raw = env.VISUAL?.trim() || env.EDITOR?.trim() || '';
-  if (!raw) return null;
-  const parts = raw.split(/\s+/);
-  return { cmd: parts[0]!, args: parts.slice(1) };
-}
-
-/**
  * Open the resolved editor on the current input buffer, then load the result
  * back into the buffer on a clean exit.
- *
- * Invariant (TTY handoff ordering — mirrors /transcript's pager handoff): the
- * editor inherits stdin (`stdio: 'inherit'`), so it reads the SAME fd 0 the
- * REPL owns. Before spawning we MUST (1) `suspendInput()` — drop the
- * compositor's keypress listener, unset raw mode, clear the input overlay — AND
- * (2) pause Node's stdin so the parent stops draining fd 0. Otherwise the REPL
- * reader and the editor both read() the shared fd and split every keystroke.
- * The inverse runs on child exit: resume stdin, then `resumeInput()` to re-arm
- * raw mode + the listener + repaint.
- *
- * Invariant (restore is unconditional): raw mode + the input claim are restored
- * in a `finally` even if `spawn` throws or the editor exits nonzero — a
- * half-suspended REPL is unrecoverable, so restoration must never be skipped.
- * The temp directory is likewise always removed.
  *
  * Contract (buffer preservation): a clean exit (code 0) REPLACES the buffer
  * with the edited file content (single trailing newline stripped, cursor at
  * end). A nonzero exit, a spawn error, or a synchronous spawn throw PRESERVES
  * the original buffer untouched and prints a notice. Never auto-submits — the
  * loaded text lands in the input box for the user to review and Enter.
+ *
+ * Contract (temp-dir lifetime): the temp directory is always removed in a
+ * `finally`, including on the refusal paths that never spawn.
  */
 export async function openEditorForBuffer(deps: EditorHandoffDeps): Promise<EditorHandoffResult> {
   const { compositor, notify } = deps;
 
-  // Non-TTY (daemon, pipe, tests without a compositor): there is no input box to
-  // seed or repaint and no terminal to hand to a full-screen editor. Refuse in
-  // one line, exactly like /transcript degrades on a non-TTY surface.
-  if (!compositor || !process.stdout.isTTY) {
-    notify('info', 'The editor handoff needs an interactive terminal — not available on this surface.');
-    return 'no-tty';
-  }
-
-  const editor = resolveEditor();
-  if (!editor) {
-    notify(
-      'error',
-      'No editor configured. Set $VISUAL or $EDITOR (e.g. `export EDITOR=vim`) to compose prompts externally.',
-    );
-    return 'no-editor';
+  // Contract (refusal before side effects): both refusal paths must return
+  // WITHOUT creating a temp dir, so the two preconditions are probed here before
+  // any filesystem work. The probe delegates to the primitive rather than
+  // duplicating the checks, because the primitive owns the single audited copy
+  // of each user-facing notice. `filePath` is inert on these paths — both checks
+  // short-circuit ahead of the spawn — so an empty string is never opened.
+  if (!compositor || !process.stdout.isTTY || !resolveEditor()) {
+    const { outcome } = await spawnEditorOnPath({ compositor, filePath: '', notify });
+    return outcome === 'no-editor' ? 'no-editor' : 'no-tty';
   }
 
   // Snapshot the composing buffer as submission-shaped text (paste placeholders
@@ -120,40 +86,18 @@ export async function openEditorForBuffer(deps: EditorHandoffDeps): Promise<Edit
   const filePath = path.join(dir, 'prompt.md');
   await fs.writeFile(filePath, original, { mode: 0o600 });
 
-  let restored = false;
-  const restoreInput = (): void => {
-    if (restored) return;
-    restored = true;
-    try { process.stdin.resume(); } catch { /* best-effort */ }
-    compositor.resumeInput();
-  };
-
-  compositor.suspendInput();
-  try { process.stdin.pause(); } catch { /* best-effort */ }
-
   try {
-    const code = await new Promise<number | null>((resolve) => {
-      let child: ReturnType<typeof spawn>;
-      try {
-        child = spawn(editor.cmd, [...editor.args, filePath], { stdio: 'inherit' });
-      } catch {
-        // Synchronous spawn failure (bad options / unusual platform error).
-        // Resolve with a sentinel the caller below maps to spawn-failed. The
-        // finally still restores the TTY and removes the temp dir.
-        resolve(Number.NaN);
-        return;
-      }
-      child.on('error', () => resolve(Number.NaN));
-      child.on('exit', (exitCode) => resolve(exitCode));
-    });
+    const { outcome, exitCode } = await spawnEditorOnPath({ compositor, filePath, notify });
 
-    if (Number.isNaN(code)) {
-      notify('warn', `Could not launch editor \`${editor.cmd}\` — keeping your current prompt.`);
+    if (outcome === 'spawn-failed') {
+      const editor = resolveEditor();
+      notify('warn', `Could not launch editor \`${editor?.cmd ?? 'editor'}\` — keeping your current prompt.`);
       return 'spawn-failed';
     }
-
-    if (code !== 0) {
-      notify('warn', `Editor exited with status ${code} — keeping your current prompt.`);
+    if (outcome !== 'clean') {
+      // Only `nonzero` remains reachable here — the guard above consumed
+      // no-tty/no-editor and `spawn-failed` returned already.
+      notify('warn', `Editor exited with status ${exitCode} — keeping your current prompt.`);
       return 'kept';
     }
 
@@ -170,7 +114,6 @@ export async function openEditorForBuffer(deps: EditorHandoffDeps): Promise<Edit
     compositor.applyEdit(InputCore.seed(normalized));
     return 'loaded';
   } finally {
-    restoreInput();
     fs.rm(dir, { recursive: true, force: true }).catch(() => {});
   }
 }

--- a/src/cli/slash/commands/editor-spawn.test.ts
+++ b/src/cli/slash/commands/editor-spawn.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Tests for the shared $EDITOR TTY handoff primitive.
+ *
+ * `editor.test.ts` covers the buffer-flavoured wrapper end-to-end; this file
+ * pins the primitive's own contract, which two callers now depend on:
+ *   (a) refusal paths (no compositor, no $VISUAL/$EDITOR) never spawn
+ *   (b) exit 0 → `clean`; nonzero → `nonzero`; sync throw / 'error' → `spawn-failed`
+ *   (c) the editor is spawned on the REAL path given, with `stdio: 'inherit'`
+ *   (d) the restore-always invariant: every path that suspends resumes, even
+ *       when spawn throws — a half-suspended REPL is unrecoverable
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+
+vi.mock('node:child_process', () => ({ spawn: vi.fn() }));
+
+import { spawn } from 'node:child_process';
+import { spawnEditorOnPath, resolveEditor } from './editor-spawn.js';
+
+const mockSpawn = vi.mocked(spawn);
+
+function makeCompositor(): {
+  suspendInput: ReturnType<typeof vi.fn>;
+  resumeInput: ReturnType<typeof vi.fn>;
+} {
+  return { suspendInput: vi.fn(), resumeInput: vi.fn() };
+}
+
+interface Notice { kind: string; message: string }
+
+function collector(): { notices: Notice[]; notify: (kind: string, message: string) => void } {
+  const notices: Notice[] = [];
+  return { notices, notify: (kind, message) => { notices.push({ kind, message }); } };
+}
+
+/** Resolve after the mocked spawn has been called, flushing microtasks. */
+async function flushUntilSpawn(): Promise<void> {
+  for (let i = 0; i < 200 && mockSpawn.mock.calls.length === 0; i++) {
+    await new Promise((r) => setTimeout(r, 1));
+  }
+}
+
+describe('spawnEditorOnPath', () => {
+  let origIsTTY: boolean | undefined;
+  let origVisual: string | undefined;
+  let origEditor: string | undefined;
+  let pauseSpy: ReturnType<typeof vi.spyOn>;
+  let resumeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    origIsTTY = process.stdout.isTTY;
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+    origVisual = process.env['VISUAL'];
+    origEditor = process.env['EDITOR'];
+    delete process.env['VISUAL'];
+    process.env['EDITOR'] = 'vim';
+    pauseSpy = vi.spyOn(process.stdin, 'pause').mockImplementation(() => process.stdin);
+    resumeSpy = vi.spyOn(process.stdin, 'resume').mockImplementation(() => process.stdin);
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process.stdout, 'isTTY', { value: origIsTTY, configurable: true });
+    if (origVisual === undefined) delete process.env['VISUAL'];
+    else process.env['VISUAL'] = origVisual;
+    if (origEditor === undefined) delete process.env['EDITOR'];
+    else process.env['EDITOR'] = origEditor;
+    pauseSpy.mockRestore();
+    resumeSpy.mockRestore();
+  });
+
+  it('refuses without a compositor and never spawns', async () => {
+    const { notices, notify } = collector();
+    const result = await spawnEditorOnPath({ compositor: null, filePath: '/tmp/x.md', notify });
+    expect(result.outcome).toBe('no-tty');
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(notices[0]?.kind).toBe('info');
+  });
+
+  it('refuses on a non-TTY stdout and never spawns', async () => {
+    Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true });
+    const { notify } = collector();
+    const compositor = makeCompositor();
+    const result = await spawnEditorOnPath({
+      compositor: compositor as never, filePath: '/tmp/x.md', notify,
+    });
+    expect(result.outcome).toBe('no-tty');
+    expect(mockSpawn).not.toHaveBeenCalled();
+    // Never suspended, so nothing to restore.
+    expect(compositor.suspendInput).not.toHaveBeenCalled();
+  });
+
+  it('refuses with no $VISUAL/$EDITOR configured and never spawns', async () => {
+    delete process.env['EDITOR'];
+    const { notices, notify } = collector();
+    const compositor = makeCompositor();
+    const result = await spawnEditorOnPath({
+      compositor: compositor as never, filePath: '/tmp/x.md', notify,
+    });
+    expect(result.outcome).toBe('no-editor');
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(notices[0]?.kind).toBe('error');
+    expect(compositor.suspendInput).not.toHaveBeenCalled();
+  });
+
+  it('spawns the resolved editor on the given path with inherited stdio', async () => {
+    const child = new EventEmitter();
+    mockSpawn.mockReturnValue(child as never);
+    const compositor = makeCompositor();
+    const { notify } = collector();
+
+    const pending = spawnEditorOnPath({
+      compositor: compositor as never, filePath: '/tmp/real/AFK.md', notify,
+    });
+    await flushUntilSpawn();
+    child.emit('exit', 0);
+    const result = await pending;
+
+    expect(result.outcome).toBe('clean');
+    expect(mockSpawn).toHaveBeenCalledWith('vim', ['/tmp/real/AFK.md'], { stdio: 'inherit' });
+  });
+
+  it('suspends before spawning and resumes after (both halves of the fd-0 claim)', async () => {
+    const child = new EventEmitter();
+    mockSpawn.mockReturnValue(child as never);
+    const compositor = makeCompositor();
+    const { notify } = collector();
+
+    const pending = spawnEditorOnPath({
+      compositor: compositor as never, filePath: '/tmp/x.md', notify,
+    });
+    await flushUntilSpawn();
+    expect(compositor.suspendInput).toHaveBeenCalledTimes(1);
+    expect(pauseSpy).toHaveBeenCalledTimes(1);
+    expect(compositor.resumeInput).not.toHaveBeenCalled();
+
+    child.emit('exit', 0);
+    await pending;
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
+    expect(compositor.resumeInput).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps a nonzero exit to `nonzero` and carries the code', async () => {
+    const child = new EventEmitter();
+    mockSpawn.mockReturnValue(child as never);
+    const compositor = makeCompositor();
+    const { notify } = collector();
+
+    const pending = spawnEditorOnPath({
+      compositor: compositor as never, filePath: '/tmp/x.md', notify,
+    });
+    await flushUntilSpawn();
+    child.emit('exit', 1);
+    const result = await pending;
+
+    expect(result).toEqual({ outcome: 'nonzero', exitCode: 1 });
+    expect(compositor.resumeInput).toHaveBeenCalledTimes(1);
+  });
+
+  it('restores the TTY when spawn throws synchronously', async () => {
+    mockSpawn.mockImplementation(() => { throw new Error('ENOENT'); });
+    const compositor = makeCompositor();
+    const { notify } = collector();
+
+    const result = await spawnEditorOnPath({
+      compositor: compositor as never, filePath: '/tmp/x.md', notify,
+    });
+
+    expect(result.outcome).toBe('spawn-failed');
+    // The restore-always invariant: suspended, so it MUST have resumed.
+    expect(compositor.suspendInput).toHaveBeenCalledTimes(1);
+    expect(compositor.resumeInput).toHaveBeenCalledTimes(1);
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('restores the TTY when the child emits an error event', async () => {
+    const child = new EventEmitter();
+    mockSpawn.mockReturnValue(child as never);
+    const compositor = makeCompositor();
+    const { notify } = collector();
+
+    const pending = spawnEditorOnPath({
+      compositor: compositor as never, filePath: '/tmp/x.md', notify,
+    });
+    await flushUntilSpawn();
+    child.emit('error', new Error('spawn failed'));
+    const result = await pending;
+
+    expect(result.outcome).toBe('spawn-failed');
+    expect(compositor.resumeInput).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('resolveEditor', () => {
+  let origVisual: string | undefined;
+  let origEditor: string | undefined;
+
+  beforeEach(() => {
+    origVisual = process.env['VISUAL'];
+    origEditor = process.env['EDITOR'];
+  });
+
+  afterEach(() => {
+    if (origVisual === undefined) delete process.env['VISUAL'];
+    else process.env['VISUAL'] = origVisual;
+    if (origEditor === undefined) delete process.env['EDITOR'];
+    else process.env['EDITOR'] = origEditor;
+  });
+
+  it('prefers $VISUAL over $EDITOR (POSIX precedence)', () => {
+    process.env['VISUAL'] = 'nvim';
+    process.env['EDITOR'] = 'vim';
+    expect(resolveEditor()).toEqual({ cmd: 'nvim', args: [] });
+  });
+
+  it('splits arguments so EDITOR="code --wait" works', () => {
+    delete process.env['VISUAL'];
+    process.env['EDITOR'] = 'code --wait';
+    expect(resolveEditor()).toEqual({ cmd: 'code', args: ['--wait'] });
+  });
+
+  it('treats an empty value as unset and returns null', () => {
+    process.env['VISUAL'] = '';
+    process.env['EDITOR'] = '';
+    expect(resolveEditor()).toBeNull();
+  });
+});

--- a/src/cli/slash/commands/editor-spawn.ts
+++ b/src/cli/slash/commands/editor-spawn.ts
@@ -1,0 +1,148 @@
+/**
+ * The $EDITOR TTY handoff primitive — one audited copy of the fragile
+ * suspend/spawn/restore dance, shared by every caller that hands the terminal
+ * to an external editor.
+ *
+ * Extracted from `editor-open.ts` so a second caller (`/afk-md`, editing a real
+ * persistent AFK.md) can reuse the dance instead of cloning it. This module
+ * owns ONLY the terminal handoff: it does not create, read, write, or delete
+ * files, and it never touches the input buffer. Those belong to the caller —
+ * `openEditorForBuffer()` layers temp-file + buffer semantics on top,
+ * `/afk-md` layers real-file + diff semantics on top.
+ *
+ * @module cli/slash/commands/editor-spawn
+ */
+
+import { spawn } from 'node:child_process';
+import { env } from '../../../config/env.js';
+import type { TerminalCompositor } from '../../terminal-compositor.js';
+
+/** Severity of a one-line notice surfaced to the user during the handoff. */
+export type EditorNotifyKind = 'info' | 'warn' | 'error';
+
+/**
+ * Outcome of a handoff attempt.
+ *
+ * `clean` means the editor exited 0 — the conventional "saved and quit" signal.
+ * `nonzero` means it exited with a failure status, which for most editors is how
+ * "quit without saving" surfaces (`:cq` in vim); callers should treat it as
+ * "abandon my changes" and leave prior state untouched.
+ */
+export type EditorSpawnOutcome = 'no-tty' | 'no-editor' | 'clean' | 'nonzero' | 'spawn-failed';
+
+export interface EditorSpawnResult {
+  outcome: EditorSpawnOutcome;
+  /** The child's exit code when one was observed; null otherwise. */
+  exitCode: number | null;
+}
+
+export interface EditorSpawnDeps {
+  /**
+   * The REPL's persistent compositor — owner of the raw-mode stdin claim we
+   * must suspend/resume around the spawn. `null` on non-TTY surfaces (daemon,
+   * pipe, tests without a compositor); the handoff refuses politely.
+   */
+  compositor: TerminalCompositor | null;
+  /** Absolute path the editor opens. The caller guarantees it exists. */
+  filePath: string;
+  /** One-line notice sink. Slash command → `ctx.out`; chord → a `commitAbove` writer. */
+  notify: (kind: EditorNotifyKind, message: string) => void;
+}
+
+/**
+ * Resolve the external editor command from the environment.
+ *
+ * Contract (resolution order): VISUAL first, then EDITOR — the standard POSIX
+ * precedence (VISUAL names a full-screen editor; EDITOR is the line-editor
+ * fallback, but modern setups point both at the same full-screen program). We
+ * treat an EMPTY string as unset: the `env` getters return `''` for
+ * `VISUAL=""`, and an empty command would spawn nothing useful, so the trim +
+ * truthiness guard collapses both `unset` and `empty` to "not configured".
+ *
+ * Deliberately NO hardcoded `vi` fallback: guessing an editor the user did not
+ * choose is worse than a one-line hint telling them to set VISUAL/EDITOR.
+ * Returns null when neither is configured. The command string is split on
+ * whitespace so `EDITOR="code --wait"` resolves to cmd=`code`, args=`--wait`.
+ */
+export function resolveEditor(): { cmd: string; args: string[] } | null {
+  const raw = env.VISUAL?.trim() || env.EDITOR?.trim() || '';
+  if (!raw) return null;
+  const parts = raw.split(/\s+/);
+  return { cmd: parts[0]!, args: parts.slice(1) };
+}
+
+/**
+ * Hand the terminal to the user's editor, opened on `filePath`.
+ *
+ * Invariant (TTY handoff ordering — mirrors /transcript's pager handoff): the
+ * editor inherits stdin (`stdio: 'inherit'`), so it reads the SAME fd 0 the
+ * REPL owns. Before spawning we MUST (1) `suspendInput()` — drop the
+ * compositor's keypress listener, unset raw mode, clear the input overlay — AND
+ * (2) pause Node's stdin so the parent stops draining fd 0. Otherwise the REPL
+ * reader and the editor both read() the shared fd and split every keystroke.
+ * The inverse runs on child exit: resume stdin, then `resumeInput()` to re-arm
+ * raw mode + the listener + repaint.
+ *
+ * Invariant (restore is unconditional): raw mode + the input claim are restored
+ * in a `finally` even if `spawn` throws or the editor exits nonzero — a
+ * half-suspended REPL is unrecoverable, so restoration must never be skipped.
+ *
+ * Contract (write visibility): this resolves only after the child process has
+ * exited, so on a `clean` outcome the editor's writes are already flushed to
+ * disk and the caller may read the file back immediately.
+ */
+export async function spawnEditorOnPath(deps: EditorSpawnDeps): Promise<EditorSpawnResult> {
+  const { compositor, filePath, notify } = deps;
+
+  // Non-TTY (daemon, pipe, tests without a compositor): there is no terminal to
+  // hand to a full-screen editor. Refuse in one line, exactly like /transcript
+  // degrades on a non-TTY surface.
+  if (!compositor || !process.stdout.isTTY) {
+    notify('info', 'The editor handoff needs an interactive terminal — not available on this surface.');
+    return { outcome: 'no-tty', exitCode: null };
+  }
+
+  const editor = resolveEditor();
+  if (!editor) {
+    notify(
+      'error',
+      'No editor configured. Set $VISUAL or $EDITOR (e.g. `export EDITOR=vim`) to compose prompts externally.',
+    );
+    return { outcome: 'no-editor', exitCode: null };
+  }
+
+  // Teardown is declared before setup so the inverse can never be orphaned.
+  let restored = false;
+  const restoreInput = (): void => {
+    if (restored) return;
+    restored = true;
+    try { process.stdin.resume(); } catch { /* best-effort */ }
+    compositor.resumeInput();
+  };
+
+  compositor.suspendInput();
+  try { process.stdin.pause(); } catch { /* best-effort */ }
+
+  try {
+    const code = await new Promise<number | null>((resolve) => {
+      let child: ReturnType<typeof spawn>;
+      try {
+        child = spawn(editor.cmd, [...editor.args, filePath], { stdio: 'inherit' });
+      } catch {
+        // Synchronous spawn failure (bad options / unusual platform error).
+        // Resolve with a sentinel the caller below maps to spawn-failed. The
+        // finally still restores the TTY.
+        resolve(Number.NaN);
+        return;
+      }
+      child.on('error', () => resolve(Number.NaN));
+      child.on('exit', (exitCode) => resolve(exitCode));
+    });
+
+    if (Number.isNaN(code)) return { outcome: 'spawn-failed', exitCode: null };
+    if (code !== 0) return { outcome: 'nonzero', exitCode: code };
+    return { outcome: 'clean', exitCode: code };
+  } finally {
+    restoreInput();
+  }
+}

--- a/src/cli/slash/index.ts
+++ b/src/cli/slash/index.ts
@@ -30,6 +30,7 @@ import { reauthCmd } from './commands/reauth.js';
 import { retryCmd } from './commands/retry.js';
 import { transcriptCmd } from './commands/transcript.js';
 import { editorCmd } from './commands/editor.js';
+import { afkMdCmd } from './commands/afk-md.js';
 import { searchCmd } from './commands/search.js';
 import { configDoctorCommands } from './commands/config-doctor.js';
 import { registerStaticPluginSkillCommands } from './plugin-skills.js';
@@ -62,6 +63,7 @@ export function registerAll(): void {
   register(retryCmd);
   register(transcriptCmd);
   register(editorCmd);
+  register(afkMdCmd);
   register(searchCmd);
   for (const cmd of configDoctorCommands) register(cmd);
   // Placeholders for plugin-backed commands. The real lists get registered

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -418,6 +418,31 @@ export function getProjectSettingsPath(cwd: string = process.cwd()): string {
   return join(cwd, '.afk', 'settings.json');
 }
 
+/**
+ * Path to the user-scope AFK.md system-prompt overlay (`$AFK_HOME/AFK.md`).
+ *
+ * Contract: this is the BROADEST tier — it applies to every project on the
+ * machine and is concatenated FIRST by `loadAfkMd()`. Note it sits at the
+ * `$AFK_HOME` root, NOT under `config/` like afk.env / afk.config.json, so it
+ * stays hand-editable next to the other top-level operator files.
+ */
+export function getUserAfkMdPath(): string {
+  return join(getAfkHome(), 'AFK.md');
+}
+
+/**
+ * Path to the project-scope AFK.md system-prompt overlay (`<cwd>/AFK.md`).
+ *
+ * The most-specific tier: concatenated SECOND by `loadAfkMd()` and documented
+ * as taking precedence on conflict. Accepts an explicit `cwd` so tests can
+ * inject a temp directory without mutating `process.cwd()` — same rationale as
+ * `getProjectSettingsPath()`. Deliberately NOT under `.afk/`: an AFK.md is a
+ * repo-root document a human is expected to read and commit.
+ */
+export function getProjectAfkMdPath(cwd: string = process.cwd()): string {
+  return join(cwd, 'AFK.md');
+}
+
 export function getLegacyEnvConfigPath(): string {
   return join(homedir(), '.afk.env');
 }


### PR DESCRIPTION
## Summary

Adds `/afk-md` (aliased `/memory`) — an in-REPL editor for the AFK.md system-prompt overlay. The differentiator is **hot-reload: an edited overlay applies to the RUNNING session**, which Claude Code's `/memory` cannot do (an Anthropic engineer confirmed on anthropics/claude-code#722 that changes are only picked up by new sessions; the long chain of `/reload` requests — #15858, #7379, #17127 — is closed unfixed).

### Command surface

```
/afk-md                 overview of both tiers and what the model receives
/afk-md user|project    edit a tier in $EDITOR, then diff + hot-reload
/afk-md show            print the composed overlay exactly as the model sees it
/afk-md add <text>      append a bullet (--user retargets to personal)
/afk-md reload          re-read from disk for edits made in another terminal
```

### Agent layer

A new optional `ProviderQuery.setSystemPrompt?(basePrompt)` mirroring the existing `setCwd?()` hook, implemented by `AnthropicDirectQuery` via a new `query/overlay-rebuild.ts` factory and forwarded by `ProviderRouter` (which also carries the value onto a fresh inner query, so a `/model` swap does not revert the prompt). `AgentSession.setSystemPrompt()` returns whether the live swap actually happened, so a surface can never claim a reload it did not achieve.

**The load-bearing detail:** the rebuild factory mutates the *shared* `StableSystemParts` in place rather than a copy. `createCwdDependentsFactory` closes over the same object, so a copy-based rebuild would let the next `setCwd()` — a `/cd`, or the first-turn worktree autoname hook — silently resurrect the pre-edit prompt. A copy-based implementation passes a naive "output contains the new text" assertion and still regresses, so there is an explicit test that runs `setSystemPrompt()` then `setCwd()` and asserts the edit survives.

`openai-compatible` deliberately leaves the hook `undefined`: it assembles its system parts as locals inside `query()` rather than retaining them on the instance, so a live swap there needs the #876 staleness rework first. That is what the optional-method convention is for — `/afk-md` reports "saved, applies on next launch" there instead of faking success.

### Why not just call it `/memory`

AFK already has a separate cross-session memory system (HOT.md + the fact archive, written by the agent through `memory_update`). `/memory` is an alias so Claude Code muscle memory works, and the overview carries one line pointing at `memory_update` for the other thing.

### Beyond parity with Claude Code's `/memory`

| Claude Code gap | This PR |
|---|---|
| No hot-reload into a live session (#722, #15858, #7379, #17127) | applies to the running session |
| `#` quick-add removed in v2.0.70; destination ambiguous (#14868, #26145) | `add <text>` / `--user`, always prints the absolute destination |
| Needs a separate `/context`; never shows the text | `show` prints the composed overlay verbatim |
| No feedback after save | unified diff with `+N -M`, capped at 40 lines with elision |
| Opens an empty buffer on create | seeded scaffold naming the tier and its precedence |
| — | per-tier token accounting + a 10k budget warning |
| — | surfaces the loader footgun where a whitespace-only tier is silently treated as absent, and where two tiers dedup to one file |

### Supporting changes

- Extracted the audited TTY suspend/spawn/restore dance out of `editor-open.ts` into `editor-spawn.ts`, so `/editor` and `/afk-md` share one copy of the fd-0 handoff instead of cloning it. That module's header already stated keeping one audited copy was its purpose; `editor.test.ts` passes **unchanged** as the regression proof.
- Added `getUserAfkMdPath()` / `getProjectAfkMdPath()` to `src/paths.ts` and routed `afk-md-tier.ts` through them, per the no-hand-joined-AFK-paths convention.

The reload path busts the AFK.md cache *before* re-reading and re-derives through `resolveBaseSystemPrompt()`, never `loadAfkMd().content` — passing the bare overlay would strip the framework doctrine from the live session. Both the ordering and that composition are pinned by tests.

## How was this tested?

Every gate in `.github/workflows/ci.yml` was run locally against the rebased branch:

| Gate | Result |
|---|---|
| `pnpm lint` | PASS |
| `pnpm build` | PASS |
| `pnpm test` | PASS — 777 files, 14,758 tests, 2 skipped, 0 failures |
| `pnpm test:coverage` | PASS (coverage floors met) |
| `pnpm test:pty` | PASS — 10 tests |
| `pnpm build:dist` (publish-bundle smoke) | PASS |
| `pnpm audit:env:check` | PASS |
| `pnpm scan:env:check` | PASS |
| `pnpm audit:chalk:check` | PASS |
| `pnpm audit:sdk:check` | PASS |
| `pnpm fix:pins:check` | PASS |
| `pnpm audit:deps` | PASS |

Not run locally: the `docs` job (website typecheck + build) — this diff touches nothing under `website/`.

New tests, 21 in total:

- `src/agent/session/set-system-prompt.test.ts` — end-to-end proof through the real provider chain with a stubbed Anthropic client (the T19 `setCwd` harness pattern): turn 1 carries the old overlay, `setSystemPrompt()`, turn 2 carries the new one and still contains the framework base; history is not wiped; **the edit survives a subsequent `setCwd()`**; clearing drops the overlay while keeping the rest of the payload.
- `src/agent/providers/anthropic-direct/query/overlay-rebuild.test.ts` — shared-prefix mutation, live-cwd vs fallback-cwd assembly, cleared-overlay normalization.
- `src/cli/slash/commands/afk-md.test.ts` — reload ordering invariant (cache bust strictly before re-derive, apply strictly after), that the applied string is the full composed prompt and not the bare overlay, honest reporting when the provider cannot swap, `add` targeting/creation/no-blank-line-stacking, non-TTY degradation, unknown subcommand.
- `src/cli/slash/commands/afk-md/targets.test.ts` — all six tier states: neither, only-user, only-project, both, symlink-deduped, whitespace-only.
- `src/cli/slash/commands/editor-spawn.test.ts` — refusal paths never spawn; exit-code mapping; the restore-always invariant holds even when `spawn` throws.

Also smoke-rendered the overview against real AFK.md files to check the output reads well.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/) — see [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] No secrets, tokens, or private paths in the diff — verified by grepping the committed diff for absolute operator paths (no matches); tests use `os.tmpdir()` fixtures

## Note for reviewers

While writing these tests I found a pre-existing repo-wide test footgun worth knowing about, not fixed here to keep this PR scoped: the vitest global setup (`src/__test-utils__/redirect-paths-env.ts`) redirects `AFK_HOME` so no test can write to the real `~/.afk`, but **nothing redirects `process.cwd()`**. Any project-scope path helper (`getProjectAfkMdPath()`, `getProjectSettingsPath()`) therefore resolves to the real repo root during tests. Combined with `vi.mock()` being silently inert on a mistyped relative specifier, a project-scope test can quietly read and append to this repository's own tracked files — which is exactly what happened to me mid-development before I caught and reverted it. A `redirect-cwd` setup file, or a guard asserting project-scope writes land under a temp dir, would close it.
