### PR TITLE
feat(cli): rank slash-command completions by recency, not alphabetically

### DIFF
--- a/docs/proposals/idle-turn-proposal.md
+++ b/docs/proposals/idle-turn-proposal.md
@@ -1,0 +1,306 @@
+# Next-action suggestion at the idle prompt
+
+*(originally "Idle-turn proposal ghost (Tier 3)" — that design was rejected after critique;
+see DECISION below for the superseding approach.)*
+
+**Status:** Tier-3 REJECTED. Its successor was also gated out by measurement. A third,
+smaller change shipped instead — see "What shipped" below.
+
+## What shipped
+
+Neither idea in this document was built. Both were killed by evidence, in order:
+
+1. **Tier-3 idle proposer** (the original idea) — rejected after a `/devils-advocate` wave;
+   three critics independently returned `strong` alternatives.
+2. **"Next action" from the end-of-turn contract** (the successor) — gated on a
+   prerequisite measurement, which **failed**. Measuring `parseTerminalState()` against 400
+   real REPL transcripts (692 assistant turns) gave a **69.5% parse rate** against a 70%
+   threshold, and — far more damaging — only **0.7% of terminal-state bodies contained
+   anything resembling a runnable slash command**. The premise that "the model already
+   computes the next action for free" is false: it emits prose about what is pending, not a
+   command. Building on it would have produced a feature that silently did nothing.
+3. **What shipped instead:** recency ranking for slash-command completion
+   (`src/cli/input/suggest-rank.ts`). Measurement during the above investigation showed
+   **92% of the 101 registered commands+aliases sit behind an ambiguous 2-char prefix**, and
+   ties were broken *alphabetically* — so `/re` resolved to `/reauth` ahead of `/refactor`,
+   `/research`, `/resolve`, `/review` and six others. Ranking the tie-break bucket by the
+   user's own input history fixes the discoverability complaint that motivated this whole
+   investigation, on a code path that is **already on by default**, with no model call, no
+   new config, and no input-pipeline risk.
+
+The through-line: the original goal was "help the user pick the next action, and surface
+skills they forgot exist." The shipped change serves that goal on the default-on path; both
+rejected designs served it on an opt-in path at much higher cost.
+
+---
+**Branch:** `afk/ai-predict-ghost-text` (worktree; tracked tree byte-identical to `main` @ `b25463e3`, 0 commits ahead/behind `main` and `origin/main`)
+**Date:** 2026-08-03
+**Verification:** claims below survived a 4-verifier adversarial wave (2026-08-03). Two
+original claims were REFUTED and are corrected inline, marked with blockquotes. Caveat: two
+verifiers read this file during verification, so the wave was not fully blind — though one
+of them refuted it anyway.
+
+## Premise correction
+
+The originating idea was "while the REPL sits idle at the user's turn, generate AI ghost
+text — maybe suggest a skill." Reconnaissance found that **ghost text already ships and is
+live on `main`**: `src/cli/input/suggest.ts` (539 LOC) is a two-tier engine rendering dim
+inline completions after the caret, accepted with `Tab` / `→`.
+
+One asterisk, verified: the two tiers have **different defaults**. Tier 1 (deterministic
+history/dropdown/slash completion) is **ON** for every user. Tier 2 — the actually-AI tier —
+is **OFF** unless `AFK_SUGGEST_ENABLED` is set. So "we already have AI prediction" is true in
+the tree and false in practice for a default install.
+
+So this proposal is not "add ghost text." It is the one thing the shipped engine
+structurally cannot do: **propose an action from an empty prompt.**
+
+## What exists today (verified by direct read)
+
+| Layer | Behaviour | Citation |
+|---|---|---|
+| Tier 1 | Sync prefix-match: dropdown top candidate → history → mid-sentence `/slash` name | `src/cli/input/suggest.ts:292-341` |
+| Tier 2 | LLM fallback, 250 ms debounce, 1500 ms hard abort, `maxTokens: 24`, FIFO cache (500), secrets redacted at egress | `suggest.ts:343-486`, prompt at `:100-131` |
+| Trigger | **Keystroke only** — sole call site is `applyEdit` → `updateGhost` | `terminal-compositor.input-dispatch.ts:182` |
+| Render | Dim suffix after caret, grapheme-aware truncation so the line never wraps (DECSTBM safety) | `terminal-compositor.render.ts:102-148` |
+| Accept | `→` when cursor at end; `Tab` with dropdown-first precedence | `input-dispatch.ts:1017-1018`, `:1114-1116` |
+| Gate | `AFK_SUGGEST_GHOST` / `interactive.suggestGhost` (default **on**); Tier 2 separately behind `AFK_SUGGEST_ENABLED` (default off); model via `AFK_SUGGEST_MODEL` | `env.ts:506-524`, `settable-keys.ts:220`, `repl-loop.ts:85` |
+
+## The gap
+
+> **Corrected after adversarial verification (2026-08-03).** An earlier draft of this
+> section claimed "exactly three independent empty-buffer blocks." That count was wrong,
+> and the framing buried the actual primary blocker. Corrected below.
+
+**Primary blocker — an absence, not a guard.** Nothing ever invokes the suggestion engine
+while the REPL sits idle. `updateGhost()` (`terminal-compositor.autocomplete.ts:156`) has
+exactly one call site repo-wide: `applyEdit` (`terminal-compositor.input-dispatch.ts:182`),
+which runs only on a buffer mutation. No timer-, mode-, resize-, paste-, or
+turn-completion-driven path computes a suggestion. This cannot be fixed by flipping a
+condition; it needs a new arm/disarm subsystem.
+
+**Secondary — the empty-buffer guards (≥4, not 3):**
+
+| file:line | condition | bypassable | load-bearing |
+|---|---|---|---|
+| `suggest.ts:299` | `if (buffer.length === 0) return null;` (Tier 1) | single line | yes — removing it makes the history branch match the newest entry for *any* buffer, since `entry.startsWith('')` |
+| `suggest.ts:352` | `buffer.length < MIN_LLM_CHARS` (`= 3`) | single line | yes — also gates the debounce/cache machinery below it |
+| `render.ts:117` | `self.input.buffer.length > 0` | one of 6 clauses | yes — pinned by regression test `terminal-compositor.ghost.test.ts:256` |
+| `render.ts:116` | `!suffix` — blocks ghost whenever `[queued]` is showing | single clause | orthogonal to emptiness, but an idle proposal must still handle it |
+| `render.ts:121` / `autocomplete.ts:177` | `!ac?.dropdownOpen` | single clause | inert for a truly empty buffer (`detectTrigger('',0)` needs a leading `/` or `@`) but a real co-located gate |
+
+The FIFO result cache has **no** special empty-key behaviour — it is simply unreachable for
+`buffer === ''` because the min-chars guard short-circuits first.
+
+**Surface scope.** The fallback readers (`src/cli/input/reader.ts`, `src/cli/input/non-tty.ts`)
+wire **no suggestion engine at all** — no ghost of any kind exists there. This feature is
+compositor-only; `reader.ts` is explicitly out of scope.
+
+**Two semantic facts:**
+
+- **No idle timer exists.** The 250 ms debounce is "idle *within* typing," not "idle at the
+  prompt." Nothing is time-driven.
+- **Skills are completed, never proposed.** `suggest.ts:319` expands a partial `/dia` →
+  `/diagnose`. It cannot say "you probably want `/diagnose`" when nothing is typed.
+
+The governing invariant is **ghost = continuation of a typed prefix**, enforced by
+`isValidContinuation` (`suggest.ts:165-168`). An idle proposal is not a continuation; it is
+an *offer*. Overloading Tier 2 with it would:
+
+- void the safety guard — `''.startsWith('')` passes trivially, so every reply validates;
+- collapse the result cache onto a single `''` key;
+- collide with `Tab`'s dropdown-first precedence at an empty buffer.
+
+**Therefore: a separate concern in its own module, not a fourth branch in `suggest.ts`**
+(which is already 539 LOC, well past the 350-line ceiling).
+
+## DECISION (2026-08-03): Tier 3 is REJECTED — superseded
+
+A `/devils-advocate` wave (pragmatist / paranoid / architect, parallel and independent)
+returned **three `strong` alternatives**, two of which converged on the same one. A Wave-3.5
+composition-boundary check returned CONFIRMED. The Tier-3 design below is retained for
+context but **should not be built**.
+
+**Superseding approach — "next action from the end-of-turn contract, seeded into Tier 1":**
+
+1. Add one bullet to `END_OF_TURN_DIRECTIVE` (`routing-directive.ts:98-124`) asking the model
+   to name the single most useful next input, preferring an existing slash/skill command.
+2. Parse it into the terminal-state structure (`terminal-state.ts`) as `suggestedNext`.
+3. Render it as a row in the existing verdict card (`verdict-card.ts` `collectRows`).
+4. **Seed it as a Tier-1 candidate source — never into `activeGhost` directly.**
+
+Why this wins: the strong model already computes "what's next" every turn at zero marginal
+inference cost. A cheap-model idle call re-derives a weaker version of an existing signal from
+a lossy 600-token echo of context the first call already had.
+
+Why step 4 is the crux: because the suggestion enters Tier 1 rather than `activeGhost`, the
+empty-buffer guards (`suggest.ts:299`, `render.ts:117`) stay **untouched** — so no ghost is
+ever armed at an empty prompt and the accidental-accept hazard never exists. The moment the
+user types one character of the suggestion, the already-shipped Tier-1 prefix-match completes
+it and Right-arrow accepts. One-keystroke acceptance via machinery that already ships and is
+already tested. The guard framed as the obstacle turns out to be the safety mechanism.
+
+Cost: ~60 LOC. No new module, no timer subsystem, no `activeProposal` field, no render-gate
+exception, no env var (hence no CI-gated `docs/env-registry.*` regen), no PTY scenario.
+
+**Rejected variant:** seeding directly into `activeGhost` (the architect's render half).
+`applyGhostAccept` (`terminal-compositor.autocomplete.ts:272-278`) has no `buffer.length > 0`
+precondition, so an empty buffer trivially satisfies all of them. It is inert today only
+because nothing ever arms a ghost on an empty buffer; this would be the first producer to do
+so.
+
+### Prerequisite before building — the kill criterion
+
+The whole approach rests on the model reliably honoring the end-of-turn contract, and
+verification found that contract is **unenforced and unmeasured**:
+`terminal-state-gate.ts:126-133` cannot distinguish "nothing parseable was emitted" from a
+legitimate Blocked/Asking verdict, and no telemetry tracks parse-failure rate.
+
+**Measure the terminal-state parse rate across recent interactive turns FIRST.**
+- parse rate < ~70% → the feature silently no-ops on most turns; do not build it, fix
+  compliance first.
+- parse rate healthy, but the offered command is accepted < ~10% of the time → the suggestion
+  is noise; remove the bullet (one-line revert).
+
+### Two known landmines
+
+- `mapBulletsToFields` resolves `deferred` with the needle list
+  `('pending','deferred','follow-up','followup','next')` (`terminal-state.ts:247`), and
+  `find()` returns on first substring match. A bullet labeled "Suggested next" contains
+  `next` and would be captured as `deferred`. Narrow the needle or order the new field first.
+- Card-to-prompt adjacency is conditional: background-subagent and shell-passthrough
+  notifications drain at the top of the *next* loop iteration
+  (`loop-iteration.ts:236-266`), printing after the verdict card and before the prompt. Any
+  UX premise that the suggestion sits directly above the cursor breaks while background work
+  is in flight.
+
+### Surface scope, verified
+
+`END_OF_TURN_DIRECTIVE` is injected only for `surface ∈ {'repl','telegram'}`
+(`routing-directive.ts:138-141`); one-shot (`chat.ts:360`) and sub-agent threads deliberately
+omit it, and the daemon bypasses `assembleSystemPrompt` entirely. `suggestedNext` inherits
+that conditionality for free and degrades to null everywhere else — `collectRows` already
+skips empty values, so no downstream change is needed.
+
+---
+
+## REJECTED DESIGN (retained for context)
+
+> Everything below describes the Tier-3 idle proposer, superseded by the decision above.
+
+### New module — `src/cli/input/idle-propose.ts` (~200 LOC)
+
+```ts
+createIdleProposer(opts): IdleProposer
+  arm(ctx: IdleContext): void   // start the timer
+  disarm(): void                // cancel timer + abort in-flight
+  dispose(): void
+```
+
+Dependency-injected exactly like `createSuggestEngine` (`completeFn`, `resolveProviderFn`,
+`delayMs`, `timeoutMs`) so it is unit-testable with no live infrastructure.
+
+### Trigger policy — the whole feature lives or dies here
+
+- Arm only when input mode flips to `idle` **and** the buffer is empty.
+  Hook: `setInputMode('idle')` at `input-surface.ts:355` / `stream-renderer.ts:916`.
+- Delay **~4 s**, not 250 ms. The signal is "the user is thinking," not "paused mid-word."
+- **Exactly one call per turn.** Never re-fire until the next turn ends.
+- Disarm on: first keypress, `setInputMode('streaming')`, dropdown open, `[queued]` suffix.
+- `Esc` dismisses for the remainder of the turn.
+
+### Context bundle — where "send a subagent" gets cashed out cheaply
+
+Assembled once at turn end, all in-process, all free. Richer than Tier 2's 200-char tail:
+
+- last assistant message tail (~400 chars)
+- **tool errors from the last turn** — highest-signal input for "what next"
+- git branch + dirty count (already held by the REPL)
+- 5 recent commands
+- **slash/skill registry: names + one-line descriptions** — `listSlashCommands` /
+  `aliasEntries` are already imported at `suggest.ts:30`
+
+Reuse `redactSecrets` at the same egress chokepoint as `buildUser` (`suggest.ts:126`).
+
+System prompt differs from Tier 2's: *"Propose the single most likely next input. Prefer an
+existing slash command when one fits. Output only the line."*
+
+**Explicitly rejected: dispatching a real subagent per idle.** 3–15 s latency and real cost,
+answering after the user has already typed. The rich-context oneshot captures most of the
+value at ~1 % of the cost.
+
+### Render + accept
+
+- Relax render gate #3 to allow an empty buffer **only** when an idle proposal is active,
+  tracked as a field distinct from `activeGhost`.
+- Render visually distinct from a completion — dim plus a leading `↳ ` marker. Users must
+  never be unsure which characters are really in their buffer.
+- **Accept: no keybinding work is needed — and that is the risk.**
+
+  > **Corrected after adversarial verification.** An earlier draft asserted "Right-arrow at
+  > an empty buffer is a no-op, so binding it is collision-free." That is **false**.
+
+  `input-dispatch.ts:1016-1029` already routes Right-arrow to `applyGhostAccept()` whenever
+  `cursor === buffer.length && activeGhost !== null && !dropdownOpen`. An empty buffer
+  satisfies `cursor === 0 === buffer.length` **identically to any other end-of-buffer
+  state**. So if the idle proposal is stored in `activeGhost`, Right-arrow accepts it with
+  zero new code.
+
+  The consequence is a *hazard*, not a win: Right-arrow at an empty prompt is currently
+  harmless muscle memory, and this silently turns it into "submit an AI-proposed command
+  into my buffer." Two options:
+
+  1. **Reuse `activeGhost`** — free accept, but inherits the accidental-accept hazard.
+  2. **Separate `activeProposal` field** — requires an explicit accept binding, but lets the
+     accept key differ from completion-accept and keeps the hazard opt-in.
+
+  Recommend (2). The cost is ~20 LOC; the benefit is that an idle proposal can never be
+  accepted by a reflex keystroke aimed at a completion.
+
+  `Tab` stays untouched either way — Tab-hijack is the most-cited reason people disable AI
+  autocomplete (`vscode-copilot-release#1013`). Note also that `(meta|ctrl)+right` word-jump
+  is dispatched *before* plain-right (`input-dispatch.ts:951`), so modified arrows never
+  reach the ghost branch.
+
+- **`isValidContinuation` must NOT be reused.** Verified: on an empty buffer
+  `''.startsWith('')` is always true, so the guard degenerates to "the model said something
+  non-blank" (`suggest.ts:165-168`). It validates nothing about continuation. The proposer
+  needs its own validator (e.g. must match a known slash command, or pass a length/shape
+  check).
+
+### Gating — off by default
+
+New key `interactive.idleSuggest` mirroring `interactive.suggestGhost`
+(`settable-keys.ts:220`), plus `AFK_SUGGEST_IDLE` env override. Off by default because it
+spends tokens while the user is not even typing — discovering that after the fact is the
+failure mode that loses trust.
+
+Cost: ~600 tok in / 32 tok out, once per turn ≈ **$0.0008/turn on Haiku**.
+
+### Files that must change
+
+| File | Change |
+|---|---|
+| `src/cli/input/idle-propose.ts` | new module |
+| `src/cli/input/idle-propose.test.ts` | new tests (mirror `suggest.test.ts` injection style) |
+| `src/cli/terminal-compositor.render.ts` | empty-buffer exception + distinct marker |
+| `src/cli/terminal-compositor.autocomplete.ts` | proposal state, arm/disarm |
+| `src/cli/terminal-compositor.input-mode.ts` | arm on `idle`, disarm on `streaming` |
+| `src/cli/input/input-surface.ts` | wire proposer lifecycle to the surface |
+| `src/config/env.ts` | `ENV_REGISTRY` entry + getter for `AFK_SUGGEST_IDLE` |
+| `src/config/settable-keys.ts` | `interactive.idleSuggest` spec |
+| `docs/env-registry.{json,md}` | regenerate via `pnpm scan:env` (CI-gated by `scan:env:check`) |
+| `AFK.md` | document default-off rationale |
+| `tests/pty/scenarios.ts` | add an idle-proposal PTY scenario (none exists for ghost today) |
+
+## Risks
+
+- **Peripheral-vision noise.** Unrequested text appearing while the user thinks is the
+  top-cited reason people disable this class of feature. Mitigated by the 4 s delay,
+  one-shot-per-turn, Esc-dismiss, and default-off.
+- **Proposal quality.** A wrong proposal at an empty prompt is worse than a wrong completion,
+  because there is no typed prefix constraining it. The tool-error signal is the main lever.
+- **Non-Anthropic sessions.** `pickModel` (`suggest.ts:529`) falls back to `ctx.model`
+  verbatim for non-Anthropic providers — which may be an expensive model. Pre-existing gap in
+  Tier 2; an idle tier makes it worse and should fix it (prefer the `local` slot, else
+  `small`/haiku).

--- a/src/cli/input/reader.ts
+++ b/src/cli/input/reader.ts
@@ -172,7 +172,10 @@ export async function readWithAutocompleteTty(
         }
         if (ac.trigger && ac.suppressedSignature === null) {
           if (ac.trigger.kind === 'slash') {
-            ac.candidates = filterSlashCandidates(ac.trigger.query).slice(0, 12);
+            ac.candidates = filterSlashCandidates(
+              ac.trigger.query,
+              opts.history?.getEntries?.() ?? [],
+            ).slice(0, 12);
           } else if (ac.trigger.kind === 'file') {
             // File candidates are bounded upstream (MAX_FILE_MATCHES) and the
             // dropdown scrolls; do NOT re-cap to 12, or entries past the 12th

--- a/src/cli/input/suggest-rank.test.ts
+++ b/src/cli/input/suggest-rank.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildRecencyRanks,
+  compareByRecency,
+  rankOf,
+  sortByRecency,
+  UNRANKED,
+} from './suggest-rank.js';
+
+describe('buildRecencyRanks', () => {
+  it('ranks the newest entry 0 and increases with age', () => {
+    const ranks = buildRecencyRanks(['/review', '/diagnose', '/ship']);
+    expect(ranks.get('/review')).toBe(0);
+    expect(ranks.get('/diagnose')).toBe(1);
+    expect(ranks.get('/ship')).toBe(2);
+  });
+
+  it('keeps the newest rank when a command recurs', () => {
+    const ranks = buildRecencyRanks(['/ship', '/diagnose', '/ship']);
+    expect(ranks.get('/ship')).toBe(0);
+  });
+
+  it('extracts a mid-sentence command', () => {
+    const ranks = buildRecencyRanks(['can you run /refactor on this module']);
+    expect(ranks.get('/refactor')).toBe(0);
+  });
+
+  it('extracts every command in one entry', () => {
+    const ranks = buildRecencyRanks(['/diagnose then /review']);
+    expect(ranks.get('/diagnose')).toBe(0);
+    expect(ranks.get('/review')).toBe(0);
+  });
+
+  it('lowercases names so casing does not split the index', () => {
+    const ranks = buildRecencyRanks(['/ReView']);
+    expect(ranks.get('/review')).toBe(0);
+  });
+
+  it('accepts registry-legal punctuation in names', () => {
+    const ranks = buildRecencyRanks(['/awa-dev:qualify', '/fix-pr 42']);
+    expect(ranks.get('/awa-dev:qualify')).toBe(0);
+    expect(ranks.get('/fix-pr')).toBe(1);
+  });
+
+  it('ignores a slash that is not a command token', () => {
+    const ranks = buildRecencyRanks(['src/cli/input', 'http://x.dev/y', '/2fa']);
+    expect(ranks.size).toBe(0);
+  });
+
+  it('returns an empty index for empty history', () => {
+    expect(buildRecencyRanks([]).size).toBe(0);
+  });
+
+  it('does not drop matches across entries (global regex lastIndex reset)', () => {
+    // Regression: SLASH_TOKEN is module-scoped and global. Without resetting
+    // lastIndex per entry, the second entry's match would be skipped.
+    const ranks = buildRecencyRanks(['/aaaaaaaaaa', '/bb']);
+    expect(ranks.get('/aaaaaaaaaa')).toBe(0);
+    expect(ranks.get('/bb')).toBe(1);
+  });
+});
+
+describe('rankOf', () => {
+  const ranks = buildRecencyRanks(['/review']);
+
+  it('resolves a value carrying a leading slash', () => {
+    expect(rankOf('/review', ranks)).toBe(0);
+  });
+
+  it('resolves a bare registry key', () => {
+    expect(rankOf('review', ranks)).toBe(0);
+  });
+
+  it('returns UNRANKED for an unused command', () => {
+    expect(rankOf('/never-run', ranks)).toBe(UNRANKED);
+  });
+});
+
+describe('compareByRecency', () => {
+  it('orders a used command ahead of an unused one', () => {
+    const ranks = buildRecencyRanks(['/review']);
+    expect(compareByRecency('/review', '/accept', ranks)).toBeLessThan(0);
+  });
+
+  it('orders the more recent of two used commands first', () => {
+    const ranks = buildRecencyRanks(['/ship', '/accept']);
+    expect(compareByRecency('/ship', '/accept', ranks)).toBeLessThan(0);
+  });
+
+  it('falls back to alphabetical when both are unranked', () => {
+    const ranks = buildRecencyRanks([]);
+    expect(compareByRecency('/accept', '/review', ranks)).toBeLessThan(0);
+    expect(compareByRecency('/review', '/accept', ranks)).toBeGreaterThan(0);
+  });
+
+  it('is symmetric and self-consistent', () => {
+    const ranks = buildRecencyRanks(['/ship']);
+    expect(compareByRecency('/ship', '/ship', ranks)).toBe(0);
+    expect(Math.sign(compareByRecency('/ship', '/accept', ranks))).toBe(
+      -Math.sign(compareByRecency('/accept', '/ship', ranks)),
+    );
+  });
+});
+
+describe('sortByRecency', () => {
+  const REAL_COLLISION = ['/reauth', '/recover', '/refactor', '/reground', '/research', '/review'];
+
+  it('is pure alphabetical with no history (preserves prior behaviour)', () => {
+    expect(sortByRecency(REAL_COLLISION, [])).toEqual([
+      '/reauth',
+      '/recover',
+      '/refactor',
+      '/reground',
+      '/research',
+      '/review',
+    ]);
+  });
+
+  it('surfaces the recently used command ahead of the alphabetical winner', () => {
+    // The motivating case: `/re` alphabetically resolves to `/reauth`, which is
+    // almost never what a user who just ran /review wants.
+    expect(sortByRecency(REAL_COLLISION, ['/review something'])[0]).toBe('/review');
+  });
+
+  it('orders multiple used commands by recency, unused ones alphabetically after', () => {
+    expect(sortByRecency(REAL_COLLISION, ['/research x', '/refactor y'])).toEqual([
+      '/research',
+      '/refactor',
+      '/reauth',
+      '/recover',
+      '/reground',
+      '/review',
+    ]);
+  });
+
+  it('does not mutate its input', () => {
+    const input = ['/review', '/accept'];
+    const copy = [...input];
+    sortByRecency(input, ['/accept']);
+    expect(input).toEqual(copy);
+  });
+
+  it('ignores history entries naming commands outside the candidate list', () => {
+    expect(sortByRecency(['/accept', '/review'], ['/unrelated-command'])).toEqual([
+      '/accept',
+      '/review',
+    ]);
+  });
+});

--- a/src/cli/input/suggest-rank.ts
+++ b/src/cli/input/suggest-rank.ts
@@ -1,0 +1,97 @@
+/**
+ * Recency ranking for slash-command completion candidates.
+ *
+ * Both completion surfaces — the autocomplete dropdown (`filterSlashCandidates`)
+ * and the Tier-1 ghost resolver (`getDeterministicGhost`) — historically broke
+ * prefix ties alphabetically. With ~100 registered commands and aliases that is
+ * almost never the command the user wants: `/re` resolves to `/reauth` ahead of
+ * `/refactor`, `/research`, `/resolve`, `/review`, and six others.
+ *
+ * This module ranks a tie-break bucket by how recently the user actually ran
+ * each command, read from the REPL's own input history. Alphabetical order is
+ * retained as the terminal tie-break, so behaviour is unchanged for a user with
+ * no history and for commands never yet used.
+ *
+ * Pure and dependency-free: callers pass a history snapshot, so this is unit
+ * testable with no REPL, no disk, and no session.
+ *
+ * @module cli/input/suggest-rank
+ */
+
+/**
+ * Matches a `/command` token: a leading slash followed by an identifier.
+ * Mirrors the character class used by the slash registry and the Tier-1
+ * mid-sentence resolver (`[A-Za-z][A-Za-z0-9_:-]*`) so a name accepted by one
+ * is recognised by the other. Global: one history entry may name several.
+ */
+const SLASH_TOKEN = /(?:^|\s)(\/[A-Za-z][A-Za-z0-9_:-]*)/g;
+
+/** Rank assigned to a command that appears nowhere in history. */
+export const UNRANKED = Number.POSITIVE_INFINITY;
+
+/**
+ * Build a `command name -> recency rank` index from a newest-first history
+ * snapshot. Rank 0 is the most recently used command; lower sorts first.
+ *
+ * Contract: `history` MUST be newest-first (the order `ReplHistory.getEntries()`
+ * returns). The first occurrence encountered therefore wins, and later — older —
+ * mentions of the same command never downgrade it. Names are lowercased, since
+ * the registry is lowercase and user input is not reliably so.
+ */
+export function buildRecencyRanks(history: readonly string[]): Map<string, number> {
+  const ranks = new Map<string, number>();
+  for (let i = 0; i < history.length; i++) {
+    const entry = history[i];
+    if (!entry) continue;
+    // A fresh lastIndex per entry: SLASH_TOKEN is module-scoped and global, so
+    // reusing it across entries without resetting would skip matches.
+    SLASH_TOKEN.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = SLASH_TOKEN.exec(entry)) !== null) {
+      const name = m[1]?.toLowerCase();
+      if (name !== undefined && !ranks.has(name)) ranks.set(name, i);
+    }
+  }
+  return ranks;
+}
+
+/**
+ * Look up a candidate's recency rank. Accepts values with or without the
+ * leading slash so both dropdown candidates (`/review`) and bare registry keys
+ * (`review`) resolve against the same index.
+ */
+export function rankOf(value: string, ranks: ReadonlyMap<string, number>): number {
+  const name = value.startsWith('/') ? value.toLowerCase() : `/${value.toLowerCase()}`;
+  return ranks.get(name) ?? UNRANKED;
+}
+
+/**
+ * Comparator: most-recently-used first, then alphabetical.
+ *
+ * Invariant: alphabetical order is the terminal tie-break, never skipped. Two
+ * commands that are both unranked compare exactly as they did before recency
+ * ranking existed — which is what keeps a no-history session, and every
+ * existing ordering test, behaving identically.
+ */
+export function compareByRecency(
+  a: string,
+  b: string,
+  ranks: ReadonlyMap<string, number>,
+): number {
+  const ra = rankOf(a, ranks);
+  const rb = rankOf(b, ranks);
+  if (ra !== rb) return ra - rb;
+  return a.localeCompare(b);
+}
+
+/**
+ * Sort a list of slash-command names by recency, then alphabetically.
+ * Returns a new array; the input is not mutated.
+ */
+export function sortByRecency(
+  names: readonly string[],
+  history: readonly string[],
+): string[] {
+  const ranks = buildRecencyRanks(history);
+  return names.slice().sort((a, b) => compareByRecency(a, b, ranks));
+}

--- a/src/cli/input/suggest.ts
+++ b/src/cli/input/suggest.ts
@@ -29,6 +29,7 @@ import type { ModelProvider } from '../../agent/provider.js';
 import { redactSecrets } from '../../agent/redact-secrets.js';
 import { env } from '../../config/env.js';
 import { list as listSlashCommands, aliasEntries } from '../slash/registry.js';
+import { sortByRecency } from './suggest-rank.js';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -327,9 +328,13 @@ export function createSuggestEngine(opts: SuggestEngineOptions = {}): SuggestEng
       const canonicalNames = listSlashCommands().map(cmd => cmd.name);
       const aliasNames = aliasEntries().map(e => e.alias);
       const allNames = [...canonicalNames, ...aliasNames];
-      const match = allNames
-        .filter(name => name.startsWith(slashPartial))
-        .sort((a, b) => a.localeCompare(b))[0];
+      // Recency-ranked, alphabetical as terminal tie-break. With ~100 names a
+      // 2-char prefix is ambiguous for most commands, so alphabetical alone
+      // rarely surfaces the one the user means.
+      const match = sortByRecency(
+        allNames.filter(name => name.startsWith(slashPartial)),
+        ctx.getHistory(),
+      )[0];
       if (match) {
         // Return the full buffer with the partial /token replaced by the full skill name.
         const prefixEnd = buffer.length - slashPartial.length;

--- a/src/cli/input/trigger.test.ts
+++ b/src/cli/input/trigger.test.ts
@@ -177,6 +177,52 @@ describe('filterSlashCandidates', () => {
     expect(vals.length).toBeGreaterThan(0);
     expect(vals).toContain('/config');
   });
+
+  describe('recency ranking', () => {
+    it('omitting history preserves the previous alphabetical ordering', () => {
+      const withoutArg = filterSlashCandidates('c').map((c) => c.value);
+      const withEmpty = filterSlashCandidates('c', []).map((c) => c.value);
+      expect(withEmpty).toEqual(withoutArg);
+      // And that ordering really is alphabetical within the prefix bucket.
+      const prefixOnly = withoutArg.filter((v) => v.slice(1).toLowerCase().startsWith('c'));
+      expect(prefixOnly).toEqual([...prefixOnly].sort((a, b) => a.localeCompare(b)));
+    });
+
+    it('promotes a recently used command above the alphabetical winner', () => {
+      // Pick the LAST prefix-bucket entry — the alphabetically worst prefix
+      // match. A subsequence-only match would legitimately stay below the
+      // whole prefix bucket, so it cannot be used to prove promotion.
+      const prefixBucket = filterSlashCandidates('c')
+        .map((c) => c.value)
+        .filter((v) => v.slice(1).toLowerCase().startsWith('c'));
+      expect(prefixBucket.length).toBeGreaterThan(1);
+      const target = prefixBucket[prefixBucket.length - 1]!;
+      expect(filterSlashCandidates('c').map((c) => c.value)[0]).not.toBe(target);
+
+      const ranked = filterSlashCandidates('c', [`${target} some args`]).map((c) => c.value);
+      expect(ranked[0]).toBe(target);
+    });
+
+    it('keeps the prefix bucket ahead of the subsequence bucket', () => {
+      // Recency must reorder WITHIN a bucket, never across buckets — a
+      // recently used subsequence-only match must not jump above prefix hits.
+      const subseqOnly = filterSlashCandidates('cfg').map((c) => c.value);
+      expect(subseqOnly).toContain('/config');
+      const ranked = filterSlashCandidates('co', ['/config x']).map((c) =>
+        c.value.slice(1).toLowerCase(),
+      );
+      const firstNonPrefix = ranked.findIndex((k) => !k.startsWith('co'));
+      if (firstNonPrefix !== -1) {
+        expect(ranked.slice(firstNonPrefix).every((k) => !k.startsWith('co'))).toBe(true);
+      }
+    });
+
+    it('ignores history naming commands that do not match the query', () => {
+      const baseline = filterSlashCandidates('c').map((c) => c.value);
+      const ranked = filterSlashCandidates('c', ['/totally-unrelated']).map((c) => c.value);
+      expect(ranked).toEqual(baseline);
+    });
+  });
 });
 
 describe('detectTrigger — flag completion for aliases', () => {

--- a/src/cli/input/trigger.ts
+++ b/src/cli/input/trigger.ts
@@ -8,6 +8,7 @@
 
 import { readdirSync, promises as fsp, type Dirent } from 'fs';
 import { list as listSlashCommands, aliasEntries, lookup } from '../slash/registry.js';
+import { buildRecencyRanks, compareByRecency } from './suggest-rank.js';
 import { resolveQuery, MAX_FILE_MATCHES } from '../multi-line-reader.js';
 import type { Candidate, Trigger } from './types.js';
 import type { SlashCommand } from '../slash/types.js';
@@ -87,13 +88,21 @@ function isSubsequence(needle: string, haystack: string): boolean {
  * Filter slash commands for the autocomplete dropdown.
  *
  * Ranking: prefix matches first (preserving the historical `startsWith`
- * behaviour and its alphabetical ordering), then subsequence matches — e.g.
- * `cfg` → `/config` — appended below, so abbreviations resolve without
- * displacing the common prefix case. Matching is case-insensitive. Canonical
- * commands and aliases (e.g. `/quit` → `/exit`, which borrow their canonical
- * command's summary) share the same ranking. Capped at 20.
+ * behaviour), then subsequence matches — e.g. `cfg` → `/config` — appended
+ * below, so abbreviations resolve without displacing the common prefix case.
+ * Matching is case-insensitive. Canonical commands and aliases (e.g. `/quit` →
+ * `/exit`, which borrow their canonical command's summary) share the same
+ * ranking. Capped at 20.
+ *
+ * Within each bucket, candidates are ordered by how recently the user ran them
+ * (`recentHistory`, newest-first), falling back to alphabetical. Omitting
+ * `recentHistory` — or passing an empty array — yields exactly the previous
+ * alphabetical ordering, so every existing caller and test is unaffected.
  */
-export function filterSlashCandidates(query: string): Candidate[] {
+export function filterSlashCandidates(
+  query: string,
+  recentHistory: readonly string[] = [],
+): Candidate[] {
   const cmds = listSlashCommands();
   const q = query.toLowerCase();
 
@@ -124,8 +133,9 @@ export function filterSlashCandidates(query: string): Candidate[] {
       ? []
       : universe.filter((u) => !prefixValues.has(u.cand.value) && isSubsequence(q, u.key));
 
+  const ranks = buildRecencyRanks(recentHistory);
   const byValue = (a: { cand: Candidate }, b: { cand: Candidate }): number =>
-    a.cand.value.localeCompare(b.cand.value);
+    compareByRecency(a.cand.value, b.cand.value, ranks);
   prefix.sort(byValue);
   subseq.sort(byValue);
   return [...prefix, ...subseq].map((u) => u.cand).slice(0, 20);

--- a/src/cli/input/types.ts
+++ b/src/cli/input/types.ts
@@ -25,6 +25,14 @@ export interface IHistoryRing {
   forward(): string | null;
   resetRecall(): void;
   readonly inRecall: boolean;
+  /**
+   * Newest-first snapshot of all entries, used to rank slash-command
+   * completions by recency (`cli/input/suggest-rank`). Optional so existing
+   * lightweight test doubles implementing only the recall surface stay valid;
+   * callers must treat an absent implementation as "no history available"
+   * and fall back to alphabetical ordering.
+   */
+  getEntries?(): readonly string[];
 }
 
 /**

--- a/src/cli/terminal-compositor.autocomplete.ts
+++ b/src/cli/terminal-compositor.autocomplete.ts
@@ -19,6 +19,7 @@ import {
 } from './input/trigger.js';
 import { stripGhostControlChars } from './input/suggest.js';
 import type { AutocompleteState } from './input/autocomplete-state.js';
+import type { IHistoryRing } from './input/types.js';
 import type { SuggestContext, SuggestEngine } from './terminal-compositor.types.js';
 
 /** Maximum dropdown rows to show inside the compositor frame. */
@@ -40,6 +41,13 @@ export interface AutocompleteHost {
   activeGhost: string | null;
   readonly ghostEngine: SuggestEngine | undefined;
   readonly ghostGetContext: (() => SuggestContext) | undefined;
+  /**
+   * Input history, read newest-first to rank slash candidates by recency.
+   * Deliberately NOT sourced from `ghostGetContext`: dropdown ordering must
+   * stay correct when ghost text is disabled (`AFK_SUGGEST_GHOST=0`), which
+   * leaves that context undefined.
+   */
+  readonly history?: IHistoryRing;
   repaint(): void;
 }
 
@@ -87,7 +95,10 @@ export function updateAutocomplete(self: AutocompleteHost): void {
   }
   if (ac.trigger && ac.suppressedSignature === null) {
     if (ac.trigger.kind === 'slash') {
-      commitCandidates(ac, filterSlashCandidates(ac.trigger.query).slice(0, 12));
+      commitCandidates(
+        ac,
+        filterSlashCandidates(ac.trigger.query, self.history?.getEntries?.() ?? []).slice(0, 12),
+      );
     } else if (ac.trigger.kind === 'file') {
       updateFileCandidates(self, ac, ac.trigger.query);
     } else {


### PR DESCRIPTION
## Problem

Both slash-completion surfaces broke prefix ties **alphabetically**. With 101 registered commands and aliases, that is almost never the command the user wants.

Measured against the live registry:

| prefix length | ambiguous prefixes | commands behind one |
|---|---|---|
| 2 chars | 14 | **93 / 101 (92%)** |
| 3 chars | 17 | 50 / 101 (50%) |

Concretely, `/re` matches 10 commands and alphabetically resolves to `/reauth` — ahead of `/refactor`, `/research`, `/resolve`, `/review`, `/recover`, `/reground`, `/repo-ground` and more. Typing `/t` picks from 15 candidates; `/s` from 9.

This is on the **default-on** path (Tier-1 ghost text and the dropdown are both enabled for every user), so it is a papercut everyone hits.

## Change

Rank each tie-break bucket by how recently the user actually ran the command, read from the REPL's own input history. Alphabetical ordering remains the **terminal** tie-break, so a session with no history — and every existing ordering test — behaves exactly as before.

Applied to both surfaces that resolve a slash prefix:

- **the autocomplete dropdown** (`filterSlashCandidates`), which also feeds the Tier-1 ghost through `getDropdownTopCandidate`
- **the Tier-1 mid-sentence ghost resolver** (`getDeterministicGhost`)

Ranking lives in a new pure module, `src/cli/input/suggest-rank.ts` (97 LOC), rather than growing `suggest.ts`. It is unit-testable with no REPL, no disk, and no session.

## Design notes on the seams

- `filterSlashCandidates` takes history as an **optional** parameter — additive, so every existing caller is unaffected and omitting it reproduces the old ordering byte-for-byte (asserted in a test).
- `IHistoryRing.getEntries` is declared **optional**, so lightweight test doubles implementing only the recall surface stay valid. Callers treat an absent implementation as "no history" and fall back to alphabetical.
- The compositor reads history **directly**, not via `ghostGetContext`. That context is `undefined` when ghost text is disabled (`AFK_SUGGEST_GHOST=0`), and dropdown ordering must stay correct independently of the ghost feature flag.
- Recency reorders **within** a bucket only — prefix matches still outrank subsequence matches. There is a regression test for exactly this, because it is the one way this change could have quietly degraded ranking quality.

## Verification

- `pnpm test` — **14,746 passing** across 773 files (2 pre-existing skips)
- `pnpm lint` (`tsc --noEmit`) — clean
- `pnpm build` — clean
- All five CI audit gates pass: `audit:sdk:check`, `audit:env:check`, `scan:env:check`, `audit:chalk:check`, `fix:pins:check`
- 26 new tests (21 unit for the ranking module, 5 integration for the dropdown wiring), including regressions for global-regex `lastIndex` reuse and for bucket-order preservation

## Also included

`docs/proposals/idle-turn-proposal.md` — the decision record for how this change was arrived at. It documents two **rejected** designs so they are not re-proposed:

1. An idle-triggered LLM "Tier 3" ghost proposer, rejected after adversarial critique.
2. Deriving a next action from the agent's end-of-turn contract, gated on a prerequisite measurement that **failed**: `parseTerminalState()` hit only a **69.5%** parse rate across 400 real transcripts (692 assistant turns), and just **0.7%** of terminal-state bodies contained anything resembling a runnable command. The premise that the model "already computes the next action for free" turned out to be false.

That investigation is what surfaced the alphabetical-ranking problem this PR actually fixes.

## Not addressed

`suggest.ts` is 544 lines and was already over the repo's 350-line ceiling before this change (+5 lines here). Splitting it is out of scope for this PR.

Tracked in #894, which also covers extracting `stripGhostControlChars` out of the render path's module graph (a layering fix worth doing on its own merits) and the non-Anthropic `pickModel` cost fallback.
