### PR TITLE
refactor(providers): promote TurnTrace to providers/shared

### DIFF
--- a/src/agent/providers/anthropic-direct/loop.ts
+++ b/src/agent/providers/anthropic-direct/loop.ts
@@ -61,7 +61,7 @@ import { consumeRoundStream } from './loop/stream-consumer.js';
 import { runToolRound } from './loop/tool-round.js';
 import { emitNonToolUseTerminal } from './loop/turn-terminal.js';
 import { TurnAccumulator } from './loop/turn-accumulator.js';
-import { TurnTrace } from './loop/turn-trace.js';
+import { TurnTrace } from '../shared/turn-trace.js';
 
 /**
  * Run one user turn through the model + tool dispatcher loop. Yields
@@ -123,7 +123,7 @@ export async function* runTurn(
   // interrupt→halt latency stamp. loop_end fires from the generator's finally
   // block so all exit paths — abort, error, clean end-of-turn, capped — are
   // covered without per-site annotation.
-  const trace = new TurnTrace(input.signal, input.traceWriter);
+  const trace = new TurnTrace(input.signal, input.traceWriter, 'anthropic-direct');
 
   try {
   while (true) {

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -58,6 +58,7 @@ import { sumProviderUsage } from '../../usage.js';
 import { contextLimitFor, autoCompactLimitFor } from '../../model-limits.js';
 import { resolveModelId } from '../../session/model-resolution.js';
 import { collectSupportedCommands } from '../shared/supported-commands.js';
+import { TurnTrace } from '../shared/turn-trace.js';
 import { debugLog } from '../../../utils/debug.js';
 import {
   resolveOpenAIAuth,
@@ -455,51 +456,17 @@ export class OpenAICompatibleQuery implements ProviderQuery {
     const turnStartTime = Date.now();
     const taskId = randomUUID();
 
-    // Interrupt→halt latency instrumentation. Stamp the instant the turn signal
-    // fires so the `finally` can report ESC→terminal wall-clock in the
-    // `interrupt_halt` phase — the field-visible proof the ESC-lag fix keeps the
-    // halt within an event-loop turn (openai@6 swallows a mid-stream abort, so
-    // without abortableStream the halt lagged the parked read). One long-lived,
-    // idempotent listener; registered only when a writer is present so a
-    // no-trace session pays nothing. `close()` also aborts this controller but
-    // with reason `'closed'`; the emit gate below fires ONLY for `'interrupted'`.
-    let interruptedAt: number | null = controller.signal.aborted ? Date.now() : null;
-    const onInterruptForTrace = (): void => {
-      if (interruptedAt === null) interruptedAt = Date.now();
-    };
-    if (this.traceWriter && !controller.signal.aborted) {
-      controller.signal.addEventListener('abort', onInterruptForTrace, { once: true });
-    }
-
-    // Witness layer: mark loop entry. Mirrors anthropic-direct/loop.ts:229.
-    // Fire-and-forget — a broken trace writer must never stall the turn.
-    void emitSessionPhase(this.traceWriter, { phase: 'loop_start' });
+    // Witness-layer turn bracket (loop_start / interrupt_halt / loop_end) —
+    // shared with anthropic-direct via providers/shared/turn-trace.ts. See
+    // TurnTrace's own doc comment for the interrupt→halt latency rationale
+    // (the field-visible proof the ESC-lag fix keeps the halt within an
+    // event-loop turn; openai@6 swallows a mid-stream abort, so without
+    // abortableStream the halt lagged the parked read).
+    const trace = new TurnTrace(controller.signal, this.traceWriter, 'openai-compatible');
     try {
-    yield* this._runTurnInner(content, controller, turnStartTime, taskId);
+      yield* this._runTurnInner(content, controller, turnStartTime, taskId);
     } finally {
-      controller.signal.removeEventListener('abort', onInterruptForTrace);
-      // Interrupt→halt latency: emit ONLY when THIS turn ended because of an ESC
-      // soft-stop (`interrupt()` aborts with reason `'interrupted'`). The abort
-      // paths funnel through finishTurn, which yields the single terminal
-      // `turn.completed` immediately before _runTurnInner returns into this
-      // finally, so `Date.now()` here is that terminal instant; `interruptedAt`
-      // is when the signal fired. A session `close()` (reason `'closed'`) and a
-      // clean/error/capped end are excluded. Fire-and-forget; mirrors
-      // anthropic-direct/loop.ts.
-      if (interruptedAt !== null && controller.signal.reason === 'interrupted') {
-        void emitSessionPhase(this.traceWriter, {
-          phase: 'interrupt_halt',
-          durationMs: Date.now() - interruptedAt,
-          metadata: { provider: 'openai-compatible' },
-        });
-      }
-      // Witness layer: loop_end fires regardless of which exit path fired —
-      // abort, error, clean end-of-turn, or iteration cap. Mirrors
-      // anthropic-direct/loop.ts:728–734.
-      void emitSessionPhase(this.traceWriter, {
-        phase: 'loop_end',
-        durationMs: Date.now() - turnStartTime,
-      });
+      trace.finish(Date.now() - turnStartTime);
     }
   }
 

--- a/src/agent/providers/shared/turn-trace.ts
+++ b/src/agent/providers/shared/turn-trace.ts
@@ -1,7 +1,13 @@
 /**
- * Witness-layer bracket around one turn of the anthropic-direct loop:
- * `loop_start` on entry, `interrupt_halt` + `loop_end` on every exit path, and
- * the interrupt-timestamp bookkeeping the halt-latency measurement needs.
+ * Witness-layer bracket around one provider turn: `loop_start` on entry,
+ * `interrupt_halt` + `loop_end` on every exit path, and the
+ * interrupt-timestamp bookkeeping the halt-latency measurement needs.
+ *
+ * Shared by both providers — promoted from `anthropic-direct/loop/turn-trace.ts`
+ * after confirming `openai-compatible/query.ts`'s inline equivalent (its own
+ * comments describe it as mirroring this one) has no anthropic-SDK-specific
+ * coupling and only one behavioral parameter: the `provider` label stamped on
+ * the `interrupt_halt` metadata, which each caller now passes explicitly.
  *
  * Contract: this owns a lifetime that belongs to NO single loop phase. The
  * abort listener can fire during any phase (or before the loop starts), and its
@@ -11,11 +17,11 @@
  * Every emit is fire-and-forget: a broken or slow trace writer must never stall
  * tool dispatch, nor an already-returning turn.
  *
- * @module agent/providers/anthropic-direct/loop/turn-trace
+ * @module agent/providers/shared/turn-trace
  */
 
-import type { TraceWriter } from '../../../trace/index.js';
-import { emitSessionPhase } from '../../../trace/emit.js';
+import type { TraceWriter } from '../../trace/index.js';
+import { emitSessionPhase } from '../../trace/emit.js';
 
 /**
  * Brackets a turn with its witness events. Construct at loop entry (which emits
@@ -27,16 +33,20 @@ export class TurnTrace {
   /**
    * @param signal      - The turn's abort signal. Watched for the ESC soft-stop.
    * @param traceWriter - Absent on a no-trace session; every method no-ops safely.
+   * @param provider    - Stamped onto the `interrupt_halt` metadata so the two
+   *                      providers' halt-latency events stay distinguishable.
    */
   constructor(
     private readonly signal: AbortSignal,
     private readonly traceWriter: TraceWriter | undefined,
+    private readonly provider: 'anthropic-direct' | 'openai-compatible',
   ) {
     // Invariant: emit order matches the pre-split loop prologue — `loop_start`
     // is the first witness event of the turn, and the interrupt listener is
     // registered after it. Both are synchronous with respect to each other
-    // (the emit is fire-and-forget), so this ordering is about keeping the
-    // trace stream byte-comparable with pre-split sessions, not correctness.
+    // (the emit is fire-and-forget, and neither statement awaits), so no abort
+    // can land between them — this ordering is about keeping the trace stream
+    // byte-comparable with pre-split sessions, not correctness.
 
     // Mark loop entry once for this turn.
     void emitSessionPhase(traceWriter, { phase: 'loop_start' });
@@ -81,7 +91,7 @@ export class TurnTrace {
       void emitSessionPhase(this.traceWriter, {
         phase: 'interrupt_halt',
         durationMs: Date.now() - this.interruptedAt,
-        metadata: { provider: 'anthropic-direct' },
+        metadata: { provider: this.provider },
       });
     }
 


### PR DESCRIPTION
## Summary

Promotes the `TurnTrace` witness-layer bracket (`loop_start` / `interrupt_halt` / `loop_end` + interrupt-timestamp bookkeeping) from `anthropic-direct/loop/turn-trace.ts` to `providers/shared/turn-trace.ts`, and has `openai-compatible/query.ts` use it instead of its own ~45-line inline equivalent. `openai-compatible`'s own comments already described that block as mirroring the anthropic-direct version.

## What changed behaviorally: nothing, except explicit parameterization of one thing that already varied

The two originals were ~70% identical. The one real parameter that differed was the `provider` string stamped onto `interrupt_halt`'s metadata (`'anthropic-direct'` vs `'openai-compatible'`, each hardcoded). That's now an explicit third constructor argument — each call site still passes its own label, so trace output is unchanged.

## What I checked before promoting (this investigation found a real false-positive on a sibling finding — see below, so I did not skip this step)

- The class has zero Anthropic-SDK-specific coupling — safe to live in `shared/`.
- The one apparent structural difference (`openai-compatible` registered its interrupt listener *before* emitting `loop_start`; `anthropic-direct` emits `loop_start` *then* registers the listener) has no observable effect: both statements are synchronous with nothing awaited between them, so no abort can land in between regardless of order. The class's own doc comment already notes this ordering is about trace-stream byte-comparability with historical sessions, not correctness.

## Verification

Full suite green — both under the default (parallel) pool and under `--no-file-parallelism` (serial), matching the clean `origin/main` baseline exactly: **773 test files, 14746 passed, 2 skipped, 0 failed.**

## A sibling finding from the same investigation was reverted, not included here

The same `/simplify` pass also flagged `anthropic-direct/loop/tool-dispatch.ts` and `openai-compatible/query/dispatch-append.ts`'s batch-or-sequential dispatch try/catch skeleton as ~75% duplicated. I extracted it too, adopting the more defensive of the two try/catch boundary shapes (openai-compatible already wrapped both the batch and sequential-fallback branches in one outer try; anthropic-direct only wrapped the batch branch). **That extraction reproduced a full-suite-only V8 heap-OOM crash**, confirmed via a confound-free comparison against a clean sibling worktree on the identical `origin/main` base (both under `--no-file-parallelism`): clean baseline 773/773, my change 772/773 with one file's worker OOM-crashing consistently, even with `--max-old-space-size=8192`. Narrow/targeted test runs of the affected files never surfaced this — only a true full-suite run did. Root cause is unconfirmed but strongly suspected to be a runaway retry loop somewhere upstream that used to terminate on an uncaught exception from `anthropic-direct`'s narrower try boundary and no longer does. Reverted that specific change entirely (not part of this PR) rather than ship on unconfirmed safety; it needs its own dedicated investigation, ideally with the "narrower try, not the wider one" shape instead, or a full-suite-based bisection to find the specific interaction.
