### PR TITLE
fix(cli): resolve palette at call time so theme swaps actually reach the UI

### DIFF
--- a/scripts/audit-chalk-sgr.ts
+++ b/scripts/audit-chalk-sgr.ts
@@ -1,0 +1,27 @@
+/** Matches a hand-rolled SGR escape literal and captures its numeric parameters. */
+export const RAW_SGR_RE = /\\(?:x1[bB]|u001[bB]|u\{0*1[bB]\}|e|033)\[([0-9;]*)m/g;
+
+/**
+ * Contract: return true only for SGR parameters that open a visible style.
+ * Reset and style-closing codes remain exempt because they do not bypass the
+ * semantic palette by introducing a tone or attribute of their own.
+ */
+export function isStylingSgr(params: string): boolean {
+  if (params === '' || params === '0') return false;
+  return params.split(';').some((raw) => {
+    const n = Number.parseInt(raw, 10);
+    if (!Number.isInteger(n)) return false;
+    if (n >= 1 && n <= 9) return true; // common attributes
+    if (n >= 11 && n <= 21) return true; // alternate fonts, Fraktur, double underline
+    if (n === 26) return true; // proportional spacing
+    if (n >= 30 && n <= 38) return true; // foreground, including extended color
+    if (n >= 40 && n <= 48) return true; // background, including extended color
+    if (n >= 51 && n <= 53) return true; // framed, encircled, overlined
+    if (n === 58) return true; // underline color
+    if (n >= 60 && n <= 64) return true; // ideogram decorations
+    if (n >= 73 && n <= 74) return true; // superscript, subscript
+    if (n >= 90 && n <= 97) return true; // bright foreground
+    if (n >= 100 && n <= 107) return true; // bright background
+    return false;
+  });
+}

--- a/scripts/audit-chalk-usage.ts
+++ b/scripts/audit-chalk-usage.ts
@@ -103,8 +103,12 @@ const CHALK_STYLE_RE = /\bchalk\s*\.\s*(?!level\b)([A-Za-z][A-Za-z0-9]*)/g;
  * because this pattern requires a literal `[` immediately after the escape —
  * so ANSI *parsers* and *strippers* are exempt by construction while ANSI
  * *emitters* are caught.
+ *
+ * Hex digits are matched case-insensitively per-alternative, not via the `i`
+ * flag — `\x1B` is `\x1b`, but `i` would also match `\E[` (not ESC) and a
+ * trailing `M` (not SGR), both false positives.
  */
-const RAW_SGR_RE = /\\(?:x1b|u001b|u\{1b\}|e|033)\[([0-9;]*)m/g;
+const RAW_SGR_RE = /\\(?:x1[bB]|u001[bB]|u\{0*1[bB]\}|e|033)\[([0-9;]*)m/g;
 
 /**
  * SGR parameters that set a color or a text attribute. Anything here means the

--- a/scripts/audit-chalk-usage.ts
+++ b/scripts/audit-chalk-usage.ts
@@ -38,6 +38,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { RAW_SGR_RE, isStylingSgr } from './audit-chalk-sgr.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..');
@@ -93,46 +94,6 @@ interface Violation {
  */
 const CHALK_STYLE_RE = /\bchalk\s*\.\s*(?!level\b)([A-Za-z][A-Za-z0-9]*)/g;
 
-/**
- * Matches a hand-rolled SGR escape literal — `\x1b[33m`, `\u001b[1m`, `\e[0m`.
- * Only the `m` final byte (Select Graphic Rendition) counts: cursor control
- * (`\x1b[2K`, `\x1b[<row>;1H`, `\x1b[s`) shares the CSI prefix but is layout,
- * not styling, and the compositor legitimately owns it.
- *
- * A regex literal that escapes the bracket (`/\x1b\[[0-9;]*m/`) does not match,
- * because this pattern requires a literal `[` immediately after the escape —
- * so ANSI *parsers* and *strippers* are exempt by construction while ANSI
- * *emitters* are caught.
- *
- * Hex digits are matched case-insensitively per-alternative, not via the `i`
- * flag — `\x1B` is `\x1b`, but `i` would also match `\E[` (not ESC) and a
- * trailing `M` (not SGR), both false positives.
- */
-const RAW_SGR_RE = /\\(?:x1[bB]|u001[bB]|u\{0*1[bB]\}|e|033)\[([0-9;]*)m/g;
-
-/**
- * SGR parameters that set a color or a text attribute. Anything here means the
- * literal is styling output, which must go through the palette instead.
- *
- * Contract: a BARE reset (`\x1b[0m` / `\x1b[m`) is deliberately NOT a
- * violation. It opens no color of its own, and ANSI-safe truncation helpers
- * legitimately append one to close a run the *caller* opened (see
- * `src/cli/display.ts`). Every real palette bypass has to open a style first,
- * and that opener is caught here — so exempting the reset costs no coverage
- * while removing a whole false-positive class.
- */
-function isStylingSgr(params: string): boolean {
-  if (params === '' || params === '0') return false;
-  return params.split(';').some((raw) => {
-    const n = Number.parseInt(raw, 10);
-    if (!Number.isInteger(n)) return false;
-    if (n >= 1 && n <= 9) return true; // bold/dim/italic/underline/blink/inverse/hidden/strike
-    if (n >= 30 && n <= 49) return true; // fg + bg, incl. 38/48 extended and 39/49 defaults
-    if (n >= 90 && n <= 97) return true; // bright fg
-    if (n >= 100 && n <= 107) return true; // bright bg
-    return false;
-  });
-}
 
 function walk(dir: string, out: string[]): void {
   if (!fs.existsSync(dir)) return;

--- a/scripts/audit-chalk-usage.ts
+++ b/scripts/audit-chalk-usage.ts
@@ -93,6 +93,43 @@ interface Violation {
  */
 const CHALK_STYLE_RE = /\bchalk\s*\.\s*(?!level\b)([A-Za-z][A-Za-z0-9]*)/g;
 
+/**
+ * Matches a hand-rolled SGR escape literal — `\x1b[33m`, `\u001b[1m`, `\e[0m`.
+ * Only the `m` final byte (Select Graphic Rendition) counts: cursor control
+ * (`\x1b[2K`, `\x1b[<row>;1H`, `\x1b[s`) shares the CSI prefix but is layout,
+ * not styling, and the compositor legitimately owns it.
+ *
+ * A regex literal that escapes the bracket (`/\x1b\[[0-9;]*m/`) does not match,
+ * because this pattern requires a literal `[` immediately after the escape —
+ * so ANSI *parsers* and *strippers* are exempt by construction while ANSI
+ * *emitters* are caught.
+ */
+const RAW_SGR_RE = /\\(?:x1b|u001b|u\{1b\}|e|033)\[([0-9;]*)m/g;
+
+/**
+ * SGR parameters that set a color or a text attribute. Anything here means the
+ * literal is styling output, which must go through the palette instead.
+ *
+ * Contract: a BARE reset (`\x1b[0m` / `\x1b[m`) is deliberately NOT a
+ * violation. It opens no color of its own, and ANSI-safe truncation helpers
+ * legitimately append one to close a run the *caller* opened (see
+ * `src/cli/display.ts`). Every real palette bypass has to open a style first,
+ * and that opener is caught here — so exempting the reset costs no coverage
+ * while removing a whole false-positive class.
+ */
+function isStylingSgr(params: string): boolean {
+  if (params === '' || params === '0') return false;
+  return params.split(';').some((raw) => {
+    const n = Number.parseInt(raw, 10);
+    if (!Number.isInteger(n)) return false;
+    if (n >= 1 && n <= 9) return true; // bold/dim/italic/underline/blink/inverse/hidden/strike
+    if (n >= 30 && n <= 49) return true; // fg + bg, incl. 38/48 extended and 39/49 defaults
+    if (n >= 90 && n <= 97) return true; // bright fg
+    if (n >= 100 && n <= 107) return true; // bright bg
+    return false;
+  });
+}
+
 function walk(dir: string, out: string[]): void {
   if (!fs.existsSync(dir)) return;
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -125,7 +162,19 @@ function scan(file: string, source: string): Violation[] {
     CHALK_STYLE_RE.lastIndex = 0;
     let match: RegExpExecArray | null;
     while ((match = CHALK_STYLE_RE.exec(line)) !== null) {
-      violations.push({ file: rel, line: i + 1, text: line.trim(), method: match[1] ?? '?' });
+      violations.push({
+        file: rel,
+        line: i + 1,
+        text: line.trim(),
+        method: `chalk.${match[1] ?? '?'}`,
+      });
+    }
+
+    RAW_SGR_RE.lastIndex = 0;
+    while ((match = RAW_SGR_RE.exec(line)) !== null) {
+      const params = match[1] ?? '';
+      if (!isStylingSgr(params)) continue;
+      violations.push({ file: rel, line: i + 1, text: line.trim(), method: `ESC[${params}m` });
     }
   }
   return violations;
@@ -150,21 +199,21 @@ function main(): void {
   }
 
   if (listMode) {
-    console.log(`\n=== All raw chalk styling sites in src/ ===`);
+    console.log(`\n=== All raw styling sites (chalk + hand-rolled SGR) in src/ ===`);
     console.log(`Allowlisted: ${allowedHits.length} site(s)`);
-    for (const h of allowedHits) console.log(`  ${h.file}:${h.line} → chalk.${h.method}`);
+    for (const h of allowedHits) console.log(`  ${h.file}:${h.line} → ${h.method}`);
     console.log(`Other: ${allViolations.length} site(s)`);
-    for (const h of allViolations) console.log(`  ${h.file}:${h.line} → chalk.${h.method}`);
+    for (const h of allViolations) console.log(`  ${h.file}:${h.line} → ${h.method}`);
   }
 
   if (allViolations.length === 0) {
     console.log(
-      `✓ audit-chalk-usage: ${files.length} files scanned, ${allowedHits.length} legitimate raw-chalk sites inside allowlist, 0 violations.`,
+      `✓ audit-chalk-usage: ${files.length} files scanned, ${allowedHits.length} legitimate raw-styling sites inside allowlist, 0 violations.`,
     );
     process.exit(0);
   }
 
-  console.error(`\n✗ audit-chalk-usage: ${allViolations.length} raw chalk styling call(s) outside the palette:\n`);
+  console.error(`\n✗ audit-chalk-usage: ${allViolations.length} raw styling site(s) outside the palette:\n`);
   const byFile = new Map<string, Violation[]>();
   for (const v of allViolations) {
     const existing = byFile.get(v.file);
@@ -174,7 +223,7 @@ function main(): void {
   for (const [file, vs] of [...byFile.entries()].sort(([a], [b]) => a.localeCompare(b))) {
     console.error(`  ${file}`);
     for (const v of vs) {
-      console.error(`    L${v.line}: chalk.${v.method}(...)`);
+      console.error(`    L${v.line}: ${v.method}`);
       console.error(`         ${v.text}`);
     }
     console.error('');
@@ -187,6 +236,7 @@ function main(): void {
   console.error('     palette.warning(x)  // ← was: chalk.yellow(x)');
   console.error('     palette.meta(x)     // ← was: chalk.gray(x)');
   console.error('     palette.heading(x)  // ← was: chalk.bold(<section title>) / chalk.cyan.bold(x)');
+  console.error('     palette.bold(x)     // ← was: a hand-rolled \\x1b[1m … \\x1b[0m literal');
   console.error('  2. If the palette lacks a fitting role, add one to src/cli/palette.ts (keep it semantic).');
   console.error('  3. If this is a genuinely uncoverable case (per-pixel art, dynamic runtime hex), add the');
   console.error('     file to ALLOWED_FILES in scripts/audit-chalk-usage.ts with a rationale.\n');

--- a/src/cli/commands/interactive/verdict-card.ts
+++ b/src/cli/commands/interactive/verdict-card.ts
@@ -40,26 +40,32 @@ interface KindStyle {
 // as 1 column, but terminals/fonts that render it as 2 push the row 1 column
 // past the right border, wrapping the trailing `│` and breaking the box. Use
 // ASCII `-` for dashes. (Chip glyphs ✓/⊘/?/⏸ are NOT ambiguous — verified.)
+//
+// Invariant: each `color` MUST be a thunk that reads `palette.<role>` when
+// called, never the chalk instance itself. `palette` is a live view swapped
+// in place by `applyTheme()` (palette.ts), but this map is built at module
+// scope — ESM hoists it above the first `applyTheme()` call, so capturing
+// `color: palette.success` would freeze the card on the dark tones forever.
 const STYLES: Record<TerminalKind, KindStyle> = {
   done: {
-    color: palette.success,
+    color: (s) => palette.success(s),
     chip: '✓ Done',
     affordance: 'Objective satisfied - review evidence and close.',
   },
   blocked: {
-    color: palette.error,
+    color: (s) => palette.error(s),
     chip: '⊘ Blocked',
     affordance: 'External dependency - unblock above to resume.',
   },
   asking: {
-    color: palette.warning,
+    color: (s) => palette.warning(s),
     chip: '? Asking',
     affordance: 'Waiting on you - answer above to continue.',
   },
   interrupted: {
     // Neutral terminal state — see verdict-ledger.ts for rationale. Meta
     // grey conveys "this happened, low salience," not "informational event."
-    color: palette.meta,
+    color: (s) => palette.meta(s),
     chip: '⏸ Interrupted',
     affordance: 'Halted with state preserved - resume when ready.',
   },

--- a/src/cli/commands/interactive/verdict-ledger.ts
+++ b/src/cli/commands/interactive/verdict-ledger.ts
@@ -32,15 +32,23 @@ import { displayWidth, truncateDisplayWidth } from '../../display.js';
 import { getTerminalWidth, ResizeBus } from '../../terminal-size.js';
 import { isPlainOutputRequested } from '../../../config/env.js';
 
-/** Compact glyph + tone for a terminal kind on the ledger rail. */
+/**
+ * Compact glyph + tone for a terminal kind on the ledger rail.
+ *
+ * Invariant: each `color` MUST be a thunk that reads `palette.<role>` when
+ * called, never the chalk instance itself. `palette` is a live view swapped
+ * in place by `applyTheme()` (palette.ts); this map is built at module scope,
+ * which ESM hoists above the first `applyTheme()` call, so a direct capture
+ * would freeze the rail on the dark tones for the whole process.
+ */
 const KIND_PILL: Record<TerminalKind, { glyph: string; color: (s: string) => string; label: string }> = {
-  done: { glyph: '✓', color: palette.success, label: 'done' },
-  blocked: { glyph: '⊘', color: palette.error, label: 'blocked' },
-  asking: { glyph: '?', color: palette.warning, label: 'asking' },
+  done: { glyph: '✓', color: (s) => palette.success(s), label: 'done' },
+  blocked: { glyph: '⊘', color: (s) => palette.error(s), label: 'blocked' },
+  asking: { glyph: '?', color: (s) => palette.warning(s), label: 'asking' },
   // Interrupted is a neutral terminal state — the user stopped the agent.
   // Use meta-grey, not info-sky: it's not an informational event, it's a
   // low-salience "the user halted me" marker.
-  interrupted: { glyph: '⏸', color: palette.meta, label: 'interrupted' },
+  interrupted: { glyph: '⏸', color: (s) => palette.meta(s), label: 'interrupted' },
 };
 
 export interface VerdictLedger {

--- a/src/cli/input-highlight.ts
+++ b/src/cli/input-highlight.ts
@@ -89,11 +89,16 @@ const PASTE_PLACEHOLDER_RE = /\[Pasted text #[0-9a-f]+ \+\d+ (?:lines|chars)\]/g
  * the post-colon suffix, so plugin-scoped forms of a special-cased command
  * pick up the same tone as the bare form.
  */
+// Invariant: each tone MUST be a thunk that reads `palette.<role>` when
+// called, never the chalk instance itself. `palette` is a live view swapped in
+// place by `applyTheme()` (palette.ts); this map is built at module scope,
+// which ESM hoists above the first `applyTheme()` call, so a direct capture
+// would freeze the chip on the dark tones regardless of the active theme.
 const TOKEN_TONE_OVERRIDES: Record<string, (s: string) => string> = {
   // /mint — color pun on the skill name. The mint-green chip visually
   // separates a /mint invocation from every other registered command in the
   // input buffer.
-  mint: palette.mint,
+  mint: (s) => palette.mint(s),
 };
 
 /**

--- a/src/cli/palette.ts
+++ b/src/cli/palette.ts
@@ -45,8 +45,21 @@
  *
  * Invariant: every theme is built from the shared default `chalk` export
  * (never `new Chalk({ level })`), so `chalk.level = 0` (NO_COLOR / CI /
- * non-TTY, set in `color-config.ts`) strips color from light-theme
- * instances too — chalk builders read the global level at call time.
+ * non-TTY, set in `color-config.ts`) strips color from every theme's
+ * instances too — a level of 0 short-circuits to the bare string at CALL
+ * time, whatever level the builder was created at.
+ *
+ * Invariant: `configureColor()` may only ever LOWER `chalk.level` (to 0), and
+ * must never raise it. Unlike the level-0 strip, the color-SPACE choice is
+ * resolved when `chalk.hex()` is CALLED — i.e. at this module's evaluation —
+ * so a builder created while chalk auto-detected level 1 emits the 16-color
+ * approximation forever, even if `chalk.level` is set to 3 afterwards. That
+ * silently collapses distinct theme hexes onto the same escape (umber's
+ * `#D7AA32` warning and dark's `chalk.yellow` both become `ESC[33m`), making
+ * two themes look identical. Raising the level therefore requires setting
+ * `FORCE_COLOR` in the environment BEFORE chalk is imported — which is
+ * exactly why `configureColor()` returns early when it sees `FORCE_COLOR`
+ * rather than translating it into a `chalk.level` assignment.
  */
 
 import chalk, { type ChalkInstance } from 'chalk';

--- a/src/cli/theme-live-swap.test.ts
+++ b/src/cli/theme-live-swap.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Regression tests for the import-time palette-capture freeze.
+ *
+ * `palette` (palette.ts) is a LIVE view: `applyTheme()` rewrites its members
+ * in place so every consumer picks up new tones on the next paint. That only
+ * holds if consumers read `palette.<role>` at CALL time. A module-scope
+ * capture — `const STYLES = { color: palette.success }` — is hoisted by ESM
+ * above the first `applyTheme()` call and therefore freezes on the dark tones
+ * for the life of the process, silently, with no type or lint error.
+ *
+ * That bug shipped three times (verdict card, verdict-ledger rail, /mint input
+ * chip) and pinned exactly the four roles whose dark->umber delta is largest
+ * (success/error/warning/meta are bare ANSI on dark but truecolor hex on
+ * umber), so the umber theme looked far closer to dark than it actually is.
+ *
+ * Invariant: these tests must run with FORCE_COLOR=3 applied BEFORE chalk is
+ * evaluated. `chalk.hex()` resolves the target color space at BUILDER-CREATION
+ * time, not at call time — a builder created while `chalk.level === 1` emits
+ * the 16-color approximation forever, even if `chalk.level` is later raised to
+ * 3. Under vitest (non-TTY) chalk auto-detects level 0, which would collapse
+ * distinct hexes onto the same escape and make these assertions vacuous. Hence
+ * the resetModules + dynamic-import dance instead of static imports.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+
+type Mods = {
+  chalk: typeof import('chalk').default;
+  palette: typeof import('./palette.js').palette;
+  applyTheme: typeof import('./theme.js').applyTheme;
+  renderVerdictCard: typeof import('./commands/interactive/verdict-card.js').renderVerdictCard;
+  createVerdictLedger: typeof import('./commands/interactive/verdict-ledger.js').createVerdictLedger;
+  colorizeInputBuffer: typeof import('./input-highlight.js').colorizeInputBuffer;
+};
+
+let m: Mods;
+let savedForceColor: string | undefined;
+
+beforeAll(async () => {
+  savedForceColor = process.env['FORCE_COLOR'];
+  process.env['FORCE_COLOR'] = '3';
+  vi.resetModules();
+  m = {
+    chalk: (await import('chalk')).default,
+    palette: (await import('./palette.js')).palette,
+    applyTheme: (await import('./theme.js')).applyTheme,
+    renderVerdictCard: (await import('./commands/interactive/verdict-card.js')).renderVerdictCard,
+    createVerdictLedger: (await import('./commands/interactive/verdict-ledger.js')).createVerdictLedger,
+    colorizeInputBuffer: (await import('./input-highlight.js')).colorizeInputBuffer,
+  };
+});
+
+afterAll(() => {
+  if (savedForceColor === undefined) delete process.env['FORCE_COLOR'];
+  else process.env['FORCE_COLOR'] = savedForceColor;
+  vi.resetModules();
+});
+
+/** The first SGR sequence in a string, or '' when it carries none. */
+function firstSgr(s: string): string {
+  return /\u001b\[[0-9;]*m/.exec(s)?.[0] ?? '';
+}
+
+/**
+ * Assert `render()` paints in the LIVE tone of `role` under every theme —
+ * i.e. the renderer resolves the palette at call time rather than freezing a
+ * captured chalk instance. Level-agnostic: it compares the renderer's escape
+ * to the palette's own escape at that same moment.
+ */
+function expectsLiveTone(role: keyof typeof m.palette, render: () => string): void {
+  const THEMES = ['dark', 'umber', 'light'] as const;
+  const escapeOf = new Map<string, string>();
+  for (const theme of THEMES) {
+    m.applyTheme(theme);
+    escapeOf.set(theme, firstSgr(m.palette[role]('x')));
+  }
+  // Guard against a vacuous pass: the themes must actually differ at this
+  // color level, or the containment checks below prove nothing.
+  expect(new Set(escapeOf.values()).size, `${role} is identical in all themes`).toBe(THEMES.length);
+
+  for (const theme of THEMES) {
+    m.applyTheme(theme);
+    const out = render();
+    expect(out, `${role} did not adopt the ${theme} tone`).toContain(escapeOf.get(theme));
+    for (const other of THEMES) {
+      if (other === theme) continue;
+      expect(out, `${role} still carries the ${other} tone under ${theme}`).not.toContain(
+        escapeOf.get(other),
+      );
+    }
+  }
+  m.applyTheme('dark');
+}
+
+describe('theme swap reaches module-scope renderers', () => {
+  it('chalk resolves truecolor, so theme escapes are distinguishable', () => {
+    expect(m.chalk.level).toBe(3);
+  });
+
+  it.each([
+    ['done', 'success'],
+    ['blocked', 'error'],
+    ['asking', 'warning'],
+    ['interrupted', 'meta'],
+  ] as const)('verdict card (%s) paints the live %s tone', (kind, role) => {
+    expectsLiveTone(role, () => m.renderVerdictCard({ kind, rawBody: 'body' }));
+  });
+
+  it('verdict-ledger rail paints the live success tone', () => {
+    const ledger = m.createVerdictLedger();
+    ledger.push({ kind: 'done', rawBody: 'ok' });
+    expectsLiveTone('success', () => ledger.render() ?? '');
+  });
+
+  it('input-buffer /mint chip paints the live mint tone', () => {
+    const registry = { has: (n: string) => n === 'mint' };
+    expectsLiveTone('mint', () => {
+      const out = m.colorizeInputBuffer('/mint ship it', registry);
+      // The chip is the first colored token in the buffer.
+      return out.slice(out.indexOf('\u001b'));
+    });
+  });
+});

--- a/src/cli/update-checker.ts
+++ b/src/cli/update-checker.ts
@@ -4,6 +4,7 @@ import { get as httpsGet } from 'https';
 import { join } from 'path';
 import { getAfkCacheDir } from '../paths.js';
 import { getVersion } from './version.js';
+import { palette } from './palette.js';
 import { env } from '../config/env.js';
 
 /** Maximum response body size accepted from the registry (64 KB). */
@@ -195,13 +196,13 @@ export async function coldStartUpdateCheck(
 }
 
 export function printUpdateBanner(info: UpdateInfo): void {
-  const yellow = '\x1b[33m';
-  const bold = '\x1b[1m';
-  const dim = '\x1b[2m';
-  const reset = '\x1b[0m';
+  // Invariant: style through the palette, never hand-rolled SGR literals. Raw
+  // escapes bypass chalk's level gate, so they printed color even under
+  // NO_COLOR / CI / a piped stderr, and they were invisible to `applyTheme()`.
   process.stderr.write(
-    `\n${yellow}${bold}Update available:${reset} ${dim}${info.currentVersion}${reset} → ${bold}${info.latestVersion}${reset}\n` +
-    `${dim}Run \`npm install -g agent-afk\` to update${reset}\n`,
+    `\n${palette.warning(palette.bold('Update available:'))} ` +
+    `${palette.dim(info.currentVersion)} → ${palette.bold(info.latestVersion)}\n` +
+    `${palette.dim('Run `npm install -g agent-afk` to update')}\n`,
   );
 }
 
@@ -370,10 +371,9 @@ export function checkPendingUpdate(): void {
     if (current === pending.targetVersion) {
       // Install landed: announce once, then clear the marker.
       unlinkSync(pendingPath());
-      const green = '\x1b[32m';
-      const bold = '\x1b[1m';
-      const reset = '\x1b[0m';
-      process.stderr.write(`${green}${bold}Updated to agent-afk v${current}${reset}\n`);
+      process.stderr.write(
+        `${palette.success(palette.bold(`Updated to agent-afk v${current}`))}\n`,
+      );
       return;
     }
 

--- a/tests/audit-chalk-sgr.test.ts
+++ b/tests/audit-chalk-sgr.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { RAW_SGR_RE, isStylingSgr } from '../scripts/audit-chalk-sgr.js';
+
+describe('raw SGR audit classification', () => {
+  it.each(['', '0', '10', '22', '23', '24', '25', '27', '28', '29', '39', '49', '50', '54', '55', '59', '65', '75'])(
+    'allows reset or style-closing parameter %j',
+    (params) => {
+      expect(isStylingSgr(params)).toBe(false);
+    },
+  );
+
+  it.each([
+    '1',
+    '9',
+    '11',
+    '21',
+    '26',
+    '30',
+    '38;5;208',
+    '40',
+    '48;2;10;20;30',
+    '51',
+    '52',
+    '53',
+    '58;5;208',
+    '60',
+    '64',
+    '73',
+    '74',
+    '90',
+    '97',
+    '100',
+    '107',
+    '0;53',
+  ])('flags styling opener parameter %j', (params) => {
+    expect(isStylingSgr(params)).toBe(true);
+  });
+
+  it.each([
+    ['\\x1b[53m', '53'],
+    ['\\x1B[58;5;208m', '58;5;208'],
+    ['\\u001b[73m', '73'],
+    ['\\u001B[74m', '74'],
+    ['\\u{001b}[51m', '51'],
+    ['\\e[52m', '52'],
+    ['\\033[60m', '60'],
+  ])('recognizes literal %s', (literal, params) => {
+    RAW_SGR_RE.lastIndex = 0;
+    expect(RAW_SGR_RE.exec(literal)?.[1]).toBe(params);
+  });
+
+  it.each(['\\x1b[2K', '\\x1b[1H', '/\\x1b\\[[0-9;]*m/', '\\x1b[53M'])('ignores non-emitter %s', (literal) => {
+    RAW_SGR_RE.lastIndex = 0;
+    expect(RAW_SGR_RE.test(literal)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why

Reported: *"the umber theme doesn't look much different from dark — is this intended or is there a bug?"*

Both, it turns out. Most of the similarity is by design, but one real defect was hiding the part that *should* have looked different.

## The bug

`src/cli/palette.ts` is a **live view**: `applyTheme()` does `Object.assign(palette, THEME_PALETTES[name])`, mutating members in place so the ~100 importing modules re-tone on their next paint. That contract only holds if consumers read `palette.<role>` at **call** time. Three sites captured the chalk instance at **module** scope instead:

| site | roles frozen |
|---|---|
| `verdict-card.ts:43` (`STYLES`) | success, error, warning, meta |
| `verdict-ledger.ts:36` (`KIND_PILL`) | success, error, warning, meta |
| `input-highlight.ts:92` (`TOKEN_TONE_OVERRIDES`) | mint |

ESM hoists the whole static import graph above `index.ts`'s own first `applyTheme()` call, so those consts captured dark's instances permanently. No type error, no lint error, no test coverage.

The cruel part is *which* roles froze. Measured CIE76 dE, dark to umber:

```
success   #00AA00 -> #8AE49E   47.7  CLEARLY DIFFERENT
error     #AA0000 -> #EF7F74   42.4  CLEARLY DIFFERENT
warning   #AA5500 -> #D7AA32   37.6  CLEARLY DIFFERENT
meta      #555555 -> #AAA19B   31.1  CLEARLY DIFFERENT
...
heading   #FFFFFF -> #F9F6F2    3.8  subtle
```

Those four are the largest deltas in the whole palette — dark renders them as bare ANSI (`ESC[32m`/`[31m`/`[33m`/`[90m`) where umber uses truecolor hex. So the freeze landed precisely on the most-saturated chrome on screen. Verified before the fix: `renderVerdictCard` emitted `ESC[32m` under umber; after, `ESC[38;2;138;228;158m`.

## What is *not* a bug (answering the original question)

Rendering a realistic assistant reply through the real markdown pipeline under both themes and bucketing every visible character by active SGR:

```
active-SGR             chars   %total  changes dark->umber?
(default fg)             307   85.3%   no       <- unstyled prose
38;2;220;220;170          16    4.4%   YES
2 (dim)                   14    3.9%   no
1+37 (bold heading)        9    2.5%   YES
...
TOTAL: 37/360 chars (10.3%) change color
```

1. **~85% of a reply is unstyled prose** inheriting the terminal's default foreground. A theme can only repaint the other ~10%.
2. **The background never changes**, and that *is* umber's identity — it is tuned for its own `#19120D` warm brown (`palette.ts:196-198`). A CLI emits foreground SGR; it cannot repaint your terminal's background.
3. **The theme is deliberately hue-preserving** (`palette.ts:203-205`: each role "keeps its dark-theme HUE IDENTITY"), and 18 of 22 colored roles are *measured* ports of Umber's ANSI table — so retuning them for contrast would break the port's provenance. Not touched here.

So after this PR umber is meaningfully distinct in the chrome, and still identical in prose and background. That last part is architectural, not a defect.

## Also fixed (same defect class)

`update-checker.ts` hand-rolled SGR literals for both update banners, bypassing chalk *and* the palette. Beyond being unthemeable, it ignored `NO_COLOR` / `CI` / non-TTY entirely — it printed color when it must not. Now routed through the palette.

The `audit:chalk:check` CI gate could not see this: it greps for `chalk.` only, so raw-ANSI leaks were structurally invisible. The gate now also flags hand-rolled SGR escapes. A bare reset (`ESC[0m`) is exempt by contract — it opens no color, and ANSI-safe truncation legitimately emits one to close a run the caller opened (`display.ts:144`); every real bypass opens a style first and is still caught. Mutation-tested: re-introducing the `update-checker` literal fails the gate.

## Latent hazard documented

`chalk.hex()` resolves its color space at **builder-creation** time, not call time — a builder created while `chalk.level === 1` emits the 16-color approximation forever, even if the level is later raised to 3. `palette.ts` claimed the opposite ("chalk builders read the global level at call time"). The conclusion it drew is still true (level 0 short-circuits at call time), but the stated reason is not, and it hides a real trap: `configureColor()` may only ever *lower* the level. Raising it would collapse distinct theme hexes onto one escape — umber's `#D7AA32` warning and dark's `chalk.yellow` both become `ESC[33m`. Corrected the invariant and named the constraint.

This is also why the new test forces `FORCE_COLOR=3` before chalk evaluates: under vitest chalk auto-detects level 0, and the collapsed escapes would have made the assertions vacuous. The test guards against that explicitly rather than trusting it.

## Verification

- `npx tsc --noEmit` clean
- `npx vitest run` — 773/774 files, 14752 passed, 2 skipped
- New `src/cli/theme-live-swap.test.ts` (7 tests), mutation-tested against every re-introduced freeze
- Gates: `audit-chalk-usage` (widened), `audit-sdk-dependency`, `audit-env-access`, `render-env-registry`, `fix:pins:check`, `pnpm build` — all pass
- All touched files remain under the 350-LOC ceiling

**One pre-existing failure, not from this PR:** `src/agent/trace/writer.test.ts > process-exit backstop seals a real crashed subprocess` (expects `status` 1, gets `null`). Confirmed identical on a clean base with these changes stashed.

## Considered and rejected

**OSC 11 background sync** — emitting `ESC ] 11 ; #19120D BEL` to set the terminal background would genuinely deliver the umber look, since the background is the theme's defining feature. Rejected: it mutates terminal state that outlives the process, and no save/restore can survive `SIGKILL`. The failure mode is a user left with a brown terminal and no catchable exit hook. Not worth it unasked; worth discussing separately if desired.

**Retuning the low-delta roles** (`heading` 3.8, `syntaxString` 7.4, `thinking` 7.4, `info` 7.6) — `info` and `heading` are measured Umber ANSI values, so changing them breaks the faithful-port contract the module documents. The four non-measured roles could be pushed further onto Umber's warm axis, but that is a taste call better made by eye than by dE.

## Follow-up not taken here

`ora()` spinners never receive a `color:` option (default cyan), and `mascot.ts` ignores the theme-aware `palette.goblin`. Both are theme leaks, both are cosmetic, and both are out of scope for a fix PR.
