### PR TITLE
fix(cli): render auto-settle timeout as an error, not a green success

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,5 +62,10 @@ agent-afk@*
 # Test artifacts
 .test-temp-edit-file/
 
+# Local scratch space — scratch clones of OTHER repos (incl. the private
+# awa-private moat) land here. Must stay ignored: this is a public repo and an
+# unignored tmp/ would stage private plugin source into it.
+tmp/
+
 # Internal roadmap (not for public repo)
 todo.md

--- a/src/cli/_lib/stream-renderer-lifecycle.ts
+++ b/src/cli/_lib/stream-renderer-lifecycle.ts
@@ -273,9 +273,19 @@ export function checkPauseAnnotations(ctx: LifecycleContext): boolean {
             `[stream-renderer] auto_settle_timeout ${JSON.stringify({ sourceId, elapsedMs: elapsed, syntheticAgentToolUseId: source.syntheticAgentToolUseId })}\n`,
           );
         }
+        // Invariant: isError MUST be true. This row is a renderer-side give-up,
+        // not a result. Nothing here touches the sub-agent's AbortController —
+        // it may still be running, and often is: a forge qualify sub-agent has
+        // been observed auto-settling here at ~90s and then failing for real
+        // ~18 minutes later. Passing false makes doneGlyph() paint a green
+        // success check on a row whose own label reads "[no-result — timed
+        // out]", so a 20-minute failure renders as a 90-second success. The
+        // glyph must agree with the label. If a real result arrives later,
+        // finalizeSubagent overwrites this row, so a transient error mark
+        // self-heals; a false success does not.
         ctx.toolLane.addResult(
           source.syntheticAgentToolUseId,
-          syntheticResult('[no-result — timed out]', false),
+          syntheticResult('[no-result — timed out]', true),
         );
         source.done = true;
         changed = true;

--- a/src/cli/_lib/stream-renderer-ordering.test.ts
+++ b/src/cli/_lib/stream-renderer-ordering.test.ts
@@ -1044,7 +1044,7 @@ describe('Bug #2 dispatch-site invariant: agentType propagates from SubagentExec
 //
 //   After fix (checkpoint 2e, checkStalledEntries replaces checkPauseAnnotations):
 //     At stalledTicks === 2K: calls toolLane.addResult(syntheticAgentToolUseId,
-//     syntheticResult('[no-result — timed out]', false)) and sets source.done = true.
+//     syntheticResult('[no-result — timed out]', true)) and sets source.done = true.
 
 describe('Bug #3 — stuck paused state: checkPauseAnnotations must have bounded exit', () => {
   afterEach(() => {
@@ -1106,7 +1106,7 @@ describe('Bug #3 — stuck paused state: checkPauseAnnotations must have bounded
     //
     // After fix (checkpoint 2e, checkStalledEntries replaces checkPauseAnnotations):
     //   At stalledTicks === 2K: calls toolLane.addResult(syntheticAgentToolUseId,
-    //   syntheticResult('[no-result — timed out]', false)) and sets source.done = true.
+    //   syntheticResult('[no-result — timed out]', true)) and sets source.done = true.
     //   The 2K+1th call sees source.done === true and skips.
     //   Assertion below PASSES.
     expect(source.done).toBe(true);


### PR DESCRIPTION
## Problem

`checkPauseAnnotations` auto-settles a stalled sub-agent row after ~90s of stream silence — 30s `PAUSE_THRESHOLD_MS` plus 750 ticks × 80ms — by injecting:

```ts
syntheticResult('[no-result — timed out]', false)
```

That second argument is `isError`. `doneGlyph()` (`tool-lane-format.ts:45-48`) paints `!isError` as a green success check. So a row whose **own label reads `[no-result — timed out]`** rendered with a success glyph.

## Why it matters

The auto-settle is **purely presentational**. Nothing on this path touches the sub-agent's `AbortController` — the child keeps running under its own 45-minute wall clock and 8-minute idle watchdog.

This bit for real. A `/forge` qualify sub-agent auto-settled here at **90 seconds**, displayed:

```
Agent(forge-qualify) · waiting 1m 31s [subagent] — ✓ [no-result — timed out]
```

…and then kept running for another **~18 minutes** before dying with a genuine stream truncation. The green check was read as "qualify finished," so the actual failure went unnoticed for the better part of an hour. The row's `waiting Xs` counter (time since last streamed event, not since dispatch) reinforced the wrong story.

## Change

Pass `true`, so the glyph agrees with the label.

If a real result arrives after the row settles, `finalizeSubagent` overwrites it (`stream-renderer-subagent.ts:371-375,446-506`) — a transient error mark **self-heals**, whereas a false success does not. That asymmetry is why `true` is the safe default for an outcome the renderer genuinely does not know.

Also updates two code comments in `stream-renderer-ordering.test.ts` that documented the old `false` argument.

## Also: ignore `tmp/`

Scratch clones of other repositories land in `tmp/` — including, in the workflow that surfaced this bug, the **private** `awa-private` moat repo. An unignored `tmp/` would stage private plugin source into this public repo. Added as a defensive ignore.

## Verification

- `pnpm lint` (`tsc --noEmit`) — exit 0
- `pnpm test src/cli/_lib src/cli/commands/interactive` — **65 files / 1516 tests pass**
- Includes the 14 `stream-renderer-ordering` tests covering this exact cutoff; they assert on `source.done`, not `isError`, so none needed behavioral changes.

## Scope

Presentational only. No change to abort semantics, sub-agent lifetime, timeout values, or control flow.
