### PR TITLE
fix(cli): remove wrap-boundary leading spaces

### DIFF
--- a/src/cli/formatter.ts
+++ b/src/cli/formatter.ts
@@ -273,13 +273,12 @@ export function renderMarkdownToTerminal(text: string, opts: RenderMarkdownOptio
                 : srcLine;
               const segs = wrapped.split('\n');
               for (let s = 0; s < segs.length; s++) {
-                // wrapToWidth runs wrap-ansi with trim:false, so a wrap at a
-                // space keeps that space at the START of the next segment.
-                // Strip it on wrap continuations (s > 0) only — otherwise the
-                // hanging indent sits one column past the item text. The first
-                // segment of each source line keeps its leading whitespace so
-                // nested-list indentation survives. Also drop trailing spaces so
-                // they don't inflate the line past the width budget.
+                // Normalize continuation whitespace defensively at this formatting
+                // boundary. wrapToWidth removes generated edge spaces while preserving
+                // source indentation, but this branch also accepts styled and nested
+                // list content whose first segment may intentionally begin with spaces.
+                // Only continuations are left-trimmed; all segments are right-trimmed
+                // so whitespace cannot inflate the line past the width budget.
                 let seg = segs[s]!;
                 if (s > 0) seg = seg.replace(/^ +/, '');
                 seg = seg.replace(/ +$/, '');

--- a/src/cli/wrap.test.ts
+++ b/src/cli/wrap.test.ts
@@ -6,6 +6,8 @@ import { describe, it, expect } from 'vitest';
 import chalk from 'chalk';
 import { wrapToWidth } from './wrap.js';
 
+const stripAnsi = (text: string): string => text.replace(/\x1B\[[0-9;]*m/g, '');
+
 describe('wrapToWidth', () => {
   it('returns short text unchanged', () => {
     expect(wrapToWidth('hello', 80)).toBe('hello');
@@ -18,11 +20,31 @@ describe('wrapToWidth', () => {
     expect(out).toContain('one');
   });
 
+  it('does not carry a boundary space onto the next line', () => {
+    const text =
+      'aaaa bbbb cccc dddd eeee ffff gggg hhhh iiii jjjj kkkk llll mmmm nnnn oooo pppp';
+
+    expect(wrapToWidth(text, 24).split('\n')).toEqual([
+      'aaaa bbbb cccc dddd eeee',
+      'ffff gggg hhhh iiii jjjj',
+      'kkkk llll mmmm nnnn oooo',
+      'pppp',
+    ]);
+  });
+
   it('wraps chalk-colored strings without throwing', () => {
     const colored = chalk.red('redword') + ' ' + 'plain ' + chalk.green('greenword');
     const out = wrapToWidth(colored, 8);
     expect(out).toContain('redword');
     expect(out.split('\n').length).toBeGreaterThan(1);
+  });
+
+  it('preserves intentional indentation after leading ANSI styles', () => {
+    const text = chalk.dim('  • one two three four');
+    const lines = wrapToWidth(text, 12, { breakLongWords: true }).split('\n');
+
+    expect(stripAnsi(lines[0]!)).toBe('  • one two');
+    expect(stripAnsi(lines[1]!)).toBe('three four');
   });
 
   it('does not throw for width 0 or Infinity', () => {

--- a/src/cli/wrap.ts
+++ b/src/cli/wrap.ts
@@ -29,11 +29,28 @@ export function wrapToWidth(
     return text;
   }
   const w = Math.floor(width);
-  return wrapAnsi(text, w, {
-    hard: opts.breakLongWords ?? false,
-    trim: false,
-    wordWrap: true,
-  });
+  return text
+    .replaceAll('\r\n', '\n')
+    .split('\n')
+    .map((line) => {
+      // wrap-ansi's trim mode removes source indentation along with wrap-boundary
+      // whitespace. Protect only the source line's leading spaces with a private-use
+      // marker absent from that line, then restore them after wrapping. This keeps
+      // intentional list/blockquote indentation while removing generated edge spaces.
+      const indentMarker = Array.from({ length: 256 }, (_, i) => String.fromCodePoint(0xE000 + i))
+        .find((candidate) => !line.includes(candidate));
+      const protectedLine = indentMarker
+        ? line.replace(/^((?:\x1B\[[0-9;]*m)*)( +)/, (_match, ansi: string, spaces: string) =>
+            ansi + indentMarker.repeat(spaces.length),
+          )
+        : line;
+      return wrapAnsi(protectedLine, w, {
+        hard: opts.breakLongWords ?? false,
+        trim: true,
+        wordWrap: true,
+      }).replaceAll(indentMarker ?? '\uE000', ' ');
+    })
+    .join('\n');
 }
 
 /**


### PR DESCRIPTION
## Summary

- remove wrap-generated leading and trailing spaces at exact word-wrap boundaries
- preserve intentional source indentation, including ANSI-styled list and blockquote rows
- leave `hardWrapToWidth` unchanged so compositor reflow keeps its byte-preservation contract
- add regressions for the original 24-column reproduction and ANSI-prefixed indentation

## Root cause

`wrap-ansi` retained a delimiter space when `trim: false` and the preceding row filled exactly to the requested width. Simply enabling trimming fixed the ragged continuation edge but also stripped meaningful leading indentation. The fix protects source-line indentation with a collision-avoiding private-use marker while `wrap-ansi` trims generated boundary whitespace, then restores the original spaces.

## Verification

- `pnpm test src/cli/wrap.test.ts src/cli/formatter.test.ts`
- `pnpm test src/cli/terminal-compositor.space-fusion.repro.test.ts src/cli/markdown-stream.test.ts src/cli/commands/interactive/tool-lane.overlay.test.ts`
- `pnpm test`
- `pnpm test:coverage`
- `pnpm lint`
- `pnpm build`
- `pnpm audit:sdk:check`
- `pnpm audit:env:check`
- `pnpm scan:env:check`
- `pnpm audit:chalk:check`
- `pnpm fix:pins:check`
- `pnpm audit:deps` (reports the repository's existing dependency advisories: 3 low, 17 moderate, 9 high; command exits successfully)

After rebasing onto `origin/main` at v5.93.2, the targeted wrap and formatter tests plus `pnpm lint` were rerun successfully.
