### PR TITLE
feat(cli): show config provenance and apply hot keys live in /config

### DIFF
--- a/src/cli/config/json-tier-parse.ts
+++ b/src/cli/config/json-tier-parse.ts
@@ -1,0 +1,305 @@
+// Contract: parse + validate ONE afk.config.json file.
+//
+// Extracted from json-tier.ts so the tier WALK (which file wins, caching,
+// fall-through) and the per-file PARSE (what a file's contents mean) are
+// separate concerns. Two consumers share this parser and they must never
+// disagree about what a file resolves to:
+//   - `loadJsonConfig()` (json-tier.ts)      — the real loader.
+//   - `resolveConfigProvenance()` (provenance.ts) — reports the value `/config`
+//     rows should display and whether a write will actually take effect.
+// Before the split, provenance re-read the same files with a bare `JSON.parse`
+// and reported RAW values, so it disagreed with the loader on every validated
+// key (an invalid `permissionMode` the loader ignores, a lowercased model
+// alias, a clamped `maxSummaryCallsPerSession`). Re-deriving validation is the
+// bug; delegating to this module is the fix. Add a key here, never at a
+// consumer.
+//
+// @module cli/config/json-tier-parse
+
+import { readFileSync, existsSync } from 'fs';
+import { isValidModel } from '../../agent/session/model-resolution.js';
+import {
+  parseModelsConfig,
+  type ModelSlotBinding,
+  type SlotName,
+} from '../../agent/session/model-slots.js';
+import { validateBranchPrefix, validateBaseRef } from '../commands/interactive/worktree.js';
+import type { RawHooksConfig } from '../../agent/hooks/config-loader.js';
+import { importFromConfigPaths, parseImportFromConfig } from '../../config/import-sources.js';
+import type { AutoRoutingConfig, CliConfig, ConfigFileSchema } from './types.js';
+
+/** One afk.config.json file's validated contents. */
+export interface ParsedJsonConfigFile {
+  readonly config: Partial<CliConfig>;
+  /**
+   * Slot bindings, kept separate from `config` because `CliConfig.models` is the
+   * fully-resolved `ModelSlots` (defaults ← file ← env) that only `loadConfig()`
+   * can compute. See {@link validatedValueView} for the dotted-path form.
+   */
+  readonly modelsPartial: Partial<Record<SlotName, ModelSlotBinding>>;
+}
+
+/**
+ * Read, parse, and validate a single afk.config.json.
+ *
+ * Three outcomes, deliberately distinct — the tier walk treats them differently:
+ *   - file absent          → returns `undefined` (NOT an error; skip the tier)
+ *   - malformed / rejected → THROWS (the caller falls through to the next tier
+ *                            and, in the loader, suppresses caching)
+ *   - valid                → returns the validated values
+ *
+ * `model` accepts any non-empty string. Known aliases are normalized to lowercase;
+ * provider-qualified and otherwise unknown model ids pass through unchanged.
+ *
+ * Throwing validators (`validateBranchPrefix`, `validateBaseRef`) are called
+ * here on purpose: a config file whose worktree refs would be parsed by git as
+ * flags is not a usable file, and the tier walk must skip it wholesale rather
+ * than honour its other keys.
+ */
+export function parseJsonConfigFile(configPath: string): ParsedJsonConfigFile | undefined {
+  if (!existsSync(configPath)) return undefined;
+
+  const content = readFileSync(configPath, 'utf-8');
+  const json: ConfigFileSchema = JSON.parse(content);
+
+  const config: Partial<CliConfig> = {};
+  const modelsPartial = parseModelsConfig(json.models);
+
+  if (typeof json.model === 'string' && json.model.length > 0) {
+    const loweredModel = json.model.toLowerCase();
+    config.model = isValidModel(loweredModel) ? loweredModel : json.model;
+  }
+
+  if (typeof json.maxTokens === 'number') {
+    config.maxTokens = json.maxTokens;
+  }
+
+  if (typeof json.temperature === 'number') {
+    config.temperature = json.temperature;
+  }
+
+  if (typeof json.systemPrompt === 'string' && json.systemPrompt.length > 0) {
+    config.systemPrompt = json.systemPrompt;
+  }
+
+  if (typeof json.permissionMode === 'string') {
+    // Validate against the known modes; ignore garbage so a typo can't
+    // silently land the session in an unexpected (or dangerous) mode.
+    const pm = json.permissionMode;
+    if (pm === 'default' || pm === 'plan' || pm === 'autonomous' || pm === 'bypassPermissions') {
+      config.permissionMode = pm;
+    }
+  }
+
+  if (json.autoRouting && typeof json.autoRouting === 'object') {
+    const ar: AutoRoutingConfig = {};
+    if (typeof json.autoRouting.interactive === 'boolean') ar.interactive = json.autoRouting.interactive;
+    if (typeof json.autoRouting.chat === 'boolean') ar.chat = json.autoRouting.chat;
+    if (typeof json.autoRouting.telegram === 'boolean') ar.telegram = json.autoRouting.telegram;
+    if (typeof json.autoRouting.daemon === 'boolean') ar.daemon = json.autoRouting.daemon;
+    config.autoRouting = ar;
+  }
+
+  if (json.daemon && typeof json.daemon === 'object') {
+    const daemon: NonNullable<CliConfig['daemon']> = {};
+    if (typeof json.daemon.task === 'string') {
+      daemon.task = json.daemon.task;
+    }
+    if (typeof json.daemon.taskId === 'string') {
+      daemon.taskId = json.daemon.taskId;
+    }
+    const wp = json.daemon.worktreePrune;
+    if (wp && typeof wp === 'object') {
+      daemon.worktreePrune = {
+        enabled: typeof wp.enabled === 'boolean' ? wp.enabled : true,
+        cron: typeof wp.cron === 'string' ? wp.cron : '0 4 * * *',
+        maxAgeDaysClean: typeof wp.maxAgeDaysClean === 'number' ? wp.maxAgeDaysClean : 14,
+        maxAgeDaysDirty: typeof wp.maxAgeDaysDirty === 'number' ? wp.maxAgeDaysDirty : 30,
+        scope: typeof wp.scope === 'string' ? wp.scope : 'all',
+      };
+    }
+    if (typeof json.daemon.verifyDone === 'boolean') {
+      daemon.verifyDone = json.daemon.verifyDone;
+    }
+    config.daemon = daemon;
+  }
+
+  if (json.telegram && typeof json.telegram === 'object') {
+    const telegram: NonNullable<ConfigFileSchema['telegram']> = {};
+    const notify = json.telegram.notify;
+    if (notify && typeof notify === 'object') {
+      const parsed: NonNullable<NonNullable<ConfigFileSchema['telegram']>['notify']> = {};
+      if (notify.mode === 'primary' || notify.mode === 'broadcast' || notify.mode === 'custom') {
+        parsed.mode = notify.mode;
+      }
+      if (typeof notify.primaryChatId === 'number' && Number.isFinite(notify.primaryChatId)) {
+        parsed.primaryChatId = notify.primaryChatId;
+      }
+      if (Array.isArray(notify.targets)) {
+        const targets = notify.targets.filter(
+          (t): t is number => typeof t === 'number' && Number.isFinite(t),
+        );
+        if (targets.length > 0) parsed.targets = targets;
+      }
+      telegram.notify = parsed;
+    }
+    if (typeof json.telegram.verifyDone === 'boolean') {
+      telegram.verifyDone = json.telegram.verifyDone;
+    }
+    if (Array.isArray(json.telegram.tagOnlyChats)) {
+      const tagOnly = json.telegram.tagOnlyChats.filter(
+        (t): t is number => typeof t === 'number' && Number.isFinite(t),
+      );
+      if (tagOnly.length > 0) telegram.tagOnlyChats = tagOnly;
+    }
+    // chatAliases: name → chat-id map. Drop non-numeric, non-finite, and
+    // zero values (0 is the sentinel for "no chat" throughout routing).
+    if (
+      json.telegram.chatAliases &&
+      typeof json.telegram.chatAliases === 'object' &&
+      !Array.isArray(json.telegram.chatAliases)
+    ) {
+      const aliases: Record<string, number> = {};
+      for (const [name, id] of Object.entries(
+        json.telegram.chatAliases as Record<string, unknown>,
+      )) {
+        if (typeof id === 'number' && Number.isFinite(id) && id !== 0) {
+          aliases[name] = id;
+        }
+      }
+      if (Object.keys(aliases).length > 0) telegram.chatAliases = aliases;
+    }
+    config.telegram = telegram;
+  }
+
+  if (json.updatePolicy && ['notify', 'auto', 'off'].includes(json.updatePolicy)) {
+    config.updatePolicy = json.updatePolicy as 'notify' | 'auto' | 'off';
+  }
+
+  if (json.theme && ['dark', 'light', 'umber', 'auto'].includes(json.theme)) {
+    config.theme = json.theme as 'dark' | 'light' | 'umber' | 'auto';
+  }
+
+  if (typeof json.autoResumeOnUsageLimit === 'boolean') {
+    config.autoResumeOnUsageLimit = json.autoResumeOnUsageLimit;
+  }
+
+  if (typeof json.enforceDoneEvidence === 'boolean') {
+    config.enforceDoneEvidence = json.enforceDoneEvidence;
+  }
+
+  if (typeof json.bgSummaries === 'boolean') {
+    config.bgSummaries = json.bgSummaries;
+  }
+
+  if (typeof json.maxSummaryCallsPerSession === 'number') {
+    // Clamp to [1, 500] — prevents runaway API spend from misconfigured values.
+    config.maxSummaryCallsPerSession = Math.min(500, Math.max(1, json.maxSummaryCallsPerSession));
+  }
+
+  // Pass hooks through as-is (the hooks loader validates it fully).
+  if (json.hooks !== null && typeof json.hooks === 'object' && !Array.isArray(json.hooks)) {
+    config.hooks = json.hooks as RawHooksConfig;
+  }
+
+  if (typeof json.enableShellHooks === 'boolean') {
+    config.enableShellHooks = json.enableShellHooks;
+  }
+
+  if (typeof json.enablePluginHooks === 'boolean') {
+    config.enablePluginHooks = json.enablePluginHooks;
+  }
+
+  // Security: `importFrom` is a user-global-only trust grant — it lets AFK
+  // live-read/execute another tool's assets (see loadImportFromConfig). A
+  // project-local afk.config.json must NOT be able to set it, so honor it
+  // only from the user-global / legacy config, never `<cwd>/afk.config.json`.
+  //
+  // Gate via an ALLOWLIST of the user-global + legacy paths
+  // (`importFromConfigPaths()`, the same set the real gate reads) rather
+  // than a cwd denylist. An allowlist fails closed: any path that isn't
+  // provably one of those two files — including a symlinked or case-variant
+  // `<cwd>/afk.config.json` — is denied, closing the exact-string-compare
+  // gap the old `configPath !== join(cwd, ...)` check left open (#501-F5).
+  //
+  // Note: `config.importFrom` is exposed on `CliConfig` for completeness and
+  // inspection (e.g. `--dump-prompt` tooling), but runtime asset scanners
+  // deliberately call `loadImportFromConfig()` directly — the agent layer
+  // cannot import from `src/cli/` without a circular-dependency violation.
+  // This guard is intentional defense-in-depth mirroring that real gate.
+  if (importFromConfigPaths().includes(configPath)) {
+    const importFrom = parseImportFromConfig(json.importFrom);
+    if (importFrom !== undefined) {
+      config.importFrom = importFrom;
+    }
+  }
+
+  if (json.interactive && typeof json.interactive === 'object') {
+    const interactive: NonNullable<CliConfig['interactive']> = {};
+    if (typeof json.interactive.worktreeAutoname === 'boolean') {
+      interactive.worktreeAutoname = json.interactive.worktreeAutoname;
+    }
+    if (typeof json.interactive.worktreeBranchPrefix === 'string') {
+      // Validate at config-read time — the value is concatenated into
+      // a `git worktree add -b <prefix><slug>` invocation, so a value
+      // starting with `--` or containing shell metacharacters would
+      // turn an attacker-writable JSON file into a CLI-flag injection.
+      // Allowlist matches `AFK_WORKTREE_BRANCH_PREFIX` env handling.
+      interactive.worktreeBranchPrefix = validateBranchPrefix(
+        json.interactive.worktreeBranchPrefix,
+        `${configPath}#/interactive/worktreeBranchPrefix`,
+      );
+    }
+    if (
+      typeof json.interactive.worktreeBase === 'string' &&
+      json.interactive.worktreeBase.trim().length > 0
+    ) {
+      // Validate at config-read time — the value is spliced into
+      // `git fetch` / `git rev-parse` / `git worktree add` invocations,
+      // so a value starting with `-` could be parsed by git as a flag.
+      validateBaseRef(
+        json.interactive.worktreeBase,
+        `${configPath}#/interactive/worktreeBase`,
+      );
+      interactive.worktreeBase = json.interactive.worktreeBase;
+    }
+    if (
+      json.interactive.worktreeOnExit === 'ask' ||
+      json.interactive.worktreeOnExit === 'keep' ||
+      json.interactive.worktreeOnExit === 'remove'
+    ) {
+      interactive.worktreeOnExit = json.interactive.worktreeOnExit;
+    }
+    if (typeof json.interactive.suggestGhost === 'boolean') {
+      interactive.suggestGhost = json.interactive.suggestGhost;
+    }
+    // Display-only enum; silently ignore anything outside the allowlist
+    // rather than throwing — a stray value shouldn't fail config load.
+    if (
+      json.interactive.thinkingUi === 'summary' ||
+      json.interactive.thinkingUi === 'live' ||
+      json.interactive.thinkingUi === 'digest' ||
+      json.interactive.thinkingUi === 'off'
+    ) {
+      interactive.thinkingUi = json.interactive.thinkingUi;
+    }
+    if (Object.keys(interactive).length > 0) {
+      config.interactive = interactive;
+    }
+  }
+
+  return { config, modelsPartial };
+}
+
+/**
+ * A parsed file's values as one dotted-path-walkable record, for consumers that
+ * ask "what does this file resolve `<path>` to?" (`/config` provenance).
+ *
+ * Splices `modelsPartial` back under `models` so `models.large` resolves to the
+ * binding the loader built (`"gpt-4o"` → `{ id: 'gpt-4o' }`), not the raw JSON.
+ */
+export function validatedValueView(parsed: ParsedJsonConfigFile): Record<string, unknown> {
+  const view: Record<string, unknown> = { ...parsed.config };
+  if (Object.keys(parsed.modelsPartial).length > 0) view['models'] = parsed.modelsPartial;
+  return view;
+}

--- a/src/cli/config/json-tier-paths.ts
+++ b/src/cli/config/json-tier-paths.ts
@@ -1,0 +1,43 @@
+// Invariant: this module is the SINGLE definition of the afk.config.json tier
+// precedence order. Two consumers walk it and they must never disagree:
+//   - `loadJsonConfig()` (json-tier.ts) — resolves the effective config at load.
+//   - `resolveConfigProvenance()` (provenance.ts) — reports WHICH tier supplied
+//     the effective value, so `/config` can warn that a write landed beneath a
+//     higher-priority file.
+// If these two walked separate lists, the menu would confidently attribute a
+// value to the wrong file — the exact class of silent-wrong-answer bug the
+// provenance feature exists to remove. Add a tier here, never at a call site.
+
+import { join } from 'path';
+import { getJsonConfigPath, getLegacyJsonConfigPath } from '../../paths.js';
+
+/** Which config file supplied a value, in descending precedence. */
+export type JsonConfigTier = 'project' | 'user' | 'legacy';
+
+export interface JsonConfigTierPath {
+  readonly tier: JsonConfigTier;
+  readonly path: string;
+}
+
+/** Human-facing label for a tier, used in `/config` provenance badges. */
+export const TIER_LABELS: Readonly<Record<JsonConfigTier, string>> = {
+  project: 'project afk.config.json',
+  user: 'user afk.config.json',
+  legacy: 'legacy config',
+};
+
+/**
+ * The afk.config.json files consulted at load, highest precedence first.
+ *
+ * Not memoized: `getJsonConfigPath()` honors `$AFK_HOME` and the project entry
+ * is relative to `process.cwd()`, both of which tests mutate between cases.
+ * Callers that need stability across a single operation should capture the
+ * result once rather than re-invoking.
+ */
+export function jsonConfigTierPaths(): readonly JsonConfigTierPath[] {
+  return [
+    { tier: 'project', path: join(process.cwd(), 'afk.config.json') },
+    { tier: 'user', path: getJsonConfigPath() },
+    { tier: 'legacy', path: getLegacyJsonConfigPath() },
+  ];
+}

--- a/src/cli/config/json-tier.ts
+++ b/src/cli/config/json-tier.ts
@@ -1,23 +1,19 @@
 // Contract: the afk.config.json tier of the CLI config loader (#368 split).
-// This module is the SINGLE home of `jsonConfigCache`. Sibling modules and
+// This module owns the tier WALK — precedence, fall-through on a bad file, and
+// caching. The per-file parse/validation concern lives in `json-tier-parse.ts`
+// so `/config` provenance can reuse the identical semantics instead of
+// re-deriving them (see the invariant note there).
+//
+// This module is also the SINGLE home of `jsonConfigCache`. Sibling modules and
 // the `config.ts` facade must never duplicate it — the facade resets it only
 // through `resetJsonConfigCache()` exported here, because ESM importers
 // cannot reassign an imported binding (same pattern as `setState()` in the
 // #366 plugin-skills split).
 
-import { readFileSync, existsSync } from 'fs';
-import { join } from 'path';
-import { isValidModel } from '../../agent/session/model-resolution.js';
-import {
-  parseModelsConfig,
-  type ModelSlotBinding,
-  type SlotName,
-} from '../../agent/session/model-slots.js';
-import { getJsonConfigPath, getLegacyJsonConfigPath } from '../../paths.js';
-import { validateBranchPrefix, validateBaseRef } from '../commands/interactive/worktree.js';
-import type { RawHooksConfig } from '../../agent/hooks/config-loader.js';
-import { importFromConfigPaths, parseImportFromConfig } from '../../config/import-sources.js';
-import type { AutoRoutingConfig, CliConfig, ConfigFileSchema } from './types.js';
+import { jsonConfigTierPaths } from './json-tier-paths.js';
+import { parseJsonConfigFile } from './json-tier-parse.js';
+import type { ModelSlotBinding, SlotName } from '../../agent/session/model-slots.js';
+import type { CliConfig } from './types.js';
 
 /**
  * Process-lifetime caches for the disk-backed config tiers. `afk chat` calls
@@ -52,11 +48,11 @@ export function resetJsonConfigCache(): void {
 /**
  * Load configuration from afk.config.json.
  *
- * `model` accepts any string — the Claude short-alias set is validated
- * only for the purpose of preserving the previous behaviour of ignoring
- * unknown short aliases ("sonnet_pro" → fall through to default). Non-
- * Claude model ids still pass through untouched because `isValidModel`
- * returns false and we only gate on it for the short-alias case.
+ * Selection is FILE-level, not per-key: the walk stops at the first EXISTING
+ * tier that parses and validates, and that file alone supplies the config. A
+ * key absent from the winning file resolves to its default — it does NOT fall
+ * through to a lower tier. Only a file that is missing, malformed, or rejected
+ * by a throwing validator is skipped.
  *
  * Returns `{ config, sourcePath }` where `sourcePath` is the absolute path
  * of the file that was actually read, or `undefined` when no config file
@@ -71,11 +67,9 @@ export function loadJsonConfig(): {
   modelsPartial: Partial<Record<SlotName, ModelSlotBinding>>;
 } {
   if (jsonConfigCache !== undefined) return jsonConfigCache;
-  const configPaths = [
-    join(process.cwd(), 'afk.config.json'),
-    getJsonConfigPath(),
-    getLegacyJsonConfigPath(),
-  ];
+  // Tier order lives in json-tier-paths.ts so `/config` provenance reporting
+  // walks the identical list — see the invariant note there.
+  const configPaths = jsonConfigTierPaths().map((t) => t.path);
 
   // Invariant: a parse failure in an earlier tier must NOT permanently
   // memoize the fallen-through result (#501-F2). If a malformed
@@ -88,259 +82,22 @@ export function loadJsonConfig(): {
   let sawParseError = false;
 
   for (const configPath of configPaths) {
-    if (existsSync(configPath)) {
-      try {
-        const content = readFileSync(configPath, 'utf-8');
-        const json: ConfigFileSchema = JSON.parse(content);
-
-        const config: Partial<CliConfig> = {};
-        const modelsPartial = parseModelsConfig(json.models);
-
-        if (typeof json.model === 'string' && json.model.length > 0) {
-          const loweredModel = json.model.toLowerCase();
-          config.model = isValidModel(loweredModel) ? loweredModel : json.model;
-        }
-
-        if (typeof json.maxTokens === 'number') {
-          config.maxTokens = json.maxTokens;
-        }
-
-        if (typeof json.temperature === 'number') {
-          config.temperature = json.temperature;
-        }
-
-        if (typeof json.systemPrompt === 'string' && json.systemPrompt.length > 0) {
-          config.systemPrompt = json.systemPrompt;
-        }
-
-        if (typeof json.permissionMode === 'string') {
-          // Validate against the known modes; ignore garbage so a typo can't
-          // silently land the session in an unexpected (or dangerous) mode.
-          const pm = json.permissionMode;
-          if (pm === 'default' || pm === 'plan' || pm === 'autonomous' || pm === 'bypassPermissions') {
-            config.permissionMode = pm;
-          }
-        }
-
-        if (json.autoRouting && typeof json.autoRouting === 'object') {
-          const ar: AutoRoutingConfig = {};
-          if (typeof json.autoRouting.interactive === 'boolean') ar.interactive = json.autoRouting.interactive;
-          if (typeof json.autoRouting.chat === 'boolean') ar.chat = json.autoRouting.chat;
-          if (typeof json.autoRouting.telegram === 'boolean') ar.telegram = json.autoRouting.telegram;
-          if (typeof json.autoRouting.daemon === 'boolean') ar.daemon = json.autoRouting.daemon;
-          config.autoRouting = ar;
-        }
-
-        if (json.daemon && typeof json.daemon === 'object') {
-          const daemon: {
-            task?: string;
-            taskId?: string;
-            worktreePrune?: {
-              enabled: boolean;
-              cron: string;
-              maxAgeDaysClean: number;
-              maxAgeDaysDirty: number;
-              scope: string;
-            };
-            verifyDone?: boolean;
-          } = {};
-          if (typeof json.daemon.task === 'string') {
-            daemon.task = json.daemon.task;
-          }
-          if (typeof json.daemon.taskId === 'string') {
-            daemon.taskId = json.daemon.taskId;
-          }
-          const wp = json.daemon.worktreePrune;
-          if (wp && typeof wp === 'object') {
-            daemon.worktreePrune = {
-              enabled: typeof wp.enabled === 'boolean' ? wp.enabled : true,
-              cron: typeof wp.cron === 'string' ? wp.cron : '0 4 * * *',
-              maxAgeDaysClean: typeof wp.maxAgeDaysClean === 'number' ? wp.maxAgeDaysClean : 14,
-              maxAgeDaysDirty: typeof wp.maxAgeDaysDirty === 'number' ? wp.maxAgeDaysDirty : 30,
-              scope: typeof wp.scope === 'string' ? wp.scope : 'all',
-            };
-          }
-          if (typeof json.daemon.verifyDone === 'boolean') {
-            daemon.verifyDone = json.daemon.verifyDone;
-          }
-          config.daemon = daemon;
-        }
-
-        if (json.telegram && typeof json.telegram === 'object') {
-          const telegram: NonNullable<ConfigFileSchema['telegram']> = {};
-          const notify = json.telegram.notify;
-          if (notify && typeof notify === 'object') {
-            const parsed: NonNullable<NonNullable<ConfigFileSchema['telegram']>['notify']> = {};
-            if (notify.mode === 'primary' || notify.mode === 'broadcast' || notify.mode === 'custom') {
-              parsed.mode = notify.mode;
-            }
-            if (typeof notify.primaryChatId === 'number' && Number.isFinite(notify.primaryChatId)) {
-              parsed.primaryChatId = notify.primaryChatId;
-            }
-            if (Array.isArray(notify.targets)) {
-              const targets = notify.targets.filter(
-                (t): t is number => typeof t === 'number' && Number.isFinite(t),
-              );
-              if (targets.length > 0) parsed.targets = targets;
-            }
-            telegram.notify = parsed;
-          }
-          if (typeof json.telegram.verifyDone === 'boolean') {
-            telegram.verifyDone = json.telegram.verifyDone;
-          }
-          if (Array.isArray(json.telegram.tagOnlyChats)) {
-            const tagOnly = json.telegram.tagOnlyChats.filter(
-              (t): t is number => typeof t === 'number' && Number.isFinite(t),
-            );
-            if (tagOnly.length > 0) telegram.tagOnlyChats = tagOnly;
-          }
-          // chatAliases: name → chat-id map. Drop non-numeric, non-finite, and
-          // zero values (0 is the sentinel for "no chat" throughout routing).
-          if (
-            json.telegram.chatAliases &&
-            typeof json.telegram.chatAliases === 'object' &&
-            !Array.isArray(json.telegram.chatAliases)
-          ) {
-            const aliases: Record<string, number> = {};
-            for (const [name, id] of Object.entries(
-              json.telegram.chatAliases as Record<string, unknown>,
-            )) {
-              if (typeof id === 'number' && Number.isFinite(id) && id !== 0) {
-                aliases[name] = id;
-              }
-            }
-            if (Object.keys(aliases).length > 0) telegram.chatAliases = aliases;
-          }
-          config.telegram = telegram;
-        }
-
-        if (json.updatePolicy && ['notify', 'auto', 'off'].includes(json.updatePolicy)) {
-          config.updatePolicy = json.updatePolicy as 'notify' | 'auto' | 'off';
-        }
-
-        if (json.theme && ['dark', 'light', 'umber', 'auto'].includes(json.theme)) {
-          config.theme = json.theme as 'dark' | 'light' | 'umber' | 'auto';
-        }
-
-        if (typeof json.autoResumeOnUsageLimit === 'boolean') {
-          config.autoResumeOnUsageLimit = json.autoResumeOnUsageLimit;
-        }
-
-        if (typeof json.enforceDoneEvidence === 'boolean') {
-          config.enforceDoneEvidence = json.enforceDoneEvidence;
-        }
-
-        if (typeof json.bgSummaries === 'boolean') {
-          config.bgSummaries = json.bgSummaries;
-        }
-
-        if (typeof json.maxSummaryCallsPerSession === 'number') {
-          // Clamp to [1, 500] — prevents runaway API spend from misconfigured values.
-          config.maxSummaryCallsPerSession = Math.min(500, Math.max(1, json.maxSummaryCallsPerSession));
-        }
-
-        // Pass hooks through as-is (the hooks loader validates it fully).
-        if (json.hooks !== null && typeof json.hooks === 'object' && !Array.isArray(json.hooks)) {
-          config.hooks = json.hooks as RawHooksConfig;
-        }
-
-        if (typeof json.enableShellHooks === 'boolean') {
-          config.enableShellHooks = json.enableShellHooks;
-        }
-
-        if (typeof json.enablePluginHooks === 'boolean') {
-          config.enablePluginHooks = json.enablePluginHooks;
-        }
-
-        // Security: `importFrom` is a user-global-only trust grant — it lets AFK
-        // live-read/execute another tool's assets (see loadImportFromConfig). A
-        // project-local afk.config.json must NOT be able to set it, so honor it
-        // only from the user-global / legacy config, never `<cwd>/afk.config.json`.
-        //
-        // Gate via an ALLOWLIST of the user-global + legacy paths
-        // (`importFromConfigPaths()`, the same set the real gate reads) rather
-        // than a cwd denylist. An allowlist fails closed: any path that isn't
-        // provably one of those two files — including a symlinked or case-variant
-        // `<cwd>/afk.config.json` — is denied, closing the exact-string-compare
-        // gap the old `configPath !== join(cwd, ...)` check left open (#501-F5).
-        //
-        // Note: `config.importFrom` is exposed on `CliConfig` for completeness and
-        // inspection (e.g. `--dump-prompt` tooling), but runtime asset scanners
-        // deliberately call `loadImportFromConfig()` directly — the agent layer
-        // cannot import from `src/cli/` without a circular-dependency violation.
-        // This guard is intentional defense-in-depth mirroring that real gate.
-        if (importFromConfigPaths().includes(configPath)) {
-          const importFrom = parseImportFromConfig(json.importFrom);
-          if (importFrom !== undefined) {
-            config.importFrom = importFrom;
-          }
-        }
-
-        if (json.interactive && typeof json.interactive === 'object') {
-          const interactive: NonNullable<CliConfig['interactive']> = {};
-          if (typeof json.interactive.worktreeAutoname === 'boolean') {
-            interactive.worktreeAutoname = json.interactive.worktreeAutoname;
-          }
-          if (typeof json.interactive.worktreeBranchPrefix === 'string') {
-            // Validate at config-read time — the value is concatenated into
-            // a `git worktree add -b <prefix><slug>` invocation, so a value
-            // starting with `--` or containing shell metacharacters would
-            // turn an attacker-writable JSON file into a CLI-flag injection.
-            // Allowlist matches `AFK_WORKTREE_BRANCH_PREFIX` env handling.
-            interactive.worktreeBranchPrefix = validateBranchPrefix(
-              json.interactive.worktreeBranchPrefix,
-              `${configPath}#/interactive/worktreeBranchPrefix`,
-            );
-          }
-          if (
-            typeof json.interactive.worktreeBase === 'string' &&
-            json.interactive.worktreeBase.trim().length > 0
-          ) {
-            // Validate at config-read time — the value is spliced into
-            // `git fetch` / `git rev-parse` / `git worktree add` invocations,
-            // so a value starting with `-` could be parsed by git as a flag.
-            validateBaseRef(
-              json.interactive.worktreeBase,
-              `${configPath}#/interactive/worktreeBase`,
-            );
-            interactive.worktreeBase = json.interactive.worktreeBase;
-          }
-          if (
-            json.interactive.worktreeOnExit === 'ask' ||
-            json.interactive.worktreeOnExit === 'keep' ||
-            json.interactive.worktreeOnExit === 'remove'
-          ) {
-            interactive.worktreeOnExit = json.interactive.worktreeOnExit;
-          }
-          if (typeof json.interactive.suggestGhost === 'boolean') {
-            interactive.suggestGhost = json.interactive.suggestGhost;
-          }
-          // Display-only enum; silently ignore anything outside the allowlist
-          // rather than throwing — a stray value shouldn't fail config load.
-          if (
-            json.interactive.thinkingUi === 'summary' ||
-            json.interactive.thinkingUi === 'live' ||
-            json.interactive.thinkingUi === 'digest' ||
-            json.interactive.thinkingUi === 'off'
-          ) {
-            interactive.thinkingUi = json.interactive.thinkingUi;
-          }
-          if (Object.keys(interactive).length > 0) {
-            config.interactive = interactive;
-          }
-        }
-
-        const result = { config, sourcePath: configPath, modelsPartial };
-        // Only memoize when the walk was clean — see the sawParseError
-        // invariant above (a fall-through past a malformed earlier tier is
-        // returned but not cached, so a later fix is picked up on re-read).
-        if (!sawParseError) jsonConfigCache = result;
-        return result;
-      } catch (error) {
-        console.error(`Warning: Failed to parse ${configPath}:`, error);
-        sawParseError = true;
-      }
+    let parsed: ReturnType<typeof parseJsonConfigFile>;
+    try {
+      parsed = parseJsonConfigFile(configPath);
+    } catch (error) {
+      console.error(`Warning: Failed to parse ${configPath}:`, error);
+      sawParseError = true;
+      continue;
     }
+    if (parsed === undefined) continue; // file absent — not an error
+
+    const result = { ...parsed, sourcePath: configPath };
+    // Only memoize when the walk was clean — see the sawParseError
+    // invariant above (a fall-through past a malformed earlier tier is
+    // returned but not cached, so a later fix is picked up on re-read).
+    if (!sawParseError) jsonConfigCache = result;
+    return result;
   }
 
   const emptyResult = { config: {}, sourcePath: undefined, modelsPartial: {} };

--- a/src/cli/config/live-apply.test.ts
+++ b/src/cli/config/live-apply.test.ts
@@ -1,0 +1,114 @@
+// Contract: live-apply runs AFTER a successful persist. The load-bearing rule is
+// that it can never turn a saved write into a reported failure — so every
+// non-applied path must resolve (not throw) and must be distinguishable from a
+// write error by the caller.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  applyConfigLive,
+  isLiveAppliable,
+  liveAppliableKeys,
+  type LiveApplyHandle,
+} from './live-apply.js';
+import { getActiveTheme, applyTheme } from '../theme.js';
+
+function fakeHandle(overrides: Partial<LiveApplyHandle> = {}): LiveApplyHandle & {
+  calls: string[];
+} {
+  const calls: string[] = [];
+  return {
+    calls,
+    setModel: async (id: string) => {
+      calls.push(`setModel:${id}`);
+    },
+    noteModel: (id: string) => {
+      calls.push(`noteModel:${id}`);
+    },
+    repaint: () => {
+      calls.push('repaint');
+    },
+    ...overrides,
+  };
+}
+
+const themeBefore = getActiveTheme();
+afterEach(() => {
+  applyTheme(themeBefore);
+  vi.restoreAllMocks();
+});
+
+describe('isLiveAppliable', () => {
+  it('covers exactly the keys with a proven mid-session mutator', () => {
+    expect(liveAppliableKeys().sort()).toEqual(['model', 'theme']);
+    expect(isLiveAppliable('model')).toBe(true);
+    expect(isLiveAppliable('theme')).toBe(true);
+    expect(isLiveAppliable('temperature')).toBe(false);
+  });
+
+  it('is not fooled by inherited Object properties', () => {
+    expect(isLiveAppliable('toString')).toBe(false);
+    expect(isLiveAppliable('constructor')).toBe(false);
+  });
+});
+
+describe('applyConfigLive — model', () => {
+  it('swaps the running model and repaints', async () => {
+    const h = fakeHandle();
+    const r = await applyConfigLive('model', 'opus', h);
+    expect(r.applied).toBe(true);
+    expect(r.applied === true && r.note).toBe('applied to this session');
+    expect(h.calls).toEqual(['setModel:opus', 'noteModel:opus', 'repaint']);
+  });
+
+  it('reports a rejected setModel as not-applied, never throwing', async () => {
+    const h = fakeHandle({
+      setModel: async () => {
+        throw new Error('provider unreachable');
+      },
+    });
+    const r = await applyConfigLive('model', 'opus', h);
+    expect(r).toEqual({ applied: false, reason: 'provider unreachable' });
+  });
+});
+
+describe('applyConfigLive — theme', () => {
+  it('applies a concrete theme to the process', async () => {
+    const h = fakeHandle();
+    const r = await applyConfigLive('theme', 'light', h);
+    expect(r.applied).toBe(true);
+    expect(getActiveTheme()).toBe('light');
+    expect(h.calls).toContain('repaint');
+  });
+
+  it('resolves `auto` and says what it resolved to', async () => {
+    const r = await applyConfigLive('theme', 'auto', fakeHandle());
+    expect(r.applied).toBe(true);
+    expect(r.applied === true && r.note).toMatch(/auto → (dark|light)/);
+  });
+
+  it('refuses an unparseable theme without throwing', async () => {
+    const r = await applyConfigLive('theme', 'chartreuse', fakeHandle());
+    expect(r).toEqual({ applied: false, reason: 'unrecognised theme "chartreuse"' });
+    expect(getActiveTheme()).toBe(themeBefore);
+  });
+});
+
+describe('applyConfigLive — non-live paths', () => {
+  it('returns a bare not-applied for a key with no handler (no spurious warning)', async () => {
+    // `reason` stays undefined so the caller prints the plain restart note
+    // rather than a "saved, but not applied live" warning on a key that was
+    // never expected to apply live.
+    const r = await applyConfigLive('temperature', '0.5', fakeHandle());
+    expect(r).toEqual({ applied: false });
+  });
+
+  it('explains itself when the surface has no live session', async () => {
+    const r = await applyConfigLive('model', 'opus', undefined);
+    expect(r).toEqual({ applied: false, reason: 'no live session on this surface' });
+  });
+
+  it('tolerates a handle without the optional hooks', async () => {
+    const r = await applyConfigLive('model', 'opus', { setModel: async () => {} });
+    expect(r.applied).toBe(true);
+  });
+});

--- a/src/cli/config/live-apply.ts
+++ b/src/cli/config/live-apply.ts
@@ -1,0 +1,99 @@
+/**
+ * Per-key live application of `/config` writes to the RUNNING session.
+ *
+ * Before this, every `/config` write printed `RESTART_NOTE` — 100% of them —
+ * even though the REPL already mutates two of those very settings live:
+ * `/model` calls `session.setModel()` (slash/commands/info.ts:287) and `/theme`
+ * calls `applyTheme()` (slash/commands/theme.ts:64). So the canonical settings
+ * surface was the *worst* way to change your model.
+ *
+ * Contract — deliberately narrow:
+ *   - A key is live-appliable ONLY if it appears in {@link LIVE_APPLIERS}. Every
+ *     other key keeps today's exact behaviour (persist + "next restart").
+ *   - We do NOT invalidate the loader's config caches globally. That would make
+ *     an unbounded set of keys change underneath subsystems that read config
+ *     more than once per session — `permissionMode` resolving differently at two
+ *     call sites is a security-relevant inconsistency, not a feature. Explicit
+ *     per-key handlers keep the blast radius equal to the key being edited.
+ *   - Persistence already happened before we are called. A live-apply failure is
+ *     therefore NON-FATAL and reported as "saved, but not applied live" — never
+ *     as a failed write, because the write did land.
+ *
+ * @module cli/config/live-apply
+ */
+
+import { applyTheme, parseThemeMode, resolveTheme } from '../theme.js';
+
+/**
+ * The capabilities a surface must supply for live application. Structural, not a
+ * session import: keeps this module testable with plain fakes and avoids dragging
+ * the agent layer into the CLI config tier.
+ */
+export interface LiveApplyHandle {
+  /** Swap the running session's model. Mirrors `/model`. */
+  setModel(id: string): Promise<void>;
+  /** Record the new model on the surface's stats so the status line agrees. */
+  noteModel?(id: string): void;
+  /** Repaint the status line / active frame after a visible change. */
+  repaint?(): void;
+}
+
+export type LiveApplyOutcome =
+  | { readonly applied: true; readonly note: string }
+  | { readonly applied: false; readonly reason?: string };
+
+type LiveApplier = (raw: string, handle: LiveApplyHandle) => Promise<LiveApplyOutcome>;
+
+/**
+ * Invariant: only add a key here once its live path is proven by an existing
+ * mid-session mutator. Both current entries mirror a shipped slash command.
+ */
+const LIVE_APPLIERS: Readonly<Record<string, LiveApplier>> = {
+  model: async (raw, handle) => {
+    await handle.setModel(raw);
+    handle.noteModel?.(raw);
+    handle.repaint?.();
+    return { applied: true, note: 'applied to this session' };
+  },
+  theme: async (raw, handle) => {
+    const mode = parseThemeMode(raw);
+    if (mode === undefined) return { applied: false, reason: `unrecognised theme "${raw}"` };
+    const resolved = resolveTheme(mode);
+    applyTheme(resolved);
+    handle.repaint?.();
+    const detail = mode === 'auto' ? ` (auto → ${resolved})` : '';
+    return { applied: true, note: `applied to this session${detail}` };
+  },
+};
+
+/** Whether a write to `path` can take effect without a restart. */
+export function isLiveAppliable(path: string): boolean {
+  return Object.prototype.hasOwnProperty.call(LIVE_APPLIERS, path);
+}
+
+/** Config paths that apply immediately — used by tests and help text. */
+export function liveAppliableKeys(): readonly string[] {
+  return Object.keys(LIVE_APPLIERS);
+}
+
+/**
+ * Apply an already-persisted config write to the running session.
+ *
+ * Never throws: a handler that rejects is reported as `applied: false` with the
+ * error message, because the value is already on disk and the caller must not
+ * present a successful write as a failure.
+ */
+export async function applyConfigLive(
+  path: string,
+  rawValue: string,
+  handle: LiveApplyHandle | undefined,
+): Promise<LiveApplyOutcome> {
+  const applier = LIVE_APPLIERS[path];
+  if (!applier) return { applied: false };
+  if (!handle) return { applied: false, reason: 'no live session on this surface' };
+  try {
+    return await applier(rawValue, handle);
+  } catch (err) {
+    return { applied: false, reason: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/src/cli/config/provenance-cache.test.ts
+++ b/src/cli/config/provenance-cache.test.ts
@@ -1,0 +1,151 @@
+// Contract: the provenance cache is a per-pass memo over config-file reads. Two
+// things must hold or it is worse than no cache at all: (1) a cached pass must
+// return exactly what an uncached pass returns — a memo that changes an answer
+// is a bug, not an optimization; (2) every disk read inside
+// `resolveConfigProvenance` must route THROUGH the cache, or the menu render
+// keeps re-reading the same four files per row (the finding this exists to fix).
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { createProvenanceCache, NO_PROVENANCE_CACHE, type ProvenanceCache } from './provenance-cache.js';
+import { resolveConfigProvenance } from './provenance.js';
+
+let tmpRoot: string;
+let cwdBefore: string;
+let homeBefore: string | undefined;
+
+/** Count how many times a resolution actually reaches the file system. */
+function countingCache(): { cache: ProvenanceCache; reads: () => number } {
+  const inner = createProvenanceCache();
+  let reads = 0;
+  return {
+    reads: () => reads,
+    cache: {
+      raw: (file, compute) =>
+        inner.raw(file, () => {
+          reads += 1;
+          return compute();
+        }),
+      validated: (file, compute) =>
+        inner.validated(file, () => {
+          reads += 1;
+          return compute();
+        }),
+    },
+  };
+}
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'afk-prov-cache-'));
+  mkdirSync(join(tmpRoot, 'project'), { recursive: true });
+  mkdirSync(join(tmpRoot, 'home', 'config'), { recursive: true });
+  cwdBefore = process.cwd();
+  process.chdir(join(tmpRoot, 'project'));
+  homeBefore = process.env['AFK_HOME'];
+  process.env['AFK_HOME'] = join(tmpRoot, 'home');
+  writeFileSync(
+    join(tmpRoot, 'home', 'config', 'afk.config.json'),
+    JSON.stringify({ model: 'sonnet', theme: 'dark', maxTokens: 4096 }),
+    'utf8',
+  );
+});
+
+afterEach(() => {
+  process.chdir(cwdBefore);
+  if (homeBefore === undefined) delete process.env['AFK_HOME'];
+  else process.env['AFK_HOME'] = homeBefore;
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('createProvenanceCache', () => {
+  it('computes once per (kind, path) and replays the memo', () => {
+    const cache = createProvenanceCache();
+    let calls = 0;
+    const compute = () => {
+      calls += 1;
+      return { a: 1 };
+    };
+    expect(cache.raw('/f', compute)).toEqual({ a: 1 });
+    expect(cache.raw('/f', compute)).toEqual({ a: 1 });
+    expect(calls).toBe(1);
+  });
+
+  it('caches `undefined` — an absent or malformed file must not be re-read', () => {
+    const cache = createProvenanceCache();
+    let calls = 0;
+    const missing = () => {
+      calls += 1;
+      return undefined;
+    };
+    cache.raw('/missing', missing);
+    cache.raw('/missing', missing);
+    expect(calls).toBe(1);
+  });
+
+  it('keeps raw and validated views of the same file apart', () => {
+    // Same bytes, different questions: raw is what an edit replaces, validated
+    // is what will load. One key space would let a raw hit answer a validated
+    // read and misreport a coerced or rejected value.
+    const cache = createProvenanceCache();
+    expect(cache.raw('/f', () => ({ model: 'SONNET' }))).toEqual({ model: 'SONNET' });
+    expect(cache.validated('/f', () => ({ model: 'sonnet' }))).toEqual({ model: 'sonnet' });
+  });
+
+  it('NO_PROVENANCE_CACHE computes every time', () => {
+    let calls = 0;
+    const compute = () => {
+      calls += 1;
+      return undefined;
+    };
+    NO_PROVENANCE_CACHE.raw('/f', compute);
+    NO_PROVENANCE_CACHE.raw('/f', compute);
+    expect(calls).toBe(2);
+  });
+});
+
+describe('resolveConfigProvenance — cached batch resolution', () => {
+  it('reads each file once for a whole batch of keys instead of once per key', () => {
+    const shared = countingCache();
+    for (const key of ['model', 'theme', 'maxTokens', 'permissionMode']) {
+      resolveConfigProvenance(key, shared.cache);
+    }
+    // At most one raw read of the user file plus one validated read per tier
+    // (project, user, legacy) — four regardless of how many keys are resolved.
+    expect(shared.reads()).toBeLessThanOrEqual(4);
+
+    const perKey = ['model', 'theme', 'maxTokens', 'permissionMode'].reduce((n, key) => {
+      const c = countingCache();
+      resolveConfigProvenance(key, c.cache);
+      return n + c.reads();
+    }, 0);
+    expect(perKey).toBeGreaterThan(shared.reads());
+  });
+
+  it('returns byte-identical provenance with and without a cache', () => {
+    writeFileSync(
+      join(tmpRoot, 'project', 'afk.config.json'),
+      JSON.stringify({ theme: 'light' }),
+      'utf8',
+    );
+    const cache = createProvenanceCache();
+    for (const key of ['model', 'theme', 'permissionMode']) {
+      expect(resolveConfigProvenance(key, cache)).toEqual(resolveConfigProvenance(key));
+    }
+  });
+
+  it('a fresh cache observes a write the previous cache predates', () => {
+    // The menu builds one cache per render pass for exactly this reason: an edit
+    // lands between renders, and the next pass must show the new value.
+    const stale = createProvenanceCache();
+    expect(resolveConfigProvenance('model', stale).effective).toBe('sonnet');
+    writeFileSync(
+      join(tmpRoot, 'home', 'config', 'afk.config.json'),
+      JSON.stringify({ model: 'opus' }),
+      'utf8',
+    );
+    expect(resolveConfigProvenance('model', stale).effective).toBe('sonnet'); // memoized
+    expect(resolveConfigProvenance('model', createProvenanceCache()).effective).toBe('opus');
+  });
+});

--- a/src/cli/config/provenance-cache.ts
+++ b/src/cli/config/provenance-cache.ts
@@ -1,0 +1,66 @@
+/**
+ * Invariant: a provenance cache is valid for exactly ONE synchronous pass and
+ * must never be retained across an `await`.
+ *
+ * `resolveConfigProvenance()` re-reads the same handful of files for every key
+ * it resolves (the raw user file, plus each tier read through the loader's
+ * validator). One key is cheap; a menu render resolves every key in a category,
+ * so a 20-key screen costs ~80 `readFileSync` + `JSON.parse` cycles over four
+ * files whose contents cannot change mid-render.
+ *
+ * The fix is a memo the CALLER owns, not a module-global one: config files are
+ * mutable at runtime — `/config` itself writes them — so a cache that outlives
+ * the render that made it would show the user the value they just replaced.
+ * Scoping the lifetime to a caller-held object makes staleness structurally
+ * impossible instead of merely unlikely (no mtime heuristic, no invalidation
+ * hook to forget). Create one per render pass, pass it down, drop it.
+ *
+ * @module cli/config/provenance-cache
+ */
+
+/** A parsed config-file view, or undefined when the loader would skip the file. */
+type TierObject = Record<string, unknown> | undefined;
+
+/**
+ * Memo over the two file reads behind provenance resolution, keyed by path.
+ *
+ * The two reads are kept separate because they answer different questions about
+ * the same bytes: `raw` is the literal file contents (what an edit replaces),
+ * `validated` is the loader's view (what will actually load). Sharing one key
+ * space would let a raw read satisfy a validated one and misreport coerced or
+ * rejected values.
+ */
+export interface ProvenanceCache {
+  /** Memoized raw (unvalidated) read of `file`. */
+  raw(file: string, compute: () => TierObject): TierObject;
+  /** Memoized validated read of `file`. */
+  validated(file: string, compute: () => TierObject): TierObject;
+}
+
+/** A fresh, empty cache. Discard it at the end of the pass that created it. */
+export function createProvenanceCache(): ProvenanceCache {
+  const rawReads = new Map<string, TierObject>();
+  const validatedReads = new Map<string, TierObject>();
+  // `undefined` is a real result (absent / malformed / rejected file), so
+  // membership — not the stored value — decides whether to recompute.
+  const memo = (store: Map<string, TierObject>, file: string, compute: () => TierObject) => {
+    if (store.has(file)) return store.get(file);
+    const value = compute();
+    store.set(file, value);
+    return value;
+  };
+  return {
+    raw: (file, compute) => memo(rawReads, file, compute),
+    validated: (file, compute) => memo(validatedReads, file, compute),
+  };
+}
+
+/**
+ * Null-object cache: computes every time, caches nothing. The default for
+ * one-shot callers (a single `/config set`), so they neither opt in to caching
+ * nor pay a branch at each read site.
+ */
+export const NO_PROVENANCE_CACHE: ProvenanceCache = {
+  raw: (_file, compute) => compute(),
+  validated: (_file, compute) => compute(),
+};

--- a/src/cli/config/provenance.test.ts
+++ b/src/cli/config/provenance.test.ts
@@ -1,0 +1,198 @@
+// Contract: `/config` writes to ONE file (the user-global afk.config.json) but
+// the loader resolves across env > project > user > legacy. These tests pin the
+// resolver that tells the menu which tier actually wins, because a wrong answer
+// here reintroduces the exact bug the feature removes: a write that saves
+// successfully, reports success, and silently never takes effect.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  resolveConfigProvenance,
+  activeEnvShadow,
+  describeSource,
+  sourceSuffix,
+  shadowNote,
+  CONFIG_ENV_SHADOWS,
+} from './provenance.js';
+import { CONFIG_KEY_SPECS } from '../../config/settable-keys.js';
+
+const TRACKED = [
+  'AFK_HOME',
+  'AFK_MODEL',
+  'CLAUDE_MODEL',
+  'AFK_MAX_TOKENS',
+  'AFK_TEMPERATURE',
+  'AFK_THEME',
+] as const;
+
+let tmpRoot: string;
+let cwdBefore: string;
+let saved: Record<string, string | undefined>;
+
+/** Write the user-global config (the file `/config` mutates). */
+function writeUserConfig(obj: unknown): void {
+  const dir = join(tmpRoot, 'home', 'config');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'afk.config.json'), JSON.stringify(obj), 'utf8');
+}
+
+/** Write a project-local config in cwd (outranks the user file). */
+function writeProjectConfig(raw: string): void {
+  writeFileSync(join(tmpRoot, 'project', 'afk.config.json'), raw, 'utf8');
+}
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'afk-provenance-'));
+  mkdirSync(join(tmpRoot, 'project'), { recursive: true });
+  cwdBefore = process.cwd();
+  process.chdir(join(tmpRoot, 'project'));
+  saved = {};
+  for (const k of TRACKED) saved[k] = process.env[k];
+  for (const k of TRACKED) delete process.env[k];
+  process.env['AFK_HOME'] = join(tmpRoot, 'home');
+});
+
+afterEach(() => {
+  process.chdir(cwdBefore);
+  for (const k of TRACKED) {
+    const v = saved[k];
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('resolveConfigProvenance — tier precedence', () => {
+  it('reports the user file when it is the only source, with no shadow', () => {
+    writeUserConfig({ model: 'sonnet' });
+    const p = resolveConfigProvenance('model');
+    expect(p.effective).toBe('sonnet');
+    expect(p.source.kind).toBe('user');
+    expect(p.shadowedBy).toBeUndefined();
+    expect(sourceSuffix(p)).toBeUndefined(); // the unsurprising case stays quiet
+  });
+
+  it('reports `default` when no tier supplies the key', () => {
+    const p = resolveConfigProvenance('model');
+    expect(p.effective).toBeUndefined();
+    expect(p.source.kind).toBe('default');
+    expect(p.shadowedBy).toBeUndefined();
+  });
+
+  it('lets a project config outrank the user file and flags it as shadowing', () => {
+    writeUserConfig({ model: 'sonnet' });
+    writeProjectConfig(JSON.stringify({ model: 'haiku' }));
+    const p = resolveConfigProvenance('model');
+    expect(p.effective).toBe('haiku');
+    expect(p.source.kind).toBe('project');
+    expect(p.shadowedBy?.kind).toBe('project');
+    // The user file's own value is still reported — that is what a write edits.
+    expect(p.userValue).toBe('sonnet');
+    expect(shadowNote(p)).toMatch(/outranks the user config/);
+  });
+
+  it('lets env outrank every file and names the variable', () => {
+    writeUserConfig({ model: 'sonnet' });
+    writeProjectConfig(JSON.stringify({ model: 'haiku' }));
+    process.env['AFK_MODEL'] = 'opus';
+    const p = resolveConfigProvenance('model');
+    expect(p.effective).toBe('opus');
+    expect(p.source).toEqual({ kind: 'env', via: 'AFK_MODEL' });
+    expect(describeSource(p.source)).toBe('env AFK_MODEL');
+    expect(shadowNote(p)).toMatch(/AFK_MODEL is set in the environment/);
+  });
+
+  it('falls back to the secondary env alias (CLAUDE_MODEL) only when the primary is unset', () => {
+    process.env['CLAUDE_MODEL'] = 'haiku';
+    expect(activeEnvShadow('model')).toBe('CLAUDE_MODEL');
+    process.env['AFK_MODEL'] = 'opus';
+    expect(activeEnvShadow('model')).toBe('AFK_MODEL');
+  });
+
+  it('treats the first loadable config as the whole-file winner', () => {
+    writeUserConfig({ model: 'sonnet' });
+    writeProjectConfig(JSON.stringify({ theme: 'light' }));
+    const p = resolveConfigProvenance('model');
+    expect(p.effective).toBeUndefined();
+    expect(p.source.kind).toBe('default');
+    expect(p.shadowedBy?.kind).toBe('project');
+    expect(p.userValue).toBe('sonnet');
+    expect(shadowNote(p)).toMatch(/loaded INSTEAD of it/);
+  });
+
+  it('reports the loader-validated value rather than invalid raw JSON', () => {
+    writeUserConfig({ permissionMode: 'yolo' });
+    const p = resolveConfigProvenance('permissionMode');
+    expect(p.effective).toBeUndefined();
+    expect(p.source.kind).toBe('default');
+    expect(p.userValue).toBe('yolo');
+  });
+
+  it('reports the loader-coerced value', () => {
+    writeUserConfig({ model: 'SONNET' });
+    const p = resolveConfigProvenance('model');
+    expect(p.effective).toBe('sonnet');
+    expect(p.source.kind).toBe('user');
+    expect(p.userValue).toBe('SONNET');
+  });
+
+  it('tolerates a malformed project config instead of throwing (mirrors the loader)', () => {
+    writeUserConfig({ model: 'sonnet' });
+    writeProjectConfig('{ not json');
+    const p = resolveConfigProvenance('model');
+    expect(p.effective).toBe('sonnet');
+    expect(p.source.kind).toBe('user');
+  });
+
+  it('resolves dotted paths', () => {
+    writeUserConfig({ interactive: { thinkingUi: 'digest' } });
+    const p = resolveConfigProvenance('interactive.thinkingUi');
+    expect(p.effective).toBe('digest');
+    expect(p.source.kind).toBe('user');
+  });
+});
+
+describe('activeEnvShadow — the loader is truthiness- and parse-gated', () => {
+  it('treats an empty env var as absent (the loader does)', () => {
+    process.env['AFK_MODEL'] = '';
+    expect(activeEnvShadow('model')).toBeUndefined();
+  });
+
+  it('ignores an unparseable AFK_MAX_TOKENS, which the loader also skips', () => {
+    process.env['AFK_MAX_TOKENS'] = 'abc';
+    expect(activeEnvShadow('maxTokens')).toBeUndefined();
+    process.env['AFK_MAX_TOKENS'] = '100';
+    expect(activeEnvShadow('maxTokens')).toBe('AFK_MAX_TOKENS');
+  });
+
+  it('ignores a non-finite AFK_TEMPERATURE', () => {
+    process.env['AFK_TEMPERATURE'] = 'hot';
+    expect(activeEnvShadow('temperature')).toBeUndefined();
+    process.env['AFK_TEMPERATURE'] = '0.7';
+    expect(activeEnvShadow('temperature')).toBe('AFK_TEMPERATURE');
+  });
+
+  it('returns undefined for a key with no env twin', () => {
+    // permissionMode resolves JSON-only (resolveCliPermissionMode) — claiming an
+    // env override for it would be wrong.
+    expect(activeEnvShadow('permissionMode')).toBeUndefined();
+    expect(CONFIG_ENV_SHADOWS['permissionMode']).toBeUndefined();
+  });
+});
+
+describe('CONFIG_ENV_SHADOWS integrity', () => {
+  it('only maps paths that are real config keys', () => {
+    const known = new Set(CONFIG_KEY_SPECS.map((s) => s.path));
+    for (const path of Object.keys(CONFIG_ENV_SHADOWS)) {
+      expect(known.has(path), `${path} is not a CONFIG_KEY_SPECS path`).toBe(true);
+    }
+  });
+
+  it('maps all four autoRouting sub-keys, since AFK_AUTO_ROUTING sets them together', () => {
+    for (const sub of ['interactive', 'chat', 'telegram', 'daemon']) {
+      expect(CONFIG_ENV_SHADOWS[`autoRouting.${sub}`]).toEqual(['AFK_AUTO_ROUTING']);
+    }
+  });
+});

--- a/src/cli/config/provenance.test.ts
+++ b/src/cli/config/provenance.test.ts
@@ -38,6 +38,13 @@ function writeUserConfig(obj: unknown): void {
   writeFileSync(join(dir, 'afk.config.json'), JSON.stringify(obj), 'utf8');
 }
 
+/** Write raw bytes to the user-global config (for malformed-file cases). */
+function writeUserConfigRaw(raw: string): void {
+  const dir = join(tmpRoot, 'home', 'config');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'afk.config.json'), raw, 'utf8');
+}
+
 /** Write a project-local config in cwd (outranks the user file). */
 function writeProjectConfig(raw: string): void {
   writeFileSync(join(tmpRoot, 'project', 'afk.config.json'), raw, 'utf8');
@@ -146,6 +153,14 @@ describe('resolveConfigProvenance — tier precedence', () => {
     expect(p.source.kind).toBe('user');
   });
 
+  it('tolerates a malformed USER config: userValue drops out and the walk falls through', () => {
+    writeUserConfigRaw('{ not json');
+    const p = resolveConfigProvenance('model');
+    expect(p.userValue).toBeUndefined();
+    expect(p.source.kind).toBe('default');
+    expect(p.shadowedBy).toBeUndefined();
+  });
+
   it('resolves dotted paths', () => {
     writeUserConfig({ interactive: { thinkingUi: 'digest' } });
     const p = resolveConfigProvenance('interactive.thinkingUi');
@@ -158,6 +173,19 @@ describe('activeEnvShadow — the loader is truthiness- and parse-gated', () => 
   it('treats an empty env var as absent (the loader does)', () => {
     process.env['AFK_MODEL'] = '';
     expect(activeEnvShadow('model')).toBeUndefined();
+  });
+
+  it('stops at a set-but-empty primary: the loader binds "" and applies NO override', () => {
+    // env-tier.ts:206 — `env.AFK_MODEL ?? env.CLAUDE_MODEL` binds '' (`??` does
+    // not fall through on empty string), then `if (modelRaw)` skips the
+    // override. So NO env shadow exists here; reporting CLAUDE_MODEL would lie
+    // about what the loader does.
+    process.env['AFK_MODEL'] = '';
+    process.env['CLAUDE_MODEL'] = 'haiku';
+    expect(activeEnvShadow('model')).toBeUndefined();
+    const p = resolveConfigProvenance('model');
+    expect(p.source.kind).not.toBe('env');
+    expect(p.shadowedBy).toBeUndefined();
   });
 
   it('ignores an unparseable AFK_MAX_TOKENS, which the loader also skips', () => {

--- a/src/cli/config/provenance.test.ts
+++ b/src/cli/config/provenance.test.ts
@@ -86,6 +86,7 @@ describe('resolveConfigProvenance — tier precedence', () => {
     expect(p.effective).toBeUndefined();
     expect(p.source.kind).toBe('default');
     expect(p.shadowedBy).toBeUndefined();
+    expect(sourceSuffix(p)).toBeUndefined(); // unshadowed default: nothing to warn about
   });
 
   it('lets a project config outrank the user file and flags it as shadowing', () => {
@@ -97,6 +98,7 @@ describe('resolveConfigProvenance — tier precedence', () => {
     expect(p.shadowedBy?.kind).toBe('project');
     // The user file's own value is still reported — that is what a write edits.
     expect(p.userValue).toBe('sonnet');
+    expect(sourceSuffix(p)).toBe('\u2190 project afk.config.json');
     expect(shadowNote(p)).toMatch(/outranks the user config/);
   });
 
@@ -126,6 +128,10 @@ describe('resolveConfigProvenance — tier precedence', () => {
     expect(p.source.kind).toBe('default');
     expect(p.shadowedBy?.kind).toBe('project');
     expect(p.userValue).toBe('sonnet');
+    // The row reads `(unset)` here; without a suffix it is indistinguishable
+    // from a key the menu controls, and the shadow surfaces only one screen
+    // deeper. Name the blocking tier on the row itself.
+    expect(sourceSuffix(p)).toBe('\u2190 default (project afk.config.json active \u2014 see \u26a0)');
     expect(shadowNote(p)).toMatch(/loaded INSTEAD of it/);
   });
 

--- a/src/cli/config/provenance.ts
+++ b/src/cli/config/provenance.ts
@@ -1,0 +1,258 @@
+/**
+ * Effective-value + provenance resolution for afk config keys.
+ *
+ * Why this exists: `/config` writes to ONE file — `$AFK_HOME/config/afk.config.json`
+ * (mutate.ts `jsonPath()`) — but the loader resolves a key across four tiers:
+ * env > project afk.config.json > user afk.config.json > legacy. So a user could
+ * set `model` in the settings menu, watch it save, restart, and still run the old
+ * model, because `AFK_MODEL` or a project-local config outranks the file that was
+ * written. No signal was surfaced anywhere. This module computes what the loader
+ * will ACTUALLY use and which tier supplied it, so the menu can render the truth
+ * and warn at write time when a write lands beneath a shadowing tier.
+ *
+ * Two semantics are load-bearing and are NOT re-derived here — both come from
+ * the loader's own code so the report cannot drift from what will actually load:
+ *   - FILE-level selection. `loadJsonConfig()` stops at the first file that
+ *     parses and validates; that file alone supplies config. A key it omits
+ *     resolves to its DEFAULT, not to a lower file. So a project config holding
+ *     one unrelated key silently neutralises the entire user config, and this
+ *     module must say so.
+ *   - Validated values. An invalid `permissionMode` is ignored, a model alias is
+ *     lowercased, `maxSummaryCallsPerSession` is clamped, and a bad worktree ref
+ *     makes the whole file fall through. Reporting the RAW JSON would misstate
+ *     every one of those. `json-tier-parse.ts` is the single parser.
+ *
+ * Read-only: nothing here mutates config. Writes stay in `src/config/mutate.ts`.
+ *
+ * @module cli/config/provenance
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { getEnvVarMeta, getEnvVarValue } from '../../config/env.js';
+import { getAtPath } from '../../config/settable-keys.js';
+import { maskSecret } from '../../config/mutate.js';
+import { parseJsonConfigFile, validatedValueView } from './json-tier-parse.js';
+import { jsonConfigTierPaths, TIER_LABELS, type JsonConfigTier } from './json-tier-paths.js';
+
+// ── The env-shadow map ───────────────────────────────────────────────────────
+
+/**
+ * Invariant: config path → the env var(s) that override it, highest precedence
+ * first. Every entry is verified against the actual override site; a key absent
+ * from this map has NO env override and its config value always wins.
+ *
+ * Sites (do not edit this map without re-reading them):
+ *   model                  cli/config/env-tier.ts:206-212  (AFK_MODEL ?? CLAUDE_MODEL)
+ *   maxTokens              cli/config/env-tier.ts:254-265  (gated: Number.isInteger)
+ *   temperature            cli/config/env-tier.ts:268-272  (gated: Number.isFinite)
+ *   systemPrompt           cli/config/env-tier.ts:275-276
+ *   autoRouting.*          cli/config/env-tier.ts:279-281  (sets ALL FOUR at once)
+ *   theme                  cli/theme.ts:136-146            (resolveTheme)
+ *   interactive.thinkingUi cli/commands/interactive.ts:158 (resolveThinkingUi)
+ *   interactive.suggestGhost cli/commands/interactive/repl-loop.ts:85
+ *   models.<tier>          agent/session/model-slots.ts:220-223
+ *
+ * Deliberately NOT here: `permissionMode` has no env override — it resolves
+ * JSON-only via `resolveCliPermissionMode()` (cli/config.ts), so listing an env
+ * twin would be wrong.
+ */
+export const CONFIG_ENV_SHADOWS: Readonly<Record<string, readonly string[]>> = {
+  model: ['AFK_MODEL', 'CLAUDE_MODEL'],
+  maxTokens: ['AFK_MAX_TOKENS'],
+  temperature: ['AFK_TEMPERATURE'],
+  systemPrompt: ['AFK_SYSTEM_PROMPT'],
+  'autoRouting.interactive': ['AFK_AUTO_ROUTING'],
+  'autoRouting.chat': ['AFK_AUTO_ROUTING'],
+  'autoRouting.telegram': ['AFK_AUTO_ROUTING'],
+  'autoRouting.daemon': ['AFK_AUTO_ROUTING'],
+  theme: ['AFK_THEME'],
+  'interactive.thinkingUi': ['AFK_THINKING_UI'],
+  'interactive.suggestGhost': ['AFK_SUGGEST_GHOST'],
+  'models.local': ['AFK_MODEL_LOCAL'],
+  'models.small': ['AFK_MODEL_SMALL'],
+  'models.medium': ['AFK_MODEL_MEDIUM'],
+  'models.large': ['AFK_MODEL_LARGE'],
+};
+
+/**
+ * Env vars whose presence overrides config only when the value parses. An
+ * unparseable `AFK_MAX_TOKENS=abc` is skipped by the loader
+ * (env-tier.ts:264-265), so config still wins and we must not claim otherwise.
+ */
+const PARSE_GATED: Readonly<Record<string, (raw: string) => boolean>> = {
+  AFK_MAX_TOKENS: (raw) => Number.isInteger(Number(raw)),
+  AFK_TEMPERATURE: (raw) => Number.isFinite(Number(raw)),
+};
+
+// ── Result shape ─────────────────────────────────────────────────────────────
+
+export type ConfigSource =
+  | { readonly kind: 'env'; readonly via: string }
+  | { readonly kind: JsonConfigTier; readonly path: string }
+  | { readonly kind: 'default' };
+
+export interface ConfigProvenance {
+  readonly path: string;
+  /** The value the loader will actually use. */
+  readonly effective: unknown;
+  /** Which tier supplied `effective` (`default` when no tier sets the key). */
+  readonly source: ConfigSource;
+  /**
+   * Set when a tier ABOVE the user-global file wins the load — i.e. a `/config`
+   * write would persist but not take effect. This is the warning the menu
+   * surfaces at write time.
+   *
+   * Because selection is FILE-level, this fires even when the shadowing file
+   * does not mention the key: a project config that loads at all suppresses the
+   * user file entirely, so the write is inert either way. `source.kind` tells
+   * the two apart (`project` = it sets the key; `default` = it merely blocks).
+   */
+  readonly shadowedBy?: ConfigSource;
+  /** The raw value in the user-global file `/config` writes to (may differ). */
+  readonly userValue: unknown;
+}
+
+/** One-line human label for a source, e.g. `env AFK_MODEL` or `user afk.config.json`. */
+export function describeSource(src: ConfigSource): string {
+  if (src.kind === 'env') return `env ${src.via}`;
+  if (src.kind === 'default') return 'default';
+  return TIER_LABELS[src.kind];
+}
+
+// ── Display helpers (plain strings — the caller applies colour) ───────────────
+
+/**
+ * Row suffix naming the tier in effect, or undefined when the value comes from
+ * the same file `/config` writes to (the unsurprising case, left unannotated to
+ * keep the menu quiet).
+ */
+export function sourceSuffix(prov: ConfigProvenance): string | undefined {
+  if (prov.source.kind === 'user' || prov.source.kind === 'default') return undefined;
+  return `← ${describeSource(prov.source)}`;
+}
+
+/**
+ * The warning shown when a write to the user-global file will NOT take effect
+ * because a higher-precedence tier wins the load. Undefined when the write is
+ * the winning tier.
+ */
+export function shadowNote(prov: ConfigProvenance): string | undefined {
+  const s = prov.shadowedBy;
+  if (!s) return undefined;
+  if (s.kind === 'env') {
+    return `${s.via} is set in the environment and overrides this file — unset it for this change to take effect.`;
+  }
+  if (s.kind === 'project') {
+    // File-level selection: when the effective source is `default`, the project
+    // file won but omitted this key; otherwise the project file supplied it.
+    return prov.source.kind === 'default'
+      ? `${s.path} outranks the user config and is loaded INSTEAD of it (config files are not merged), so this key falls back to its default — set it in that file for this change to take effect.`
+      : `${s.path} sets this key and outranks the user config — edit that file for this change to take effect.`;
+  }
+  return `${describeSource(s)} overrides this file.`;
+}
+
+// ── Resolution ───────────────────────────────────────────────────────────────
+
+/**
+ * The RAW contents of the file `/config` writes to — used only for `userValue`,
+ * which describes what an edit would replace. Deliberately unvalidated: it
+ * answers "what is literally in my file", not "what will load".
+ */
+function readRawJsonFile(file: string): Record<string, unknown> | undefined {
+  if (!existsSync(file)) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(file, 'utf-8'));
+    return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : undefined;
+  } catch {
+    // A malformed file is skipped by the loader too (json-tier.ts falls through
+    // on parse error), so skipping it here keeps provenance consistent with
+    // what will actually load rather than throwing into the menu render.
+    return undefined;
+  }
+}
+
+/**
+ * The VALIDATED contents of a tier, or undefined when the loader would skip it
+ * (absent, malformed, or rejected by a throwing validator). Same parser the
+ * loader uses, so the two cannot disagree.
+ */
+function readValidatedTier(file: string): Record<string, unknown> | undefined {
+  try {
+    const parsed = parseJsonConfigFile(file);
+    return parsed === undefined ? undefined : validatedValueView(parsed);
+  } catch {
+    // Malformed JSON or a validator that threw: `loadJsonConfig()` warns and
+    // falls through to the next tier, so we skip it too. Never throws into the
+    // menu render.
+    return undefined;
+  }
+}
+
+/** The env var currently overriding `path`, if any (honors the parse gates). */
+export function activeEnvShadow(path: string): string | undefined {
+  for (const name of CONFIG_ENV_SHADOWS[path] ?? []) {
+    const raw = getEnvVarValue(name);
+    if (raw === undefined) continue;
+    const gate = PARSE_GATED[name];
+    if (gate && !gate(raw)) continue;
+    return name;
+  }
+  return undefined;
+}
+
+/**
+ * Resolve a config key to the value the loader will use, plus its origin.
+ *
+ * Precedence mirrors the loader exactly: env > (first loadable JSON file) >
+ * default. Note the middle term: the JSON tiers are NOT merged per key. The
+ * first tier whose file loads WINS THE WHOLE FILE, so a key it omits reports
+ * `default` rather than a lower tier's value — which is exactly what
+ * `loadJsonConfig()` does, and the reason a project config with one unrelated
+ * key makes every user-config value inert.
+ */
+export function resolveConfigProvenance(path: string): ConfigProvenance {
+  const tiers = jsonConfigTierPaths();
+  const userTier = tiers.find((t) => t.tier === 'user');
+  // `userValue` is the RAW value in the write-target file: it describes what a
+  // `/config` edit replaces, independent of whether that file wins the walk.
+  const userValue = userTier
+    ? getAtPath((readRawJsonFile(userTier.path) ?? {}) as never, path)
+    : undefined;
+
+  const envVar = activeEnvShadow(path);
+  if (envVar !== undefined) {
+    const meta = getEnvVarMeta(envVar);
+    const raw = getEnvVarValue(envVar);
+    const shown = meta?.secret === true ? maskSecret(raw) : raw;
+    const source: ConfigSource = { kind: 'env', via: envVar };
+    return { path, effective: shown, source, shadowedBy: source, userValue };
+  }
+
+  for (const tier of tiers) {
+    const obj = readValidatedTier(tier.path);
+    if (obj === undefined) continue; // absent / malformed / rejected → next tier
+    // FILE-level selection: this tier wins even if it omits `path`. An absent
+    // key here resolves to the default, so `effective` is undefined and the
+    // source is 'default' — but a tier above 'user' still shadows the write,
+    // because the write cannot take effect while that file is the one loading.
+    const value = getAtPath(obj as never, path);
+    const source: ConfigSource = { kind: tier.tier, path: tier.path };
+    // Only a tier ABOVE 'user' shadows what `/config` writes. 'user' is the
+    // write target itself, and 'legacy' ranks below it (and can only be reached
+    // when the user file is absent or unloadable, in which case a write to the
+    // user file creates the higher-precedence tier and does take effect).
+    const shadowedBy = tier.tier === 'project' ? { shadowedBy: source } : {};
+    return {
+      path,
+      effective: value,
+      source: value === undefined ? { kind: 'default' } : source,
+      ...shadowedBy,
+      userValue,
+    };
+  }
+
+  return { path, effective: undefined, source: { kind: 'default' }, userValue };
+}

--- a/src/cli/config/provenance.ts
+++ b/src/cli/config/provenance.ts
@@ -28,7 +28,7 @@
  */
 
 import { readFileSync, existsSync } from 'fs';
-import { getEnvVarMeta, getEnvVarValue } from '../../config/env.js';
+import { getEnvVarMeta, getEnvVarValue, isEnvVarSet } from '../../config/env.js';
 import { getAtPath } from '../../config/settable-keys.js';
 import { maskSecret } from '../../config/mutate.js';
 import { parseJsonConfigFile, validatedValueView } from './json-tier-parse.js';
@@ -191,11 +191,25 @@ function readValidatedTier(file: string): Record<string, unknown> | undefined {
   }
 }
 
-/** The env var currently overriding `path`, if any (honors the parse gates). */
+/**
+ * The env var currently overriding `path`, if any (honors the parse gates).
+ *
+ * Invariant: a SET-but-empty var STOPS the walk instead of falling through to
+ * a lower-precedence alias. The loader binds multi-var chains with `??`
+ * (env-tier.ts:206, `env.AFK_MODEL ?? env.CLAUDE_MODEL`), and `??` does not
+ * fall through on '' — the truthiness gate then skips the override entirely.
+ * Falling through here would report a shadow (e.g. CLAUDE_MODEL) that the
+ * loader never applies. Unset vars, by contrast, DO fall through in both
+ * layers. Single-var entries are unaffected: stop and continue agree when no
+ * alias remains.
+ */
 export function activeEnvShadow(path: string): string | undefined {
   for (const name of CONFIG_ENV_SHADOWS[path] ?? []) {
+    if (!isEnvVarSet(name)) continue; // unset → the loader's `??` falls to the next alias
     const raw = getEnvVarValue(name);
-    if (raw === undefined) continue;
+    // Set-but-empty: the loader binds '' and its truthiness gate skips the
+    // override — no shadow, and no fall-through to a lower-precedence alias.
+    if (raw === undefined) return undefined;
     const gate = PARSE_GATED[name];
     if (gate && !gate(raw)) continue;
     return name;

--- a/src/cli/config/provenance.ts
+++ b/src/cli/config/provenance.ts
@@ -33,6 +33,7 @@ import { getAtPath } from '../../config/settable-keys.js';
 import { maskSecret } from '../../config/mutate.js';
 import { parseJsonConfigFile, validatedValueView } from './json-tier-parse.js';
 import { jsonConfigTierPaths, TIER_LABELS, type JsonConfigTier } from './json-tier-paths.js';
+import { NO_PROVENANCE_CACHE, type ProvenanceCache } from './provenance-cache.js';
 
 // ── The env-shadow map ───────────────────────────────────────────────────────
 
@@ -125,9 +126,21 @@ export function describeSource(src: ConfigSource): string {
  * Row suffix naming the tier in effect, or undefined when the value comes from
  * the same file `/config` writes to (the unsurprising case, left unannotated to
  * keep the menu quiet).
+ *
+ * The one noisy `default` is a shadowed one: a higher tier won the load but
+ * omits this key, so the row shows `(unset)` while a write to the user file
+ * would still be inert. Unannotated, that row is indistinguishable from a key
+ * the menu genuinely controls, and the user only discovers the shadow one
+ * screen deeper in the edit header — the misattribution this suffix exists to
+ * prevent.
  */
 export function sourceSuffix(prov: ConfigProvenance): string | undefined {
-  if (prov.source.kind === 'user' || prov.source.kind === 'default') return undefined;
+  if (prov.source.kind === 'default') {
+    return prov.shadowedBy
+      ? `← default (${describeSource(prov.shadowedBy)} active — see ⚠)`
+      : undefined;
+  }
+  if (prov.source.kind === 'user') return undefined;
   return `← ${describeSource(prov.source)}`;
 }
 
@@ -226,14 +239,25 @@ export function activeEnvShadow(path: string): string | undefined {
  * `default` rather than a lower tier's value — which is exactly what
  * `loadJsonConfig()` does, and the reason a project config with one unrelated
  * key makes every user-config value inert.
+ *
+ * `cache` deduplicates the file reads across a batch of keys — pass one shared
+ * cache per render pass and drop it after (see provenance-cache.ts: it must not
+ * survive an `await`, or a write made mid-session would render stale). Omit it
+ * for one-shot resolution; every read then hits disk, as before.
  */
-export function resolveConfigProvenance(path: string): ConfigProvenance {
+export function resolveConfigProvenance(
+  path: string,
+  cache: ProvenanceCache = NO_PROVENANCE_CACHE,
+): ConfigProvenance {
   const tiers = jsonConfigTierPaths();
   const userTier = tiers.find((t) => t.tier === 'user');
   // `userValue` is the RAW value in the write-target file: it describes what a
   // `/config` edit replaces, independent of whether that file wins the walk.
   const userValue = userTier
-    ? getAtPath((readRawJsonFile(userTier.path) ?? {}) as never, path)
+    ? getAtPath(
+        (cache.raw(userTier.path, () => readRawJsonFile(userTier.path)) ?? {}) as never,
+        path,
+      )
     : undefined;
 
   const envVar = activeEnvShadow(path);
@@ -246,7 +270,7 @@ export function resolveConfigProvenance(path: string): ConfigProvenance {
   }
 
   for (const tier of tiers) {
-    const obj = readValidatedTier(tier.path);
+    const obj = cache.validated(tier.path, () => readValidatedTier(tier.path));
     if (obj === undefined) continue; // absent / malformed / rejected → next tier
     // FILE-level selection: this tier wins even if it omits `path`. An absent
     // key here resolves to the default, so `effective` is undefined and the

--- a/src/cli/render/config-menu-model.ts
+++ b/src/cli/render/config-menu-model.ts
@@ -1,0 +1,145 @@
+/**
+ * Pure presentation model for the `/config` settings menu: categorisation,
+ * value formatting, row labels, and per-key editor planning.
+ *
+ * Split out of config-menu.ts (which owns the async orchestrator + the real
+ * adapters) to keep both files under the 350-LOC ceiling and to let these
+ * helpers be unit-tested with no overlay, no session, and no disk.
+ *
+ * @module cli/render/config-menu-model
+ */
+
+import { palette } from '../palette.js';
+import {
+  coerceConfigValue,
+  type ConfigKeySpec,
+} from '../../config/settable-keys.js';
+
+// ── Categorisation (pure) ───────────────────────────────────────────────────
+
+/** Display order for categories. Any category not listed here is dropped. */
+export const CATEGORY_ORDER = [
+  'Model & routing',
+  'Interactive',
+  'Session',
+  'Telegram',
+  'Advanced',
+] as const;
+
+/**
+ * Map a config key path to its menu category. Total over every path in
+ * CONFIG_KEY_SPECS (asserted by a test) — a new spec that matches nothing here
+ * lands in 'Session' rather than vanishing, but the test will flag it so the
+ * author can place it deliberately.
+ */
+export function categoryOf(path: string): (typeof CATEGORY_ORDER)[number] {
+  if (
+    path === 'model' ||
+    path.startsWith('models.') ||
+    path === 'temperature' ||
+    path === 'maxTokens' ||
+    path.startsWith('autoRouting.')
+  ) {
+    return 'Model & routing';
+  }
+  if (path.startsWith('interactive.')) return 'Interactive';
+  if (path.startsWith('telegram.')) return 'Telegram';
+  if (path.startsWith('daemon.')) return 'Advanced';
+  if (
+    path === 'systemPrompt' ||
+    path === 'permissionMode' ||
+    path === 'enableShellHooks' ||
+    path === 'enablePluginHooks' ||
+    path === 'updatePolicy'
+  ) {
+    return 'Advanced';
+  }
+  return 'Session';
+}
+
+interface MenuCategory {
+  name: (typeof CATEGORY_ORDER)[number];
+  keys: readonly ConfigKeySpec[];
+}
+
+/** Group specs into ordered, non-empty categories. */
+export function buildCategories(specs: readonly ConfigKeySpec[]): MenuCategory[] {
+  const byCat = new Map<string, ConfigKeySpec[]>();
+  for (const spec of specs) {
+    const cat = categoryOf(spec.path);
+    const bucket = byCat.get(cat);
+    if (bucket) bucket.push(spec);
+    else byCat.set(cat, [spec]);
+  }
+  const out: MenuCategory[] = [];
+  for (const name of CATEGORY_ORDER) {
+    const keys = byCat.get(name);
+    if (keys && keys.length > 0) out.push({ name, keys });
+  }
+  return out;
+}
+
+// ── Value formatting + validation (pure) ─────────────────────────────────────
+
+/** Render a persisted config value as a compact display string. */
+export function formatValue(v: unknown): string {
+  if (v === undefined) return '(unset)';
+  if (v === null) return 'null';
+  if (Array.isArray(v)) return v.length === 0 ? '(empty)' : v.join(',');
+  if (typeof v === 'object') return JSON.stringify(v);
+  return String(v);
+}
+
+/**
+ * One key row: `🔒 path            value  (type)  ← env AFK_MODEL`.
+ *
+ * `suffix` names the tier actually supplying the value when it is NOT the file
+ * this menu writes to — without it, a key overridden by env or a project config
+ * renders identically to one the menu controls, which is the misattribution this
+ * row exists to prevent.
+ */
+export function keyRowLabel(
+  spec: ConfigKeySpec,
+  current: unknown,
+  pad: number,
+  suffix?: string,
+): string {
+  const lock = spec.tier === 'human' ? '🔒 ' : '   ';
+  const tail = suffix ? `  ${palette.warning(suffix)}` : '';
+  return `${lock}${spec.path.padEnd(pad)}  ${formatValue(current)}  (${spec.type})${tail}`;
+}
+
+/**
+ * Editor shape for a key: a fixed-option picker (boolean/enum) or a free-text
+ * overlay (everything else), with a help line describing the accepted input.
+ */
+type EditorPlan =
+  | { kind: 'pick'; options: string[] }
+  | { kind: 'text'; help: string };
+
+export function editorFor(spec: ConfigKeySpec): EditorPlan {
+  if (spec.type === 'boolean') return { kind: 'pick', options: ['true', 'false'] };
+  if (spec.type === 'enum' && spec.enumValues && spec.enumValues.length > 0) {
+    return { kind: 'pick', options: [...spec.enumValues] };
+  }
+  let help = 'enter to save · esc to cancel';
+  if (spec.type === 'number' && spec.clamp) {
+    const range = `[${spec.clamp.min}..${spec.clamp.max}]${spec.clamp.integer ? ' integer' : ''}`;
+    help = `number ${range} · enter to save · esc to cancel`;
+  } else if (spec.type === 'number') {
+    help = 'number · enter to save · esc to cancel';
+  } else if (spec.type === 'number-array') {
+    help = 'comma-separated numbers · enter to save · esc to cancel';
+  } else if (spec.type === 'model-slot') {
+    help = 'model id (e.g. sonnet) · enter to save · esc to cancel';
+  }
+  return { kind: 'text', help };
+}
+
+/** A synchronous validator for the text overlay — wraps `coerceConfigValue`. */
+export function makeValidator(spec: ConfigKeySpec): (raw: string) => string | null {
+  return (raw: string): string | null => {
+    const r = coerceConfigValue(spec, raw);
+    return r.ok ? null : r.error;
+  };
+}

--- a/src/cli/render/config-menu.test.ts
+++ b/src/cli/render/config-menu.test.ts
@@ -7,6 +7,9 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { runConfigMenu, type MenuOverlays, type MenuIo } from './config-menu.js';
+import type { ConfigProvenance } from '../config/provenance.js';
+import type { LiveApplyOutcome } from '../config/live-apply.js';
 import {
   CATEGORY_ORDER,
   categoryOf,
@@ -15,10 +18,7 @@ import {
   keyRowLabel,
   editorFor,
   makeValidator,
-  runConfigMenu,
-  type MenuOverlays,
-  type MenuIo,
-} from './config-menu.js';
+} from './config-menu-model.js';
 import { CONFIG_KEY_SPECS, getConfigKeySpec, type ConfigKeySpec } from '../../config/settable-keys.js';
 
 // ── Fakes ────────────────────────────────────────────────────────────────────
@@ -247,5 +247,127 @@ describe('runConfigMenu', () => {
     expect(ov.emits.length).toBe(1);
     expect(ov.emits[0]).toContain('✗');
     expect(ov.emits[0]).toContain('refused');
+  });
+});
+
+// ── Provenance + live-apply wiring ───────────────────────────────────────────
+//
+// Contract: both MenuIo members are OPTIONAL. An io that omits them must render
+// and write exactly as before — that back-compat is what keeps every fake above
+// (and every non-TTY surface) valid.
+
+describe('provenance + live-apply wiring', () => {
+  const provIo = (
+    values: Record<string, unknown>,
+    prov: Partial<Record<string, ConfigProvenance>>,
+    live?: LiveApplyOutcome,
+  ): MenuIo & { writes: Array<{ path: string; value: string }>; liveCalls: string[] } => {
+    const writes: Array<{ path: string; value: string }> = [];
+    const liveCalls: string[] = [];
+    return {
+      writes,
+      liveCalls,
+      specs: () => TWO_KEY_SPECS,
+      current: (p) => values[p],
+      write: (p, v) => {
+        writes.push({ path: p, value: v });
+        return v;
+      },
+      provenance: (p) =>
+        prov[p] ?? {
+          path: p,
+          effective: values[p],
+          source: { kind: 'user', path: '/u/afk.config.json' },
+          userValue: values[p],
+        },
+      applyLive: async (p, v) => {
+        liveCalls.push(`${p}=${v}`);
+        return live ?? { applied: false };
+      },
+    };
+  };
+
+  it('renders the EFFECTIVE value and names the shadowing tier in the row', async () => {
+    // Enter the category (0), Esc out of the key list, Esc out of the menu.
+    const ov = new FakeOverlays([0, null, null], []);
+    const io = provIo(
+      { temperature: 1.0 },
+      {
+        temperature: {
+          path: 'temperature',
+          effective: 0.2,
+          source: { kind: 'env', via: 'AFK_TEMPERATURE' },
+          shadowedBy: { kind: 'env', via: 'AFK_TEMPERATURE' },
+          userValue: 1.0,
+        },
+      },
+    );
+
+    await runConfigMenu(ov, io);
+
+    const rows = ov.pickCalls[1]!.options.join('\n');
+    // The env value wins the display, NOT the 1.0 sitting in the file.
+    expect(rows).toContain('0.2');
+    expect(rows).not.toMatch(/temperature\s+1\b/);
+    expect(rows).toContain('env AFK_TEMPERATURE');
+  });
+
+  it('warns before AND after a write that lands beneath a shadowing tier', async () => {
+    const ov = new FakeOverlays([0, 0, null, null], ['1.5']);
+    const io = provIo(
+      { temperature: 1.0 },
+      {
+        temperature: {
+          path: 'temperature',
+          effective: 0.2,
+          source: { kind: 'env', via: 'AFK_TEMPERATURE' },
+          shadowedBy: { kind: 'env', via: 'AFK_TEMPERATURE' },
+          userValue: 1.0,
+        },
+      },
+    );
+
+    await runConfigMenu(ov, io);
+
+    expect(io.writes).toEqual([{ path: 'temperature', value: '1.5' }]);
+    // Pre-write: the edit header carries the warning.
+    const editHeader = ov.textCalls[0]!.header.join('\n');
+    expect(editHeader).toContain('AFK_TEMPERATURE');
+    // Post-write: success line, then the shadow warning.
+    expect(ov.emits.some((e) => e.includes('✓'))).toBe(true);
+    expect(ov.emits.some((e) => e.includes('AFK_TEMPERATURE'))).toBe(true);
+  });
+
+  it('reports a live-applied key instead of the restart note', async () => {
+    const ov = new FakeOverlays([0, 0, null, null], ['1.5']);
+    const io = provIo({ temperature: 1.0 }, {}, { applied: true, note: 'applied to this session' });
+
+    await runConfigMenu(ov, io);
+
+    expect(io.liveCalls).toEqual(['temperature=1.5']);
+    const ok = ov.emits.find((e) => e.includes('✓'))!;
+    expect(ok).toContain('applied to this session');
+    expect(ok).not.toContain('restart');
+  });
+
+  it('keeps a saved-but-not-applied write reported as a SUCCESS plus a caveat', async () => {
+    const ov = new FakeOverlays([0, 0, null, null], ['1.5']);
+    const io = provIo({ temperature: 1.0 }, {}, { applied: false, reason: 'provider unreachable' });
+
+    await runConfigMenu(ov, io);
+
+    expect(io.writes).toHaveLength(1); // the write still counts
+    expect(ov.emits.some((e) => e.includes('✓'))).toBe(true);
+    expect(ov.emits.some((e) => e.includes('saved, but not applied live'))).toBe(true);
+  });
+
+  it('falls back to the pre-provenance rendering when io omits both members', async () => {
+    const ov = new FakeOverlays([0, 0, null, null], ['1.5']);
+    const io = new FakeIo(TWO_KEY_SPECS, { temperature: 1.0 });
+
+    await runConfigMenu(ov, io);
+
+    expect(io.writes).toEqual([{ path: 'temperature', value: '1.5', human: false }]);
+    expect(ov.emits.find((e) => e.includes('✓'))).toContain('restart');
   });
 });

--- a/src/cli/render/config-menu.ts
+++ b/src/cli/render/config-menu.ts
@@ -11,10 +11,19 @@
  *     nested, so the single-overlay guard (terminal-compositor.input-mode.ts:95)
  *     always holds — each overlay `exitPickerMode`s before the next enters.
  *
- * Value semantics: writes go through `setConfigValue`, which persists to
- * afk.config.json but is CACHED AT LOAD — the running session is unchanged until
- * restart (mutate.ts:19-21). Every write echoes `RESTART_NOTE` so the user is
- * never surprised.
+ * Value semantics: writes go through `setConfigValue`, which persists to the
+ * user-global afk.config.json. That store is CACHED AT LOAD, so by default the
+ * running session is unchanged until restart (mutate.ts:19-21) and the write
+ * echoes `RESTART_NOTE`. Two refinements sit on top:
+ *   - Liveness (config/live-apply.ts): a small allowlist of keys whose live path
+ *     is already proven by a shipped slash command (`model` → `/model`, `theme`
+ *     → `/theme`) is pushed into the running session and reports "applied to
+ *     this session" instead. Everything else keeps the restart note verbatim.
+ *   - Provenance (config/provenance.ts): rows show the value the LOADER will
+ *     use, which is not always the value in the file we write — env and a
+ *     project-local afk.config.json both outrank it. When a higher tier wins,
+ *     the row names it and the editor warns before and after the write, because
+ *     a silently-inert save is the worst outcome this menu can produce.
  *
  * Security: config keys are only tier 'agent' | 'human' — never `secret` (secrets
  * are env-only). So editing config keys in-REPL cannot leak a credential.
@@ -34,128 +43,22 @@ import { palette } from '../palette.js';
 import { runPicker } from './picker.js';
 import { runTextInput } from './text-input.js';
 import type { TerminalCompositor } from '../terminal-compositor.js';
+import { CONFIG_KEY_SPECS, type ConfigKeySpec } from '../../config/settable-keys.js';
 import {
-  CONFIG_KEY_SPECS,
-  coerceConfigValue,
-  type ConfigKeySpec,
-} from '../../config/settable-keys.js';
+  buildCategories,
+  editorFor,
+  formatValue,
+  keyRowLabel,
+  makeValidator,
+} from './config-menu-model.js';
 import { setConfigValue, getConfigValue, RESTART_NOTE } from '../../config/mutate.js';
-
-// ── Categorisation (pure) ───────────────────────────────────────────────────
-
-/** Display order for categories. Any category not listed here is dropped. */
-export const CATEGORY_ORDER = [
-  'Model & routing',
-  'Interactive',
-  'Session',
-  'Telegram',
-  'Advanced',
-] as const;
-
-/**
- * Map a config key path to its menu category. Total over every path in
- * CONFIG_KEY_SPECS (asserted by a test) — a new spec that matches nothing here
- * lands in 'Session' rather than vanishing, but the test will flag it so the
- * author can place it deliberately.
- */
-export function categoryOf(path: string): (typeof CATEGORY_ORDER)[number] {
-  if (
-    path === 'model' ||
-    path.startsWith('models.') ||
-    path === 'temperature' ||
-    path === 'maxTokens' ||
-    path.startsWith('autoRouting.')
-  ) {
-    return 'Model & routing';
-  }
-  if (path.startsWith('interactive.')) return 'Interactive';
-  if (path.startsWith('telegram.')) return 'Telegram';
-  if (path.startsWith('daemon.')) return 'Advanced';
-  if (
-    path === 'systemPrompt' ||
-    path === 'permissionMode' ||
-    path === 'enableShellHooks' ||
-    path === 'enablePluginHooks' ||
-    path === 'updatePolicy'
-  ) {
-    return 'Advanced';
-  }
-  return 'Session';
-}
-
-interface MenuCategory {
-  name: (typeof CATEGORY_ORDER)[number];
-  keys: readonly ConfigKeySpec[];
-}
-
-/** Group specs into ordered, non-empty categories. */
-export function buildCategories(specs: readonly ConfigKeySpec[]): MenuCategory[] {
-  const byCat = new Map<string, ConfigKeySpec[]>();
-  for (const spec of specs) {
-    const cat = categoryOf(spec.path);
-    const bucket = byCat.get(cat);
-    if (bucket) bucket.push(spec);
-    else byCat.set(cat, [spec]);
-  }
-  const out: MenuCategory[] = [];
-  for (const name of CATEGORY_ORDER) {
-    const keys = byCat.get(name);
-    if (keys && keys.length > 0) out.push({ name, keys });
-  }
-  return out;
-}
-
-// ── Value formatting + validation (pure) ─────────────────────────────────────
-
-/** Render a persisted config value as a compact display string. */
-export function formatValue(v: unknown): string {
-  if (v === undefined) return '(unset)';
-  if (v === null) return 'null';
-  if (Array.isArray(v)) return v.length === 0 ? '(empty)' : v.join(',');
-  if (typeof v === 'object') return JSON.stringify(v);
-  return String(v);
-}
-
-/** One key row: `🔒 path            value  (type)` — lock glyph on human-tier keys. */
-export function keyRowLabel(spec: ConfigKeySpec, current: unknown, pad: number): string {
-  const lock = spec.tier === 'human' ? '🔒 ' : '   ';
-  return `${lock}${spec.path.padEnd(pad)}  ${formatValue(current)}  (${spec.type})`;
-}
-
-/**
- * Editor shape for a key: a fixed-option picker (boolean/enum) or a free-text
- * overlay (everything else), with a help line describing the accepted input.
- */
-type EditorPlan =
-  | { kind: 'pick'; options: string[] }
-  | { kind: 'text'; help: string };
-
-export function editorFor(spec: ConfigKeySpec): EditorPlan {
-  if (spec.type === 'boolean') return { kind: 'pick', options: ['true', 'false'] };
-  if (spec.type === 'enum' && spec.enumValues && spec.enumValues.length > 0) {
-    return { kind: 'pick', options: [...spec.enumValues] };
-  }
-  let help = 'enter to save · esc to cancel';
-  if (spec.type === 'number' && spec.clamp) {
-    const range = `[${spec.clamp.min}..${spec.clamp.max}]${spec.clamp.integer ? ' integer' : ''}`;
-    help = `number ${range} · enter to save · esc to cancel`;
-  } else if (spec.type === 'number') {
-    help = 'number · enter to save · esc to cancel';
-  } else if (spec.type === 'number-array') {
-    help = 'comma-separated numbers · enter to save · esc to cancel';
-  } else if (spec.type === 'model-slot') {
-    help = 'model id (e.g. sonnet) · enter to save · esc to cancel';
-  }
-  return { kind: 'text', help };
-}
-
-/** A synchronous validator for the text overlay — wraps `coerceConfigValue`. */
-export function makeValidator(spec: ConfigKeySpec): (raw: string) => string | null {
-  return (raw: string): string | null => {
-    const r = coerceConfigValue(spec, raw);
-    return r.ok ? null : r.error;
-  };
-}
+import {
+  resolveConfigProvenance,
+  sourceSuffix,
+  shadowNote,
+  type ConfigProvenance,
+} from '../config/provenance.js';
+import { applyConfigLive, type LiveApplyHandle, type LiveApplyOutcome } from '../config/live-apply.js';
 
 // ── Injected effects (for testability) ───────────────────────────────────────
 
@@ -179,6 +82,16 @@ export interface MenuIo {
   current(path: string): unknown;
   /** Persist a value; return the display form of what was written, or throw. */
   write(path: string, rawValue: string, allowHuman: boolean): string;
+  /**
+   * Effective value + originating tier. Optional: surfaces that omit it get the
+   * pre-provenance rendering (persisted value only, no tier annotation).
+   */
+  provenance?(path: string): ConfigProvenance;
+  /**
+   * Push an already-persisted write into the running session. Optional: absent
+   * on surfaces with no live session, where every write stays restart-scoped.
+   */
+  applyLive?(path: string, rawValue: string): Promise<LiveApplyOutcome>;
 }
 
 // ── Orchestrator ─────────────────────────────────────────────────────────────
@@ -215,7 +128,21 @@ export async function runConfigMenu(ov: MenuOverlays, io: MenuIo): Promise<void>
       const keyHeader = [palette.bold(`${TITLE} › ${cat.name}`), ''];
       const ki = await ov.pick(
         keyHeader,
-        cat.keys.map((k) => keyRowLabel(k, io.current(k.path), pad)),
+        cat.keys.map((k) => {
+          // Invariant: `io.current` must be called for EVERY row even when
+          // provenance supersedes its value. It is the only read that throws
+          // MalformedConfigError on a broken write-target file, and the caller
+          // (config-doctor.ts) relies on that throw to degrade to the read-only
+          // view. Provenance deliberately tolerates unparseable files (it mirrors
+          // the loader's fall-through), so dropping this call silently opens a
+          // menu whose every write would fail.
+          const persisted = io.current(k.path);
+          const prov = io.provenance?.(k.path);
+          // Show the value the loader will actually use, not the file value —
+          // they differ exactly when a higher tier shadows this key.
+          const shown = prov ? prov.effective : persisted;
+          return keyRowLabel(k, shown, pad, prov ? sourceSuffix(prov) : undefined);
+        }),
       );
       if (ki === null) break; // Esc → back to categories
       const spec = cat.keys[ki];
@@ -227,10 +154,15 @@ export async function runConfigMenu(ov: MenuOverlays, io: MenuIo): Promise<void>
 
 async function editKey(ov: MenuOverlays, io: MenuIo, spec: ConfigKeySpec): Promise<void> {
   const current = io.current(spec.path);
+  const prov = io.provenance?.(spec.path);
+  const shadow = prov ? shadowNote(prov) : undefined;
   const header = [
     palette.bold(`${TITLE} › ${spec.path}`),
     palette.dim(spec.description),
-    palette.dim(`current: ${formatValue(current)}`),
+    palette.dim(`current: ${formatValue(prov ? prov.effective : current)}`),
+    // Warn BEFORE the edit, not only after the write — a user who learns their
+    // change is inert only after saving has already wasted the round trip.
+    ...(shadow ? [palette.warning(`⚠ ${shadow}`)] : []),
     '',
   ];
   const plan = editorFor(spec);
@@ -267,7 +199,15 @@ async function editKey(ov: MenuOverlays, io: MenuIo, spec: ConfigKeySpec): Promi
 
   try {
     const display = io.write(spec.path, rawValue, allowHuman);
-    ov.emit(`${palette.success('  ✓')} ${spec.path} = ${palette.bold(display)}  ${palette.dim(`— ${RESTART_NOTE}`)}`);
+    // Persistence succeeded. Liveness is reported separately and never
+    // downgrades the write: a failed live-apply still leaves a saved value.
+    const live = await io.applyLive?.(spec.path, rawValue);
+    const note = live?.applied === true ? live.note : RESTART_NOTE;
+    ov.emit(`${palette.success('  ✓')} ${spec.path} = ${palette.bold(display)}  ${palette.dim(`— ${note}`)}`);
+    if (live && live.applied === false && live.reason !== undefined) {
+      ov.emit(`${palette.warning('  ⚠')} ${palette.dim(`saved, but not applied live: ${live.reason}`)}`);
+    }
+    if (shadow) ov.emit(`${palette.warning('  ⚠')} ${palette.dim(shadow)}`);
   } catch (err) {
     ov.emit(`${palette.error('  ✗')} ${palette.error(err instanceof Error ? err.message : String(err))}`);
   }
@@ -293,12 +233,19 @@ export function overlaysFromCompositor(c: TerminalCompositor): MenuOverlays {
   };
 }
 
-/** Real io backed by the config-mutation engine. */
-export function defaultIo(): MenuIo {
+/**
+ * Real io backed by the config-mutation engine.
+ *
+ * `handle` is the running session's live-apply capability; omit it on surfaces
+ * without one (tests, non-TTY) and every write stays restart-scoped.
+ */
+export function defaultIo(handle?: LiveApplyHandle): MenuIo {
   return {
     specs: () => CONFIG_KEY_SPECS,
     current: (path) => getConfigValue(path).value,
     write: (path, rawValue, allowHuman) =>
       String(setConfigValue(path, rawValue, allowHuman ? { allowHumanOnly: true } : undefined).value),
+    provenance: (path) => resolveConfigProvenance(path),
+    applyLive: (path, rawValue) => applyConfigLive(path, rawValue, handle),
   };
 }

--- a/src/cli/render/config-menu.ts
+++ b/src/cli/render/config-menu.ts
@@ -58,6 +58,7 @@ import {
   shadowNote,
   type ConfigProvenance,
 } from '../config/provenance.js';
+import { createProvenanceCache, type ProvenanceCache } from '../config/provenance-cache.js';
 import { applyConfigLive, type LiveApplyHandle, type LiveApplyOutcome } from '../config/live-apply.js';
 
 // ── Injected effects (for testability) ───────────────────────────────────────
@@ -85,8 +86,12 @@ export interface MenuIo {
   /**
    * Effective value + originating tier. Optional: surfaces that omit it get the
    * pre-provenance rendering (persisted value only, no tier annotation).
+   *
+   * `cache` is supplied when a whole screen of keys is resolved at once, so the
+   * tier files are read once per render instead of once per row. Implementations
+   * may ignore it (the resolver treats an absent cache as "read every time").
    */
-  provenance?(path: string): ConfigProvenance;
+  provenance?(path: string, cache?: ProvenanceCache): ConfigProvenance;
   /**
    * Push an already-persisted write into the running session. Optional: absent
    * on surfaces with no live session, where every write stays restart-scoped.
@@ -126,6 +131,13 @@ export async function runConfigMenu(ov: MenuOverlays, io: MenuIo): Promise<void>
     const pad = Math.min(28, Math.max(...cat.keys.map((k) => k.path.length)));
     for (;;) {
       const keyHeader = [palette.bold(`${TITLE} › ${cat.name}`), ''];
+      // Invariant: one cache per render, created INSIDE the loop and never
+      // awaited across. Every row resolves against the same four files, so
+      // hoisting the reads turns ~4 reads-per-key into ~4 reads-per-screen —
+      // but a cache that survived `editKey` below would re-render the value the
+      // user just overwrote. Rebuilding it each pass is the whole invalidation
+      // strategy.
+      const provCache = createProvenanceCache();
       const ki = await ov.pick(
         keyHeader,
         cat.keys.map((k) => {
@@ -137,7 +149,7 @@ export async function runConfigMenu(ov: MenuOverlays, io: MenuIo): Promise<void>
           // the loader's fall-through), so dropping this call silently opens a
           // menu whose every write would fail.
           const persisted = io.current(k.path);
-          const prov = io.provenance?.(k.path);
+          const prov = io.provenance?.(k.path, provCache);
           // Show the value the loader will actually use, not the file value —
           // they differ exactly when a higher tier shadows this key.
           const shown = prov ? prov.effective : persisted;
@@ -245,7 +257,7 @@ export function defaultIo(handle?: LiveApplyHandle): MenuIo {
     current: (path) => getConfigValue(path).value,
     write: (path, rawValue, allowHuman) =>
       String(setConfigValue(path, rawValue, allowHuman ? { allowHumanOnly: true } : undefined).value),
-    provenance: (path) => resolveConfigProvenance(path),
+    provenance: (path, cache) => resolveConfigProvenance(path, cache),
     applyLive: (path, rawValue) => applyConfigLive(path, rawValue, handle),
   };
 }

--- a/src/cli/slash/commands/config-doctor.test.ts
+++ b/src/cli/slash/commands/config-doctor.test.ts
@@ -144,6 +144,44 @@ describe('/config slash command', () => {
 describe('/config fast-paths', () => {
   const configCmd = configDoctorCommands.find((c) => c.name === '/config')!;
 
+  it('/config set model persists and applies through the real session adapter', async () => {
+    const tmpHome = join(tmpdir(), `afk-cfg-set-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    const originalAfkHome = process.env['AFK_HOME'];
+    process.env['AFK_HOME'] = tmpHome;
+    try {
+      const { ctx, lines } = makeCtx();
+      const setModel = vi.fn().mockResolvedValue(undefined);
+      ctx.session.current.setModel = setModel;
+      const result = await configCmd.handler(ctx, 'set model haiku');
+
+      expect(result).toBe('continue');
+      expect(setModel).toHaveBeenCalledWith('haiku');
+      expect(ctx.stats.model).toBe('haiku');
+      expect(ctx.ui.repaintStatusLine).toHaveBeenCalled();
+      expect(lines.join('\n')).toMatch(/SUCCESS:.*applied to this session/);
+      expect(existsSync(join(tmpHome, 'config', 'afk.config.json'))).toBe(true);
+    } finally {
+      if (existsSync(tmpHome)) rmSync(tmpHome, { recursive: true, force: true });
+      if (originalAfkHome === undefined) delete process.env['AFK_HOME'];
+      else process.env['AFK_HOME'] = originalAfkHome;
+    }
+  });
+
+  it('/config set on a non-live key keeps restart-scoped behavior', async () => {
+    const tmpHome = join(tmpdir(), `afk-cfg-set-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    const originalAfkHome = process.env['AFK_HOME'];
+    process.env['AFK_HOME'] = tmpHome;
+    try {
+      const { ctx, lines } = makeCtx();
+      await configCmd.handler(ctx, 'set temperature 0.5');
+      expect(lines.join('\n')).toMatch(/SUCCESS:.*next session\/daemon restart/);
+    } finally {
+      if (existsSync(tmpHome)) rmSync(tmpHome, { recursive: true, force: true });
+      if (originalAfkHome === undefined) delete process.env['AFK_HOME'];
+      else process.env['AFK_HOME'] = originalAfkHome;
+    }
+  });
+
   it('/config view renders the read-only dump', async () => {
     const { ctx, lines } = makeCtx();
     const result = await configCmd.handler(ctx, 'view');

--- a/src/cli/slash/commands/config-doctor.test.ts
+++ b/src/cli/slash/commands/config-doctor.test.ts
@@ -182,6 +182,35 @@ describe('/config fast-paths', () => {
     }
   });
 
+  it('/config set warns before AND after a write shadowed by an env var', async () => {
+    const tmpHome = join(tmpdir(), `afk-cfg-set-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    const originalAfkHome = process.env['AFK_HOME'];
+    const originalAfkModel = process.env['AFK_MODEL'];
+    process.env['AFK_HOME'] = tmpHome;
+    process.env['AFK_MODEL'] = 'opus';
+    try {
+      const { ctx, lines } = makeCtx();
+      ctx.session.current.setModel = vi.fn().mockResolvedValue(undefined);
+      const result = await configCmd.handler(ctx, 'set model haiku');
+      expect(result).toBe('continue');
+      const warnIdxs = lines
+        .map((l, i) => ({ l, i }))
+        .filter(({ l }) => l.startsWith('WARN:') && l.includes('AFK_MODEL is set in the environment'))
+        .map(({ i }) => i);
+      const successIdx = lines.findIndex((l) => l.startsWith('SUCCESS:'));
+      expect(successIdx).toBeGreaterThanOrEqual(0);
+      expect(warnIdxs.length).toBe(2);
+      expect(Math.min(...warnIdxs)).toBeLessThan(successIdx);
+      expect(Math.max(...warnIdxs)).toBeGreaterThan(successIdx);
+    } finally {
+      if (existsSync(tmpHome)) rmSync(tmpHome, { recursive: true, force: true });
+      if (originalAfkHome === undefined) delete process.env['AFK_HOME'];
+      else process.env['AFK_HOME'] = originalAfkHome;
+      if (originalAfkModel === undefined) delete process.env['AFK_MODEL'];
+      else process.env['AFK_MODEL'] = originalAfkModel;
+    }
+  });
+
   it('/config view renders the read-only dump', async () => {
     const { ctx, lines } = makeCtx();
     const result = await configCmd.handler(ctx, 'view');

--- a/src/cli/slash/commands/config-doctor.ts
+++ b/src/cli/slash/commands/config-doctor.ts
@@ -148,6 +148,12 @@ async function handleConfigSet(ctx: SlashContext, rest: string): Promise<'contin
     return 'continue';
   }
   try {
+    // Warn BEFORE the write too, not only after (the interactive menu shows
+    // the same note in its edit header). The fast-path cannot abort a flagged
+    // write, but the user still learns it is inert before it lands rather
+    // than only after it has.
+    const shadow = shadowNote(resolveConfigProvenance(path));
+    if (shadow) ctx.out.warn(shadow);
     const r = setConfigValue(path, value);
     // Liveness is reported after the write and never downgrades it — the value
     // is on disk either way.
@@ -158,9 +164,9 @@ async function handleConfigSet(ctx: SlashContext, rest: string): Promise<'contin
     if (!live.applied && live.reason !== undefined) {
       ctx.out.warn(`saved, but not applied live: ${live.reason}`);
     }
-    // A write that lands beneath a higher-precedence tier is inert. Say so here
-    // rather than letting the user discover it after a restart.
-    const shadow = shadowNote(resolveConfigProvenance(path));
+    // A write that lands beneath a higher-precedence tier is inert. Repeat the
+    // pre-write warning so the confirmation does not read as success alone.
+    // (Computed once: a user-file write cannot change env/project shadowing.)
     if (shadow) ctx.out.warn(shadow);
   } catch (err) {
     ctx.out.error(err instanceof Error ? err.message : String(err));

--- a/src/cli/slash/commands/config-doctor.ts
+++ b/src/cli/slash/commands/config-doctor.ts
@@ -22,7 +22,31 @@ import { runDoctorChecks } from '../../commands/doctor-checks.js';
 import { getConfigKeySpec } from '../../../config/settable-keys.js';
 import { setConfigValue, RESTART_NOTE } from '../../../config/mutate.js';
 import { runConfigMenu, overlaysFromCompositor, defaultIo } from '../../render/config-menu.js';
+import { resolveConfigProvenance, shadowNote } from '../../config/provenance.js';
+import { applyConfigLive, type LiveApplyHandle } from '../../config/live-apply.js';
+import type { AgentModelInput } from '../../../agent/types.js';
 import type { SlashCommand, SlashContext, Writer } from '../types.js';
+
+/**
+ * The running session's live-apply capability, in the shape `live-apply.ts`
+ * expects. Mirrors what `/model` and `/theme` already do by hand
+ * (info.ts:287-289, theme.ts:64-69) so `/config` applies a hot key the same way
+ * the dedicated command would.
+ */
+function liveHandle(ctx: SlashContext): LiveApplyHandle {
+  return {
+    setModel: async (id) => {
+      await ctx.session.current.setModel(id as AgentModelInput);
+    },
+    noteModel: (id) => {
+      ctx.stats.model = id as AgentModelInput;
+    },
+    repaint: () => {
+      ctx.ui.repaintStatusLine();
+      ctx.getCompositor?.()?.repaint();
+    },
+  };
+}
 
 // ---------------------------------------------------------------------------
 // /config — read-only view (shared by `/config view`, the non-TTY fallback,
@@ -102,7 +126,7 @@ function renderConfigView(out: Writer): void {
  * refuses human-tier keys (they require the interactive confirm or the CLI) and
  * unknown keys. Works on every surface (no compositor needed).
  */
-function handleConfigSet(ctx: SlashContext, rest: string): 'continue' {
+async function handleConfigSet(ctx: SlashContext, rest: string): Promise<'continue'> {
   const trimmed = rest.trim();
   const sp = trimmed.indexOf(' ');
   if (sp === -1) {
@@ -125,7 +149,19 @@ function handleConfigSet(ctx: SlashContext, rest: string): 'continue' {
   }
   try {
     const r = setConfigValue(path, value);
-    ctx.out.success(`✓ set ${path} = ${String(r.value)} — ${RESTART_NOTE}`);
+    // Liveness is reported after the write and never downgrades it — the value
+    // is on disk either way.
+    const live = await applyConfigLive(path, value, liveHandle(ctx));
+    ctx.out.success(
+      `✓ set ${path} = ${String(r.value)} — ${live.applied ? live.note : RESTART_NOTE}`,
+    );
+    if (!live.applied && live.reason !== undefined) {
+      ctx.out.warn(`saved, but not applied live: ${live.reason}`);
+    }
+    // A write that lands beneath a higher-precedence tier is inert. Say so here
+    // rather than letting the user discover it after a restart.
+    const shadow = shadowNote(resolveConfigProvenance(path));
+    if (shadow) ctx.out.warn(shadow);
   } catch (err) {
     ctx.out.error(err instanceof Error ? err.message : String(err));
   }
@@ -140,7 +176,7 @@ const configCmd: SlashCommand = {
   name: '/config',
   summary: 'View or edit configuration — interactive settings menu on a TTY',
   usage: '/config [view | set <key> <value>]',
-  hint: 'Browse and edit config mid-session in an arrow-key settings menu. `/config view` prints the resolved configuration; `/config set <key> <value>` sets one agent-tier key. Changes apply on the next restart — same store as `afk config`.',
+  hint: 'Browse and edit config mid-session in an arrow-key settings menu. Rows show the value the loader will actually use and name the tier it came from, so an env var or project-local afk.config.json that overrides your change is visible before you make it. `model` and `theme` apply immediately; other keys apply on the next restart. Same store as `afk config`.',
   async handler(ctx, args) {
     const a = args.trim();
 
@@ -149,7 +185,7 @@ const configCmd: SlashCommand = {
       return 'continue';
     }
     if (a === 'set' || a.startsWith('set ')) {
-      return handleConfigSet(ctx, a === 'set' ? '' : a.slice(4));
+      return await handleConfigSet(ctx, a === 'set' ? '' : a.slice(4));
     }
     if (a.length > 0 && a !== 'edit' && a !== 'menu') {
       ctx.out.warn(`Unknown argument: ${a}  (usage: /config [view | set <key> <value>])`);
@@ -177,7 +213,7 @@ const configCmd: SlashCommand = {
     // (registry.ts) into the REPL loop, which has no catch and would tear the
     // session down.
     try {
-      await runConfigMenu(overlaysFromCompositor(compositor), defaultIo());
+      await runConfigMenu(overlaysFromCompositor(compositor), defaultIo(liveHandle(ctx)));
     } catch (err) {
       ctx.out.error(
         `Could not open the settings menu: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1749,3 +1749,21 @@ export function getMissingRequiredEnvVars(category?: EnvVarCategory): EnvVarMeta
 export function isEnvVarSet(name: string): boolean {
   return process.env[name] !== undefined;
 }
+
+/**
+ * Read an env var's value by a name known only at runtime.
+ *
+ * Contract: returns `undefined` for both unset AND empty-string, because every
+ * config-overriding read site in the loader is truthiness-gated (`if
+ * (env.AFK_MODEL)`, env-tier.ts:206) — an empty var does NOT override config, so
+ * reporting it as a live override would be a lie. This deliberately differs from
+ * {@link isEnvVarSet}, which answers presence (`!== undefined`) and would call an
+ * empty var "set".
+ *
+ * Same rationale as `isEnvVarSet` for living here: the dynamic `process.env` read
+ * stays inside env.ts, preserving the invariant enforced by `pnpm audit:env:check`.
+ */
+export function getEnvVarValue(name: string): string | undefined {
+  const raw = process.env[name];
+  return raw === undefined || raw === '' ? undefined : raw;
+}


### PR DESCRIPTION
## Summary

- show each `/config` menu row's effective value and the env/project/user/default tier supplying it
- warn before and after writes that are shadowed by an environment variable or project config
- apply `model` and `theme` changes to the running REPL after persistence while leaving all other keys restart-scoped
- share JSON tier order and per-file validation between the real loader and provenance reporting, preserving whole-file precedence and coercion semantics
- split menu presentation and JSON parsing into focused modules under the 350-LOC ceiling

## Why

`/config` writes the user-global config, while runtime loading can be won by an environment variable or project-local config. Previously, a write could save successfully but never take effect, with no indication why. The command also always said a restart was required even for model and theme, despite dedicated slash commands already supporting live mutation.

## Verification

- `pnpm lint`
- focused config suites: 5 files, 162 tests passed
- full `pnpm test`: 778 files, 14,842 passed, 2 skipped
- `pnpm build`
- `pnpm audit:env:check`
- `pnpm scan:env:check`
- `pnpm audit:chalk:check`
- `pnpm fix:pins:check`
- `pnpm audit:sdk:check`
- `git diff --check`

After rebasing onto `origin/main` (`v5.93.3`), lint, the focused 162-test slice, and build were rerun successfully.
