### PR TITLE
fix(agent-tool): normalize blank optional arguments

### DIFF
--- a/src/agent/tools/handlers/_cwd-utils.test.ts
+++ b/src/agent/tools/handlers/_cwd-utils.test.ts
@@ -63,6 +63,39 @@ describe('resolveAndContain', () => {
       resolveAndContain('/tmp/other/x.txt', ctx({ readRoots: [BASE, '/tmp/other'] }), 'write'),
     ).toThrow(/outside the allowed write roots/);
   });
+
+  // Contract: a granted root may be a single FILE, and it grants EXACTLY that
+  // file (`path.relative(root, target) === ''`). This is load-bearing, not
+  // incidental: home-root dotfiles (~/.zshrc, ~/.gitconfig) sit directly at
+  // $HOME, and $HOME is refused as a grant by the breadth guard
+  // (subagent/root-validation.ts), so file-granular grants are the ONLY
+  // least-privilege way to read them. The agent-tool schema + its home-rejection
+  // error both now tell callers to do this, so the behavior must stay pinned.
+  describe('file-granular read roots', () => {
+    const dotfile = '/tmp/other/.zshrc';
+
+    it('admits the exact granted file', () => {
+      expect(resolveAndContain(dotfile, ctx({ readRoots: [BASE, dotfile] }))).toBe(dotfile);
+    });
+
+    it('does not admit a sibling of the granted file', () => {
+      expect(() =>
+        resolveAndContain('/tmp/other/.netrc', ctx({ readRoots: [BASE, dotfile] })),
+      ).toThrow(/outside the allowed read roots/);
+    });
+
+    it('does not admit the granted file\u2019s parent directory', () => {
+      expect(() => resolveAndContain('/tmp/other', ctx({ readRoots: [BASE, dotfile] }))).toThrow(
+        /outside the allowed read roots/,
+      );
+    });
+
+    it('does not admit a path that merely shares the file name prefix', () => {
+      expect(() =>
+        resolveAndContain('/tmp/other/.zshrc.bak', ctx({ readRoots: [BASE, dotfile] })),
+      ).toThrow(/outside the allowed read roots/);
+    });
+  });
 });
 
 describe('wouldBeRestricted', () => {

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -425,7 +425,10 @@ export const agentTool: AnthropicToolDef = {
           "child's first cwd-relative tool call. Does not auto-propagate to " +
           'further nested subagents — each `agent` call must specify `cwd` ' +
           'explicitly to operate in a worktree. To NOT set a cwd, omit the field ' +
-          'entirely; a blank value is treated as omitted, never as a path.',
+          'entirely; a blank value is treated as omitted, never as a path. A ' +
+          'filesystem root, your home directory, or an ancestor of it is refused; ' +
+          'when the child only needs to READ files outside its tree, keep cwd and ' +
+          'add readRoots instead of relocating cwd.',
       },
       writeRoots: {
         type: 'array',
@@ -437,7 +440,7 @@ export const agentTool: AnthropicToolDef = {
         type: 'array',
         items: { type: 'string' },
         description:
-          'Optional extra read roots to pre-grant to the forked child. Use when the task data lives OUTSIDE the repo — e.g. `~/Downloads`, a scratch data dir. Each entry must be an absolute path with no `..` segments (and not a filesystem root or your home dir). Composed WITH (never replaces) the fork\'s inherited read scope, so the child keeps its repo/worktree/state reach AND gains the named dirs. Writes stay confined. Grandchildren must be re-granted (not inherited). Unlike writeRoots, NOT mutually exclusive with isolation:"worktree" — widening reads inside an isolated worktree is legitimate.',
+          'Optional extra read roots to pre-grant to the forked child. Use when the task data lives OUTSIDE the repo — e.g. `~/Downloads`, a scratch data dir. Each entry must be an absolute path with no `..` segments (and not a filesystem root or your home dir). An entry may be a DIRECTORY or a single FILE — a file grants exactly that file, which is how to read home-root dotfiles (`~/.zshrc`, `~/.gitconfig`) given the home dir itself is refused; list the files rather than guessing at a directory that encloses them. Composed WITH (never replaces) the fork\'s inherited read scope, so the child keeps its repo/worktree/state reach AND gains the named dirs. Writes stay confined. Grandchildren must be re-granted (not inherited). Unlike writeRoots, NOT mutually exclusive with isolation:"worktree" — widening reads inside an isolated worktree is legitimate.',
       },
       isolation: {
         type: 'string',

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -424,7 +424,8 @@ export const agentTool: AnthropicToolDef = {
           'at dispatch time — a non-existent path surfaces as an error on the ' +
           "child's first cwd-relative tool call. Does not auto-propagate to " +
           'further nested subagents — each `agent` call must specify `cwd` ' +
-          'explicitly to operate in a worktree.',
+          'explicitly to operate in a worktree. To NOT set a cwd, omit the field ' +
+          'entirely; a blank value is treated as omitted, never as a path.',
       },
       writeRoots: {
         type: 'array',
@@ -451,7 +452,8 @@ export const agentTool: AnthropicToolDef = {
           'dirty or commits-ahead tree is preserved and locked instead of ' +
           'removed, so work in progress is never destroyed (recover it via the ' +
           '`worktree` tool). Mutually exclusive with `cwd` (the runtime owns the ' +
-          "child's cwd when isolating). Ignored for read-only agents such as " +
+          "child's cwd when isolating) — to isolate, omit `cwd` rather than " +
+          'blanking it. Ignored for read-only agents such as ' +
           'research-agent — they have nothing to isolate. Not supported together ' +
           'with mode:"background" in this release.',
       },

--- a/src/agent/tools/subagent-executor.test.ts
+++ b/src/agent/tools/subagent-executor.test.ts
@@ -442,13 +442,21 @@ describe('SubagentExecutor', () => {
       expect(result.content).toContain('cwd must be a string');
     });
 
-    it('rejects empty-string cwd', async () => {
+    it('treats empty-string cwd as absent and dispatches with the parent fallback', async () => {
+      // Was: rejected with "cwd must be a non-empty string". A model padding
+      // the optional with '' saw a required-field error it could not satisfy
+      // alongside isolation, and abandoned isolation rather than retrying.
+      const handle = mockHandle();
+      mockSubagentMgr.forkSubagent = vi.fn().mockResolvedValue(handle);
+
       const result = await executor.execute(
         makeCall({ input: { prompt: 'test', cwd: '' } }),
       );
 
-      expect(result.isError).toBe(true);
-      expect(result.content).toContain('non-empty');
+      expect(result.isError).toBeFalsy();
+      const call = (mockSubagentMgr.forkSubagent as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+      expect(call).toBeDefined();
+      expect(Object.prototype.hasOwnProperty.call(call.config, 'cwd')).toBe(false);
     });
 
     it('rejects relative cwd', async () => {

--- a/src/agent/tools/subagent/input-parse.test.ts
+++ b/src/agent/tools/subagent/input-parse.test.ts
@@ -473,6 +473,15 @@ describe('parseAgentInput', () => {
       );
     });
 
+    it('redirects a home-directory cwd to readRoots rather than a narrower cwd', () => {
+      // Observed failure: an agent asked to explain the operator's dotfiles set
+      // cwd to $HOME, was refused, and re-planned around WHERE TO STAND instead
+      // of WHAT TO GRANT. A read-only task should never relocate cwd.
+      expect(() => parseAgentInput({ prompt: 'p', cwd: os.homedir() })).toThrow(
+        /grant those paths via readRoots/,
+      );
+    });
+
     it('throws when cwd is an ancestor of the home directory', () => {
       const parentOfHome = path.dirname(os.homedir());
       expect(() => parseAgentInput({ prompt: 'p', cwd: parentOfHome })).toThrow(
@@ -751,6 +760,22 @@ describe('parseAgentInput', () => {
       expect(() => parseAgentInput({ prompt: 'p', readRoots: [os.homedir()] })).toThrow(
         /must not be a filesystem root, your home directory, or an ancestor/,
       );
+    });
+
+    it('points a home-directory rejection at file-granular grants', () => {
+      // The remedy noun matters. "grant a specific subdirectory instead" is the
+      // WRONG advice for this task class: home-root dotfiles (~/.zshrc,
+      // ~/.gitconfig) sit directly at $HOME, so no grantable subdirectory
+      // encloses them — a caller told to find one enumerates guesses instead of
+      // listing the files it actually needs.
+      expect(() => parseAgentInput({ prompt: 'p', readRoots: [os.homedir()] })).toThrow(
+        /a single file is a valid read root/,
+      );
+    });
+
+    it('accepts a single FILE as an entry (the home-root dotfile shape)', () => {
+      const dotfile = path.join(os.homedir(), '.zshrc');
+      expect(parseAgentInput({ prompt: 'p', readRoots: [dotfile] }).readRoots).toEqual([dotfile]);
     });
 
     it('throws when an entry is an ancestor of the home directory', () => {

--- a/src/agent/tools/subagent/input-parse.test.ts
+++ b/src/agent/tools/subagent/input-parse.test.ts
@@ -164,11 +164,13 @@ describe('parseAgentInput', () => {
       );
     });
 
-    it('throws when model is null (explicit non-string)', () => {
-      // `null !== undefined`, so it reaches the type check and is rejected.
-      expect(() => parseAgentInput({ prompt: 'p', model: null })).toThrow(
-        /model must be a string/,
-      );
+    it('treats a null model as absent (inherit the parent model)', () => {
+      // Was: threw. `null` is serializer padding for "no value", not intent.
+      expect(parseAgentInput({ prompt: 'p', model: null }).model).toBeUndefined();
+    });
+
+    it('treats an empty-string model as absent rather than dispatching model ""', () => {
+      expect(parseAgentInput({ prompt: 'p', model: '' }).model).toBeUndefined();
     });
   });
 
@@ -304,16 +306,25 @@ describe('parseAgentInput', () => {
     });
 
     it('falls through to the alias when canonical is a whitespace-only string', () => {
-      // `agentInput['agent_type'] ?? agentInput['subagent_type']` uses nullish
-      // coalescing, so a present-but-empty agent_type ('') still wins the ??
-      // (it is not null/undefined). It then trims to '' and is dropped — the
-      // alias is NOT consulted. This pins that documented precedence.
+      // Previously the body pinned the opposite of this title: nullish
+      // coalescing (`agent_type ?? subagent_type`) let a present-but-blank
+      // canonical win the `??` (it is not null/undefined), then trimmed it away
+      // — so BOTH were dropped and the caller's real alias was ignored.
+      // readOptional skips blanks by key order, so precedence now matches the
+      // documented "canonical wins" rule only when canonical is real.
       const result = parseAgentInput({
         prompt: 'p',
         agent_type: '   ',
         subagent_type: 'alias',
       });
-      expect(result.agent_type).toBeUndefined();
+      expect(result.agent_type).toBe('alias');
+    });
+
+    it('keeps canonical precedence when BOTH are real', () => {
+      expect(
+        parseAgentInput({ prompt: 'p', agent_type: 'canonical', subagent_type: 'alias' })
+          .agent_type,
+      ).toBe('canonical');
     });
 
     it('throws when agent_type is not a string (number)', () => {
@@ -340,10 +351,11 @@ describe('parseAgentInput', () => {
       );
     });
 
-    it('accepts an empty-string id_prefix verbatim (no default substitution)', () => {
-      // An explicit '' is a string, so it passes the type check and is used
-      // as-is — the default only applies when the field is absent.
-      expect(parseAgentInput({ prompt: 'p', id_prefix: '' }).id_prefix).toBe('');
+    it('falls back to the default for a blank id_prefix', () => {
+      // Was: used '' verbatim, yielding unlabelled subagent ids. Blank is
+      // not-supplied, so the default applies.
+      expect(parseAgentInput({ prompt: 'p', id_prefix: '' }).id_prefix).toBe('agent-tool');
+      expect(parseAgentInput({ prompt: 'p', id_prefix: null }).id_prefix).toBe('agent-tool');
     });
 
     it('throws when id_prefix is not a string (number)', () => {
@@ -402,10 +414,21 @@ describe('parseAgentInput', () => {
       );
     });
 
-    it('throws when cwd is an empty string', () => {
-      expect(() => parseAgentInput({ prompt: 'p', cwd: '' })).toThrow(
-        /cwd must be a non-empty string/,
-      );
+    it('treats an empty-string cwd as absent (blank means not-supplied)', () => {
+      // Was: threw "cwd must be a non-empty string". A model padding the
+      // optional with '' read that as "cwd is required" and, because cwd and
+      // isolation are mutually exclusive, gave up isolation entirely.
+      const result = parseAgentInput({ prompt: 'p', cwd: '' });
+      expect(result.cwd).toBeUndefined();
+      expect('cwd' in result).toBe(false);
+    });
+
+    it('treats a whitespace-only cwd as absent', () => {
+      expect(parseAgentInput({ prompt: 'p', cwd: '   ' }).cwd).toBeUndefined();
+    });
+
+    it('treats a null cwd as absent', () => {
+      expect(parseAgentInput({ prompt: 'p', cwd: null }).cwd).toBeUndefined();
     });
 
     it('throws when cwd is a relative path', () => {
@@ -851,6 +874,86 @@ describe('parseAgentInput', () => {
       expect(() =>
         parseAgentInput({ prompt: 'p', cwd: '/tmp/wt/x', isolation: 'worktree' }),
       ).toThrow(/mutually exclusive/);
+    });
+
+    it('names the escape hatch in the cwd/isolation conflict message', () => {
+      // The model gets another round after this throw, so the message must say
+      // WHICH field to drop for WHICH goal — a rule-only message led callers to
+      // drop isolation and silently degrade to an unisolated dispatch.
+      expect(() =>
+        parseAgentInput({ prompt: 'p', cwd: '/tmp/wt/x', isolation: 'worktree' }),
+      ).toThrow(/OMIT cwd entirely/);
+    });
+
+    it('names the escape hatch in the writeRoots/isolation conflict message', () => {
+      expect(() =>
+        parseAgentInput({ prompt: 'p', writeRoots: ['/tmp/w'], isolation: 'worktree' }),
+      ).toThrow(/Omit writeRoots to isolate/);
+    });
+  });
+
+  // Regression: the padded-optional trap. A model that pads optionals with ''
+  // (or null) hit "cwd and isolation are mutually exclusive", retried with
+  // isolation alone but still emitted cwd:'', hit "cwd must be a non-empty
+  // string", concluded cwd was REQUIRED — and therefore that isolation was
+  // inexpressible — then dropped isolation and dispatched into the shared tree.
+  // Every case below must parse, not throw.
+  describe('blank optional fields normalize to absent (padded-serializer trap)', () => {
+    it("accepts cwd:'' alongside isolation:'worktree' and keeps the isolation", () => {
+      const result = parseAgentInput({ prompt: 'p', cwd: '', isolation: 'worktree' });
+      expect(result.isolation).toBe('worktree');
+      expect('cwd' in result).toBe(false);
+    });
+
+    it("accepts cwd:null alongside isolation:'worktree'", () => {
+      expect(parseAgentInput({ prompt: 'p', cwd: null, isolation: 'worktree' }).isolation).toBe(
+        'worktree',
+      );
+    });
+
+    it('accepts a fully padded dispatch (every optional blank)', () => {
+      const result = parseAgentInput({
+        prompt: 'p',
+        cwd: '',
+        model: '',
+        agent_type: '',
+        id_prefix: '',
+        mode: '',
+        isolation: '',
+        max_turns: null,
+        max_tool_use_iterations: null,
+        attachments: null,
+        writeRoots: null,
+        readRoots: null,
+      });
+      expect(result.mode).toBe('foreground');
+      expect(result.id_prefix).toBe('agent-tool');
+      expect(result.max_turns).toBe(0);
+      expect(result.max_turns_explicit).toBe(false);
+      expect(result.max_tool_use_iterations_explicit).toBe(false);
+      expect(result.cwd).toBeUndefined();
+      expect(result.model).toBeUndefined();
+      expect(result.agent_type).toBeUndefined();
+      expect(result.isolation).toBeUndefined();
+      expect(result.attachments).toBeUndefined();
+      expect(result.writeRoots).toBeUndefined();
+      expect(result.readRoots).toBeUndefined();
+    });
+
+    it('lets a real subagent_type through a blank canonical agent_type', () => {
+      // Plain `??` kept the blank because '' !== undefined, dropping both.
+      expect(
+        parseAgentInput({ prompt: 'p', agent_type: '', subagent_type: 'research-agent' })
+          .agent_type,
+      ).toBe('research-agent');
+    });
+
+    it('still rejects a wrong-typed optional loudly (blank-collapse is not coercion)', () => {
+      expect(() => parseAgentInput({ prompt: 'p', cwd: 42 })).toThrow(/cwd must be a string/);
+      expect(() => parseAgentInput({ prompt: 'p', max_turns: '10' })).toThrow(
+        /max_turns must be a number/,
+      );
+      expect(() => parseAgentInput({ prompt: 'p', mode: 'back' })).toThrow(/"back"/);
     });
 
     it("allows cwd together with isolation:'none' (none is a no-op)", () => {

--- a/src/agent/tools/subagent/input-parse.ts
+++ b/src/agent/tools/subagent/input-parse.ts
@@ -113,6 +113,13 @@ export interface AgentInput {
    * even attempt to shadow secrets. This is defense-in-depth ON TOP of the
    * read-time floor in `resolveAndContain` / the path-approval hook.
    *
+   * An entry may be a DIRECTORY or a single FILE. A file grants exactly that
+   * file (containment compares `path.relative(root, target) === ''`), which is
+   * the only least-privilege way to reach home-ROOT dotfiles — `~/.zshrc`,
+   * `~/.gitconfig`, `~/.tmux.conf` sit directly at `$HOME`, and `$HOME` itself
+   * is refused by rule (a). Granting the enclosing dir is not an option there,
+   * so file-granular grants are the intended shape, not a workaround.
+   *
    * Deliberately NOT mutually exclusive with `isolation:'worktree'` — widening a
    * confined worktree fork's READS is legitimate (only WRITES break isolation).
    */
@@ -278,7 +285,9 @@ export function parseAgentInput(input: unknown): AgentInput {
       throw new Error(
         `Agent tool cwd must not be a filesystem root, your home directory, ` +
           `or an ancestor of it (checked after resolving symlinks) — pass a ` +
-          `specific subdirectory instead, got: ${JSON.stringify(cwdValue)}`,
+          `specific subdirectory instead. If the child only needs to READ files ` +
+          `outside its tree (dotfiles, ~/.config), do NOT move cwd there: leave ` +
+          `cwd alone and grant those paths via readRoots. Got: ${JSON.stringify(cwdValue)}`,
       );
     }
     cwd = cwdValue;
@@ -395,8 +404,11 @@ export function parseAgentInput(input: unknown): AgentInput {
       if (isTooBroadRoot(resolved) || isTooBroadRoot(realResolved)) {
         throw new Error(
           `Agent tool readRoots entries must not be a filesystem root, your home directory, ` +
-            `or an ancestor of it (checked after resolving symlinks) — grant a specific ` +
-            `subdirectory instead, got: ${JSON.stringify(entry)}`,
+            `or an ancestor of it (checked after resolving symlinks) — grant specific ` +
+            `subdirectories, or the individual FILES you need: a single file is a valid ` +
+            `read root and grants exactly that file, which is how to reach home-root ` +
+            `dotfiles (e.g. "<home>/.zshrc", "<home>/.gitconfig") without granting the ` +
+            `home directory. Got: ${JSON.stringify(entry)}`,
         );
       }
       // (b) Denylist rejection — never let a grant target the credential floor.

--- a/src/agent/tools/subagent/input-parse.ts
+++ b/src/agent/tools/subagent/input-parse.ts
@@ -12,6 +12,12 @@ import { isAbsolute, resolve as resolvePath } from 'node:path';
 import { isReadDenied } from '../handlers/read-denylist.js';
 import { realpathSafe } from '../handlers/_cwd-utils.js';
 import { isTooBroadRoot } from './root-validation.js';
+import {
+  readOptional,
+  readOptionalAliasString,
+  readOptionalNumber,
+  readOptionalString,
+} from './optional-input.js';
 
 export type AgentExecutionMode = 'foreground' | 'background';
 
@@ -147,8 +153,13 @@ export function parseAgentInput(input: unknown): AgentInput {
     throw new Error('Agent tool prompt cannot be empty');
   }
 
+  // Every OPTIONAL field below is read through `optional-input.ts`, so a blank
+  // (`undefined` / `null` / whitespace-only) value means "not supplied" rather
+  // than "supplied invalidly" — model serializers pad optionals they do not
+  // want, and reading that padding as intent trapped callers behind
+  // contradictory errors (see that module's Contract note).
   let attachments: string[] | undefined;
-  const attachmentsValue = agentInput['attachments'];
+  const attachmentsValue = readOptional(agentInput, 'attachments');
   if (attachmentsValue !== undefined) {
     if (!Array.isArray(attachmentsValue)) {
       throw new Error('Agent tool attachments must be an array of absolute image paths');
@@ -171,73 +182,43 @@ export function parseAgentInput(input: unknown): AgentInput {
     if (paths.length > 0) attachments = paths;
   }
 
-  let model: string | undefined;
-  const modelValue = agentInput['model'];
-  if (modelValue !== undefined) {
-    if (typeof modelValue !== 'string') {
-      throw new Error('Agent tool model must be a string');
-    }
-    model = modelValue;
-  }
+  const model = readOptionalString(agentInput, 'model');
 
   // Turn budget: default 0 = unlimited (matches AgentSession's falsy-maxTurns
   // = no-cap check in assertCanSend). A positive value caps conversation
   // turns; 0/negatives mean unlimited. No upper ceiling — the caller, or a
   // named agent's `maxTurns` frontmatter, owns any cap it wants.
-  let max_turns = 0;
-  let max_turns_explicit = false;
-  const maxTurnsValue = agentInput['max_turns'];
-  if (maxTurnsValue !== undefined) {
-    if (typeof maxTurnsValue !== 'number') {
-      throw new Error('Agent tool max_turns must be a number');
-    }
-    max_turns = Math.max(0, Math.floor(maxTurnsValue));
-    max_turns_explicit = true;
-  }
+  const maxTurnsValue = readOptionalNumber(agentInput, 'max_turns');
+  const max_turns_explicit = maxTurnsValue !== undefined;
+  const max_turns = maxTurnsValue === undefined ? 0 : Math.max(0, Math.floor(maxTurnsValue));
 
   // Tool-use-round budget within the single child turn (anti-hang ceiling).
   // Default 0 = unlimited on the agent-tool path; a positive value caps
   // rounds. Honored uniformly by both providers (see config-types.ts
   // maxToolUseIterations and providers/shared/tool-loop-cap.ts).
-  let max_tool_use_iterations = 0;
-  let max_tool_use_iterations_explicit = false;
-  const maxToolIterValue = agentInput['max_tool_use_iterations'];
-  if (maxToolIterValue !== undefined) {
-    if (typeof maxToolIterValue !== 'number') {
-      throw new Error('Agent tool max_tool_use_iterations must be a number');
-    }
-    max_tool_use_iterations = Math.max(0, Math.floor(maxToolIterValue));
-    max_tool_use_iterations_explicit = true;
-  }
+  const maxToolIterValue = readOptionalNumber(agentInput, 'max_tool_use_iterations');
+  const max_tool_use_iterations_explicit = maxToolIterValue !== undefined;
+  const max_tool_use_iterations =
+    maxToolIterValue === undefined ? 0 : Math.max(0, Math.floor(maxToolIterValue));
 
   // agent_type: canonical param; `subagent_type` accepted as an alias for
-  // Claude Code-ported prompts (bundled SKILL.mds already write it). When
-  // both are present the canonical name wins.
-  let agent_type: string | undefined;
-  const agentTypeValue = agentInput['agent_type'] ?? agentInput['subagent_type'];
-  if (agentTypeValue !== undefined) {
-    if (typeof agentTypeValue !== 'string') {
-      throw new Error('Agent tool agent_type must be a string');
-    }
-    const trimmed = agentTypeValue.trim();
-    if (trimmed.length > 0) agent_type = trimmed;
-  }
+  // Claude Code-ported prompts (bundled SKILL.mds already write it). When both
+  // are present the canonical name wins — but a BLANK canonical no longer
+  // shadows a real alias (plain `??` kept `''` because `'' !== undefined`).
+  const agent_type = readOptionalAliasString(
+    agentInput,
+    ['agent_type', 'subagent_type'],
+    'agent_type',
+  )?.trim();
 
-  let id_prefix = 'agent-tool';
-  const idPrefixValue = agentInput['id_prefix'];
-  if (idPrefixValue !== undefined) {
-    if (typeof idPrefixValue !== 'string') {
-      throw new Error('Agent tool id_prefix must be a string');
-    }
-    id_prefix = idPrefixValue;
-  }
+  const id_prefix = readOptionalString(agentInput, 'id_prefix') ?? 'agent-tool';
 
   // mode: default 'foreground'. Unknown strings reject loudly rather than
   // silently coercing — a typo like "back" would be silently downgraded
   // to a foreground run, exactly the surprise this feature is built to
   // avoid.
   let mode: AgentExecutionMode = 'foreground';
-  const modeValue = agentInput['mode'];
+  const modeValue = readOptional(agentInput, 'mode');
   if (modeValue !== undefined) {
     if (modeValue !== 'foreground' && modeValue !== 'background') {
       throw new Error(
@@ -255,7 +236,9 @@ export function parseAgentInput(input: unknown): AgentInput {
   // cwd: optional absolute path. Existence is not checked because the call
   // site is sync and any ENOENT surfaces cleanly through the child's first
   // tool call. Rules:
-  //   1. Must be a non-empty string when present.
+  //   1. Must be a string when meaningfully present. A BLANK value ('', '  ',
+  //      null) reads as ABSENT, not invalid (see optional-input.ts), so padded
+  //      input cannot fabricate a conflict with `isolation` below.
   //   2. Must be absolute (`path.isAbsolute`) — relative paths would otherwise
   //      resolve against `process.cwd()` and silently land somewhere
   //      unrelated to the caller's intent.
@@ -276,16 +259,8 @@ export function parseAgentInput(input: unknown): AgentInput {
   //      (isReadDenied) rejection here — that is a separate, deliberately
   //      out-of-scope hardening decision; this is breadth-only.
   let cwd: string | undefined;
-  const cwdValue = agentInput['cwd'];
+  const cwdValue = readOptionalString(agentInput, 'cwd');
   if (cwdValue !== undefined) {
-    if (typeof cwdValue !== 'string') {
-      throw new Error(
-        `Agent tool cwd must be a string, got: ${JSON.stringify(cwdValue)}`,
-      );
-    }
-    if (cwdValue.length === 0) {
-      throw new Error('Agent tool cwd must be a non-empty string');
-    }
     if (!isAbsolute(cwdValue)) {
       throw new Error(
         `Agent tool cwd must be an absolute path, got: ${JSON.stringify(cwdValue)}`,
@@ -321,7 +296,7 @@ export function parseAgentInput(input: unknown): AgentInput {
   // rejection here — out of scope, see readRoots below. An empty array
   // normalizes to undefined (no-op grant).
   let writeRoots: string[] | undefined;
-  const writeRootsValue = agentInput['writeRoots'];
+  const writeRootsValue = readOptional(agentInput, 'writeRoots');
   if (writeRootsValue !== undefined) {
     if (!Array.isArray(writeRootsValue)) {
       throw new Error(
@@ -383,7 +358,7 @@ export function parseAgentInput(input: unknown): AgentInput {
   // An empty array normalizes to undefined (no-op grant). Deliberately NOT
   // mutually exclusive with isolation:'worktree' (that constraint is write-only).
   let readRoots: string[] | undefined;
-  const readRootsValue = agentInput['readRoots'];
+  const readRootsValue = readOptional(agentInput, 'readRoots');
   if (readRootsValue !== undefined) {
     if (!Array.isArray(readRootsValue)) {
       throw new Error(
@@ -449,21 +424,31 @@ export function parseAgentInput(input: unknown): AgentInput {
   //     foreground teardown that removes the worktree, so nothing would reclaim
   //     it in-turn (proposal Open Q1). Reject rather than leak.
   let isolation: 'worktree' | undefined;
-  const isolationValue = agentInput['isolation'];
+  const isolationValue = readOptional(agentInput, 'isolation');
   if (isolationValue !== undefined && isolationValue !== 'none') {
     if (isolationValue !== 'worktree') {
       throw new Error(
         `Agent tool isolation must be "none" or "worktree", got: ${JSON.stringify(isolationValue)}`,
       );
     }
+    // Every mutual-exclusion message below names the ESCAPE, not just the
+    // conflict. The model gets another tool round after a validation throw
+    // (subagent-executor returns `isError`, it does not abort the turn), so a
+    // message that states only the rule leaves the caller guessing which field
+    // to drop — and the observed failure mode is dropping `isolation`, i.e.
+    // silently giving up the capability instead of retrying.
     if (cwd !== undefined) {
       throw new Error(
-        'Agent tool cwd and isolation are mutually exclusive — pass one or the other',
+        'Agent tool cwd and isolation are mutually exclusive — pass one or the other. ' +
+          'To isolate, OMIT cwd entirely (the runtime creates and owns the worktree). ' +
+          'To run in a specific directory, omit isolation instead.',
       );
     }
     if (writeRoots !== undefined) {
       throw new Error(
-        'Agent tool writeRoots and isolation are mutually exclusive — a worktree-isolated child is fully confined by design',
+        'Agent tool writeRoots and isolation are mutually exclusive — a worktree-isolated ' +
+          'child is fully confined by design. Omit writeRoots to isolate, or omit isolation ' +
+          'to keep the extra write grants.',
       );
     }
     if (mode === 'background') {

--- a/src/agent/tools/subagent/optional-input.test.ts
+++ b/src/agent/tools/subagent/optional-input.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for the blank-tolerant optional-field readers.
+ *
+ * The contract under test: for an OPTIONAL field, blank (`undefined`, `null`,
+ * whitespace-only string) is indistinguishable from omitted, while a
+ * wrong-TYPED value still rejects loudly. Blank-collapse must not become
+ * type coercion.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  isBlankInput,
+  readOptional,
+  readOptionalAliasString,
+  readOptionalNumber,
+  readOptionalString,
+} from './optional-input.js';
+
+describe('isBlankInput', () => {
+  it.each([undefined, null, '', ' ', '\n\t  '])('treats %o as blank', (value) => {
+    expect(isBlankInput(value)).toBe(true);
+  });
+
+  it.each([0, false, 'x', ' x ', [], {}, [''], NaN])('treats %o as present', (value) => {
+    // 0 and false are load-bearing: a numeric/boolean field must be able to
+    // carry a falsy value without being read as "not supplied".
+    expect(isBlankInput(value)).toBe(false);
+  });
+});
+
+describe('readOptional', () => {
+  it('returns undefined when the key is blank', () => {
+    expect(readOptional({ a: '' }, 'a')).toBeUndefined();
+    expect(readOptional({ a: null }, 'a')).toBeUndefined();
+    expect(readOptional({}, 'a')).toBeUndefined();
+  });
+
+  it('returns a present value verbatim, untrimmed', () => {
+    expect(readOptional({ a: ' /tmp/x ' }, 'a')).toBe(' /tmp/x ');
+    expect(readOptional({ a: 0 }, 'a')).toBe(0);
+    expect(readOptional({ a: false }, 'a')).toBe(false);
+  });
+
+  it('skips blank keys in order and returns the first real one', () => {
+    expect(readOptional({ a: '', b: 'real' }, 'a', 'b')).toBe('real');
+    expect(readOptional({ a: 'first', b: 'second' }, 'a', 'b')).toBe('first');
+    expect(readOptional({ a: '', b: null }, 'a', 'b')).toBeUndefined();
+  });
+});
+
+describe('readOptionalString', () => {
+  it('collapses blank to undefined', () => {
+    expect(readOptionalString({ cwd: '  ' }, 'cwd')).toBeUndefined();
+  });
+
+  it('throws on a wrong type, naming the field and the value', () => {
+    expect(() => readOptionalString({ cwd: 42 }, 'cwd')).toThrow(
+      /Agent tool cwd must be a string, got: 42/,
+    );
+  });
+
+  it('reports errors under an explicit label', () => {
+    expect(() => readOptionalString({ subagent_type: 7 }, 'subagent_type', 'agent_type')).toThrow(
+      /agent_type must be a string/,
+    );
+  });
+});
+
+describe('readOptionalAliasString', () => {
+  it('falls through blanks to the alias', () => {
+    expect(readOptionalAliasString({ a: '', b: 'x' }, ['a', 'b'], 'a')).toBe('x');
+  });
+
+  it('throws under the canonical label when the winning value is mistyped', () => {
+    expect(() => readOptionalAliasString({ a: '', b: 7 }, ['a', 'b'], 'a')).toThrow(
+      /Agent tool a must be a string, got: 7/,
+    );
+  });
+});
+
+describe('readOptionalNumber', () => {
+  it('collapses blank to undefined so the caller default applies', () => {
+    expect(readOptionalNumber({ max_turns: null }, 'max_turns')).toBeUndefined();
+    expect(readOptionalNumber({ max_turns: '' }, 'max_turns')).toBeUndefined();
+  });
+
+  it('preserves 0 (a falsy but meaningful value)', () => {
+    expect(readOptionalNumber({ max_turns: 0 }, 'max_turns')).toBe(0);
+  });
+
+  it('refuses to coerce a numeric string', () => {
+    expect(() => readOptionalNumber({ max_turns: '10' }, 'max_turns')).toThrow(
+      /max_turns must be a number, got: "10"/,
+    );
+  });
+});

--- a/src/agent/tools/subagent/optional-input.ts
+++ b/src/agent/tools/subagent/optional-input.ts
@@ -1,0 +1,115 @@
+/**
+ * Blank-tolerant readers for OPTIONAL Agent-tool input fields.
+ *
+ * Contract: for an optional field, "supplied blank" and "not supplied" are the
+ * same request — `undefined`, `null`, and whitespace-only strings all read as
+ * absent. Model serializers (OpenAI-family ones especially) routinely pad an
+ * arguments object with `""`/`null` for optionals they do not want; a parser
+ * that only tests `!== undefined` reads that padding as caller intent and
+ * rejects a request nobody made.
+ *
+ * This is NOT the "silent coercion" this parser deliberately refuses for
+ * `mode`. A typo like `mode:"back"` carries real-but-wrong intent, and
+ * defaulting it would hide a mistake. A blank carries no intent at all, so
+ * there is nothing to hide — collapsing it restores the omitted-field path.
+ *
+ * Load-bearing case: `cwd` and `isolation` are mutually exclusive, so a padded
+ * `cwd:''` next to `isolation:'worktree'` produced a self-contradictory error
+ * PAIR — "cwd and isolation are mutually exclusive", then "cwd must be a
+ * non-empty string" — which reads as "cwd is required, and requiring it forbids
+ * isolation". Models resolved that by dropping isolation and silently degrading
+ * to an unisolated dispatch, i.e. an input-normalization gap surfaced as a
+ * capability loss.
+ *
+ * Scope: opt-in per field, NEVER dispatcher-wide. `write_file.content`,
+ * `edit_file.new_string`, and `browser_act.value` all take `''` as a real
+ * payload (empty file, deletion, clear-the-input), so blank must stay
+ * meaningful there. Array ENTRIES are out of scope for the same reason:
+ * silently dropping a blank entry from `readRoots`/`writeRoots` would quietly
+ * shrink a grant, so those keep rejecting loudly.
+ *
+ * @module agent/tools/subagent/optional-input
+ */
+
+/** True when a value carries no caller intent: absent, null, or whitespace-only. */
+export function isBlankInput(value: unknown): boolean {
+  if (value === undefined || value === null) return true;
+  return typeof value === 'string' && value.trim().length === 0;
+}
+
+/**
+ * First non-blank value among `keys`, or `undefined` when every one is blank.
+ *
+ * The multi-key form serves alias pairs (`agent_type` / `subagent_type`): a
+ * padded `agent_type:''` no longer shadows a real `subagent_type`, which plain
+ * `??` allowed because `'' !== undefined`.
+ */
+export function readOptional(
+  input: Record<string, unknown>,
+  ...keys: readonly string[]
+): unknown {
+  for (const key of keys) {
+    const value = input[key];
+    if (!isBlankInput(value)) return value;
+  }
+  return undefined;
+}
+
+/**
+ * {@link readOptional} plus a string type check.
+ *
+ * Blank → `undefined`; wrong type → throw. `label` names the field in the error
+ * (defaults to `key`) so an alias pair can report the canonical name.
+ * Non-blank values are returned verbatim — never trimmed, because trimming a
+ * path or model id would silently alter a value the caller did supply.
+ */
+export function readOptionalString(
+  input: Record<string, unknown>,
+  key: string,
+  label: string = key,
+): string | undefined {
+  const value = readOptional(input, key);
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string') {
+    throw new Error(`Agent tool ${label} must be a string, got: ${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+/**
+ * {@link readOptionalString} for alias pairs: reads `keys` in precedence order
+ * and reports errors under `label`.
+ */
+export function readOptionalAliasString(
+  input: Record<string, unknown>,
+  keys: readonly string[],
+  label: string,
+): string | undefined {
+  const value = readOptional(input, ...keys);
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string') {
+    throw new Error(`Agent tool ${label} must be a string, got: ${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+/**
+ * {@link readOptional} plus a number type check.
+ *
+ * Blank → `undefined` (caller applies its own default); wrong type → throw.
+ * A numeric string is deliberately NOT coerced: `max_turns:"10"` is a schema
+ * violation with real intent behind it, and quietly accepting it would mask a
+ * caller bug the loud error surfaces in one round.
+ */
+export function readOptionalNumber(
+  input: Record<string, unknown>,
+  key: string,
+  label: string = key,
+): number | undefined {
+  const value = readOptional(input, key);
+  if (value === undefined) return undefined;
+  if (typeof value !== 'number') {
+    throw new Error(`Agent tool ${label} must be a number, got: ${JSON.stringify(value)}`);
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary

- treat blank optional `agent` tool fields (`undefined`, `null`, or whitespace-only strings) as omitted instead of caller intent
- keep meaningful invalid values loud while allowing padded serializers to express `isolation: "worktree"` without a fabricated `cwd` conflict
- make `cwd`/`isolation` exclusion errors name the exact retry and document exact-file `readRoots` as the least-privilege path for home-root dotfiles
- add regression coverage for alias fallback, budgets, arrays, isolation conflicts, and file-granular containment

## Why

OpenAI-compatible model serializers can pad optional tool arguments with empty strings or nulls. The agent parser previously interpreted those blanks as deliberate values. In the observed isolation failure, `cwd: ""` made a valid `isolation: "worktree"` request appear contradictory, causing the model to drop isolation and degrade the dispatch.

A second observed failure asked a child to inspect dotfiles by setting `cwd` or `readRoots` to the home directory. That broad grant is correctly refused because it would weaken Bash credential restrictions. A single file is already a valid read root and grants exactly that file, but neither the schema nor the error exposed that safe escape hatch.

## Security

- no breadth guard or read-denylist policy is relaxed
- `$HOME`, filesystem roots, and protected credential paths remain refused
- blank normalization is opt-in inside the Agent parser, not dispatcher-wide
- array entries remain strict, so blank grant entries are not silently dropped

## Verification

- `pnpm test:file src/agent/tools/subagent/optional-input.test.ts src/agent/tools/subagent/input-parse.test.ts src/agent/tools/handlers/_cwd-utils.test.ts` — 195 passed
- `pnpm test` — passed
- `pnpm test:coverage` — passed, including coverage floors
- `pnpm test:pty` — 10 passed
- `pnpm lint` — passed
- `pnpm build` — passed
- `pnpm audit:sdk:check` — passed
- `pnpm audit:env:check` — passed
- `pnpm scan:env:check` — passed
- `pnpm audit:chalk:check` — passed
- `pnpm fix:pins:check` — passed
- `pnpm audit:deps` — completed with the repository baseline vulnerability report (29 total: 3 low, 17 moderate, 9 high)

The branch was rebased onto `origin/main` at v5.95.1 and targeted tests, lint, and build were rerun after the rebase.
