### PR TITLE
fix(pricing): correct prompt-cache cost accounting and surface hit rate

### DIFF
--- a/src/agent/providers/anthropic-direct/pricing.test.ts
+++ b/src/agent/providers/anthropic-direct/pricing.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Unit tests for the prompt-cache-aware pricing model.
+ *
+ * Every assertion here is a golden pinned against Anthropic's published
+ * rates (https://platform.claude.com/docs/en/build-with-claude/prompt-caching#pricing,
+ * verified 2026-08-05). A wrong rate fails silently and persists into saved
+ * cost reports, so these are exact values rather than "cost > 0".
+ *
+ * @module agent/providers/anthropic-direct/pricing.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { deriveCallCostUsd, MODEL_PRICING } from './pricing.js';
+
+const M = 1_000_000;
+
+describe('deriveCallCostUsd — cache-write TTL rates', () => {
+  it('prices a 1h cache write at 2x base input, not the 5m 1.25x', () => {
+    // Regression: the rate was hardcoded at 1.25x (the 5-minute rate) while
+    // cache-policy.ts defaults AFK_PROMPT_CACHE_TTL to '1h', understating the
+    // write component of every cached session by 37.5%.
+    // sonnet-5: $3 base → 5m write $3.75, 1h write $6.00.
+    const at5m = deriveCallCostUsd('claude-sonnet-5', 0, 0, 0, M, {
+      ephemeral5m: M,
+      ephemeral1h: 0,
+    });
+    const at1h = deriveCallCostUsd('claude-sonnet-5', 0, 0, 0, M, {
+      ephemeral5m: 0,
+      ephemeral1h: M,
+    });
+    expect(at5m).toBeCloseTo(3.75, 8);
+    expect(at1h).toBeCloseTo(6.0, 8);
+    // The whole point: 1h costs strictly more. Guards against a future edit
+    // that collapses both branches back to one rate.
+    expect(at1h!).toBeGreaterThan(at5m!);
+  });
+
+  it('bills a mixed-TTL call by segment rather than picking one rate', () => {
+    // The API bills 1h and 5m segments separately when breakpoints mix TTLs.
+    const cost = deriveCallCostUsd('claude-sonnet-5', 0, 0, 0, M, {
+      ephemeral5m: M / 2,
+      ephemeral1h: M / 2,
+    });
+    expect(cost).toBeCloseTo(0.5 * 3.75 + 0.5 * 6.0, 8);
+  });
+
+  it('defaults to the 5m rate when no TTL split is supplied', () => {
+    const cost = deriveCallCostUsd('claude-sonnet-5', 0, 0, 0, M);
+    expect(cost).toBeCloseTo(3.75, 8);
+  });
+
+  it('derives both write rates from base input when a row omits them', () => {
+    // Rows may omit explicit cache rates; the 1.25x / 2x multipliers apply.
+    const rows = [...MODEL_PRICING.entries()];
+    for (const [model, p] of rows) {
+      const oneHour = deriveCallCostUsd(model, 0, 0, 0, M, {
+        ephemeral5m: 0,
+        ephemeral1h: M,
+      });
+      const expected = p.cacheWrite1hPerMTok ?? p.inputPerMTok * 2;
+      expect(oneHour, `1h write rate for ${model}`).toBeCloseTo(expected, 8);
+    }
+  });
+});
+
+describe('deriveCallCostUsd — plain input is cache-exclusive', () => {
+  it('does not subtract cache counts from input_tokens', () => {
+    // Per the Messages API docs, `input_tokens` counts only tokens neither
+    // read from nor used to create a cache. The old code subtracted both off
+    // it again and clamped at zero — so in a warm session (cache_read >>
+    // input) the plain-input term silently vanished.
+    const cost = deriveCallCostUsd('claude-sonnet-5', 1000, 0, 100_000, 0);
+    const expectedPlain = (1000 / M) * 3.0;
+    const expectedRead = (100_000 / M) * 0.3;
+    expect(cost).toBeCloseTo(expectedPlain + expectedRead, 8);
+  });
+
+  it('keeps the plain-input term when cache counts dwarf it', () => {
+    // The clamping bug's signature: cost identical with and without a huge
+    // cache_read would mean plain input was being zeroed out.
+    const withCache = deriveCallCostUsd('claude-sonnet-5', 500, 0, 200_000, 0)!;
+    const readOnly = deriveCallCostUsd('claude-sonnet-5', 0, 0, 200_000, 0)!;
+    expect(withCache - readOnly).toBeCloseTo((500 / M) * 3.0, 8);
+  });
+});
+
+describe('deriveCallCostUsd — published rate goldens', () => {
+  it('opus-4-5 uses $5/$25, not the retired opus-4.1 $15/$75', () => {
+    // Regression: the 4.5 row carried the retired Opus 4.1/4.0 rates,
+    // overstating every Opus 4.5 cost report 3x. Same copy-paste class as the
+    // Haiku 3.5 -> 4.5 mixup. 1M in + 1M out = $5 + $25 = $30.
+    const cost = deriveCallCostUsd('claude-opus-4-5-20250929', M, M, 0, 0);
+    expect(cost).toBeCloseTo(30.0, 8);
+  });
+
+  it('opus-5 uses the published $5.00/$25.00 rates', () => {
+    expect(deriveCallCostUsd('claude-opus-5', M, M, 0, 0)).toBeCloseTo(30.0, 8);
+  });
+
+  it('returns undefined for an unknown model rather than zero', () => {
+    expect(deriveCallCostUsd('claude-unknown-99', 1000, 500, 0, 0)).toBeUndefined();
+  });
+
+  it('every table row produces a positive cost for non-zero tokens', () => {
+    for (const [model] of MODEL_PRICING) {
+      const cost = deriveCallCostUsd(model, 1000, 500, 0, 0);
+      expect(cost, `cost for ${model}`).toBeDefined();
+      expect(cost!, `cost for ${model}`).toBeGreaterThan(0);
+    }
+  });
+
+  it('every table row prices a 1h write above a 5m write', () => {
+    for (const [model] of MODEL_PRICING) {
+      const w5 = deriveCallCostUsd(model, 0, 0, 0, M, { ephemeral5m: M, ephemeral1h: 0 })!;
+      const w1 = deriveCallCostUsd(model, 0, 0, 0, M, { ephemeral5m: 0, ephemeral1h: M })!;
+      expect(w1, `1h vs 5m for ${model}`).toBeGreaterThan(w5);
+    }
+  });
+});

--- a/src/agent/providers/anthropic-direct/pricing.ts
+++ b/src/agent/providers/anthropic-direct/pricing.ts
@@ -1,0 +1,162 @@
+/**
+ * Static pricing table + per-call cost derivation for the `anthropic-direct`
+ * provider.
+ *
+ * Extracted from `types.ts` (which sat at ~595 LOC, well over the repo's
+ * 350-line ceiling) so pricing is one concern in one file. `types.ts`
+ * re-exports both symbols, so existing call sites and tests are unaffected.
+ *
+ * @module agent/providers/anthropic-direct/pricing
+ */
+
+/**
+ * Invariant: three billing facts govern this module, all from
+ * https://platform.claude.com/docs/en/build-with-claude/prompt-caching#pricing
+ * (verified 2026-08-05). Changing any of them changes reported dollars, so
+ * they are stated once here rather than re-derived at each use site.
+ *
+ *  1. `input_tokens` from the Messages API counts ONLY tokens that were
+ *     neither read from nor used to create a cache. It does NOT include
+ *     cache reads or cache writes. Total input processed for a call is
+ *     `input_tokens + cache_read_input_tokens + cache_creation_input_tokens`.
+ *     Therefore the plain-input cost term is `input_tokens` verbatim —
+ *     subtracting the cache counts off it (as this code did until 2026-08-05)
+ *     double-subtracts and, because cache reads dwarf plain input in a warm
+ *     session, clamps the term to zero.
+ *  2. Cache WRITES are priced by TTL: 1.25× the base input rate for a 5-minute
+ *     entry, but 2× for a 1-hour entry. A single flat write rate is only
+ *     correct for a caller that never requests 1h — and `cache-policy.ts`
+ *     defaults `AFK_PROMPT_CACHE_TTL` to `1h`, so the flat 1.25× that lived
+ *     here understated the write component of every cached session by 37.5%.
+ *  3. Cache READS are 0.1× the base input rate regardless of TTL.
+ *
+ * The API reports the write split directly on `usage.cache_creation`
+ * (`ephemeral_5m_input_tokens` / `ephemeral_1h_input_tokens`), so cost is
+ * derived from what was actually billed rather than inferred from local
+ * config. `toProviderUsage` supplies that split; the fallback when the field
+ * is absent lives there too, keeping this module pure and env-free.
+ */
+
+/** Multiplier on base input rate for a 5-minute cache write. */
+const CACHE_WRITE_5M_MULTIPLIER = 1.25;
+/** Multiplier on base input rate for a 1-hour cache write. */
+const CACHE_WRITE_1H_MULTIPLIER = 2.0;
+/** Multiplier on base input rate for a cache read (any TTL). */
+const CACHE_READ_MULTIPLIER = 0.1;
+
+/**
+ * Rates are USD per 1 million tokens.
+ *
+ * Sources: https://platform.claude.com/docs/en/build-with-claude/prompt-caching#pricing
+ * (checked 2026-08-05).
+ *
+ * MAINTENANCE: update when Anthropic revises list prices. An unknown model
+ * yields `undefined` cost (not zero) — see {@link deriveCallCostUsd}.
+ */
+export interface ModelPricing {
+  inputPerMTok: number;
+  outputPerMTok: number;
+  /** 5-minute cache-write rate per MTok (default: 1.25 × input rate). */
+  cacheWrite5mPerMTok?: number;
+  /** 1-hour cache-write rate per MTok (default: 2 × input rate). */
+  cacheWrite1hPerMTok?: number;
+  /** Cache-read rate per MTok (default: 0.10 × input rate). */
+  cacheReadPerMTok?: number;
+}
+
+/** @internal exported only for unit tests */
+export const MODEL_PRICING: ReadonlyMap<string, ModelPricing> = new Map<string, ModelPricing>([
+  // Claude Sonnet 5 (GA 2026-06): standard $3 / $15 per MTok. Introductory
+  // $2 / $10 pricing applies through 2026-08-31; the standard rate is used here
+  // for post-intro durability of long-lived persisted cost reports.
+  ['claude-sonnet-5', { inputPerMTok: 3.0, outputPerMTok: 15.0, cacheWrite5mPerMTok: 3.75, cacheWrite1hPerMTok: 6.0, cacheReadPerMTok: 0.30 }],
+  // Claude Opus 5 (GA 2026-07-24): $5 / $25 per MTok.
+  ['claude-opus-5', { inputPerMTok: 5.0, outputPerMTok: 25.0, cacheWrite5mPerMTok: 6.25, cacheWrite1hPerMTok: 10.0, cacheReadPerMTok: 0.50 }],
+  // Opus 4.6/4.7/4.8 share Opus 5's $5 / $25 rates.
+  ['claude-opus-4-8', { inputPerMTok: 5.0, outputPerMTok: 25.0, cacheWrite5mPerMTok: 6.25, cacheWrite1hPerMTok: 10.0, cacheReadPerMTok: 0.50 }],
+  ['claude-opus-4-7', { inputPerMTok: 5.0, outputPerMTok: 25.0, cacheWrite5mPerMTok: 6.25, cacheWrite1hPerMTok: 10.0, cacheReadPerMTok: 0.50 }],
+  ['claude-opus-4-6', { inputPerMTok: 5.0, outputPerMTok: 25.0, cacheWrite5mPerMTok: 6.25, cacheWrite1hPerMTok: 10.0, cacheReadPerMTok: 0.50 }],
+  // Claude 4.5/4.6 family (kept for backward compat with persisted sessions)
+  ['claude-sonnet-4-6', { inputPerMTok: 3.0, outputPerMTok: 15.0, cacheWrite5mPerMTok: 3.75, cacheWrite1hPerMTok: 6.0, cacheReadPerMTok: 0.30 }],
+  ['claude-sonnet-4-5-20250929', { inputPerMTok: 3.0, outputPerMTok: 15.0, cacheWrite5mPerMTok: 3.75, cacheWrite1hPerMTok: 6.0, cacheReadPerMTok: 0.30 }],
+  // Opus 4.5 is $5 / $25 — NOT the $15 / $75 that lived here until 2026-08-05.
+  // Those are the retired Opus 4.1/4.0 rates, copied onto the 4.5 row and
+  // overstating every Opus 4.5 cost report 3×. Same copy-paste class as the
+  // Haiku 3.5→4.5 mixup fixed earlier; see pricing.test.ts for the golden pin.
+  ['claude-opus-4-5-20250929', { inputPerMTok: 5.0, outputPerMTok: 25.0, cacheWrite5mPerMTok: 6.25, cacheWrite1hPerMTok: 10.0, cacheReadPerMTok: 0.50 }],
+  // Haiku 4.5: $1.00 input / $5.00 output per MTok. The previous $0.80/$4.00
+  // values were the Haiku 3.5 rates accidentally copied to the 4.5 row.
+  ['claude-haiku-4-5-20250929', { inputPerMTok: 1.00, outputPerMTok: 5.0, cacheWrite5mPerMTok: 1.25, cacheWrite1hPerMTok: 2.0, cacheReadPerMTok: 0.10 }],
+  ['claude-haiku-4-5-20251001', { inputPerMTok: 1.00, outputPerMTok: 5.0, cacheWrite5mPerMTok: 1.25, cacheWrite1hPerMTok: 2.0, cacheReadPerMTok: 0.10 }],
+  // Claude 3.7 family (kept for backward compat with persisted sessions)
+  ['claude-3-7-sonnet-20250219', { inputPerMTok: 3.0, outputPerMTok: 15.0, cacheWrite5mPerMTok: 3.75, cacheWrite1hPerMTok: 6.0, cacheReadPerMTok: 0.30 }],
+  // Claude 3.5 family
+  ['claude-3-5-sonnet-20241022', { inputPerMTok: 3.0, outputPerMTok: 15.0, cacheWrite5mPerMTok: 3.75, cacheWrite1hPerMTok: 6.0, cacheReadPerMTok: 0.30 }],
+  ['claude-3-5-sonnet-20240620', { inputPerMTok: 3.0, outputPerMTok: 15.0, cacheWrite5mPerMTok: 3.75, cacheWrite1hPerMTok: 6.0, cacheReadPerMTok: 0.30 }],
+  ['claude-3-5-haiku-20241022', { inputPerMTok: 0.80, outputPerMTok: 4.0, cacheWrite5mPerMTok: 1.0, cacheWrite1hPerMTok: 1.60, cacheReadPerMTok: 0.08 }],
+  // Claude 3 family
+  ['claude-3-opus-20240229', { inputPerMTok: 15.0, outputPerMTok: 75.0, cacheWrite5mPerMTok: 18.75, cacheWrite1hPerMTok: 30.0, cacheReadPerMTok: 1.50 }],
+  ['claude-3-sonnet-20240229', { inputPerMTok: 3.0, outputPerMTok: 15.0, cacheWrite5mPerMTok: 3.75, cacheWrite1hPerMTok: 6.0, cacheReadPerMTok: 0.30 }],
+  ['claude-3-haiku-20240307', { inputPerMTok: 0.25, outputPerMTok: 1.25, cacheWrite5mPerMTok: 0.30, cacheWrite1hPerMTok: 0.50, cacheReadPerMTok: 0.03 }],
+]);
+
+/**
+ * Cache-write tokens split by the TTL they were written at. Mirrors the
+ * Messages API's `usage.cache_creation` object. A call may write at both
+ * TTLs in one request (the API bills 1h and 5m segments separately when
+ * breakpoints mix TTLs), so this is a pair, not an enum.
+ */
+export interface CacheWriteSplit {
+  ephemeral5m: number;
+  ephemeral1h: number;
+}
+
+/**
+ * Contract: returns the USD cost of ONE API call, or `undefined` when the
+ * model is absent from {@link MODEL_PRICING} — callers must treat `undefined`
+ * as "cost unavailable" and must not coerce it to zero.
+ *
+ * Pure: no env reads, no clock. `cacheWriteSplit` is supplied by the caller so
+ * this stays deterministic under test; when omitted, every cache-write token
+ * is priced at the 5-minute rate (the API's own default TTL).
+ *
+ * `inputTokens` must be the raw `usage.input_tokens` — already cache-exclusive
+ * per fact 1 in the module header. Do not pre-subtract cache counts from it.
+ *
+ * @internal exported for unit tests
+ */
+export function deriveCallCostUsd(
+  model: string,
+  inputTokens: number,
+  outputTokens: number,
+  cachedInputTokens: number,
+  cacheCreationTokens: number,
+  cacheWriteSplit?: CacheWriteSplit,
+): number | undefined {
+  const pricing = MODEL_PRICING.get(model);
+  if (!pricing) return undefined;
+
+  const M = 1_000_000;
+
+  // `input_tokens` already excludes cache reads and writes — use it verbatim.
+  const inputCost = (inputTokens / M) * pricing.inputPerMTok;
+  const outputCost = (outputTokens / M) * pricing.outputPerMTok;
+
+  const write5mRate =
+    pricing.cacheWrite5mPerMTok ?? pricing.inputPerMTok * CACHE_WRITE_5M_MULTIPLIER;
+  const write1hRate =
+    pricing.cacheWrite1hPerMTok ?? pricing.inputPerMTok * CACHE_WRITE_1H_MULTIPLIER;
+  const readRate = pricing.cacheReadPerMTok ?? pricing.inputPerMTok * CACHE_READ_MULTIPLIER;
+
+  // Absent an explicit split, attribute all writes to the 5m rate. Callers
+  // that know the request asked for 1h pass the split (see toProviderUsage).
+  const split: CacheWriteSplit = cacheWriteSplit ?? {
+    ephemeral5m: cacheCreationTokens,
+    ephemeral1h: 0,
+  };
+  const cacheWriteCost =
+    (split.ephemeral5m / M) * write5mRate + (split.ephemeral1h / M) * write1hRate;
+  const cacheReadCost = (cachedInputTokens / M) * readRate;
+
+  return inputCost + outputCost + cacheWriteCost + cacheReadCost;
+}

--- a/src/agent/providers/anthropic-direct/query/auto-compact.test.ts
+++ b/src/agent/providers/anthropic-direct/query/auto-compact.test.ts
@@ -211,7 +211,26 @@ describe('buildContextUsageFields', () => {
       output_tokens: 700,
       cache_read_input_tokens: 3000,
       cache_creation_input_tokens: 200,
+      // The one field display code may safely read as a scalar. With no
+      // provider-supplied footprint this falls back to input + output (2200),
+      // deliberately NOT the 4700 sum — the mixed basis is why this field
+      // exists. See the invariant on ContextUsageApiBreakdown.
+      context_window_tokens: 2200,
     });
+  });
+
+  it('carries the provider footprint into context_window_tokens when present', () => {
+    const { apiUsage } = buildContextUsageFields({
+      inputTokens: 50_000,
+      outputTokens: 10_000,
+      cachedInputTokens: 399_000,
+      cacheCreationTokens: 1_000,
+      contextWindowTokens: 410_000,
+    });
+    expect(apiUsage?.context_window_tokens).toBe(410_000);
+    // Summing the mixed-basis fields would give 460_000 — the double-count
+    // this field exists to prevent.
+    expect(apiUsage?.context_window_tokens).not.toBe(460_000);
   });
 
   it('derives totalTokens from inputTokens + outputTokens (matches the context-% formula, excludes cache)', () => {
@@ -245,6 +264,7 @@ describe('buildContextUsageFields', () => {
       output_tokens: 42,
       cache_read_input_tokens: 0,
       cache_creation_input_tokens: 0,
+      context_window_tokens: 42,
     });
   });
 

--- a/src/agent/providers/anthropic-direct/types.test.ts
+++ b/src/agent/providers/anthropic-direct/types.test.ts
@@ -5,7 +5,7 @@
  * @module agent/providers/anthropic-direct/types.test
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import {
   toProviderUsage,
   sumProviderUsage,
@@ -45,8 +45,10 @@ describe('deriveCallCostUsd', () => {
   });
 
   it('accounts for cache-read tokens at a discounted rate', () => {
-    // Plain input = 1000 - 200 cached = 800; cache-read: 200 at 0.30/MTok
-    const plain = (800 / 1_000_000) * 3.0;
+    // `input_tokens` is already cache-exclusive per the Messages API docs, so
+    // plain input is the full 1000 — NOT 1000-200. This assertion previously
+    // encoded the double-subtraction bug (expected 800) and so kept it alive.
+    const plain = (1000 / 1_000_000) * 3.0;
     const cacheRead = (200 / 1_000_000) * 0.30;
     const output = (100 / 1_000_000) * 15.0;
     const expected = plain + cacheRead + output;
@@ -55,8 +57,9 @@ describe('deriveCallCostUsd', () => {
   });
 
   it('accounts for cache-creation tokens at a premium rate', () => {
-    // Plain input = 1000 - 300 cache-creation = 700; cache-write: 300 at 3.75/MTok
-    const plain = (700 / 1_000_000) * 3.0;
+    // Plain input is the full 1000 (cache-exclusive); cache-write 300 at the
+    // 5m rate of 3.75/MTok, which is the default when no TTL split is given.
+    const plain = (1000 / 1_000_000) * 3.0;
     const cacheWrite = (300 / 1_000_000) * 3.75;
     const output = (50 / 1_000_000) * 15.0;
     const expected = plain + cacheWrite + output;
@@ -170,5 +173,52 @@ describe('sumProviderUsage — totalCostUsd accumulation', () => {
     const b = toProviderUsage(makeUsage(), 'end_turn'); // no model
     const sum = sumProviderUsage(a, b);
     expect(sum.totalCostUsd).toBeCloseTo(a.totalCostUsd ?? 0, 8);
+  });
+});
+
+describe('toProviderUsage — cache-write TTL attribution', () => {
+  const ENV_TTL = 'AFK_PROMPT_CACHE_TTL';
+  const restore = process.env[ENV_TTL];
+  afterEach(() => {
+    if (restore === undefined) delete process.env[ENV_TTL];
+    else process.env[ENV_TTL] = restore;
+  });
+
+  it("prefers the API's own cache_creation breakdown over local config", () => {
+    // The API reports what it actually billed. Even with the local TTL set to
+    // 5m, a response saying the write was 1h must be priced at the 1h rate.
+    process.env[ENV_TTL] = '5m';
+    const usage = makeUsage({
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_creation_input_tokens: 1_000_000,
+      cache_creation: { ephemeral_5m_input_tokens: 0, ephemeral_1h_input_tokens: 1_000_000 },
+    } as Partial<Usage>);
+    const out = toProviderUsage(usage, 'end_turn', 'claude-sonnet-5');
+    expect(out.totalCostUsd).toBeCloseTo(6.0, 8); // 1h rate, not 3.75
+  });
+
+  it('falls back to the configured TTL when cache_creation is absent', () => {
+    // Endpoints that omit the breakdown must not silently get 5m pricing while
+    // cache-policy.ts is stamping 1h breakpoints on the request.
+    process.env[ENV_TTL] = '1h';
+    const usage = makeUsage({
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_creation_input_tokens: 1_000_000,
+    });
+    const out = toProviderUsage(usage, 'end_turn', 'claude-sonnet-5');
+    expect(out.totalCostUsd).toBeCloseTo(6.0, 8);
+  });
+
+  it('uses the 5m rate when the configured TTL is 5m and no breakdown exists', () => {
+    process.env[ENV_TTL] = '5m';
+    const usage = makeUsage({
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_creation_input_tokens: 1_000_000,
+    });
+    const out = toProviderUsage(usage, 'end_turn', 'claude-sonnet-5');
+    expect(out.totalCostUsd).toBeCloseTo(3.75, 8);
   });
 });

--- a/src/agent/providers/anthropic-direct/types.ts
+++ b/src/agent/providers/anthropic-direct/types.ts
@@ -18,6 +18,8 @@ import type {
 } from '@anthropic-ai/sdk/resources';
 import type { ProviderEvent, ProviderUsage } from '../../provider.js';
 import type { ToolFailureClass } from '../../trace/types.js';
+import { getCacheTtl } from './cache-policy.js';
+import { deriveCallCostUsd, type CacheWriteSplit } from './pricing.js';
 
 /**
  * Auth mode is selected by token shape. OAuth-mode tokens (`sk-ant-oat01-*`)
@@ -457,87 +459,42 @@ export interface ToolDispatcherLike {
 }
 
 /**
- * Static pricing table for known Claude models.
- * Rates are in USD per 1 million tokens.
- *
- * Sources: https://www.anthropic.com/pricing (checked 2025-07)
- *
- * MAINTENANCE: update when Anthropic revises list prices.
- * Units: USD / 1 000 000 tokens (MTok).
- *
- * Cache-write tokens are billed at 1.25× the base input rate;
- * cache-read tokens are billed at 0.1× the base input rate.
+ * Re-export of the pricing table and per-call cost derivation from their new
+ * home at `./pricing.ts`. Backward-compatibility shim — the pricing concern
+ * moved into its own file to keep this module under the repo's file-size
+ * ceiling. Existing call sites and tests import from here unchanged.
  */
-interface ModelPricing {
-  inputPerMTok: number;
-  outputPerMTok: number;
-  /** Cache-write surcharge per MTok (default: 1.25 × input rate). */
-  cacheWritePerMTok?: number;
-  /** Cache-read rate per MTok (default: 0.10 × input rate). */
-  cacheReadPerMTok?: number;
-}
-
-/** @internal exported only for unit tests */
-export const MODEL_PRICING: ReadonlyMap<string, ModelPricing> = new Map([
-  // Claude Sonnet 5 (GA 2026-06): standard $3 / $15 per MTok. Introductory
-  // $2 / $10 pricing applies through 2026-08-31; the standard rate is used here
-  // for post-intro durability of long-lived persisted cost reports.
-  ['claude-sonnet-5', { inputPerMTok: 3.0, outputPerMTok: 15.0, cacheWritePerMTok: 3.75, cacheReadPerMTok: 0.30 }],
-  // Claude Opus 5 (GA 2026-07-24): $5 / $25 per MTok (input/output) per
-  // Anthropic's models/pricing docs. Cache write/read follow the standard
-  // 1.25× / 0.10× multipliers.
-  ['claude-opus-5', { inputPerMTok: 5.0, outputPerMTok: 25.0, cacheWritePerMTok: 6.25, cacheReadPerMTok: 0.50 }],
-  // Claude 4.5 family (kept for backward compat with persisted sessions)
-  ['claude-sonnet-4-5-20250929', { inputPerMTok: 3.0, outputPerMTok: 15.0, cacheWritePerMTok: 3.75, cacheReadPerMTok: 0.30 }],
-  ['claude-opus-4-5-20250929',   { inputPerMTok: 15.0, outputPerMTok: 75.0, cacheWritePerMTok: 18.75, cacheReadPerMTok: 1.50 }],
-  // Haiku 4.5: $1.00 input / $5.00 output per MTok per https://www.anthropic.com/pricing
-  // The previous $0.80/$4.00 values were the Haiku 3.5 rates accidentally
-  // copied to the 4.5 row, causing per-turn cost under-reporting by ~20%.
-  // Cache rates follow the standard 1.25× / 0.10× multipliers.
-  ['claude-haiku-4-5-20250929',  { inputPerMTok: 1.00, outputPerMTok: 5.0,  cacheWritePerMTok: 1.25,  cacheReadPerMTok: 0.10 }],
-  ['claude-haiku-4-5-20251001',  { inputPerMTok: 1.00, outputPerMTok: 5.0,  cacheWritePerMTok: 1.25,  cacheReadPerMTok: 0.10 }],
-  // Claude 3.7 family (kept for backward compat with persisted sessions)
-  ['claude-3-7-sonnet-20250219', { inputPerMTok: 3.0, outputPerMTok: 15.0, cacheWritePerMTok: 3.75, cacheReadPerMTok: 0.30 }],
-  // Claude 3.5 family
-  ['claude-3-5-sonnet-20241022', { inputPerMTok: 3.0,  outputPerMTok: 15.0, cacheWritePerMTok: 3.75, cacheReadPerMTok: 0.30 }],
-  ['claude-3-5-sonnet-20240620', { inputPerMTok: 3.0,  outputPerMTok: 15.0, cacheWritePerMTok: 3.75, cacheReadPerMTok: 0.30 }],
-  ['claude-3-5-haiku-20241022',  { inputPerMTok: 0.80, outputPerMTok: 4.0,  cacheWritePerMTok: 1.0,   cacheReadPerMTok: 0.08 }],
-  // Claude 3 family
-  ['claude-3-opus-20240229',     { inputPerMTok: 15.0, outputPerMTok: 75.0, cacheWritePerMTok: 18.75, cacheReadPerMTok: 1.50 }],
-  ['claude-3-sonnet-20240229',   { inputPerMTok: 3.0,  outputPerMTok: 15.0, cacheWritePerMTok: 3.75, cacheReadPerMTok: 0.30 }],
-  ['claude-3-haiku-20240307',    { inputPerMTok: 0.25, outputPerMTok: 1.25, cacheWritePerMTok: 0.30,  cacheReadPerMTok: 0.03 }],
-]);
+export { MODEL_PRICING } from './pricing.js';
+export { deriveCallCostUsd };
+export type { ModelPricing, CacheWriteSplit } from './pricing.js';
 
 /**
- * Derive the USD cost of a single API call given token counts and a model id.
+ * Contract: split this call's cache-write tokens by the TTL they were billed
+ * at, so `deriveCallCostUsd` can apply 1.25× (5m) vs 2× (1h) correctly.
  *
- * Returns `undefined` when the model is unknown (not in the pricing table) —
- * callers must treat `undefined` as "cost unavailable" and avoid treating it
- * as zero.
+ * Prefers the API's own `usage.cache_creation` breakdown — that is what was
+ * actually billed, and it is the only source that stays right when a request
+ * mixes TTLs. Falls back to attributing every write token to the locally
+ * configured TTL (`getCacheTtl()`), which is correct for this provider because
+ * `cache-policy.ts` stamps every breakpoint in a request with that one TTL.
+ * The fallback matters: without it an endpoint that omits `cache_creation`
+ * would be priced at 5m rates while `AFK_PROMPT_CACHE_TTL` defaults to `1h`.
  *
- * @internal exported for unit tests
+ * This is the single env-reading boundary for pricing — `pricing.ts` stays
+ * pure so its golden-rate tests cannot drift with ambient config.
  */
-export function deriveCallCostUsd(
-  model: string,
-  inputTokens: number,
-  outputTokens: number,
-  cachedInputTokens: number,
-  cacheCreationTokens: number,
-): number | undefined {
-  const pricing = MODEL_PRICING.get(model);
-  if (!pricing) return undefined;
-
-  const M = 1_000_000;
-  // Plain (non-cached, non-creation) input tokens
-  const plainInput = Math.max(0, inputTokens - cachedInputTokens - cacheCreationTokens);
-  const inputCost = (plainInput / M) * pricing.inputPerMTok;
-  const outputCost = (outputTokens / M) * pricing.outputPerMTok;
-  const cacheWriteRate = pricing.cacheWritePerMTok ?? pricing.inputPerMTok * 1.25;
-  const cacheReadRate = pricing.cacheReadPerMTok ?? pricing.inputPerMTok * 0.10;
-  const cacheWriteCost = (cacheCreationTokens / M) * cacheWriteRate;
-  const cacheReadCost = (cachedInputTokens / M) * cacheReadRate;
-
-  return inputCost + outputCost + cacheWriteCost + cacheReadCost;
+function resolveCacheWriteSplit(usage: Usage): CacheWriteSplit {
+  const breakdown = usage.cache_creation;
+  if (breakdown) {
+    return {
+      ephemeral5m: breakdown.ephemeral_5m_input_tokens ?? 0,
+      ephemeral1h: breakdown.ephemeral_1h_input_tokens ?? 0,
+    };
+  }
+  const total = usage.cache_creation_input_tokens ?? 0;
+  return getCacheTtl() === '1h'
+    ? { ephemeral5m: 0, ephemeral1h: total }
+    : { ephemeral5m: total, ephemeral1h: 0 };
 }
 
 /**
@@ -577,6 +534,7 @@ export function toProviderUsage(
       usage.output_tokens ?? 0,
       usage.cache_read_input_tokens ?? 0,
       usage.cache_creation_input_tokens ?? 0,
+      resolveCacheWriteSplit(usage),
     );
     if (cost !== undefined) out.totalCostUsd = cost;
   }

--- a/src/agent/providers/shared/auto-compact.ts
+++ b/src/agent/providers/shared/auto-compact.ts
@@ -60,6 +60,22 @@ export type ContextUsageApiBreakdown = {
   output_tokens: number;
   cache_read_input_tokens: number;
   cache_creation_input_tokens: number;
+  /**
+   * Invariant: the four fields above are a MIXED BASIS and must never be
+   * summed. `sumProviderUsage` accumulates input/output cumulatively across
+   * every tool-loop round of a turn, but keeps the two cache fields at their
+   * latest (last-round) value. By round N the latest `cache_read` already
+   * contains everything the earlier rounds sent, so adding the cumulative
+   * input/output back on top double-counts them — inflation that grows with
+   * round count and can push a displayed total past the context limit while
+   * the separately-derived percentage stays correct.
+   *
+   * This field is the single safe scalar: the provider-computed context-window
+   * footprint of the LAST round only (input + output + cache_read +
+   * cache_creation for that one call). Display code wanting "how full is the
+   * context" reads this, not a sum. See turn-accumulator.ts `addRoundUsage`.
+   */
+  context_window_tokens: number;
 };
 
 /** Consumer-facing context-usage fields derived from a completed turn. */
@@ -104,6 +120,7 @@ export function buildContextUsageFields(
       output_tokens: last.outputTokens ?? 0,
       cache_read_input_tokens: last.cachedInputTokens ?? 0,
       cache_creation_input_tokens: last.cacheCreationTokens ?? 0,
+      context_window_tokens: contextWindowTokensUsed(last),
     },
   };
 }

--- a/src/agent/types/config-types.ts
+++ b/src/agent/types/config-types.ts
@@ -708,8 +708,13 @@ export interface AgentConfig {
    * - `{ threshold: 0.85 }` — enabled with a custom fraction (0–1 exclusive).
    *
    * The threshold is evaluated against
-   * `(inputTokens + outputTokens + cachedInputTokens + cacheCreationTokens) / contextLimit`
-   * from the last completed turn. Auto-compaction is guarded by
+   * `contextWindowTokensUsed(usage) / contextLimit` from the last completed
+   * turn — i.e. the LAST ROUND's window occupancy (input + output + cache_read
+   * + cache_creation for that single call), not a sum across the turn's
+   * rounds. Summing the accumulated fields would double-count: input/output
+   * accumulate across rounds while the cache counts are last-round-only, and
+   * the latest cache_read already contains the earlier rounds' tokens.
+   * Auto-compaction is guarded by
    * `abort.isIdle()` so it never fires while a turn is in flight, and
    * by the existing re-entrance lock in `compact-handler.ts`.
    */

--- a/src/agent/types/sdk-types.ts
+++ b/src/agent/types/sdk-types.ts
@@ -425,5 +425,14 @@ export type SDKControlGetContextUsageResponse = {
     output_tokens: number;
     cache_creation_input_tokens: number;
     cache_read_input_tokens: number;
+    /**
+     * Last round's true context-window occupancy. Optional for back-compat
+     * with providers that predate the field. Display code wanting "how full
+     * is the context" reads THIS — never the sum of the four fields above,
+     * which are a mixed basis (cumulative input/output vs. last-round-only
+     * cache counts) and double-count when added. See
+     * `providers/shared/auto-compact.ts` for the full invariant.
+     */
+    context_window_tokens?: number;
   } | null;
 };

--- a/src/cli/commands/trace-usage-format.test.ts
+++ b/src/cli/commands/trace-usage-format.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Unit tests for closure-event cache-usage rendering.
+ *
+ * @module cli/commands/trace-usage-format.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { formatCacheUsage } from './trace-usage-format.js';
+
+describe('formatCacheUsage', () => {
+  it('renders read, write, and hit rate when cache activity exists', () => {
+    const out = formatCacheUsage({ cacheRead: 9000, cacheCreation: 1000 });
+    expect(out).toContain('r=9.0k');
+    expect(out).toContain('w=1.0k');
+    expect(out).toContain('hit=90%');
+  });
+
+  it('reports a 0% hit rate for a cold session that only wrote', () => {
+    // The signature of a prefix that keeps getting invalidated: every call
+    // writes, none reads. This is the case the renderer exists to surface.
+    expect(formatCacheUsage({ cacheRead: 0, cacheCreation: 50_000 })).toContain('hit=0%');
+  });
+
+  it('reports 100% for a fully warm call', () => {
+    expect(formatCacheUsage({ cacheRead: 50_000, cacheCreation: 0 })).toContain('hit=100%');
+  });
+
+  it('renders nothing when the session used no cache', () => {
+    // Uncached and pre-cache-era traces must render exactly as before.
+    expect(formatCacheUsage({ input: 100, output: 50 })).toBe('');
+    expect(formatCacheUsage({ cacheRead: 0, cacheCreation: 0 })).toBe('');
+    expect(formatCacheUsage(undefined)).toBe('');
+  });
+
+  it('treats missing cache fields as zero rather than NaN', () => {
+    const out = formatCacheUsage({ cacheRead: 1000 });
+    expect(out).toContain('w=0');
+    expect(out).not.toContain('NaN');
+  });
+
+  it('scales token counts through k and m suffixes', () => {
+    expect(formatCacheUsage({ cacheRead: 999, cacheCreation: 0 })).toContain('r=999');
+    expect(formatCacheUsage({ cacheRead: 2_500_000, cacheCreation: 0 })).toContain('r=2.5m');
+  });
+});

--- a/src/cli/commands/trace-usage-format.ts
+++ b/src/cli/commands/trace-usage-format.ts
@@ -1,0 +1,56 @@
+/**
+ * Cache-usage formatting for `afk trace show`.
+ *
+ * Lives in its own file because `trace.ts` is already far past the repo's
+ * 350-line ceiling; this is one whole concern (how prompt-cache token counts
+ * are rendered) rather than another branch inside the event renderer.
+ *
+ * @module cli/commands/trace-usage-format
+ */
+
+/** The `finalTokens` object carried on a `closure` trace event. */
+export interface FinalTokens {
+  input?: number | undefined;
+  output?: number | undefined;
+  cacheRead?: number | undefined;
+  cacheCreation?: number | undefined;
+}
+
+/**
+ * Contract: render the prompt-cache slice of a closure's token counts as a
+ * compact suffix, or `''` when the session recorded no cache activity (so
+ * uncached and pre-cache-era traces render exactly as before).
+ *
+ * History: the closure renderer printed reason/turns/cost/stop-reason and
+ * silently dropped `cacheRead`/`cacheCreation`, even though the trace schema
+ * has carried both since the field was added. Combined with `/cost` and the
+ * turn footer also omitting them, prompt-cache effectiveness was invisible on
+ * every surface an operator actually reads — a cache that degraded to a 100%
+ * miss rate would show up only on the monthly bill. Emitting the hit rate here
+ * makes the regression observable in the one artifact that is durable per
+ * session.
+ *
+ * The hit rate is `cacheRead / (cacheRead + cacheCreation)` — the share of
+ * cacheable tokens served from an existing entry rather than freshly written.
+ * A healthy warm session trends high; a prefix that keeps getting invalidated
+ * shows sustained low values because every call re-writes what it should have
+ * read.
+ */
+export function formatCacheUsage(tokens: FinalTokens | undefined): string {
+  if (!tokens) return '';
+  const read = tokens.cacheRead ?? 0;
+  const created = tokens.cacheCreation ?? 0;
+  const cacheable = read + created;
+  if (cacheable === 0) return '';
+
+  const parts = [`cache r=${fmtTokens(read)}`, `w=${fmtTokens(created)}`];
+  parts.push(`hit=${Math.round((read / cacheable) * 100)}%`);
+  return `  ${parts.join(' ')}`;
+}
+
+/** Compact token count: 1234 → `1.2k`, 1234567 → `1.2m`. */
+function fmtTokens(n: number): string {
+  if (n < 1000) return String(n);
+  if (n < 1_000_000) return `${(n / 1000).toFixed(1)}k`;
+  return `${(n / 1_000_000).toFixed(1)}m`;
+}

--- a/src/cli/commands/trace.ts
+++ b/src/cli/commands/trace.ts
@@ -28,6 +28,7 @@ import { readFile, readdir, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import { handleCommandError } from '../errors/index.js';
+import { formatCacheUsage } from './trace-usage-format.js';
 import { getAfkStateDir, getTraceDir } from '../../paths.js';
 import { readLedger } from '../../agent/session-ledger.js';
 import type { TraceEvent } from '../../agent/trace/index.js';
@@ -412,9 +413,12 @@ function renderEvent(event: TraceEvent, ctx: RenderContext): string | null {
       // stops (a turn that ends with no output and no error) diagnosable only
       // by reading the raw trace.jsonl. See docs: silent-model-loop debugging.
       const stop = p.lastStopReason ? `  stop=${p.lastStopReason}` : '';
+      // Prompt-cache hit rate was recorded but never rendered — see
+      // trace-usage-format.ts for why that made cache regressions invisible.
+      const cache = formatCacheUsage(p.finalTokens);
       return line(
         'closure',
-        `${p.reason}  turns=${p.finalTurnCount}${stop}  ${fmtUsd(p.finalCostUsd)}${guidance}`,
+        `${p.reason}  turns=${p.finalTurnCount}${stop}  ${fmtUsd(p.finalCostUsd)}${cache}${guidance}`,
       );
     }
 

--- a/src/cli/context-sampler.test.ts
+++ b/src/cli/context-sampler.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Unit tests for ContextSampler's token accounting.
+ *
+ * Focus: the sampler must report an absolute `used` count on the SAME basis
+ * as the `percentage` it displays beside it. Summing the `apiUsage` fields
+ * (its previous behaviour) mixes cumulative input/output with last-round-only
+ * cache counts and double-counts every prior round.
+ *
+ * @module cli/context-sampler.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ContextSampler } from './context-sampler.js';
+import type { AgentSession } from '../agent/session.js';
+
+type Payload = Awaited<ReturnType<AgentSession['getContextUsage']>>;
+
+/** Minimal stub matching the sampler's narrow ContextUsageSource surface. */
+function sourceOf(payload: Record<string, unknown>): AgentSession {
+  return {
+    getContextUsage: async () => payload as unknown as Payload,
+  } as unknown as AgentSession;
+}
+
+describe('ContextSampler — used-token basis', () => {
+  it('reports the provider-computed total, not a sum of the mixed-basis fields', async () => {
+    // A realistic round-3 payload: input/output accumulated across the turn's
+    // rounds, cache counts from the last round only. The naive sum is
+    // 3000+900+50000+2000 = 55,900 — but the last round's true occupancy is
+    // 53,000. The inflation is exactly the earlier rounds' input+output, which
+    // the latest cache_read already contains.
+    const sampler = new ContextSampler(
+      sourceOf({
+        totalTokens: 53_000,
+        percentage: 26.5,
+        maxTokens: 200_000,
+        isAutoCompactEnabled: false,
+        apiUsage: {
+          input_tokens: 3000,
+          output_tokens: 900,
+          cache_read_input_tokens: 50_000,
+          cache_creation_input_tokens: 2000,
+          context_window_tokens: 53_000,
+        },
+      }),
+    );
+
+    await sampler.refresh();
+    expect(sampler.getDetail()?.used).toBe(53_000);
+    expect(sampler.getDetail()?.used).not.toBe(55_900);
+  });
+
+  it('keeps used consistent with the percentage it is displayed beside', async () => {
+    // The regression this guards: an inflated absolute rendered next to a
+    // correctly-derived ratio, in the same status-line segment.
+    const sampler = new ContextSampler(
+      sourceOf({
+        totalTokens: 100_000,
+        percentage: 50,
+        maxTokens: 200_000,
+        isAutoCompactEnabled: false,
+        apiUsage: {
+          input_tokens: 9000,
+          output_tokens: 4000,
+          cache_read_input_tokens: 95_000,
+          cache_creation_input_tokens: 1000,
+          context_window_tokens: 100_000,
+        },
+      }),
+    );
+
+    await sampler.refresh();
+    const detail = sampler.getDetail()!;
+    expect(detail.used / detail.limit).toBeCloseTo(detail.percentage / 100, 6);
+  });
+
+  it('falls back to the breakdown field when totalTokens is absent', async () => {
+    const sampler = new ContextSampler(
+      sourceOf({
+        percentage: 10,
+        maxTokens: 200_000,
+        isAutoCompactEnabled: false,
+        apiUsage: {
+          input_tokens: 1000,
+          output_tokens: 500,
+          cache_read_input_tokens: 18_000,
+          cache_creation_input_tokens: 500,
+          context_window_tokens: 20_000,
+        },
+      }),
+    );
+
+    await sampler.refresh();
+    expect(sampler.getDetail()?.used).toBe(20_000);
+  });
+
+  it('falls back to cache-excluded input+output when no footprint is present', async () => {
+    // Mirrors contextWindowTokensUsed's own fallback. The 40k cache_read must
+    // NOT be added back — that is the double-count this change removes.
+    const sampler = new ContextSampler(
+      sourceOf({
+        percentage: 10,
+        maxTokens: 200_000,
+        isAutoCompactEnabled: false,
+        apiUsage: {
+          input_tokens: 1000,
+          output_tokens: 500,
+          cache_read_input_tokens: 40_000,
+          cache_creation_input_tokens: 0,
+        },
+      }),
+    );
+
+    await sampler.refresh();
+    expect(sampler.getDetail()?.used).toBe(1500);
+  });
+
+  it('reports zero rather than a bad sum when neither basis is available', async () => {
+    const sampler = new ContextSampler(
+      sourceOf({
+        percentage: 5,
+        maxTokens: 200_000,
+        isAutoCompactEnabled: false,
+        apiUsage: null,
+      }),
+    );
+
+    await sampler.refresh();
+    expect(sampler.getDetail()?.used).toBe(0);
+  });
+});

--- a/src/cli/context-sampler.ts
+++ b/src/cli/context-sampler.ts
@@ -32,6 +32,8 @@ interface ContextUsageSource {
       output_tokens: number;
       cache_creation_input_tokens: number;
       cache_read_input_tokens: number;
+      /** Last round's true window occupancy. Never sum the fields above. */
+      context_window_tokens?: number;
     } | null;
     percentage?: number;
     totalTokens?: number;
@@ -145,7 +147,7 @@ export class ContextSampler {
       // Discard results from a superseded source (generation mismatch).
       if (this.generation !== capturedGeneration) return;
 
-      const used = computeTotalTokens(payload.apiUsage);
+      const used = resolveUsedTokens(payload);
       const limit = payload.maxTokens ?? 0;
       const percentage = payload.percentage;
 
@@ -163,19 +165,29 @@ export class ContextSampler {
   }
 }
 
-function computeTotalTokens(
-  usage: {
-    input_tokens: number;
-    output_tokens: number;
-    cache_creation_input_tokens: number;
-    cache_read_input_tokens: number;
-  } | null | undefined,
-): number {
-  if (!usage) return 0;
-  return (
-    usage.input_tokens +
-    usage.output_tokens +
-    usage.cache_creation_input_tokens +
-    usage.cache_read_input_tokens
-  );
+/**
+ * Contract: return the context-window footprint the status line should show
+ * next to the percentage, using the same basis the percentage is derived from.
+ *
+ * Must NOT sum the `apiUsage` fields. They are a mixed basis — cumulative
+ * input/output alongside last-round-only cache counts — so adding them
+ * double-counts every prior round's tokens (the latest `cache_read` already
+ * contains them). That is what this function used to do, which rendered an
+ * inflated absolute count beside a correctly-computed ratio.
+ *
+ * Prefers the provider-computed `totalTokens` (the last round's true
+ * occupancy), then the explicit `context_window_tokens` breakdown field. The
+ * last resort is `input + output` — deliberately cache-excluded, mirroring
+ * `contextWindowTokensUsed`'s own fallback in providers/shared/auto-compact.ts
+ * so both paths degrade identically. Never adds the cache counts back in.
+ */
+function resolveUsedTokens(payload: {
+  totalTokens?: number;
+  apiUsage?: { input_tokens?: number; output_tokens?: number; context_window_tokens?: number } | null;
+}): number {
+  if (typeof payload.totalTokens === 'number') return payload.totalTokens;
+  const api = payload.apiUsage;
+  if (!api) return 0;
+  if (typeof api.context_window_tokens === 'number') return api.context_window_tokens;
+  return (api.input_tokens ?? 0) + (api.output_tokens ?? 0);
 }

--- a/src/cli/slash/commands/info.ts
+++ b/src/cli/slash/commands/info.ts
@@ -114,7 +114,14 @@ function renderSdkBreakdown(
   const output = api?.output_tokens ?? 0;
   const cacheRead = api?.cache_read_input_tokens ?? 0;
   const cacheCreate = api?.cache_creation_input_tokens ?? 0;
-  const lastTurnTotal = input + output + cacheRead + cacheCreate;
+  // Contract: never sum the four fields above — they are a mixed basis
+  // (cumulative input/output vs. last-round-only cache counts), so adding them
+  // double-counts every prior round. `context_window_tokens` is the
+  // provider-computed footprint of the last round; fall back to the
+  // authoritative cumulative total rather than reconstructing a bad sum.
+  const lastTurnTotal = api?.context_window_tokens ?? usage.totalTokens ?? 0;
+  const cacheTotal = cacheRead + cacheCreate;
+  const hitRate = cacheTotal > 0 ? Math.round((cacheRead / cacheTotal) * 100) : undefined;
 
   out.line();
   out.line(palette.bold('Token usage') + palette.dim('  (SDK breakdown)'));
@@ -129,11 +136,14 @@ function renderSdkBreakdown(
   // Last-turn API usage (what Anthropic billed for the most recent call).
   out.line();
   out.line(palette.dim('  Last turn (API):'));
-  out.line(`    input       ${palette.meta(formatTokens(input))}`);
-  out.line(`    output      ${palette.meta(formatTokens(output))}`);
-  out.line(`    cache read  ${palette.meta(formatTokens(cacheRead))}`);
-  out.line(`    cache creat ${palette.meta(formatTokens(cacheCreate))}`);
-  out.line(`    total       ${palette.meta(formatTokens(lastTurnTotal))}`);
+  out.line(`    input       ${palette.meta(formatTokens(input))}  ${palette.dim('(turn total)')}`);
+  out.line(`    output      ${palette.meta(formatTokens(output))}  ${palette.dim('(turn total)')}`);
+  out.line(`    cache read  ${palette.meta(formatTokens(cacheRead))}  ${palette.dim('(last call)')}`);
+  out.line(`    cache creat ${palette.meta(formatTokens(cacheCreate))}  ${palette.dim('(last call)')}`);
+  if (hitRate !== undefined) {
+    out.line(`    cache hit   ${palette.meta(`${hitRate}%`)}  ${palette.dim('(of cached tokens, last call)')}`);
+  }
+  out.line(`    window      ${palette.meta(formatTokens(lastTurnTotal))}  ${palette.dim('(last call occupancy)')}`);
 
   // Top categories by tokens.
   const cats = usage.categories ?? [];

--- a/src/cli/status-line-context.test.ts
+++ b/src/cli/status-line-context.test.ts
@@ -158,7 +158,12 @@ describe('ContextSampler', () => {
     expect(detail).toBeDefined();
     expect(detail?.percentage).toBe(50);
     expect(detail?.limit).toBe(100000);
-    expect(detail?.used).toBe(1000); // 250+250+500
+    // 500 = input 250 + output 250. The 500 cache_read tokens are NOT added:
+    // this stub predates `context_window_tokens`, so the sampler falls back to
+    // the cache-excluded input+output basis (same policy as
+    // contextWindowTokensUsed). Previously this asserted 1000 — the mixed-basis
+    // sum that double-counts prior rounds already contained in cache_read.
+    expect(detail?.used).toBe(500);
     sampler.dispose();
   });
 });


### PR DESCRIPTION
## Summary

Started as "are we caching tool results?" The caching mechanism turned out to be sound — the cached prefix is byte-stable (the `Date:` line in the system prompt is guarded to return the same string reference across turns, tools are frozen at session construction, HOT.md is read once pre-session), tool_result blocks do land inside the cached prefix, and the non-mutating stamp discipline is correct.

The **accounting around it** was not. Three defects, one root cause: cache-aware corrections were made at the provider layer and never propagated to the pricing, display, and observability consumers downstream.

## What was wrong

### 1. Cache writes billed at the 5-minute rate while we request 1-hour

`deriveCallCostUsd` hardcoded `inputPerMTok * 1.25` — the 5m TTL rate. `cache-policy.ts:26` defaults `TTL_DEFAULT = '1h'`, which Anthropic bills at **2x** base input. Every cost figure understated the cache-write component by 37.5%, on every cached session, which is the default.

> 5-minute cache write tokens are 1.25 times the base input tokens price
> 1-hour cache write tokens are **2 times** the base input tokens price
> — [prompt-caching#pricing](https://platform.claude.com/docs/en/build-with-claude/prompt-caching#pricing)

Now derived from the API's own `usage.cache_creation` split (`ephemeral_5m_input_tokens` / `ephemeral_1h_input_tokens`) — what was actually billed, and the only source that stays correct when a request mixes TTLs. When absent, writes fall back to the configured TTL instead of silently assuming 5m.

### 2. Plain input double-subtracted, clamped to zero

```ts
const plainInput = Math.max(0, inputTokens - cachedInputTokens - cacheCreationTokens);
```

`input_tokens` already excludes cache reads and writes (docs' own worked example: `cache_read: 100000`, `input_tokens: 50`, total processed 100,050). Subtracting them again drives the term to `0` in any warm session, since cache reads dwarf plain input.

This repo already found and documented this exact misconception — `providers/shared/auto-compact.ts:30-34` says *"A prior comment here claimed Anthropic's `input_tokens` 'already includes cache reads' — that is wrong."* The correction never reached the cost function.

### 3. Opus 4.5 priced 3x too high

The `claude-opus-4-5-20250929` row carried `$15/$75` — the **retired Opus 4.1/4.0** rates. Published Opus 4.5 pricing is `$5/$25`. Same copy-paste class as the Haiku 3.5→4.5 mixup that `types.test.ts` already has a regression test for. Also adds missing Opus 4.6/4.7/4.8 and Sonnet 4.6 rows, which previously returned `undefined` cost.

### 4. Status line and `/tokens` summed a mixed-basis object

`sumProviderUsage` accumulates input/output cumulatively across a turn's rounds but keeps cache counts at last-round-only (deliberately — `usage.ts:29-35`). By round N the latest `cache_read` already contains every prior round, so adding cumulative input/output back on top double-counts, and the inflation grows with round count.

`turn-accumulator.ts:88-96` documents this precise trap and computes `contextWindowTokens` correctly because of it. Two display sites re-summed anyway — `context-sampler.ts:148` and `info.ts:117` — rendering an inflated absolute right beside a correctly-derived percentage. `config-types.ts:711` documented the wrong formula as if it were live.

### 5. No way to notice any of the above

`afk trace show` printed reason/turns/cost/stop-reason and dropped `cacheRead`/`cacheCreation`, which the schema has carried all along. `/cost` and the turn footer show nothing. Nothing anywhere computed a hit rate. A cache degrading to a 100% miss would have surfaced only on the monthly bill.

## What changed

| Area | Change |
|---|---|
| `pricing.ts` **(new)** | TTL-aware write rates, cache-exclusive plain input, corrected Opus 4.5, added 4.6/4.7/4.8 + Sonnet 4.6. Pure — no env, no clock. |
| `types.ts` | Re-exports pricing; `resolveCacheWriteSplit` reads the API breakdown with a configured-TTL fallback. Single env boundary for pricing. |
| `shared/auto-compact.ts` | Adds `context_window_tokens` — the one scalar display code may safely read — with the mixed-basis invariant documented on the type. |
| `context-sampler.ts`, `info.ts` | Stop summing. Fall back to input+output (cache-excluded), mirroring `contextWindowTokensUsed`. |
| `trace-usage-format.ts` **(new)** | `cache r=/w=/hit=%` on the closure line. `/tokens` gains a hit-rate row. |
| `config-types.ts` | Doc comment now describes the formula the code actually runs. |

Two existing tests asserted the buggy behaviour and are corrected with comments naming what they were locking in:
- `types.test.ts` expected plain input `800` from `1000 - 200 cached`
- `status-line-context.test.ts` expected `used = 1000 // 250+250+500`

## File-size convention

Pricing moved out of `types.ts` (595 LOC, well over the 350 ceiling) into its own file rather than growing it further; `types.ts` re-exports so call sites are unchanged. Same reason `trace-usage-format.ts` exists instead of a new branch in `trace.ts` (804 LOC).

## Verification

```
pnpm lint                 clean
pnpm build                clean
pnpm test                 789 files / 14,968 passed / 2 skipped
pnpm test:coverage        floors met
pnpm audit:sdk:check      lock matches (no new SDK symbol — cache_creation
                          already on the imported Usage type)
pnpm audit:env:check      0 violations
pnpm audit:chalk:check    0 violations
pnpm fix:pins:check       up to date
```

New tests pin every published rate as a golden, both TTL branches, the mixed-TTL split, the no-double-subtract property, and the 0%/100% cache-hit rendering.

## Not addressed here (deliberate — behaviour changes wanting a call)

- **`baseUrl` blanket-disables caching** (`cache-policy.ts:37-45`). Any non-empty `baseUrl` is assumed to be a local shim, but `AFK_MODEL_<TIER>_BASE_URL` is documented for remote Anthropic-compatible gateways — those users silently lose caching with no override. Wants either an `AFK_FORCE_PROMPT_CACHE=1` escape hatch or a loopback-only check.
- **1h TTL as the global default.** Anthropic's guidance: *"If you have prompts used more frequently than every 5 minutes, continue to use the 5-minute cache, because this will continue to be refreshed at no additional charge."* An active REPL refreshes free at 1.25x writes; 1h pays 2x for durability it never uses. Right for daemon/Telegram idle, wrong for REPL — a surface-aware default is a real cost lever, and now that #1 is fixed the premium is finally visible.
- **No anchor breakpoint.** Only 2 of 4 slots used, both at the frontier. Fine for normal rounds, but a wide parallel fan-out (>20 blocks in one round) exceeds the lookback window with nothing behind it. Lowest confidence item — the subagent assigned to it timed out and I reasoned it through from the docs rather than measuring real fan-out widths.
