### PR TITLE
fix(subagent): tell a forked child its tool-round budget at dispatch

### DIFF
--- a/docs/subagent-tool-budget.md
+++ b/docs/subagent-tool-budget.md
@@ -1,0 +1,87 @@
+# The subagent tool-round budget preamble
+
+Reference for `src/agent/subagent/budget-preamble.ts` — the module that
+discloses a forked child's tool-use-round cap to the child itself.
+
+This document carries the `History:`-class material (root cause, incident
+record, decision log) that the long-comment convention in `AFK.md` keeps out
+of the source. The rounds-vs-calls invariant and the fork-site contract stay
+inline in the code as `Invariant:` / `Contract:` blocks.
+
+## What the budget is
+
+The cap meter is tool-use ROUNDS, not tool CALLS. A round is one assistant
+turn that requests tools, so a turn issuing five parallel calls costs 1
+round, not 5 — `providers/anthropic-direct/loop/tool-round.ts` and
+`providers/openai-compatible/query.ts` both increment once per round, after
+dispatching the whole batch. A child that batches independent calls into one
+reply therefore buys roughly 10x the evidence per unit of budget compared
+with one that calls tools one at a time.
+
+## Why the child was never told
+
+Until this module existed, nothing told the child any of that. The only
+budget text that ever reached the model was `WIND_DOWN_NOTE`
+(`providers/shared/tool-loop-cap.ts`), appended on the FINAL round — after
+the budget was already spent, too late to change how the child paced itself.
+The per-round `round 7/50` label produced by `formatRoundLabel` goes out on a
+progress `ProviderEvent` consumed by terminal/UI renderers, and never enters
+model history. The model that is actually doing the pacing never sees it.
+
+So children paced blind: they averaged 1.6–3.0 tool calls per round, and
+burned the full round budget (50, by default) on the evidentiary equivalent
+of about 50 individual tool calls' worth of work — an order of magnitude
+short of what the same round budget could buy if batched.
+
+## The measured cost
+
+296 of 4,671 forks capped (6.34%), $990 in a single telemetry window, with
+the cap rate climbing week over week. That measurement is what motivated
+writing this module rather than leaving the gap in place.
+
+## Why injection happens at the provider-neutral fork site
+
+This module is deliberately provider-agnostic and is applied at exactly ONE
+site — `SubagentManager.forkSubagent`, the sole path to a child
+`AgentSession`. Injecting here rather than inside a provider is what keeps
+the two providers from drifting apart on this behavior.
+
+The repo has already been burned once by exactly that failure: for a while,
+`openai-compatible` shipped without the graceful wind-down that
+`anthropic-direct` had already gotten, because the wind-down logic lived
+inside the anthropic-direct provider instead of at a shared, provider-neutral
+site. Every provider must render `systemPrompt` to function at all, so
+injecting the budget preamble into `systemPrompt` at the fork site means no
+provider has to separately cooperate, remember, or re-implement anything for
+this to work — the same structural fix as the shared wind-down note.
+
+## Where the block lands in the assembled prompt
+
+`injectToolBudgetPreamble` appends the preamble block after any
+caller-supplied `config.systemPrompt`, so within the fork's OWN prompt
+literal the block sits last — operational trailer rather than mission,
+keeping the child's actual instructions at top salience.
+
+That is "last" only relative to the caller-supplied prompt, not last in the
+prompt actually sent to the model. The fork's `config.systemPrompt` becomes
+the `userSystem` argument to `assembleSystemPrompt`
+(`providers/anthropic-direct/query/system-prompt.ts`, mirrored by the
+equivalent assembly in `providers/openai-compatible/index.ts`), which places
+`userSystem` at position 2 of 6 in the final prompt — after `toolBase`, and
+before `memoryPrompt`, `hotMemory`, the `# Environment` fragment, and the
+skill `manifest`. All of those later sections are appended AFTER the budget
+preamble in what the model actually receives.
+
+## Open gaps
+
+- The runtime still has no non-convergence detector. The preamble's closing
+  sentence ("If new evidence has stopped changing your conclusion, stop
+  gathering and answer now.") is a prose stand-in for that missing
+  mechanism, not a substitute with the same reliability — nothing today
+  actually terminates a child whose queries keep varying while its
+  conclusion stops changing.
+- Post-merge, watch a metric pair, not a single number: the cap rate (forks
+  hitting `tool_use_loop_capped`) should fall, but answer completeness must
+  not fall with it. A drop in cap rate that comes from children truncating
+  their investigation early to stay "under budget" would be a regression
+  wearing the shape of an improvement.

--- a/src/agent/subagent.test.ts
+++ b/src/agent/subagent.test.ts
@@ -280,6 +280,54 @@ describe('SubagentManager', () => {
     expect((shared.lastConfig as unknown as Record<string, unknown>)['maxToolUseIterations']).toBe(0);
   });
 
+  // Regression (cap-burn): a child used to learn its tool-round budget ONLY from
+  // WIND_DOWN_NOTE, on the final round, after the budget was already spent — so
+  // it could not pace itself and averaged 1.6-3.0 calls per round against a
+  // meter that charges per ROUND. Disclosure happens at forkSubagent because
+  // that is the sole path to a child AgentSession; asserting on the config the
+  // child session is actually constructed with is what pins the chokepoint
+  // rather than any one dispatch path.
+  it('discloses the resolved tool-round budget in the child systemPrompt', async () => {
+    shared.lastConfig = null;
+    const mgr = new SubagentManager();
+    await mgr.forkSubagent({
+      parent: { sessionId: 'p' },
+      config: { model: 'sonnet', systemPrompt: 'You are the research agent.' },
+    });
+    const sp = (shared.lastConfig as unknown as Record<string, unknown>)['systemPrompt'];
+    expect(typeof sp).toBe('string');
+    // The DEFAULT cap is disclosed even though no caller passed one.
+    expect(sp as string).toContain(`${SUBAGENT_DEFAULT_MAX_TOOL_USE_ITERATIONS} tool-use rounds`);
+    // The caller's own prompt survives, and keeps top salience.
+    expect(sp as string).toMatch(/^You are the research agent\./);
+  });
+
+  it('discloses an explicitly overridden budget rather than the default', async () => {
+    shared.lastConfig = null;
+    const mgr = new SubagentManager();
+    await mgr.forkSubagent({
+      parent: { sessionId: 'p' },
+      config: { model: 'sonnet', maxToolUseIterations: 7 },
+    });
+    const sp = (shared.lastConfig as unknown as Record<string, unknown>)['systemPrompt'];
+    expect(sp as string).toContain('7 tool-use rounds');
+    expect(sp as string).not.toContain(
+      `${SUBAGENT_DEFAULT_MAX_TOOL_USE_ITERATIONS} tool-use rounds`,
+    );
+  });
+
+  it('discloses no budget to an explicitly unbounded child', async () => {
+    shared.lastConfig = null;
+    const mgr = new SubagentManager();
+    await mgr.forkSubagent({
+      parent: { sessionId: 'p' },
+      config: { model: 'sonnet', systemPrompt: 'untouched', maxToolUseIterations: 0 },
+    });
+    expect((shared.lastConfig as unknown as Record<string, unknown>)['systemPrompt']).toBe(
+      'untouched',
+    );
+  });
+
   // Anti-hang (sibling of the iteration cap): a fork that hits an OAuth
   // usage-limit 429 must FAIL FAST with the classified error, not silently
   // auto-pause and poll for reset (up to 2h in retry-layer.ts) while its

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -64,6 +64,7 @@ import {
   resolveSubagentTimeoutMs,
   resolveSubagentIdleTimeoutMs,
 } from './subagent/constants.js';
+import { injectToolBudgetPreamble } from './subagent/budget-preamble.js';
 import type {
   ForkParent,
   ForkSubagentOptions,
@@ -474,7 +475,16 @@ export class SubagentManager {
       );
     }
 
-    const childConfig: AgentConfig = {
+    // Invariant (budget disclosure): the preamble is applied HERE, wrapping the
+    // whole literal, because this is the sole path to a child AgentSession —
+    // agent-tool, compose/DAG, skill forks, and in-process callers all converge
+    // on forkSubagent, while `tools/subagent/child-config.ts` is reached only by
+    // the agent-tool paths. It wraps rather than sits inside the literal so it
+    // reads the FINAL resolved `maxToolUseIterations` (line ~571 below), not the
+    // caller's pre-default value. Injecting at this provider-neutral site is
+    // also what stops the two providers from drifting on it — see the module
+    // header on ./subagent/budget-preamble.js.
+    const childConfig: AgentConfig = injectToolBudgetPreamble({
       ...options.config,
       // Invariant (trace seal ownership): mark this session as a fork so it
       // never seals the SHARED witness trace. The whole tree shares ONE
@@ -656,7 +666,7 @@ export class SubagentManager {
       ...(options.phaseRole === 'read-only'
         ? { provider: buildPhaseRestrictedProvider('read-only', effectiveChildModel) }
         : {}),
-    };
+    });
 
     // Occupancy touch: subagents never write presence files (top-level-only
     // by design — presence.ts), so the worktree sweep's live-session guard

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -480,10 +480,12 @@ export class SubagentManager {
     // agent-tool, compose/DAG, skill forks, and in-process callers all converge
     // on forkSubagent, while `tools/subagent/child-config.ts` is reached only by
     // the agent-tool paths. It wraps rather than sits inside the literal so it
-    // reads the FINAL resolved `maxToolUseIterations` (line ~571 below), not the
-    // caller's pre-default value. Injecting at this provider-neutral site is
-    // also what stops the two providers from drifting on it — see the module
-    // header on ./subagent/budget-preamble.js.
+    // reads the FINAL resolved `maxToolUseIterations` — the
+    // `options.config.maxToolUseIterations ?? SUBAGENT_DEFAULT_MAX_TOOL_USE_ITERATIONS`
+    // default applied further down in this same literal — not the caller's
+    // pre-default value. Injecting at this provider-neutral site is also what
+    // stops the two providers from drifting on it — see the module header on
+    // ./subagent/budget-preamble.js.
     const childConfig: AgentConfig = injectToolBudgetPreamble({
       ...options.config,
       // Invariant (trace seal ownership): mark this session as a fork so it

--- a/src/agent/subagent/budget-preamble.test.ts
+++ b/src/agent/subagent/budget-preamble.test.ts
@@ -23,6 +23,20 @@ describe('renderBudgetPreamble', () => {
     expect(renderBudgetPreamble(12)).toContain('12 tool-use rounds');
     expect(renderBudgetPreamble(12)).not.toContain('50 tool-use rounds');
   });
+
+  // Regression: the "roughly 50 and roughly 500" example used to be a hardcoded
+  // literal that stayed put regardless of maxRounds, so a small cap (e.g. 7)
+  // rendered a preamble that contradicted itself — "7 is a hard ceiling"
+  // alongside an example scaled for 50. The example must track maxRounds.
+  it('scales the batching example to the default cap of 50', () => {
+    expect(renderBudgetPreamble(50)).toContain('roughly 50 and roughly 500 tool calls');
+  });
+
+  it('scales the batching example to a small cap instead of the hardcoded 50/500', () => {
+    const text = renderBudgetPreamble(7);
+    expect(text).toContain('roughly 7 and roughly 70 tool calls');
+    expect(text).not.toContain('roughly 50');
+  });
 });
 
 describe('injectToolBudgetPreamble', () => {

--- a/src/agent/subagent/budget-preamble.test.ts
+++ b/src/agent/subagent/budget-preamble.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+
+import { injectToolBudgetPreamble, renderBudgetPreamble } from './budget-preamble.js';
+import type { AgentConfig } from '../types/config-types.js';
+
+describe('renderBudgetPreamble', () => {
+  it('states the round count and that a round is one reply, not one call', () => {
+    const text = renderBudgetPreamble(50);
+    expect(text).toContain('50 tool-use rounds');
+    expect(text).toContain('costs 1 round, not 5');
+  });
+
+  // The framing is load-bearing, not decoration: disclosing a budget WITHOUT
+  // "ceiling, not target" risks inverting the fix into "I have 50 rounds, let
+  // me use them". Assert the framing survives future edits to the wording.
+  it('frames the budget as a ceiling to finish under, not an allowance to spend', () => {
+    const text = renderBudgetPreamble(50);
+    expect(text).toContain('hard ceiling, not a target');
+    expect(text).toContain('stop gathering and answer now');
+  });
+
+  it('interpolates the actual cap, not a hardcoded default', () => {
+    expect(renderBudgetPreamble(12)).toContain('12 tool-use rounds');
+    expect(renderBudgetPreamble(12)).not.toContain('50 tool-use rounds');
+  });
+});
+
+describe('injectToolBudgetPreamble', () => {
+  it('appends after an existing string prompt so the child mission keeps top salience', () => {
+    const config: AgentConfig = { systemPrompt: 'You are the research agent.', maxToolUseIterations: 50 };
+    const out = injectToolBudgetPreamble(config);
+    expect(typeof out.systemPrompt).toBe('string');
+    expect(out.systemPrompt as string).toMatch(/^You are the research agent\./);
+    expect(out.systemPrompt as string).toContain('50 tool-use rounds');
+  });
+
+  it('becomes the system prompt when none is set', () => {
+    const out = injectToolBudgetPreamble({ maxToolUseIterations: 20 });
+    expect(out.systemPrompt).toBe(renderBudgetPreamble(20));
+  });
+
+  it('treats an empty-string prompt as absent rather than emitting leading blank lines', () => {
+    const out = injectToolBudgetPreamble({ systemPrompt: '', maxToolUseIterations: 20 });
+    expect(out.systemPrompt).toBe(renderBudgetPreamble(20));
+  });
+
+  it('appends into the append slot of a preset prompt', () => {
+    const out = injectToolBudgetPreamble({
+      systemPrompt: { type: 'preset', preset: 'claude_code', append: 'extra' },
+      maxToolUseIterations: 30,
+    });
+    expect(out.systemPrompt).toEqual({
+      type: 'preset',
+      preset: 'claude_code',
+      append: `extra\n\n${renderBudgetPreamble(30)}`,
+    });
+  });
+
+  it('fills an empty preset append without a leading separator', () => {
+    const out = injectToolBudgetPreamble({
+      systemPrompt: { type: 'preset', preset: 'claude_code' },
+      maxToolUseIterations: 30,
+    });
+    expect(out.systemPrompt).toEqual({
+      type: 'preset',
+      preset: 'claude_code',
+      append: renderBudgetPreamble(30),
+    });
+  });
+
+  // `0` means unbounded (resolveMaxToolIterations) — a child with no ceiling
+  // has no budget to disclose, and claiming one would be a lie.
+  it.each([
+    ['unset', undefined],
+    ['zero (unbounded)', 0],
+    ['negative', -1],
+  ])('is a no-op when the cap is %s', (_label, cap) => {
+    const config: AgentConfig = {
+      systemPrompt: 'untouched',
+      ...(cap === undefined ? {} : { maxToolUseIterations: cap }),
+    };
+    const out = injectToolBudgetPreamble(config);
+    expect(out).toBe(config);
+    expect(out.systemPrompt).toBe('untouched');
+  });
+
+  it('floors a fractional cap rather than printing a decimal', () => {
+    const out = injectToolBudgetPreamble({ maxToolUseIterations: 12.7 });
+    expect(out.systemPrompt).toContain('12 tool-use rounds');
+    expect(out.systemPrompt).not.toContain('12.7');
+  });
+
+  it('does not mutate the input config', () => {
+    const config: AgentConfig = { systemPrompt: 'original', maxToolUseIterations: 50 };
+    injectToolBudgetPreamble(config);
+    expect(config.systemPrompt).toBe('original');
+  });
+});

--- a/src/agent/subagent/budget-preamble.ts
+++ b/src/agent/subagent/budget-preamble.ts
@@ -9,27 +9,17 @@
  * therefore buys ~10x the evidence per unit budget compared with one that
  * calls tools one at a time.
  *
- * Until this module existed, nothing told the child any of that. The only
- * budget text that ever reached the model was `WIND_DOWN_NOTE`
- * (`providers/shared/tool-loop-cap.ts`), appended on the FINAL round — after
- * the budget was already spent. The per-round `round 7/50` label from
- * `formatRoundLabel` goes to a progress ProviderEvent consumed by terminal/UI
- * renderers and never enters model history. So children paced blind, averaged
- * 1.6-3.0 calls per round, and burned the full 50 rounds on ~50 calls' worth
- * of evidence. Measured cost of that gap: 296 of 4,671 forks capped (6.34%),
- * $990 in a single telemetry window, with the rate climbing week over week.
- *
  * This module is deliberately provider-agnostic and is applied at ONE site —
  * `SubagentManager.forkSubagent`, the sole path to a child `AgentSession`.
- * Injecting here rather than inside a provider is what keeps the two providers
- * from drifting apart; the repo has already been burned once by exactly that
- * failure (openai-compatible shipped without the graceful wind-down for a
- * while after anthropic-direct got it). Every provider must render
- * `systemPrompt`, so no provider has to cooperate for this to work.
  *
  * Shape handling mirrors `companion/primer-loader.ts:injectCompanionPrimer` —
  * same union, same shallow-copy discipline, same "no prompt set → the block
  * becomes the prompt" fallback.
+ *
+ * History: why the child was never told about the budget before this module
+ * existed, the measured cost of that gap, and why injection happens at this
+ * specific provider-neutral fork site (incl. the openai-compatible wind-down
+ * drift precedent that motivated it) live in docs/subagent-tool-budget.md.
  *
  * @module agent/subagent/budget-preamble
  */
@@ -54,7 +44,7 @@ export function renderBudgetPreamble(maxRounds: number): string {
     `You have ${maxRounds} tool-use rounds for this turn. A round is one reply that requests tools:`,
     'issuing five tool calls in a SINGLE reply costs 1 round, not 5. Batch independent reads,',
     'greps, and commands into one reply instead of calling them one at a time — it is the',
-    'difference between roughly 50 and roughly 500 tool calls on the same budget.',
+    `difference between roughly ${maxRounds} and roughly ${maxRounds * 10} tool calls on the same budget.`,
     '',
     `${maxRounds} is a hard ceiling, not a target. Aim to finish well under it. When the budget is`,
     'spent you get one final reply with tools removed and must answer from what you already',
@@ -71,7 +61,14 @@ export function renderBudgetPreamble(maxRounds: number): string {
  * with no ceiling has no budget to disclose.
  *
  * Appends AFTER any existing prompt so the child's actual instructions keep
- * top salience and this sits last, as operational trailer rather than mission.
+ * top salience and this sits last within the caller's prompt — operational
+ * trailer rather than mission. That is "last" only within the prompt this
+ * config supplies: provider assembly (`assembleSystemPrompt` in
+ * `providers/anthropic-direct/query/system-prompt.ts`, mirrored in
+ * `providers/openai-compatible/index.ts`) places this prompt at position 2 of
+ * 6 and appends further sections — memory instructions, hot memory, the
+ * environment fragment, and the skill manifest — after it in what the model
+ * actually receives.
  *
  * Does not mutate the input — returns a shallow copy.
  */

--- a/src/agent/subagent/budget-preamble.ts
+++ b/src/agent/subagent/budget-preamble.ts
@@ -1,0 +1,106 @@
+/**
+ * Disclose a forked child's tool-round budget to the child itself.
+ *
+ * Invariant: the cap meter is tool-use ROUNDS, not tool CALLS. A round is one
+ * assistant turn that requests tools, so a turn issuing five parallel calls
+ * costs 1 round, not 5 (`providers/anthropic-direct/loop/tool-round.ts` and
+ * `providers/openai-compatible/query.ts` both increment once per round, after
+ * dispatching the whole batch). A child that batches independent calls
+ * therefore buys ~10x the evidence per unit budget compared with one that
+ * calls tools one at a time.
+ *
+ * Until this module existed, nothing told the child any of that. The only
+ * budget text that ever reached the model was `WIND_DOWN_NOTE`
+ * (`providers/shared/tool-loop-cap.ts`), appended on the FINAL round — after
+ * the budget was already spent. The per-round `round 7/50` label from
+ * `formatRoundLabel` goes to a progress ProviderEvent consumed by terminal/UI
+ * renderers and never enters model history. So children paced blind, averaged
+ * 1.6-3.0 calls per round, and burned the full 50 rounds on ~50 calls' worth
+ * of evidence. Measured cost of that gap: 296 of 4,671 forks capped (6.34%),
+ * $990 in a single telemetry window, with the rate climbing week over week.
+ *
+ * This module is deliberately provider-agnostic and is applied at ONE site —
+ * `SubagentManager.forkSubagent`, the sole path to a child `AgentSession`.
+ * Injecting here rather than inside a provider is what keeps the two providers
+ * from drifting apart; the repo has already been burned once by exactly that
+ * failure (openai-compatible shipped without the graceful wind-down for a
+ * while after anthropic-direct got it). Every provider must render
+ * `systemPrompt`, so no provider has to cooperate for this to work.
+ *
+ * Shape handling mirrors `companion/primer-loader.ts:injectCompanionPrimer` —
+ * same union, same shallow-copy discipline, same "no prompt set → the block
+ * becomes the prompt" fallback.
+ *
+ * @module agent/subagent/budget-preamble
+ */
+
+import type { AgentConfig } from '../types/config-types.js';
+
+/**
+ * Render the budget preamble for a given round cap.
+ *
+ * Contract: the text frames `maxRounds` as a CEILING to finish well under, not
+ * an allowance to spend. That framing is load-bearing — disclosing a budget
+ * without it risks the opposite failure ("I have 50 rounds, let me use them"),
+ * and a wide-scope task will exhaust any budget it is told about. The final
+ * sentence is the cheapest available substitute for the non-convergence
+ * detector the runtime still lacks: nothing today terminates a child whose
+ * queries keep varying while its conclusion stops changing.
+ */
+export function renderBudgetPreamble(maxRounds: number): string {
+  return [
+    '# Tool budget',
+    '',
+    `You have ${maxRounds} tool-use rounds for this turn. A round is one reply that requests tools:`,
+    'issuing five tool calls in a SINGLE reply costs 1 round, not 5. Batch independent reads,',
+    'greps, and commands into one reply instead of calling them one at a time — it is the',
+    'difference between roughly 50 and roughly 500 tool calls on the same budget.',
+    '',
+    `${maxRounds} is a hard ceiling, not a target. Aim to finish well under it. When the budget is`,
+    'spent you get one final reply with tools removed and must answer from what you already',
+    'gathered, so a partial answer delivered early beats a complete one you never get to give.',
+    'If new evidence has stopped changing your conclusion, stop gathering and answer now.',
+  ].join('\n');
+}
+
+/**
+ * Append the tool-budget preamble to a forked child's system prompt.
+ *
+ * No-op (returns the config unchanged) when `maxToolUseIterations` is absent or
+ * non-positive — `0` means unbounded (`resolveMaxToolIterations`), and a child
+ * with no ceiling has no budget to disclose.
+ *
+ * Appends AFTER any existing prompt so the child's actual instructions keep
+ * top salience and this sits last, as operational trailer rather than mission.
+ *
+ * Does not mutate the input — returns a shallow copy.
+ */
+export function injectToolBudgetPreamble(config: AgentConfig): AgentConfig {
+  const maxRounds = config.maxToolUseIterations;
+  if (typeof maxRounds !== 'number' || !Number.isFinite(maxRounds) || maxRounds <= 0) {
+    return config;
+  }
+
+  const block = renderBudgetPreamble(Math.floor(maxRounds));
+  const sp = config.systemPrompt;
+
+  if (typeof sp === 'string') {
+    return sp.length > 0
+      ? { ...config, systemPrompt: `${sp}\n\n${block}` }
+      : { ...config, systemPrompt: block };
+  }
+
+  if (sp && typeof sp === 'object' && 'type' in sp && sp.type === 'preset') {
+    const existingAppend = sp.append ?? '';
+    return {
+      ...config,
+      systemPrompt: {
+        ...sp,
+        append: existingAppend.length > 0 ? `${existingAppend}\n\n${block}` : block,
+      },
+    };
+  }
+
+  // No system prompt set — the preamble becomes the system prompt.
+  return { ...config, systemPrompt: block };
+}


### PR DESCRIPTION
## What

Tell a forked subagent its tool-round budget at dispatch, instead of only at wind-down when the budget is already gone.

## Why

The cap meter is tool-use **rounds**, not tool **calls** — a round costs 1 no matter how many calls it batches (both providers increment once per round, after dispatching the whole batch). So a child that batches independent calls gets ~500 tool calls out of its 50-round budget; a child that calls tools one at a time gets ~50.

Nothing told the child any of that:

- `WIND_DOWN_NOTE` is the only budget text that ever reaches model history, and it is appended on the **final** round.
- The `round 7/50` label from `formatRoundLabel` goes to a progress `ProviderEvent` consumed by terminal/UI renderers. `conversationHistory` only ever receives assistant messages, so the model never sees it.
- No other disclosure surface exists: `get_runtime_state`'s `RuntimeSelf` schema has no cap field, the numeric ceilings in `agents/builtins.ts` live only in comments and constants, the `agent`/`compose` tool schemas describe the *dispatcher's* knob rather than the child's resolved value, and named-agent prompts contain zero budget mentions.

Measured consequence — capped children average **1.6–3.0 calls per round**, i.e. running at roughly a tenth of the evidence ceiling their budget actually permits, then getting cut off mid-investigation.

| Telemetry | Value |
|---|---|
| Forks capped | 296 / 4,671 (**6.34%**) |
| Spend, one window | **$990.30** |
| Trend | 5.34% → **13.65%/week** |
| Card `closure-anomaly-iteration-cap` | 153 closures / 90 sessions / **$496.74** |

All 153 closures were forks — top-level defaults to `0` (uncapped), and `AFK_MAX_TOOL_USE_ITERATIONS` is unset by default.

## How

A 697-char preamble appended to the child's system prompt, stating the resolved cap, that a round is one *reply* rather than one *call*, and that the number is a ceiling to finish well under.

No-op when the cap is `0`/unset — that means unbounded, so there is no budget to disclose and claiming one would be a lie.

### Why `forkSubagent` and not `child-config.ts`

`SubagentManager.forkSubagent` is the sole path to a child `AgentSession`. `tools/subagent/child-config.ts` looks like the natural home but is reached by **only the agent-tool paths**:

| Dispatch path | Through `buildChildConfig`? |
|---|---|
| agent tool (fg / bg / worktree-isolated) | yes |
| compose / DAG nodes | **no** — own per-node config |
| skill forks | **no** — separate builder |
| in-process callers (mint phases, user-skills, audit-fit) | **no** — hand-built config |

Injecting at the chokepoint is also provider-neutral, so neither provider has to cooperate. That is deliberate: this repo has already been burned once by exactly that drift, when openai-compatible shipped without the graceful wind-down after anthropic-direct got it.

Shape handling mirrors the existing `companion/primer-loader.ts:injectCompanionPrimer` — same union, same shallow-copy discipline, same no-prompt fallback. The new concern lives in its own 106-LOC module rather than growing `subagent.ts`.

## Verification

- **Failing baseline proven.** With the wiring reverted (`git stash push -- src/agent/subagent.ts`), the two disclosure assertions fail; restored, they pass. A regression test that never fails before the fix would be worthless.
- Full suite: **15,000 passed / 0 failed** (788 files).
- Gates green: `lint`, `build`, `audit:sdk:check`, `audit:env:check`, `scan:env:check`, `audit:chalk:check`, `fix:pins:check`.
- No exact-string prompt assertion broke — injecting downstream of `buildChildConfig` leaves `child-config.test.ts` and `subagent-executor.named-agents.test.ts` untouched.

13 unit tests cover the render text and every union shape; 3 integration tests assert on the config the child session is actually constructed with, which is what pins the chokepoint rather than any single dispatch path.

## Known limitation — please read before assuming this closes the problem

**Disclosure alone is not expected to eliminate cap-burn.** The shadow-verification wave for the underlying diagnosis accidentally ran a controlled experiment on this very fix:

| Wave | Budget | Task shape | Outcome |
|---|---|---|---|
| 2 agents | 18 rounds | narrow — verify 3 named claims | **both finished** |
| 3 agents | 20–22 rounds | broad — "enumerate every X" | **all three capped** |

Same disclosure, same batching instruction, same model; the capped group had *more* budget. The variable that moved was **task breadth**. An unbounded-breadth task will exhaust any budget it is told about.

So this is the cheap, universal first move — expect it to shave the tail, not remove it. The real remaining gap is that **nothing terminates a child whose queries keep varying while its conclusion stops changing**: the repeat circuit breaker needs 8 *consecutive byte-identical* calls and only nudges, `suspected-loop-detector` is explicitly observe-only, and the idle watchdog measures silence while these children are never idle. That is left to a follow-up so this change can be measured on its own.

## Follow-ups (not in this PR)

1. Non-convergence / no-new-evidence detection — the actual mechanism gap.
2. Task-scope discipline at dispatch — likely higher leverage than disclosure, currently unmeasured.
3. Possible bug, unverified: `anthropic-direct` may not strip `WIND_DOWN_NOTE` from its long-lived message array after the wind-down round. `openai-compatible` is structurally safe because it rebuilds `messages` from `priorTurns`. If the note persists, it leaks into resumed history and would tell a resumed session its budget is spent when it is not.

Full diagnosis, including the corrected attribution method: `~/.afk/workspace/reports/cap-burn-diagnosis-2026-08-05.md`
