### PR TITLE
fix(pricing): resolve dated wire ids for Opus 4.6/4.7/4.8 and Sonnet 4.6

### DIFF
--- a/src/agent/providers/anthropic-direct/pricing.test.ts
+++ b/src/agent/providers/anthropic-direct/pricing.test.ts
@@ -117,3 +117,34 @@ describe('deriveCallCostUsd — published rate goldens', () => {
     }
   });
 });
+
+describe('deriveCallCostUsd — dated wire ids fall back to dateless rows (#911)', () => {
+  // #909 added Opus 4.6/4.7/4.8 and Sonnet 4.6 rows keyed dateless
+  // (`claude-opus-4-8`), but the wire ids the API actually sends are dated
+  // (`claude-opus-4-8-20260528` — see resolve-effort.test.ts:32,44,49 for the
+  // production-verified ids). The exact-match lookup missed those, silently
+  // dropping cost for exactly the models the dateless rows were added to
+  // price. Each case below pins a dated id against its dateless twin.
+  it.each([
+    ['claude-opus-4-8', 'claude-opus-4-8-20260528'],
+    ['claude-opus-4-7', 'claude-opus-4-7-20250901'],
+    ['claude-opus-4-6', 'claude-opus-4-6-20250901'],
+    ['claude-sonnet-4-6', 'claude-sonnet-4-6-20250901'],
+  ])('%s dated as %s resolves to the same defined cost', (dateless, dated) => {
+    const datelessCost = deriveCallCostUsd(dateless, M, M, 0, 0);
+    const datedCost = deriveCallCostUsd(dated, M, M, 0, 0);
+    expect(datelessCost).toBeDefined();
+    expect(datedCost).toBeDefined();
+    expect(datedCost).toBeCloseTo(datelessCost!, 8);
+  });
+
+  it('does not let normalization match an unrelated row', () => {
+    // A genuinely unknown model — even one that looks date-suffixed — must
+    // still return undefined rather than falling back to some other row.
+    expect(deriveCallCostUsd('claude-unknown-99-20260528', 1000, 500, 0, 0)).toBeUndefined();
+  });
+
+  it('still returns undefined for an unknown model with no date suffix', () => {
+    expect(deriveCallCostUsd('claude-unknown-99', 1000, 500, 0, 0)).toBeUndefined();
+  });
+});

--- a/src/agent/providers/anthropic-direct/pricing.ts
+++ b/src/agent/providers/anthropic-direct/pricing.ts
@@ -111,6 +111,28 @@ export interface CacheWriteSplit {
   ephemeral1h: number;
 }
 
+/** Trailing `-YYYYMMDD` wire-id date suffix, e.g. the `-20260528` in
+ * `claude-opus-4-8-20260528`. Exactly 8 digits so a short version segment
+ * (`-4-8`) or a non-numeric alias suffix (`-latest`) never matches. */
+const DATE_SUFFIX = /-\d{8}$/;
+
+/**
+ * Contract: exact match first; on a miss, strip one trailing `-YYYYMMDD`
+ * suffix and retry against the same table. Some {@link MODEL_PRICING} rows
+ * are keyed dateless (e.g. `claude-opus-4-8`) while the wire ids Anthropic
+ * actually sends are dated (`claude-opus-4-8-20260528`); this fixes that
+ * whole class in one place instead of enumerating dated keys per row, with
+ * no new imports and no env reads. A model with neither an exact nor a
+ * stripped match still returns `undefined` — this only retries the same
+ * table with a shorter key, it never invents a mapping.
+ */
+function lookupPricing(model: string): ModelPricing | undefined {
+  const exact = MODEL_PRICING.get(model);
+  if (exact) return exact;
+  const base = model.replace(DATE_SUFFIX, '');
+  return base === model ? undefined : MODEL_PRICING.get(base);
+}
+
 /**
  * Contract: returns the USD cost of ONE API call, or `undefined` when the
  * model is absent from {@link MODEL_PRICING} — callers must treat `undefined`
@@ -133,7 +155,7 @@ export function deriveCallCostUsd(
   cacheCreationTokens: number,
   cacheWriteSplit?: CacheWriteSplit,
 ): number | undefined {
-  const pricing = MODEL_PRICING.get(model);
+  const pricing = lookupPricing(model);
   if (!pricing) return undefined;
 
   const M = 1_000_000;


### PR DESCRIPTION
Closes #911

## Problem

`MODEL_PRICING` (`src/agent/providers/anthropic-direct/pricing.ts:76-80`) keys the Opus 4.6/4.7/4.8 and Sonnet 4.6 rows **dateless** (`claude-opus-4-8`), while every other dated-family row carries its date (`claude-opus-4-5-20250929`, `claude-haiku-4-5-20250929`, `claude-sonnet-4-5-20250929`). The lookup at `pricing.ts:136-137` was exact-match `MODEL_PRICING.get(model)`, returning `undefined` on a miss. `loop.ts:261` passes the resolved model string through raw, so a dated wire id for one of those four models (e.g. `claude-opus-4-8-20260528`, asserted as production behaviour in `resolve-effort.test.ts:32,44,49`) silently lost its cost — the exact outcome the #909 rows were added to fix.

## Fix

Chose **option A** (pure normalization fallback) over option B (adding the four dated keys as data) because it fixes the whole class — any future dated id landing on a dateless row — in one place, not just today's four instances, with zero new imports and zero env reads.

Added `lookupPricing()` in `pricing.ts`: try `MODEL_PRICING.get(model)` first; on a miss, strip one trailing `-YYYYMMDD` suffix (regex-anchored to exactly 8 digits, so it can't accidentally match a short version segment like `-4-8` or a non-numeric alias like `-latest`) and retry against the same table. A model with no exact match and no successful strip still returns `undefined` — the helper only retries the same table with a shorter key, it never invents a mapping, so the documented "unknown model → `undefined`, never zero" contract in `deriveCallCostUsd` is unchanged and still tested.

**Rejected the issue's suggested `resolveModelInput()` approach.** That function lives in `src/agent/session/model-slots.ts`, which imports `env` from `src/config/env.js` and reads process-global bindings installed by `loadConfig()`. Importing it into `pricing.ts` would break this module's explicitly documented purity invariant (`pricing.ts`'s own docstring: "Pure: no env reads, no clock ... so its golden-rate tests cannot drift with ambient config" — see `types.ts:483-484` for the parallel note on why the one env-reading boundary for pricing lives in `types.ts`, not here). A pure string-suffix strip needs no env access and preserves that invariant.

## Changes

- `src/agent/providers/anthropic-direct/pricing.ts` — added `DATE_SUFFIX` regex + `lookupPricing()` helper; `deriveCallCostUsd` now calls it instead of `MODEL_PRICING.get()` directly. +23 lines net.
- `src/agent/providers/anthropic-direct/pricing.test.ts` — new `describe` block appended at end of file (per parallel-agent merge-conflict avoidance): each of the four affected models' dated id pinned against its dateless twin, plus two `undefined`-contract guards (unrelated date-suffixed unknown model; plain unknown model). +31 lines.

## Gates run

- `pnpm install` — clean (the `dist/postinstall.mjs` MODULE_NOT_FOUND is the documented benign pre-build noise).
- `pnpm lint` (`tsc --noEmit`) — clean, no errors.
- `pnpm test src/agent/providers/anthropic-direct/pricing.test.ts` — 17/17 passed (11 pre-existing + 6 new).
- `pnpm test src/agent/providers/anthropic-direct/types.test.ts` — 19/19 passed (re-exported pricing symbols unaffected).

Full suite / coverage not run here (three agents working in parallel on this file region-by-region; CI runs the full suite on this PR).

## Scope

Touched only the `MODEL_PRICING` lookup lane (`pricing.ts` ~lines 111-160, `pricing.test.ts` end-of-file append). Did not touch `deriveCallCostUsd`'s cost-arithmetic body, `resolveCacheWriteSplit`/`types.ts`, or any of the CLI usage-formatting files — those are owned by sibling in-flight PRs on the same file.
