### PR TITLE
fix(pricing): bill cache-creation residual outside known TTL buckets, clamp wire-sourced counts

### DIFF
--- a/src/agent/providers/anthropic-direct/pricing.test.ts
+++ b/src/agent/providers/anthropic-direct/pricing.test.ts
@@ -63,6 +63,68 @@ describe('deriveCallCostUsd — cache-write TTL rates', () => {
   });
 });
 
+describe('deriveCallCostUsd — cache-creation residual outside known TTL buckets', () => {
+  it('bills the residual at the 1h rate instead of dropping it (issue #912)', () => {
+    // cacheCreationTokens (1000) exceeds ephemeral5m+ephemeral1h (700) by 300 —
+    // a hypothetical third TTL tier the two known buckets don't cover. Before
+    // the fix, those 300 tokens cost $0 with no error anywhere.
+    const cost = deriveCallCostUsd('claude-sonnet-5', 0, 0, 0, 1000, {
+      ephemeral5m: 500,
+      ephemeral1h: 200,
+    })!;
+    const expected = (500 / M) * 3.75 + (200 / M) * 6.0 + (300 / M) * 6.0;
+    expect(cost).toBeCloseTo(expected, 8);
+    // Equivalent: the residual is billed at the same rate as an explicit 1h
+    // write of the same size (300 tokens), confirming which rate was used.
+    const explicit1hOnly = deriveCallCostUsd('claude-sonnet-5', 0, 0, 0, 700, {
+      ephemeral5m: 500,
+      ephemeral1h: 200,
+    })!;
+    expect(cost - explicit1hOnly).toBeCloseTo((300 / M) * 6.0, 8);
+  });
+
+  it('is unchanged when the split already sums to the full total (regression guard)', () => {
+    // A consistent split (today's only reachable shape, per the SDK's
+    // required, non-nullable CacheCreation fields) must cost exactly what it
+    // did before the residual logic was added.
+    const cost = deriveCallCostUsd('claude-sonnet-5', 0, 0, 0, 1000, {
+      ephemeral5m: 600,
+      ephemeral1h: 400,
+    });
+    const expected = (600 / M) * 3.75 + (400 / M) * 6.0;
+    expect(cost).toBeCloseTo(expected, 8);
+  });
+
+  it('does not double-bill when no split is supplied and the fallback already equals the total', () => {
+    const cost = deriveCallCostUsd('claude-sonnet-5', 0, 0, 0, 1000);
+    expect(cost).toBeCloseTo((1000 / M) * 3.75, 8);
+  });
+
+  it('negative token counts do not produce a negative cost', () => {
+    const cost = deriveCallCostUsd('claude-sonnet-5', -1000, -500, -200, -300)!;
+    expect(cost).toBe(0);
+    expect(cost).not.toBeLessThan(0);
+  });
+
+  it('NaN token counts do not produce a NaN cost', () => {
+    const cost = deriveCallCostUsd('claude-sonnet-5', NaN, 500, 0, 0)!;
+    expect(Number.isNaN(cost)).toBe(false);
+    expect(cost).toBeCloseTo((500 / M) * 15.0, 8);
+  });
+
+  it('a negative or NaN split field does not poison the residual or go negative', () => {
+    const cost = deriveCallCostUsd('claude-sonnet-5', 0, 0, 0, 1000, {
+      ephemeral5m: NaN,
+      ephemeral1h: -200,
+    })!;
+    // Both split fields clamp to 0, so the full 1000 becomes residual, billed
+    // at the 1h rate — and the result must be finite and non-negative.
+    expect(Number.isFinite(cost)).toBe(true);
+    expect(cost).not.toBeLessThan(0);
+    expect(cost).toBeCloseTo((1000 / M) * 6.0, 8);
+  });
+});
+
 describe('deriveCallCostUsd — plain input is cache-exclusive', () => {
   it('does not subtract cache counts from input_tokens', () => {
     // Per the Messages API docs, `input_tokens` counts only tokens neither

--- a/src/agent/providers/anthropic-direct/pricing.ts
+++ b/src/agent/providers/anthropic-direct/pricing.ts
@@ -118,10 +118,17 @@ export interface CacheWriteSplit {
  *
  * Pure: no env reads, no clock. `cacheWriteSplit` is supplied by the caller so
  * this stays deterministic under test; when omitted, every cache-write token
- * is priced at the 5-minute rate (the API's own default TTL).
+ * is priced at the 5-minute rate (the API's own default TTL). Any portion of
+ * `cacheCreationTokens` not covered by `split.ephemeral5m + split.ephemeral1h`
+ * (a TTL tier this module doesn't yet know about) is billed as a residual at
+ * the 1h rate — see the inline Invariant comment for why.
  *
  * `inputTokens` must be the raw `usage.input_tokens` — already cache-exclusive
  * per fact 1 in the module header. Do not pre-subtract cache counts from it.
+ *
+ * All five numeric parameters are clamped to finite, non-negative values
+ * before use — a negative or NaN wire-sourced count cannot produce a
+ * negative or NaN result.
  *
  * @internal exported for unit tests
  */
@@ -138,9 +145,22 @@ export function deriveCallCostUsd(
 
   const M = 1_000_000;
 
+  // Guard: every count below is wire-sourced (Messages API `usage.*` fields,
+  // or a hand-built fixture in a direct test call). A negative or NaN value
+  // must not produce a negative or NaN totalCostUsd. `resolveCacheWriteSplit`
+  // (types.ts) clamps the split fields on the production call path, but this
+  // function is also called directly (see pricing.test.ts), so it re-clamps
+  // everything itself rather than trusting the caller. No import needed —
+  // `Number.isFinite` is a global — so this keeps the module pure.
+  const clamp = (n: number): number => (Number.isFinite(n) && n >= 0 ? n : 0);
+  const safeInput = clamp(inputTokens);
+  const safeOutput = clamp(outputTokens);
+  const safeCachedInput = clamp(cachedInputTokens);
+  const safeCacheCreation = clamp(cacheCreationTokens);
+
   // `input_tokens` already excludes cache reads and writes — use it verbatim.
-  const inputCost = (inputTokens / M) * pricing.inputPerMTok;
-  const outputCost = (outputTokens / M) * pricing.outputPerMTok;
+  const inputCost = (safeInput / M) * pricing.inputPerMTok;
+  const outputCost = (safeOutput / M) * pricing.outputPerMTok;
 
   const write5mRate =
     pricing.cacheWrite5mPerMTok ?? pricing.inputPerMTok * CACHE_WRITE_5M_MULTIPLIER;
@@ -151,12 +171,27 @@ export function deriveCallCostUsd(
   // Absent an explicit split, attribute all writes to the 5m rate. Callers
   // that know the request asked for 1h pass the split (see toProviderUsage).
   const split: CacheWriteSplit = cacheWriteSplit ?? {
-    ephemeral5m: cacheCreationTokens,
+    ephemeral5m: safeCacheCreation,
     ephemeral1h: 0,
   };
+  const safe5m = clamp(split.ephemeral5m);
+  const safe1h = clamp(split.ephemeral1h);
+
+  // Invariant: `cacheCreationTokens` is the API's authoritative billed total;
+  // `ephemeral5m + ephemeral1h` is only the sum of the two TTL tiers this
+  // module currently knows how to price. A positive gap between them means a
+  // tier this code doesn't recognize was billed (e.g. Anthropic adds a third
+  // TTL the way it added 1h alongside 5m) — price the gap instead of letting
+  // it default to $0. An unrecognized future tier is more likely to be a
+  // longer-lived cache than a shorter one (the trend so far is 5m -> 1h), so
+  // the residual bills at the 1h rate: the conservative choice, since it
+  // risks overcounting a still-hypothetical short tier rather than
+  // undercounting real spend.
+  const residual = Math.max(0, safeCacheCreation - (safe5m + safe1h));
+
   const cacheWriteCost =
-    (split.ephemeral5m / M) * write5mRate + (split.ephemeral1h / M) * write1hRate;
-  const cacheReadCost = (cachedInputTokens / M) * readRate;
+    (safe5m / M) * write5mRate + (safe1h / M) * write1hRate + (residual / M) * write1hRate;
+  const cacheReadCost = (safeCachedInput / M) * readRate;
 
   return inputCost + outputCost + cacheWriteCost + cacheReadCost;
 }

--- a/src/agent/providers/anthropic-direct/types.test.ts
+++ b/src/agent/providers/anthropic-direct/types.test.ts
@@ -221,4 +221,67 @@ describe('toProviderUsage — cache-write TTL attribution', () => {
     const out = toProviderUsage(usage, 'end_turn', 'claude-sonnet-5');
     expect(out.totalCostUsd).toBeCloseTo(3.75, 8);
   });
+
+  it('bills a breakdown residual (issue #912): total exceeds ephemeral5m + ephemeral1h', () => {
+    // A third TTL tier the two known buckets don't cover — 1_000_000 total,
+    // only 700_000 attributed across 5m/1h. The 300_000 residual must be
+    // priced (at the 1h rate), not silently dropped.
+    const usage = makeUsage({
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_creation_input_tokens: 1_000_000,
+      cache_creation: {
+        ephemeral_5m_input_tokens: 500_000,
+        ephemeral_1h_input_tokens: 200_000,
+      },
+    } as Partial<Usage>);
+    const out = toProviderUsage(usage, 'end_turn', 'claude-sonnet-5');
+    const expected = (500_000 / 1e6) * 3.75 + (200_000 / 1e6) * 6.0 + (300_000 / 1e6) * 6.0;
+    expect(out.totalCostUsd).toBeCloseTo(expected, 8);
+  });
+});
+
+describe('resolveCacheWriteSplit boundary — finite/non-negative guard (issue #912)', () => {
+  it('clamps a negative breakdown field to 0 instead of poisoning totalCostUsd', () => {
+    const usage = makeUsage({
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_creation_input_tokens: 1_000_000,
+      cache_creation: {
+        ephemeral_5m_input_tokens: -500_000,
+        ephemeral_1h_input_tokens: 200_000,
+      },
+    } as Partial<Usage>);
+    const out = toProviderUsage(usage, 'end_turn', 'claude-sonnet-5');
+    expect(out.totalCostUsd).toBeDefined();
+    expect(Number.isFinite(out.totalCostUsd)).toBe(true);
+    expect(out.totalCostUsd!).not.toBeLessThan(0);
+  });
+
+  it('clamps a NaN breakdown field to 0 instead of propagating NaN', () => {
+    const usage = makeUsage({
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_creation_input_tokens: 1_000_000,
+      cache_creation: {
+        ephemeral_5m_input_tokens: NaN,
+        ephemeral_1h_input_tokens: 200_000,
+      },
+    } as Partial<Usage>);
+    const out = toProviderUsage(usage, 'end_turn', 'claude-sonnet-5');
+    expect(out.totalCostUsd).toBeDefined();
+    expect(Number.isNaN(out.totalCostUsd)).toBe(false);
+  });
+
+  it('clamps a negative cache_creation_input_tokens total on the fallback path', () => {
+    const usage = makeUsage({
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_creation_input_tokens: -1_000_000,
+    });
+    const out = toProviderUsage(usage, 'end_turn', 'claude-sonnet-5');
+    expect(out.totalCostUsd).toBeDefined();
+    expect(Number.isFinite(out.totalCostUsd)).toBe(true);
+    expect(out.totalCostUsd!).not.toBeLessThan(0);
+  });
 });

--- a/src/agent/providers/anthropic-direct/types.ts
+++ b/src/agent/providers/anthropic-direct/types.ts
@@ -484,14 +484,21 @@ export type { ModelPricing, CacheWriteSplit } from './pricing.js';
  * pure so its golden-rate tests cannot drift with ambient config.
  */
 function resolveCacheWriteSplit(usage: Usage): CacheWriteSplit {
+  // Invariant: the SDK types every field read below as a required `number`,
+  // but that is a compile-time guarantee only — a malformed response (or a
+  // hand-built fixture) could still carry a negative or NaN count, which
+  // would propagate into a negative/NaN totalCostUsd downstream. Clamp here
+  // so both branches below (explicit breakdown vs. total-only fallback)
+  // return only finite, non-negative counts.
+  const clampCount = (n: number): number => (Number.isFinite(n) && n >= 0 ? n : 0);
   const breakdown = usage.cache_creation;
   if (breakdown) {
     return {
-      ephemeral5m: breakdown.ephemeral_5m_input_tokens ?? 0,
-      ephemeral1h: breakdown.ephemeral_1h_input_tokens ?? 0,
+      ephemeral5m: clampCount(breakdown.ephemeral_5m_input_tokens ?? 0),
+      ephemeral1h: clampCount(breakdown.ephemeral_1h_input_tokens ?? 0),
     };
   }
-  const total = usage.cache_creation_input_tokens ?? 0;
+  const total = clampCount(usage.cache_creation_input_tokens ?? 0);
   return getCacheTtl() === '1h'
     ? { ephemeral5m: 0, ephemeral1h: total }
     : { ephemeral5m: total, ephemeral1h: 0 };


### PR DESCRIPTION
Closes #912

## Problem

Two input-trust gaps at the cost boundary in `deriveCallCostUsd` / `resolveCacheWriteSplit`, both introduced by #909 and surfaced by `/review` on that PR. Neither is reachable under Anthropic's current documented API contract.

### 1. Cache-creation tokens outside the two known TTL buckets billed at $0

`deriveCallCostUsd` computed cache-write cost exclusively from `split.ephemeral5m` and `split.ephemeral1h`. `cacheCreationTokens` only reached the cost through the no-split fallback. Any portion of the reported creation total not covered by the two known buckets was silently unpriced.

**Reachability, stated honestly: this is a latent forward-compat hazard, not a live bug.** Today it cannot diverge — the SDK's `CacheCreation` type declares both fields required and non-nullable, and `resolveCacheWriteSplit`'s no-breakdown branch attributes the full total, so the two known fields always sum exactly to `cache_creation_input_tokens`. The forward trigger is what matters: if Anthropic adds a third TTL tier the way it added 1h alongside 5m, `cache_creation` arrives populated, the two known fields sum to *less* than the total, and the new tier's tokens cost $0 with no error anywhere. Given #909's whole premise is that a cache-write TTL rate drifted out of sync with real billing for months undetected, closing the same failure shape now is cheap.

**Fix:** after computing the split, bill the residual `cacheCreationTokens - (ephemeral5m + ephemeral1h)` at the 1h rate when positive.

**Rate justification:** an unknown future TTL tier is billed at the 1h (higher) rate rather than the 5m rate. The observed trend is tiers growing longer-lived (5m, then 1h added alongside it), so a hypothetical third tier is more likely long-lived than short. Billing the residual at 1h risks slightly overcounting a still-hypothetical short tier, but that is the safer failure direction than undercounting real spend — which is the exact defect this PR closes.

### 2. No finite/non-negative guard on wire-sourced counts

`resolveCacheWriteSplit` null-coalesced but never range-checked, and `deriveCallCostUsd` applied no `Number.isFinite`/non-negative guard to its five numeric parameters. A negative or `NaN` count would produce a negative or `NaN` `totalCostUsd` reaching `/cost`, the turn footer, and persisted cost reports.

**Reachability is low** — the SDK types every one of these fields as a required `number`, so this needs an API contract violation or a hand-edited artifact to trigger. This is hardening, not a response to an observed failure.

**Fix:** clamp each count (`Number.isFinite(x) && x >= 0`, else `0`) at the `resolveCacheWriteSplit` boundary in `types.ts` — one guard covers both call paths (`toProviderUsage` and any other future caller). `deriveCallCostUsd` also re-clamps its own five parameters redundantly, since it is itself an exported, directly-callable contract (exercised directly in `pricing.test.ts`) and can't assume every caller routes through `resolveCacheWriteSplit`. The redundant guard uses only the global `Number.isFinite` — no new import — so `pricing.ts` stays pure (no env reads, no clock).

## Purity constraint honored

`pricing.ts`'s module header declares it pure: no env reads, no clock. No import was added to `pricing.ts`. The configured-TTL value continues to arrive as data from the caller — `resolveCacheWriteSplit` in `types.ts` remains the sole env-reading boundary for pricing.

## Files changed

- `src/agent/providers/anthropic-direct/pricing.ts` — residual billing + local clamp inside `deriveCallCostUsd` (no new import).
- `src/agent/providers/anthropic-direct/types.ts` — clamp inside `resolveCacheWriteSplit`.
- `src/agent/providers/anthropic-direct/pricing.test.ts` — new `describe` block (divergent split bills the residual, consistent split unchanged, negative/NaN inputs don't produce negative/NaN cost).
- `src/agent/providers/anthropic-direct/types.test.ts` — new tests exercising the same guarantees through `toProviderUsage` (the `resolveCacheWriteSplit` call path).

## Scope

Stayed within `deriveCallCostUsd`'s body and `resolveCacheWriteSplit` only. Did not touch the `MODEL_PRICING` map, the model lookup line, or `info.ts` / `context-sampler.ts` / `trace-usage-format.ts` (owned by sibling PRs landing in parallel).

## Gates run

- `pnpm install` — clean (benign pre-build postinstall warning about missing `dist/postinstall.mjs`, expected in a fresh worktree).
- `pnpm lint` (`tsc --noEmit`) — clean.
- `pnpm test src/agent/providers/anthropic-direct/pricing.test.ts` — 17/17 passed.
- `pnpm test src/agent/providers/anthropic-direct/types.test.ts` — 23/23 passed.
- `pnpm audit:sdk:check` — OK, no new SDK import added.

Full suite / coverage not run locally per instructions (parallel-agent slowdown); CI covers it.
