### PR TITLE
fix(cli): dedupe the cache hit-rate formula, correct the cumulative-total mislabel, align field precedence

### DIFF
--- a/src/cli/commands/trace-usage-format.test.ts
+++ b/src/cli/commands/trace-usage-format.test.ts
@@ -5,7 +5,25 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { formatCacheUsage } from './trace-usage-format.js';
+import { formatCacheUsage, cacheHitRate } from './trace-usage-format.js';
+
+describe('cacheHitRate', () => {
+  it('computes a 90% hit rate', () => {
+    expect(cacheHitRate(9000, 1000)).toBe(90);
+  });
+
+  it('computes a 0% hit rate for a cold, write-only session', () => {
+    expect(cacheHitRate(0, 50_000)).toBe(0);
+  });
+
+  it('computes a 100% hit rate for a fully warm call', () => {
+    expect(cacheHitRate(50_000, 0)).toBe(100);
+  });
+
+  it('returns undefined rather than NaN when both inputs are zero', () => {
+    expect(cacheHitRate(0, 0)).toBeUndefined();
+  });
+});
 
 describe('formatCacheUsage', () => {
   it('renders read, write, and hit rate when cache activity exists', () => {

--- a/src/cli/commands/trace-usage-format.ts
+++ b/src/cli/commands/trace-usage-format.ts
@@ -17,6 +17,28 @@ export interface FinalTokens {
 }
 
 /**
+ * Contract: return the prompt-cache hit rate as a rounded percentage
+ * (0–100), or `undefined` when there is no cacheable activity to report
+ * (`read + created === 0`) — callers must treat `undefined` as "nothing to
+ * show," never coerce it into a rendered `NaN%`.
+ *
+ * The hit rate is `read / (read + created)` — the share of cacheable tokens
+ * served from an existing entry rather than freshly written. A healthy warm
+ * session trends high; a prefix that keeps getting invalidated shows
+ * sustained low values because every call re-writes what it should have
+ * read.
+ *
+ * Single source of truth for this formula: `formatCacheUsage` below (trace
+ * closure rendering) and `/tokens` (`src/cli/slash/commands/info.ts`) both
+ * call this instead of each reimplementing the ratio, so the two surfaces
+ * cannot drift onto different numbers for the same inputs.
+ */
+export function cacheHitRate(read: number, created: number): number | undefined {
+  const cacheable = read + created;
+  return cacheable > 0 ? Math.round((read / cacheable) * 100) : undefined;
+}
+
+/**
  * Contract: render the prompt-cache slice of a closure's token counts as a
  * compact suffix, or `''` when the session recorded no cache activity (so
  * uncached and pre-cache-era traces render exactly as before).
@@ -29,22 +51,15 @@ export interface FinalTokens {
  * miss rate would show up only on the monthly bill. Emitting the hit rate here
  * makes the regression observable in the one artifact that is durable per
  * session.
- *
- * The hit rate is `cacheRead / (cacheRead + cacheCreation)` — the share of
- * cacheable tokens served from an existing entry rather than freshly written.
- * A healthy warm session trends high; a prefix that keeps getting invalidated
- * shows sustained low values because every call re-writes what it should have
- * read.
  */
 export function formatCacheUsage(tokens: FinalTokens | undefined): string {
   if (!tokens) return '';
   const read = tokens.cacheRead ?? 0;
   const created = tokens.cacheCreation ?? 0;
-  const cacheable = read + created;
-  if (cacheable === 0) return '';
+  const hitRate = cacheHitRate(read, created);
+  if (hitRate === undefined) return '';
 
-  const parts = [`cache r=${fmtTokens(read)}`, `w=${fmtTokens(created)}`];
-  parts.push(`hit=${Math.round((read / cacheable) * 100)}%`);
+  const parts = [`cache r=${fmtTokens(read)}`, `w=${fmtTokens(created)}`, `hit=${hitRate}%`];
   return `  ${parts.join(' ')}`;
 }
 

--- a/src/cli/context-sampler.ts
+++ b/src/cli/context-sampler.ts
@@ -180,6 +180,14 @@ export class ContextSampler {
  * last resort is `input + output` — deliberately cache-excluded, mirroring
  * `contextWindowTokensUsed`'s own fallback in providers/shared/auto-compact.ts
  * so both paths degrade identically. Never adds the cache counts back in.
+ *
+ * `/tokens` (src/cli/slash/commands/info.ts) reads the same two fields in
+ * this same totalTokens-first order for consistency between the status line
+ * and that display. The order is arbitrary today: `buildContextUsageFields`
+ * (auto-compact.ts) is the sole producer for both providers and assigns both
+ * fields the identical last-round footprint, so no payload observed today
+ * distinguishes the two orders. Keep the two sites in sync if this ever
+ * changes rather than re-deriving the choice independently.
  */
 function resolveUsedTokens(payload: {
   totalTokens?: number;

--- a/src/cli/slash/commands/info.test.ts
+++ b/src/cli/slash/commands/info.test.ts
@@ -167,6 +167,92 @@ describe('/model', () => {
   });
 });
 
+const tokensCmd = infoCommands.find((c) => c.name === '/tokens')!;
+
+/** Minimal getContextUsage() stub — only the fields renderSdkBreakdown reads. */
+function makeUsagePayload(overrides: {
+  totalTokens?: number;
+  contextWindowTokens?: number;
+  cacheRead?: number;
+  cacheCreate?: number;
+}): unknown {
+  return {
+    totalTokens: overrides.totalTokens,
+    maxTokens: 200_000,
+    percentage: 10,
+    isAutoCompactEnabled: false,
+    apiUsage: {
+      input_tokens: 100,
+      output_tokens: 50,
+      cache_read_input_tokens: overrides.cacheRead ?? 0,
+      cache_creation_input_tokens: overrides.cacheCreate ?? 0,
+      ...(overrides.contextWindowTokens !== undefined
+        ? { context_window_tokens: overrides.contextWindowTokens }
+        : {}),
+    },
+  };
+}
+
+function makeTokensCtx(usagePayload: unknown): { ctx: SlashContext; lines: string[] } {
+  const lines: string[] = [];
+  const ctx = {
+    session: {
+      current: {
+        getContextUsage: vi.fn(async () => usagePayload),
+      } as unknown as SlashContext['session']['current'],
+    } as SlashContext['session'],
+    stats: makeStats(),
+    out: {
+      line: (t = ''): void => { lines.push(t); },
+      raw: (t: string): void => { lines.push(t); },
+      success: (t: string): void => { lines.push(`SUCCESS:${t}`); },
+      info: (t: string): void => { lines.push(`INFO:${t}`); },
+      warn: (t: string): void => { lines.push(`WARN:${t}`); },
+      error: (t: string): void => { lines.push(`ERROR:${t}`); },
+    },
+    ui: { clearScreen: vi.fn(), repaintStatusLine: vi.fn() },
+  } as unknown as SlashContext;
+  return { ctx, lines };
+}
+
+describe('/tokens — cache hit rate', () => {
+  it('renders a 90% hit rate via the shared cacheHitRate formula', async () => {
+    const { ctx, lines } = makeTokensCtx(makeUsagePayload({ cacheRead: 9000, cacheCreate: 1000 }));
+    await tokensCmd.handler(ctx, '');
+    expect(lines.join('\n')).toMatch(/cache hit\s+90%/);
+  });
+
+  it('reports 0% for a cold, write-only call rather than omitting the line', async () => {
+    const { ctx, lines } = makeTokensCtx(makeUsagePayload({ cacheRead: 0, cacheCreate: 50_000 }));
+    await tokensCmd.handler(ctx, '');
+    expect(lines.join('\n')).toMatch(/cache hit\s+0%/);
+  });
+
+  it('omits the cache-hit line entirely when there is no cacheable activity', async () => {
+    const { ctx, lines } = makeTokensCtx(makeUsagePayload({ cacheRead: 0, cacheCreate: 0 }));
+    await tokensCmd.handler(ctx, '');
+    expect(lines.join('\n')).not.toMatch(/cache hit/);
+  });
+});
+
+describe('/tokens — last-turn window precedence', () => {
+  it('prefers totalTokens over context_window_tokens when both are present', async () => {
+    const { ctx, lines } = makeTokensCtx(
+      makeUsagePayload({ totalTokens: 42_000, contextWindowTokens: 99_000 }),
+    );
+    await tokensCmd.handler(ctx, '');
+    expect(lines.join('\n')).toMatch(/window\s+42k/);
+  });
+
+  it('falls back to context_window_tokens when totalTokens is absent', async () => {
+    const { ctx, lines } = makeTokensCtx(
+      makeUsagePayload({ totalTokens: undefined, contextWindowTokens: 77_000 }),
+    );
+    await tokensCmd.handler(ctx, '');
+    expect(lines.join('\n')).toMatch(/window\s+77k/);
+  });
+});
+
 const usageCmd = infoCommands.find((c) => c.name === '/usage')!;
 const mockFetchUsage = vi.mocked(fetchSubscriptionUsage);
 

--- a/src/cli/slash/commands/info.ts
+++ b/src/cli/slash/commands/info.ts
@@ -14,6 +14,7 @@
 import { palette } from '../../palette.js';
 import { divider } from '../../render.js';
 import { formatCost, formatTokens } from '../../format-utils.js';
+import { cacheHitRate } from '../../commands/trace-usage-format.js';
 import { contextLimitFor, MODEL_CONTEXT_LIMITS } from '../../model-limits.js';
 import { renderDebugBanner } from '../../debug-banner.js';
 import { providerForModel } from '../../../agent/providers/index.js';
@@ -114,14 +115,13 @@ function renderSdkBreakdown(
   const output = api?.output_tokens ?? 0;
   const cacheRead = api?.cache_read_input_tokens ?? 0;
   const cacheCreate = api?.cache_creation_input_tokens ?? 0;
-  // Contract: never sum the four fields above — they are a mixed basis
-  // (cumulative input/output vs. last-round-only cache counts), so adding them
-  // double-counts every prior round. `context_window_tokens` is the
-  // provider-computed footprint of the last round; fall back to the
-  // authoritative cumulative total rather than reconstructing a bad sum.
-  const lastTurnTotal = api?.context_window_tokens ?? usage.totalTokens ?? 0;
-  const cacheTotal = cacheRead + cacheCreate;
-  const hitRate = cacheTotal > 0 ? Math.round((cacheRead / cacheTotal) * 100) : undefined;
+  // Contract: never sum the four fields above (mixed basis, double-counts
+  // prior rounds). `totalTokens` and `context_window_tokens` both hold the
+  // SAME last-round footprint (buildContextUsageFields, auto-compact.ts), so
+  // neither is a cumulative total. Precedence matches context-sampler.ts's
+  // resolveUsedTokens (status line) — arbitrary today per that docstring.
+  const lastTurnTotal = usage.totalTokens ?? api?.context_window_tokens ?? 0;
+  const hitRate = cacheHitRate(cacheRead, cacheCreate);
 
   out.line();
   out.line(palette.bold('Token usage') + palette.dim('  (SDK breakdown)'));


### PR DESCRIPTION
Closes #913.

Three display-layer defects surfaced by the `/review` pass on #909, all in the `/tokens` and status-line token rendering. All three are in the code #909 introduced or touched.

## 1. The cache hit-rate formula was duplicated, and only one copy was tested

`info.ts` reimplemented the ratio inline while an identical formula already lived in `trace-usage-format.ts`, pinned by `trace-usage-format.test.ts` across the 90% / 0% / 100% / no-NaN cases. `info.test.ts` had **zero** cache coverage, so the `/tokens` copy was unpinned.

Extracted `cacheHitRate(read, created): number | undefined` as a pure function in `trace-usage-format.ts`. Both `formatCacheUsage` and `info.ts`'s `renderSdkBreakdown` now call it, so the two surfaces cannot drift onto different numbers for the same inputs.

Incidental hardening: the extracted function returns `undefined` when `read + created <= 0`, where the old inline guard tested `=== 0`. A negative count now renders nothing instead of an out-of-range percentage.

## 2. A doc comment mislabelled a last-round value as cumulative

`info.ts` called `usage.totalTokens` "the authoritative cumulative total." It is not: `buildContextUsageFields` (`providers/shared/auto-compact.ts`) assigns it `contextWindowTokensUsed(last)` — the last round's footprint — the same value it assigns `apiUsage.context_window_tokens`. That file's own docstring states it "[d]eliberately does NOT read `ProviderUsage.totalTokens` — that field is provider-dependent and would diverge from the percentage."

Comment replaced with an accurate description. **No rendering change** — the displayed number was already correct.

This one is worth calling out because defect #4 in #909's own description was *"`config-types.ts:711` documented the wrong formula as if it were live"* — the same class of error, in the same area, reintroduced by the change that fixed it.

## 3. The two display sites ordered the same two fields oppositely

`context-sampler.ts` preferred `totalTokens` then `context_window_tokens`; `info.ts` preferred the reverse.

Currently unobservable, and that was verified rather than assumed: `buildContextUsageFields` is the sole producer for both providers (`AnthropicDirectQuery` and `OpenAICompatibleQuery` are the only implementations of `ProviderQuery.getContextUsage()` with real logic; `ProviderRouter.getContextUsage()` is a pure delegate), and it assigns both fields the identical value.

Standardized both sites on `totalTokens`-first (`info.ts` changed to match `context-sampler.ts`'s existing order) with a note at each site recording that the order is arbitrary today and that the two must stay in sync if a second producer ever appears.

## Verification

```
pnpm lint                                    clean (tsc --noEmit, strict)
pnpm test src/cli/slash/commands/info.test.ts            15 passed
pnpm test src/cli/commands/trace-usage-format.test.ts    10 passed
pnpm test src/cli/context-sampler.test.ts                 5 passed
pnpm test src/cli/status-line-context.test.ts             7 passed
pnpm audit:chalk:check                       0 violations
```

New coverage: 4 direct `cacheHitRate` tests, 5 `/tokens` rendering tests (hit rate present / zero / omitted, window-precedence both-present / fallback) where there were previously none.

`info.ts` is net **0 LOC** (8 insertions, 8 deletions) — it sits at 545 lines, already over the repo's 350 ceiling, so this change deliberately does not grow it.

The full suite and `pnpm test:coverage` were **not** run locally — CI covers them.

## Related

- #909 — the PR this reviews the aftermath of.
- #914, #915 — the other two follow-ups from the same review. This PR is disjoint from both (they touch `src/agent/providers/anthropic-direct/`; this touches only `src/cli/`), so there is no merge-order dependency.
