### PR TITLE
fix(cli): route /compact spinner through the compositor so typed input stays visible

### DIFF
--- a/src/cli/slash/commands/core.ts
+++ b/src/cli/slash/commands/core.ts
@@ -59,10 +59,39 @@ const compactCmd: SlashCommand = {
   summary: 'Compact history (summarize older messages)',
   hint: 'When context is filling up but you want to keep the thread — summarizes old turns and keeps the recent ones intact.',
   async handler(ctx) {
-    const spinner = ora({
-      text: palette.meta('Summarizing earlier turns...'),
-      ...REPL_SPINNER_OPTIONS,
-    }).start();
+    // When the persistent TerminalCompositor is armed (TTY REPL), route the
+    // progress indicator through its in-frame spinner instead of a bare ora:
+    // ora's imperative cursor writes race the compositor's frame repaints on
+    // the same physical rows (see terminal-compositor.ts:~800), which is why
+    // a user typing during compaction couldn't see their own keystrokes.
+    // Non-TTY surfaces (Telegram, daemon, tests) have no compositor to race
+    // with, so they keep the original bare-ora behavior unchanged.
+    const compositor = ctx.getCompositor?.() ?? null;
+    const spinner = compositor
+      ? null
+      : ora({
+          text: palette.meta('Summarizing earlier turns...'),
+          ...REPL_SPINNER_OPTIONS,
+        }).start();
+    if (compositor) {
+      // The in-frame spinner carries no caller-supplied label — it rotates
+      // work-derived/flavour verbs (see input/work-derived-verb.ts), and there
+      // is no 'compact' tool category to map onto. Commit the intent line above
+      // the frame instead, so the operator still learns WHAT is running; unlike
+      // a spinner label it also survives into scrollback next to the result.
+      ctx.out.info('Summarizing earlier turns...');
+      compositor.setSpinner({ enabled: true });
+    }
+    // Single stop point reused on every exit path below (success and catch)
+    // so the two flavors of "turn the spinner off" can never drift out of
+    // sync — a spinner left enabled is a worse bug than the race it replaces.
+    const stopSpinner = (): void => {
+      if (compositor) {
+        compositor.setSpinner({ enabled: false });
+      } else {
+        spinner?.stop();
+      }
+    };
     try {
       // Invariant: fire PreCompact before compaction so registered handlers can
       // block or observe the operation. block -> HookBlockedError -> skip.
@@ -76,7 +105,7 @@ const compactCmd: SlashCommand = {
         });
       }
       const result = await session.compact();
-      spinner.stop();
+      stopSpinner();
       if (!result.compacted) {
         const reason = result.reason ?? 'unknown';
         if (reason === 'aborted') {
@@ -114,7 +143,7 @@ const compactCmd: SlashCommand = {
         );
       }
     } catch (err) {
-      spinner.stop();
+      stopSpinner();
       if (err instanceof AbortError) throw err;
       if (err instanceof HookBlockedError) {
         ctx.out.info(`Compaction skipped: ${err.reason ?? 'blocked by hook'}`);

--- a/src/cli/slash/commands/core.ts
+++ b/src/cli/slash/commands/core.ts
@@ -67,30 +67,19 @@ const compactCmd: SlashCommand = {
     // Non-TTY surfaces (Telegram, daemon, tests) have no compositor to race
     // with, so they keep the original bare-ora behavior unchanged.
     const compositor = ctx.getCompositor?.() ?? null;
-    const spinner = compositor
-      ? null
-      : ora({
-          text: palette.meta('Summarizing earlier turns...'),
-          ...REPL_SPINNER_OPTIONS,
-        }).start();
-    if (compositor) {
-      // The in-frame spinner carries no caller-supplied label — it rotates
-      // work-derived/flavour verbs (see input/work-derived-verb.ts), and there
-      // is no 'compact' tool category to map onto. Commit the intent line above
-      // the frame instead, so the operator still learns WHAT is running; unlike
-      // a spinner label it also survives into scrollback next to the result.
-      ctx.out.info('Summarizing earlier turns...');
-      compositor.setSpinner({ enabled: true });
-    }
+    let spinner: ReturnType<typeof ora> | null = null;
+    let spinnerActive = false;
     // Single stop point reused on every exit path below (success and catch)
     // so the two flavors of "turn the spinner off" can never drift out of
     // sync — a spinner left enabled is a worse bug than the race it replaces.
     const stopSpinner = (): void => {
+      if (!spinnerActive) return;
       if (compositor) {
         compositor.setSpinner({ enabled: false });
       } else {
         spinner?.stop();
       }
+      spinnerActive = false;
     };
     try {
       // Invariant: fire PreCompact before compaction so registered handlers can
@@ -103,6 +92,26 @@ const compactCmd: SlashCommand = {
           sessionId: session.sessionId,
           trigger: 'manual',
         });
+      }
+      // Do not announce or animate compaction until PreCompact hooks have
+      // allowed it. The compositor notice is durable scrollback, so emitting it
+      // before dispatch would falsely claim summarization began when a hook
+      // blocks the operation.
+      if (compositor) {
+        // The in-frame spinner carries no caller-supplied label — it rotates
+        // work-derived/flavour verbs (see input/work-derived-verb.ts), and there
+        // is no 'compact' tool category to map onto. Commit the intent line above
+        // the frame instead, so the operator still learns WHAT is running; unlike
+        // a spinner label it also survives into scrollback next to the result.
+        ctx.out.info('Summarizing earlier turns...');
+        compositor.setSpinner({ enabled: true });
+        spinnerActive = true;
+      } else {
+        spinner = ora({
+          text: palette.meta('Summarizing earlier turns...'),
+          ...REPL_SPINNER_OPTIONS,
+        }).start();
+        spinnerActive = true;
       }
       const result = await session.compact();
       stopSpinner();

--- a/src/cli/slash/core-compact.test.ts
+++ b/src/cli/slash/core-compact.test.ts
@@ -390,7 +390,7 @@ describe('/compact spinner routing (H1: compositor vs. bare ora)', () => {
     expect(lines.find((l) => l.startsWith('ERROR:'))).toContain('compact blew up');
   });
 
-  it('disables the in-frame spinner when the PreCompact hook blocks (HookBlockedError path)', async () => {
+  it('does not announce or start the in-frame spinner when the PreCompact hook blocks', async () => {
     const session = fakeSession();
     const registry = createHookRegistry();
     registry.register('PreCompact', async () => ({
@@ -398,15 +398,16 @@ describe('/compact spinner routing (H1: compositor vs. bare ora)', () => {
       reason: 'frozen',
     }));
     const sessionWithRegistry = { ...session, hookRegistry: registry, sessionId: 'test-sess' };
-    const { ctx, setSpinner } = makeCtxWithCompositor(sessionWithRegistry as unknown as typeof session);
+    const { ctx, setSpinner, lines } = makeCtxWithCompositor(sessionWithRegistry as unknown as typeof session);
 
     const result = await getCompactCmd().handler(ctx, '');
 
     expect(result).toBe('continue');
     expect(session.compact).not.toHaveBeenCalled();
-    expect(setSpinner).toHaveBeenCalledTimes(2);
-    expect(setSpinner).toHaveBeenNthCalledWith(1, { enabled: true });
-    expect(setSpinner).toHaveBeenNthCalledWith(2, { enabled: false });
+    expect(setSpinner).not.toHaveBeenCalled();
+    expect(lines).not.toContain('INFO:Summarizing earlier turns...');
+    expect(lines).toContain('INFO:Compaction skipped: frozen');
+    expect(oraFactory).not.toHaveBeenCalled();
   });
 
   it('disables the in-frame spinner and rethrows on AbortError', async () => {

--- a/src/cli/slash/core-compact.test.ts
+++ b/src/cli/slash/core-compact.test.ts
@@ -11,7 +11,25 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { SlashCommand, SlashContext, SessionStats } from './types.js';
 import { coreCommands } from './commands/core.js';
 import { createHookRegistry } from '../../agent/hooks.js';
-import { HookBlockedError } from '../../utils/errors.js';
+import { HookBlockedError, AbortError } from '../../utils/errors.js';
+
+// File-wide `ora` mock so the H1 spinner-routing tests below can assert
+// whether the bare-ora constructor was invoked at all (it must NOT be, on
+// the compositor path — that is the entire point of the fix: a bare ora
+// racing the persistent TerminalCompositor's frame repaints is the bug).
+// Mirrors the stop()-returns-inst mocking style used in
+// interactive-lifecycle.test.ts / interactive.boot-warnings.test.ts. Every
+// pre-existing test below (which predates this mock) is unaffected — it
+// only inspects `lines`, never `ora` internals — so the mocked start/stop
+// no-ops are behaviorally transparent to them.
+const oraFactory = vi.hoisted(() =>
+  vi.fn(() => {
+    const inst = { start: vi.fn(), stop: vi.fn() };
+    inst.start.mockReturnValue(inst);
+    return inst;
+  }),
+);
+vi.mock('ora', () => ({ default: oraFactory }));
 
 function makeStats(): SessionStats {
   return {
@@ -74,6 +92,24 @@ function getCompactCmd(): SlashCommand {
   const cmd = coreCommands.find((c) => c.name === '/compact');
   if (!cmd) throw new Error('compact command not registered');
   return cmd;
+}
+
+/**
+ * Extends `makeCtx` with a mock `getCompositor` — the H1 fix's TTY path.
+ * `setSpinner` is the only compositor method the handler calls; kept as a
+ * bare `vi.fn()` (structural typing satisfies `TerminalCompositor` for the
+ * handler's purposes, matching how `core-rewind.test.ts` mocks
+ * `suspendInput`/`resumeInput` with a `Mock`-cast object rather than a full
+ * compositor instance).
+ */
+function makeCtxWithCompositor(
+  session: FakeSession,
+): { ctx: SlashContext; lines: string[]; setSpinner: ReturnType<typeof vi.fn> } {
+  const { ctx, lines } = makeCtx(session);
+  const setSpinner = vi.fn();
+  ctx.getCompositor = () =>
+    ({ setSpinner }) as unknown as ReturnType<NonNullable<SlashContext['getCompositor']>>;
+  return { ctx, lines, setSpinner };
 }
 
 describe('/compact slash handler', () => {
@@ -273,5 +309,145 @@ describe('/compact PreCompact hook integration', () => {
     // HookBlockedError thrown by handler surfaces as a block (fail-safe) -> skipped.
     const info = lines.find((l) => l.startsWith('INFO:'));
     expect(info).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// H1: route the progress indicator through the compositor's in-frame
+// spinner instead of a bare ora, so a single frame owns both the spinner
+// row and the input line (see terminal-compositor.ts:~800 for the ora-vs-
+// compositor region-tracking race this avoids).
+// ---------------------------------------------------------------------------
+
+describe('/compact spinner routing (H1: compositor vs. bare ora)', () => {
+  beforeEach(() => {
+    oraFactory.mockClear();
+  });
+
+  it('with a compositor: enables then disables the in-frame spinner and never constructs ora', async () => {
+    const session = fakeSession();
+    session.compact.mockResolvedValue({
+      compacted: true,
+      messagesBefore: 10,
+      messagesAfter: 4,
+    });
+    const { ctx, setSpinner } = makeCtxWithCompositor(session);
+
+    await getCompactCmd().handler(ctx, '');
+
+    expect(setSpinner).toHaveBeenCalledTimes(2);
+    expect(setSpinner).toHaveBeenNthCalledWith(1, { enabled: true });
+    expect(setSpinner).toHaveBeenNthCalledWith(2, { enabled: false });
+    expect(oraFactory).not.toHaveBeenCalled();
+  });
+
+  it('without a compositor (getCompositor absent): falls back to the bare-ora path unchanged', async () => {
+    const session = fakeSession();
+    session.compact.mockResolvedValue({
+      compacted: true,
+      messagesBefore: 10,
+      messagesAfter: 4,
+    });
+    const { ctx } = makeCtx(session); // no getCompositor at all
+    expect(ctx.getCompositor).toBeUndefined();
+
+    await getCompactCmd().handler(ctx, '');
+
+    expect(oraFactory).toHaveBeenCalledTimes(1);
+    const instance = oraFactory.mock.results[0]?.value as { start: ReturnType<typeof vi.fn>; stop: ReturnType<typeof vi.fn> };
+    expect(instance.start).toHaveBeenCalledTimes(1);
+    expect(instance.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('without a compositor (getCompositor returns null): falls back to the bare-ora path unchanged', async () => {
+    const session = fakeSession();
+    session.compact.mockResolvedValue({
+      compacted: true,
+      messagesBefore: 10,
+      messagesAfter: 4,
+    });
+    const { ctx } = makeCtx(session);
+    ctx.getCompositor = () => null;
+
+    await getCompactCmd().handler(ctx, '');
+
+    expect(oraFactory).toHaveBeenCalledTimes(1);
+    const instance = oraFactory.mock.results[0]?.value as { start: ReturnType<typeof vi.fn>; stop: ReturnType<typeof vi.fn> };
+    expect(instance.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the in-frame spinner even when session.compact() rejects', async () => {
+    const session = fakeSession();
+    session.compact.mockRejectedValue(new Error('compact blew up'));
+    const { ctx, setSpinner, lines } = makeCtxWithCompositor(session);
+
+    await getCompactCmd().handler(ctx, '');
+
+    expect(setSpinner).toHaveBeenCalledTimes(2);
+    expect(setSpinner).toHaveBeenNthCalledWith(1, { enabled: true });
+    expect(setSpinner).toHaveBeenNthCalledWith(2, { enabled: false });
+    expect(oraFactory).not.toHaveBeenCalled();
+    expect(lines.find((l) => l.startsWith('ERROR:'))).toContain('compact blew up');
+  });
+
+  it('disables the in-frame spinner when the PreCompact hook blocks (HookBlockedError path)', async () => {
+    const session = fakeSession();
+    const registry = createHookRegistry();
+    registry.register('PreCompact', async () => ({
+      decision: 'block' as const,
+      reason: 'frozen',
+    }));
+    const sessionWithRegistry = { ...session, hookRegistry: registry, sessionId: 'test-sess' };
+    const { ctx, setSpinner } = makeCtxWithCompositor(sessionWithRegistry as unknown as typeof session);
+
+    const result = await getCompactCmd().handler(ctx, '');
+
+    expect(result).toBe('continue');
+    expect(session.compact).not.toHaveBeenCalled();
+    expect(setSpinner).toHaveBeenCalledTimes(2);
+    expect(setSpinner).toHaveBeenNthCalledWith(1, { enabled: true });
+    expect(setSpinner).toHaveBeenNthCalledWith(2, { enabled: false });
+  });
+
+  it('disables the in-frame spinner and rethrows on AbortError', async () => {
+    const session = fakeSession();
+    session.compact.mockRejectedValue(new AbortError('user cancelled'));
+    const { ctx, setSpinner } = makeCtxWithCompositor(session);
+
+    await expect(getCompactCmd().handler(ctx, '')).rejects.toBeInstanceOf(AbortError);
+
+    expect(setSpinner).toHaveBeenCalledTimes(2);
+    expect(setSpinner).toHaveBeenNthCalledWith(1, { enabled: true });
+    expect(setSpinner).toHaveBeenNthCalledWith(2, { enabled: false });
+  });
+
+  it('with a compositor: still disables the spinner on every !result.compacted branch', async () => {
+    const reasons = [
+      'aborted',
+      'summarization-failed: x',
+      'microcompacted',
+      'nothing-to-summarize',
+      'not-supported',
+      'responses-compaction-unavailable',
+      'some-unknown-reason',
+    ];
+    for (const reason of reasons) {
+      oraFactory.mockClear();
+      const session = fakeSession();
+      session.compact.mockResolvedValue({
+        compacted: false,
+        reason,
+        messagesBefore: 2,
+        messagesAfter: 2,
+      });
+      const { ctx, setSpinner } = makeCtxWithCompositor(session);
+
+      await getCompactCmd().handler(ctx, '');
+
+      expect(setSpinner).toHaveBeenCalledTimes(2);
+      expect(setSpinner).toHaveBeenNthCalledWith(1, { enabled: true });
+      expect(setSpinner).toHaveBeenNthCalledWith(2, { enabled: false });
+      expect(oraFactory).not.toHaveBeenCalled();
+    }
   });
 });


### PR DESCRIPTION
## Summary

Typing your next message while `/compact` runs was visually broken — the input line got shredded and you couldn't see what you were typing.

**Root cause:** `/compact` was the only slash command that started a bare `ora()` spinner while the persistent `TerminalCompositor` was still armed.

The compositor stays armed for the whole handler — raw mode on, keypress listener live — so every keystroke fires `dispatchKey -> applyEdit -> repaint`, an **absolute-CUP** frame write. ora repaints on its own 80ms interval using **relative** `cursorTo(0)` / `clearLine` / `moveCursor`. Two writers, two coordinate systems, same physical rows, no shared clock.

This is precisely the race `SpinnerController` was built to eliminate. The codebase already documents it:

> `terminal-compositor.ts:800` — "ora's imperative cursor + linesToClear tracking collides with log-update's region tracking when both run concurrently. The SpinnerController owns the spinner state + 80ms ticker; the compositor owns the frame..."

`/compact` just never migrated onto it.

**Not a recent regression.** The defect dates to the initial public commit `0a23cff4`. `git diff febb3a8e^ 6a8853f3` is byte-empty, so the prompt-rail revert (#920) was textbook-clean and is not implicated.

**No data was ever lost**, even before this fix — typed text commits to the queue FIFO and renders a `[queued]` suffix (`terminal-compositor.render.ts:56-60`). The bug was purely visual.

### The fix

When a compositor is armed, drive `compositor.setSpinner()` so a single frame owns both the spinner row and the input line. The bare-ora branch is kept for the null-compositor case (Telegram, daemon, non-TTY) where there is nothing to race with — those surfaces are byte-identical to before.

### Rejected alternative (worth flagging for review)

The obvious-looking fix is `suspendInput()` / `resumeInput()`, the convention used by `/rewind`, `/transcript`, and `editor-spawn`. **That would have been a regression in disguise.**

That convention is only correct when handing the TTY to *another active stdin reader*. `/compact` has none. `suspendInput()` removes the keypress listener and drops raw mode (`terminal-compositor.lifecycle.ts:105,107`), so it "fixes" the visual artifact by making typing impossible — breaking the exact queue-while-compacting workflow this bug is about. It was implemented and tested in a throwaway worktree to confirm this before being discarded.

### Tradeoff

`setSpinner` takes no caller-supplied label — `verbForToolName` maps tool *categories* and there is no `compact` category, so forcing one would yield a false "Working". Instead the intent line is committed above the frame via `ctx.out.info()`. Unlike a spinner label, it also survives into scrollback next to the result.

TTY users previously saw a static `Summarizing earlier turns...`; they now see that line in scrollback plus the in-frame spinner's rotating verbs.

## How was this tested?

| Gate | Result |
|---|---|
| `pnpm test` (full suite) | **15150 passed**, 2 skipped, 794 files |
| `pnpm test src/cli/slash/core-compact.test.ts` | 17/17 (7 new) |
| `pnpm test src/cli/slash/` | 665/665, 48 files |
| `pnpm test src/cli/commands/interactive/` | 1008/1008, 36 files |
| `pnpm lint` (`tsc --noEmit`) | clean |

The 7 new tests in `core-compact.test.ts` cover: compositor path enables then disables the in-frame spinner and never constructs ora; both null-compositor fallbacks (absent `getCompositor`, and one returning `null`); and spinner teardown on every exit path — `session.compact()` rejecting, `HookBlockedError`, `AbortError` rethrow, and all `!result.compacted` reason branches. A spinner left enabled would be worse than the race it replaces, so every `return`/`throw` in the handler was audited against a single `stopSpinner()` call site.

Also verified during diagnosis that ora was the **sole** offender: the input row is painted during idle (`frame.ts:102,134`), `commitAbove` correctly repaints it (`committed-band-commit.ts:550-552`), MascotBar is inert during a slash command (`mascot-bar.ts:152-160`), and auto-compaction rides the turn's already-coordinated spinner (`stream-renderer.ts:493`) rather than this path. The two remaining `ora()` call sites (`interactive.ts:267,470`) both run pre-arm and carry comments saying so.

**Known gap:** no live PTY reproduction. The mechanism is established from source plus the codebase's own comments, and the unit tests verify the routing, but no human watched a real terminal. `tests/pty/` has a harness if a reviewer wants empirical confirmation.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/) — see [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] No secrets, tokens, or private paths in the diff
