### PR TITLE
fix(cli): hold composed tool-lane rows to the shared reading measure

### DIFF
--- a/src/cli/commands/interactive/tool-lane-render-agent.ts
+++ b/src/cli/commands/interactive/tool-lane-render-agent.ts
@@ -1,9 +1,8 @@
 import { palette } from '../../palette.js';
-import { getTerminalWidth } from '../../terminal-size.js';
 import { formatToolCallStat } from '../../format-utils.js';
 import { MAX_VISIBLE_CHILDREN, batchBadge } from './tool-lane-format.js';
 import type { ToolEntry, Entry } from './tool-lane-render.js';
-import { getGlyphs, clampLineToTerminal } from './tool-lane-render.js';
+import { getGlyphs, clampLineToTerminal, toolLaneWidth } from './tool-lane-render.js';
 import { renderFlushChildren } from './tool-lane-render-children.js';
 
 /**
@@ -126,7 +125,7 @@ function formatAgentSummary(
   // Invariant: ONE width read per render frame, shared by the head row below
   // and the recursive child frame. Two reads could straddle a resize and emit
   // a head row clamped to the old width above children clamped to the new one.
-  const cols = getTerminalWidth();
+  const cols = toolLaneWidth();
   // Clamped for the same reason every child row is: a root nesting entry
   // arrives with an unbounded prefix (the root dispatch path passes no
   // maxWidth), and the stats tail adds ~28 columns on top — a depth-0 `agent`
@@ -209,7 +208,7 @@ function formatAgentHeader(agent: ToolEntry, ancestorIsLast: readonly boolean[] 
   // encoding constraint above. formatAgentSummary clamps its head row, so this
   // one must too, or the same entry committed through the two paths would
   // differ whenever the row exceeds the terminal width.
-  return clampLineToTerminal(ancestorPrefix + head + agent.prefix, getTerminalWidth());
+  return clampLineToTerminal(ancestorPrefix + head + agent.prefix, toolLaneWidth());
 }
 
 /**
@@ -254,7 +253,7 @@ function formatAgentChildren(
     // committed eagerly by formatAgentHeader without the badge (batchSize was
     // unknown then), so the closer is the only completion-time anchor.
     summaryWithBatchBadge(agent),
-    getTerminalWidth(),
+    toolLaneWidth(),
     externalAncestors,
     g,
   );

--- a/src/cli/commands/interactive/tool-lane-render-children.ts
+++ b/src/cli/commands/interactive/tool-lane-render-children.ts
@@ -1,6 +1,5 @@
 import { palette } from '../../palette.js';
 import { NESTING_TOOLS } from '../../tool-category.js';
-import { getTerminalWidth } from '../../terminal-size.js';
 import {
   MAX_VISIBLE_CHILDREN,
   inProgressVerb,
@@ -16,6 +15,7 @@ import {
   colorizeIndent,
   renderTextChildLines,
   getGlyphs,
+  toolLaneWidth,
 } from './tool-lane-render.js';
 import {
   groupSiblings,
@@ -94,7 +94,7 @@ function renderOverlayChildren(
   // Default at the parameter site keeps external callers signature-compatible
   // (they call with no cols, get a fresh read); recursive call below threads
   // the captured value to avoid repeated reads.
-  cols: number = getTerminalWidth(),
+  cols: number = toolLaneWidth(),
   // `ancestorIsLast[i]` = true iff the ancestor column at slot i has closed
   // (its branch ended above this row) → render `g.spineClosed`; false →
   // render an open `g.spine` (`│`). Default `[]` for the depth-1 entrypoint
@@ -354,7 +354,7 @@ function renderFlushChildren(
   agentResultSummary?: string,
   // Hoist getTerminalWidth() to a single read per top-level invocation.
   // Recursive call below threads the captured value through.
-  cols: number = getTerminalWidth(),
+  cols: number = toolLaneWidth(),
   // Mirror {@link renderOverlayChildren}: track last-ness of each ancestor
   // so the spine column closes correctly when a parent was last at its level.
   ancestorIsLast: readonly boolean[] = [],

--- a/src/cli/commands/interactive/tool-lane-render-grouped-root.ts
+++ b/src/cli/commands/interactive/tool-lane-render-grouped-root.ts
@@ -1,6 +1,5 @@
 import { displayWidth, truncateDisplayWidth } from '../../display.js';
 import { palette } from '../../palette.js';
-import { getTerminalWidth } from '../../terminal-size.js';
 import { styleForToolName } from '../../tool-category.js';
 import {
   batchBadge,
@@ -12,7 +11,7 @@ import {
   shortenPaths,
 } from './tool-lane-format.js';
 import type { ToolEntry } from './tool-lane-render.js';
-import { clampLineToTerminal } from './tool-lane-render.js';
+import { clampLineToTerminal, toolLaneWidth } from './tool-lane-render.js';
 
 function groupedResultSuffix(
   entries: ToolEntry[],
@@ -115,7 +114,7 @@ export function renderGroupedRootTools(
   // clamp here is the only thing standing between a 350-column bash command
   // and a wrapped scrollback row. The live overlay already clamps its
   // equivalents (tool-lane.ts); flush must not be the lone exception.
-  const cols = getTerminalWidth();
+  const cols = toolLaneWidth();
   for (const toolName of groupOrder) {
     const entries = groups.get(toolName)!;
     if (entries.length === 1) {

--- a/src/cli/commands/interactive/tool-lane-render.ts
+++ b/src/cli/commands/interactive/tool-lane-render.ts
@@ -297,9 +297,10 @@ export function renderTextChildLines(text: string, indent: string, g: Readonly<G
   if (!text || !text.trim()) return [];
   const prefix = palette.dim(g.textPrefix);
   // 2 cols for the text prefix, plus a small safety margin for ANSI widths.
-  // Clamped to the shared reading measure so tool-lane text keeps the same
-  // right edge as adjacent prose (see `render/measure.ts`).
-  const maxWidth = Math.max(1, capToMeasure(getTerminalWidth() - indent.length - 2 - 2));
+  // Derived from `toolLaneWidth()` — the same row budget `clampLineToTerminal`
+  // enforces on the composed line below — so the wrapped text can never
+  // exceed the clamp that will later be applied to it (see `render/measure.ts`).
+  const maxWidth = Math.max(1, toolLaneWidth() - indent.length - 2 - 2);
   const colored = colorizeIndent(indent, g);
   const out: string[] = [];
   for (const para of text.split('\n')) {

--- a/src/cli/commands/interactive/tool-lane-render.ts
+++ b/src/cli/commands/interactive/tool-lane-render.ts
@@ -30,6 +30,35 @@ export function clampLineToTerminal(line: string, cols: number): string {
   return truncateDisplayWidth(line, cols);
 }
 
+/**
+ * Invariant: every composed tool-lane row shares ONE width budget, and that
+ * budget is the shared reading measure — not the raw terminal width.
+ *
+ * The budget is load-bearing twice over, which is why it has a name instead of
+ * being inlined at each call site:
+ *
+ *  1. Wrap prevention. A composed row that exceeds the terminal hard-wraps to
+ *     column 0 with no spine glyph, splitting the tree (see
+ *     {@link clampLineToTerminal}). Every row must be clamped to at most the
+ *     terminal width.
+ *  2. Reading measure. `renderTextChildLines` below already caps wrapped
+ *     tool-lane *text* at the shared measure, and prose, thinking, and
+ *     subagent text do the same (see `render/measure.ts`). Composed tool rows
+ *     did not, so on a terminal wider than the measure the lane's own text
+ *     stopped at one column while its tool rows ran to the screen edge —
+ *     exactly the "adjacent unbordered blocks stop at different columns"
+ *     discontinuity the measure invariant exists to prevent.
+ *
+ * `capToMeasure` is a pure `min`, never a widen, so (2) strictly strengthens
+ * (1): the wrap guarantee still holds, and on terminals at or below the
+ * measure this is a no-op. Callers that must agree on a width (the
+ * `formatAgentSummary` / `formatAgentHeader` head-row encoding pair) agree by
+ * calling this, not by both happening to read the terminal.
+ */
+export function toolLaneWidth(): number {
+  return capToMeasure(getTerminalWidth());
+}
+
 interface ToolEntryFields {
   toolUseId: string;
   toolName: string;

--- a/src/cli/commands/interactive/tool-lane.ts
+++ b/src/cli/commands/interactive/tool-lane.ts
@@ -3,7 +3,6 @@ import { palette } from '../../palette.js';
 import { SUBAGENT_TOOLS, NESTING_TOOLS, SKILL_TOOLS } from '../../tool-category.js';
 import { formatToolLine, formatToolResultLine, formatOutcome, formatDiffBlock, doneGlyph, sanitizeLabel, batchBadge } from './tool-lane-format.js';
 import type { DiffPayload } from '../../../utils/diff.js';
-import { getTerminalWidth } from '../../terminal-size.js';
 import { truncateDisplayWidth, stripAnsi } from '../../display.js';
 import {
   renderOverlayChildren,
@@ -12,6 +11,7 @@ import {
   formatAgentChildren,
   renderGroupedRootTools,
   getGlyphs,
+  toolLaneWidth,
   type ToolEntry,
   type TextEntry,
   type Entry,
@@ -328,7 +328,7 @@ export class ToolLane {
     // `renderOverlayChildren` / `renderFlushChildren` in tool-lane-render.ts.
     // Read once per frame — `getTerminalWidth()` is a process.stdout.columns
     // lookup, but consistency across the frame matters more than a few µs.
-    const cols = getTerminalWidth();
+    const cols = toolLaneWidth();
     const clamp = (line: string): string => truncateDisplayWidth(line, cols);
 
     // Collect root-level tool entries (those rendered at the top of the

--- a/src/cli/render/measure.test.ts
+++ b/src/cli/render/measure.test.ts
@@ -9,8 +9,11 @@ import { calculateContentWidth } from '../markdown-stream-format.js';
 import { formatThinkingParagraph } from '../commands/interactive/thinking-paragraph.js';
 import {
   renderTextChildLines,
+  toolLaneWidth,
   UNICODE_GLYPHS,
+  type ToolEntry,
 } from '../commands/interactive/tool-lane-render.js';
+import { renderGroupedRootTools } from '../commands/interactive/tool-lane-render-grouped-root.js';
 
 const stripAnsi = (s: string): string => s.replace(/\x1b\[[0-9;]*m/g, '');
 
@@ -136,6 +139,15 @@ describe('adjacency — unbordered surfaces share a right edge', () => {
   const LONG = 'lorem ipsum dolor sit amet consectetur adipiscing elit sed do '.repeat(12);
   const CHROME_SLACK = 12; // indent + prefix + spine glyph budget
 
+  /** A single root tool entry whose composed row far exceeds any test width. */
+  const longToolEntry = (): ToolEntry => ({
+    kind: 'tool',
+    toolUseId: 'tu_measure_1',
+    toolName: 'bash',
+    toolInput: JSON.stringify({ command: LONG }),
+    prefix: `bash(${LONG})`,
+  });
+
   for (const cols of [120, 200]) {
     it(`bounds prose, thinking, and tool-lane text at ${cols} cols`, () => {
       withMeasureEnv(undefined, () =>
@@ -152,16 +164,30 @@ describe('adjacency — unbordered surfaces share a right edge', () => {
           const laneLines = renderTextChildLines(LONG, '  ', UNICODE_GLYPHS);
           const laneMax = Math.max(...laneLines.map((l) => stripAnsi(l).length));
 
+          // Composed tool ROWS, not just the lane's wrapped text. These are
+          // built by string concatenation (prefix + args + outcome) and clamped
+          // as a unit, so they need their own coverage: capping the lane's text
+          // while its sibling rows ran to the screen edge was the exact
+          // discontinuity this describe() exists to catch, and it went
+          // unnoticed because only the text path was pinned here.
+          const rowLines = renderGroupedRootTools(
+            new Map([['bash', [longToolEntry()]]]),
+            ['bash'],
+          );
+          const rowMax = Math.max(...rowLines.map((l) => stripAnsi(l).length));
+
           const ceiling = DEFAULT_TEXT_MEASURE + CHROME_SLACK;
           expect(proseWidth).toBeLessThanOrEqual(ceiling);
           expect(thinkingMax).toBeLessThanOrEqual(ceiling);
           expect(laneMax).toBeLessThanOrEqual(ceiling);
+          expect(rowMax).toBeLessThanOrEqual(ceiling);
 
           // And crucially: they do not scale with the terminal.
           if (cols > ceiling) {
             expect(proseWidth).toBeLessThan(cols);
             expect(thinkingMax).toBeLessThan(cols);
             expect(laneMax).toBeLessThan(cols);
+            expect(rowMax).toBeLessThan(cols);
           }
         }),
       );

--- a/src/cli/render/measure.test.ts
+++ b/src/cli/render/measure.test.ts
@@ -10,6 +10,7 @@ import { formatThinkingParagraph } from '../commands/interactive/thinking-paragr
 import {
   renderTextChildLines,
   toolLaneWidth,
+  clampLineToTerminal,
   UNICODE_GLYPHS,
   type ToolEntry,
 } from '../commands/interactive/tool-lane-render.js';
@@ -204,4 +205,28 @@ describe('adjacency — unbordered surfaces share a right edge', () => {
       }),
     );
   });
+
+  // Regression: PR #923 fed the RAW terminal width into `capToMeasure` when
+  // computing the text-wrap budget, then separately clamped the composed
+  // line to `toolLaneWidth()` (the row budget). Both are capped to the same
+  // measure constant, but wrap budget included chrome (indent/prefix) that
+  // the row clamp did not budget for, so the composed line (indent + prefix
+  // + wrapped text) could exceed the row clamp and get its tail silently
+  // truncated by `clampLineToTerminal`. The `rowMax <= ceiling` assertion
+  // above does not catch this: it only bounds the max width, not whether the
+  // clamp actually altered any line. Pin the real invariant instead — for
+  // every wrapped line, re-applying the row clamp must be a no-op.
+  for (const cols of [120, 200]) {
+    it(`clamping wrapped tool-lane text at the row budget is a no-op at ${cols} cols`, () => {
+      withMeasureEnv(undefined, () =>
+        withCols(cols, () => {
+          const laneLines = renderTextChildLines(LONG, '  ', UNICODE_GLYPHS);
+          const rowBudget = toolLaneWidth();
+          for (const line of laneLines) {
+            expect(clampLineToTerminal(line, rowBudget)).toBe(line);
+          }
+        }),
+      );
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- `render/measure.ts` establishes an invariant: every unbordered text surface (prose, thinking, subagent text, tool-lane wrapped text) must share one reading measure (`DEFAULT_TEXT_MEASURE = 100`), because adjacent unbordered blocks stopping at different columns read as broken wrapping rather than an intentional edge.
- Composed tool-lane *rows* (built by string concatenation — prefix + args + outcome) were the one surface that didn't honor it: they clamped to raw `getTerminalWidth()` instead of the shared measure. On a terminal wider than 100 cols, the lane's own text stopped at ~100 while its sibling tool rows ran to the screen edge — a 60-column right-edge discontinuity at 160 cols.
- Adds one named read point, `toolLaneWidth()`, in `src/cli/commands/interactive/tool-lane-render.ts` (the module all four render files already import from), and routes all 7 width reads through it instead of `getTerminalWidth()`:
  - `tool-lane.ts:331`
  - `tool-lane-render-grouped-root.ts:118`
  - `tool-lane-render-children.ts:97,357` (parameter defaults)
  - `tool-lane-render-agent.ts:129,212,257`
- A named helper rather than 7 inline `capToMeasure(getTerminalWidth())` calls because two of those sites are a hard pairing: `formatAgentSummary` and `formatAgentHeader` can both emit a head row for the same entry across a session, and the file's own encoding constraint requires their clamp width to agree — otherwise the same entry committed through the two paths would differ whenever the row exceeds the terminal width. They now agree by calling one function, not by both happening to read the terminal the same way.
- `capToMeasure` is a pure `min`, never a widen, so the existing wrap-prevention guarantee is strictly strengthened, not replaced — the row is still clamped to at most the terminal width, just also to the measure when the terminal exceeds it. On terminals at or below the measure (the common 80–100 column case) this is a no-op. `AFK_TEXT_MEASURE=full` restores the previous uncapped behavior for anyone who wants it.

**Before/after at 160 cols:** prose/thinking/tool-lane-text capped at 100 (unchanged); composed tool rows now also capped at 100 (previously ran to 160).

## Test results
- `pnpm lint` (tsc --noEmit): clean.
- `pnpm test` (full suite): 15,142 passed / 1 failed / 2 skipped. The 1 failure is pre-existing and unrelated (see Out of scope).
- Extended the adjacency test in `src/cli/render/measure.test.ts` to cover composed rows, not just the lane's wrapped text — that coverage gap is why the discontinuity went unnoticed (the `describe()` block claims "a new unbordered surface that skips capToMeasure fails here" while only pinning the text path). Verified the new assertion fails without the fix (`expected 200 to be less than or equal to 112`) and passes with it.
- Re-ran the touched test files directly in this session as a cheap re-confirmation before opening this PR (`measure.test.ts` + all `tool-lane*.test.ts`): same result, same single pre-existing failure.

## Out of scope
`src/agent/trace/writer.test.ts > "process-exit backstop seals a real crashed subprocess"` fails on this branch (`expected 1, got null`) but is a **pre-existing failure, not a regression** — confirmed failing identically on clean base `c9374cd2` (current `origin/main` ancestor) with this branch's changes stashed out. It's unrelated to rendering/measure logic and intentionally not touched here.