### PR TITLE
fix(permissions): restore $HOME expansion for doubled-slash tilde denylist entries (#921)

### DIFF
--- a/src/agent/tools/handlers/read-denylist.test.ts
+++ b/src/agent/tools/handlers/read-denylist.test.ts
@@ -29,7 +29,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { _resetFsCaseCacheForTests } from '../fs-case.js';
 import { mkdirSync, rmSync, symlinkSync, existsSync, writeFileSync } from 'fs';
-import { basename, dirname, join } from 'path';
+import { basename, dirname, join, resolve } from 'path';
 import { homedir, tmpdir } from 'os';
 import {
   isReadDenied,
@@ -589,6 +589,30 @@ describe('parseReadDenylistEntries — the single parser both surfaces share', (
   it('expands a bare ~ and a leading ~/', () => {
     expect(parseReadDenylistEntries('~')).toEqual([homedir()]);
     expect(parseReadDenylistEntries('~/.netrc')).toEqual([join(homedir(), '.netrc')]);
+  });
+
+  // Regression guard (#921): PR #893 swapped the hand-rolled
+  // `join(homedir(), p.slice(1))` expansion for the shared `expandHome`,
+  // which builds `resolve(homedir(), input.slice(2))`. `resolve()` lets an
+  // ABSOLUTE second argument win, and `'~//x'.slice(2)` is `/x` (absolute) —
+  // so a doubled leading slash silently un-denied the path the operator
+  // meant to floor (`/x` instead of `$HOME/x`). The parser now collapses a
+  // leading `~/+` to `~/` before expanding, so the doubled-slash spelling
+  // resolves the same as the single-slash one.
+  it('collapses a doubled leading slash instead of falling through resolve() to an absolute path (#921)', () => {
+    expect(parseReadDenylistEntries('~//x')).toEqual([join(homedir(), 'x')]);
+    expect(parseReadDenylistEntries('~///x')).toEqual([join(homedir(), 'x')]);
+  });
+
+  // Same regression guard, the other direction: fixing the doubled-slash
+  // case must not perturb any spelling that already worked.
+  it('leaves already-correct tilde spellings unchanged (#921)', () => {
+    expect(parseReadDenylistEntries('~')).toEqual([homedir()]);
+    expect(parseReadDenylistEntries('~/')).toEqual([homedir()]);
+    expect(parseReadDenylistEntries('~/x')).toEqual([join(homedir(), 'x')]);
+    // `~user/…` is NOT expanded (no portable home lookup) — it falls through
+    // to a plain `resolve()` relative to cwd, same as any non-tilde entry.
+    expect(parseReadDenylistEntries('~user/x')).toEqual([resolve('~user/x')]);
   });
 });
 

--- a/src/agent/tools/handlers/read-denylist.ts
+++ b/src/agent/tools/handlers/read-denylist.ts
@@ -248,6 +248,18 @@ let cached:
  * `resolve()` alone turns that into a literal `./~/…` directory that matches
  * nothing — a security control silently protecting no path. `~user/…` is NOT
  * expanded (no portable home lookup); spell those absolutely.
+ *
+ * A doubled leading slash (`~//x`, `~///x`) is collapsed to `~/x` BEFORE
+ * calling {@link expandHome}. `expandHome` builds the expansion with
+ * `resolve(homedir(), input.slice(2))`, and `resolve()` lets an ABSOLUTE
+ * second argument win over the first — `~//x`.slice(2) is `/x` (absolute),
+ * so unnormalized it resolves to `/x` instead of `$HOME/x`, silently
+ * un-denying the path the operator meant to floor (issue #921, regressed by
+ * PR #893's switch from a hand-rolled `join(homedir(), …)` expander, which
+ * does not have this failure mode, to the shared `expandHome`). Normalizing
+ * here — rather than in `expandHome` itself — keeps the fix scoped to this
+ * parser; `expandHome` has other adopters (plugin source resolution) this
+ * denylist parser must not risk widening.
  */
 export function parseReadDenylistEntries(raw: string | undefined): string[] {
   if (!raw) return [];
@@ -255,7 +267,7 @@ export function parseReadDenylistEntries(raw: string | undefined): string[] {
     .split(':')
     .map((p) => p.trim())
     .filter(Boolean)
-    .map((p) => (p === '~' || p.startsWith('~/') ? expandHome(p) : p))
+    .map((p) => (p === '~' || p.startsWith('~/') ? expandHome(p.replace(/^~\/+/, '~/')) : p))
     .map((p) => resolve(p));
 }
 


### PR DESCRIPTION
Closes #921.

## What was wrong

PR #893 (commit `6e99cac9`) replaced a hand-rolled tilde expander in the `AFK_READ_DENYLIST` parser with the canonical `expandHome()`:

```diff
-    .map((p) => (p === '~' || p.startsWith('~/') ? join(homedir(), p.slice(1)) : p))
+    .map((p) => (p === '~' || p.startsWith('~/') ? expandHome(p) : p))
```

The two are equivalent for every spelling except one. `join(homedir(), …)` keeps its second argument under the base; `expandHome` uses `resolve(homedir(), input.slice(2))`, and `resolve()` lets an **absolute** second argument win outright. Slicing `~//foo/bar` at index 2 yields `/foo/bar` — absolute — so the entry resolved to `/foo/bar` instead of `$HOME/foo/bar`.

The operator's intended path stopped being denied. That is a **fail-open change to a security control**, and it was undeclared: #893's description states the only intentional behavior change is expanding a bare `~`.

Blast radius was both surfaces, because `parseReadDenylistEntries` is the single shared parser — `bash-restriction-hook.ts:491` calls it too. The shared-parser invariant held (the two surfaces still agreed with each other); they just agreed on the wrong path.

## The fix

Collapse a leading `~/+` to `~/` before expanding, at the call site:

```diff
-    .map((p) => (p === '~' || p.startsWith('~/') ? expandHome(p) : p))
+    .map((p) => (p === '~' || p.startsWith('~/') ? expandHome(p.replace(/^~\/+/, '~/')) : p))
```

This restores the pre-#893 semantic (`~//x` = `$HOME/x`) rather than accepting the new one. Two reasons: the change was never declared, so nothing depends on it; and when a security control's semantics are ambiguous, the reading that keeps the operator's path protected is the safe default.

**`expandHome()` itself is deliberately untouched.** It is the canonical expander with unrelated adopters, and widening the fix there would change plugin source resolution to buy nothing this issue asks for. The docblock records why the normalization lives at the call site so a future refactor does not "simplify" it back.

## Tests

Added next to the existing bare-`~` case in `read-denylist.test.ts`:

- `collapses a doubled leading slash instead of falling through resolve() to an absolute path (#921)` — `~//x` and `~///x` both land at `$HOME/x`
- `leaves already-correct tilde spellings unchanged (#921)` — pins `~`, `~/`, `~/x`, and `~user/…` passthrough

The regression produced no test movement in either direction when it shipped, because nothing covered the `~//` form. It is pinned now.

## Verification

- `pnpm test src/agent/tools/handlers/read-denylist.test.ts` — 69 passed
- `pnpm test src/agent/tools/hooks/bash-restriction-hook.test.ts` — 86 passed (shares the parser, untouched, no regression)
- `pnpm lint` — clean

## Follow-up found, not fixed here

The same doubled-slash edge exists at other `expandHome` call sites:

- `src/agent/plugins/source.ts:160` (`toAbsolute`, used by `parseSource`) — `~//evil` resolves to `/evil`. Reachable from any user-supplied plugin-source string.
- `src/agent/tools/handlers/terminal-font-size.ts:72,188,241` — same mechanism, but every current call site passes a hardcoded literal without doubled slashes, so it is latent rather than reachable.

Left out of this PR to keep a security fix single-purpose. Worth a separate issue deciding whether `expandHome` should normalize internally.
