### PR TITLE
fix(agents): grant research-agent memory_search so the ground-state surveyor can reach the archive (#883)

### DIFF
--- a/src/agent/agents/builtins.ts
+++ b/src/agent/agents/builtins.ts
@@ -116,7 +116,23 @@ export function builtinAgents(): Map<string, RegisteredAgent> {
         // `nestedAgentTypes`, and the subagent executor mechanically restricts
         // research-agent to dispatching ONLY git-investigator (no bare/other
         // dispatch), so the read-only contract can't be escalated.
-        tools: [...researchAgent.allowedTools, 'Agent(git-investigator)'],
+        //
+        // `memory_search` is granted by the same registry-entry mechanism, for
+        // the same reason it must not go in the shared const. Without it the
+        // cross-session fact archive is unreachable from a research-agent, and
+        // the failure is SILENT: `/ground-state` dispatches its memory surveyor
+        // as this type and instructs it to "call the memory_search tool", so the
+        // surveyor degrades to reading HOT.md/AFK.md off disk and then truthfully
+        // reports which stores it consulted — a report that looks satisfied while
+        // a third of the recon wave never happened (issue #883). The tool is
+        // read-only by construction and already trusted by the MOST restricted
+        // role in the system (READ_ONLY_PHASE_TOOLS, mint's spec/research/plan
+        // phases) and by RECON_ALLOWED_TOOLS, so withholding it from a read-only
+        // research agent was incoherent rather than protective — the same
+        // argument CHILD_ALLOWED_TOOLS already makes at nesting.ts:124-131.
+        // Note `memory_update`/`procedure_write` are deliberately NOT granted:
+        // those mutate, and target:"hot" reaches every future session's prompt.
+        tools: [...researchAgent.allowedTools, 'memory_search', 'Agent(git-investigator)'],
         // Anti-runaway bound (see READONLY_AGENT_MAX_TOOL_USE_ITERATIONS): a
         // read-only research/review agent that keeps tool-calling without ever
         // emitting a final message otherwise runs unbounded on the (uncapped)

--- a/src/agent/agents/registry.test.ts
+++ b/src/agent/agents/registry.test.ts
@@ -10,6 +10,8 @@ import { join } from 'node:path';
 
 import { loadAgentRegistry } from './registry.js';
 import { builtinAgents } from './builtins.js';
+import { resolveAgentToolAccess } from './resolve.js';
+import { CHILD_ALLOWED_TOOLS, RECON_ALLOWED_TOOLS } from '../tools/nesting.js';
 
 let tmp: string;
 let prevAfkHome: string | undefined;
@@ -42,16 +44,19 @@ describe('loadAgentRegistry', () => {
     expect(registry.get('git-investigator')?.bashReadOnly).toBe(true);
     expect(registry.get('general-purpose')?.source).toBe('builtin');
     expect(registry.get('Explore')?.source).toBe('builtin');
-    // research-agent keeps its vendored read-only contract PLUS the scoped
-    // git-investigator dispatch grant (matches the vendored prompt frontmatter;
-    // resolve.ts turns Agent(git-investigator) into nestedAgentTypes and the
-    // executor restricts research-agent to dispatching only git-investigator).
+    // research-agent keeps its vendored read-only contract PLUS two
+    // registry-entry grants: `memory_search` (read-only archive access — see
+    // the #883 test below) and the scoped git-investigator dispatch grant
+    // (matches the vendored prompt frontmatter; resolve.ts turns
+    // Agent(git-investigator) into nestedAgentTypes and the executor restricts
+    // research-agent to dispatching only git-investigator).
     expect(registry.get('research-agent')?.definition.tools).toEqual([
       'Read',
       'Grep',
       'Glob',
       'WebFetch',
       'WebSearch',
+      'memory_search',
       'Agent(git-investigator)',
     ]);
     // Anti-runaway bound: the read-only research/review builtins carry an
@@ -103,6 +108,35 @@ describe('loadAgentRegistry', () => {
     }
     expect(sawRestricted, 'expected ≥1 restricted read-only builtin').toBe(true);
     expect(sawInheritAll, 'expected the inherit-all worker (general-purpose)').toBe(true);
+  });
+
+  // Regression guard for #883. Asserting the registry's static `tools` array
+  // is not enough: what the dispatcher enforces is the RESOLVED access set,
+  // and resolution intersects the declared tokens with the child's runtime
+  // pool — so a tool can be declared and still be unreachable if the pool
+  // omits it. This pins the effective set on BOTH child surfaces a surveyor
+  // can actually land on. `/ground-state` is enforced read-only by name
+  // (RECON_ALLOWED_TOOLS); a research-agent dispatched from an ordinary parent
+  // gets CHILD_ALLOWED_TOOLS. memory_search must survive both, or the memory
+  // third of the recon wave silently degrades to reading files off disk.
+  it('research-agent can reach memory_search on every child surface it is dispatched from (#883)', () => {
+    const registry = loadAgentRegistry({ cwd: join(tmp, 'proj'), warn: () => {} });
+    const entry = registry.get('research-agent');
+    expect(entry).toBeDefined();
+
+    for (const [surface, pool] of [
+      ['read-only skill child (ground-state)', RECON_ALLOWED_TOOLS],
+      ['ordinary child', CHILD_ALLOWED_TOOLS],
+    ] as const) {
+      const resolved = resolveAgentToolAccess(entry!, [...pool]);
+      expect(resolved.allowedTools, `memory_search unreachable on ${surface}`).toContain(
+        'memory_search',
+      );
+      // The grant must not have widened the read-only contract on the way in.
+      for (const forbidden of ['write_file', 'edit_file', 'bash', 'memory_update']) {
+        expect(resolved.allowedTools, `${forbidden} leaked on ${surface}`).not.toContain(forbidden);
+      }
+    }
   });
 
   it('strips vendored frontmatter from builtin prompts (body-only system prompt)', () => {


### PR DESCRIPTION
Closes #883.

## What was wrong

`/ground-state` dispatches its **memory surveyor** as `research-agent`, whose mechanically-enforced allowlist contained no `memory_search`. The memory third of the mandated pre-flight recon could not reach the cross-session fact archive at all.

The failure mode is what makes this worth fixing rather than documenting: it is **silent**. The surveyor degrades to reading `HOT.md` / `AFK.md` off disk, and the skill asks it to "report which stores you consulted" — so it truthfully reports `HOT.md: read; AFK.md: read` and the gap *looks* satisfied. Every `/ground-state` run has been paying for a memory surveyor structurally incapable of consulting memory.

## Mechanism (verified, not inferred)

The child pools are not the problem — both `CHILD_ALLOWED_TOOLS` and `RECON_ALLOWED_TOOLS` already include `memory_search` (`nesting.ts:132`, `nesting.ts:152-170`), and `nesting.ts:124-131` argues explicitly that excluding it while the *more* restricted `READ_ONLY_PHASE_TOOLS` trusts it would be incoherent.

The gap is one level down. `/ground-state`'s own fork gets `RECON_ALLOWED_TOOLS` and can reach memory; the **nested surveyor** it dispatches resolves against the `research-agent` registry entry, which declared only `[...researchAgent.allowedTools, 'Agent(git-investigator)']`. Resolution intersects declared tokens with the pool, so a tool absent from the declaration is unreachable no matter how permissive the pool is.

## The fix

One token, at the registry entry in `builtins.ts`:

```diff
-        tools: [...researchAgent.allowedTools, 'Agent(git-investigator)'],
+        tools: [...researchAgent.allowedTools, 'memory_search', 'Agent(git-investigator)'],
```

This is the issue's **Option 2**, and it turns out the codebase had already built the precedent: the adjacent `Agent(git-investigator)` grant lives at this exact spot, with a comment explaining that it must *not* go in the shared `researchAgent.allowedTools` const — because diagnose's read-only leaf surface and audit-fit's `inspectorTools` gate both derive from that const. Same reasoning applies here, so the grant lands in the same place and those gates are unchanged.

The byte-locked vendored prompt (`prompts/research-agent.md`) is untouched; `vendored.test.ts` stays green.

`memory_update` and `procedure_write` are deliberately **not** granted — they mutate, and `target: "hot"` reaches every future session's system prompt.

## Tests

`registry.test.ts` — `research-agent can reach memory_search on every child surface it is dispatched from (#883)`.

It asserts the **resolved** access set from `resolveAgentToolAccess`, not the static `tools` array, because resolution intersects declared tokens against the runtime pool — a test on the declaration alone would pass while the tool stayed unreachable. It runs both surfaces a surveyor can land on (`RECON_ALLOWED_TOOLS` for the read-only skill child, `CHILD_ALLOWED_TOOLS` for an ordinary parent) and also asserts the grant did not widen the read-only contract (`write_file`, `edit_file`, `bash`, `memory_update` all still absent).

**Verified the test actually catches the bug**: stashing the one-line fix and re-running produces `memory_search unreachable on read-only skill child (ground-state)` — 2 failed / 22 passed. The pre-existing exact-array assertion at `registry.test.ts:49` was the blast radius and is updated.

## Gates

- `pnpm lint` — clean
- `pnpm test src/agent/agents/registry.test.ts` — 24 passed
- `pnpm test` on `vendored.test.ts`, `resolve.test.ts`, `tool-def.test.ts`, `subagent-executor.named-agents.test.ts`, `nesting.test.ts` — **112 passed**, byte-lock intact

## Scope note for the reviewer

Acceptance criterion 1 ("a real run reports real query counts from the surveyor itself") is **proven only at the tool-access layer**, not by an end-to-end `/ground-state` run — the test proves the surveyor *can* call `memory_search`; it does not prove a live model *will*. In practice the dispatch prompt instructs it to (`SKILL.md:44`) and the tool now appears in the child's advertised schema, so the mechanical blocker is removed.

One deliberate omission: `researchAgent.description` still reads "Mechanically locked to Read, Grep, Glob, WebFetch, WebSearch". It is left unchanged because it mirrors the byte-locked `.md` frontmatter verbatim, and the existing `Agent(git-investigator)` grant is undocumented there for the same reason. Worth a follow-up deciding whether the registry-granted tools should be reflected in the description shown to orchestrating models.
