### PR TITLE
fix(worktree): name the ignored entry that preserved a tree, and stop the test that manufactured them

### DIFF
--- a/src/agent/tools/handlers/edit-file.test.ts
+++ b/src/agent/tools/handlers/edit-file.test.ts
@@ -2,14 +2,24 @@
  * Tests for the edit_file tool handler.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, afterAll } from 'vitest';
 import { readFile, writeFile, mkdir } from 'fs/promises';
 import { rm } from 'fs/promises';
+import os from 'os';
 import path from 'path';
+import { randomBytes } from 'crypto';
 import { editFileHandler } from './edit-file.js';
 
-// Use a temporary directory for test files
-const tempDir = path.join(process.cwd(), '.test-temp-edit-file');
+// Invariant: this scratch dir must live OUTSIDE the repo working tree. Rooted
+// at `process.cwd()` it landed as `.test-temp-edit-file/` in whatever checkout
+// ran the suite, and any run that did not reach `afterEach` (Ctrl+C, OOM, a
+// killed worker) left it behind. Being gitignored, `git status` reports it
+// clean while the worktree ignored-file probe classifies the unrecognised name
+// as non-rebuildable — so every worktree that had ever run the tests was
+// preserved on session exit, forever, citing local state the user never
+// created. Under os.tmpdir() the same abandoned run leaks nothing into a
+// checkout. The random suffix keeps two concurrent suite runs from sharing it.
+const tempDir = path.join(os.tmpdir(), `afk-edit-file-test-${process.pid}-${randomBytes(4).toString('hex')}`);
 
 async function createTempFile(filename: string, content: string): Promise<string> {
   await mkdir(tempDir, { recursive: true });
@@ -21,6 +31,14 @@ async function createTempFile(filename: string, content: string): Promise<string
 async function readTempFile(filePath: string): Promise<string> {
   return readFile(filePath, 'utf-8');
 }
+
+// File-scoped, not describe-scoped: the second describe below mkdirs tempDir
+// inside its cases and registers no afterEach, so the per-test cleanup in the
+// first block is not the last writer and the dir outlives the run. That is
+// what left one behind on every suite invocation.
+afterAll(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
 
 describe('editFileHandler', () => {
   beforeEach(async () => {

--- a/src/agent/worktree-ignored-probe.test.ts
+++ b/src/agent/worktree-ignored-probe.test.ts
@@ -233,9 +233,13 @@ describe('hasNonRebuildableIgnoredFiles — collapsed-directory expansion', () =
 describe('probeNonRebuildableIgnoredFiles — verdict provenance', () => {
   it('reports a real find as non-rebuildable-entry', async () => {
     const exec = mockExec('!! local-notes.md\n');
+    // `detail` names the offending entry: without it the caller can only say
+    // "non-rebuildable ignored files (e.g. .env)", which reads as a finding
+    // and sends the user hunting for a file that is not there.
     expect(await probeNonRebuildableIgnoredFiles(exec, '/tmp/wt')).toEqual({
       protect: true,
       because: 'non-rebuildable-entry',
+      detail: 'local-notes.md',
     });
   });
 

--- a/src/agent/worktree-ignored-probe.ts
+++ b/src/agent/worktree-ignored-probe.ts
@@ -57,8 +57,16 @@ const PROBE_EXEC_OPTS = { maxBuffer: 64 * 1024 * 1024, timeout: 10_000 } as cons
 /** Why the probe says a tree must be preserved. */
 export type IgnoredProbeVerdict =
   | { protect: false }
-  /** Found an ignored entry a rebuild would not restore. */
-  | { protect: true; because: 'non-rebuildable-entry' }
+  /**
+   * Found an ignored entry a rebuild would not restore. `detail` is the
+   * repo-relative path of that entry, and carrying it is not cosmetic: a
+   * verdict that only says "something protected this" leaves the caller to
+   * describe the find generically ("e.g. `.env`"), which reads as a FINDING.
+   * A user then hunts for a secret that does not exist while the real cause —
+   * test detritus, a scratch dir — stays invisible and the tree is preserved
+   * on every exit with no way to learn why.
+   */
+  | { protect: true; because: 'non-rebuildable-entry'; detail: string }
   /**
    * git itself failed, so the answer is unknown and we protect on principle.
    * Distinguished from a real find so callers can SAY SO: a silent protect here
@@ -123,7 +131,7 @@ async function inspectableDirHidesLocalState(
   for (const entry of nested.entries) {
     if (entry === dirEntry) continue; // git echoed the directory — no new information
     if (classifyIgnoredEntry(entry) === 'protected') {
-      return { protect: true, because: 'non-rebuildable-entry' };
+      return { protect: true, because: 'non-rebuildable-entry', detail: entry };
     }
   }
   return { protect: false };
@@ -149,7 +157,9 @@ export async function probeNonRebuildableIgnoredFiles(
   if ('failure' in top) return { protect: true, because: 'git-failed', detail: top.failure };
   for (const entry of top.entries) {
     const verdict = classifyIgnoredEntry(entry);
-    if (verdict === 'protected') return { protect: true, because: 'non-rebuildable-entry' };
+    if (verdict === 'protected') {
+      return { protect: true, because: 'non-rebuildable-entry', detail: entry };
+    }
     if (verdict === 'inspectable' && entry.endsWith('/')) {
       const nested = await inspectableDirHidesLocalState(execFile, worktreePath, entry);
       if (nested.protect) return nested;

--- a/src/agent/worktree-sweep.ts
+++ b/src/agent/worktree-sweep.ts
@@ -56,7 +56,11 @@ type DirtyReason =
   | 'clean'
   | 'uncommitted changes'
   | 'git status failed'
-  | 'non-rebuildable ignored files'
+  // Carries the offending path. Naming it is the difference between a warning
+  // the reader can act on and one that sends them hunting for a secret that
+  // is not there: the entry holding a tree is as often leftover test detritus
+  // as it is a real `.env`.
+  | `non-rebuildable ignored files: ${string}`
   | 'ignored-file probe failed';
 
 interface WorktreeMeta {
@@ -720,7 +724,7 @@ export async function runSweep(options: SweepOptions): Promise<SweepResult> {
           dirtyReason =
             probe.because === 'git-failed'
               ? 'ignored-file probe failed'
-              : 'non-rebuildable ignored files';
+              : `non-rebuildable ignored files: ${probe.detail}`;
         }
         // A protect-on-failure is indistinguishable from a real find at the
         // verdict level, so surface it: otherwise a worktree that git can no

--- a/src/cli/commands/interactive/worktree.test.ts
+++ b/src/cli/commands/interactive/worktree.test.ts
@@ -263,7 +263,41 @@ describe('setupWorktree', () => {
     const logged = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
     expect(logged).toMatch(/preserved/);
     expect(logged).toMatch(/ignored/);
+    // The message must NAME the entry that protected the tree. A generic
+    // "(e.g. .env)" reads as a finding: a user whose tree was held by leftover
+    // test detritus went looking for a secret that did not exist, and the real
+    // cause stayed invisible across every exit.
+    expect(logged).toContain('.env');
+    expect(logged).not.toContain('e.g.');
     logSpy.mockRestore();
+  });
+
+  // Regression (this session): the tree was held by an unrecognised ignored
+  // entry that is NOT a secret — leftover `.test-temp-edit-file/` from the
+  // suite. The old wording claimed `.env`; the message must say what is
+  // actually there.
+  it('names the real offending entry when it is not a secret', async () => {
+    const mock = makeMock(async ({ args }) => {
+      if (args.includes('rev-parse')) {
+        return { stdout: `${repoRoot}/.git\n`, stderr: '' };
+      }
+      if (args.includes('status') && args.includes('--ignored')) {
+        return { stdout: '!! .test-temp-edit-file/\n!! node_modules/\n', stderr: '' };
+      }
+      if (args.includes('status') && args.includes('--porcelain')) {
+        return { stdout: '', stderr: '' };
+      }
+      return { stdout: '', stderr: '' };
+    });
+
+    const handle = await setupWorktree('feat-x', { execFile: mock });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await handle.cleanup();
+    const logged = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    logSpy.mockRestore();
+
+    expect(logged).toContain('.test-temp-edit-file/');
+    expect(logged).not.toContain('.env');
   });
 
   it('cleanup still removes a clean tree whose ignored content is only build output', async () => {

--- a/src/cli/commands/interactive/worktree.ts
+++ b/src/cli/commands/interactive/worktree.ts
@@ -19,7 +19,7 @@ import { randomBytes } from 'node:crypto';
 
 import { recordCdIntent, shellWrapperActive } from '../../../utils/cd-on-exit.js';
 import { detectShellFromEnv } from '../shell-init.js';
-import { hasNonRebuildableIgnoredFiles } from '../../../agent/worktree-ignored-probe.js';
+import { probeNonRebuildableIgnoredFiles } from '../../../agent/worktree-ignored-probe.js';
 import { registerWorktreeRoot } from '../../../agent/worktree-root-registry.js';
 import type { WorktreeDisposition } from './worktree-disposition.js';
 
@@ -728,9 +728,18 @@ async function createWorktreeAt(
       // Rebuildable output (node_modules/, dist/) stays non-protective on
       // purpose: treating it as protective would strand every worktree the
       // user ever finished with.
-      if (await hasNonRebuildableIgnoredFiles(execFile, currentPath)) {
+      // Contract: name the entry that ACTUALLY protected the tree. The old
+      // wording ("non-rebuildable ignored files (e.g. .env)") read as a
+      // finding, so a user who had no `.env` went hunting for a secret that
+      // did not exist while the real cause — leftover test detritus, a
+      // scratch dir — stayed invisible and the tree was preserved on every
+      // single exit with nothing in the message to explain why.
+      const ignoredProbe = await probeNonRebuildableIgnoredFiles(execFile, currentPath);
+      if (ignoredProbe.protect) {
         preserveWorktree(
-          'non-rebuildable ignored files (e.g. .env) that `git status` cannot see',
+          ignoredProbe.because === 'git-failed'
+            ? `the ignored-file probe failed (${ignoredProbe.detail}), so removal would be a guess`
+            : `ignored local state \`git status\` cannot see: ${ignoredProbe.detail}`,
         );
         return;
       }


### PR DESCRIPTION
## What

Session exit reported this on **every** quit, in 22 of 29 local worktrees:

```
Worktree preserved at .../.afk-worktrees/afk-improve-tui-spacing (branch: afk/improve-tui-spacing)
  — non-rebuildable ignored files (e.g. .env) that `git status` cannot see.
```

There was no `.env`. The entry actually holding the tree was `.test-temp-edit-file/` — **the edit_file test's own scratch dir**, which the suite rooted at `process.cwd()` and therefore left inside whatever checkout ran the tests.

```
$ git -C .afk-worktrees/afk-improve-tui-spacing status --porcelain --ignored
!! .afk-worktree-meta.json    → opaque       (rebuildable)
!! .test-temp-edit-file/      → protected    ← held the tree
!! coverage/ dist/ node_modules/  → inspectable / opaque

probe verdict: {"protect":true,"because":"non-rebuildable-entry"}
```

Being gitignored, `git status` called each tree clean; the probe classified the unrecognised name as non-rebuildable — its deliberate fail-safe default (`worktree-ignored-patterns.ts`) — and preserved it. Two consequences:

- The canned `(e.g. .env)` wording **read as a finding**, sending the reader hunting for a secret that did not exist while the real cause stayed invisible.
- The probe check runs *before* the disposition check (`worktree.ts`), so it also silently overrode an explicit "remove" choice.

## Changes

1. **`IgnoredProbeVerdict` carries `detail`** — the repo-relative path of the entry that protected the tree. A verdict that only says "something protected this" forces every caller into the canned-example wording that caused the confusion.

2. **Both human-facing surfaces name it.** REPL session-exit now prints ``ignored local state `git status` cannot see: .test-temp-edit-file/``, and the sweep's `stale-dirty` warning carries the path in `DirtyReason` (widened to a template-literal type, so the compiler still constrains the shape).

3. **`edit-file.test.ts` writes under `os.tmpdir()`** instead of `process.cwd()`. Two leaks, not one: any run dying before `afterEach` (Ctrl+C, OOM, a killed worker) leaked the dir into the checkout permanently — *and* the second describe block mkdirs `tempDir` inside its cases with no `afterEach`, so the dir outlived every run regardless. A file-scoped `afterAll` closes the second; `os.tmpdir()` makes the first harmless. A random suffix keeps concurrent suite runs apart.

## Deliberately not changed

The classifier's unrecognised-entry default stays `protected`. It is correct — teaching it this repo's test-dir name would trade a fail-safe for a special case. Fixing the emitter removes the input instead.

## Verification

- `pnpm lint`, `pnpm build`, `pnpm test` (800 files / 15254 tests), `audit:sdk:check`, `audit:env:check`, `scan:env:check`, `audit:chalk:check`, `fix:pins:check`, `audit:deps` — all green.
- A full suite run now leaves the repo working tree clean (`find . -name .test-temp-edit-file` → 0) and leaves no scratch dir in `tmpdir`.
- New/updated tests: the probe verdict asserts `detail`; the REPL cleanup test asserts the offending entry is named and that the message no longer says `e.g.`; a new case covers a non-secret entry (`.test-temp-edit-file/`) and asserts the message does not claim `.env`.
