### PR TITLE
fix(worktree): stop generated build artifacts and symlinked dep trees from making worktrees immortal

### DIFF
--- a/src/agent/worktree-ignored-patterns.test.ts
+++ b/src/agent/worktree-ignored-patterns.test.ts
@@ -143,6 +143,37 @@ describe('classifyIgnoredEntry — leaf-matching does not over-reach', () => {
     });
   }
 
+  // `logs/` is rebuildable-listed but is RUNTIME output, not compiler output:
+  // nothing regenerates it, so a file a human kept there survives builds and
+  // must survive the sweep. Suppressing name hints inside it traded a permanent
+  // false positive for a permanent data-loss risk.
+  const runtimeOutput = ['logs/credentials.js', 'logs/secret-audit.html', 'logs/secret.map'];
+  for (const entry of runtimeOutput) {
+    it(`protects ${entry} — logs/ is runtime output, not a generated mirror`, () => {
+      expect(classifyIgnoredEntry(entry)).toBe('protected');
+    });
+  }
+
+  // Invariant: the accepted blast radius of the name-hint suppression, pinned
+  // so it can never widen silently. Each of these was `protected` before the
+  // suppression existed and is reapable now. They are compiler output — the
+  // next build deletes them regardless, so the sweep is not what destroys
+  // them — but the set is asserted rather than incidental, and a credential in
+  // a DATA format stays protected everywhere (see dataUnderBuildOutput above).
+  const acceptedReapable = [
+    'dist/secret-notes.js',
+    'out/client_secret.js',
+    'dist/.secrets.js',
+    'coverage/credentials.css',
+    'dist/my-secret.ts',
+    'dist/secret.env.html',
+  ];
+  for (const entry of acceptedReapable) {
+    it(`accepts ${entry} as reapable compiler output (pinned blast radius)`, () => {
+      expect(classifyIgnoredEntry(entry)).not.toBe('protected');
+    });
+  }
+
   // Outside generated output the name hints are untouched — that is where a
   // credential-shaped name is actually evidence of one.
   const authoredHints = ['credentials.json', 'src/secrets.txt', 'credentials.html', '.secrets'];

--- a/src/agent/worktree-ignored-patterns.test.ts
+++ b/src/agent/worktree-ignored-patterns.test.ts
@@ -90,6 +90,67 @@ describe('classifyIgnoredEntry — leaf-matching does not over-reach', () => {
       expect(isSensitiveLeaf(entry)).toBe(true);
     });
   }
+
+  // Regression: every build artifact echoes the name of the source file it was
+  // produced from. A repo holding `src/agent/auth/credential-resolver.ts` emits
+  // `dist/agent/auth/credential-resolver.d.ts` and a coverage page of the same
+  // name — both matched `/credential/`, protected the tree, and made every
+  // worktree that had run a build or a coverage pass permanently unreapable,
+  // citing a "secret" that was compiler output. The suppression is scoped to
+  // the DIRECTORY, not to an extension list: the mirror follows the toolchain.
+  const generatedMirrors = [
+    'dist/agent/auth/credential-resolver.d.ts',
+    'dist/agent/auth/credential-resolver.js',
+    'dist/agent/auth/credential-resolver.d.ts.map',
+    'coverage/src/agent/auth/credential-resolver.ts.html',
+    'coverage/src/agent/redact-secrets.ts.html',
+    'node_modules/@scope/secret-box/index.js',
+    'dist/docs/secret-handling.css',
+  ];
+  for (const entry of generatedMirrors) {
+    it(`treats ${entry} as generated output, not a secret`, () => {
+      expect(classifyIgnoredEntry(entry)).not.toBe('protected');
+    });
+  }
+
+  // The suppression reaches ONLY the name hints, and only on an artifact
+  // extension. A credential FORMAT protects the tree from anywhere, and a data
+  // file under build output keeps the guarantee #759 pinned — no toolchain
+  // name-mirrors a source module into `.json`, so excluding it costs nothing.
+  const formatAnchored = [
+    'coverage/prod.env',
+    'dist/app.env',
+    'coverage/src/tls.pem',
+    'dist/deploy.key',
+    'coverage/secret.db',
+    'dist/cache/store.sqlite3',
+  ];
+  for (const entry of formatAnchored) {
+    it(`still protects ${entry} despite living under generated output`, () => {
+      expect(isSensitiveLeaf(entry)).toBe(true);
+      expect(classifyIgnoredEntry(entry)).toBe('protected');
+    });
+  }
+
+  const dataUnderBuildOutput = [
+    'dist/nested/app-credentials.json',
+    'dist/secrets.yaml',
+    'coverage/credentials.txt',
+  ];
+  for (const entry of dataUnderBuildOutput) {
+    it(`keeps ${entry} protected — a data file is not a generated mirror`, () => {
+      expect(classifyIgnoredEntry(entry)).toBe('protected');
+    });
+  }
+
+  // Outside generated output the name hints are untouched — that is where a
+  // credential-shaped name is actually evidence of one.
+  const authoredHints = ['credentials.json', 'src/secrets.txt', 'credentials.html', '.secrets'];
+  for (const entry of authoredHints) {
+    it(`keeps ${entry} protected outside generated output`, () => {
+      expect(classifyIgnoredEntry(entry)).toBe('protected');
+    });
+  }
 });
 
 /**

--- a/src/agent/worktree-ignored-patterns.test.ts
+++ b/src/agent/worktree-ignored-patterns.test.ts
@@ -96,19 +96,28 @@ describe('classifyIgnoredEntry — leaf-matching does not over-reach', () => {
   // `dist/agent/auth/credential-resolver.d.ts` and a coverage page of the same
   // name — both matched `/credential/`, protected the tree, and made every
   // worktree that had run a build or a coverage pass permanently unreapable,
-  // citing a "secret" that was compiler output. The suppression is scoped to
-  // the DIRECTORY, not to an extension list: the mirror follows the toolchain.
+  // citing a "secret" that was compiler output. The suppression fires only at
+  // the INTERSECTION of both conditions — the entry sits under a rebuildable
+  // DIRECTORY *and* its leaf carries an artifact EXTENSION — so the mirror
+  // follows the toolchain without reaching a data file dropped alongside it.
   const generatedMirrors = [
     'dist/agent/auth/credential-resolver.d.ts',
     'dist/agent/auth/credential-resolver.js',
     'dist/agent/auth/credential-resolver.d.ts.map',
     'coverage/src/agent/auth/credential-resolver.ts.html',
     'coverage/src/agent/redact-secrets.ts.html',
-    'node_modules/@scope/secret-box/index.js',
+    'node_modules/@scope/box/secret-loader.js',
     'dist/docs/secret-handling.css',
   ];
   for (const entry of generatedMirrors) {
+    // Both assertions together, on the SAME entry, pin the intentional
+    // divergence between the two exported surfaces: the leaf really does read
+    // as sensitive, and the path context is what overrides it. Asserting only
+    // the classification would stay green if `isSensitiveLeaf` quietly stopped
+    // matching the hint, which would make the suppression a no-op rather than
+    // a deliberate override.
     it(`treats ${entry} as generated output, not a secret`, () => {
+      expect(isSensitiveLeaf(entry)).toBe(true);
       expect(classifyIgnoredEntry(entry)).not.toBe('protected');
     });
   }

--- a/src/agent/worktree-ignored-patterns.ts
+++ b/src/agent/worktree-ignored-patterns.ts
@@ -44,11 +44,46 @@ const SENSITIVE_LEAF_PATTERNS: readonly RegExp[] = [
   /^id_rsa/,
   /^id_ed25519/,
   /^\.netrc$/,
-  /credential/,
-  /secret/,
   /\.sqlite3?$/,
   /\.db$/,
 ];
+
+/**
+ * Sensitive by NAME rather than by FORMAT, and the distinction is the whole
+ * point: the table above says "this IS a credential", these say "this is ABOUT
+ * credentials". Inside generated output the second claim is worthless, because
+ * every build artifact echoes the name of the source file it came from.
+ *
+ * Invariant: suppressed only at the INTERSECTION of two conditions — the entry
+ * sits under a rebuildable directory ({@link isUnderGeneratedOutput}) AND its
+ * leaf carries a {@link GENERATED_ARTIFACT_EXTENSIONS} suffix. A repo holding
+ * `src/agent/auth/credential-resolver.ts` emits
+ * `dist/agent/auth/credential-resolver.d ts` and a coverage page of the same
+ * name; both matched `/credential/`, protected the tree, and made every
+ * worktree that had ever run a build or a coverage pass permanently unreapable
+ * — the same immortality the module docblock exists to prevent, arriving
+ * through the sensitivity table instead of the rebuildable one.
+ *
+ * Neither condition alone is enough. Directory alone would reap a hand-placed
+ * `dist/nested/app-credentials.json`, which #759 deliberately protects and
+ * pins with a test. Extension alone would reap an authored `credentials.html`
+ * at the repo root. Requiring both isolates the actual false positive: a
+ * compiled or rendered artifact whose name is an echo of the source module it
+ * was generated from.
+ */
+const SENSITIVE_NAME_HINTS: readonly RegExp[] = [/credential/, /secret/];
+
+/**
+ * Suffixes a compiler or report generator produces. Paired with the directory
+ * gate above, never used alone.
+ *
+ * Contract: data formats are deliberately absent. `.json`, `.yaml`, `.txt` and
+ * friends are where a real credential file plausibly lives even inside `dist/`,
+ * and no toolchain name-mirrors a source module into them — so excluding them
+ * costs nothing against the false positive and keeps #759's guarantee intact.
+ */
+const GENERATED_ARTIFACT_EXTENSIONS =
+  /\.(?:js|mjs|cjs|jsx|ts|tsx|mts|cts|map|html?|css|svg)$/;
 
 /**
  * Dependency trees and caches: machine-owned, never hand-authored, and often
@@ -171,10 +206,38 @@ export function leafOf(normalizedPath: string): string {
     : withoutTrailingSlash.slice(lastSlash + 1);
 }
 
-/** True when the entry's final segment names something unrecoverable. */
+/**
+ * True when the entry is a compiled or rendered artifact sitting inside build
+ * output — the one place a credential-shaped NAME carries no information,
+ * because the name was inherited from the source module it was generated from.
+ * Both directory tables count: `dist/` (inspectable) and `node_modules/`
+ * (opaque) are equally generated, differing only in expansion cost.
+ */
+function isGeneratedArtifact(normalizedPath: string, leaf: string): boolean {
+  if (!GENERATED_ARTIFACT_EXTENSIONS.test(leaf)) return false;
+  return (
+    OPAQUE_REBUILDABLE_DIRS.some((re) => re.test(normalizedPath)) ||
+    INSPECTABLE_REBUILDABLE_DIRS.some((re) => re.test(normalizedPath))
+  );
+}
+
+/**
+ * True when the entry's final segment names something unrecoverable, judged on
+ * the leaf alone. Format anchors and name hints both count here — callers with
+ * path context should prefer {@link classifyIgnoredEntry}, which additionally
+ * suppresses the name hints inside generated output.
+ */
 export function isSensitiveLeaf(relPath: string): boolean {
   const leaf = leafOf(normalizeIgnoredPath(relPath)).toLowerCase();
   if (leaf === '') return false;
+  return (
+    SENSITIVE_LEAF_PATTERNS.some((re) => re.test(leaf)) ||
+    SENSITIVE_NAME_HINTS.some((re) => re.test(leaf))
+  );
+}
+
+/** Leaf matches a table entry naming a credential FORMAT, wherever it sits. */
+function isSensitiveFormat(leaf: string): boolean {
   return SENSITIVE_LEAF_PATTERNS.some((re) => re.test(leaf));
 }
 
@@ -191,11 +254,21 @@ export function isSensitiveLeaf(relPath: string): boolean {
  * directory name is only meaningful as a prefix, so leaf-matching those would
  * classify a bare file named `dist` as build output — and would collapse the
  * deliberate `logs/` asymmetry documented above.
+ *
+ * Sensitivity splits along the same seam. A credential FORMAT protects the tree
+ * from anywhere; a credential-shaped NAME protects everywhere except on a
+ * generated artifact, where the name is an echo of the source module it was
+ * built from rather than evidence of a secret (see
+ * {@link SENSITIVE_NAME_HINTS}).
  */
 export function classifyIgnoredEntry(relPath: string): IgnoredEntryClass {
   const normalized = normalizeIgnoredPath(relPath);
   if (normalized === '') return 'protected';
-  if (isSensitiveLeaf(normalized)) return 'protected';
+  const leaf = leafOf(normalized).toLowerCase();
+  if (isSensitiveFormat(leaf)) return 'protected';
+  if (!isGeneratedArtifact(normalized, leaf) && SENSITIVE_NAME_HINTS.some((re) => re.test(leaf))) {
+    return 'protected';
+  }
   const isDirectory = normalized.endsWith('/');
   if (!isDirectory && REBUILDABLE_FILE_PATTERNS.some((re) => re.test(leafOf(normalized)))) {
     return 'opaque';

--- a/src/agent/worktree-ignored-patterns.ts
+++ b/src/agent/worktree-ignored-patterns.ts
@@ -58,7 +58,7 @@ const SENSITIVE_LEAF_PATTERNS: readonly RegExp[] = [
  * sits under a rebuildable directory ({@link isUnderGeneratedOutput}) AND its
  * leaf carries a {@link GENERATED_ARTIFACT_EXTENSIONS} suffix. A repo holding
  * `src/agent/auth/credential-resolver.ts` emits
- * `dist/agent/auth/credential-resolver.d ts` and a coverage page of the same
+ * `dist/agent/auth/credential-resolver.d.ts` and a coverage page of the same
  * name; both matched `/credential/`, protected the tree, and made every
  * worktree that had ever run a build or a coverage pass permanently unreapable
  * — the same immortality the module docblock exists to prevent, arriving

--- a/src/agent/worktree-ignored-patterns.ts
+++ b/src/agent/worktree-ignored-patterns.ts
@@ -207,14 +207,37 @@ export function leafOf(normalizedPath: string): string {
 }
 
 /**
- * True when the entry is a compiled or rendered artifact sitting inside build
- * output — the one place a credential-shaped NAME carries no information,
- * because the name was inherited from the source module it was generated from.
- * Both directory tables count: `dist/` (inspectable) and `node_modules/`
- * (opaque) are equally generated, differing only in expansion cost.
+ * Rebuildable directories holding RUNTIME output rather than COMPILER output.
+ *
+ * Invariant: name-hint suppression must never reach inside these. The seam is
+ * survivability of a hand-placed file: everything in `dist/`, `out/`,
+ * `coverage/` and friends is regenerated wholesale by the next build, so a file
+ * a human dropped there is already doomed independently of the sweep — reaping
+ * the checkout destroys nothing the toolchain was not about to destroy anyway.
+ * `logs/` is the one member of {@link INSPECTABLE_REBUILDABLE_DIRS} where that
+ * is false: nothing regenerates it, and the table's own docblock admits it
+ * plausibly holds "a captured transcript" a human kept. Suppressing there
+ * traded a permanent false positive for a permanent data-loss risk.
+ */
+const RUNTIME_OUTPUT_DIRS: readonly RegExp[] = [/(?:^|\/)logs\//];
+
+/**
+ * True when the entry is a compiled or rendered artifact sitting inside
+ * COMPILER output — the one place a credential-shaped NAME carries no
+ * information, because the name was inherited from the source module it was
+ * generated from. Both rebuildable tables count (`dist/` inspectable,
+ * `node_modules/` opaque — they differ only in expansion cost), minus the
+ * runtime-output exclusion above.
+ *
+ * Residual accepted risk, stated because it is real: a hand-placed
+ * `dist/secret-notes.js` or `out/client_secret.js` is reapable under this rule.
+ * Such a file does not survive the next `pnpm build` either, so the sweep is
+ * not what destroys it — but a credential in a DATA format (`.json`, `.yaml`,
+ * `.txt`) stays protected everywhere, which is the #759 guarantee.
  */
 function isGeneratedArtifact(normalizedPath: string, leaf: string): boolean {
   if (!GENERATED_ARTIFACT_EXTENSIONS.test(leaf)) return false;
+  if (RUNTIME_OUTPUT_DIRS.some((re) => re.test(normalizedPath))) return false;
   return (
     OPAQUE_REBUILDABLE_DIRS.some((re) => re.test(normalizedPath)) ||
     INSPECTABLE_REBUILDABLE_DIRS.some((re) => re.test(normalizedPath))

--- a/src/agent/worktree-ignored-probe.test.ts
+++ b/src/agent/worktree-ignored-probe.test.ts
@@ -25,6 +25,27 @@ const throwingExec: ExecFileFn = (async () => {
   throw new Error('fatal: not a git repository');
 }) as unknown as ExecFileFn;
 
+/**
+ * Records every git argv so a test can assert which calls were made.
+ *
+ * Module-scoped rather than local to one describe: the symlink suite needs the
+ * same recording to prove an expansion was ISSUED. A fixed-stdout mock cannot —
+ * it answers identically whether the scoped call happened or was skipped, which
+ * is exactly how a skipped expansion stayed green.
+ */
+function recordingExec(
+  responder: (args: readonly string[]) => string,
+): { exec: ExecFileFn; calls: string[][] } {
+  const calls: string[][] = [];
+  const exec = (async (_cmd: string, args: string[]) => {
+    calls.push([...args]);
+    return { stdout: responder(args), stderr: '' };
+  }) as unknown as ExecFileFn;
+  return { exec, calls };
+}
+
+const isScoped = (args: readonly string[]): boolean => args.includes('--untracked-files=all');
+
 describe('isRebuildableIgnoredEntry', () => {
   const rebuildable = [
     'node_modules/', 'node_modules/foo/index.js', '.pnpm/', '.yarn/',
@@ -154,20 +175,6 @@ describe('hasNonRebuildableIgnoredFiles', () => {
  * for dependency trees.
  */
 describe('hasNonRebuildableIgnoredFiles — collapsed-directory expansion', () => {
-  /** Records every git argv so a test can assert which calls were made. */
-  function recordingExec(
-    responder: (args: readonly string[]) => string,
-  ): { exec: ExecFileFn; calls: string[][] } {
-    const calls: string[][] = [];
-    const exec = (async (_cmd: string, args: string[]) => {
-      calls.push([...args]);
-      return { stdout: responder(args), stderr: '' };
-    }) as unknown as ExecFileFn;
-    return { exec, calls };
-  }
-
-  const isScoped = (args: readonly string[]): boolean => args.includes('--untracked-files=all');
-
   it('expands a collapsed build dir and protects when it hides a secret', async () => {
     const { exec, calls } = recordingExec((args) =>
       isScoped(args) ? '!! dist/cli/index.js\n!! dist/secrets.env\n' : '!! dist/\n',
@@ -315,9 +322,17 @@ describe('probeNonRebuildableIgnoredFiles — symlinked directories', () => {
   beforeAll(async () => {
     root = await mkdtemp(join(tmpdir(), 'afk-symlink-probe-'));
     await mkdir(join(root, 'real-deps'), { recursive: true });
+    // A real secret BEHIND the link. The expansion assertions below are only
+    // meaningful if the target actually holds something worth finding — an
+    // empty target makes "expanded and found nothing" indistinguishable from
+    // "never expanded at all", which is how the skipped-expansion bug survived.
+    await writeFile(join(root, 'real-deps', 'prod.env'), 'API_TOKEN=live\n');
+    await mkdir(join(root, 'real-build'), { recursive: true });
+    await writeFile(join(root, 'real-build', 'index.js'), 'console.log(1)\n');
     await mkdir(join(root, 'wt'), { recursive: true });
     await symlink('../real-deps', join(root, 'wt', 'node_modules'), 'dir');
     await symlink('../real-deps', join(root, 'wt', 'dist'), 'dir');
+    await symlink('../real-build', join(root, 'wt', 'build'), 'dir');
     // Same names, but authored FILES — the case that must stay protected.
     await mkdir(join(root, 'wt-files'), { recursive: true });
     await writeFile(join(root, 'wt-files', 'dist'), 'hand-authored, not a build dir');
@@ -335,11 +350,47 @@ describe('probeNonRebuildableIgnoredFiles — symlinked directories', () => {
     expect(verdict).toEqual({ protect: false });
   });
 
-  it('treats a symlinked build dir as inspectable, expanding rather than protecting', async () => {
-    const verdict = await probeNonRebuildableIgnoredFiles(
-      mockExec('!! dist\n'),
-      join(root, 'wt'),
+  /**
+   * Regression (the bug this suite failed to catch): `classifyResolvingSymlinkedDirs`
+   * built the slash-appended `dist/` to reach its verdict but returned only the
+   * verdict, so the caller's gate re-tested the ORIGINAL slash-less `dist` —
+   * always false for a symlink, since git never appends a slash to one. The
+   * expansion was skipped and the tree read reapable WITHOUT the inside ever
+   * being inspected. A fixed-stdout mock could not see the difference; these
+   * assert on the recorded argv.
+   */
+  it('ISSUES the scoped expansion for a symlinked build dir and protects on what it finds', async () => {
+    const { exec, calls } = recordingExec((args) =>
+      isScoped(args) ? '!! dist/prod.env\n' : '!! dist\n',
     );
+    const verdict = await probeNonRebuildableIgnoredFiles(exec, join(root, 'wt'));
+
+    // (a) the expansion actually happened, scoped to the resolved directory
+    const scoped = calls.filter(isScoped);
+    expect(scoped).toHaveLength(1);
+    expect(scoped[0]).toContain('dist/');
+
+    // (b) and its result drove the verdict
+    expect(verdict).toEqual({
+      protect: true,
+      because: 'non-rebuildable-entry',
+      detail: 'dist/prod.env',
+    });
+  });
+
+  it('expands a symlinked build dir and still reaps when it holds only output', async () => {
+    const { exec, calls } = recordingExec((args) =>
+      isScoped(args) ? '!! build/index.js\n' : '!! build\n',
+    );
+    const verdict = await probeNonRebuildableIgnoredFiles(exec, join(root, 'wt'));
+    expect(calls.filter(isScoped)).toHaveLength(1);
+    expect(verdict).toEqual({ protect: false });
+  });
+
+  it('never pays for an expansion of a symlinked dependency tree', async () => {
+    const { exec, calls } = recordingExec(() => '!! node_modules\n');
+    const verdict = await probeNonRebuildableIgnoredFiles(exec, join(root, 'wt'));
+    expect(calls.filter(isScoped)).toHaveLength(0);
     expect(verdict).toEqual({ protect: false });
   });
 

--- a/src/agent/worktree-ignored-probe.test.ts
+++ b/src/agent/worktree-ignored-probe.test.ts
@@ -6,7 +6,10 @@
  * make every worktree immortal and stop the sweep reclaiming anything at all.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   isRebuildableIgnoredEntry,
   hasNonRebuildableIgnoredFiles,
@@ -294,5 +297,69 @@ describe('probeNonRebuildableIgnoredFiles — verdict provenance', () => {
   it('still collapses to a boolean for the legacy surface', async () => {
     expect(await hasNonRebuildableIgnoredFiles(mockExec('!! local-notes.md\n'), '/tmp/wt')).toBe(true);
     expect(await hasNonRebuildableIgnoredFiles(mockExec('!! node_modules/\n'), '/tmp/wt')).toBe(false);
+  });
+});
+
+/**
+ * Git appends a trailing slash only for a REAL directory, so a symlinked
+ * dependency tree — the standard way a worktree avoids a duplicate install —
+ * arrives as a bare `node_modules`, matches no directory pattern, and used to
+ * fall through to `protected`, making that worktree permanently unreapable.
+ * These use the real filesystem because the disambiguation IS a stat: the
+ * string is identical to a hand-authored file of the same name, which must
+ * keep protecting the tree.
+ */
+describe('probeNonRebuildableIgnoredFiles — symlinked directories', () => {
+  let root: string;
+
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), 'afk-symlink-probe-'));
+    await mkdir(join(root, 'real-deps'), { recursive: true });
+    await mkdir(join(root, 'wt'), { recursive: true });
+    await symlink('../real-deps', join(root, 'wt', 'node_modules'), 'dir');
+    await symlink('../real-deps', join(root, 'wt', 'dist'), 'dir');
+    // Same names, but authored FILES — the case that must stay protected.
+    await mkdir(join(root, 'wt-files'), { recursive: true });
+    await writeFile(join(root, 'wt-files', 'dist'), 'hand-authored, not a build dir');
+  });
+
+  afterAll(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('treats a symlinked node_modules as reapable despite the missing slash', async () => {
+    const verdict = await probeNonRebuildableIgnoredFiles(
+      mockExec('!! node_modules\n'),
+      join(root, 'wt'),
+    );
+    expect(verdict).toEqual({ protect: false });
+  });
+
+  it('treats a symlinked build dir as inspectable, expanding rather than protecting', async () => {
+    const verdict = await probeNonRebuildableIgnoredFiles(
+      mockExec('!! dist\n'),
+      join(root, 'wt'),
+    );
+    expect(verdict).toEqual({ protect: false });
+  });
+
+  it('still protects a hand-authored FILE sharing a build-directory name', async () => {
+    const verdict = await probeNonRebuildableIgnoredFiles(
+      mockExec('!! dist\n'),
+      join(root, 'wt-files'),
+    );
+    expect(verdict).toEqual({ protect: true, because: 'non-rebuildable-entry', detail: 'dist' });
+  });
+
+  it('protects when the entry cannot be stat-ed at all (broken link, race)', async () => {
+    const verdict = await probeNonRebuildableIgnoredFiles(
+      mockExec('!! node_modules\n'),
+      join(root, 'does-not-exist'),
+    );
+    expect(verdict).toEqual({
+      protect: true,
+      because: 'non-rebuildable-entry',
+      detail: 'node_modules',
+    });
   });
 });

--- a/src/agent/worktree-ignored-probe.ts
+++ b/src/agent/worktree-ignored-probe.ts
@@ -101,20 +101,32 @@ export function isRebuildableIgnoredEntry(relPath: string): boolean {
  * thousands of syscalls. `stat` follows the link deliberately (a symlink TO a
  * directory is what we are detecting); a broken link or a vanished entry throws
  * and keeps the protective verdict, matching the module's fail-safe direction.
+ *
+ * Invariant: `resolvedEntry` is returned ALONGSIDE the verdict, not discarded,
+ * and callers must gate directory-shaped follow-up work on it rather than on
+ * the raw loop variable. The verdict is derived from the slash-appended string
+ * (`dist` -> `dist/`), so re-testing the original bare `entry` for a trailing
+ * slash asks a question the resolution already answered — and always answers
+ * `false` for exactly the symlinked directory this function exists to detect.
+ * That mismatch silently skipped the `inspectable` expansion, returning
+ * "reapable" for a symlinked `dist/` WITHOUT ever looking inside it.
  */
 async function classifyResolvingSymlinkedDirs(
   worktreePath: string,
   entry: string,
-): Promise<IgnoredEntryClass> {
+): Promise<{ verdict: IgnoredEntryClass; resolvedEntry: string }> {
   const verdict = classifyIgnoredEntry(entry);
-  if (verdict !== 'protected' || entry.endsWith('/')) return verdict;
+  if (verdict !== 'protected' || entry.endsWith('/')) return { verdict, resolvedEntry: entry };
   try {
     const stats = await stat(join(worktreePath, entry));
-    if (stats.isDirectory()) return classifyIgnoredEntry(`${entry}/`);
+    if (stats.isDirectory()) {
+      const resolvedEntry = `${entry}/`;
+      return { verdict: classifyIgnoredEntry(resolvedEntry), resolvedEntry };
+    }
   } catch {
     /* broken symlink, race, or permission error — keep the protective verdict */
   }
-  return verdict;
+  return { verdict, resolvedEntry: entry };
 }
 
 /**
@@ -168,7 +180,8 @@ async function inspectableDirHidesLocalState(
   }
   for (const entry of nested.entries) {
     if (entry === dirEntry) continue; // git echoed the directory — no new information
-    if ((await classifyResolvingSymlinkedDirs(worktreePath, entry)) === 'protected') {
+    const { verdict } = await classifyResolvingSymlinkedDirs(worktreePath, entry);
+    if (verdict === 'protected') {
       return { protect: true, because: 'non-rebuildable-entry', detail: entry };
     }
   }
@@ -194,12 +207,16 @@ export async function probeNonRebuildableIgnoredFiles(
   // Unreadable → never force-remove on a guess.
   if ('failure' in top) return { protect: true, because: 'git-failed', detail: top.failure };
   for (const entry of top.entries) {
-    const verdict = await classifyResolvingSymlinkedDirs(worktreePath, entry);
+    const { verdict, resolvedEntry } = await classifyResolvingSymlinkedDirs(worktreePath, entry);
     if (verdict === 'protected') {
       return { protect: true, because: 'non-rebuildable-entry', detail: entry };
     }
-    if (verdict === 'inspectable' && entry.endsWith('/')) {
-      const nested = await inspectableDirHidesLocalState(execFile, worktreePath, entry);
+    // Invariant: gate on `resolvedEntry`, never on `entry` — see
+    // `classifyResolvingSymlinkedDirs`. A symlinked `dist` arrives slash-less
+    // from git, so testing the raw entry skips the expansion that finds a
+    // secret inside it.
+    if (verdict === 'inspectable' && resolvedEntry.endsWith('/')) {
+      const nested = await inspectableDirHidesLocalState(execFile, worktreePath, resolvedEntry);
       if (nested.protect) return nested;
     }
   }

--- a/src/agent/worktree-ignored-probe.ts
+++ b/src/agent/worktree-ignored-probe.ts
@@ -25,8 +25,10 @@
  * @module agent/worktree-ignored-probe
  */
 
+import { stat } from 'node:fs/promises';
+import { join } from 'node:path';
 import type { ExecFileFn } from './worktree-sweep.js';
-import { classifyIgnoredEntry } from './worktree-ignored-patterns.js';
+import { classifyIgnoredEntry, type IgnoredEntryClass } from './worktree-ignored-patterns.js';
 
 export {
   classifyIgnoredEntry,
@@ -80,6 +82,42 @@ export function isRebuildableIgnoredEntry(relPath: string): boolean {
 }
 
 /**
+ * Classify one entry, resolving the one ambiguity git leaves in its output.
+ *
+ * Invariant: `git status --ignored` appends a trailing slash only for a real
+ * DIRECTORY. A SYMLINKED one — `node_modules -> ../../node_modules`, the
+ * standard way a worktree avoids a duplicate install — is printed as
+ * `!! node_modules`, matching no directory pattern (all of which require the
+ * slash) and falling through to `protected`. That made the worktree permanently
+ * unreapable over a symlink whose removal loses nothing.
+ *
+ * The patterns module cannot fix this: from the string alone, a symlinked
+ * `dist` and a hand-authored FILE named `dist` are identical, and the latter
+ * must stay protected. Only the filesystem can tell them apart, so the
+ * disambiguation lives here, on the IO side of the split.
+ *
+ * Contract: the `stat` is paid ONLY by an entry that would otherwise be
+ * protected — the rare path — so expanding a populated `dist/` does not become
+ * thousands of syscalls. `stat` follows the link deliberately (a symlink TO a
+ * directory is what we are detecting); a broken link or a vanished entry throws
+ * and keeps the protective verdict, matching the module's fail-safe direction.
+ */
+async function classifyResolvingSymlinkedDirs(
+  worktreePath: string,
+  entry: string,
+): Promise<IgnoredEntryClass> {
+  const verdict = classifyIgnoredEntry(entry);
+  if (verdict !== 'protected' || entry.endsWith('/')) return verdict;
+  try {
+    const stats = await stat(join(worktreePath, entry));
+    if (stats.isDirectory()) return classifyIgnoredEntry(`${entry}/`);
+  } catch {
+    /* broken symlink, race, or permission error — keep the protective verdict */
+  }
+  return verdict;
+}
+
+/**
  * Ignored entries git reports for the worktree, or `undefined` when git failed.
  * `scopePath` restricts the walk to one directory and expands it per-file
  * (`--untracked-files=all`) instead of collapsing it to a single line.
@@ -130,7 +168,7 @@ async function inspectableDirHidesLocalState(
   }
   for (const entry of nested.entries) {
     if (entry === dirEntry) continue; // git echoed the directory — no new information
-    if (classifyIgnoredEntry(entry) === 'protected') {
+    if ((await classifyResolvingSymlinkedDirs(worktreePath, entry)) === 'protected') {
       return { protect: true, because: 'non-rebuildable-entry', detail: entry };
     }
   }
@@ -156,7 +194,7 @@ export async function probeNonRebuildableIgnoredFiles(
   // Unreadable → never force-remove on a guess.
   if ('failure' in top) return { protect: true, because: 'git-failed', detail: top.failure };
   for (const entry of top.entries) {
-    const verdict = classifyIgnoredEntry(entry);
+    const verdict = await classifyResolvingSymlinkedDirs(worktreePath, entry);
     if (verdict === 'protected') {
       return { protect: true, because: 'non-rebuildable-entry', detail: entry };
     }

--- a/src/agent/worktree-orphan-guard.test.ts
+++ b/src/agent/worktree-orphan-guard.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach } from 'vitest';
-import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { mkdtemp, mkdir, writeFile, rm, symlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { classifyOrphanDir } from './worktree-orphan-guard.js';
@@ -116,5 +116,53 @@ describe('classifyOrphanDir — failure and bounds', () => {
     await writeFile(filePath, 'x');
     const verdict = await classifyOrphanDir(filePath, AGED_MS, HOUR_MS);
     expect(verdict.remove).toBe(false);
+  });
+});
+
+/**
+ * `readdir` does not follow links, so `Dirent.isDirectory()` is false for a
+ * SYMLINKED directory regardless of target. A symlinked `node_modules` — the
+ * standard way a worktree avoids a duplicate install — therefore fell to the
+ * file branch, matched no directory pattern (all require a trailing slash) and
+ * classified `protected`, pinning the orphan on disk forever. The ignored probe
+ * already resolved this via `stat`; these pin that the two production consumers
+ * of the shared policy now agree on the identical on-disk layout.
+ */
+describe('classifyOrphanDir — symlinked directories', () => {
+  it('reclaims an orphan whose node_modules is a symlink to a dependency tree', async () => {
+    const target = await mkdtemp(join(tmpdir(), 'afk-orphan-deps-'));
+    try {
+      // Content behind the link is irrelevant: removing the orphan unlinks the
+      // symlink and never traverses it, so an opaque tree is reapable whatever
+      // it holds. Populated anyway, so a descent would be observable.
+      await writeFile(join(target, 'prod.env'), 'API_TOKEN=live\n');
+      await symlink(target, join(root, 'node_modules'), 'dir');
+      const verdict = await classifyOrphanDir(root, AGED_MS, HOUR_MS);
+      expect(verdict).toEqual({ remove: true });
+    } finally {
+      await rm(target, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves an orphan holding a symlinked directory that is NOT rebuildable', async () => {
+    const target = await mkdtemp(join(tmpdir(), 'afk-orphan-src-'));
+    try {
+      await symlink(target, join(root, 'my-notes'), 'dir');
+      const verdict = await classifyOrphanDir(root, AGED_MS, HOUR_MS);
+      expect(verdict).toEqual({
+        remove: false,
+        because: 'non-rebuildable-content',
+        detail: 'my-notes',
+      });
+    } finally {
+      await rm(target, { recursive: true, force: true });
+    }
+  });
+
+  it('fails SAFE on a broken symlink — unresolvable means protected', async () => {
+    await symlink(join(root, 'nowhere'), join(root, 'node_modules'), 'dir');
+    const verdict = await classifyOrphanDir(root, AGED_MS, HOUR_MS);
+    expect(verdict.remove).toBe(false);
+    if (!verdict.remove) expect(verdict.because).toBe('non-rebuildable-content');
   });
 });

--- a/src/agent/worktree-orphan-guard.ts
+++ b/src/agent/worktree-orphan-guard.ts
@@ -24,7 +24,8 @@
  * @module agent/worktree-orphan-guard
  */
 
-import { readdir } from 'node:fs/promises';
+import { readdir, stat } from 'node:fs/promises';
+import type { Dirent } from 'node:fs';
 import { join } from 'node:path';
 import { classifyIgnoredEntry } from './worktree-ignored-patterns.js';
 
@@ -38,6 +39,33 @@ import { classifyIgnoredEntry } from './worktree-ignored-patterns.js';
  */
 function isRebuildable(relPath: string): boolean {
   return classifyIgnoredEntry(relPath) !== 'protected';
+}
+
+/**
+ * True when `entry` names a directory, resolving symlinks the way the ignored
+ * probe does.
+ *
+ * Invariant: `Dirent.isDirectory()` is false for a SYMLINK regardless of its
+ * target, because `readdir` does not follow links. A symlinked `node_modules`
+ * — the standard way a worktree avoids a duplicate install — therefore fell to
+ * the file branch, matched no directory pattern (all of which require a
+ * trailing slash), and classified `protected`, pinning the orphan on disk
+ * forever. The probe already resolves this case via `stat`; mirroring it here
+ * keeps the two production consumers of the shared policy from disagreeing on
+ * an identical on-disk layout.
+ *
+ * Fail-safe direction is unchanged: a broken link, a race, or a permission
+ * error throws and answers `false`, which routes the entry to the file branch
+ * where an unrecognised name still protects the tree.
+ */
+async function resolvesToDirectory(entry: Dirent, fullPath: string): Promise<boolean> {
+  if (entry.isDirectory()) return true;
+  if (!entry.isSymbolicLink()) return false;
+  try {
+    return (await stat(fullPath)).isDirectory();
+  } catch {
+    return false;
+  }
 }
 
 /** Why an orphaned directory must be left on disk. */
@@ -124,6 +152,20 @@ export async function classifyOrphanDir(
       }
 
       const rel = dir.rel === '' ? entry.name : `${dir.rel}/${entry.name}`;
+      const fullPath = join(dir.abs, entry.name);
+      const isDirLike = await resolvesToDirectory(entry, fullPath);
+
+      // Invariant: a SYMLINKED directory is classified but never descended
+      // into. Removing the orphan unlinks the symlink and never traverses it,
+      // so its target's contents are not at risk and walking them would only
+      // duplicate work already owned by another tree — or cycle, if the link
+      // points at an ancestor. Classifying it is still required: an opaque
+      // symlinked `node_modules` must clear the way for reclamation instead of
+      // falling to the file branch and protecting the orphan forever.
+      if (isDirLike && !entry.isDirectory()) {
+        if (classifyIgnoredEntry(`${rel}/`) === 'opaque') continue;
+        return { remove: false, because: 'non-rebuildable-content', detail: rel };
+      }
 
       if (entry.isDirectory()) {
         // Invariant: only an `opaque` directory may be skipped wholesale. The
@@ -141,7 +183,7 @@ export async function classifyOrphanDir(
         if (dir.depth + 1 > maxDepth) {
           return { remove: false, because: 'scan-failed', detail: `depth limit at ${rel}` };
         }
-        pending.push({ abs: join(dir.abs, entry.name), rel, depth: dir.depth + 1 });
+        pending.push({ abs: fullPath, rel, depth: dir.depth + 1 });
         continue;
       }
 


### PR DESCRIPTION
Follow-up to #926, which made the preserve message name the entry that held a worktree instead of citing a generic `.env`. Pointing it at the real worktrees immediately exposed **two more false positives of the same class** — both permanent, both invisible while the message was generic, neither involving an actual secret.

```
# after #926, still preserved on every exit:
PRESERVED  afk-improve-tui-spacing   (coverage/src/agent/auth/credential-resolver.ts.html)
PRESERVED  afk-bash-parallel-concurrency   (dist/agent/auth/credential-resolver.d.ts)
PRESERVED  review-pr-872   (node_modules)          ← no trailing slash
```

## 1. Generated artifacts mirror source filenames

This repo has 8 source files named `*credential*`/`*secret*`. A build emits `dist/agent/auth/credential-resolver.d.ts`; a coverage pass emits `coverage/src/agent/auth/credential-resolver.ts.html`. Both matched the unanchored `/credential/` sensitivity pattern → `protected` → **every worktree that had ever run `pnpm build` or `pnpm test:coverage` was preserved forever.**

The fix splits the sensitivity table by what each half actually asserts:

| | claim | scope |
|---|---|---|
| **Format anchors** — `.env` `.pem` `.key` `.db` … | "this **is** a credential" | protects from anywhere |
| **Name hints** — `credential` `secret` | "this is **about** credentials" | suppressed on a generated artifact |

"Generated artifact" is the **intersection** of living under a rebuildable directory **and** carrying a compiler/renderer extension (`.js` `.d.ts` `.map` `.html` `.css` …). Neither condition alone is enough:

- *Directory alone* would reap a hand-placed `dist/nested/app-credentials.json` — which #759 deliberately protects and pins with a test.
- *Extension alone* would reap an authored `credentials.html` at the repo root.

Data formats (`.json`, `.yaml`, `.txt`) stay out of the extension list on purpose: no toolchain name-mirrors a source module into them, so excluding them costs nothing here and keeps #759's guarantee intact.

## 2. Symlinked dependency trees

`git status --ignored` appends a trailing slash only for a **real** directory. A symlinked one — `node_modules -> ../../node_modules`, the standard way a worktree avoids a duplicate install — arrives as bare `node_modules`, matches no directory pattern (all require `\/`), and falls through to `protected`.

Widening the patterns to accept a bare segment is the obvious fix and is **wrong**: from the string alone, a symlinked `dist` is indistinguishable from a hand-authored *file* named `dist`, which an existing test pins as protected. Only the filesystem can separate them — so the disambiguation lives in the **probe (IO)**, not the patterns module (pure policy), preserving that split.

The `stat` is paid only by an entry that would *otherwise be protected*, so expanding a populated `dist/` does not become thousands of syscalls. A broken link, a race, or a permission error keeps the protective verdict, matching the module's fail-safe direction.

## Effect

Worktrees held by ignored state on this checkout: **29 of 29 → 2 of 29**. Both survivors are correct — each holds a real `.afk/` project-state dir.

## Verification

- `pnpm lint`, `pnpm build`, `pnpm test` (800 files / 15278 tests), `audit:sdk:check`, `audit:env:check`, `scan:env:check`, `audit:chalk:check`, `fix:pins:check`, `audit:deps` — all green.
- Re-ran the real probe against all 29 local worktrees before and after.
- New tests: generated mirrors across `.d.ts`/`.js`/`.map`/`.html`/`.css` are reapable; format anchors and data files under build output stay protected; name hints outside generated output are untouched; four filesystem-backed cases cover the symlink split (symlinked `node_modules`, symlinked `dist`, an authored file sharing a build-directory name, and an un-stat-able entry).


---

## Review follow-up (commit `51d64b2a`)

A `/review` pass on this PR found the name-hint suppression reaching further than the description above admitted. Running the pre-change and as-merged classifiers side by side over a path corpus showed **eight paths flipping `protected` → reapable, none of them asserted by any test**:

```
dist/secret-notes.js      logs/credentials.js       logs/secret-audit.html
out/client_secret.js      dist/.secrets.js          coverage/credentials.css
dist/my-secret.ts         dist/secret.env.html
```

Two production consumers reach this classifier, not one — `worktree-sweep.ts:721` and `worktree-orphan-guard.ts:40`, the latter's own comment stating it relies on the `protected` default to catch "a stray secret".

**The seam is survivability of a hand-placed file.** `dist/`, `out/`, `build/`, `target/`, `coverage/`, `node_modules/` are regenerated wholesale by the next build — a file dropped there is already doomed independently of the sweep. `logs/` is the one member of `INSPECTABLE_REBUILDABLE_DIRS` where that is false: nothing regenerates it, and the table's own docblock admits it plausibly holds "a captured transcript" someone kept.

So:
- `RUNTIME_OUTPUT_DIRS` excludes `logs/` from `isGeneratedArtifact` — `logs/credentials.js`, `logs/secret-audit.html`, `logs/secret.map` are protected again, with tests.
- The remaining six are **pinned by assertion and documented as accepted risk** in the function docblock, so the blast radius can never widen silently.

Both motivating fixes are untouched, and every previously pinned invariant is unmoved (#759's `dist/nested/app-credentials.json`, the data formats, the authored-name hints, the bare files named like build dirs).

### Known gap, deliberately not fixed here
`worktree-orphan-guard.ts:40` calls `classifyIgnoredEntry` directly and so bypasses the symlink-aware path added in this PR — an orphan directory holding a symlinked `node_modules` stays immortal. Separate lifecycle, separate change.
