### PR TITLE
fix(agents): tell research-agent about its registry grants, not just grant them

### DIFF
--- a/src/agent/agents/builtins.ts
+++ b/src/agent/agents/builtins.ts
@@ -36,6 +36,47 @@ function vendoredPromptBody(raw: string): string {
   return parseAgentMarkdown(raw)?.definition.prompt ?? raw;
 }
 
+/**
+ * Invariant: a registry-entry tool grant and the agent's BELIEF about its tool
+ * surface are two separate systems, and both must be updated together.
+ *
+ * The vendored prompt bodies are byte-pinned to upstream
+ * (src/skills/_agents/vendored.test.ts), so they still name the tool allowlist
+ * upstream shipped with. research-agent's body asserts a CLOSED set —
+ * "Your tool surface is a hard allowlist enforced by Claude Code: `Read, Grep,
+ * Glob, WebFetch, WebSearch`" — which predates the grants the registry entries
+ * below add. An agent told it has a hard five-tool surface does not attempt a
+ * sixth, so a grant made only in `tools:` is INERT: #883 shipped the mechanical
+ * access (verified at the tool-access layer) while the surveyor kept correctly
+ * reporting `memory_search` as unavailable, because it was reading its prompt,
+ * not its grant.
+ *
+ * Reconciling at composition time (rather than editing the vendored file and
+ * re-pinning) keeps the vendored copy byte-equal with upstream and the pin
+ * green. Callers pass the SAME array they spread into `tools`, so the note and
+ * the grant cannot drift apart.
+ */
+function withRegistryGrants(body: string, grants: readonly string[]): string {
+  if (grants.length === 0) return body;
+  return `${body}
+
+## Tools granted by this runtime, beyond the list above
+
+This runtime additionally grants you: ${grants.join(', ')}.
+
+Any earlier statement in this prompt that your tool surface is a fixed or "hard"
+allowlist describes the upstream default, not your actual surface — it is
+superseded by this section. These tools are live; use them when relevant. Every
+other restriction above (no Edit, no Write, no Bash, no mutation) still holds.`;
+}
+
+/**
+ * Registry-entry grants for research-agent, beyond `researchAgent.allowedTools`.
+ * Single source of truth: spread into `tools` AND rendered into the prompt via
+ * `withRegistryGrants`, so mechanical access and stated access stay in lockstep.
+ */
+const RESEARCH_AGENT_REGISTRY_GRANTS = ['memory_search', 'Agent(git-investigator)'] as const;
+
 const GENERAL_PURPOSE_PROMPT = `You are a general-purpose sub-agent for complex, multi-step tasks that require both exploration and action.
 
 Work autonomously from the task prompt you were dispatched with: investigate, act, and verify. You have the parent session's full child tool surface. Keep intermediate exploration out of your reply.
@@ -103,7 +144,10 @@ export function builtinAgents(): Map<string, RegisteredAgent> {
       source: 'builtin',
       definition: {
         description: researchAgent.description,
-        prompt: vendoredPromptBody(researchAgent.systemPrompt),
+        prompt: withRegistryGrants(
+          vendoredPromptBody(researchAgent.systemPrompt),
+          RESEARCH_AGENT_REGISTRY_GRANTS,
+        ),
         // The scoped `Agent(git-investigator)` grant matches the vendored
         // prompt's frontmatter intent (`tools: …, Agent(git-investigator)`)
         // and lets research-agent nest a git-investigator when a finding needs
@@ -132,7 +176,7 @@ export function builtinAgents(): Map<string, RegisteredAgent> {
         // argument CHILD_ALLOWED_TOOLS already makes at nesting.ts:124-131.
         // Note `memory_update`/`procedure_write` are deliberately NOT granted:
         // those mutate, and target:"hot" reaches every future session's prompt.
-        tools: [...researchAgent.allowedTools, 'memory_search', 'Agent(git-investigator)'],
+        tools: [...researchAgent.allowedTools, ...RESEARCH_AGENT_REGISTRY_GRANTS],
         // Anti-runaway bound (see READONLY_AGENT_MAX_TOOL_USE_ITERATIONS): a
         // read-only research/review agent that keeps tool-calling without ever
         // emitting a final message otherwise runs unbounded on the (uncapped)

--- a/src/agent/agents/registry.test.ts
+++ b/src/agent/agents/registry.test.ts
@@ -139,6 +139,39 @@ describe('loadAgentRegistry', () => {
     }
   });
 
+  // The other half of #883. The test above proves the grant is mechanically
+  // REACHABLE; this proves the agent is TOLD it has it. The vendored body is
+  // byte-pinned upstream and asserts a closed allowlist ("Your tool surface is
+  // a hard allowlist enforced by Claude Code: Read, Grep, Glob, WebFetch,
+  // WebSearch"), so a grant made only in `tools:` is inert — the surveyor reads
+  // its prompt, believes it has five tools, and never calls the sixth. That is
+  // exactly what shipped: #883 was verified at the tool-access layer only, and
+  // the observable behaviour did not change.
+  it('tells research-agent about every registry grant beyond its vendored allowlist (#883)', async () => {
+    const registry = loadAgentRegistry({ cwd: join(tmp, 'proj'), warn: () => {} });
+    const entry = registry.get('research-agent');
+    expect(entry).toBeDefined();
+
+    const { researchAgent } = await import('../../skills/_agents/index.js');
+    const prompt = entry!.definition.prompt;
+
+    // Anything granted at the registry entry but absent from the vendored
+    // allowlist is a tool the prompt does not otherwise account for.
+    const extras = (entry!.definition.tools ?? []).filter(
+      (t) => !researchAgent.allowedTools.includes(t as never),
+    );
+    expect(extras.length).toBeGreaterThan(0);
+    for (const tool of extras) {
+      expect(prompt, `prompt never mentions granted tool ${tool}`).toContain(tool);
+    }
+
+    // The reconciliation must explicitly override the body's closed-allowlist
+    // claim, not merely append a name the earlier sentence still contradicts.
+    expect(prompt).toMatch(/superseded by this section/);
+    // And it must not have relaxed the read-only contract on the way through.
+    expect(prompt).toMatch(/no Edit, no Write, no Bash, no mutation/);
+  });
+
   it('strips vendored frontmatter from builtin prompts (body-only system prompt)', () => {
     const registry = loadAgentRegistry({ cwd: join(tmp, 'proj'), warn: () => {} });
     for (const name of ['research-agent', 'git-investigator']) {


### PR DESCRIPTION
## The bug

#925 (closing #883) granted `research-agent` the `memory_search` tool at its registry entry. That grant is real and live — it's in the shipped v5.97.3 bundle:

```
tools:[...Do.allowedTools,"memory_search","Agent(git-investigator)"]
```

**It changed nothing observable.** `/ground-state`'s memory surveyor kept degrading to reading `HOT.md`/`AFK.md` off disk, and kept reporting `memory_search` as unavailable.

The reason is that the agent is still told otherwise. The vendored prompt body is byte-pinned to upstream and asserts a **closed** set:

> Your tool surface is a hard allowlist enforced by Claude Code: `Read, Grep, Glob, WebFetch, WebSearch`. You have no access to Edit, Write, NotebookEdit, or Bash.

`grep -c memory_search src/skills/_agents/prompts/research-agent.md` → **0**.

An agent told it has a *hard* five-tool surface does not attempt a sixth. The surveyor's "memory_search is missing from my allowlist" was an accurate report of its **prompt**, not of its **grant**.

## Why it survived review, merge, release, and tests

A registry-entry tool grant and the agent's **belief** about its tool surface are two separate systems. #925 updated only the first, and was verified only at the tool-access layer — `registry.test.ts` asserted the *resolved access set* on both child pools, which passed, correctly, while the behaviour stayed broken.

#925's commit message names the tradeoff explicitly — *"The vendored prompt stays byte-equal with upstream"* — as a deliberate choice. It was the right instinct about the file and the wrong conclusion about the agent.

## The fix

Reconcile at **prompt-composition time** rather than editing the vendored copy, so upstream byte-equality and the SHA-256 pin survive:

- `withRegistryGrants()` (`src/agent/agents/builtins.ts`) appends a section naming the granted tools and **explicitly superseding** the closed-allowlist sentence — while restating that every other restriction (no Edit, no Write, no Bash, no mutation) still holds. Appending a tool name without overriding the earlier "hard allowlist" claim would leave the prompt self-contradictory.
- Grants come from a single const, `RESEARCH_AGENT_REGISTRY_GRANTS`, which is spread into `tools` **and** rendered into the prompt. Mechanical access and stated access cannot drift apart, so a future grant can't be silently inert the way this one was.
- `git-investigator` uses the same composition path and has no registry grants beyond its allowlist, so the helper no-ops for it.

Rejected alternatives: editing the vendored prompt + `pnpm fix:pins` (abandons upstream parity for this agent); patching only `/ground-state`'s dispatch prompt (fixes one caller, leaves every other `research-agent` dispatch blind).

## Verification

- `pnpm lint` — clean
- `registry.test.ts` + `vendored.test.ts` — **45/45**
- `pnpm fix:pins:check` — **"All hash pins are up to date"** (upstream byte-equality preserved, which is this approach's central claim)
- **Verified to fail without the fix**: reverting the single call site yields `prompt never mentions granted tool memory_search`
- **Verified at the behaviour layer**: rendered the composed prompt and read the appended section. Re-checking the access layer would have repeated exactly the mistake that let this ship.

The new test asserts the *general property* — every registry grant beyond the vendored allowlist must appear in the prompt — rather than the literal string `memory_search`, so it covers future grants too.

## Impact

Every `/ground-state` run since #925 merged has had its memory third silently degraded to file reads. Those results were archive-free; treat them accordingly.

Merging cuts a patch release (`fix(agents):` via `auto-release.yml`).
