### PR TITLE
fix(agent): preserve abort origins across provider teardown

### DIFF
--- a/src/agent/abort-reason.test.ts
+++ b/src/agent/abort-reason.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { BudgetExceededError, TimeoutError } from '../utils/errors.js';
+import { abortFailureClass, providerAbortReason } from './abort-reason.js';
+import { BENIGN_FAILURE_CLASSES } from './trace/types.js';
+
+function abortedSignal(reason: unknown): AbortSignal {
+  const controller = new AbortController();
+  controller.abort(reason);
+  return controller.signal;
+}
+
+describe('abort reason classification', () => {
+  it.each([
+    [new TimeoutError('session', 100), 'timeout'],
+    [new BudgetExceededError(2, 1), 'budget'],
+    ['Budget $2.00 exceeded limit of $1.00', 'budget'],
+    ['session timed out after 100ms', 'timeout'],
+    ['sigint', 'interrupted'],
+  ] as const)('maps %o to %s', (reason, expected) => {
+    expect(providerAbortReason(reason)).toBe(expected);
+  });
+
+  it('keeps user interruption benign while timeout and budget remain visible', () => {
+    expect(abortFailureClass(abortedSignal('interrupted'))).toBe('abort');
+    expect(BENIGN_FAILURE_CLASSES.has(abortFailureClass(abortedSignal('interrupted')))).toBe(true);
+    expect(BENIGN_FAILURE_CLASSES.has(abortFailureClass(abortedSignal('timeout')))).toBe(false);
+    expect(BENIGN_FAILURE_CLASSES.has(abortFailureClass(abortedSignal('budget')))).toBe(false);
+  });
+});

--- a/src/agent/abort-reason.ts
+++ b/src/agent/abort-reason.ts
@@ -1,0 +1,28 @@
+import type { ToolFailureClass } from './trace/types.js';
+import { BudgetExceededError, TimeoutError } from '../utils/errors.js';
+
+/** Provider-level reason preserved on the per-turn AbortSignal. */
+export type ProviderAbortReason = 'interrupted' | 'timeout' | 'budget' | 'closed';
+
+/**
+ * Reduce the session controller's open-ended reason to the provider contract.
+ * Typed errors are authoritative; string fallbacks preserve compatibility with
+ * the budget producer and callers that serialize errors before aborting.
+ */
+export function providerAbortReason(reason: unknown): ProviderAbortReason {
+  if (reason instanceof TimeoutError) return 'timeout';
+  if (reason instanceof BudgetExceededError) return 'budget';
+  if (typeof reason === 'string') {
+    if (reason === 'budget' || reason.startsWith('Budget ')) return 'budget';
+    if (reason === 'timeout' || reason.includes('timed out')) return 'timeout';
+    if (reason === 'closed') return 'closed';
+  }
+  return 'interrupted';
+}
+
+/** Classify a synthetic tool failure from the reason preserved on its signal. */
+export function abortFailureClass(signal: AbortSignal): ToolFailureClass {
+  const reason = providerAbortReason(signal.reason);
+  if (reason === 'timeout' || reason === 'budget') return reason;
+  return 'abort';
+}

--- a/src/agent/provider.ts
+++ b/src/agent/provider.ts
@@ -332,7 +332,7 @@ export interface ProviderQueryArgs {
  * harness having to widen a Claude-specific union.
  */
 export interface ProviderQuery extends AsyncIterable<ProviderEvent> {
-  interrupt(): Promise<void>;
+  interrupt(reason?: import('./abort-reason.js').ProviderAbortReason): Promise<void>;
   setModel(model?: string): Promise<void>;
   setPermissionMode(mode: string): Promise<void>;
   supportedCommands(): Promise<ProviderCommandInfo[]>;

--- a/src/agent/providers/anthropic-direct/loop/tool-dispatch.ts
+++ b/src/agent/providers/anthropic-direct/loop/tool-dispatch.ts
@@ -17,6 +17,7 @@
 import type { ContentBlockParam, ToolResultBlockParam } from '@anthropic-ai/sdk/resources';
 import type { ProviderEvent } from '../../../provider.js';
 import type { RunTurnInput, ToolCall, ToolResult, TurnResult } from '../types.js';
+import { abortFailureClass } from '../../../abort-reason.js';
 import { emitToolCall } from '../../../trace/emit.js';
 import { extractRawToolInput } from '../../../facets/raw-input.js';
 import { summarizeToolInput } from '../../shared/tool-input-summary.js';
@@ -115,17 +116,11 @@ export async function* dispatchToolCalls(
   } else {
     results = [];
     for (const call of calls) {
-      // `abort` here covers ANY signal-fired teardown — deliberate user
-      // cancel, session timeout, or budget exhaustion all funnel through the
-      // same AbortSignal (requestAbort() only tracks 'interrupted' | 'closed',
-      // see abort-coordinator.ts:56), so the original cause is lost by the
-      // time this dispatch site sees `signal.aborted`. Widening AbortReason
-      // to carry the origin is the real fix; out of scope here.
       if (input.signal.aborted) {
         results.push({
           content: 'Tool call aborted',
           isError: true,
-          failureClass: 'abort',
+          failureClass: abortFailureClass(input.signal),
         });
         continue;
       }

--- a/src/agent/providers/anthropic-direct/query.ts
+++ b/src/agent/providers/anthropic-direct/query.ts
@@ -638,8 +638,8 @@ export class AnthropicDirectQuery implements ProviderQuery {
     return withSystemBreakpoint(blocks, getCacheTtl());
   }
 
-  async interrupt(): Promise<void> {
-    this.abort.requestAbort('interrupted');
+  async interrupt(reason: import('../../abort-reason.js').ProviderAbortReason = 'interrupted'): Promise<void> {
+    this.abort.requestAbort(reason);
   }
 
   /**

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -897,10 +897,10 @@ export class OpenAICompatibleQuery implements ProviderQuery {
 
   // ---- ProviderQuery surface ------------------------------------------------
 
-  async interrupt(): Promise<void> {
+  async interrupt(reason: import('../../abort-reason.js').ProviderAbortReason = 'interrupted'): Promise<void> {
     // Aborts the in-flight turn, or parks the reason for the next begin()
     // when the interrupt lands between turns.
-    this.abort.requestAbort('interrupted');
+    this.abort.requestAbort(reason);
   }
 
   /**

--- a/src/agent/providers/openai-compatible/query/dispatch-append.ts
+++ b/src/agent/providers/openai-compatible/query/dispatch-append.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import { abortFailureClass } from '../../../abort-reason.js';
 import { emitToolCall } from '../../../trace/emit.js';
 import type { TraceWriter } from '../../../trace/index.js';
 import type { ProviderEvent } from '../../../provider.js';
@@ -123,18 +124,12 @@ export async function* dispatchAndAppendToolCalls({
 
   if (signal.aborted) {
     // Aborted before dispatch — synthesize aborted results and emit outputs.
-    // `abort` here (both the pushed result and the yielded event below) covers
-    // ANY signal-fired teardown — deliberate user cancel, session timeout, or
-    // budget exhaustion all funnel through the same AbortSignal
-    // (requestAbort() only tracks 'interrupted' | 'closed', see
-    // abort-coordinator.ts:56), so the original cause is lost by the time this
-    // dispatch site sees `signal.aborted`. Widening AbortReason to carry the
-    // origin is the real fix; out of scope here.
+    const failureClass = abortFailureClass(signal);
     for (const call of calls) {
       const result: ToolResult = {
         content: 'Tool call aborted',
         isError: true,
-        failureClass: 'abort',
+        failureClass,
       };
       results.push({ call, result });
       yield {
@@ -143,7 +138,7 @@ export async function* dispatchAndAppendToolCalls({
         toolName: call.name,
         content: result.content,
         isError: true,
-        failureClass: 'abort',
+        failureClass,
         sessionId,
       };
     }
@@ -156,13 +151,11 @@ export async function* dispatchAndAppendToolCalls({
       } else {
         dispatcherResults = [];
         for (const call of calls) {
-          // Same abort-origin caveat as the pre-dispatch branch above:
-          // `signal.aborted` cannot distinguish cancel/timeout/budget here either.
           if (signal.aborted) {
             dispatcherResults.push({
               content: 'Tool call aborted',
               isError: true,
-              failureClass: 'abort',
+              failureClass: abortFailureClass(signal),
             });
             continue;
           }

--- a/src/agent/providers/router/provider-router.ts
+++ b/src/agent/providers/router/provider-router.ts
@@ -441,8 +441,8 @@ export class ProviderRouter implements ProviderQuery {
 
   // ---- ProviderQuery delegation ------------------------------------------
 
-  async interrupt(): Promise<void> {
-    await this.active?.query.interrupt();
+  async interrupt(reason: import('../../abort-reason.js').ProviderAbortReason = 'interrupted'): Promise<void> {
+    await this.active?.query.interrupt(reason);
   }
 
   async setModel(model?: string): Promise<void> {

--- a/src/agent/providers/shared/abort-coordinator.test.ts
+++ b/src/agent/providers/shared/abort-coordinator.test.ts
@@ -82,16 +82,19 @@ describe('shared/abort-coordinator', () => {
   });
 
   describe('pending-abort drain (abort arrives between turns)', () => {
-    it('parks the reason and fires it on the next begin()', () => {
-      const abort = new AbortCoordinator();
-      // No scope in flight — this is the interrupt()-between-turns path.
-      abort.requestAbort('interrupted');
-      expect(abort.isIdle()).toBe(true);
+    it.each(['interrupted', 'timeout', 'budget'] as const)(
+      'parks the %s reason and fires it on the next begin()',
+      (reason) => {
+        const abort = new AbortCoordinator();
+        // No scope in flight — this is the interrupt()-between-turns path.
+        abort.requestAbort(reason);
+        expect(abort.isIdle()).toBe(true);
 
-      const controller = abort.begin();
-      expect(controller.signal.aborted).toBe(true);
-      expect(controller.signal.reason).toBe('interrupted');
-    });
+        const controller = abort.begin();
+        expect(controller.signal.aborted).toBe(true);
+        expect(controller.signal.reason).toBe(reason);
+      },
+    );
 
     it('drains the parked reason exactly once', () => {
       const abort = new AbortCoordinator();

--- a/src/agent/providers/shared/abort-coordinator.ts
+++ b/src/agent/providers/shared/abort-coordinator.ts
@@ -53,7 +53,9 @@
  * @module agent/providers/shared/abort-coordinator
  */
 
-export type AbortReason = 'interrupted' | 'closed';
+import type { ProviderAbortReason } from '../../abort-reason.js';
+
+export type AbortReason = ProviderAbortReason;
 
 /** The sentinel resolved value of `closedPromise`. */
 export const CLOSED_SENTINEL = '__closed__' as const;

--- a/src/agent/session/agent-session.ts
+++ b/src/agent/session/agent-session.ts
@@ -29,6 +29,7 @@ import type {
   RewindTarget,
 } from '../provider.js';
 import { DEFAULT_SESSION_TIMEOUT_MS, RESET_DRAIN_TIMEOUT_MS, withTimeout } from '../timeout.js';
+import { providerAbortReason } from '../abort-reason.js';
 import { dispatchSessionEnd, dispatchSessionStart } from './hooks-dispatch.js';
 import { HookBlockedError } from '../../utils/errors.js';
 import {
@@ -880,7 +881,7 @@ export class AgentSession implements IAgentSession {
   private async onAbort(): Promise<void> {
     void this.ledger.seal('abort');
     try {
-      await this.providerQuery.interrupt();
+      await this.providerQuery.interrupt(providerAbortReason(this.abortController.signal.reason));
     } catch {
       // Provider interrupt may fail if session is already torn down; swallow.
     }

--- a/src/agent/session/stream-consumer-budget.test.ts
+++ b/src/agent/session/stream-consumer-budget.test.ts
@@ -51,7 +51,7 @@ function makeSessionMetadata(): SessionMetadata {
  */
 function makeDeps(opts: {
   maxBudgetUsd?: number;
-  abortBudget?: (reason: string) => void;
+  abortBudget?: (reason: BudgetExceededError) => void;
 } = {}): TransformDeps {
   let sessionMeta = makeSessionMetadata();
   const history: Message[] = [];
@@ -113,13 +113,14 @@ describe('transformProviderEvent — budget enforcement (C6)', () => {
     expect((result as { type: 'error'; error: Error }).error).toBeInstanceOf(BudgetExceededError);
 
     expect(abortBudget).toHaveBeenCalledOnce();
-    const reason = abortBudget.mock.calls[0]![0] as string;
+    const reason = abortBudget.mock.calls[0]![0] as BudgetExceededError;
+    expect(reason).toBeInstanceOf(BudgetExceededError);
 
     // Must contain the accumulated cost and the ceiling.
-    expect(reason).toContain('0.0500');
-    expect(reason).toContain('0.0200');
+    expect(reason.message).toContain('0.0500');
+    expect(reason.message).toContain('0.0200');
     // Must be readable — not just numbers.
-    expect(reason.toLowerCase()).toMatch(/budget|ceiling|limit/);
+    expect(reason.message.toLowerCase()).toMatch(/budget|ceiling|limit/);
   });
 
   it('accumulates cost across multiple turns before triggering', () => {
@@ -141,9 +142,9 @@ describe('transformProviderEvent — budget enforcement (C6)', () => {
     expect(r3?.type).toBe('error');
     expect(abortBudget).toHaveBeenCalledOnce();
 
-    const reason = abortBudget.mock.calls[0]![0] as string;
-    expect(reason).toContain('0.0900');
-    expect(reason).toContain('0.0800');
+    const reason = abortBudget.mock.calls[0]![0] as BudgetExceededError;
+    expect(reason.message).toContain('0.0900');
+    expect(reason.message).toContain('0.0800');
   });
 
   it('does NOT call abortBudget when total remains below ceiling', () => {

--- a/src/agent/session/stream-consumer.ts
+++ b/src/agent/session/stream-consumer.ts
@@ -41,7 +41,7 @@ export type TransformDeps = {
    * Called when `maxBudgetUsd` is exceeded. Implementors should abort the
    * session's internal AbortController.
    */
-  abortBudget?: (reason: string) => void;
+  abortBudget?: (reason: BudgetExceededError) => void;
   /**
    * Internal accumulator for running session cost. Mutated by
    * `transformProviderEvent` on each `turn.completed` event. Callers should
@@ -476,7 +476,7 @@ export function transformProviderEvent(
             lastTurnCostUsd: metadata.totalCostUsd,
           });
           const err = new BudgetExceededError(deps._runningCostUsd, deps.maxBudgetUsd);
-          deps.abortBudget(err.message);
+          deps.abortBudget(err);
           return { type: 'error', error: err };
         }
       }

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -16,6 +16,7 @@ import {
 } from '../../config/concurrency.js';
 import { debugLog } from '../../utils/debug.js';
 import { HookBlockedError } from '../../utils/errors.js';
+import { abortFailureClass } from '../abort-reason.js';
 import { settleWithConcurrencyLimit } from '../concurrency-pool.js';
 import type { HookRegistry, PreToolUseContext, PostToolUseContext, PostToolUseFailureContext } from '../hooks.js';
 import type { AnthropicToolDef } from '../providers/anthropic-direct/types.js';
@@ -909,7 +910,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
 
   async execute(call: ToolCall): Promise<ToolResult> {
     if (call.signal.aborted) {
-      return { content: 'Tool call aborted', isError: true, failureClass: 'abort' };
+      return { content: 'Tool call aborted', isError: true, failureClass: abortFailureClass(call.signal) };
     }
 
     const gateResult = await this.runPreDispatchGates(call);
@@ -951,7 +952,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
       const call = calls[i]!;
 
       if (call.signal.aborted) {
-        results[i] = { content: 'Tool call aborted', isError: true, failureClass: 'abort' };
+        results[i] = { content: 'Tool call aborted', isError: true, failureClass: abortFailureClass(call.signal) };
         blocked.add(i);
         continue;
       }
@@ -1030,7 +1031,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
                   result: {
                     content: 'Tool call aborted',
                     isError: true,
-                    failureClass: 'abort',
+                    failureClass: abortFailureClass(call.signal),
                   } as ToolResult,
                   originalIndex,
                 };
@@ -1068,7 +1069,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
         for (const batchIdx of batch.indices) {
           const { call, originalIndex } = executableCalls[batchIdx]!;
           if (call.signal.aborted) {
-            results[originalIndex] = { content: 'Tool call aborted', isError: true, failureClass: 'abort' };
+            results[originalIndex] = { content: 'Tool call aborted', isError: true, failureClass: abortFailureClass(call.signal) };
             continue;
           }
           const refusal = this.checkRepeatFailureGuard(call);

--- a/src/agent/tools/handlers/browser-act.ts
+++ b/src/agent/tools/handlers/browser-act.ts
@@ -23,6 +23,7 @@ import type { BrowserHandlerOptions } from './browser-open.js';
 import type { Target, ActAction } from '../../../browser/types.js';
 import { truncateTargetText, hashSelector } from '../../../browser/sanitize.js';
 import { env } from '../../../config/env.js';
+import { abortFailureClass } from '../../abort-reason.js';
 import { emitBrowserEvent } from '../../trace/emit.js';
 import type { BrowserEventTarget } from '../../trace/types.js';
 
@@ -171,7 +172,7 @@ export function createBrowserActHandler(opts: BrowserHandlerOptions = {}): ToolH
     if (signal.aborted) {
       const reason = signal.reason;
       const msg = reason instanceof Error ? reason.message : String(reason ?? 'aborted');
-      return { content: `browser_act aborted: ${msg}`, isError: true, failureClass: 'abort' };
+      return { content: `browser_act aborted: ${msg}`, isError: true, failureClass: abortFailureClass(signal) };
     }
 
     const parsed = parseInput(input);

--- a/src/agent/tools/handlers/browser-open.ts
+++ b/src/agent/tools/handlers/browser-open.ts
@@ -19,6 +19,7 @@
 import type { ToolHandler, ToolHandlerContext } from '../types.js';
 import type { BrowserObservation } from '../../../browser/types.js';
 import { env } from '../../../config/env.js';
+import { abortFailureClass } from '../../abort-reason.js';
 import { emitBrowserEvent } from '../../trace/emit.js';
 
 import {
@@ -101,7 +102,7 @@ export function createBrowserOpenHandler(opts: BrowserHandlerOptions = {}): Tool
     if (signal.aborted) {
       const reason = signal.reason;
       const msg = reason instanceof Error ? reason.message : String(reason ?? 'aborted');
-      return { content: `browser_open aborted: ${msg}`, isError: true, failureClass: 'abort' };
+      return { content: `browser_open aborted: ${msg}`, isError: true, failureClass: abortFailureClass(signal) };
     }
 
     const parsed = parseInput(input);

--- a/src/agent/trace/budget.test.ts
+++ b/src/agent/trace/budget.test.ts
@@ -16,6 +16,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { ProviderEvent, ProviderUsage } from '../provider.js';
 import type { Message, SessionMetadata } from '../types.js';
+import type { BudgetExceededError } from '../../utils/errors.js';
 import { transformProviderEvent, type TransformDeps } from '../session/stream-consumer.js';
 import { InMemoryTraceWriter } from './writer.js';
 
@@ -29,7 +30,7 @@ function makeSessionMetadata(): SessionMetadata {
 
 function makeDeps(opts: {
   maxBudgetUsd?: number;
-  abortBudget?: (reason: string) => void;
+  abortBudget?: (reason: BudgetExceededError) => void;
   traceWriter?: InMemoryTraceWriter;
 }): TransformDeps {
   let sessionMeta = makeSessionMetadata();

--- a/src/agent/trace/types.ts
+++ b/src/agent/trace/types.ts
@@ -60,6 +60,7 @@ export interface ToolCallStartedPayload {
 export const TOOL_FAILURE_CLASSES = [
   'policy-refusal',
   'timeout',
+  'budget',
   'permission-denied',
   'hook-block',
   'abort',
@@ -84,6 +85,8 @@ export const TOOL_FAILURE_CLASSES = [
  *                              subagent_lifecycle `failed` payload (own-budget expiry)
  *                              and, for a cascaded ancestor-timeout, via the `cancelled`
  *                              payload's `timeout` flag.
+ *   - `budget`               — the session-wide cost ceiling aborted the call. Like `timeout`,
+ *                              this is deliberately non-benign and remains visible in stats.
  *   - `permission-denied`    — permission gate or read-only-skill bash gate denied the call.
  *   - `hook-block`           — a PreToolUse hook returned `decision: 'block'`.
  *   - `abort`                — the call's AbortSignal was already fired.
@@ -100,7 +103,7 @@ export const TOOL_FAILURE_CLASSES = [
  *
  * The `tool-failure-density` detector treats `policy-refusal`, `permission-denied`,
  * `hook-block`, `abort`, and `elicitation-declined` as "the system correctly said no" —
- * excluded from failure stats entirely — while `timeout`, `denial-breaker`, and
+ * excluded from failure stats entirely — while `timeout`, `budget`, `denial-breaker`, and
  * unclassified failures still count. That split is `BENIGN_FAILURE_CLASSES` below.
  */
 export type ToolFailureClass = (typeof TOOL_FAILURE_CLASSES)[number];

--- a/src/cli/commands/interactive/tool-lane-format.test.ts
+++ b/src/cli/commands/interactive/tool-lane-format.test.ts
@@ -133,7 +133,7 @@ describe('doneGlyph — benign rejection vs real fault (#75)', () => {
     },
   );
 
-  it.each(['timeout', 'denial-breaker', 'repeat-failure'] as const)(
+  it.each(['timeout', 'budget', 'denial-breaker', 'repeat-failure'] as const)(
     'keeps the error glyph for `%s`, which is a real fault',
     (cls) => {
       expect(stripAnsi(doneGlyph(true, cls))).toBe('✗');
@@ -164,7 +164,7 @@ describe('doneGlyph — benign rejection vs real fault (#75)', () => {
     expect([...benign].sort()).toEqual(
       ['abort', 'elicitation-declined', 'hook-block', 'permission-denied', 'policy-refusal'].sort(),
     );
-    expect([...real].sort()).toEqual(['denial-breaker', 'repeat-failure', 'timeout'].sort());
+    expect([...real].sort()).toEqual(['budget', 'denial-breaker', 'repeat-failure', 'timeout'].sort());
   });
 
   it('resolves the benign glyph tone from `palette` at call time (no theme-swap freeze)', () => {

--- a/src/improve/scan/detectors/tool-failure-density.test.ts
+++ b/src/improve/scan/detectors/tool-failure-density.test.ts
@@ -514,18 +514,20 @@ describe('detectToolFailureDensity — failureClass exclusion', () => {
     expect(r.detail['excludedByClass']).toEqual({ 'elicitation-declined': 5 });
   });
 
-  it("counts 'timeout' as a real failure (not excluded) and surfaces it in the breakdown", () => {
-    resetSeq();
-    // 4 timeouts out of 4 calls → 100% → fires. timeout is NOT excluded.
-    const lines: string[] = [];
-    for (let i = 0; i < 4; i++) {
-      lines.push(...toolPair(`t-${i}`, 'browser_open', { isError: true, failureClass: 'timeout' }));
-    }
-    const r = detectToolFailureDensity([makeSession('s1', lines)])[0]!;
-    expect(r.detail['failureCount']).toBe(4);
-    expect(r.detail['totalCalls']).toBe(4);
-    expect(r.detail['failureClassBreakdown']).toEqual({ timeout: 4 });
-  });
+  it.each(['timeout', 'budget'] as const)(
+    "counts '%s' as a real failure (not excluded) and surfaces it in the breakdown",
+    (failureClass) => {
+      resetSeq();
+      const lines: string[] = [];
+      for (let i = 0; i < 4; i++) {
+        lines.push(...toolPair(`t-${i}`, 'browser_open', { isError: true, failureClass }));
+      }
+      const r = detectToolFailureDensity([makeSession('s1', lines)])[0]!;
+      expect(r.detail['failureCount']).toBe(4);
+      expect(r.detail['totalCalls']).toBe(4);
+      expect(r.detail['failureClassBreakdown']).toEqual({ [failureClass]: 4 });
+    },
+  );
 
   it('reports a mixed failureClassBreakdown including unclassified failures', () => {
     resetSeq();


### PR DESCRIPTION
## Summary
- Preserve the originating timeout or budget reason when session teardown interrupts a provider turn.
- Classify timeout- and budget-aborted tool calls as real operational failures while keeping deliberate user interruption benign.
- Apply the shared classifier at every synthetic abort-result site and pin TUI/failure-density behavior.

## Diagnosis
The session controller retained typed timeout and budget errors, but `ProviderQuery.interrupt()` flattened every teardown to `interrupted`. Synthetic tool results therefore stamped timeout and budget exhaustion as benign `abort` failures, hiding them behind the neutral TUI glyph and excluding them from failure-density statistics.

## Behavior changes
- Provider abort reasons now distinguish `interrupted`, `timeout`, `budget`, and `closed`.
- Timeout and budget aborts remain visible in tool failure rendering and statistics.
- User interruption continues to use the benign `abort` class.
- Budget teardown passes the typed `BudgetExceededError` through the reason channel.

## Test results
- Focused tests (10 files): 406 passed, 1 skipped.
- `pnpm lint`: passed.
- `pnpm build`: passed.
- `pnpm test:coverage`: passed (full Vitest suite and coverage thresholds).
- `pnpm test:pty`: passed (1 file, 10 tests).
- `pnpm audit:env:check`: passed (814 files, 0 violations).
- `pnpm scan:env:check`: passed (149 variables in sync).
- `pnpm audit:sdk:check`: passed.
- `pnpm audit:chalk:check`: passed (814 files, 0 violations).
- `pnpm fix:pins:check`: passed.
- `pnpm audit:deps`: passed; no critical production advisories (29 non-blocking advisories: 3 low, 17 moderate, 9 high).
- `git diff --check`: passed.

## Verification
- **CONFIRM:** timeout and budget reasons are preserved from session abort through provider interruption and the shared abort coordinator.
- **CONFIRM:** timeout and budget synthetic failures are non-benign, while deliberate interruption remains benign.
- **REFINE:** all relevant production stamp sites use the shared classifier and its core/downstream behavior is unit-tested; direct provider-dispatch integration tests for typed timeout/budget signals are not included, so coverage is compositional rather than end-to-end at each stamp site.

Fixes #856
