### PR TITLE
fix(cli): bound every raw REPL write to the terminal width

### DIFF
--- a/src/cli/commands/interactive/bootstrap-surface.ts
+++ b/src/cli/commands/interactive/bootstrap-surface.ts
@@ -14,6 +14,7 @@ import type { CliOptions } from './shared.js';
 import type { ResolvedResumeTarget } from '../../resume-session.js';
 import { createDefaultTraceWriter } from '../../../agent/trace/factory.js';
 import { palette } from '../../palette.js';
+import { boundLineToTerminal } from '../../render/bounded-line.js';
 
 /**
  * Seed session stats + permission/thinking-UI mode, print the `trace:` and
@@ -101,9 +102,15 @@ export function createReplSurface(a: {
   // after `armCompositor` resolves (when a borrowed compositor is available)
   // so between-turn slash output commits above the live overlay instead of
   // overlaying onto the input row. See CompletionWriter docs in shared.ts.
+  //
+  // Invariant: while these slots hold the raw `console.log` default there is
+  // no compositor to wrap what they emit, so each line is bounded to the
+  // terminal here. Once `runReplLoop` swaps in `compositor.commitAbove`, that
+  // sink owns wrapping (and band reflow on resize) and this bound is gone
+  // with the closure — the two must never both wrap the same line.
   const completionWriter: CompletionWriter = {
-    fn: (line) => console.log(line),
-    idleFn: (line) => console.log(line),
+    fn: (line) => console.log(boundLineToTerminal(line)),
+    idleFn: (line) => console.log(boundLineToTerminal(line)),
   };
   // Construct StatusLine BEFORE createReplRenderer so the renderer can route
   // its inter-turn raw writes through statusLine.withFullScrollRegion(...) —

--- a/src/cli/commands/interactive/loop-iteration.ts
+++ b/src/cli/commands/interactive/loop-iteration.ts
@@ -15,6 +15,7 @@ import { isDebugEnabled, debugLog } from '../../../utils/debug.js';
 import { sanitizeForDisplay } from '../../../utils/terminal-sanitize.js';
 import { env } from '../../../config/env.js';
 import { palette } from '../../palette.js';
+import { truncateDisplayWidth } from '../../display.js';
 import { ringBellIfEnabled } from '../../_lib/capture-mode.js';
 import { cyclePermissionMode } from '../../permission-mode-cycle.js';
 import {
@@ -259,7 +260,9 @@ export async function runInputLoop(
         const seconds = job.endedAt !== undefined
           ? Math.max(0, Math.round((job.endedAt - job.startedAt) / 100) / 10)
           : 0;
-        const label = job.label.length > 60 ? `${job.label.slice(0, 60)}…` : job.label;
+        // Display-width truncation, not code-unit — see the same fix in
+        // slash/commands/bgsub.ts: `slice(0, 60) + '…'` measured 61 cells.
+        const label = truncateDisplayWidth(job.label, 60);
         ctx.replRenderer.writeLine(
           palette.dim(`  ${glyph} [${job.jobId}] subagent ${job.status} · ${seconds}s · `) + label,
         );

--- a/src/cli/commands/interactive/repl-renderer.test.ts
+++ b/src/cli/commands/interactive/repl-renderer.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { createReplRenderer } from './repl-renderer.js';
+import { displayWidth, stripAnsi } from '../../display.js';
 
 function makeStdout(isTTY: boolean) {
   const write = vi.fn();
@@ -138,6 +139,61 @@ describe('createReplRenderer', () => {
 
       expect(commitAbove).toHaveBeenCalledWith('hello');
       expect(stdout.write).not.toHaveBeenCalled();
+    });
+  });
+  describe('width bounding (out-of-bounds guard)', () => {
+    const originalColumns = process.stdout.columns;
+    const setColumns = (n: number): void => {
+      Object.defineProperty(process.stdout, 'columns', {
+        configurable: true,
+        writable: true,
+        value: n,
+      });
+    };
+    afterEach(() => setColumns(originalColumns as number));
+
+    it('wraps an over-wide line on the disarmed TTY path so no row exits the right edge', () => {
+      setColumns(62);
+      const stdout = makeStdout(true);
+      const renderer = createReplRenderer(stdout);
+
+      renderer.writeLine('  ↳ ' + 'x'.repeat(300));
+
+      const written = stdout.write.mock.calls[0]?.[0] as string;
+      const rows = written.replace(/\n$/, '').split('\n');
+      expect(rows.length).toBeGreaterThan(1);
+      for (const row of rows) {
+        expect(
+          displayWidth(row),
+          `row exceeds 62: ${JSON.stringify(stripAnsi(row))}`,
+        ).toBeLessThanOrEqual(62);
+      }
+      // Continuation rows keep the source indent instead of snapping to col 0.
+      for (const row of rows.slice(1)) expect(row.startsWith('  ')).toBe(true);
+    });
+
+    it('does NOT pre-wrap on the armed path — commitAbove owns wrapping and band reflow', () => {
+      setColumns(62);
+      const stdout = makeStdout(true);
+      const commitAbove = vi.fn();
+      const renderer = createReplRenderer(stdout);
+      renderer.setCompositor({ isArmed: () => true, commitAbove });
+
+      const long = '  ↳ ' + 'x'.repeat(300);
+      renderer.writeLine(long);
+
+      expect(commitAbove).toHaveBeenCalledWith(long);
+    });
+
+    it('leaves non-TTY output byte-identical so piped rows stay whole', () => {
+      setColumns(62);
+      const stdout = makeStdout(false);
+      const renderer = createReplRenderer(stdout);
+
+      const long = 'x'.repeat(300);
+      renderer.writeLine(long);
+
+      expect(stdout.write).toHaveBeenCalledWith(long + '\n');
     });
   });
 });

--- a/src/cli/commands/interactive/repl-renderer.ts
+++ b/src/cli/commands/interactive/repl-renderer.ts
@@ -26,6 +26,7 @@
  */
 
 import { isPlainOutputRequested } from '../../../config/env.js';
+import { boundLineToTerminal } from '../../render/bounded-line.js';
 
 interface CompositorRef {
   isArmed(): boolean;
@@ -91,12 +92,19 @@ export function createReplRenderer(
       // xterm/iTerm2/Apple Terminal — and the displaced top line does not
       // enter the terminal's scrollback buffer. Route through the guard
       // so the write happens with full-screen scroll semantics instead.
+      //
+      // Invariant: this is the disarmed path, i.e. a RAW write with no
+      // compositor to wrap it — bound it here so an over-wide row is wrapped
+      // with its indent hanging rather than auto-wrapped by the terminal to
+      // column 0. The armed path above needs no bounding: commitAbove wraps
+      // at the live width and reflows the retained band on resize.
+      const bounded = boundLineToTerminal(text, stdout);
       if (guard) {
         guard.withFullScrollRegion(() => {
-          stdout.write(text + '\n');
+          stdout.write(bounded + '\n');
         });
       } else {
-        stdout.write(text + '\n');
+        stdout.write(bounded + '\n');
       }
     },
     setCompositor(c) {

--- a/src/cli/render/bounded-line.test.ts
+++ b/src/cli/render/bounded-line.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, afterEach } from 'vitest';
+
+import { hangingWrap, boundLineToTerminal } from './bounded-line.js';
+import { displayWidth, stripAnsi } from '../display.js';
+
+/**
+ * Every assertion here defends ONE invariant: no row handed to a TTY may
+ * exceed the terminal width. `hangingWrap` is pure, so most cases exercise it
+ * directly; `boundLineToTerminal` is covered for its TTY gate only.
+ */
+
+const originalColumns = process.stdout.columns;
+
+afterEach(() => {
+  Object.defineProperty(process.stdout, 'columns', {
+    configurable: true,
+    writable: true,
+    value: originalColumns,
+  });
+});
+
+function setColumns(n: number): void {
+  Object.defineProperty(process.stdout, 'columns', {
+    configurable: true,
+    writable: true,
+    value: n,
+  });
+}
+
+/** Assert no produced row exceeds `width` display cells. */
+function expectAllRowsFit(out: string, width: number): void {
+  for (const row of out.split('\n')) {
+    expect(
+      displayWidth(row),
+      `row exceeds width ${width}: ${JSON.stringify(stripAnsi(row))}`,
+    ).toBeLessThanOrEqual(width);
+  }
+}
+
+describe('hangingWrap', () => {
+  it('passes a fitting line through byte-identical', () => {
+    const line = '  ↳ short enough';
+    expect(hangingWrap(line, 62)).toBe(line);
+  });
+
+  it('preserves empty and blank lines exactly', () => {
+    expect(hangingWrap('', 62)).toBe('');
+    expect(hangingWrap('\n\n', 62)).toBe('\n\n');
+  });
+
+  it('wraps an over-wide line and hangs the source indent on continuations', () => {
+    const line = '  ↳ ' + 'word '.repeat(40).trim();
+    const out = hangingWrap(line, 40);
+    const rows = out.split('\n');
+
+    expect(rows.length).toBeGreaterThan(1);
+    expectAllRowsFit(out, 40);
+    // Continuation rows keep the row's own indent — never column 0.
+    for (const row of rows.slice(1)) {
+      expect(row.startsWith('  ')).toBe(true);
+      expect(row.startsWith('   ')).toBe(false);
+    }
+  });
+
+  it('breaks an unbreakable token rather than overflowing', () => {
+    const line = '  $ bash git cat-file -e ' + 'a'.repeat(200);
+    expectAllRowsFit(hangingWrap(line, 62), 62);
+  });
+
+  it('bounds wide (CJK) and emoji graphemes by display cells, not code units', () => {
+    expectAllRowsFit(hangingWrap('  ' + '漢字'.repeat(60), 40), 40);
+    expectAllRowsFit(hangingWrap('  ' + '🎉'.repeat(60), 40), 40);
+  });
+
+  it('bounds a styled line without counting ANSI bytes as width', () => {
+    const styled = `\x1b[2m  ↳ ${'x'.repeat(200)}\x1b[22m`;
+    const out = hangingWrap(styled, 50);
+    expectAllRowsFit(out, 50);
+    expect(stripAnsi(out).replaceAll('\n', '').replaceAll(' ', '')).toContain('x'.repeat(50));
+  });
+
+  it('wraps each logical line of a multi-line payload independently', () => {
+    const out = hangingWrap(['  a'.repeat(40), 'short', '    b'.repeat(40)].join('\n'), 30);
+    expectAllRowsFit(out, 30);
+    expect(out.split('\n').some((r) => r === 'short')).toBe(true);
+  });
+
+  it('drops the hanging indent when honoring it would leave < 8 content columns', () => {
+    const out = hangingWrap(' '.repeat(30) + 'x'.repeat(80), 34);
+    expectAllRowsFit(out, 34);
+    expect(out.split('\n').length).toBeGreaterThan(1);
+  });
+
+  it('is a no-op for a non-positive or non-finite width', () => {
+    const line = 'x'.repeat(200);
+    expect(hangingWrap(line, 0)).toBe(line);
+    expect(hangingWrap(line, -5)).toBe(line);
+    expect(hangingWrap(line, Number.POSITIVE_INFINITY)).toBe(line);
+    expect(hangingWrap(line, Number.NaN)).toBe(line);
+  });
+
+  it('bounds the real /worktree list table row shape at narrow widths', () => {
+    // The exact composition from src/cli/slash/commands/worktree.ts (~100 cols).
+    const row =
+      '  ' +
+      '/Users/x/Projects/open_source/agent-afk/.afk-worktrees/some-branch'.slice(-44).padEnd(45) +
+      '  ' +
+      'griffin'.padEnd(12) +
+      '  ' +
+      '3d'.padEnd(5) +
+      '  ' +
+      'stale-dirty'.padEnd(22) +
+      '  ' +
+      'warn';
+    expect(displayWidth(row)).toBeGreaterThan(62);
+    for (const cols of [40, 62, 80, 100, 120]) {
+      expectAllRowsFit(hangingWrap(row, cols), cols);
+    }
+  });
+});
+
+describe('boundLineToTerminal', () => {
+  it('returns non-TTY output byte-identical so pipes keep whole logical rows', () => {
+    setColumns(40);
+    const line = 'x'.repeat(200);
+    expect(boundLineToTerminal(line, { isTTY: false })).toBe(line);
+    expect(boundLineToTerminal(line, {})).toBe(line);
+  });
+
+  it('bounds TTY output to the live terminal width', () => {
+    setColumns(62);
+    const out = boundLineToTerminal('  ↳ ' + 'y'.repeat(200), { isTTY: true });
+    expectAllRowsFit(out, 62);
+  });
+
+  it('tracks a width change between calls (resize)', () => {
+    const line = '  ↳ ' + 'z '.repeat(80).trim();
+    setColumns(100);
+    expectAllRowsFit(boundLineToTerminal(line, { isTTY: true }), 100);
+    setColumns(45);
+    expectAllRowsFit(boundLineToTerminal(line, { isTTY: true }), 45);
+  });
+});

--- a/src/cli/render/bounded-line.ts
+++ b/src/cli/render/bounded-line.ts
@@ -1,0 +1,142 @@
+/**
+ * Bounded-line wrapping — the last stop before a composed row reaches a TTY.
+ *
+ * ## Why this exists
+ *
+ * Every REPL row is composed by a caller (a slash command's table, a status
+ * notice, a resume banner) and handed to a write seam. Callers budget their
+ * own width — or don't. When one emits a row wider than the terminal, the
+ * terminal auto-wraps it, and the continuation lands at COLUMN 0: the row's
+ * leading indent is lost, tree glyphs and table columns detach, and the
+ * output reads as broken rather than wrapped. Truncating instead would
+ * bound the row but destroy content.
+ *
+ * Invariant: no row handed to a TTY may exceed the terminal width. This
+ * module is the enforcement point, applied at the RAW write seams rather
+ * than at the ~40 call sites, so a new caller cannot reintroduce the bug by
+ * forgetting to budget. Rows that already fit pass through byte-identical.
+ *
+ * The four raw seams, all of which write straight to the terminal with no
+ * compositor to wrap them:
+ *   - `slash/writer.ts` — sinkless `console.log` (all slash-command output)
+ *   - `commands/interactive/repl-renderer.ts` — the disarmed TTY branch
+ *   - `commands/interactive/bootstrap-surface.ts` — `CompletionWriter`'s
+ *     pre-arm `console.log` default for `fn` / `idleFn`
+ *   - `terminal-compositor.committed-band-commit.ts` — `commitAbove`'s
+ *     disarmed early return
+ *
+ * Deliberately NOT applied to the armed compositor path: `commitAbove`
+ * already hard-wraps to the live width for its row accounting AND re-wraps
+ * the retained band on resize, so pre-wrapping there would freeze rows at
+ * today's width and a later WIDEN could no longer rejoin them (guarded by
+ * `tests/pty/compositor-scrollback.pty.test.ts`'s width-resize-fragment
+ * cases).
+ *
+ * ## Wrap, don't truncate; hang the indent
+ *
+ * A row that overflows is wrapped at the width and every continuation row is
+ * re-prefixed with the SOURCE row's own leading indent, so wrapped output
+ * stays visually attached to the row that produced it:
+ *
+ *     `  ↳ some long message that does not fit in the terminal width`
+ *
+ *     `  ↳ some long message that does not`
+ *     `  fit in the terminal width`
+ *
+ * ## Not applied to non-TTY output
+ *
+ * Piped/redirected output stays byte-identical: `afk worktree list | grep`
+ * must see whole logical rows, and a consumer's parser must not have to
+ * reassemble rows this module split for a human. The TTY check lives in
+ * {@link boundLineToTerminal}; {@link hangingWrap} is pure and testable.
+ */
+
+import { displayWidth } from '../display.js';
+import { getTerminalWidth } from '../terminal-size.js';
+import { hardWrapToWidth, wrapToWidth } from '../wrap.js';
+
+/**
+ * Minimum content columns preserved beside a hanging indent.
+ *
+ * Contract: when a row's own indent is so deep that honoring it would leave
+ * fewer than this many columns for text, the hanging indent is abandoned and
+ * the row is plain hard-wrapped at the full width instead. Without this
+ * floor, a deeply-indented row on a narrow terminal degrades into a column
+ * of one or two characters — bounded, but unreadable.
+ */
+const MIN_CONTENT_COLUMNS = 8;
+
+/** Leading ANSI SGR runs, then literal spaces: `\x1b[2m` + `  ` + text. */
+const LEADING_INDENT = /^((?:\x1B\[[0-9;]*m)*)( *)/;
+
+/**
+ * Wrap one logical line to `width` display columns, preserving its indent on
+ * every continuation row.
+ *
+ * Returns the line unchanged when it already fits — the common case, and the
+ * reason this is safe to call on every write.
+ */
+function wrapOneLine(line: string, width: number): string {
+  if (displayWidth(line) <= width) return line;
+
+  const match = LEADING_INDENT.exec(line);
+  const leadingAnsi = match?.[1] ?? '';
+  const indent = match?.[2] ?? '';
+  const contentWidth = width - indent.length;
+
+  // Pathological indent (deeper than the terminal can usefully hold): drop
+  // the hanging indent rather than squeezing text into a sliver.
+  if (contentWidth < MIN_CONTENT_COLUMNS) {
+    return hardWrapToWidth(line, width);
+  }
+
+  // Re-attach the leading SGR run to the body so the wrapped text keeps its
+  // styling; the indent itself is re-emitted as plain spaces (a space has no
+  // glyph, so its styling is unobservable).
+  const body = leadingAnsi + line.slice(match?.[0]?.length ?? 0);
+  const rows = wrapToWidth(body, contentWidth, { breakLongWords: true }).split('\n');
+
+  return rows
+    .map((row) => {
+      const prefixed = indent + row;
+      // Defensive: wrap-ansi is width-correct for every input we know of, but
+      // this module's whole contract is "never exceeds width", so a row that
+      // somehow overshoots is hard-wrapped rather than emitted over-wide.
+      return displayWidth(prefixed) > width ? hardWrapToWidth(prefixed, width) : prefixed;
+    })
+    .join('\n');
+}
+
+/**
+ * Wrap `text` so that no resulting row exceeds `width` display columns,
+ * preserving each source row's indent on its continuation rows.
+ *
+ * Pure: no terminal or environment reads. Embedded newlines are honored —
+ * each logical line is wrapped independently. Non-finite or non-positive
+ * `width` returns `text` unchanged.
+ */
+export function hangingWrap(text: string, width: number): string {
+  if (!Number.isFinite(width) || width <= 0) return text;
+  const w = Math.floor(width);
+  return text
+    .replaceAll('\r\n', '\n')
+    .split('\n')
+    .map((line) => wrapOneLine(line, w))
+    .join('\n');
+}
+
+/**
+ * Bound a composed row to the live terminal width, or pass it through
+ * untouched when the sink is not a TTY.
+ *
+ * Contract: TTY output is wrapped (never truncated) to `getTerminalWidth()`;
+ * non-TTY output is returned byte-identical so piped consumers still see
+ * whole logical rows.
+ */
+export function boundLineToTerminal(
+  text: string,
+  stream: { isTTY?: boolean } = process.stdout,
+): string {
+  if (stream.isTTY !== true) return text;
+  return hangingWrap(text, getTerminalWidth());
+}

--- a/src/cli/slash/commands/bgsub.ts
+++ b/src/cli/slash/commands/bgsub.ts
@@ -25,6 +25,7 @@
 import { palette } from '../../palette.js';
 import { formatDuration } from '../../format-utils.js';
 import { getTerminalWidth } from '../../terminal-size.js';
+import { truncateDisplayWidth } from '../../display.js';
 import type { SlashCommand } from '../types.js';
 import type { BackgroundAgentRegistry, BackgroundJob } from '../../../agent/background-registry.js';
 import type { BackgroundSummarizer } from '../../../agent/background-summarizer.js';
@@ -93,7 +94,9 @@ function formatJobLine(job: BackgroundJob): string {
   const elapsed = job.endedAt !== undefined
     ? formatDuration(job.endedAt - job.startedAt)
     : formatDuration(Date.now() - job.startedAt);
-  const label = job.label.length > 60 ? `${job.label.slice(0, 60)}…` : job.label;
+  // Display-width truncation, not code-unit: `slice(0, 60) + '…'` measured 61
+  // cells (and mis-measured every wide/emoji/combining grapheme it cut).
+  const label = truncateDisplayWidth(job.label, 60);
   const mainLine = `  ${glyph} ${palette.bold(job.jobId)}  ${label}  ${palette.dim(`(${job.status} · ${elapsed} · ${job.model})`)}`;
 
   if (!summarizerRef || job.status !== 'running') return mainLine;

--- a/src/cli/slash/writer.test.ts
+++ b/src/cli/slash/writer.test.ts
@@ -12,6 +12,7 @@
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { createConsoleWriter, type WriterSink } from './writer.js';
+import { displayWidth, stripAnsi } from '../display.js';
 
 describe('createConsoleWriter — sink routing', () => {
   describe('without a sink (default)', () => {
@@ -143,5 +144,76 @@ describe('createConsoleWriter — sink routing', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+});
+
+describe('createConsoleWriter — width bounding', () => {
+  const originalColumns = process.stdout.columns;
+  const originalIsTTY = process.stdout.isTTY;
+  const setTerminal = (cols: number, isTTY: boolean): void => {
+    Object.defineProperty(process.stdout, 'columns', { configurable: true, writable: true, value: cols });
+    Object.defineProperty(process.stdout, 'isTTY', { configurable: true, writable: true, value: isTTY });
+  };
+
+  afterEach(() => {
+    setTerminal(originalColumns as number, originalIsTTY as boolean);
+    vi.restoreAllMocks();
+  });
+
+  /** The real `/worktree list` row shape — ~100 columns of fixed padEnd(). */
+  const wideTableRow =
+    '  ' + 'some/path'.padEnd(45) + '  ' + 'owner'.padEnd(12) + '  ' + '3d'.padEnd(5) +
+    '  ' + 'stale-dirty'.padEnd(22) + '  ' + 'warn';
+
+  it('wraps a sinkless over-wide row so nothing exits the right edge on a TTY', () => {
+    setTerminal(62, true);
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const w = createConsoleWriter();
+
+    w.line(wideTableRow);
+
+    const emitted = spy.mock.calls[0]?.[0] as string;
+    const rows = emitted.split('\n');
+    expect(rows.length).toBeGreaterThan(1);
+    for (const row of rows) {
+      expect(displayWidth(row), `row exceeds 62: ${JSON.stringify(stripAnsi(row))}`).toBeLessThanOrEqual(62);
+    }
+  });
+
+  it('bounds the prefixed helpers (info/warn/error/success) too', () => {
+    setTerminal(40, true);
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const w = createConsoleWriter();
+
+    w.info('i'.repeat(120));
+    w.warn('w'.repeat(120));
+    w.error('e'.repeat(120));
+    w.success('s'.repeat(120));
+
+    for (const call of spy.mock.calls) {
+      for (const row of (call[0] as string).split('\n')) {
+        expect(displayWidth(row)).toBeLessThanOrEqual(40);
+      }
+    }
+  });
+
+  it('leaves non-TTY output byte-identical so piped rows stay whole', () => {
+    setTerminal(62, false);
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const w = createConsoleWriter();
+
+    w.line(wideTableRow);
+
+    expect(spy).toHaveBeenCalledWith(wideTableRow);
+  });
+
+  it('does not bound the sink path — the sink owner wraps and reflows', () => {
+    setTerminal(62, true);
+    const calls: string[] = [];
+    const w = createConsoleWriter({ fn: (line) => calls.push(line) });
+
+    w.line(wideTableRow);
+
+    expect(calls).toEqual([wideTableRow]);
   });
 });

--- a/src/cli/slash/writer.ts
+++ b/src/cli/slash/writer.ts
@@ -31,6 +31,7 @@
  */
 
 import { palette } from '../palette.js';
+import { boundLineToTerminal } from '../render/bounded-line.js';
 import type { Writer } from './types.js';
 
 /**
@@ -54,9 +55,17 @@ export function createConsoleWriter(sink?: WriterSink): Writer {
   // `sink.fn` fresh so REPL hot-swaps (between console.log and
   // compositor.commitAbove) take effect immediately, even on writers
   // that outlive a single turn (cf. bootstrap.ts's long-lived slashCtx.out).
+  // Invariant: the sinkless path is a RAW write to the terminal, so it is
+  // bounded here — slash tables are composed with fixed column widths
+  // (`/worktree list` alone is ~100 columns) and would otherwise auto-wrap to
+  // column 0 on a narrower terminal, detaching every continuation row from
+  // its table. The sink path is deliberately NOT bounded: its owner
+  // (`CompletionWriter` / `compositor.commitAbove`) already wraps at the live
+  // width and re-wraps the retained band on resize, and pre-wrapping here
+  // would freeze rows at today's width so a later widen could not rejoin them.
   const writeLine = sink !== undefined
     ? (text: string) => { sink.fn(text); }
-    : (text: string) => { console.log(text); };
+    : (text: string) => { console.log(boundLineToTerminal(text)); };
   const writeRaw = (sink !== undefined && sink.rawFn !== undefined)
     ? (text: string) => { sink.rawFn!(text); }
     : (text: string) => { process.stdout.write(text); };

--- a/src/cli/terminal-compositor.committed-band-commit.ts
+++ b/src/cli/terminal-compositor.committed-band-commit.ts
@@ -22,6 +22,7 @@ import {
   snapFlushCountToLogicalBoundary,
 } from './terminal-compositor.scrollback.js';
 import { hardWrapToWidth } from './wrap.js';
+import { boundLineToTerminal } from './render/bounded-line.js';
 import { decideCommitMode } from './commit-mode.js';
 import {
   reflowCommittedBandToWidth,
@@ -96,8 +97,13 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
   };
 
   if (!self.armed || !self.logUpdate) {
+    // Disarmed: no frame, no band, no reflow — this is a raw terminal write,
+    // so it is bounded here. The armed path below hard-wraps to `cols` as part
+    // of its row accounting (line-count math depends on it) and must not be
+    // pre-wrapped by this call.
+    const bounded = boundLineToTerminal(text, self.stdout);
     writeWithGuard(() => {
-      self.stdout.write(text + '\n');
+      self.stdout.write(bounded + '\n');
     });
     return;
   }


### PR DESCRIPTION
## Problem

Text goes out of bounds in the TUI. A row composed with a fixed column budget can exceed the live terminal width, and the terminal then auto-wraps it to **column 0** — so the continuation row loses the indent, tree glyph, or table column that produced it, and the output reads as broken rather than wrapped.

`/worktree list` is the clearest case: its table is built from literal `padEnd()` calls totalling ~100 columns. On a 62-column terminal every row breaks in half, with the second half hard against the left edge.

## Diagnosis

Two independent things were conflated in the original report, and only one of them is a bug:

1. **The tool lane was never at fault.** `toolLaneWidth()` = `min(getTerminalWidth(), 100)` already clamps every composed row on *both* the live-overlay path (`tool-lane.ts:331`) and the committed/flush path (`tool-lane-render-grouped-root.ts:117`). A measurement probe at 62 columns produced a max row width of exactly 62 on both paths, including a 250-char bash command — the vector the code comments call out as the risk.

2. **Rows already written before a narrowing resize cannot be recalled.** Rows still resident in the retained `committedBand` *are* re-wrapped on resize (`reflowCommittedBandToWidth` + `repositionCommittedBand`); rows already evicted past that cap into the terminal's own scrollback are written-and-forgotten, and no read-back path exists. A screenshot taken after shrinking the window will always show pre-resize rows reflowed by the terminal. That is inherent, not fixable here.

3. **The actual bug: the raw write seams.** Everything that is *not* the tool lane reaches the terminal through one of four seams that write straight to stdout with no compositor to wrap them, and none of them bounded anything:

| Seam | Path |
|---|---|
| `slash/writer.ts` | sinkless `console.log` — all slash-command output |
| `commands/interactive/repl-renderer.ts` | the disarmed TTY branch (between turns — exactly when slash commands run) |
| `commands/interactive/bootstrap-surface.ts` | `CompletionWriter`'s pre-arm `console.log` default for `fn` / `idleFn` |
| `terminal-compositor.committed-band-commit.ts` | `commitAbove`'s disarmed early return |

Each trusted its ~40 callers to have budgeted their own width. Many hadn't: `/worktree list` (~100 cols), `bg list` (~127 cols), `queue list` (unbounded command tail), the resume banner (80/120-char caps unrelated to terminal width).

## Fix

Add `src/cli/render/bounded-line.ts` and apply it at those four seams, so bounding is a **property of the seam** rather than a rule each call site has to remember. A new caller cannot reintroduce the bug by forgetting to budget.

- Over-wide rows are **wrapped, never truncated** — no content is lost.
- Every continuation row is re-prefixed with the source row's own leading indent, so wrapped output stays visually attached to the row that produced it:

```
  ↳ some long message that does not fit in this terminal

  ↳ some long message that does not
  fit in this terminal
```

- Rows that already fit pass through byte-identical (the common case, and why this is safe on every write).
- A pathological indent — deeper than `width - 8` — drops the hanging indent and plain hard-wraps, rather than squeezing text into an unreadable sliver.
- Long unbreakable tokens (hashes, URLs, paths) are broken at the column boundary rather than overflowing.

**Deliberately not applied to the armed compositor path.** `commitAbove` already hard-wraps to the live width for its row accounting *and* re-wraps the retained band on resize. Pre-wrapping there would freeze rows at today's width so a later **widen** could no longer rejoin them — the behaviour `tests/pty/compositor-scrollback.pty.test.ts`'s `width-resize-fragment-widen` case guards. That test still passes.

**Non-TTY output is byte-identical.** `afk worktree list | grep` must see whole logical rows; a consumer's parser must never have to reassemble rows this module split for a human.

Also fixes two display-width off-by-ones in `bgsub.ts` and `loop-iteration.ts`: `slice(0, 60) + '…'` measured 61 cells and mis-measured every wide, emoji, or combining grapheme it cut. Both now use `truncateDisplayWidth`, which budgets the ellipsis inside the limit.

## Verification

- `pnpm test` — 801 files / 15,276 tests pass
- `pnpm test:pty` — 10/10, including all four `width-resize-*` reflow guards
- `pnpm lint`, `pnpm build`, `audit:sdk:check`, `audit:env:check`, `scan:env:check`, `audit:chalk:check`, `fix:pins:check` — all pass
- 25 new assertions across three files. The invariant "no row exceeds the terminal width" is asserted directly against the real `/worktree list` row shape at 40 / 62 / 80 / 100 / 120 columns, plus ANSI-styled rows, CJK and emoji graphemes, 200-char unbreakable tokens, multi-line payloads, and the resize case.

## Not included

- Making the fixed-width tables themselves *responsive* (shrinking or dropping columns instead of wrapping). Wrapping is now correct and lossless; column-aware degradation is an aesthetic follow-up.
- The one-shot `commander` surfaces that `console.log` directly without passing through a seam (`improve/*`, `schedule`, `plugin`, `marketplace`). They share the same fixed-`padEnd` pattern and are worth a follow-up pass.
