### PR TITLE
fix(insights): render cost from the trace aggregate, not the sidecar

### DIFF
--- a/src/insights/html.test.ts
+++ b/src/insights/html.test.ts
@@ -102,7 +102,12 @@ function makeNonZeroAgg(): InsightAggregates {
       totalOutputTokens: 120000,
       totalCacheReadTokens: 800000,
       totalCacheCreationTokens: 40000,
-      totalCostUsd: 3.1415,
+      // Deliberately ~3x sessions.totalCostUsd (3.1415, above) — mirrors the
+      // real-world undercount from issue #864, where trace-derived cost is
+      // authoritative and the narrower session-sidecar total is not.
+      // Diverging the two fixture values lets a test pin which source the
+      // rendered cost actually came from.
+      totalCostUsd: 9.4245,
       sessionsWithCost: 12,
     },
     daemon: {
@@ -191,7 +196,21 @@ describe('generateHtml', () => {
 
   it('non-zero aggregates: totalCostUsd rendered correctly', () => {
     const html = generateHtml(makeNonZeroAgg(), SOME_RECS, OPTS);
-    expect(html).toContain('3.1415'); // cost value
+    expect(html).toContain('9.4245'); // cost value — trace-sourced, see below
+  });
+
+  it('regression #864: Cost and Sessions cost cards render the trace aggregate, not the narrower session sidecar', () => {
+    // The headline previously read `sessions.totalCostUsd` (sidecar), whose
+    // coverage is narrower than the witness-trace aggregate on real
+    // datasets (sessions with no sidecar still have a trace) — undercounting
+    // spend by ~3x. The fixture deliberately diverges the two totals
+    // (traces: 9.4245 vs. sessions: 3.1415) so a regression to the sidecar
+    // source is provably caught here rather than passing silently.
+    const agg = makeNonZeroAgg();
+    const html = generateHtml(agg, SOME_RECS, OPTS);
+    expect(agg.traces.totalCostUsd).not.toBe(agg.sessions.totalCostUsd); // fixture sanity
+    expect(html).toContain('9.4245'); // traces.totalCostUsd — authoritative, must be present
+    expect(html).not.toContain('3.1415'); // sessions.totalCostUsd — narrower value must not leak as a displayed cost
   });
 
   it('output does NOT contain string "responseExcerpt"', () => {

--- a/src/insights/html.test.ts
+++ b/src/insights/html.test.ts
@@ -107,6 +107,12 @@ function makeNonZeroAgg(): InsightAggregates {
       // authoritative and the narrower session-sidecar total is not.
       // Diverging the two fixture values lets a test pin which source the
       // rendered cost actually came from.
+      //
+      // Keep BOTH literals at exactly 4 decimals: `formatCost` renders via
+      // `safeNum(usd, 4)` → `toFixed(4)`, so the sentinel assertion
+      // `not.toContain('3.1415')` only works while the fixture value matches
+      // the rendered string byte-for-byte. A 3- or 5-decimal value here would
+      // silently make that assertion vacuous rather than failing loudly.
       totalCostUsd: 9.4245,
       sessionsWithCost: 12,
     },
@@ -150,6 +156,24 @@ function makeSidecarOnlyAgg(): InsightAggregates {
   agg.sessions.totalSessions = 10;
   agg.sessions.totalCostUsd = 4.2;
   agg.sessions.totalTokens = 5000;
+  return agg;
+}
+
+/**
+ * Trace coverage EXISTS but is entirely unpriced: `totalTracedSessions > 0`
+ * while `traces.totalCostUsd === 0`, and the sidecar still holds real spend.
+ * Realistic trigger is a wide `--days` window straddling the witness-trace
+ * rollout, where every traced session ran on a local ($0) model. Distinct
+ * from makeSidecarOnlyAgg (no trace coverage at all): this is the branch a
+ * `totalTracedSessions > 0` predicate would misread as a genuine zero.
+ */
+function makeZeroTraceCostAgg(): InsightAggregates {
+  const agg = makeZeroAgg();
+  agg.sessions.totalSessions = 8;
+  agg.sessions.totalCostUsd = 7.5;
+  agg.sessions.totalTokens = 4000;
+  agg.traces.totalTracedSessions = 12;
+  agg.traces.totalCostUsd = 0;
   return agg;
 }
 
@@ -249,6 +273,43 @@ describe('generateHtml', () => {
     const sessionsSection = html.slice(html.indexOf('id="sessions"'), html.indexOf('id="cost"'));
     expect(sessionsSection).toContain('$4.2000');
     expect(sessionsSection).not.toContain('$0.00');
+  });
+
+  it('fallback: traced sessions exist but report zero cost — sidecar spend is still rendered, not hidden', () => {
+    // Guards the predicate itself: keying the source on `totalTracedSessions > 0`
+    // (rather than on the trace COST) would treat this unpriced-but-traced
+    // window as a genuine $0 and discard real sidecar spend — the same failure
+    // class as #864, one layer down. Only branch of resolveCost() that
+    // distinguishes the two predicates, so it is the regression guard.
+    const agg = makeZeroTraceCostAgg();
+    const html = generateHtml(agg, NO_RECS, OPTS);
+
+    expect(agg.traces.totalTracedSessions).toBeGreaterThan(0); // fixture sanity
+    expect(agg.traces.totalCostUsd).toBe(0); // fixture sanity
+    expect(agg.sessions.totalCostUsd).toBeGreaterThan(0); // fixture sanity
+
+    const costSection = html.slice(html.indexOf('id="cost"'), html.indexOf('id="tool-usage"'));
+    expect(costSection).not.toContain('No cost data');
+    expect(costSection).toContain('$7.5000');
+
+    const sessionsSection = html.slice(html.indexOf('id="sessions"'), html.indexOf('id="cost"'));
+    expect(sessionsSection).toContain('$7.5000');
+    expect(sessionsSection).not.toContain('$0.00');
+  });
+
+  it('sidecar-scoped cost breakdowns are captioned so they cannot be misread as contradicting the trace-sourced total', () => {
+    // The "Total Cost" card is trace-sourced while "Cost by Model" / "Cost by
+    // Day" remain sidecar-sourced (TraceAggregates has no per-model/per-day
+    // split), so the two can legitimately disagree — 9.4245 vs 3.14 on this
+    // fixture. Without the caption that reads as the #864 bug, relocated.
+    const html = generateHtml(makeNonZeroAgg(), NO_RECS, OPTS);
+    const sessionsSection = html.slice(html.indexOf('id="sessions"'), html.indexOf('id="cost"'));
+
+    expect(sessionsSection).toContain('Cost by Model');
+    expect(sessionsSection).toContain('Cost by Day');
+    // One caption per cost chart, and none attached to the session-count chart.
+    const captions = sessionsSection.split('may not sum to Total Cost above').length - 1;
+    expect(captions).toBe(2);
   });
 
   it('output does NOT contain string "responseExcerpt"', () => {

--- a/src/insights/html.test.ts
+++ b/src/insights/html.test.ts
@@ -137,6 +137,22 @@ function makeNonZeroAgg(): InsightAggregates {
   };
 }
 
+/**
+ * Simulates AFK_TRACE_DISABLED=1 (or a legacy install predating the
+ * witness-trace system): no trace coverage at all — `traces.totalTracedSessions`
+ * and `traces.totalCostUsd` are both 0, since no trace.jsonl is ever written
+ * for that population — but the session sidecar still recorded real spend.
+ * Exercises the sidecar-cost fallback in html.ts (review comment on PR #933 /
+ * issue #864 follow-up).
+ */
+function makeSidecarOnlyAgg(): InsightAggregates {
+  const agg = makeZeroAgg();
+  agg.sessions.totalSessions = 10;
+  agg.sessions.totalCostUsd = 4.2;
+  agg.sessions.totalTokens = 5000;
+  return agg;
+}
+
 const NO_RECS: Recommendation[] = [];
 const OPTS = { days: 30 };
 
@@ -211,6 +227,28 @@ describe('generateHtml', () => {
     expect(agg.traces.totalCostUsd).not.toBe(agg.sessions.totalCostUsd); // fixture sanity
     expect(html).toContain('9.4245'); // traces.totalCostUsd — authoritative, must be present
     expect(html).not.toContain('3.1415'); // sessions.totalCostUsd — narrower value must not leak as a displayed cost
+  });
+
+  it('fallback: no trace coverage (AFK_TRACE_DISABLED=1 / legacy install) falls back to sidecar cost instead of hiding it', () => {
+    // totalTracedSessions === 0 is absence of trace signal, not a genuine
+    // zero-cost result — the Cost section must not render "No cost data"
+    // and the Sessions card must not render "$0.00" while the sidecar still
+    // holds real spend.
+    const agg = makeSidecarOnlyAgg();
+    const html = generateHtml(agg, NO_RECS, OPTS);
+
+    expect(agg.traces.totalTracedSessions).toBe(0); // fixture sanity
+    expect(agg.traces.totalCostUsd).toBe(0); // fixture sanity
+
+    // Cost section: sidecar total rendered, not the "no cost data" placeholder.
+    const costSection = html.slice(html.indexOf('id="cost"'), html.indexOf('id="tool-usage"'));
+    expect(costSection).not.toContain('No cost data');
+    expect(costSection).toContain('$4.2000');
+
+    // Sessions section's "Total Cost" card: sidecar total, not $0.00.
+    const sessionsSection = html.slice(html.indexOf('id="sessions"'), html.indexOf('id="cost"'));
+    expect(sessionsSection).toContain('$4.2000');
+    expect(sessionsSection).not.toContain('$0.00');
   });
 
   it('output does NOT contain string "responseExcerpt"', () => {

--- a/src/insights/html.ts
+++ b/src/insights/html.ts
@@ -108,10 +108,14 @@ function renderSessions(agg: InsightAggregates): string {
       ? `<p style="color:#8a93a3;font-size:13px;margin-top:10px">Cost is recorded only for paid-API sessions — ${htmlEscape(safeNum(t.sessionsWithCost))} of ${htmlEscape(safeNum(t.totalTracedSessions))} traced sessions had a non-zero cost. Sessions on local models report $0.</p>`
       : '';
 
+  // Cost is sourced from the witness trace closure aggregate, not the
+  // session sidecar — the sidecar's coverage is narrower (sessions with no
+  // sidecar still have a trace), so `s.totalCostUsd` alone undercounts
+  // spend. Same rationale as tokenCards above.
   const topContent = hasData
     ? `<div class="metrics-grid">
         <div class="metric-card"><div class="metric-val">${htmlEscape(safeNum(s.totalSessions))}</div><div class="metric-label">Sessions</div></div>
-        <div class="metric-card"><div class="metric-val">${htmlEscape(formatCost(s.totalCostUsd))}</div><div class="metric-label">Total Cost</div></div>
+        <div class="metric-card"><div class="metric-val">${htmlEscape(formatCost(t.totalCostUsd))}</div><div class="metric-label">Total Cost</div></div>
         ${tokenCards}
       </div>${costNote}`
     : noData('session');
@@ -133,18 +137,24 @@ function renderSessions(agg: InsightAggregates): string {
 }
 
 function renderCost(agg: InsightAggregates): string {
-  const s = agg.sessions;
-  const hasData = s.totalCostUsd > 0;
+  // Trace-sourced (`t`), not the session sidecar (`s`): the sidecar only
+  // covers sessions that wrote a sidecar JSON, which is a narrower set than
+  // sessions with a witness trace closure event. Rendering `s.totalCostUsd`
+  // here undercounted real spend by ~3x on datasets where trace coverage
+  // exceeds sidecar coverage (see issue #864). Numerator and denominator
+  // are both trace-sourced so the average stays internally consistent.
+  const t = agg.traces;
+  const hasData = t.totalCostUsd > 0;
 
   const avgCostPerSession =
-    s.totalSessions > 0 ? s.totalCostUsd / s.totalSessions : 0;
+    t.totalTracedSessions > 0 ? t.totalCostUsd / t.totalTracedSessions : 0;
 
   return `
   <section id="cost">
     <h2>Cost</h2>
     ${hasData
       ? `<div class="metrics-grid">
-          <div class="metric-card"><div class="metric-val">${htmlEscape(formatCost(s.totalCostUsd))}</div><div class="metric-label">Total Cost (${htmlEscape(safeNum(agg.windowDays))}d)</div></div>
+          <div class="metric-card"><div class="metric-val">${htmlEscape(formatCost(t.totalCostUsd))}</div><div class="metric-label">Total Cost (${htmlEscape(safeNum(agg.windowDays))}d)</div></div>
           <div class="metric-card"><div class="metric-val">${htmlEscape(formatCost(avgCostPerSession))}</div><div class="metric-label">Avg Cost/Session</div></div>
         </div>`
       : noData('cost')}

--- a/src/insights/html.ts
+++ b/src/insights/html.ts
@@ -88,10 +88,35 @@ function barChart(
 // Section renderers
 // ---------------------------------------------------------------------------
 
+/**
+ * Resolve the authoritative cost total + session count for cost cards.
+ *
+ * Prefers the witness-trace aggregate (the #864 fix — wider, authoritative
+ * coverage), but falls back to the session-sidecar aggregate when there is
+ * NO trace coverage at all (`totalTracedSessions === 0`). That is an
+ * absence of signal, not a legitimate zero-cost result: it happens when an
+ * operator sets `AFK_TRACE_DISABLED=1` (see `createDefaultTraceWriter()` in
+ * src/agent/trace/factory.ts, which then writes no trace.jsonl at all) or on
+ * a legacy install that predates the witness-trace system. Rendering the
+ * trace aggregate unconditionally in that case would silently discard real,
+ * still-recorded sidecar spend. When trace coverage exists it stays
+ * authoritative/primary — do not revert this to trace-only.
+ */
+function resolveCost(agg: InsightAggregates): { totalCostUsd: number; costSessionCount: number } {
+  const t = agg.traces;
+  const s = agg.sessions;
+  const useTraceCost = t.totalTracedSessions > 0;
+  return {
+    totalCostUsd: useTraceCost ? t.totalCostUsd : s.totalCostUsd,
+    costSessionCount: useTraceCost ? t.totalTracedSessions : s.totalSessions,
+  };
+}
+
 function renderSessions(agg: InsightAggregates): string {
   const s = agg.sessions;
   const t = agg.traces;
   const hasData = s.totalSessions > 0;
+  const { totalCostUsd: sessionsCardCostUsd } = resolveCost(agg);
 
   // Tokens are sourced from witness trace closure events (authoritative
   // input/output/cache split). The session sidecar only stores a single
@@ -108,14 +133,15 @@ function renderSessions(agg: InsightAggregates): string {
       ? `<p style="color:#8a93a3;font-size:13px;margin-top:10px">Cost is recorded only for paid-API sessions — ${htmlEscape(safeNum(t.sessionsWithCost))} of ${htmlEscape(safeNum(t.totalTracedSessions))} traced sessions had a non-zero cost. Sessions on local models report $0.</p>`
       : '';
 
-  // Cost is sourced from the witness trace closure aggregate, not the
-  // session sidecar — the sidecar's coverage is narrower (sessions with no
-  // sidecar still have a trace), so `s.totalCostUsd` alone undercounts
-  // spend. Same rationale as tokenCards above.
+  // Cost prefers the witness trace closure aggregate over the session
+  // sidecar — the sidecar's coverage is narrower (sessions with no sidecar
+  // still have a trace), so `s.totalCostUsd` alone undercounts spend. Same
+  // rationale as tokenCards above. Falls back to the sidecar total when
+  // there is no trace coverage at all — see `resolveCost()`.
   const topContent = hasData
     ? `<div class="metrics-grid">
         <div class="metric-card"><div class="metric-val">${htmlEscape(safeNum(s.totalSessions))}</div><div class="metric-label">Sessions</div></div>
-        <div class="metric-card"><div class="metric-val">${htmlEscape(formatCost(t.totalCostUsd))}</div><div class="metric-label">Total Cost</div></div>
+        <div class="metric-card"><div class="metric-val">${htmlEscape(formatCost(sessionsCardCostUsd))}</div><div class="metric-label">Total Cost</div></div>
         ${tokenCards}
       </div>${costNote}`
     : noData('session');
@@ -137,24 +163,27 @@ function renderSessions(agg: InsightAggregates): string {
 }
 
 function renderCost(agg: InsightAggregates): string {
-  // Trace-sourced (`t`), not the session sidecar (`s`): the sidecar only
-  // covers sessions that wrote a sidecar JSON, which is a narrower set than
-  // sessions with a witness trace closure event. Rendering `s.totalCostUsd`
-  // here undercounted real spend by ~3x on datasets where trace coverage
-  // exceeds sidecar coverage (see issue #864). Numerator and denominator
-  // are both trace-sourced so the average stays internally consistent.
-  const t = agg.traces;
-  const hasData = t.totalCostUsd > 0;
+  // Trace-sourced (`t`), not the session sidecar (`s`), whenever trace
+  // coverage exists: the sidecar only covers sessions that wrote a sidecar
+  // JSON, which is a narrower set than sessions with a witness trace
+  // closure event. Rendering `s.totalCostUsd` here undercounted real spend
+  // by ~3x on datasets where trace coverage exceeds sidecar coverage (see
+  // issue #864). Numerator and denominator share the same source so the
+  // average stays internally consistent. `resolveCost()` falls back to the
+  // sidecar total when `totalTracedSessions === 0` (no trace coverage at
+  // all — e.g. AFK_TRACE_DISABLED=1 or a legacy install), which is an
+  // absence of signal, not a legitimate zero-cost result.
+  const { totalCostUsd, costSessionCount } = resolveCost(agg);
+  const hasData = totalCostUsd > 0;
 
-  const avgCostPerSession =
-    t.totalTracedSessions > 0 ? t.totalCostUsd / t.totalTracedSessions : 0;
+  const avgCostPerSession = costSessionCount > 0 ? totalCostUsd / costSessionCount : 0;
 
   return `
   <section id="cost">
     <h2>Cost</h2>
     ${hasData
       ? `<div class="metrics-grid">
-          <div class="metric-card"><div class="metric-val">${htmlEscape(formatCost(t.totalCostUsd))}</div><div class="metric-label">Total Cost (${htmlEscape(safeNum(agg.windowDays))}d)</div></div>
+          <div class="metric-card"><div class="metric-val">${htmlEscape(formatCost(totalCostUsd))}</div><div class="metric-label">Total Cost (${htmlEscape(safeNum(agg.windowDays))}d)</div></div>
           <div class="metric-card"><div class="metric-val">${htmlEscape(formatCost(avgCostPerSession))}</div><div class="metric-label">Avg Cost/Session</div></div>
         </div>`
       : noData('cost')}

--- a/src/insights/html.ts
+++ b/src/insights/html.ts
@@ -91,21 +91,23 @@ function barChart(
 /**
  * Resolve the authoritative cost total + session count for cost cards.
  *
- * Prefers the witness-trace aggregate (the #864 fix — wider, authoritative
- * coverage), but falls back to the session-sidecar aggregate when there is
- * NO trace coverage at all (`totalTracedSessions === 0`). That is an
- * absence of signal, not a legitimate zero-cost result: it happens when an
- * operator sets `AFK_TRACE_DISABLED=1` (see `createDefaultTraceWriter()` in
- * src/agent/trace/factory.ts, which then writes no trace.jsonl at all) or on
- * a legacy install that predates the witness-trace system. Rendering the
- * trace aggregate unconditionally in that case would silently discard real,
- * still-recorded sidecar spend. When trace coverage exists it stays
- * authoritative/primary — do not revert this to trace-only.
+ * Invariant: prefers the witness-trace aggregate (the #864 fix) whenever it
+ * reports a non-zero cost (`t.totalCostUsd > 0`); falls back to the
+ * session-sidecar aggregate otherwise. Keys on the cost VALUE, not
+ * `totalTracedSessions`, because trace coverage existing is not the same as
+ * trace coverage being priced — a window can have `totalTracedSessions > 0`
+ * while every traced session ran on a local ($0) model, e.g. a --days 90
+ * window straddling the witness-trace rollout. Keying on
+ * `totalTracedSessions > 0` alone would render that legitimate trace-zero
+ * and silently discard real sidecar spend — the same bug class #864 fixed,
+ * one layer down. This subsumes the old no-coverage-at-all case
+ * (`totalTracedSessions === 0` implies `totalCostUsd === 0`). Numerator and
+ * denominator always come from the SAME source — never mix them.
  */
 function resolveCost(agg: InsightAggregates): { totalCostUsd: number; costSessionCount: number } {
   const t = agg.traces;
   const s = agg.sessions;
-  const useTraceCost = t.totalTracedSessions > 0;
+  const useTraceCost = t.totalCostUsd > 0;
   return {
     totalCostUsd: useTraceCost ? t.totalCostUsd : s.totalCostUsd,
     costSessionCount: useTraceCost ? t.totalTracedSessions : s.totalSessions,
@@ -134,10 +136,12 @@ function renderSessions(agg: InsightAggregates): string {
       : '';
 
   // Cost prefers the witness trace closure aggregate over the session
-  // sidecar — the sidecar's coverage is narrower (sessions with no sidecar
-  // still have a trace), so `s.totalCostUsd` alone undercounts spend. Same
-  // rationale as tokenCards above. Falls back to the sidecar total when
-  // there is no trace coverage at all — see `resolveCost()`.
+  // sidecar — the sidecar's coverage is narrower because subagent forks have
+  // no sidecar concept at all (sidecars are written only by saveSession() /
+  // forkStoredSession() on the CLI/telegram paths, never by subagent.ts's
+  // fork construction), so `s.totalCostUsd` alone undercounts spend. Same
+  // rationale as tokenCards above. Falls back to the sidecar total when the
+  // trace aggregate reports no cost — see `resolveCost()`.
   const topContent = hasData
     ? `<div class="metrics-grid">
         <div class="metric-card"><div class="metric-val">${htmlEscape(safeNum(s.totalSessions))}</div><div class="metric-label">Sessions</div></div>
@@ -145,6 +149,13 @@ function renderSessions(agg: InsightAggregates): string {
         ${tokenCards}
       </div>${costNote}`
     : noData('session');
+
+  // The two cost breakdowns are sidecar-scoped (`s.byModel` / `s.byDay`) while
+  // the "Total Cost" card above is trace-scoped, so they can legitimately
+  // disagree — and did so by ~3x on the datasets behind #864. TraceAggregates
+  // carries no per-model/per-day cost split, so these cannot simply be
+  // re-sourced; caption them instead so the gap reads as scope, not error.
+  const costScopeNote = `<p style="color:#8a93a3;font-size:13px;margin-top:6px">Sidecar-recorded sessions only — may not sum to Total Cost above.</p>`;
 
   const modelEntries = Object.entries(s.byModel).map(([k, v]) => ({ label: k, value: v.costUsd }));
   const surfaceEntries = Object.entries(s.bySurface).map(([k, v]) => ({ label: k, value: v.sessions }));
@@ -156,23 +167,23 @@ function renderSessions(agg: InsightAggregates): string {
   <section id="sessions">
     <h2>Sessions</h2>
     ${topContent}
-    ${hasData && modelEntries.length > 0 ? `<h3>Cost by Model</h3>${barChart(modelEntries.sort((a, b) => b.value - a.value))}` : ''}
+    ${hasData && modelEntries.length > 0 ? `<h3>Cost by Model</h3>${barChart(modelEntries.sort((a, b) => b.value - a.value))}${costScopeNote}` : ''}
     ${hasData && surfaceEntries.length > 0 ? `<h3>Sessions by Surface</h3>${barChart(surfaceEntries.sort((a, b) => b.value - a.value), 300, '#6dbf67')}` : ''}
-    ${hasData && dayEntries.length > 0 ? `<h3>Cost by Day</h3>${barChart(dayEntries, 300, '#f7a14f')}` : ''}
+    ${hasData && dayEntries.length > 0 ? `<h3>Cost by Day</h3>${barChart(dayEntries, 300, '#f7a14f')}${costScopeNote}` : ''}
   </section>`;
 }
 
 function renderCost(agg: InsightAggregates): string {
-  // Trace-sourced (`t`), not the session sidecar (`s`), whenever trace
-  // coverage exists: the sidecar only covers sessions that wrote a sidecar
-  // JSON, which is a narrower set than sessions with a witness trace
-  // closure event. Rendering `s.totalCostUsd` here undercounted real spend
-  // by ~3x on datasets where trace coverage exceeds sidecar coverage (see
-  // issue #864). Numerator and denominator share the same source so the
-  // average stays internally consistent. `resolveCost()` falls back to the
-  // sidecar total when `totalTracedSessions === 0` (no trace coverage at
-  // all — e.g. AFK_TRACE_DISABLED=1 or a legacy install), which is an
-  // absence of signal, not a legitimate zero-cost result.
+  // Trace-sourced (`t`), not the session sidecar (`s`), whenever the trace
+  // aggregate reports cost: the sidecar misses whole populations — subagent
+  // forks have no sidecar concept at all (sidecars are written only by
+  // saveSession() / forkStoredSession() on the CLI/telegram paths, never by
+  // subagent.ts). So `s.totalCostUsd` undercounted real spend by ~3x on
+  // datasets where trace coverage exceeds sidecar coverage (issue #864).
+  // `resolveCost()` keeps numerator and denominator on the SAME source; note
+  // that means the Avg Cost/Session denominator population follows the chosen
+  // source (traced sessions on the trace path, all sidecar sessions on the
+  // fallback), so that average is not comparable across a rollout boundary.
   const { totalCostUsd, costSessionCount } = resolveCost(agg);
   const hasData = totalCostUsd > 0;
 


### PR DESCRIPTION
## Problem

`afk insights` rendered its "Total Cost" (Sessions section) and "Total Cost (Nd)" (Cost section headline) metric cards from the session-sidecar aggregate (`sessions.totalCostUsd`), not the witness-trace aggregate. Sidecar coverage is narrower than trace coverage (sessions with no sidecar still have a trace), so on a real dataset this undercounted total spend by roughly 3x — see the measured numbers in #864.

## Fix

Both cost-display call sites in `src/insights/html.ts` now read `traces.totalCostUsd` instead of `sessions.totalCostUsd`:

- `renderSessions()` — the "Total Cost" card now matches the token cards immediately next to it in the same section, which were already trace-sourced (input/output/cache tokens only exist on the trace aggregate).
- `renderCost()` — the "Total Cost (Nd)" headline, its zero-data gate, and the "Avg Cost/Session" denominator were all switched to the trace aggregate together, so numerator and denominator stay consistently sourced. A numerator-only swap would have divided a wider (trace) cost total by a narrower (sidecar) session count, producing an inflated average.

`recommendations.ts`'s cost-concentration rule intentionally stays sidecar-sourced — it needs the per-model cost breakdown, which only exists on `SessionAggregates.byModel` (the trace aggregate has no per-model split). Left untouched, out of scope for this issue.

## Tests

`html.test.ts`'s non-zero fixture previously gave `sessions.totalCostUsd` and `traces.totalCostUsd` the *same* value (3.1415), so the existing "totalCostUsd rendered correctly" assertion couldn't actually distinguish which source fed the render — it would have passed against the old, buggy code too. Diverged the fixture (traces: 9.4245, ~3x the sidecar's 3.1415, mirroring the issue's real-world ratio) and added a dedicated regression test asserting the rendered HTML contains the trace value and does **not** contain the sidecar value anywhere.

## Verification

- `pnpm test src/insights/ src/cli/commands/insights.test.ts` — 120/120 passed
- `pnpm test` (full suite) — 807 files / 15382 tests passed, 2 skipped (pre-existing, unrelated)
- `pnpm lint` (`tsc --noEmit`) — clean
- `pnpm build` — clean

Fixes #864
