### PR TITLE
fix(review): make the severity rubric impact-only, block security mediums explicitly

### DIFF
--- a/docs/bundled-plugins.md
+++ b/docs/bundled-plugins.md
@@ -38,6 +38,36 @@ still saying "grep production source files", the one shell-implying verb the
 rest of this change removed, and Check B verified absence claims only at
 blocking/critical/high — the same severity-scope gap Check A had just closed.
 
+Re-bumped again (#937): severity and disposition are now **separate axes**.
+`severity` answers "how bad is this defect", `blocking` answers "does this
+prevent merge"; the old rubric welded them, defining `high` by impact
+("wrong output under reachable conditions") but `medium` by category
+("missing edge case, perf degraded under load, deprecated API"), so
+blocking on tier alone made "you used a deprecated API" a hard merge
+blocker. The rubric is now single-axis (impact), hygiene re-homes to
+`low`, and every finding carries an explicit `blocking: true|false` from a
+default table with per-finding overrides that each need a one-clause
+justification. Two medium classes are never overridable: the `security`
+dimension, and material data-integrity risk / likely production failure
+under normal usage. Reviewed by /review, which found the first cut
+incomplete in three ways, all fixed here: (1) the two pre-existing
+severity-downgrade rules (low confidence, Wave 1.5 `diff-only`) fed
+straight into the blocking default, so a security `medium` could reach
+`blocking: false` with no override and no justification — an "Invariant —
+assignment order" block now pins `blocking` to the pre-downgrade severity;
+(2) neither wave's dispatch contract transmitted the blocking table and no
+actor was named for the mapping, so Wave 1 was told to emit a field whose
+rules it never received — Wave 1 is now the named assigner and the table
+is in its `receives` list; (3) the shadow-verify trigger still keyed on
+tier while the gate keyed on `blocking`, leaving the newly-introduced
+waiver as the only pipeline decision with no independent reader —
+overridden findings are now routed to /shadow-verify, and the 3-claim
+concurrency bound is prioritised waiver-first because an unreviewed
+waiver removes a blocker while an unreviewed `critical` still blocks. The
+two never-overridable clauses and the ordering invariant are now guarded
+by a substring assertion, not the file hash alone (see 'review keeps the
+severity/disposition split' below).
+
 The bundled copy is the SOLE copy of /review: upstream deleted its own
 review skill on 2026-07-24 (ce27e45), a deliberate dedup of a skill that
 only ever shadowed this one. So #726 had nothing to back-port. The defect

--- a/src/bundled-plugins/awa-bundled/bundled.test.ts
+++ b/src/bundled-plugins/awa-bundled/bundled.test.ts
@@ -101,7 +101,7 @@ const PINNED_HASHES = {
   research: 'abe79d75a5f3c74696ef002293dbe8714e446f8955de97089d1005f1e70bc269',
   // History: /review Wave 1 no longer mandates a `git show` re-read (#726, #777).
   // Full rationale: docs/bundled-plugins.md#review-726
-  review: '15083aee942b69f8c5e4516c6def5c656f86a84ed769118b4b4618e1434d1551',
+  review: 'd92f10a3d0a1290c1f00e2141476a256c08b285854ce1639aaf0a1414fc4d394',
   // History: /shadow-verify gained the confidence-trigger + composition-axis
   // verdicts (#52, #187).
   // Full rationale: docs/bundled-plugins.md#shadow-verify-52

--- a/src/bundled-plugins/awa-bundled/bundled.test.ts
+++ b/src/bundled-plugins/awa-bundled/bundled.test.ts
@@ -101,7 +101,7 @@ const PINNED_HASHES = {
   research: 'abe79d75a5f3c74696ef002293dbe8714e446f8955de97089d1005f1e70bc269',
   // History: /review Wave 1 no longer mandates a `git show` re-read (#726, #777).
   // Full rationale: docs/bundled-plugins.md#review-726
-  review: '827aa8f10c6de141bce19b5f7bac9394b319ca9cb68c108ed627a6d5f2c2df20',
+  review: '15083aee942b69f8c5e4516c6def5c656f86a84ed769118b4b4618e1434d1551',
   // History: /shadow-verify gained the confidence-trigger + composition-axis
   // verdicts (#52, #187).
   // Full rationale: docs/bundled-plugins.md#shadow-verify-52

--- a/src/bundled-plugins/awa-bundled/bundled.test.ts
+++ b/src/bundled-plugins/awa-bundled/bundled.test.ts
@@ -99,9 +99,12 @@ const PINNED_HASHES = {
   // ~/.afk/skills/ if it drifts back.
   refactor: '3adf801b9a61eba80afd34fef1e8c78a892ec07256dabb073370622a62d1b40f',
   research: 'abe79d75a5f3c74696ef002293dbe8714e446f8955de97089d1005f1e70bc269',
-  // History: /review Wave 1 no longer mandates a `git show` re-read (#726, #777).
+  // History: /review Wave 1 no longer mandates a `git show` re-read (#726,
+  // #777); severity and disposition split into separate axes with an explicit
+  // `blocking` field, never-overridable security/data-integrity mediums, and a
+  // pre-downgrade assignment-order invariant (#937).
   // Full rationale: docs/bundled-plugins.md#review-726
-  review: 'd92f10a3d0a1290c1f00e2141476a256c08b285854ce1639aaf0a1414fc4d394',
+  review: '4bac29d1b06c80afde003094b77315c56f71aa39f04c7115da268cbafdde06db',
   // History: /shadow-verify gained the confidence-trigger + composition-axis
   // verdicts (#52, #187).
   // Full rationale: docs/bundled-plugins.md#shadow-verify-52
@@ -207,6 +210,40 @@ describe('bundled skills', () => {
       expect(content).toContain(
         '**Wave 1.5 — Citation + absence-claim verification (INLINE',
       );
+    });
+
+    // Invariant: severity and disposition are separate axes (#937). The two
+    // never-overridable medium classes and the pre-downgrade assignment order
+    // are the whole point of the split — a later edit that drops either one
+    // reopens the bypass it closed, and the file hash alone cannot say which
+    // clause went missing.
+    it('review keeps the severity/disposition split (#937)', () => {
+      const content = readBundled('review');
+
+      // Disposition is an explicit per-finding field, not a tier threshold.
+      expect(content).toContain('**Wave 1 assigns** an explicit `blocking: true|false`');
+      expect(content).toContain(
+        'Emit **DO NOT MERGE** when one or more findings carry `blocking: true`',
+      );
+
+      // Neither never-overridable medium class may be waived.
+      expect(content).toContain(
+        'A `medium` in the `security` dimension is **never** overridable to `false`',
+      );
+      expect(content).toContain(
+        'material data-integrity risk or a likely production failure under normal usage is **never** overridable to `false`',
+      );
+
+      // A downgrade lowers severity, never disposition — otherwise the two
+      // clauses above are bypassable without invoking an override at all.
+      expect(content).toContain('**Invariant — assignment order.**');
+      expect(content).toContain('assigned from the **pre-downgrade** severity');
+      expect(content).toContain(
+        'keeps the `blocking` value its pre-downgrade severity earned',
+      );
+
+      // An overridden disposition gets an independent reader.
+      expect(content).toContain('whose `blocking` value departs from the default table');
     });
   });
 });

--- a/src/bundled-plugins/awa-bundled/skills/review/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/review/SKILL.md
@@ -103,7 +103,29 @@ Returns a combined verification manifest: `[{type: citation|absence, claim, stat
 
 Sort overall: critical → high → medium → low → nit; security first within tier; semantic/invariant findings above mechanical findings within tier. Template-fill summary block.
 
-**Merge-decision rule (mandatory — do not improvise a threshold).** Emit **DO NOT MERGE** when one or more `critical`, `high`, or `medium` findings survive Wave 1.5 filtering. Emit **MERGE** only when every surviving finding is `low` or `nit`. `medium` is **blocking by default** — a medium is an unfixed defect the author has not yet seen, not a nice-to-have. A `security`-dimension `medium` is always blocking and must be named as such in the decision line — today's narrow reachability is tomorrow's incident. State the counts that drove the decision on the same line, **with a dimension breakdown for any medium**, e.g. `Decision: DO NOT MERGE — 1 high, 2 medium (1 security, 1 correctness).` or `Decision: MERGE — 0 blocking (3 low, 1 nit).` If zero findings survived, say `Decision: MERGE — 0 findings.` Never emit a bare verdict with no counts.
+**Merge-decision rule (mandatory — do not improvise a threshold).**
+
+Severity and disposition are **separate axes**. `severity` answers "how bad is this defect?" — it is a property of the finding. `blocking` answers "does this prevent merge?" — it is policy. Never let one silently encode the other.
+
+Every finding carries an explicit `blocking: true|false`, assigned from this default table:
+
+| severity | default `blocking` |
+|---|---|
+| `critical` | true |
+| `high` | true |
+| `medium` | true |
+| `low` | false |
+| `nit` | false |
+
+**Overrides (each requires a one-clause justification appended to the finding):**
+- A `medium` may be marked `blocking: false` when it is a bounded, non-data-affecting defect the author can reasonably land and follow up — e.g. a rare-input formatting error with no downstream consumer.
+- A `medium` in the `security` dimension is **never** overridable to `false`; today's narrow reachability is tomorrow's incident.
+- A `medium` representing a material data-integrity risk or a likely production failure under normal usage is **never** overridable to `false` — a race that intermittently loses user state stays blocking even when its blast radius keeps it out of `high`.
+- A `low` or `nit` may be marked `blocking: true` only for a stated external constraint (release gate, compliance requirement). Do not use this to smuggle a preference.
+
+Emit **DO NOT MERGE** when one or more findings carry `blocking: true` after Wave 1.5 filtering. Emit **MERGE** only when every surviving finding is `blocking: false`.
+
+State the counts that drove the decision on the same line, **with a dimension breakdown for any blocking medium**, e.g. `Decision: DO NOT MERGE — 1 high, 2 medium blocking (1 security, 1 correctness); 1 medium waived, 3 low.` or `Decision: MERGE — 0 blocking (2 medium waived, 3 low, 1 nit).` If zero findings survived, say `Decision: MERGE — 0 findings.` Never emit a bare verdict with no counts, and never waive a finding silently — a waived medium must appear in the count with its justification.
 
 This is the terminal step — after emitting the decision, STOP. Do not act on any finding: no edits, commits, pushes, or PR/MR mutations. A blocking bug is a finding to report, not a fix to apply.
 
@@ -123,7 +145,7 @@ Confidence `low` → auto-downgrade one tier + append `[low confidence — verif
 
 **Output per dimension:** if you have read the relevant file(s) and have either real findings or a confirmed clean read, emit findings or `no issues found — read <file>`. If evidence is insufficient — you could not read the file, the tool was unavailable, no production importers were found for the symbol, or no test file exists at the asserted path — emit `unverified — <reason>` naming the missing evidence rather than invent a finding to fill the slot. Banned words from the hedging list (`ensure`, `consider`, `may`, `could`) remain banned **inside findings**; the `unverified` channel is the sanctioned path for uncertainty.
 
-**Finding schema:** `severity · confidence · dimension · file:line_range · ref:<sha> · citation-type:(diff-context|file-state) · finding (one concrete sentence naming the failure mode) · evidence (verbatim code ≤4 lines) · suggestion (one concrete fix)`.
+**Finding schema:** `severity · blocking:(true|false) · confidence · dimension · file:line_range · ref:<sha> · citation-type:(diff-context|file-state) · finding (one concrete sentence naming the failure mode) · evidence (verbatim code ≤4 lines) · suggestion (one concrete fix)`. When `blocking` departs from the default table, append `· waived: <one clause>` (or `· escalated: <one clause>`) naming the reason.
 
 **Epistemic scope disclosure (required in synthesis output).** The "What was not checked" section must include:
 - Which ref citations were verified against in Wave 1.5 (list the SHA or `unknown` if patch-file input). Example: `Citations verified inline against branch HEAD abc1234.`

--- a/src/bundled-plugins/awa-bundled/skills/review/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/review/SKILL.md
@@ -46,13 +46,13 @@ Never fabricate intent. When none is available the value is the literal `(none s
 
 **Concurrency floor — declared, conditional, and enforced.** *Through synthesis*, a full-regime review peaks at **2 concurrent sub-agent sessions** (Wave 1's two dimension agents) and dispatches **3 in total** (Wave 1 ×2, then Wave 2 ×1, sequential). Wave 1.5 runs inline in the orchestrator and dispatches nothing. **No wave nests a child**: the sub-agents are shell-less by design, and nothing in this skill requires them to run a command, so none of them needs to nest a `git-investigator` to comply. If you add a requirement here that needs a shell, you have silently doubled this floor — put that requirement in Wave 1.5 instead.
 
-**The post-synthesis tail is the conditional half of that budget.** A review that surfaces a `critical`/`high` finding invokes `/shadow-verify` (see **Post-synthesis** below), which dispatches one verifier per claim in parallel — so the whole-run budget is **peak 3 concurrent, 5–6 total**, and it lands on exactly the high-stakes reviews most likely to hit a rate ceiling. Bound it: **at most 3 claims in a single round, no repeat rounds**, and hand the verifiers Wave 1.5's manifest so each re-derives the *claim* instead of re-locating evidence Wave 1.5 already pinned at the ref. Wave 1.5 verifies that a citation is real; shadow-verify re-derives whether the inference drawn from it holds — never substitute one for the other.
+**The post-synthesis tail is the conditional half of that budget.** A review that surfaces a `critical`/`high` finding — or one whose `blocking` value departs from the default table (see **Post-synthesis** below) — invokes `/shadow-verify`, which dispatches one verifier per claim in parallel — so the whole-run budget is **peak 3 concurrent, 5–6 total**, and it lands on exactly the high-stakes reviews most likely to hit a rate ceiling. Bound it: **at most 3 claims in a single round, no repeat rounds**, and hand the verifiers Wave 1.5's manifest so each re-derives the *claim* instead of re-locating evidence Wave 1.5 already pinned at the ref. Wave 1.5 verifies that a citation is real; shadow-verify re-derives whether the inference drawn from it holds — never substitute one for the other.
 
 **Wave 1 — Full review (regime=full, 2 parallel agents, `subagent_type: "research-agent"`).** Dispatch:
 - **security · api-compat** — contracts, auth, injection, breaking changes, secret exposure.
 - **correctness · spec-compliance · test-coverage · perf-observability** — logic bugs, regressions, whether the change satisfies its **stated intent** (unmet requirement or unrequested scope creep), missing tests, hot-path perf, logging gaps.
 
-Each agent receives: full diff + file tree + triage header + **reviewed ref (SHA)** + the **stated intent** (what the change is meant to accomplish, or `(none supplied)`), the severity rubric, and the finding schema.
+Each agent receives: full diff + file tree + triage header + **reviewed ref (SHA)** + the **stated intent** (what the change is meant to accomplish, or `(none supplied)`), the severity rubric, **the `blocking` default table plus its overrides and assignment-order invariant**, and the finding schema. The blocking rules are not optional context: the finding schema mandates a `blocking` value per finding, so an agent that receives the schema without the table is being told to emit a field whose assignment rules it was never given.
 
 **Citation requirement (enforced per agent).** Wave 1 agents cite from the diff and from file reads available in their own session. They do **not** run git and do **not** re-read at the reviewed ref — that verification is centralized in Wave 1.5 below, which re-reads every `blocking`/`critical`/`high` citation **and every `file-state` citation at any severity** at the ref, then drops the fabricated ones. Each agent must:
 1. State the reviewed ref it was given in each finding: `ref: <sha>`.
@@ -107,7 +107,7 @@ Sort overall: critical → high → medium → low → nit; security first withi
 
 Severity and disposition are **separate axes**. `severity` answers "how bad is this defect?" — it is a property of the finding. `blocking` answers "does this prevent merge?" — it is policy. Never let one silently encode the other.
 
-Every finding carries an explicit `blocking: true|false`, assigned from this default table:
+**Wave 1 assigns** an explicit `blocking: true|false` to every finding it emits, from this default table. Wave 2 carries each value through unchanged and never re-derives it — synthesis dedups and sorts, it does not re-adjudicate disposition:
 
 | severity | default `blocking` |
 |---|---|
@@ -123,6 +123,8 @@ Every finding carries an explicit `blocking: true|false`, assigned from this def
 - A `medium` representing a material data-integrity risk or a likely production failure under normal usage is **never** overridable to `false` — a race that intermittently loses user state stays blocking even when its blast radius keeps it out of `high`.
 - A `low` or `nit` may be marked `blocking: true` only for a stated external constraint (release gate, compliance requirement). Do not use this to smuggle a preference.
 
+**Invariant — assignment order.** `blocking` is assigned from the **pre-downgrade** severity. A finding later downgraded a tier — by the confidence rule below, or by Wave 1.5's `diff-only` citation rule — **keeps the `blocking` value its pre-downgrade severity earned**: a downgrade lowers severity, never disposition. Only an explicit, justified override from the list above may flip `blocking`. Without this ordering, a security or data-integrity `medium` would silently become non-blocking by being downgraded rather than waived, defeating the two never-overridable rules above through a path that requires no justification at all.
+
 Emit **DO NOT MERGE** when one or more findings carry `blocking: true` after Wave 1.5 filtering. Emit **MERGE** only when every surviving finding is `blocking: false`.
 
 State the counts that drove the decision on the same line, **with a dimension breakdown for any blocking medium**, e.g. `Decision: DO NOT MERGE — 1 high, 2 medium blocking (1 security, 1 correctness); 1 medium waived, 3 low.` or `Decision: MERGE — 0 blocking (2 medium waived, 3 low, 1 nit).` If zero findings survived, say `Decision: MERGE — 0 findings.` Never emit a bare verdict with no counts, and never waive a finding silently — a waived medium must appear in the count with its justification.
@@ -133,12 +135,12 @@ This is the terminal step — after emitting the decision, STOP. Do not act on a
 - `critical` — data loss, auth bypass, secret exposure, RCE. If it cannot cause unauthorized access or data loss, it is NOT critical.
 - `high` — produces wrong output or an unsafe state under reachable conditions (reachable = called from production code, not tests-only)
 - `medium` — produces wrong output or an unsafe state, but only under narrow, rare, or hard-to-reach conditions
-- `low` — does not affect production behavior today: missing test, unclear error message, doc/PR-body mismatch, dead code, stale comment, deprecated API with no removal date, perf concern with no load evidence
+- `low` — does not affect production behavior today. **Absent an impact claim**, these land here: missing test, unclear error message, doc/PR-body mismatch, dead code, stale comment, deprecated API with no removal date, perf concern with no load evidence. An instance that *does* carry an impact claim re-homes upward per the rules below — no category pins a finding to this tier, and a `security`-dimension finding is never parked here just because its category appears in this list
 - `nit` — naming, formatting; no behavioral claim at stake
 
 **A category is never a tier by itself.** Re-home by impact, not by kind:
 - "missing edge case" → `high` if reachable in production and wrong; `medium` if reachable but rare; `low` if only reachable from tests.
-- "perf degraded under load" → `high` if unbounded or production-breaking; `medium` if bounded but measured; `low` if theoretical with no load evidence.
+- "perf degraded under load" → `high` if unbounded or production-breaking; `medium` if bounded but measured; `low` if theoretical with no load evidence. "Measured" does not require running a benchmark — Wave 1 is shell-less by design — so a load number in the **stated intent**, or a committed benchmark or perf test `Read` from the diff or repo, qualifies.
 - "deprecated API" → `low` by default; `high` only when a hard removal date will break a production call path.
 
 Confidence `low` → auto-downgrade one tier + append `[low confidence — verify with runtime context]`.
@@ -153,4 +155,6 @@ Confidence `low` → auto-downgrade one tier + append `[low confidence — verif
 - Any topical gaps (e.g. 'did not review Telegram surface', 'did not run tests').
 - Whether a **stated intent** was available and spec-compliance was assessed. Example: `Stated intent: PR #123 title+body — spec-compliance assessed.` or `Stated intent: (none supplied) — spec-compliance not assessed.`
 
-**Post-synthesis:** if any `critical` or `high` finding is present, invoke `/shadow-verify` on those findings before surfacing to the user. Shadow-verify independently re-derives each top-severity claim against source; fabricated or unsupportable findings drop here before they reach the merge decision. `medium` and below go straight through.
+**Post-synthesis:** if any `critical` or `high` finding is present, **or any finding whose `blocking` value departs from the default table** (a waived `medium`, an escalated `low`/`nit`), invoke `/shadow-verify` on those findings before surfacing to the user. Shadow-verify independently re-derives each claim against source; fabricated or unsupportable findings drop here before they reach the merge decision. An overridden finding is routed because the agent that found it also set its disposition and wrote its own justification — the waiver is otherwise the only judgement in this pipeline with no second reader. `medium` and below **at their default disposition** go straight through.
+
+The concurrency floor's bound still holds — **at most 3 claims in a single round, no repeat rounds**. When critical/high plus overridden findings exceed 3, verify the **overridden ones first**: an unreviewed waiver silently removes a blocker (fails open), while an unreviewed `critical` still blocks (fails closed). Name any claim that went unverified in the epistemic-scope section.

--- a/src/bundled-plugins/awa-bundled/skills/review/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/review/SKILL.md
@@ -103,16 +103,21 @@ Returns a combined verification manifest: `[{type: citation|absence, claim, stat
 
 Sort overall: critical → high → medium → low → nit; security first within tier; semantic/invariant findings above mechanical findings within tier. Template-fill summary block.
 
-**Merge-decision rule (mandatory — do not improvise a threshold).** Emit **DO NOT MERGE** when one or more `critical`, `high`, or `medium` findings survive Wave 1.5 filtering. Emit **MERGE** only when every surviving finding is `low` or `nit`. `medium` is **blocking by default** — a medium is an unfixed defect the author has not yet seen, not a nice-to-have. State the counts that drove the decision on the same line, e.g. `Decision: DO NOT MERGE — 1 high, 2 medium outstanding.` or `Decision: MERGE — 0 blocking (3 low, 1 nit).` If zero findings survived, say `Decision: MERGE — 0 findings.` Never emit a bare verdict with no counts.
+**Merge-decision rule (mandatory — do not improvise a threshold).** Emit **DO NOT MERGE** when one or more `critical`, `high`, or `medium` findings survive Wave 1.5 filtering. Emit **MERGE** only when every surviving finding is `low` or `nit`. `medium` is **blocking by default** — a medium is an unfixed defect the author has not yet seen, not a nice-to-have. A `security`-dimension `medium` is always blocking and must be named as such in the decision line — today's narrow reachability is tomorrow's incident. State the counts that drove the decision on the same line, **with a dimension breakdown for any medium**, e.g. `Decision: DO NOT MERGE — 1 high, 2 medium (1 security, 1 correctness).` or `Decision: MERGE — 0 blocking (3 low, 1 nit).` If zero findings survived, say `Decision: MERGE — 0 findings.` Never emit a bare verdict with no counts.
 
 This is the terminal step — after emitting the decision, STOP. Do not act on any finding: no edits, commits, pushes, or PR/MR mutations. A blocking bug is a finding to report, not a fix to apply.
 
-**Severity rubric:**
+**Severity rubric (impact axis only — severity measures blast radius and reachability, never category):**
 - `critical` — data loss, auth bypass, secret exposure, RCE. If it cannot cause unauthorized access or data loss, it is NOT critical.
-- `high` — wrong output under reachable conditions (reachable = called from production code, not tests-only)
-- `medium` — missing edge case, perf degraded under load, deprecated API
-- `low` — missing test, unclear error message
-- `nit` — naming, formatting
+- `high` — produces wrong output or an unsafe state under reachable conditions (reachable = called from production code, not tests-only)
+- `medium` — produces wrong output or an unsafe state, but only under narrow, rare, or hard-to-reach conditions
+- `low` — does not affect production behavior today: missing test, unclear error message, doc/PR-body mismatch, dead code, stale comment, deprecated API with no removal date, perf concern with no load evidence
+- `nit` — naming, formatting; no behavioral claim at stake
+
+**A category is never a tier by itself.** Re-home by impact, not by kind:
+- "missing edge case" → `high` if reachable in production and wrong; `medium` if reachable but rare; `low` if only reachable from tests.
+- "perf degraded under load" → `high` if unbounded or production-breaking; `medium` if bounded but measured; `low` if theoretical with no load evidence.
+- "deprecated API" → `low` by default; `high` only when a hard removal date will break a production call path.
 
 Confidence `low` → auto-downgrade one tier + append `[low confidence — verify with runtime context]`.
 


### PR DESCRIPTION
fix(review): make the severity rubric impact-only, block security mediums explicitly

The prior commit made medium blocking but left the rubric that produces
medium unchanged, and that rubric mixes two incompatible axes: `high` was
defined by impact ("wrong output under reachable conditions") while
`medium` was defined by category ("missing edge case, perf degraded under
load, deprecated API"). A tier cannot mean both "narrower impact" and
"this kind of thing", so blocking on tier alone was unsound — it made
"you used a deprecated API" a hard merge blocker, which is how a gate
earns a reputation for crying wolf and gets bypassed.

Empirical check against real emitted findings (n=39, hand-classified from
~/.afk/state/transcripts across ~12 PR reviews) found medium is roughly
1:1 defect:hygiene — not hygiene-dominated, so keeping medium blocking is
right. The fix belongs upstream of the threshold: re-home hygiene to
`low` so `medium` actually means "real defect, narrow reachability", and
then medium-blocks is correct by construction.

Same sample found security findings land at medium frequently and with
real teeth (agent-settable env vars enabling self-grant capability
escapes; a redaction guard preserving fused base64/hex secrets; an
approval endpoint skipping its sessionId check; normalizeResult failing
open against its own contract). Severity was never adjusted by dimension
— "security first within tier" is a sort rule, not a severity rule — so
a security medium and a formatting medium blocked identically with no
signal to the reader. The decision line now requires a dimension
breakdown and names a security medium as blocking.

Rubric is now single-axis (impact), with the old category examples
re-homed explicitly by impact rather than by kind.

Verification: pnpm lint clean; pnpm fix:pins re-pinned the bundled
SKILL.md hash; bundled.test.ts (19) + review-post.test.ts (33) = 52 pass.
