### PR TITLE
feat(model-limits): register claude-sonnet-4-6 limits explicitly

### DIFF
--- a/src/agent/model-limits.test.ts
+++ b/src/agent/model-limits.test.ts
@@ -123,3 +123,36 @@ describe('maxOutputTokensFor — retired-but-Active Opus pin', () => {
     expect(contextLimitFor('claude-opus-4-8')).toBe(200_000);
   });
 });
+
+describe('claude-sonnet-4-6 — explicit limit pins (A/B baseline vs claude-sonnet-5)', () => {
+  // Invariant: 4.6 is not a first-class alias but IS reachable by raw wire id and
+  // already priced (providers/anthropic-direct/pricing.ts). Both values below
+  // equal the fallbacks they replace, so these tests pin INTENT, not a behaviour
+  // change: they fail if someone edits DEFAULT_MAX_OUTPUT / DEFAULT_CONTEXT_LIMIT
+  // or "upgrades" 4.6 to Sonnet 5's 1M window, either of which would silently
+  // invalidate a 4.6-vs-5 A/B comparison.
+  it('pins the 64k output ceiling (first-party: the Sonnet 5 entry says "up from 64k on Sonnet 4.6")', () => {
+    expect(maxOutputTokensFor('claude-sonnet-4-6')).toBe(64_000);
+    // Contrast: the Sonnet 5 sibling is double. An A/B that silently gave 4.6
+    // Sonnet 5's ceiling would compare two different output budgets.
+    expect(maxOutputTokensFor('claude-sonnet-5')).toBe(128_000);
+  });
+
+  it('pins the 200k context window — NOT Sonnet 5 1M (this repo sends no 1M beta header)', () => {
+    // 1M on the 4.x line requires a `context-1m` beta this codebase never sends:
+    // composeBetaHeader (providers/anthropic-direct/beta-headers.ts) emits a
+    // closed set (OAuth, effort, extended-cache-ttl, fast-mode). Over-reporting
+    // here would suppress auto-compaction and cause hard API errors mid-run.
+    expect(contextLimitFor('claude-sonnet-4-6')).toBe(200_000);
+    expect(contextLimitFor('claude-sonnet-5')).toBe(1_000_000);
+  });
+
+  it('takes NO auto-compact budget entry: 200k is its real window, not a cap (haiku precedent)', () => {
+    // MODEL_AUTOCOMPACT_BUDGET exists to cap a 1M window down to a 200k working
+    // budget. 4.6's window IS 200k, so an entry would be Math.min(200k, 200k) —
+    // a no-op that falsely implies a larger window is being throttled. Same
+    // reasoning as haiku above, which is deliberately absent from the table.
+    expect(autoCompactLimitFor('claude-sonnet-4-6')).toBe(200_000);
+    expect(autoCompactLimitFor('claude-sonnet-4-6')).toBe(contextLimitFor('claude-sonnet-4-6'));
+  });
+});

--- a/src/agent/model-limits.ts
+++ b/src/agent/model-limits.ts
@@ -44,6 +44,15 @@ export const MODEL_MAX_OUTPUT_TOKENS: Record<string, number> = {
   'claude-opus-4-8': 128_000,
   // Claude Sonnet 5 (GA 2026-06): 128k max output (up from 64k on Sonnet 4.6).
   'claude-sonnet-5': 128_000,
+  // 'claude-sonnet-4-6' is not a first-class alias (MODEL_MAP.sonnet resolves to
+  // claude-sonnet-5) but stays reachable by its raw wire id (`--model
+  // claude-sonnet-4-6`, a config or env override) and is already priced in
+  // providers/anthropic-direct/pricing.ts. 64k is first-party per the Sonnet 5
+  // entry above — "up from 64k on Sonnet 4.6". That equals DEFAULT_MAX_OUTPUT,
+  // so this pin is a runtime no-op today; its value is making the number
+  // intentional and test-pinned rather than an accident of the fallback, so a
+  // future change to DEFAULT_MAX_OUTPUT cannot silently move 4.6's ceiling.
+  'claude-sonnet-4-6': 64_000,
   'claude-haiku-4-5-20251001': 64_000,
   // Claude Fable 5 (Mythos-class, GA 2026-06-09): 128k max output.
   'claude-fable-5': 128_000,
@@ -124,6 +133,18 @@ export const MODEL_CONTEXT_LIMITS: Record<string, number> = {
   // Claude Opus 5 (GA 2026-07-24): native 1M window. Base `opus` still
   // auto-compacts early via MODEL_AUTOCOMPACT_BUDGET (cost/latency policy).
   'claude-opus-5': 1_000_000,
+  // Claude Sonnet 4.6: 200k. Deliberately NOT 1M — the native-1M/"no smaller
+  // variant" claim above is specific to Sonnet 5. The 4.x line served 200k by
+  // default with 1M only behind a `context-1m` beta header, and this repo never
+  // sends one: composeBetaHeader (providers/anthropic-direct/beta-headers.ts)
+  // emits a closed set — OAuth entries, effort, extended-cache TTL, fast-mode —
+  // and no 1M beta string exists anywhere in src/. So 200k is correct BY
+  // CONSTRUCTION for every request this codebase can issue, regardless of what
+  // the API might serve behind a header we do not send. This equals the
+  // Anthropic DEFAULT_CONTEXT_LIMIT fallback, so the pin is a no-op today; it
+  // guards the asymmetry — under-reporting only compacts early, over-reporting
+  // suppresses compaction and yields hard API errors mid-run.
+  'claude-sonnet-4-6': 200_000,
   // OpenAI flagship + cost-tier models (windows per OpenAI platform docs
   // as of 2026-Q1). Listed here so the openai-compatible provider's
   // getContextUsage() returns an accurate percentage instead of the


### PR DESCRIPTION
## What

Registers `claude-sonnet-4-6` in `src/agent/model-limits.ts` so it stops silently inheriting the unknown-Anthropic fallbacks. The id is routable today (anthropic-direct claims all `claude-*` ids) and is already in the pricing table (`src/agent/providers/anthropic-direct/pricing.ts:80`, $3/$15 per MTok), but had no limits entry.

Motivation: A/B testing `claude-sonnet-4-6` against `claude-sonnet-5`. An unregistered id makes that comparison invalid, because 4.6's numbers were an accident of the fallback rather than a declared intent.

## Values chosen, and the evidence for each

### `MODEL_MAX_OUTPUT_TOKENS['claude-sonnet-4-6'] = 64_000`

First-party evidence already in this repo: the `claude-sonnet-5` entry directly above it reads *"128k max output (up from 64k on Sonnet 4.6)"* (`model-limits.ts:45`). That is a statement about 4.6, not an inference.

### `MODEL_CONTEXT_LIMITS['claude-sonnet-4-6'] = 200_000`

Deliberately **not** Sonnet 5's 1M. The native-1M / "no smaller variant" claim documented in this file is specific to Sonnet 5. The 4.x line served 200k by default, with 1M available only behind a `context-1m` beta header.

The decisive evidence is this repo's own header behaviour, which settles the question without relying on any external doc:

- `composeBetaHeader()` (`src/agent/providers/anthropic-direct/beta-headers.ts`) emits a **closed set** of betas: OAuth entries, `effort-2025-11-24`, `extended-cache-ttl-2025-04-11`, and `fast-mode-2026-02-01`.
- No 1M beta string (`context-1m` or similar) exists **anywhere** in `src/` — verified by grep.

So 200k is correct **by construction** for every request this codebase can issue, regardless of what the API might serve behind a header we do not send.

This also respects the safety asymmetry: under-reporting the window only makes a session auto-compact earlier than strictly necessary, while over-reporting suppresses compaction and produces hard API errors mid-run.

### `MODEL_AUTOCOMPACT_BUDGET` — no entry (deliberate)

That table exists to cap a **1M** window down to a 200k working budget for cost/latency. Sonnet 4.6's window *is* 200k, so an entry would compute `Math.min(200k, 200k)` — a no-op that would falsely imply a larger window is being throttled. This matches how `haiku` is handled: its 200k is a real window, and it is correctly absent from the budget table. A test pins this equality so the reasoning is checkable.

### `src/agent/model-capabilities.ts` — no entry needed

Checked, nothing required:

- Vision: the `/^claude-/i` pattern already matches the id. Verified at runtime — `supportsVision('claude-sonnet-4-6')` returns `true`.
- Effort/thinking: `resolveEffort` in `providers/anthropic-direct/resolve-params.ts` already allowlists the `4-6` sonnet variant. Verified at runtime — it returns `'max'`.

Adding entries would have been redundant.

## Is this a runtime no-op?

**Yes — and that is stated plainly rather than oversold.** Both pinned values equal the fallbacks they replace. Measured on the base commit *before* the change:

```
contextLimitFor('claude-sonnet-4-6')     -> 200000
maxOutputTokensFor('claude-sonnet-4-6')  ->  64000
autoCompactLimitFor('claude-sonnet-4-6') -> 200000
```

Those are identical after the change. No limit moves; no behaviour changes for any model.

The value of the PR is that these numbers become **intentional and test-pinned** rather than accidental. A future edit to `DEFAULT_MAX_OUTPUT` / `DEFAULT_CONTEXT_LIMIT`, or an "upgrade" of 4.6 to a 1M window, now fails a test instead of silently invalidating a 4.6-vs-5 A/B comparison.

## Tests added

Three, in `src/agent/model-limits.test.ts` under `claude-sonnet-4-6 — explicit limit pins (A/B baseline vs claude-sonnet-5)`:

1. pins the 64k output ceiling, and contrasts it against Sonnet 5's 128k
2. pins the 200k context window, and contrasts it against Sonnet 5's 1M
3. asserts no autocompact budget entry — `autoCompactLimitFor === contextLimitFor` for this id

## Gates

- `pnpm lint` (tsc --noEmit, maximally strict) — **pass**, exit 0
- `vitest run src/agent/model-limits.test.ts` — **17 passed**
- `vitest run src/agent/` — **104 failed | 257 passed**, but this is **pre-existing and environmental**, not caused by this change. Deps were installed with `--ignore-scripts`, so `better_sqlite3.node` native bindings are absent (1209 "Could not locate the bindings file" errors). Confirmed by stashing this change and re-running on the clean base commit: **identical** 104 failed files / 65 failed tests. This branch adds 3 passing tests (5089 → 5092) and zero new failures.
- Targeted re-run of every model-related suite (`model-limits`, `cli/model-limits`, `schema-classification`, `pricing`, `resolve-effort`, `model-slots`) — **150 passed**.

## Scope

Limits registration only. Deliberately untouched: `MODEL_MAP`, which model any default/alias resolves to, forge, and any `sonnet_4_6` short alias.

Note: `model-limits.ts` is 276 LOC, within the 350 limit — no refactor performed.
