### PR TITLE
fix(tokens): surface max_tokens truncation instead of failing silently (#952)

### DIFF
--- a/src/agent/providers/anthropic-direct/loop.orphan.test.ts
+++ b/src/agent/providers/anthropic-direct/loop.orphan.test.ts
@@ -186,6 +186,8 @@ describe('loop.ts runTurn — orphan tool_use prevention', () => {
   });
 
   // #952: text-only truncation (no tool_use) → notice without a tool name.
+  // #960: the partial text and the notice are now ONE assistant.message, not
+  // two — see the dedicated merged-message test below for the full rationale.
   it('surfaces a truncation notice for text-only max_tokens truncation', async () => {
     const client = makeClient(() => fromArray(makeTextStream('a partial answer', 'max_tokens')));
     const dispatcher = makeDispatcher(() => Promise.resolve({ content: 'never called' }));
@@ -209,12 +211,62 @@ describe('loop.ts runTurn — orphan tool_use prevention', () => {
     expect(noticed).toHaveLength(1);
     expect(noticed[0]!.text).toContain('allow a longer reply');
     expect(noticed[0]!.text).not.toContain('NOT dispatched');
-    // The model's partial text is still delivered as its own assistant.message.
-    expect(
-      events.some(
-        (e) => e.type === 'assistant.message' && (e as { text: string }).text === 'a partial answer',
-      ),
-    ).toBe(true);
+    // The model's partial text is delivered INSIDE the same assistant.message
+    // as the notice (#960), not as a separate event.
+    expect(noticed[0]!.text).toContain('a partial answer');
+    // Exactly one assistant.message for the whole turn — the partial text and
+    // the notice were never split into two events.
+    expect(events.filter((e) => e.type === 'assistant.message')).toHaveLength(1);
+  });
+
+  // #960: a last-wins consumer (the non-streaming `sendMessage()` path in
+  // agent-session.ts, and a subagent's final-message capture in handle.ts)
+  // keeps only the LAST `assistant.message` of a turn. Before this fix,
+  // emitNonToolUseTerminal yielded the partial text and the truncation notice
+  // as two separate assistant.message events, so those consumers silently
+  // discarded the model's real (partial) answer and kept only the warning.
+  // Pin the fix at the event level: one merged message, answer first.
+  it('merges the partial answer and the truncation notice into ONE assistant.message (#960)', async () => {
+    const client = makeClient(() => fromArray(makeTextStream('a partial answer', 'max_tokens')));
+    const dispatcher = makeDispatcher(() => Promise.resolve({ content: 'never called' }));
+    const events = await collect(
+      runTurn({
+        client,
+        messages: [{ role: 'user', content: 'explain' }],
+        system: null,
+        tools: null,
+        toolDispatcher: dispatcher,
+        model: 'claude-test',
+        maxTokens: 8_000,
+        headers: {},
+        signal: new AbortController().signal,
+        ctx,
+      }),
+    );
+
+    const assistantMessages = events.filter(
+      (e) => e.type === 'assistant.message',
+    ) as Array<{ text: string }>;
+    // A last-wins consumer keeps assistantMessages.at(-1) — that message alone
+    // must carry both the answer and the notice, or the answer is lost.
+    expect(assistantMessages).toHaveLength(1);
+    const merged = assistantMessages[0]!.text;
+    expect(merged).toContain('output-token limit');
+    // Answer first, notice second, joined by exactly one blank line — the
+    // model's raw text is preserved verbatim as the message prefix so a
+    // last-wins consumer reading this one event still recovers the full
+    // partial answer.
+    expect(merged.startsWith('a partial answer\n\n')).toBe(true);
+    expect(merged.indexOf('a partial answer')).toBeLessThan(merged.indexOf('output-token limit'));
+
+    // The `suggestion` event (short text) must carry ONLY the model's own
+    // text, never the appended operator notice.
+    const suggestion = events.find((e) => e.type === 'suggestion') as
+      | { suggestion: string }
+      | undefined;
+    expect(suggestion, 'a suggestion should be emitted for short partial text').toBeDefined();
+    expect(suggestion!.suggestion).toBe('a partial answer');
+    expect(suggestion!.suggestion).not.toContain('output-token limit');
   });
 
   it('rolls back the assistant tool_use push when the dispatcher accessor throws', async () => {

--- a/src/agent/providers/anthropic-direct/loop.orphan.test.ts
+++ b/src/agent/providers/anthropic-direct/loop.orphan.test.ts
@@ -39,6 +39,68 @@ import {
 //      `input.toolDispatcher` throws). Pre-fix: assistant tool_use push
 //      remained in history. Post-fix: rollback splices it back out.
 
+/**
+ * A `max_tokens` stream carrying BOTH partial text and one or more `tool_use`
+ * blocks that never got dispatched — the shape that exercises the notice's
+ * dropped-tool naming (and its de-duplication) on the partial-text path.
+ */
+function makeTextStreamWithDroppedTool(
+  text: string,
+  toolNames: string[],
+): RawMessageStreamEvent[] {
+  const events: RawMessageStreamEvent[] = [
+    {
+      type: 'message_start',
+      message: {
+        id: 'msg_truncate_mixed',
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model: 'claude-test',
+        stop_reason: null,
+        stop_sequence: null,
+        usage: baseUsage(),
+      },
+    } as unknown as RawMessageStreamEvent,
+    {
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'text', text: '' },
+    } as unknown as RawMessageStreamEvent,
+    {
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'text_delta', text },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'content_block_stop', index: 0 } as unknown as RawMessageStreamEvent,
+  ];
+  toolNames.forEach((name, i) => {
+    const index = i + 1;
+    events.push(
+      {
+        type: 'content_block_start',
+        index,
+        content_block: { type: 'tool_use', id: `toolu_dropped_${index}`, name, input: {} },
+      } as unknown as RawMessageStreamEvent,
+      {
+        type: 'content_block_delta',
+        index,
+        delta: { type: 'input_json_delta', partial_json: '{"file":"a.ts"}' },
+      } as unknown as RawMessageStreamEvent,
+      { type: 'content_block_stop', index } as unknown as RawMessageStreamEvent,
+    );
+  });
+  events.push(
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'max_tokens', stop_sequence: null },
+      usage: { output_tokens: 4 },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'message_stop' } as unknown as RawMessageStreamEvent,
+  );
+  return events;
+}
+
 describe('loop.ts runTurn — orphan tool_use prevention', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -121,10 +183,17 @@ describe('loop.ts runTurn — orphan tool_use prevention', () => {
     expect(flatTooluses).not.toContain('toolu_orphan');
   });
 
-  // #952: the strip above is silent — a dropped tool call reads as the agent
-  // stalling. runTurn must surface a display-only truncation notice NAMING the
-  // dropped tool so the operator knows the action never ran.
-  it('surfaces a truncation notice naming the dropped tool when max_tokens strips a tool_use', async () => {
+  // #960 REGRESSION GUARD — do not "fix" this test by making it expect a notice.
+  //
+  // A truncated turn that produced NO text must emit NO `assistant.message`.
+  // The absence is the signal: stream-consumer drops a textless turn, so
+  // `handle.ts` never sets `finalMessage`, reaches its ZERO-OUTPUT branch, and
+  // THROWS — which is what makes a zero-output subagent resolve `failed` (not a
+  // false `succeeded`) and what lets stream-cut-retry re-dispatch it. An earlier
+  // revision of this PR emitted a standalone notice here; that set
+  // `finalMessage`, silently unreachable-ing the throw, and a truncated child
+  // returned to its parent as a SUCCESS whose whole content was the warning.
+  it('emits NO assistant.message when max_tokens strips a tool_use and no text was produced', async () => {
     const truncatedToolUseStream: RawMessageStreamEvent[] = [
       {
         type: 'message_start',
@@ -175,14 +244,78 @@ describe('loop.ts runTurn — orphan tool_use prevention', () => {
       }),
     );
 
-    const notice = events.find(
-      (e) => e.type === 'assistant.message' && /output-token limit/.test((e as { text: string }).text),
-    ) as { text: string } | undefined;
-    expect(notice, 'a truncation notice event should be emitted').toBeDefined();
-    expect(notice!.text).toContain('read_file'); // names the dropped tool
-    expect(notice!.text).toContain('NOT dispatched');
+    // The textless turn stays textless: no assistant.message at all, so a
+    // downstream `if (event.text)` consumer sees nothing and the zero-output
+    // path stays reachable.
+    expect(events.filter((e) => e.type === 'assistant.message')).toHaveLength(0);
+    // ...and specifically no notice smuggled in on that channel.
+    expect(
+      events.some(
+        (e) =>
+          e.type === 'assistant.message' &&
+          /output-token limit/.test((e as { text: string }).text),
+      ),
+      'a textless truncated turn must not emit a standalone notice as assistant.message',
+    ).toBe(false);
     // A turn.completed must still follow — the turn ends cleanly, not as an error.
+    // (The orphan-strip invariant itself is pinned by the first test above.)
     expect(events.some((e) => e.type === 'turn.completed')).toBe(true);
+  });
+
+  // #952: when the turn DID produce text, the notice rides on that message and
+  // names the dropped tool — this is the path that stayed after #960 narrowed
+  // the textless case above.
+  it('names the dropped tool in the notice when partial text exists', async () => {
+    const client = makeClient(() =>
+      fromArray(makeTextStreamWithDroppedTool('partial answer', ['read_file'])),
+    );
+    const dispatcher = makeDispatcher(() => Promise.resolve({ content: 'never called' }));
+    const events = await collect(
+      runTurn({
+        client,
+        messages: [{ role: 'user', content: 'do a thing' }],
+        system: null,
+        tools: null,
+        toolDispatcher: dispatcher,
+        model: 'claude-test',
+        maxTokens: 8_000,
+        headers: {},
+        signal: new AbortController().signal,
+        ctx,
+      }),
+    );
+    const msgs = events.filter((e) => e.type === 'assistant.message') as Array<{ text: string }>;
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]!.text).toContain('partial answer');
+    expect(msgs[0]!.text).toContain('read_file');
+    expect(msgs[0]!.text).toContain('NOT dispatched');
+  });
+
+  // The notice de-dupes tool names (`[...new Set(names)]`) so a model that
+  // truncated two calls to the SAME tool does not read as two distinct
+  // dropped actions.
+  it('names a repeated dropped tool only once in the truncation notice', async () => {
+    const client = makeClient(() =>
+      fromArray(makeTextStreamWithDroppedTool('partial answer', ['read_file', 'read_file'])),
+    );
+    const dispatcher = makeDispatcher(() => Promise.resolve({ content: 'never called' }));
+    const events = await collect(
+      runTurn({
+        client,
+        messages: [{ role: 'user', content: 'do a thing' }],
+        system: null,
+        tools: null,
+        toolDispatcher: dispatcher,
+        model: 'claude-test',
+        maxTokens: 8_000,
+        headers: {},
+        signal: new AbortController().signal,
+        ctx,
+      }),
+    );
+    const msgs = events.filter((e) => e.type === 'assistant.message') as Array<{ text: string }>;
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]!.text.match(/read_file/g)).toHaveLength(1);
   });
 
   // #952: text-only truncation (no tool_use) → notice without a tool name.

--- a/src/agent/providers/anthropic-direct/loop.orphan.test.ts
+++ b/src/agent/providers/anthropic-direct/loop.orphan.test.ts
@@ -121,6 +121,102 @@ describe('loop.ts runTurn — orphan tool_use prevention', () => {
     expect(flatTooluses).not.toContain('toolu_orphan');
   });
 
+  // #952: the strip above is silent — a dropped tool call reads as the agent
+  // stalling. runTurn must surface a display-only truncation notice NAMING the
+  // dropped tool so the operator knows the action never ran.
+  it('surfaces a truncation notice naming the dropped tool when max_tokens strips a tool_use', async () => {
+    const truncatedToolUseStream: RawMessageStreamEvent[] = [
+      {
+        type: 'message_start',
+        message: {
+          id: 'msg_truncate2',
+          type: 'message',
+          role: 'assistant',
+          content: [],
+          model: 'claude-test',
+          stop_reason: null,
+          stop_sequence: null,
+          usage: baseUsage(),
+        },
+      } as unknown as RawMessageStreamEvent,
+      {
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'tool_use', id: 'toolu_dropped', name: 'read_file', input: {} },
+      } as unknown as RawMessageStreamEvent,
+      {
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'input_json_delta', partial_json: '{"file":"a.ts"}' },
+      } as unknown as RawMessageStreamEvent,
+      { type: 'content_block_stop', index: 0 } as unknown as RawMessageStreamEvent,
+      {
+        type: 'message_delta',
+        delta: { stop_reason: 'max_tokens', stop_sequence: null },
+        usage: { output_tokens: 4 },
+      } as unknown as RawMessageStreamEvent,
+      { type: 'message_stop' } as unknown as RawMessageStreamEvent,
+    ];
+
+    const client = makeClient(() => fromArray(truncatedToolUseStream));
+    const dispatcher = makeDispatcher(() => Promise.resolve({ content: 'never called' }));
+    const events = await collect(
+      runTurn({
+        client,
+        messages: [{ role: 'user', content: 'do a thing' }],
+        system: null,
+        tools: null,
+        toolDispatcher: dispatcher,
+        model: 'claude-test',
+        maxTokens: 8_000,
+        headers: {},
+        signal: new AbortController().signal,
+        ctx,
+      }),
+    );
+
+    const notice = events.find(
+      (e) => e.type === 'assistant.message' && /output-token limit/.test((e as { text: string }).text),
+    ) as { text: string } | undefined;
+    expect(notice, 'a truncation notice event should be emitted').toBeDefined();
+    expect(notice!.text).toContain('read_file'); // names the dropped tool
+    expect(notice!.text).toContain('NOT dispatched');
+    // A turn.completed must still follow — the turn ends cleanly, not as an error.
+    expect(events.some((e) => e.type === 'turn.completed')).toBe(true);
+  });
+
+  // #952: text-only truncation (no tool_use) → notice without a tool name.
+  it('surfaces a truncation notice for text-only max_tokens truncation', async () => {
+    const client = makeClient(() => fromArray(makeTextStream('a partial answer', 'max_tokens')));
+    const dispatcher = makeDispatcher(() => Promise.resolve({ content: 'never called' }));
+    const events = await collect(
+      runTurn({
+        client,
+        messages: [{ role: 'user', content: 'explain' }],
+        system: null,
+        tools: null,
+        toolDispatcher: dispatcher,
+        model: 'claude-test',
+        maxTokens: 8_000,
+        headers: {},
+        signal: new AbortController().signal,
+        ctx,
+      }),
+    );
+    const noticed = events.filter(
+      (e) => e.type === 'assistant.message' && /output-token limit/.test((e as { text: string }).text),
+    ) as Array<{ text: string }>;
+    expect(noticed).toHaveLength(1);
+    expect(noticed[0]!.text).toContain('allow a longer reply');
+    expect(noticed[0]!.text).not.toContain('NOT dispatched');
+    // The model's partial text is still delivered as its own assistant.message.
+    expect(
+      events.some(
+        (e) => e.type === 'assistant.message' && (e as { text: string }).text === 'a partial answer',
+      ),
+    ).toBe(true);
+  });
+
   it('rolls back the assistant tool_use push when the dispatcher accessor throws', async () => {
     // Build a dispatcher whose `executeBatch` is a getter that throws on
     // access. This simulates a throw between "tool_use is committed to

--- a/src/agent/providers/anthropic-direct/loop/turn-terminal.ts
+++ b/src/agent/providers/anthropic-direct/loop/turn-terminal.ts
@@ -9,11 +9,33 @@
  */
 
 import type { ProviderEvent } from '../../../provider.js';
+import { isTruncationStopReason } from '../../shared/truncation.js';
 import type { RunTurnInput, TurnResult } from '../types.js';
 import type { TurnAccumulator } from './turn-accumulator.js';
 
 /** Text at or below this length is also offered as a `suggestion`. */
 const SUGGESTION_MAX_LENGTH = 200;
+
+/**
+ * Operator-facing notice for a turn cut off at the output-token cap (#952).
+ * `droppedToolNames` are the `tool_use` blocks about to be stripped from
+ * history below — when non-empty, the model announced an action that was
+ * truncated mid-request and never dispatched, which otherwise reads as the
+ * agent stalling. Display-only: not pushed to history.
+ */
+function truncationNotice(droppedToolNames: string[]): string {
+  const base =
+    '⚠ This turn was cut off at the output-token limit (stop_reason "max_tokens") before the ' +
+    'model finished — anything above is partial, not a complete answer.';
+  if (droppedToolNames.length > 0) {
+    const names = [...new Set(droppedToolNames)].join(', ');
+    return (
+      `${base} A tool call was truncated mid-request and was NOT dispatched (${names}); ` +
+      'that action did not run. Raise --max-output-tokens / AFK_MAX_OUTPUT_TOKENS, then retry.'
+    );
+  }
+  return `${base} Raise --max-output-tokens / AFK_MAX_OUTPUT_TOKENS to allow a longer reply.`;
+}
 
 /**
  * Emit the closing events for a non-`tool_use` stop reason, pushing the
@@ -70,6 +92,22 @@ export function* emitNonToolUseTerminal(
         sessionId: input.ctx.sessionId,
       };
     }
+  }
+
+  // #952: a `max_tokens` truncation is otherwise invisible on every live surface
+  // (REPL, Telegram, chat) — the closure reason never leaves the trace stream, so
+  // a partial turn is indistinguishable from a clean completion, and the worst
+  // case (a tool call cut mid-arguments, stripped below and never dispatched)
+  // reads as the agent giving up mid-task. Surface a display-only notice — NOT
+  // pushed to history, mirroring the `refusal` branch above — after the partial
+  // text so the answer still shows first. The dropped-tool names come from
+  // `toolUseBlocks` (the exact blocks the strip below removes).
+  if (isTruncationStopReason(turnResult.stopReason)) {
+    yield {
+      type: 'assistant.message',
+      text: truncationNotice(turnResult.toolUseBlocks.map((b) => b.name)),
+      sessionId: input.ctx.sessionId,
+    };
   }
 
   // Anthropic API contract: every `tool_use` block in assistant content MUST be

--- a/src/agent/providers/anthropic-direct/loop/turn-terminal.ts
+++ b/src/agent/providers/anthropic-direct/loop/turn-terminal.ts
@@ -9,33 +9,12 @@
  */
 
 import type { ProviderEvent } from '../../../provider.js';
-import { isTruncationStopReason } from '../../shared/truncation.js';
+import { isTruncationStopReason, truncationNotice } from '../../shared/truncation.js';
 import type { RunTurnInput, TurnResult } from '../types.js';
 import type { TurnAccumulator } from './turn-accumulator.js';
 
 /** Text at or below this length is also offered as a `suggestion`. */
 const SUGGESTION_MAX_LENGTH = 200;
-
-/**
- * Operator-facing notice for a turn cut off at the output-token cap (#952).
- * `droppedToolNames` are the `tool_use` blocks about to be stripped from
- * history below — when non-empty, the model announced an action that was
- * truncated mid-request and never dispatched, which otherwise reads as the
- * agent stalling. Display-only: not pushed to history.
- */
-function truncationNotice(droppedToolNames: string[]): string {
-  const base =
-    '⚠ This turn was cut off at the output-token limit (stop_reason "max_tokens") before the ' +
-    'model finished — anything above is partial, not a complete answer.';
-  if (droppedToolNames.length > 0) {
-    const names = [...new Set(droppedToolNames)].join(', ');
-    return (
-      `${base} A tool call was truncated mid-request and was NOT dispatched (${names}); ` +
-      'that action did not run. Raise --max-output-tokens / AFK_MAX_OUTPUT_TOKENS, then retry.'
-    );
-  }
-  return `${base} Raise --max-output-tokens / AFK_MAX_OUTPUT_TOKENS to allow a longer reply.`;
-}
 
 /**
  * Emit the closing events for a non-`tool_use` stop reason, pushing the
@@ -92,7 +71,7 @@ export function* emitNonToolUseTerminal(
   // the LAST assistant message of a turn, so two messages here would silently
   // discard the real answer and surface only the warning.
   const truncationText = isTruncationStopReason(turnResult.stopReason)
-    ? truncationNotice(turnResult.toolUseBlocks.map((b) => b.name))
+    ? truncationNotice(turnResult.toolUseBlocks.map((b) => b.name), turnResult.stopReason)
     : null;
 
   if (turnResult.text.length > 0) {

--- a/src/agent/providers/anthropic-direct/loop/turn-terminal.ts
+++ b/src/agent/providers/anthropic-direct/loop/turn-terminal.ts
@@ -70,6 +70,33 @@ export function* emitNonToolUseTerminal(
   // `sendMessage()` path and a subagent's final-message capture — keep only
   // the LAST assistant message of a turn, so two messages here would silently
   // discard the real answer and surface only the warning.
+  //
+  // Invariant (#960): the notice rides ONLY on an existing partial-text
+  // message — a turn that produced NO text emits no `assistant.message` at
+  // all, and must keep emitting none. A textless turn has to stay textless all
+  // the way downstream, because "the model produced nothing" is detected by the
+  // ABSENCE of a message event, not by any positive signal:
+  //
+  //   stream-consumer.ts `case 'assistant.message'` gates on `if (event.text)`,
+  //   so a textless turn yields no `{type:'message'}` OutputEvent; `handle.ts`
+  //   therefore leaves `finalMessage` unset, falls past its `if (finalMessage)`
+  //   return, and reaches the ZERO-OUTPUT branch that stamps STREAM_INCOMPLETE
+  //   and THROWS — which is what makes a zero-output child resolve `failed`
+  //   instead of a false `succeeded`, and what lets `stream-cut-retry.ts`
+  //   re-dispatch a read-only child that died having produced nothing.
+  //
+  // Emitting a standalone notice here would make that whole chain unreachable:
+  // the notice is non-empty, so `finalMessage` gets set, the throw never runs,
+  // and a truncated child returns to its parent as a SUCCESS whose entire
+  // content is this warning — zero findings, dressed as an answer. `handle.ts`
+  // names `max_tokens` explicitly as a stop reason that reaches its zero-output
+  // branch "via an empty-text turn the stream consumer drops"; that assumption
+  // is load-bearing and this branch must not break it.
+  //
+  // Consequence, accepted deliberately: a truncation with no partial text stays
+  // invisible on live surfaces (unchanged from before #952). Fixing that needs a
+  // display-only event channel that renders WITHOUT becoming a terminal message
+  // — tracked as a follow-up, not bolted on here.
   const truncationText = isTruncationStopReason(turnResult.stopReason)
     ? truncationNotice(turnResult.toolUseBlocks.map((b) => b.name), turnResult.stopReason)
     : null;
@@ -89,14 +116,6 @@ export function* emitNonToolUseTerminal(
         sessionId: input.ctx.sessionId,
       };
     }
-  } else if (truncationText) {
-    // No partial text to attach to (e.g. a tool call truncated before any
-    // text block) — the notice stands alone, exactly as before.
-    yield {
-      type: 'assistant.message',
-      text: truncationText,
-      sessionId: input.ctx.sessionId,
-    };
   }
 
   // Anthropic API contract: every `tool_use` block in assistant content MUST be

--- a/src/agent/providers/anthropic-direct/loop/turn-terminal.ts
+++ b/src/agent/providers/anthropic-direct/loop/turn-terminal.ts
@@ -79,12 +79,30 @@ export function* emitNonToolUseTerminal(
     return;
   }
 
+  // #952: a `max_tokens` truncation is otherwise invisible on every live surface
+  // (REPL, Telegram, chat) — the closure reason never leaves the trace stream, so
+  // a partial turn is indistinguishable from a clean completion, and the worst
+  // case (a tool call cut mid-arguments, stripped below and never dispatched)
+  // reads as the agent giving up mid-task. The dropped-tool names come from
+  // `toolUseBlocks` (the exact blocks the strip below removes).
+  //
+  // The notice is APPENDED to the partial-text message below (not yielded as a
+  // second `assistant.message`): last-wins consumers — the non-streaming
+  // `sendMessage()` path and a subagent's final-message capture — keep only
+  // the LAST assistant message of a turn, so two messages here would silently
+  // discard the real answer and surface only the warning.
+  const truncationText = isTruncationStopReason(turnResult.stopReason)
+    ? truncationNotice(turnResult.toolUseBlocks.map((b) => b.name))
+    : null;
+
   if (turnResult.text.length > 0) {
     yield {
       type: 'assistant.message',
-      text: turnResult.text,
+      text: truncationText ? `${turnResult.text}\n\n${truncationText}` : turnResult.text,
       sessionId: input.ctx.sessionId,
     };
+    // The suggestion always mirrors the model's own text, never the appended
+    // notice — it feeds a quick-reply candidate, not an operator warning.
     if (turnResult.text.length <= SUGGESTION_MAX_LENGTH) {
       yield {
         type: 'suggestion',
@@ -92,20 +110,12 @@ export function* emitNonToolUseTerminal(
         sessionId: input.ctx.sessionId,
       };
     }
-  }
-
-  // #952: a `max_tokens` truncation is otherwise invisible on every live surface
-  // (REPL, Telegram, chat) — the closure reason never leaves the trace stream, so
-  // a partial turn is indistinguishable from a clean completion, and the worst
-  // case (a tool call cut mid-arguments, stripped below and never dispatched)
-  // reads as the agent giving up mid-task. Surface a display-only notice — NOT
-  // pushed to history, mirroring the `refusal` branch above — after the partial
-  // text so the answer still shows first. The dropped-tool names come from
-  // `toolUseBlocks` (the exact blocks the strip below removes).
-  if (isTruncationStopReason(turnResult.stopReason)) {
+  } else if (truncationText) {
+    // No partial text to attach to (e.g. a tool call truncated before any
+    // text block) — the notice stands alone, exactly as before.
     yield {
       type: 'assistant.message',
-      text: truncationNotice(turnResult.toolUseBlocks.map((b) => b.name)),
+      text: truncationText,
       sessionId: input.ctx.sessionId,
     };
   }

--- a/src/agent/providers/openai-compatible/query.truncation.test.ts
+++ b/src/agent/providers/openai-compatible/query.truncation.test.ts
@@ -105,8 +105,11 @@ describe('openai-compatible truncation notice (#952)', () => {
   it('names a tool call truncated mid-arguments as NOT dispatched', async () => {
     // A tool call that began streaming and was cut off by the cap. isToolCallStop
     // returns false for an explicit non-tool finish_reason, so this call is never
-    // dispatched — the drop is correct but was previously silent.
+    // dispatched — the drop is correct but was previously silent. The model also
+    // produced text here, which is the ONLY path the notice rides on (see the
+    // textless guard below).
     pendingChunks = [
+      { choices: [{ delta: { content: 'let me read that' } }] },
       {
         choices: [
           {
@@ -131,11 +134,53 @@ describe('openai-compatible truncation notice (#952)', () => {
     const messages = assistantMessages(events);
 
     expect(messages).toHaveLength(1);
+    expect(messages[0]).toContain('let me read that');
     expect(messages[0]).toContain('output-token limit');
     expect(messages[0]).toContain('read_file');
     expect(messages[0]).toContain('NOT dispatched');
 
     // The truncated call really did not run: no tool events were emitted.
+    expect(events.some((e) => e.type === 'tool.start' || e.type === 'tool.end')).toBe(false);
+  });
+
+  // #960 REGRESSION GUARD — do not "fix" this by making it expect a notice.
+  //
+  // A truncated turn that produced NO text must yield an EMPTY
+  // assistant.message. The emptiness is the signal: stream-consumer's
+  // `if (event.text)` gate drops it, so `subagent/handle.ts` never sets
+  // `finalMessage`, reaches its ZERO-OUTPUT branch, and THROWS — which is what
+  // makes a zero-output child resolve `failed` instead of a false `succeeded`,
+  // and what lets stream-cut-retry re-dispatch a read-only child that produced
+  // nothing. Substituting the notice as the body here would set `finalMessage`
+  // and hand the parent a SUCCESS whose entire content is the warning.
+  // Mirrors the anthropic-direct guard in loop.orphan.test.ts.
+  it('emits an EMPTY assistant.message when the cap cuts a turn before any text', async () => {
+    pendingChunks = [
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: 'call_abc',
+                  function: { name: 'read_file', arguments: '{"file_pa' },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        choices: [{ delta: {}, finish_reason: 'length' }],
+        usage: { prompt_tokens: 10, completion_tokens: 9, total_tokens: 19 },
+      },
+    ];
+    const events = await collect(buildQueryFromConfig(baseConfig(), singleInput('read it')));
+    const messages = assistantMessages(events);
+
+    expect(messages).toEqual(['']);
+    expect(messages[0]).not.toContain('output-token limit');
     expect(events.some((e) => e.type === 'tool.start' || e.type === 'tool.end')).toBe(false);
   });
 

--- a/src/agent/providers/openai-compatible/query.truncation.test.ts
+++ b/src/agent/providers/openai-compatible/query.truncation.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Truncation-notice coverage for the openai-compatible turn loop (#952).
+ *
+ * The sibling anthropic-direct behaviour is pinned by
+ * `anthropic-direct/loop.orphan.test.ts`; this file pins the same
+ * operator-visible contract on the other provider, which reaches truncation
+ * through entirely different machinery (a derived `finalizedToolCalls(state)`
+ * view rather than a `TurnResult.toolUseBlocks` array).
+ *
+ * The behaviour under test had ZERO coverage before this file: no test in this
+ * directory drove `finish_reason: 'length'` at all, which is how the notice
+ * came to be deferred out of the original #952 change.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type OpenAI from 'openai';
+import type { ProviderEvent, ProviderUserTurn } from '../../provider.js';
+import type { AgentConfig } from '../../types/config-types.js';
+import {
+  __setOpenAIClientFactory,
+  buildQueryFromConfig,
+  type OpenAIClientFactory,
+} from './query.js';
+import type { OpenAIChunk } from './translate.js';
+
+let pendingChunks: OpenAIChunk[] = [];
+
+function installMockClient(): void {
+  const factory: OpenAIClientFactory = () =>
+    ({
+      chat: {
+        completions: {
+          create: async (args: { stream?: boolean }) => {
+            if (!args.stream) throw new Error('mock only supports streaming mode');
+            const chunks = pendingChunks.slice();
+            return (async function* () {
+              for (const c of chunks) yield c;
+            })();
+          },
+        },
+      },
+    }) as unknown as OpenAI;
+  __setOpenAIClientFactory(factory);
+}
+
+async function collect(query: AsyncIterable<ProviderEvent>): Promise<ProviderEvent[]> {
+  const out: ProviderEvent[] = [];
+  for await (const ev of query) out.push(ev);
+  return out;
+}
+
+async function* singleInput(content: string): AsyncIterable<ProviderUserTurn> {
+  yield { content };
+}
+
+function baseConfig(over: Partial<AgentConfig> = {}): AgentConfig {
+  return { model: 'gpt-4o-mini', apiKey: 'sk-test-key', ...over } as AgentConfig;
+}
+
+/** The turn's single terminal assistant.message (there must never be two). */
+function assistantMessages(events: ProviderEvent[]): string[] {
+  return events
+    .filter((e): e is Extract<ProviderEvent, { type: 'assistant.message' }> =>
+      e.type === 'assistant.message',
+    )
+    .map((e) => e.text);
+}
+
+beforeEach(() => {
+  pendingChunks = [];
+  installMockClient();
+});
+
+afterEach(() => {
+  __setOpenAIClientFactory(null);
+});
+
+describe('openai-compatible truncation notice (#952)', () => {
+  it('appends a notice to the partial text on finish_reason "length"', async () => {
+    pendingChunks = [
+      { choices: [{ delta: { content: 'a partial answer' } }] },
+      {
+        choices: [{ delta: {}, finish_reason: 'length' }],
+        usage: { prompt_tokens: 10, completion_tokens: 4, total_tokens: 14 },
+      },
+    ];
+    const events = await collect(buildQueryFromConfig(baseConfig(), singleInput('hi')));
+    const messages = assistantMessages(events);
+
+    // Exactly ONE assistant.message: last-wins consumers (non-streaming
+    // sendMessage, subagent final-message capture) keep only the last, so a
+    // second event would discard the model's real answer.
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toContain('a partial answer');
+    expect(messages[0]).toContain('output-token limit');
+    expect(messages[0]).toContain('finish_reason "length"');
+    // Text-only truncation names no tool and points at the cap knob.
+    expect(messages[0]).toContain('allow a longer reply');
+    expect(messages[0]).not.toContain('NOT dispatched');
+    // Partial answer must come FIRST — the notice is a suffix, not a headline.
+    expect(messages[0]!.indexOf('a partial answer')).toBeLessThan(
+      messages[0]!.indexOf('output-token limit'),
+    );
+  });
+
+  it('names a tool call truncated mid-arguments as NOT dispatched', async () => {
+    // A tool call that began streaming and was cut off by the cap. isToolCallStop
+    // returns false for an explicit non-tool finish_reason, so this call is never
+    // dispatched — the drop is correct but was previously silent.
+    pendingChunks = [
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: 'call_abc',
+                  function: { name: 'read_file', arguments: '{"file_pa' },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        choices: [{ delta: {}, finish_reason: 'length' }],
+        usage: { prompt_tokens: 10, completion_tokens: 9, total_tokens: 19 },
+      },
+    ];
+    const events = await collect(buildQueryFromConfig(baseConfig(), singleInput('read it')));
+    const messages = assistantMessages(events);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toContain('output-token limit');
+    expect(messages[0]).toContain('read_file');
+    expect(messages[0]).toContain('NOT dispatched');
+
+    // The truncated call really did not run: no tool events were emitted.
+    expect(events.some((e) => e.type === 'tool.start' || e.type === 'tool.end')).toBe(false);
+  });
+
+  it('classifies the turn as truncated on turn.completed (trace + closure signal)', async () => {
+    pendingChunks = [
+      { choices: [{ delta: { content: 'cut' } }] },
+      {
+        choices: [{ delta: {}, finish_reason: 'length' }],
+        usage: { prompt_tokens: 5, completion_tokens: 1, total_tokens: 6 },
+      },
+    ];
+    const events = await collect(buildQueryFromConfig(baseConfig(), singleInput('hi')));
+    const final = events.at(-1);
+    expect(final?.type).toBe('turn.completed');
+    if (final?.type === 'turn.completed') {
+      // closure-reason.ts maps this to ClosureReason 'truncated'.
+      expect(final.usage.stopReason).toBe('length');
+    }
+  });
+
+  it('stays silent on a clean stop — no notice on a normal completion', async () => {
+    pendingChunks = [
+      { choices: [{ delta: { content: 'all done' } }] },
+      {
+        choices: [{ delta: {}, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 3, completion_tokens: 2, total_tokens: 5 },
+      },
+    ];
+    const events = await collect(buildQueryFromConfig(baseConfig(), singleInput('hi')));
+    const messages = assistantMessages(events);
+    expect(messages).toEqual(['all done']);
+    expect(messages[0]).not.toContain('output-token limit');
+  });
+});

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -708,6 +708,19 @@ export class OpenAICompatibleQuery implements ProviderQuery {
     // warning. Same rule as the anthropic-direct terminal path. Deliberately
     // applied AFTER the priorTurns push above: the notice is operator-facing
     // and must not enter conversation history.
+    //
+    // Invariant (#960): the notice rides ONLY on non-empty model text. A turn
+    // that produced NO text must keep yielding an EMPTY assistant.message, so
+    // that stream-consumer's `if (event.text)` gate drops it and the turn stays
+    // textless downstream. That absence is load-bearing: it is what leaves
+    // `finalMessage` unset in `subagent/handle.ts`, letting the run reach the
+    // ZERO-OUTPUT branch that stamps STREAM_INCOMPLETE and THROWS — which
+    // resolves a zero-output child as `failed` rather than a false `succeeded`,
+    // and lets `stream-cut-retry.ts` re-dispatch a read-only child that
+    // produced nothing. Substituting the notice as the message body here would
+    // make that chain unreachable and hand the parent a SUCCESS whose entire
+    // content is this warning. Mirrors the identical rule in
+    // `anthropic-direct/loop/turn-terminal.ts`.
     const truncationText = isTruncationStopReason(accumulatedUsage.stopReason)
       ? truncationNotice(droppedToolNames, accumulatedUsage.stopReason, {
           // The ChatGPT OAuth Responses backend rejects every output-cap
@@ -723,7 +736,7 @@ export class OpenAICompatibleQuery implements ProviderQuery {
       text:
         truncationText && finalAssistantText.length > 0
           ? `${finalAssistantText}\n\n${truncationText}`
-          : (truncationText ?? finalAssistantText),
+          : finalAssistantText,
       sessionId: this.initSessionId,
     };
     // If the turn was cut short by a spent budget, preserve that signal for

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -58,6 +58,7 @@ import { sumProviderUsage } from '../../usage.js';
 import { contextLimitFor, autoCompactLimitFor } from '../../model-limits.js';
 import { resolveModelId } from '../../session/model-resolution.js';
 import { collectSupportedCommands } from '../shared/supported-commands.js';
+import { isTruncationStopReason, truncationNotice } from '../shared/truncation.js';
 import { TurnTrace } from '../shared/turn-trace.js';
 import { debugLog } from '../../../utils/debug.js';
 import {
@@ -538,6 +539,16 @@ export class OpenAICompatibleQuery implements ProviderQuery {
     // CLI's formatToolCallStat renders a truthful "N tool calls" (PR 508 codex
     // review, P2).
     let toolCallCount = 0;
+    // Invariant: tool calls that were being streamed when the output cap cut the
+    // round off. `isToolCallStop` returns false for any explicit non-tool finish
+    // reason, so a call truncated mid-arguments sets needsToolDispatch=false and
+    // is discarded in-memory — it never reaches `dispatchAndAppendToolCalls`,
+    // which is the ONLY site that builds an assistant `tool_calls` message. That
+    // silent drop is correct (a half-built call would poison history with an
+    // empty tool_call_id) but invisible, so capture the names at the break to
+    // name them in the terminal notice. Must be captured inside the loop:
+    // `result.state` is a fresh StreamState per iteration.
+    let droppedToolNames: string[] = [];
 
     for (;;) {
       if (controller.signal.aborted) {
@@ -581,6 +592,9 @@ export class OpenAICompatibleQuery implements ProviderQuery {
       if (!result.needsToolDispatch) {
         // Model answered in text: a normal completion, or — when winding down —
         // the wind-down round's synthesized final answer. Emit terminal events.
+        if (isTruncationStopReason(result.state.finishReason)) {
+          droppedToolNames = finalizedToolCalls(result.state).map((c) => c.name);
+        }
         break;
       }
 
@@ -686,9 +700,30 @@ export class OpenAICompatibleQuery implements ProviderQuery {
       this.priorTurns.push(assistantTurn);
     }
 
+    // Invariant: the truncation notice is APPENDED to the single terminal
+    // assistant.message, never yielded as a second one — last-wins consumers
+    // (the non-streaming sendMessage() path, a subagent's final-message
+    // capture) keep only the LAST assistant message of a turn, so a second
+    // event would discard the model's real partial answer and surface only the
+    // warning. Same rule as the anthropic-direct terminal path. Deliberately
+    // applied AFTER the priorTurns push above: the notice is operator-facing
+    // and must not enter conversation history.
+    const truncationText = isTruncationStopReason(accumulatedUsage.stopReason)
+      ? truncationNotice(droppedToolNames, accumulatedUsage.stopReason, {
+          // The ChatGPT OAuth Responses backend rejects every output-cap
+          // parameter, so advertising our cap setting there is ineffective.
+          canIncreaseOutputLimit: !(
+            this.opts.auth.source === 'chatgpt-oauth' &&
+            accumulatedUsage.stopReason === 'max_output_tokens'
+          ),
+        })
+      : null;
     yield {
       type: 'assistant.message',
-      text: finalAssistantText,
+      text:
+        truncationText && finalAssistantText.length > 0
+          ? `${finalAssistantText}\n\n${truncationText}`
+          : (truncationText ?? finalAssistantText),
       sessionId: this.initSessionId,
     };
     // If the turn was cut short by a spent budget, preserve that signal for

--- a/src/agent/providers/shared/truncation.test.ts
+++ b/src/agent/providers/shared/truncation.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { truncationNotice } from './truncation.js';
+
+describe('truncationNotice', () => {
+  it('recommends continuation instead of an unsupported cap setting', () => {
+    const notice = truncationNotice([], 'max_output_tokens', {
+      canIncreaseOutputLimit: false,
+    });
+
+    expect(notice).toContain('Continue in a follow-up turn or retry');
+    expect(notice).not.toContain('--max-output-tokens');
+    expect(notice).not.toContain('AFK_MAX_OUTPUT_TOKENS');
+  });
+
+  it('uses the neutral remediation for an undispatched tool too', () => {
+    const notice = truncationNotice(['read_file'], 'max_output_tokens', {
+      canIncreaseOutputLimit: false,
+    });
+
+    expect(notice).toContain('NOT dispatched (read_file)');
+    expect(notice).toContain('retry so the model can finish the action');
+    expect(notice).not.toContain('--max-output-tokens');
+  });
+
+  it('keeps the configurable-cap remediation by default', () => {
+    const notice = truncationNotice([], 'length');
+
+    expect(notice).toContain('--max-output-tokens / AFK_MAX_OUTPUT_TOKENS');
+  });
+});

--- a/src/agent/providers/shared/truncation.ts
+++ b/src/agent/providers/shared/truncation.ts
@@ -1,26 +1,50 @@
 /**
- * Shared predicate for output-token truncation stop reasons.
+ * Invariant: shared predicate for output-token truncation stop reasons.
  *
  * A turn is "truncated" when the provider cut it off at the output-token cap
- * rather than the model finishing on its own. Anthropic emits `'max_tokens'`;
- * OpenAI-compatible providers emit `'length'`.
+ * rather than the model finishing on its own. The sentinel is set by the wire
+ * format, not by us, so all three spellings must be recognised:
+ *
+ *   - `'max_tokens'`        — Anthropic Messages API `stop_reason`.
+ *   - `'length'`            — OpenAI **Chat Completions** `finish_reason`.
+ *   - `'max_output_tokens'` — OpenAI **Responses** API. That wire has no
+ *     `finish_reason`; `responses-translate.ts` derives the stop reason from
+ *     `response.incomplete_details.reason` on a `response.incomplete` event,
+ *     and the reason string it hands back is `'max_output_tokens'` — a third
+ *     spelling of the same event, not a variant of `'length'`.
+ *
+ * Missing the Responses spelling is not cosmetic: it silently un-classifies
+ * every truncated turn on that wire, so the closure classifier records a
+ * non-truncated reason and a truncated subagent returns to its parent with no
+ * partial-result banner — exactly the invisibility #952 exists to remove.
  *
  * Lives in `providers/shared/` — the leaf both layers that need it import from
  * *downward*: `session/closure-reason.ts` re-exports it for closure
  * classification, the anthropic-direct terminal path uses it to surface a
  * truncation notice, and the subagent result path uses it to mark a truncated
  * child's output as an incomplete partial. Keeping one definition prevents the
- * `'max_tokens' || 'length'` literals from drifting across those three sites.
+ * sentinel literals from drifting across those sites.
  *
  * @module agent/providers/shared/truncation
  */
 
 /**
+ * The exact stop-reason strings that mean "cut off at the output-token cap",
+ * one per wire format. Exported so tests can assert the set itself rather than
+ * re-listing literals that would then drift from the predicate.
+ */
+export const TRUNCATION_STOP_REASONS: readonly string[] = [
+  'max_tokens', // Anthropic Messages
+  'length', // OpenAI Chat Completions
+  'max_output_tokens', // OpenAI Responses (incomplete_details.reason)
+];
+
+/**
  * True when `stopReason` means the response was cut off by the output-token cap
- * (`'max_tokens'` on Anthropic, `'length'` on OpenAI-compatible) rather than
- * completing naturally. Accepts `null` so callers holding a `string | null`
- * stop reason (e.g. `TurnResult.stopReason`) need not pre-coalesce.
+ * rather than completing naturally. Accepts `null` so callers holding a
+ * `string | null` stop reason (e.g. `TurnResult.stopReason`) need not
+ * pre-coalesce.
  */
 export function isTruncationStopReason(stopReason: string | null | undefined): boolean {
-  return stopReason === 'max_tokens' || stopReason === 'length';
+  return stopReason != null && TRUNCATION_STOP_REASONS.includes(stopReason);
 }

--- a/src/agent/providers/shared/truncation.ts
+++ b/src/agent/providers/shared/truncation.ts
@@ -32,21 +32,30 @@
  * The exact stop-reason strings that mean "cut off at the output-token cap",
  * one per wire format. Exported so tests can assert the set itself rather than
  * re-listing literals that would then drift from the predicate.
+ *
+ * `as const` (not `readonly string[]`) so consumers keep the element literal
+ * union (`'max_tokens' | 'length' | 'max_output_tokens'`) instead of a widened
+ * `string` — e.g. a `switch` over this set can be exhaustiveness-checked.
  */
-export const TRUNCATION_STOP_REASONS: readonly string[] = [
+export const TRUNCATION_STOP_REASONS = [
   'max_tokens', // Anthropic Messages
   'length', // OpenAI Chat Completions
   'max_output_tokens', // OpenAI Responses (incomplete_details.reason)
-];
+] as const;
 
 /**
  * True when `stopReason` means the response was cut off by the output-token cap
  * rather than completing naturally. Accepts `null` so callers holding a
  * `string | null` stop reason (e.g. `TurnResult.stopReason`) need not
- * pre-coalesce.
+ * pre-coalesce. Deliberately keeps the wide `string | null | undefined`
+ * parameter — narrowing it to the tuple's literal union would reject every
+ * real caller, which always holds a provider-reported `string`, not a
+ * pre-known member of this set. Widen `TRUNCATION_STOP_REASONS` back to
+ * `readonly string[]` at the `includes` call instead of narrowing the
+ * parameter.
  */
 export function isTruncationStopReason(stopReason: string | null | undefined): boolean {
-  return stopReason != null && TRUNCATION_STOP_REASONS.includes(stopReason);
+  return stopReason != null && (TRUNCATION_STOP_REASONS as readonly string[]).includes(stopReason);
 }
 
 /**

--- a/src/agent/providers/shared/truncation.ts
+++ b/src/agent/providers/shared/truncation.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared predicate for output-token truncation stop reasons.
+ *
+ * A turn is "truncated" when the provider cut it off at the output-token cap
+ * rather than the model finishing on its own. Anthropic emits `'max_tokens'`;
+ * OpenAI-compatible providers emit `'length'`.
+ *
+ * Lives in `providers/shared/` — the leaf both layers that need it import from
+ * *downward*: `session/closure-reason.ts` re-exports it for closure
+ * classification, the anthropic-direct terminal path uses it to surface a
+ * truncation notice, and the subagent result path uses it to mark a truncated
+ * child's output as an incomplete partial. Keeping one definition prevents the
+ * `'max_tokens' || 'length'` literals from drifting across those three sites.
+ *
+ * @module agent/providers/shared/truncation
+ */
+
+/**
+ * True when `stopReason` means the response was cut off by the output-token cap
+ * (`'max_tokens'` on Anthropic, `'length'` on OpenAI-compatible) rather than
+ * completing naturally. Accepts `null` so callers holding a `string | null`
+ * stop reason (e.g. `TurnResult.stopReason`) need not pre-coalesce.
+ */
+export function isTruncationStopReason(stopReason: string | null | undefined): boolean {
+  return stopReason === 'max_tokens' || stopReason === 'length';
+}

--- a/src/agent/providers/shared/truncation.ts
+++ b/src/agent/providers/shared/truncation.ts
@@ -48,3 +48,67 @@ export const TRUNCATION_STOP_REASONS: readonly string[] = [
 export function isTruncationStopReason(stopReason: string | null | undefined): boolean {
   return stopReason != null && TRUNCATION_STOP_REASONS.includes(stopReason);
 }
+
+/**
+ * Contract: render the wire-accurate field name for a truncation sentinel, so
+ * the notice below quotes something the operator can actually grep for in
+ * provider docs. Each wire names the field differently and only one of the
+ * three is literally called `finish_reason`.
+ */
+function sentinelLabel(stopReason: string | null | undefined): string {
+  switch (stopReason) {
+    case 'max_tokens':
+      return 'stop_reason "max_tokens"';
+    case 'length':
+      return 'finish_reason "length"';
+    case 'max_output_tokens':
+      return 'incomplete_details.reason "max_output_tokens"';
+    default:
+      return 'the provider output-token cap';
+  }
+}
+
+/**
+ * Operator-facing notice for a turn cut off at the output-token cap (#952).
+ *
+ * Shared by both providers on purpose. The anthropic-direct terminal path and
+ * the openai-compatible turn loop reach truncation through very different
+ * machinery (a `TurnResult.toolUseBlocks` array vs. a derived
+ * `finalizedToolCalls(state)` view), but the operator-visible consequence is
+ * identical, so the WORDING must not fork. A half-mirrored notice — one
+ * provider naming the dropped tool, the other not — is itself a form of
+ * provider drift, which is why this text lives here rather than in either
+ * provider's terminal module.
+ *
+ * `droppedToolNames` are the tool calls that were truncated mid-request and
+ * therefore never dispatched. When non-empty the model announced an action that
+ * did not run, which otherwise reads to the operator as the agent stalling.
+ *
+ * Display-only in both callers: appended to the yielded `assistant.message`
+ * text, never pushed into conversation history. It is an operator warning, not
+ * model context — feeding it back would teach the model it had been cut off
+ * when the transcript it sees is already complete.
+ */
+export function truncationNotice(
+  droppedToolNames: string[],
+  stopReason?: string | null,
+  options: { canIncreaseOutputLimit?: boolean } = {},
+): string {
+  const base =
+    `⚠ This turn was cut off at the output-token limit (${sentinelLabel(stopReason)}) before the ` +
+    'model finished — anything above is partial, not a complete answer.';
+  if (droppedToolNames.length > 0) {
+    const names = [...new Set(droppedToolNames)].join(', ');
+    const remediation = options.canIncreaseOutputLimit === false
+      ? 'Continue in a follow-up turn or retry so the model can finish the action.'
+      : 'Raise --max-output-tokens / AFK_MAX_OUTPUT_TOKENS, then retry.';
+    return (
+      `${base} A tool call was truncated mid-request and was NOT dispatched (${names}); ` +
+      `that action did not run. ${remediation}`
+    );
+  }
+  if (options.canIncreaseOutputLimit === false) {
+    return `${base} Continue in a follow-up turn or retry the request.`;
+  }
+  return `${base} Raise --max-output-tokens / AFK_MAX_OUTPUT_TOKENS to allow a longer reply.`;
+}

--- a/src/agent/session/closure-reason.test.ts
+++ b/src/agent/session/closure-reason.test.ts
@@ -10,6 +10,7 @@ import {
   type ClosureReasonInputs,
 } from './closure-reason.js';
 import { SOFT_DEADLINE_WIND_DOWN } from '../providers/shared/soft-deadline.js';
+import { TRUNCATION_STOP_REASONS } from '../providers/shared/truncation.js';
 
 const base: ClosureReasonInputs = {
   dispatchReason: 'close',
@@ -21,9 +22,26 @@ const base: ClosureReasonInputs = {
 };
 
 describe('isTruncationStopReason', () => {
-  it('flags Anthropic max_tokens and OpenAI length', () => {
+  it('flags Anthropic max_tokens and OpenAI Chat Completions length', () => {
     expect(isTruncationStopReason('max_tokens')).toBe(true);
     expect(isTruncationStopReason('length')).toBe(true);
+  });
+
+  // The Responses API has no `finish_reason`: responses-translate.ts derives the
+  // stop reason from `response.incomplete_details.reason`, which spells this
+  // event `'max_output_tokens'` (pinned by responses-translate.test.ts). Missing
+  // it un-classified every truncated turn on that wire — the closure reason fell
+  // through to `model_end_turn` and a truncated subagent reached its parent with
+  // no partial-result banner, which is precisely the invisibility #952 removes.
+  it('flags the OpenAI Responses-wire spelling max_output_tokens', () => {
+    expect(isTruncationStopReason('max_output_tokens')).toBe(true);
+  });
+
+  it('covers every sentinel in TRUNCATION_STOP_REASONS (no drift)', () => {
+    for (const reason of TRUNCATION_STOP_REASONS) {
+      expect(isTruncationStopReason(reason)).toBe(true);
+    }
+    expect(TRUNCATION_STOP_REASONS).toContain('max_output_tokens');
   });
 
   it('does not flag clean / tool / unknown stop reasons', () => {
@@ -31,6 +49,9 @@ describe('isTruncationStopReason', () => {
     expect(isTruncationStopReason('stop')).toBe(false);
     expect(isTruncationStopReason('tool_use')).toBe(false);
     expect(isTruncationStopReason(undefined)).toBe(false);
+    expect(isTruncationStopReason(null)).toBe(false);
+    // Adjacent but distinct: a *request* field name, never a stop reason.
+    expect(isTruncationStopReason('max_completion_tokens')).toBe(false);
   });
 });
 

--- a/src/agent/session/closure-reason.ts
+++ b/src/agent/session/closure-reason.ts
@@ -34,9 +34,10 @@
  *     the session carries the model's synthesized summary rather than dying
  *     mid-work at the hard abort. Classified as `timeout` because the budget
  *     that ran out WAS the clock — only the handling was gentler.
- *  7. a truncation stop reason (`max_tokens` / `length`) on an otherwise clean
- *     close → `truncated` — the model's final turn was cut off by the
- *     output-token ceiling, previously indistinguishable from a clean end.
+ *  7. a truncation stop reason (`max_tokens` / `length` / `max_output_tokens`)
+ *     on an otherwise clean close → `truncated` — the model's final turn was
+ *     cut off by the output-token ceiling, previously indistinguishable from a
+ *     clean end.
  *  8. otherwise → `model_end_turn`.
  *
  * @module agent/session/closure-reason
@@ -49,7 +50,7 @@ import { SOFT_DEADLINE_WIND_DOWN } from '../providers/shared/soft-deadline.js';
 import { isTruncationStopReason } from '../providers/shared/truncation.js';
 
 // Canonical definition lives in providers/shared/truncation.ts so the
-// `'max_tokens' || 'length'` literals stay single-sourced across the closure
+// per-wire sentinel literals stay single-sourced across the closure
 // classifier, the anthropic-direct terminal path, and the subagent result path.
 // Re-exported here so existing importers (and closure-reason.test.ts) resolve
 // `isTruncationStopReason` from this module unchanged.

--- a/src/agent/session/closure-reason.ts
+++ b/src/agent/session/closure-reason.ts
@@ -46,14 +46,14 @@ import type { ClosureReason } from '../trace/index.js';
 import { OVERLOAD_EXHAUSTED } from '../providers/anthropic-direct/overload-pause.js';
 import { SOFT_DEADLINE_WIND_DOWN } from '../providers/shared/soft-deadline.js';
 
-/**
- * Provider stop reasons that mean the response was cut off by the output-token
- * cap rather than completing naturally. Anthropic emits `'max_tokens'`;
- * OpenAI-compatible providers emit `'length'`.
- */
-export function isTruncationStopReason(stopReason: string | undefined): boolean {
-  return stopReason === 'max_tokens' || stopReason === 'length';
-}
+import { isTruncationStopReason } from '../providers/shared/truncation.js';
+
+// Canonical definition lives in providers/shared/truncation.ts so the
+// `'max_tokens' || 'length'` literals stay single-sourced across the closure
+// classifier, the anthropic-direct terminal path, and the subagent result path.
+// Re-exported here so existing importers (and closure-reason.test.ts) resolve
+// `isTruncationStopReason` from this module unchanged.
+export { isTruncationStopReason };
 
 export interface ClosureReasonInputs {
   /** The reason string passed to `dispatchSessionEndOnce` (close/reset/error). */

--- a/src/agent/subagent/handle-streaming.test.ts
+++ b/src/agent/subagent/handle-streaming.test.ts
@@ -324,6 +324,38 @@ describe('SubagentHandle streaming', () => {
       expect(result.error?.name).toBe('StreamIncompleteError');
     });
 
+    // #960: the guard above names `max_tokens` in its rationale but only ever
+    // exercised `end_turn`, so nothing pinned the truncation sentinel — which is
+    // how a change that emitted a standalone notice for a textless `max_tokens`
+    // turn (setting `finalMessage` and making this whole branch unreachable)
+    // passed a green suite. Pin every truncation sentinel explicitly.
+    it.each(['max_tokens', 'length', 'max_output_tokens'])(
+      'resolves FAILED with STREAM_INCOMPLETE for a textless turn ending in %s',
+      async (stopReason) => {
+        const events: OutputEvent[] = [{ type: 'done', metadata: { stopReason } }];
+        const session = createDeterministicMockSession(events, {
+          role: 'assistant',
+          content: 'unused',
+          timestamp: new Date(),
+        });
+        const handle = new SubagentHandleImpl(
+          `subagent-textless-${stopReason}-test`,
+          session,
+          controller,
+          abortGraph,
+          undefined,
+          5000,
+          undefined,
+          vi.fn(),
+        );
+
+        const result = await handle.runToResult('p');
+        expect(result.status).toBe('failed');
+        expect(result.stopReason).toBe(STREAM_INCOMPLETE);
+        expect(result.error?.name).toBe('StreamIncompleteError');
+      },
+    );
+
     it('returns a capped partial result (not a throw) when the tool-use cap fires with no message', async () => {
       // Anti-hang contract: a forked child that hits its tool-use-iteration cap
       // ends the turn with a `tool_use_loop_capped` done and no assistant

--- a/src/agent/subagent/result.test.ts
+++ b/src/agent/subagent/result.test.ts
@@ -18,6 +18,7 @@ import {
   STREAM_INCOMPLETE,
 } from './result.js';
 import { TOOL_USE_LOOP_CAPPED } from '../providers/shared/tool-loop-cap.js';
+import { TRUNCATION_STOP_REASONS } from '../providers/shared/truncation.js';
 import { SOFT_DEADLINE_WIND_DOWN } from '../providers/shared/soft-deadline.js';
 import { OVERLOAD_EXHAUSTED } from '../providers/anthropic-direct/overload-pause.js';
 
@@ -180,9 +181,15 @@ describe('isIncompleteStopReason — partial-result classification', () => {
   // #952: a child cut off at the output-token cap streamed real text and
   // reached a terminal message, so it resolves `succeeded` — but that text ends
   // mid-thought and must be marked partial, exactly like the tool-loop-cap case.
-  it('is true for output-token truncation on both providers (max_tokens / length)', () => {
-    expect(isIncompleteStopReason('max_tokens')).toBe(true); // anthropic
-    expect(isIncompleteStopReason('length')).toBe(true); // openai-compatible
+  it('is true for output-token truncation on every wire sentinel', () => {
+    expect(isIncompleteStopReason('max_tokens')).toBe(true); // anthropic messages
+    expect(isIncompleteStopReason('length')).toBe(true); // openai chat completions
+    expect(isIncompleteStopReason('max_output_tokens')).toBe(true); // openai responses
+    // Driven off the shared constant so a newly-added wire sentinel cannot pass
+    // the predicate while silently skipping the subagent partial-result banner.
+    for (const reason of TRUNCATION_STOP_REASONS) {
+      expect(isIncompleteStopReason(reason), reason).toBe(true);
+    }
   });
 
   it('is false for a genuinely unrelated provider stop reason', () => {
@@ -222,7 +229,7 @@ describe('annotateIfIncomplete — parent-visible partial marker', () => {
   });
 
   it('prepends a PARTIAL marker naming output-token truncation and preserves the body (#952)', () => {
-    for (const reason of ['max_tokens', 'length']) {
+    for (const reason of TRUNCATION_STOP_REASONS) {
       const out = annotateIfIncomplete(BODY, reason);
       expect(out, reason).not.toBe(BODY);
       expect(out, reason).toContain('PARTIAL RESULT');

--- a/src/agent/subagent/result.test.ts
+++ b/src/agent/subagent/result.test.ts
@@ -177,8 +177,17 @@ describe('isIncompleteStopReason — partial-result classification', () => {
     expect(isIncompleteStopReason(undefined)).toBe(false);
   });
 
-  it('is false for an unrelated provider stop reason', () => {
-    expect(isIncompleteStopReason('max_tokens')).toBe(false);
+  // #952: a child cut off at the output-token cap streamed real text and
+  // reached a terminal message, so it resolves `succeeded` — but that text ends
+  // mid-thought and must be marked partial, exactly like the tool-loop-cap case.
+  it('is true for output-token truncation on both providers (max_tokens / length)', () => {
+    expect(isIncompleteStopReason('max_tokens')).toBe(true); // anthropic
+    expect(isIncompleteStopReason('length')).toBe(true); // openai-compatible
+  });
+
+  it('is false for a genuinely unrelated provider stop reason', () => {
+    expect(isIncompleteStopReason('stop_sequence')).toBe(false);
+    expect(isIncompleteStopReason('pause_turn')).toBe(false);
   });
 });
 
@@ -210,6 +219,16 @@ describe('annotateIfIncomplete — parent-visible partial marker', () => {
     expect(out).toContain('PARTIAL RESULT');
     expect(out).toContain('cut off');
     expect(out.endsWith(BODY)).toBe(true);
+  });
+
+  it('prepends a PARTIAL marker naming output-token truncation and preserves the body (#952)', () => {
+    for (const reason of ['max_tokens', 'length']) {
+      const out = annotateIfIncomplete(BODY, reason);
+      expect(out, reason).not.toBe(BODY);
+      expect(out, reason).toContain('PARTIAL RESULT');
+      expect(out, reason).toContain('output-token limit');
+      expect(out.endsWith(BODY), reason).toBe(true);
+    }
   });
 });
 

--- a/src/agent/subagent/result.ts
+++ b/src/agent/subagent/result.ts
@@ -110,7 +110,7 @@ export function annotateIfIncomplete(content: string, stopReason: string | undef
         : stopReason === OVERLOAD_EXHAUSTED
           ? 'was stopped by a sustained upstream overload (HTTP 529) before finishing'
           : isTruncationStopReason(stopReason)
-            ? 'was cut off at the output-token limit (max_tokens) before finishing'
+            ? 'was cut off at the output-token limit before finishing'
             : 'was cut off before finishing (its stream ended without a final message)';
   return (
     `[⚠ PARTIAL RESULT — the subagent ${why}. The text below is an incomplete ` +

--- a/src/agent/subagent/result.ts
+++ b/src/agent/subagent/result.ts
@@ -14,6 +14,7 @@ import { parseSignal, type Signal } from '../signal-block.js';
 import { TOOL_USE_LOOP_CAPPED } from '../providers/shared/tool-loop-cap.js';
 import { SOFT_DEADLINE_WIND_DOWN } from '../providers/shared/soft-deadline.js';
 import { OVERLOAD_EXHAUSTED } from '../providers/anthropic-direct/overload-pause.js';
+import { isTruncationStopReason } from '../providers/shared/truncation.js';
 
 export type SubagentStatus = 'idle' | 'running' | 'succeeded' | 'failed' | 'cancelled';
 
@@ -70,13 +71,22 @@ export const STREAM_INCOMPLETE = 'stream_incomplete';
  * wind-down answer is by construction "here is what I established and what
  * remains unresolved", so omitting this arm would hand a parent model an
  * explicitly-unfinished report as though it were a conclusion.
+ *
+ * A truncation stop reason (`'max_tokens'` / `'length'`, via
+ * {@link isTruncationStopReason}) is included for the same reason (#952): a
+ * child cut off at the output-token cap streamed real text and reached a
+ * terminal message, so `handle.ts` resolves it `succeeded` — but that text ends
+ * mid-thought, so a parent must treat it as an incomplete partial, not a
+ * conclusion. Without this arm a truncated child got no `[PARTIAL RESULT]`
+ * banner while the tool-loop-cap case did.
  */
 export function isIncompleteStopReason(stopReason: string | undefined): boolean {
   return (
     stopReason === TOOL_USE_LOOP_CAPPED ||
     stopReason === SOFT_DEADLINE_WIND_DOWN ||
     stopReason === STREAM_INCOMPLETE ||
-    stopReason === OVERLOAD_EXHAUSTED
+    stopReason === OVERLOAD_EXHAUSTED ||
+    isTruncationStopReason(stopReason)
   );
 }
 
@@ -99,7 +109,9 @@ export function annotateIfIncomplete(content: string, stopReason: string | undef
         ? 'ran out of wall-clock budget and was asked to summarize early'
         : stopReason === OVERLOAD_EXHAUSTED
           ? 'was stopped by a sustained upstream overload (HTTP 529) before finishing'
-          : 'was cut off before finishing (its stream ended without a final message)';
+          : isTruncationStopReason(stopReason)
+            ? 'was cut off at the output-token limit (max_tokens) before finishing'
+            : 'was cut off before finishing (its stream ended without a final message)';
   return (
     `[⚠ PARTIAL RESULT — the subagent ${why}. The text below is an incomplete ` +
     `intermediate finding, NOT a final answer; treat it as such.]\n\n${content}`


### PR DESCRIPTION
## Summary

Makes `max_tokens` **truncation** visible. A turn cut at the output-token cap is already classified `ClosureReason: 'truncated'` — but that signal never leaves the trace stream, so on the REPL, Telegram, and one-shot `chat` a truncated turn is **indistinguishable from a clean completion**. The worst variant: a tool call cut mid-arguments is stripped (correctly, to avoid an orphan-`tool_use` 400) and then silently dropped — the agent announces an action and stops, which reads as a mid-task stall.

Sibling of #951/#953/#954 (PR #959), which fixed *resolution*; this fixes *observability*.

### Changes
1. **anthropic-direct `turn-terminal.ts`** — emit a **display-only** truncation notice (mirrors the existing `refusal` branch precedent — yielded as `assistant.message`, **not** pushed to history via `input.messages.push`) after the partial text so the answer still shows first. When a `tool_use` block is stripped under truncation, the notice **names the dropped tool** (`turnResult.toolUseBlocks`) so the never-dispatched action is legible.
2. **subagent `result.ts`** — a truncated child streams real text and reaches a terminal message, so `handle.ts` resolves it `succeeded`; but that text ends mid-thought. `isIncompleteStopReason` now includes truncation, so a truncated child carries the same `[⚠ PARTIAL RESULT]` banner as the tool-loop-cap / wind-down cases. **Provider-agnostic** — covers anthropic `'max_tokens'` and openai `'length'`.
3. **new `providers/shared/truncation.ts`** — single-sources the `'max_tokens' || 'length'` predicate. `session/closure-reason.ts` now re-exports it (its test is unaffected), so the literals no longer drift across the closure classifier, the terminal path, and the subagent path. `providers/shared/` is the correct home — `result.ts` already imports its sibling stop-reason constants (`TOOL_USE_LOOP_CAPPED`, `SOFT_DEADLINE_WIND_DOWN`) from there, and `session/` → `providers/` is a downward import.

### Deliberately scoped out (named follow-up, not dropped)
The **openai-compatible LIVE-turn notice** (`query.ts` terminal emit) is not added here. Its `finish_reason` handling and partial-`tool_call` accumulation differ enough from anthropic's clean `TurnResult.toolUseBlocks` choke point to warrant a separate change + test; a text-only half-mirror (notice without tool naming) would itself be a form of provider drift. The **cross-provider subagent banner in change (2) already covers truncated openai *children***, so the agent-of-agents path is not drift-exposed — only the openai top-level live surface is, and that is the follow-up.

## How was this tested?

- `pnpm lint` ✓ · `pnpm build` ✓
- New tests:
  - `loop.orphan.test.ts`: a `max_tokens`-stripped `tool_use` emits a notice naming the dropped tool (`read_file`) + `NOT dispatched`, and `turn.completed` still fires; a text-only `max_tokens` turn emits an "allow a longer reply" notice **and** still delivers the model's partial text as its own `assistant.message`.
  - `result.test.ts`: flipped the stale `isIncompleteStopReason('max_tokens') === false` assertion (it encoded the bug) → now `true` for both `max_tokens` and `length`; `stop_sequence`/`pause_turn` remain false; `annotateIfIncomplete` prepends the banner naming the output-token limit for both providers.
- Regression net (green): `anthropic-direct/` + `subagent/` + `session/` = **1179 tests** pass, including the orphan-strip invariant (`loop.orphan.test.ts`) and closure-reason (18).

Closes #952

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes (touched files + anthropic-direct/subagent/session suites)
- [x] Commits are signed off (`git commit -s`) per the DCO
- [x] No secrets, tokens, or private paths in the diff
