### PR TITLE
fix(tokens): surface max_tokens truncation on the openai-compatible turn too

### DIFF
--- a/src/agent/providers/anthropic-direct/loop/turn-terminal.ts
+++ b/src/agent/providers/anthropic-direct/loop/turn-terminal.ts
@@ -9,33 +9,12 @@
  */
 
 import type { ProviderEvent } from '../../../provider.js';
-import { isTruncationStopReason } from '../../shared/truncation.js';
+import { isTruncationStopReason, truncationNotice } from '../../shared/truncation.js';
 import type { RunTurnInput, TurnResult } from '../types.js';
 import type { TurnAccumulator } from './turn-accumulator.js';
 
 /** Text at or below this length is also offered as a `suggestion`. */
 const SUGGESTION_MAX_LENGTH = 200;
-
-/**
- * Operator-facing notice for a turn cut off at the output-token cap (#952).
- * `droppedToolNames` are the `tool_use` blocks about to be stripped from
- * history below — when non-empty, the model announced an action that was
- * truncated mid-request and never dispatched, which otherwise reads as the
- * agent stalling. Display-only: not pushed to history.
- */
-function truncationNotice(droppedToolNames: string[]): string {
-  const base =
-    '⚠ This turn was cut off at the output-token limit (stop_reason "max_tokens") before the ' +
-    'model finished — anything above is partial, not a complete answer.';
-  if (droppedToolNames.length > 0) {
-    const names = [...new Set(droppedToolNames)].join(', ');
-    return (
-      `${base} A tool call was truncated mid-request and was NOT dispatched (${names}); ` +
-      'that action did not run. Raise --max-output-tokens / AFK_MAX_OUTPUT_TOKENS, then retry.'
-    );
-  }
-  return `${base} Raise --max-output-tokens / AFK_MAX_OUTPUT_TOKENS to allow a longer reply.`;
-}
 
 /**
  * Emit the closing events for a non-`tool_use` stop reason, pushing the
@@ -92,7 +71,7 @@ export function* emitNonToolUseTerminal(
   // the LAST assistant message of a turn, so two messages here would silently
   // discard the real answer and surface only the warning.
   const truncationText = isTruncationStopReason(turnResult.stopReason)
-    ? truncationNotice(turnResult.toolUseBlocks.map((b) => b.name))
+    ? truncationNotice(turnResult.toolUseBlocks.map((b) => b.name), turnResult.stopReason)
     : null;
 
   if (turnResult.text.length > 0) {

--- a/src/agent/providers/openai-compatible/query.truncation.test.ts
+++ b/src/agent/providers/openai-compatible/query.truncation.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Truncation-notice coverage for the openai-compatible turn loop (#952).
+ *
+ * The sibling anthropic-direct behaviour is pinned by
+ * `anthropic-direct/loop.orphan.test.ts`; this file pins the same
+ * operator-visible contract on the other provider, which reaches truncation
+ * through entirely different machinery (a derived `finalizedToolCalls(state)`
+ * view rather than a `TurnResult.toolUseBlocks` array).
+ *
+ * The behaviour under test had ZERO coverage before this file: no test in this
+ * directory drove `finish_reason: 'length'` at all, which is how the notice
+ * came to be deferred out of the original #952 change.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type OpenAI from 'openai';
+import type { ProviderEvent, ProviderUserTurn } from '../../provider.js';
+import type { AgentConfig } from '../../types/config-types.js';
+import {
+  __setOpenAIClientFactory,
+  buildQueryFromConfig,
+  type OpenAIClientFactory,
+} from './query.js';
+import type { OpenAIChunk } from './translate.js';
+
+let pendingChunks: OpenAIChunk[] = [];
+
+function installMockClient(): void {
+  const factory: OpenAIClientFactory = () =>
+    ({
+      chat: {
+        completions: {
+          create: async (args: { stream?: boolean }) => {
+            if (!args.stream) throw new Error('mock only supports streaming mode');
+            const chunks = pendingChunks.slice();
+            return (async function* () {
+              for (const c of chunks) yield c;
+            })();
+          },
+        },
+      },
+    }) as unknown as OpenAI;
+  __setOpenAIClientFactory(factory);
+}
+
+async function collect(query: AsyncIterable<ProviderEvent>): Promise<ProviderEvent[]> {
+  const out: ProviderEvent[] = [];
+  for await (const ev of query) out.push(ev);
+  return out;
+}
+
+async function* singleInput(content: string): AsyncIterable<ProviderUserTurn> {
+  yield { content };
+}
+
+function baseConfig(over: Partial<AgentConfig> = {}): AgentConfig {
+  return { model: 'gpt-4o-mini', apiKey: 'sk-test-key', ...over } as AgentConfig;
+}
+
+/** The turn's single terminal assistant.message (there must never be two). */
+function assistantMessages(events: ProviderEvent[]): string[] {
+  return events
+    .filter((e): e is Extract<ProviderEvent, { type: 'assistant.message' }> =>
+      e.type === 'assistant.message',
+    )
+    .map((e) => e.text);
+}
+
+beforeEach(() => {
+  pendingChunks = [];
+  installMockClient();
+});
+
+afterEach(() => {
+  __setOpenAIClientFactory(null);
+});
+
+describe('openai-compatible truncation notice (#952)', () => {
+  it('appends a notice to the partial text on finish_reason "length"', async () => {
+    pendingChunks = [
+      { choices: [{ delta: { content: 'a partial answer' } }] },
+      {
+        choices: [{ delta: {}, finish_reason: 'length' }],
+        usage: { prompt_tokens: 10, completion_tokens: 4, total_tokens: 14 },
+      },
+    ];
+    const events = await collect(buildQueryFromConfig(baseConfig(), singleInput('hi')));
+    const messages = assistantMessages(events);
+
+    // Exactly ONE assistant.message: last-wins consumers (non-streaming
+    // sendMessage, subagent final-message capture) keep only the last, so a
+    // second event would discard the model's real answer.
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toContain('a partial answer');
+    expect(messages[0]).toContain('output-token limit');
+    expect(messages[0]).toContain('finish_reason "length"');
+    // Text-only truncation names no tool and points at the cap knob.
+    expect(messages[0]).toContain('allow a longer reply');
+    expect(messages[0]).not.toContain('NOT dispatched');
+    // Partial answer must come FIRST — the notice is a suffix, not a headline.
+    expect(messages[0]!.indexOf('a partial answer')).toBeLessThan(
+      messages[0]!.indexOf('output-token limit'),
+    );
+  });
+
+  it('names a tool call truncated mid-arguments as NOT dispatched', async () => {
+    // A tool call that began streaming and was cut off by the cap. isToolCallStop
+    // returns false for an explicit non-tool finish_reason, so this call is never
+    // dispatched — the drop is correct but was previously silent.
+    pendingChunks = [
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: 'call_abc',
+                  function: { name: 'read_file', arguments: '{"file_pa' },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        choices: [{ delta: {}, finish_reason: 'length' }],
+        usage: { prompt_tokens: 10, completion_tokens: 9, total_tokens: 19 },
+      },
+    ];
+    const events = await collect(buildQueryFromConfig(baseConfig(), singleInput('read it')));
+    const messages = assistantMessages(events);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toContain('output-token limit');
+    expect(messages[0]).toContain('read_file');
+    expect(messages[0]).toContain('NOT dispatched');
+
+    // The truncated call really did not run: no tool events were emitted.
+    expect(events.some((e) => e.type === 'tool.start' || e.type === 'tool.end')).toBe(false);
+  });
+
+  it('classifies the turn as truncated on turn.completed (trace + closure signal)', async () => {
+    pendingChunks = [
+      { choices: [{ delta: { content: 'cut' } }] },
+      {
+        choices: [{ delta: {}, finish_reason: 'length' }],
+        usage: { prompt_tokens: 5, completion_tokens: 1, total_tokens: 6 },
+      },
+    ];
+    const events = await collect(buildQueryFromConfig(baseConfig(), singleInput('hi')));
+    const final = events.at(-1);
+    expect(final?.type).toBe('turn.completed');
+    if (final?.type === 'turn.completed') {
+      // closure-reason.ts maps this to ClosureReason 'truncated'.
+      expect(final.usage.stopReason).toBe('length');
+    }
+  });
+
+  it('stays silent on a clean stop — no notice on a normal completion', async () => {
+    pendingChunks = [
+      { choices: [{ delta: { content: 'all done' } }] },
+      {
+        choices: [{ delta: {}, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 3, completion_tokens: 2, total_tokens: 5 },
+      },
+    ];
+    const events = await collect(buildQueryFromConfig(baseConfig(), singleInput('hi')));
+    const messages = assistantMessages(events);
+    expect(messages).toEqual(['all done']);
+    expect(messages[0]).not.toContain('output-token limit');
+  });
+});

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -58,6 +58,7 @@ import { sumProviderUsage } from '../../usage.js';
 import { contextLimitFor, autoCompactLimitFor } from '../../model-limits.js';
 import { resolveModelId } from '../../session/model-resolution.js';
 import { collectSupportedCommands } from '../shared/supported-commands.js';
+import { isTruncationStopReason, truncationNotice } from '../shared/truncation.js';
 import { TurnTrace } from '../shared/turn-trace.js';
 import { debugLog } from '../../../utils/debug.js';
 import {
@@ -538,6 +539,16 @@ export class OpenAICompatibleQuery implements ProviderQuery {
     // CLI's formatToolCallStat renders a truthful "N tool calls" (PR 508 codex
     // review, P2).
     let toolCallCount = 0;
+    // Invariant: tool calls that were being streamed when the output cap cut the
+    // round off. `isToolCallStop` returns false for any explicit non-tool finish
+    // reason, so a call truncated mid-arguments sets needsToolDispatch=false and
+    // is discarded in-memory — it never reaches `dispatchAndAppendToolCalls`,
+    // which is the ONLY site that builds an assistant `tool_calls` message. That
+    // silent drop is correct (a half-built call would poison history with an
+    // empty tool_call_id) but invisible, so capture the names at the break to
+    // name them in the terminal notice. Must be captured inside the loop:
+    // `result.state` is a fresh StreamState per iteration.
+    let droppedToolNames: string[] = [];
 
     for (;;) {
       if (controller.signal.aborted) {
@@ -581,6 +592,9 @@ export class OpenAICompatibleQuery implements ProviderQuery {
       if (!result.needsToolDispatch) {
         // Model answered in text: a normal completion, or — when winding down —
         // the wind-down round's synthesized final answer. Emit terminal events.
+        if (isTruncationStopReason(result.state.finishReason)) {
+          droppedToolNames = finalizedToolCalls(result.state).map((c) => c.name);
+        }
         break;
       }
 
@@ -686,9 +700,23 @@ export class OpenAICompatibleQuery implements ProviderQuery {
       this.priorTurns.push(assistantTurn);
     }
 
+    // Invariant: the truncation notice is APPENDED to the single terminal
+    // assistant.message, never yielded as a second one — last-wins consumers
+    // (the non-streaming sendMessage() path, a subagent's final-message
+    // capture) keep only the LAST assistant message of a turn, so a second
+    // event would discard the model's real partial answer and surface only the
+    // warning. Same rule as the anthropic-direct terminal path. Deliberately
+    // applied AFTER the priorTurns push above: the notice is operator-facing
+    // and must not enter conversation history.
+    const truncationText = isTruncationStopReason(accumulatedUsage.stopReason)
+      ? truncationNotice(droppedToolNames, accumulatedUsage.stopReason)
+      : null;
     yield {
       type: 'assistant.message',
-      text: finalAssistantText,
+      text:
+        truncationText && finalAssistantText.length > 0
+          ? `${finalAssistantText}\n\n${truncationText}`
+          : (truncationText ?? finalAssistantText),
       sessionId: this.initSessionId,
     };
     // If the turn was cut short by a spent budget, preserve that signal for

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -709,7 +709,14 @@ export class OpenAICompatibleQuery implements ProviderQuery {
     // applied AFTER the priorTurns push above: the notice is operator-facing
     // and must not enter conversation history.
     const truncationText = isTruncationStopReason(accumulatedUsage.stopReason)
-      ? truncationNotice(droppedToolNames, accumulatedUsage.stopReason)
+      ? truncationNotice(droppedToolNames, accumulatedUsage.stopReason, {
+          // The ChatGPT OAuth Responses backend rejects every output-cap
+          // parameter, so advertising our cap setting there is ineffective.
+          canIncreaseOutputLimit: !(
+            this.opts.auth.source === 'chatgpt-oauth' &&
+            accumulatedUsage.stopReason === 'max_output_tokens'
+          ),
+        })
       : null;
     yield {
       type: 'assistant.message',

--- a/src/agent/providers/shared/truncation.test.ts
+++ b/src/agent/providers/shared/truncation.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { truncationNotice } from './truncation.js';
+
+describe('truncationNotice', () => {
+  it('recommends continuation instead of an unsupported cap setting', () => {
+    const notice = truncationNotice([], 'max_output_tokens', {
+      canIncreaseOutputLimit: false,
+    });
+
+    expect(notice).toContain('Continue in a follow-up turn or retry');
+    expect(notice).not.toContain('--max-output-tokens');
+    expect(notice).not.toContain('AFK_MAX_OUTPUT_TOKENS');
+  });
+
+  it('uses the neutral remediation for an undispatched tool too', () => {
+    const notice = truncationNotice(['read_file'], 'max_output_tokens', {
+      canIncreaseOutputLimit: false,
+    });
+
+    expect(notice).toContain('NOT dispatched (read_file)');
+    expect(notice).toContain('retry so the model can finish the action');
+    expect(notice).not.toContain('--max-output-tokens');
+  });
+
+  it('keeps the configurable-cap remediation by default', () => {
+    const notice = truncationNotice([], 'length');
+
+    expect(notice).toContain('--max-output-tokens / AFK_MAX_OUTPUT_TOKENS');
+  });
+});

--- a/src/agent/providers/shared/truncation.ts
+++ b/src/agent/providers/shared/truncation.ts
@@ -48,3 +48,60 @@ export const TRUNCATION_STOP_REASONS: readonly string[] = [
 export function isTruncationStopReason(stopReason: string | null | undefined): boolean {
   return stopReason != null && TRUNCATION_STOP_REASONS.includes(stopReason);
 }
+
+/**
+ * Contract: render the wire-accurate field name for a truncation sentinel, so
+ * the notice below quotes something the operator can actually grep for in
+ * provider docs. Each wire names the field differently and only one of the
+ * three is literally called `finish_reason`.
+ */
+function sentinelLabel(stopReason: string | null | undefined): string {
+  switch (stopReason) {
+    case 'max_tokens':
+      return 'stop_reason "max_tokens"';
+    case 'length':
+      return 'finish_reason "length"';
+    case 'max_output_tokens':
+      return 'incomplete_details.reason "max_output_tokens"';
+    default:
+      return 'the provider output-token cap';
+  }
+}
+
+/**
+ * Operator-facing notice for a turn cut off at the output-token cap (#952).
+ *
+ * Shared by both providers on purpose. The anthropic-direct terminal path and
+ * the openai-compatible turn loop reach truncation through very different
+ * machinery (a `TurnResult.toolUseBlocks` array vs. a derived
+ * `finalizedToolCalls(state)` view), but the operator-visible consequence is
+ * identical, so the WORDING must not fork. A half-mirrored notice — one
+ * provider naming the dropped tool, the other not — is itself a form of
+ * provider drift, which is why this text lives here rather than in either
+ * provider's terminal module.
+ *
+ * `droppedToolNames` are the tool calls that were truncated mid-request and
+ * therefore never dispatched. When non-empty the model announced an action that
+ * did not run, which otherwise reads to the operator as the agent stalling.
+ *
+ * Display-only in both callers: appended to the yielded `assistant.message`
+ * text, never pushed into conversation history. It is an operator warning, not
+ * model context — feeding it back would teach the model it had been cut off
+ * when the transcript it sees is already complete.
+ */
+export function truncationNotice(
+  droppedToolNames: string[],
+  stopReason?: string | null,
+): string {
+  const base =
+    `⚠ This turn was cut off at the output-token limit (${sentinelLabel(stopReason)}) before the ` +
+    'model finished — anything above is partial, not a complete answer.';
+  if (droppedToolNames.length > 0) {
+    const names = [...new Set(droppedToolNames)].join(', ');
+    return (
+      `${base} A tool call was truncated mid-request and was NOT dispatched (${names}); ` +
+      'that action did not run. Raise --max-output-tokens / AFK_MAX_OUTPUT_TOKENS, then retry.'
+    );
+  }
+  return `${base} Raise --max-output-tokens / AFK_MAX_OUTPUT_TOKENS to allow a longer reply.`;
+}

--- a/src/agent/providers/shared/truncation.ts
+++ b/src/agent/providers/shared/truncation.ts
@@ -92,16 +92,23 @@ function sentinelLabel(stopReason: string | null | undefined): string {
 export function truncationNotice(
   droppedToolNames: string[],
   stopReason?: string | null,
+  options: { canIncreaseOutputLimit?: boolean } = {},
 ): string {
   const base =
     `⚠ This turn was cut off at the output-token limit (${sentinelLabel(stopReason)}) before the ` +
     'model finished — anything above is partial, not a complete answer.';
   if (droppedToolNames.length > 0) {
     const names = [...new Set(droppedToolNames)].join(', ');
+    const remediation = options.canIncreaseOutputLimit === false
+      ? 'Continue in a follow-up turn or retry so the model can finish the action.'
+      : 'Raise --max-output-tokens / AFK_MAX_OUTPUT_TOKENS, then retry.';
     return (
       `${base} A tool call was truncated mid-request and was NOT dispatched (${names}); ` +
-      'that action did not run. Raise --max-output-tokens / AFK_MAX_OUTPUT_TOKENS, then retry.'
+      `that action did not run. ${remediation}`
     );
+  }
+  if (options.canIncreaseOutputLimit === false) {
+    return `${base} Continue in a follow-up turn or retry the request.`;
   }
   return `${base} Raise --max-output-tokens / AFK_MAX_OUTPUT_TOKENS to allow a longer reply.`;
 }


### PR DESCRIPTION
## Summary

The deferred half of #960. That PR surfaced `max_tokens` truncation on **anthropic-direct** and explicitly named the openai-compatible live-turn notice as a follow-up rather than shipping a half-mirror. This is that follow-up.

**Stacked on #960** — base branch is `fix/surface-max-tokens-truncation-952`, not `main`. Merge #960 first; this diff then reduces to the four files below.

### The bug

On the openai-compatible path a truncated turn was worse than invisible. When the output cap cuts a round off mid-tool-call:

- `isToolCallStop` returns `false` for any explicit non-tool finish reason (`translate.ts`), so `needsToolDispatch` is false;
- the half-built call is discarded in memory — **correctly**, since a call with an empty `tool_call_id` would poison history and 400 the next request;
- but nothing was emitted in its place. The turn broke out of the loop with whatever partial text existed, which for a truncated tool call is `''`.

The operator saw an empty assistant message and an agent that appeared to stall. The new negative-control test reproduces precisely that against the pre-fix file:

```
AssertionError: expected '' to contain 'output-token limit'
```

### Changes

1. **`providers/shared/truncation.ts`** — `truncationNotice()` moves here from `anthropic-direct/loop/turn-terminal.ts` and is now shared by both providers. #960 deferred this work partly because a half-mirrored notice (one provider naming the dropped tool, the other not) would itself be provider drift; sharing the string makes that drift unrepresentable. `sentinelLabel()` renders the wire-accurate field name per provider — `stop_reason "max_tokens"` / `finish_reason "length"` / `incomplete_details.reason "max_output_tokens"` — so the quoted term is greppable in the right provider's docs.
2. **`openai-compatible/query.ts`** — capture `finalizedToolCalls(state).map(c => c.name)` at the break when the round ended on a truncation sentinel, and append the notice to the terminal `assistant.message`.
3. **`anthropic-direct/loop/turn-terminal.ts`** — imports the shared helper; local copy deleted. Behaviour unchanged (its existing assertions in `loop.orphan.test.ts` still pass untouched).

### Why append rather than emit a second message

Load-bearing, not stylistic. Last-wins consumers — the non-streaming `sendMessage()` path and a subagent's final-message capture — keep only the **last** assistant message of a turn, so a second event would discard the model's real partial answer and surface only the warning. The notice is appended **after** the `priorTurns` push, so it stays operator-facing and never enters conversation history. Same rule the anthropic path already documents at `turn-terminal.ts`.

## How was this tested?

- `pnpm lint` ✓ · `audit:sdk:check` ✓ · `audit:env:check` ✓ · `audit:chalk:check` ✓
- **1492 tests pass** across `openai-compatible/`, `anthropic-direct/`, `session/`, `subagent/` (116 files).
- New `query.truncation.test.ts` (4 tests) — this behaviour had **zero** coverage before: no test in the directory drove `finish_reason: 'length'` at all, which is how the gap survived the original change. Placed in a new file rather than the already 3,397-line `query.test.ts`.
  - notice appended to partial text, partial answer ordered first, exactly one `assistant.message`
  - a tool call truncated mid-arguments is named + marked `NOT dispatched`, and provably never ran (no `tool.start`/`tool.end`)
  - `turn.completed` carries `stopReason: 'length'` so closure classification still reads `truncated`
  - clean `finish_reason: 'stop'` emits no notice
- **Negative control**: each new assertion was confirmed to FAIL against the pre-fix `query.ts` (output quoted above), so the tests pin the fix rather than passing vacuously.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes (touched files + openai-compatible/anthropic-direct/session/subagent suites)
- [x] Commits are signed off (`git commit -s`) per the DCO
- [x] No secrets, tokens, or private paths in the diff
