### PR TITLE
fix(cli): surface plugin shadowing notices on default runs

### DIFF
--- a/src/cli/commands/interactive/loop-iteration.test.ts
+++ b/src/cli/commands/interactive/loop-iteration.test.ts
@@ -117,6 +117,7 @@ import type { InteractiveCtx } from './shared.js';
 import { BackgroundAgentRegistry } from '../../../agent/background-registry.js';
 import { runTurn } from './turn-handler.js';
 import * as slashMod from '../../slash/registry.js';
+import * as pluginSkillsMod from '../../slash/plugin-skills.js';
 import { createHookRegistry } from '../../../agent/hooks.js';
 import { HookBlockedError } from '../../../utils/errors.js';
 import { HookHandlerTimeoutError } from '../../../agent/hook-registry.js';
@@ -196,6 +197,49 @@ beforeEach(() => {
     return { handled: false as const };
   });
   delete process.env.AFK_SHELL_PASSTHROUGH;
+});
+
+describe('runReplLoop — plugin shadowing notices are not debug-gated', () => {
+  it('surfaces collision notices on a default (non-debug) run', async () => {
+    // Regression: the notice assignment used to sit behind `isDebugEnabled()`,
+    // which this file mocks to `false` — so on every default run a shadowed
+    // plugin command was suppressed and discoverable only via `/skills`. The
+    // gate belonged to the adjacent debug BANNER, not to these notices; the two
+    // were conflated. With `isDebugEnabled: () => false` still in force, the
+    // notice must reach the renderer anyway.
+    vi.mocked(pluginSkillsMod.getPluginShadowingNoticeLines).mockReturnValue([
+      '  /mint: vendored or user skill wins; plugin form /example-plugin:mint stays reachable.',
+    ]);
+    // Two reads: iteration 1 lets the waitForInitialization().then() chain
+    // settle (it awaits autoRegisterPluginPassthroughs), iteration 2 flushes
+    // the pending notices at the top of the loop before exiting.
+    surfaceState.readLineQueue = [
+      { text: 'hello', attachments: [] },
+      { text: '/exit', attachments: [] },
+    ];
+
+    const ctx = makeCtx();
+    await runReplLoop(ctx, makeTranscript() as never, makeTurnState(), vi.fn());
+
+    const lines = vi.mocked(ctx.replRenderer.writeLine).mock.calls.map((c) => String(c[0]));
+    expect(lines.some((l) => l.includes('/example-plugin:mint'))).toBe(true);
+  });
+
+  it('stays silent when nothing collided', async () => {
+    // The no-collision path is the common one — an empty array must not emit a
+    // blank line or a header. Guards against "fix the gate, add noise instead".
+    vi.mocked(pluginSkillsMod.getPluginShadowingNoticeLines).mockReturnValue([]);
+    surfaceState.readLineQueue = [
+      { text: 'hello', attachments: [] },
+      { text: '/exit', attachments: [] },
+    ];
+
+    const ctx = makeCtx();
+    await runReplLoop(ctx, makeTranscript() as never, makeTurnState(), vi.fn());
+
+    const lines = vi.mocked(ctx.replRenderer.writeLine).mock.calls.map((c) => String(c[0]));
+    expect(lines.some((l) => l.includes('stays reachable'))).toBe(false);
+  });
 });
 
 describe('runReplLoop — seed-buffer auto-submit fast-path (multi-iteration)', () => {

--- a/src/cli/commands/interactive/loop-iteration.ts
+++ b/src/cli/commands/interactive/loop-iteration.ts
@@ -137,9 +137,16 @@ export async function runInputLoop(
     // Vendored or user skills win bare-name collisions with plugin skills —
     // surface a one-time dim notice telling the user where the shadowed
     // plugin form is still reachable (e.g. `/example-plugin:mint`).
-    if (isDebugEnabled()) {
-      pendingShadowingNotices = getPluginShadowingNoticeLines();
-    }
+    //
+    // Deliberately NOT gated on isDebugEnabled(), unlike the init banner
+    // above. A shadowed command is a behavioural surprise the user has to
+    // know about — their `/mint` may now resolve to a different skill than
+    // it did yesterday — not diagnostic noise. The two concerns were
+    // conflated behind one gate, which suppressed every collision notice on
+    // a default run and left shadowing discoverable only by pulling up
+    // `/skills`. Returns an empty array when nothing collided, so the
+    // common no-collision path stays silent.
+    pendingShadowingNotices = getPluginShadowingNoticeLines();
   }).catch(() => { /* init / plugin discovery non-critical */ });
 
   // Slash-command submit queue: a slash handler may return


### PR DESCRIPTION
## Problem

The one-time notice telling a user that a plugin command was shadowed by a vendored or user skill never appears on a default run.

`getPluginShadowingNoticeLines()` exists and is wired into the REPL loop, but the assignment sits behind `isDebugEnabled()`:

```ts
if (isDebugEnabled()) {
  pendingShadowingNotices = getPluginShadowingNoticeLines();
}
```

So unless the user sets `AFK_DEBUG=1`, a collision is silent. Shadowing is then discoverable only by running `/skills` and noticing an alt row.

## Why the gate is wrong

It belongs to the **adjacent debug banner**, not to these notices. The comment a few lines up explains that gate on its own terms:

> Gated on isDebugEnabled() — the banner's tool count is SDK-advertised, not the whitelisted subset, so it's misleading and noisy by default.

That rationale is about `pendingInitMeta`. The two unrelated concerns ended up behind one flag, and the notice inherited a justification that was never about it.

A shadowed command is a **behavioural surprise**, not diagnostics — the user's `/mint` may now resolve to a different skill than it did yesterday, and this notice is the only proactive signal that it happened. Suppressing it by default is precisely backwards.

## Change

Remove the gate. The consumption site already guards on `length > 0`, so the common no-collision path stays silent — this adds no noise to a normal session.

## Tests

Two regression tests, both running with `isDebugEnabled` mocked to `false` — the exact condition that hid the bug:

- a collision surfaces the notice to the renderer
- no collision emits nothing (guards against "fix the gate, add noise instead")

Verified the first test genuinely fails against the unfixed source rather than passing vacuously:

```
Tests  1 failed | 1 passed | 28 skipped (30)
  → expect(lines.some((l) => l.includes('/example-plugin:mint'))).toBe(true)
```

## Verification

| Gate | Result |
|---|---|
| `pnpm lint` | pass |
| `pnpm test:coverage` | 813 files, 15499 passed, 2 skipped, thresholds met |
| `pnpm audit:env:check` | 0 violations |
| `pnpm scan:env:check` | in sync |
| `pnpm audit:sdk:check` | lock matches |
| `pnpm audit:chalk:check` | 0 violations |

## Context

Found while scoping Claude Code plugin-command parity. It matters more than it looks: a follow-up PR will load `<plugin>/commands/*.md`, which adds a large number of new names into the same shared slash namespace. Landing that on top of invisible collisions would let a user's trusted `/foo` silently repoint with no signal at all. This is the prerequisite.
