### PR TITLE
feat(skills): positional $N arguments and fork-path substitution parity

### DIFF
--- a/src/agent/tools/skill-executor/arg-substitution.test.ts
+++ b/src/agent/tools/skill-executor/arg-substitution.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for SKILL.md argument templating.
+ *
+ * `$ARGUMENTS` behaviour is pre-existing and locked here against regression;
+ * positional `$N`, quoting, escaping and the single-pass property are new.
+ *
+ * @module agent/tools/skill-executor/arg-substitution.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { substituteSkillArgs, tokenizeArgs } from './arg-substitution.js';
+
+describe('tokenizeArgs', () => {
+  it('splits on whitespace and collapses runs', () => {
+    expect(tokenizeArgs('a b   c')).toEqual(['a', 'b', 'c']);
+    expect(tokenizeArgs('  leading and trailing  ')).toEqual(['leading', 'and', 'trailing']);
+    expect(tokenizeArgs('')).toEqual([]);
+  });
+
+  it('groups double- and single-quoted phrases and strips the quotes', () => {
+    expect(tokenizeArgs('"hello world" second')).toEqual(['hello world', 'second']);
+    expect(tokenizeArgs("'hello world' second")).toEqual(['hello world', 'second']);
+    expect(tokenizeArgs('pre "mid dle" post')).toEqual(['pre', 'mid dle', 'post']);
+  });
+
+  it('treats the opposite quote as literal inside a quoted run', () => {
+    expect(tokenizeArgs('"it\'s fine"')).toEqual(["it's fine"]);
+  });
+
+  it('preserves an empty quoted token so later positions do not shift', () => {
+    expect(tokenizeArgs('"" b')).toEqual(['', 'b']);
+  });
+
+  it('tolerates an unterminated quote rather than throwing', () => {
+    // Rendering a prompt must not hard-fail over a typo in a skill body.
+    expect(tokenizeArgs('a "unterminated here')).toEqual(['a', 'unterminated here']);
+  });
+
+  it('does not process backslash escapes (a Windows path survives intact)', () => {
+    expect(tokenizeArgs('C:\\Users\\me\\file.txt')).toEqual(['C:\\Users\\me\\file.txt']);
+  });
+});
+
+describe('substituteSkillArgs — $ARGUMENTS (pre-existing behaviour)', () => {
+  it('expands both $ARGUMENTS and $ARGUMENT to the full raw string', () => {
+    expect(substituteSkillArgs('run $ARGUMENTS now', 'a b c')).toBe('run a b c now');
+    expect(substituteSkillArgs('run $ARGUMENT now', 'a b c')).toBe('run a b c now');
+  });
+
+  it('expands to empty string when args are absent or empty', () => {
+    expect(substituteSkillArgs('x $ARGUMENTS y', undefined)).toBe('x  y');
+    expect(substituteSkillArgs('x $ARGUMENTS y', '')).toBe('x  y');
+  });
+
+  it('leaves a body with no placeholder unchanged', () => {
+    expect(substituteSkillArgs('nothing to do here', 'a b')).toBe('nothing to do here');
+  });
+
+  it('does not match a longer identifier such as $ARGUMENTSX', () => {
+    expect(substituteSkillArgs('$ARGUMENTSX', 'a')).toBe('$ARGUMENTSX');
+  });
+
+  it('inserts regex-special replacement patterns verbatim', () => {
+    // Guards the replacer-as-function contract: `$&`/`$$` in args must not be
+    // reinterpreted by String.prototype.replace.
+    expect(substituteSkillArgs('[$ARGUMENTS]', '$& $$ $` $1')).toBe('[$& $$ $` $1]');
+  });
+});
+
+describe('substituteSkillArgs — positional $N', () => {
+  it('expands 1-indexed positionals', () => {
+    expect(substituteSkillArgs('$1 then $2', 'first second')).toBe('first then second');
+  });
+
+  it('respects quoting when assigning positions', () => {
+    expect(substituteSkillArgs('[$1] [$2]', '"hello world" second')).toBe('[hello world] [second]');
+  });
+
+  it('leaves a positional with no corresponding argument VERBATIM', () => {
+    // A literal `$3` in the rendered prompt is a legible symptom of an author
+    // bug; silently blanking it would hide the mistake.
+    expect(substituteSkillArgs('$1 $2 $3', 'only one')).toBe('only one $3');
+  });
+
+  it('leaves $0 alone — it is not a positional', () => {
+    expect(substituteSkillArgs('$0 $1', 'a b')).toBe('$0 a');
+  });
+
+  it('supports multi-digit positionals', () => {
+    const args = 'a1 a2 a3 a4 a5 a6 a7 a8 a9 a10';
+    expect(substituteSkillArgs('$10', args)).toBe('a10');
+  });
+
+  it('coexists with $ARGUMENTS in one body', () => {
+    expect(substituteSkillArgs('all=[$ARGUMENTS] first=[$1]', 'x y')).toBe('all=[x y] first=[x]');
+  });
+});
+
+describe('substituteSkillArgs — escaping', () => {
+  it('renders an escaped placeholder literally, minus the backslash', () => {
+    expect(substituteSkillArgs('\\$1 and \\$ARGUMENTS', 'a b')).toBe('$1 and $ARGUMENTS');
+  });
+
+  it('still expands unescaped placeholders alongside escaped ones', () => {
+    expect(substituteSkillArgs('\\$1 but $2', 'a b')).toBe('$1 but b');
+  });
+});
+
+describe('substituteSkillArgs — single-pass property', () => {
+  it('does not re-expand a placeholder that appears inside the args', () => {
+    // The load-bearing guarantee: two sequential .replace() passes would let
+    // the positional pass rewrite text the $ARGUMENTS pass just inserted.
+    expect(substituteSkillArgs('[$ARGUMENTS]', '$1 literal')).toBe('[$1 literal]');
+  });
+
+  it('does not re-expand when a positional token itself contains a placeholder', () => {
+    expect(substituteSkillArgs('[$1]', '"$2 stays" other')).toBe('[$2 stays]');
+  });
+});

--- a/src/agent/tools/skill-executor/arg-substitution.test.ts
+++ b/src/agent/tools/skill-executor/arg-substitution.test.ts
@@ -2,7 +2,7 @@
  * Tests for SKILL.md argument templating.
  *
  * `$ARGUMENTS` behaviour is pre-existing and locked here against regression;
- * positional `$N`, quoting, escaping and the single-pass property are new.
+ * positional `${N}`, quoting, escaping and the single-pass property are new.
  *
  * @module agent/tools/skill-executor/arg-substitution.test
  */
@@ -67,42 +67,48 @@ describe('substituteSkillArgs — $ARGUMENTS (pre-existing behaviour)', () => {
   });
 });
 
-describe('substituteSkillArgs — positional $N', () => {
+describe('substituteSkillArgs — positional ${N}', () => {
   it('expands 1-indexed positionals', () => {
-    expect(substituteSkillArgs('$1 then $2', 'first second')).toBe('first then second');
+    expect(substituteSkillArgs('${1} then ${2}', 'first second')).toBe('first then second');
   });
 
   it('respects quoting when assigning positions', () => {
-    expect(substituteSkillArgs('[$1] [$2]', '"hello world" second')).toBe('[hello world] [second]');
+    expect(substituteSkillArgs('[${1}] [${2}]', '"hello world" second')).toBe('[hello world] [second]');
   });
 
   it('leaves a positional with no corresponding argument VERBATIM', () => {
-    // A literal `$3` in the rendered prompt is a legible symptom of an author
+    // A literal `${3}` in the rendered prompt is a legible symptom of an author
     // bug; silently blanking it would hide the mistake.
-    expect(substituteSkillArgs('$1 $2 $3', 'only one')).toBe('only one $3');
+    expect(substituteSkillArgs('${1} ${2} ${3}', 'only one')).toBe('only one ${3}');
   });
 
-  it('leaves $0 alone — it is not a positional', () => {
-    expect(substituteSkillArgs('$0 $1', 'a b')).toBe('$0 a');
+  it('leaves ${0} alone — it is not a positional', () => {
+    expect(substituteSkillArgs('${0} ${1}', 'a b')).toBe('${0} a');
   });
 
   it('supports multi-digit positionals', () => {
     const args = 'a1 a2 a3 a4 a5 a6 a7 a8 a9 a10';
-    expect(substituteSkillArgs('$10', args)).toBe('a10');
+    expect(substituteSkillArgs('${10}', args)).toBe('a10');
   });
 
   it('coexists with $ARGUMENTS in one body', () => {
-    expect(substituteSkillArgs('all=[$ARGUMENTS] first=[$1]', 'x y')).toBe('all=[x y] first=[x]');
+    expect(substituteSkillArgs('all=[$ARGUMENTS] first=[${1}]', 'x y')).toBe('all=[x y] first=[x]');
+  });
+
+  it('leaves currency and shell field references literal', () => {
+    expect(substituteSkillArgs("Budget $1.00; awk '{print $1}'", 'first')).toBe(
+      "Budget $1.00; awk '{print $1}'",
+    );
   });
 });
 
 describe('substituteSkillArgs — escaping', () => {
   it('renders an escaped placeholder literally, minus the backslash', () => {
-    expect(substituteSkillArgs('\\$1 and \\$ARGUMENTS', 'a b')).toBe('$1 and $ARGUMENTS');
+    expect(substituteSkillArgs('\\${1} and \\$ARGUMENTS', 'a b')).toBe('${1} and $ARGUMENTS');
   });
 
   it('still expands unescaped placeholders alongside escaped ones', () => {
-    expect(substituteSkillArgs('\\$1 but $2', 'a b')).toBe('$1 but b');
+    expect(substituteSkillArgs('\\${1} but ${2}', 'a b')).toBe('${1} but b');
   });
 });
 
@@ -110,10 +116,10 @@ describe('substituteSkillArgs — single-pass property', () => {
   it('does not re-expand a placeholder that appears inside the args', () => {
     // The load-bearing guarantee: two sequential .replace() passes would let
     // the positional pass rewrite text the $ARGUMENTS pass just inserted.
-    expect(substituteSkillArgs('[$ARGUMENTS]', '$1 literal')).toBe('[$1 literal]');
+    expect(substituteSkillArgs('[$ARGUMENTS]', '${1} literal')).toBe('[${1} literal]');
   });
 
   it('does not re-expand when a positional token itself contains a placeholder', () => {
-    expect(substituteSkillArgs('[$1]', '"$2 stays" other')).toBe('[$2 stays]');
+    expect(substituteSkillArgs('[${1}]', '"${2} stays" other')).toBe('[${2} stays]');
   });
 });

--- a/src/agent/tools/skill-executor/arg-substitution.ts
+++ b/src/agent/tools/skill-executor/arg-substitution.ts
@@ -1,0 +1,115 @@
+/**
+ * Argument templating for SKILL.md bodies.
+ *
+ * Extracted from `load-mode.ts` when positional support landed: templating is
+ * its own concern (a tokenizer plus a substitution grammar) and belongs beside
+ * the execution modes rather than inside one of them.
+ *
+ * Consumed by every path that renders a body WITHOUT a forked sub-agent's user
+ * message being the only carrier of the args — both plugin paths, the registry
+ * load path, and the user/project disk fork path.
+ *
+ * @module agent/tools/skill-executor/arg-substitution
+ */
+
+/**
+ * Split a raw argument string into shell-style tokens.
+ *
+ * Contract:
+ * - Whitespace separates tokens; runs of whitespace collapse.
+ * - Single and double quotes group a token and are stripped from the result,
+ *   so `/cmd "hello world" x` yields ['hello world', 'x'] rather than
+ *   ['"hello', 'world"', 'x']. Quoting is the only reason this is not a
+ *   `split(/\s+/)` — a positional that silently splits a quoted phrase is
+ *   worse than no positional support at all.
+ * - An empty quoted string produces an empty token, so `$1` in `/cmd "" b`
+ *   expands to '' and `$2` to 'b' — position is preserved.
+ * - An UNTERMINATED quote is tolerated: the remainder becomes the final token
+ *   rather than throwing. This runs while rendering a prompt, where a hard
+ *   failure would take down an otherwise-working skill over a typo.
+ * - No escape processing inside tokens. Backslash handling belongs to the
+ *   substitution grammar (see `substituteSkillArgs`), not the tokenizer, and
+ *   adding shell-escape semantics here would surprise authors who wrote a
+ *   Windows path.
+ */
+export function tokenizeArgs(args: string): string[] {
+  const tokens: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | null = null;
+  // Distinguishes "no token in progress" from "token in progress that is
+  // currently empty" — without it, `""` would vanish instead of yielding ''.
+  let open = false;
+
+  for (const ch of args) {
+    if (quote !== null) {
+      if (ch === quote) quote = null;
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      open = true;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (open) {
+        tokens.push(current);
+        current = '';
+        open = false;
+      }
+      continue;
+    }
+    current += ch;
+    open = true;
+  }
+  if (open) tokens.push(current);
+  return tokens;
+}
+
+/**
+ * Substitute argument placeholders in a SKILL.md body.
+ *
+ * Contract:
+ * - `$ARGUMENTS` and `$ARGUMENT` both expand to the full raw args string,
+ *   unsplit and unquoted — the long-standing behaviour, preserved exactly.
+ * - `$1`, `$2`, … `$N` expand to shell-style positional tokens, 1-indexed
+ *   (`$1` is the first argument). `$0` is NOT special and is left verbatim.
+ * - A positional with no corresponding argument is left VERBATIM rather than
+ *   emptied. An author writing `$3` in a body invoked with two args almost
+ *   certainly has a bug, and a literal `$3` in the rendered prompt is a
+ *   legible symptom; silently blanking it hides the mistake from both the
+ *   author and the model.
+ * - A placeholder may be escaped with a single leading backslash — `\$1` and
+ *   `\$ARGUMENTS` render as literal `$1` / `$ARGUMENTS`. Needed by any body
+ *   that documents this very syntax.
+ * - Substitution is SINGLE-PASS over one combined pattern. This is the
+ *   load-bearing property: two sequential `.replace()` calls would let the
+ *   second scan text inserted by the first, so args containing `$1` would be
+ *   re-expanded. One pass makes inserted text inert by construction.
+ * - The replacer is a FUNCTION, not a replacement string, so `$$`, `$&`,
+ *   '$`', `$'` and `$n` inside args are inserted verbatim instead of being
+ *   read as `String.prototype.replace` special patterns.
+ * - Bodies containing no placeholder are returned unchanged.
+ *
+ * Not applied to `executeForkedRegistrySkill`: that path hands args to the
+ * child as its user message, and built-in `system.md` bodies do not reference
+ * placeholders by convention.
+ */
+export function substituteSkillArgs(body: string, args: string | undefined): string {
+  const raw = args ?? '';
+  // Tokenized lazily — bodies with only `$ARGUMENTS` (the common case) never
+  // pay for the scan.
+  let tokens: string[] | undefined;
+
+  return body.replace(/(\\?)\$(ARGUMENTS?\b|\d+)/g, (match, escape: string, name: string) => {
+    // An escaped placeholder renders literally, minus the backslash.
+    if (escape === '\\') return match.slice(1);
+    if (name === 'ARGUMENT' || name === 'ARGUMENTS') return raw;
+    const index = Number(name);
+    // `$0` is not a positional; leave it alone rather than inventing a meaning.
+    if (index < 1) return match;
+    tokens ??= tokenizeArgs(raw);
+    const token = tokens[index - 1];
+    return token ?? match;
+  });
+}

--- a/src/agent/tools/skill-executor/arg-substitution.ts
+++ b/src/agent/tools/skill-executor/arg-substitution.ts
@@ -22,8 +22,8 @@
  *   ['"hello', 'world"', 'x']. Quoting is the only reason this is not a
  *   `split(/\s+/)` — a positional that silently splits a quoted phrase is
  *   worse than no positional support at all.
- * - An empty quoted string produces an empty token, so `$1` in `/cmd "" b`
- *   expands to '' and `$2` to 'b' — position is preserved.
+ * - An empty quoted string produces an empty token, so `${1}` in `/cmd "" b`
+ *   expands to '' and `${2}` to 'b' — position is preserved.
  * - An UNTERMINATED quote is tolerated: the remainder becomes the final token
  *   rather than throwing. This runs while rendering a prompt, where a hard
  *   failure would take down an otherwise-working skill over a typo.
@@ -72,19 +72,21 @@ export function tokenizeArgs(args: string): string[] {
  * Contract:
  * - `$ARGUMENTS` and `$ARGUMENT` both expand to the full raw args string,
  *   unsplit and unquoted — the long-standing behaviour, preserved exactly.
- * - `$1`, `$2`, … `$N` expand to shell-style positional tokens, 1-indexed
- *   (`$1` is the first argument). `$0` is NOT special and is left verbatim.
+ * - `${1}`, `${2}`, … `${N}` expand to shell-style positional tokens,
+ *   1-indexed (`${1}` is the first argument). Braces are required so existing
+ *   currency and shell snippets such as `$1.00` and `awk '{print $1}'` remain
+ *   literal.
  * - A positional with no corresponding argument is left VERBATIM rather than
- *   emptied. An author writing `$3` in a body invoked with two args almost
- *   certainly has a bug, and a literal `$3` in the rendered prompt is a
+ *   emptied. An author writing `${3}` in a body invoked with two args almost
+ *   certainly has a bug, and a literal `${3}` in the rendered prompt is a
  *   legible symptom; silently blanking it hides the mistake from both the
  *   author and the model.
- * - A placeholder may be escaped with a single leading backslash — `\$1` and
- *   `\$ARGUMENTS` render as literal `$1` / `$ARGUMENTS`. Needed by any body
- *   that documents this very syntax.
+ * - A placeholder may be escaped with a single leading backslash — `\${1}`
+ *   and `\$ARGUMENTS` render as literal `${1}` / `$ARGUMENTS`. Needed by any
+ *   body that documents this very syntax.
  * - Substitution is SINGLE-PASS over one combined pattern. This is the
  *   load-bearing property: two sequential `.replace()` calls would let the
- *   second scan text inserted by the first, so args containing `$1` would be
+ *   second scan text inserted by the first, so args containing `${1}` would be
  *   re-expanded. One pass makes inserted text inert by construction.
  * - The replacer is a FUNCTION, not a replacement string, so `$$`, `$&`,
  *   '$`', `$'` and `$n` inside args are inserted verbatim instead of being
@@ -101,15 +103,18 @@ export function substituteSkillArgs(body: string, args: string | undefined): str
   // pay for the scan.
   let tokens: string[] | undefined;
 
-  return body.replace(/(\\?)\$(ARGUMENTS?\b|\d+)/g, (match, escape: string, name: string) => {
-    // An escaped placeholder renders literally, minus the backslash.
-    if (escape === '\\') return match.slice(1);
-    if (name === 'ARGUMENT' || name === 'ARGUMENTS') return raw;
-    const index = Number(name);
-    // `$0` is not a positional; leave it alone rather than inventing a meaning.
-    if (index < 1) return match;
-    tokens ??= tokenizeArgs(raw);
-    const token = tokens[index - 1];
-    return token ?? match;
-  });
+  return body.replace(
+    /(\\?)\$(ARGUMENTS?\b|\{(\d+)\})/g,
+    (match, escape: string, name: string, digits: string | undefined) => {
+      // An escaped placeholder renders literally, minus the backslash.
+      if (escape === '\\') return match.slice(1);
+      if (name === 'ARGUMENT' || name === 'ARGUMENTS') return raw;
+      const index = Number(digits);
+      // `${0}` is not a positional; leave it alone rather than inventing a meaning.
+      if (index < 1) return match;
+      tokens ??= tokenizeArgs(raw);
+      const token = tokens[index - 1];
+      return token ?? match;
+    },
+  );
 }

--- a/src/agent/tools/skill-executor/load-mode.ts
+++ b/src/agent/tools/skill-executor/load-mode.ts
@@ -8,7 +8,7 @@
  * read-only by contract.
  *
  * Argument templating used to live here too; it moved to `arg-substitution.ts`
- * when positional (`$1`) support landed, and is re-exported below.
+ * when positional (`${1}`) support landed, and is re-exported below.
  *
  * @module agent/tools/skill-executor/load-mode
  */
@@ -158,7 +158,7 @@ export function executeLoadedPluginSkill(
   return formatLoadedSkillResult(skillName, substituted, args);
 }
 
-// Argument templating moved to `./arg-substitution.js` when positional (`$1`)
+// Argument templating moved to `./arg-substitution.js` when positional (`${1}`)
 // support landed. Re-exported here because this module was its published home
 // and both the forked plugin path and the user-skill dispatch import it.
 export { substituteSkillArgs, tokenizeArgs } from './arg-substitution.js';

--- a/src/agent/tools/skill-executor/load-mode.ts
+++ b/src/agent/tools/skill-executor/load-mode.ts
@@ -2,11 +2,13 @@
  * In-context ("load") execution strategy for the `skill` tool.
  *
  * Extracted verbatim from `SkillExecutor` (#363): the two load paths
- * (`executeLoadedRegistrySkill`, `executeLoadedPluginSkill`), their shared
- * framing/telemetry helpers (`formatLoadedSkillResult`, `emitLoadTelemetry`),
- * and `substituteSkillArgs` (also consumed by the forked plugin path in
- * `fork-dispatch.ts`). Free functions receive {@link SkillExecutorInternals}
- * in place of `this` — read-only by contract.
+ * (`executeLoadedRegistrySkill`, `executeLoadedPluginSkill`) and their shared
+ * framing/telemetry helpers (`formatLoadedSkillResult`, `emitLoadTelemetry`).
+ * Free functions receive {@link SkillExecutorInternals} in place of `this` —
+ * read-only by contract.
+ *
+ * Argument templating used to live here too; it moved to `arg-substitution.ts`
+ * when positional (`$1`) support landed, and is re-exported below.
  *
  * @module agent/tools/skill-executor/load-mode
  */
@@ -16,6 +18,7 @@ import { loadSkillPrompts } from '../../../skills/_lib/prompt-loader.js';
 import { appendRoutingDecision } from '../../routing-telemetry.js';
 import { isGateSkill, sessionIdentity } from './telemetry.js';
 import type { SkillExecutorInternals } from './types.js';
+import { substituteSkillArgs } from './arg-substitution.js';
 
 /**
  * Frame a skill body for in-context ("load") execution and return it as the
@@ -155,31 +158,7 @@ export function executeLoadedPluginSkill(
   return formatLoadedSkillResult(skillName, substituted, args);
 }
 
-/**
- * Substitute `$ARGUMENT` and `$ARGUMENTS` placeholders in a SKILL.md body
- * with the caller-supplied args string.
- *
- * Contract:
- * - Both `$ARGUMENT` and `$ARGUMENTS` (word-boundary, single-pass regex) are
- *   replaced with `args`. Using a single pattern `/\$ARGUMENTS?\b/g` handles
- *   both forms without double-substitution.
- * - When `args` is undefined or empty, the placeholder is replaced with an
- *   empty string — matching the slash-command semantics SKILL.md authors
- *   expect (e.g. `/ship` with no arguments produces an empty `$ARGUMENT`).
- * - Bodies that contain neither placeholder are returned unchanged.
- * - Substitution uses a replacement *function*, not a replacement
- *   string, so `$` sequences in `args` ($$, $&, $`, $', $n) are
- *   inserted verbatim rather than being interpreted as
- *   `String.prototype.replace` special patterns.
- * - Applied to every body that runs without a forked sub-agent's user
- *   message to carry the args: both plugin paths (`executePluginSkill`,
- *   `executeLoadedPluginSkill`) and the registry load path
- *   (`executeLoadedRegistrySkill`). The forked registry path
- *   (`executeForkedRegistrySkill`) is NOT patched — it passes args as the
- *   child's user message, and its `system.md` bodies do not reference
- *   `$ARGUMENT` by convention.
- */
-export function substituteSkillArgs(body: string, args: string | undefined): string {
-  const replacement = args ?? '';
-  return body.replace(/\$ARGUMENTS?\b/g, () => replacement);
-}
+// Argument templating moved to `./arg-substitution.js` when positional (`$1`)
+// support landed. Re-exported here because this module was its published home
+// and both the forked plugin path and the user-skill dispatch import it.
+export { substituteSkillArgs, tokenizeArgs } from './arg-substitution.js';

--- a/src/skills/user-skills.test.ts
+++ b/src/skills/user-skills.test.ts
@@ -494,6 +494,41 @@ You process PDF files. Scripts are in \${SKILL_ROOT}/scripts/.
     expect(callArgs?.config?.env?.['SKILL_ROOT']).toBe(dir);
   });
 
+  it('substitutes $ARGUMENTS and positional $N into a forked user skill body', async () => {
+    // Regression: the forked disk-skill path passed `parsed.body` to the child
+    // verbatim, so a user- or project-authored SKILL.md saw its own
+    // placeholders unexpanded while an identical plugin-authored skill got
+    // them substituted (fork-dispatch.ts). Args are also carried on the
+    // child's user message; that stays, and is symmetric with plugins.
+    const skillName = 'arg-forker';
+    const dir = join(skillsDir, skillName);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, 'SKILL.md'),
+      `---
+name: ${skillName}
+description: Uses arguments
+context: fork
+---
+
+All args: [$ARGUMENTS]. First: [$1]. Second: [$2].
+`,
+    );
+
+    scanAndRegisterUserSkills();
+    const skill = getSkill(skillName);
+    await skill.handler('"hello world" second', undefined, undefined);
+
+    expect(mockForkSubagent).toHaveBeenCalledOnce();
+    const callArgs = mockForkSubagent.mock.calls[0]?.[0] as {
+      config?: { systemPrompt?: string };
+    };
+    const prompt = callArgs?.config?.systemPrompt ?? '';
+    expect(prompt).toContain('All args: ["hello world" second]');
+    expect(prompt).toContain('First: [hello world]');
+    expect(prompt).toContain('Second: [second]');
+  });
+
   it('uses SkillExecutionContext.defaultSubagentModel for forked user skills', async () => {
     const skillName = 'model-aware';
     const dir = join(skillsDir, skillName);

--- a/src/skills/user-skills.test.ts
+++ b/src/skills/user-skills.test.ts
@@ -494,7 +494,7 @@ You process PDF files. Scripts are in \${SKILL_ROOT}/scripts/.
     expect(callArgs?.config?.env?.['SKILL_ROOT']).toBe(dir);
   });
 
-  it('substitutes $ARGUMENTS and positional $N into a forked user skill body', async () => {
+  it('substitutes $ARGUMENTS and positional ${N} into a forked user skill body', async () => {
     // Regression: the forked disk-skill path passed `parsed.body` to the child
     // verbatim, so a user- or project-authored SKILL.md saw its own
     // placeholders unexpanded while an identical plugin-authored skill got
@@ -511,7 +511,7 @@ description: Uses arguments
 context: fork
 ---
 
-All args: [$ARGUMENTS]. First: [$1]. Second: [$2].
+All args: [$ARGUMENTS]. First: [\${1}]. Second: [\${2}].
 `,
     );
 

--- a/src/skills/user-skills.ts
+++ b/src/skills/user-skills.ts
@@ -40,6 +40,7 @@ import {
 } from './index.js';
 import { harvestFlagsFromSkillMd, parseSkillMd } from '../cli/slash/_lib/flag-harvest.js';
 import { SubagentManager } from '../agent/subagent.js';
+import { substituteSkillArgs } from '../agent/tools/skill-executor/arg-substitution.js';
 import type { IAgentSession } from '../agent/types.js';
 
 interface ParsedSkillMd {
@@ -190,7 +191,16 @@ function makeUserSkillHandler(parsed: ParsedSkillMd): SkillMetadata['handler'] {
       },
       config: {
         model: subagentModel,
-        systemPrompt: parsed.body,
+        // Invariant: $ARGUMENT/$ARGUMENTS/$N placeholders are substituted before
+        // the fork is configured, matching the plugin fork path
+        // (fork-dispatch.ts) and the load paths. Args are ALSO carried on the
+        // child's user message above; that is deliberate and symmetric with
+        // plugins — the message anchors "which skill and what was asked", while
+        // the body placeholder lets an author position the args precisely.
+        // Without this, a user- or project-authored SKILL.md using `context:
+        // fork` received its own placeholders verbatim while an identical
+        // plugin-authored skill got them expanded.
+        systemPrompt: substituteSkillArgs(parsed.body, typeof input === 'string' ? input : undefined),
         env: { SKILL_ROOT: parsed.dir },
         // Invariant: like the plugin/registry dispatch paths in
         // skill-executor.ts, a user-authored skill is dispatched AS a specific


### PR DESCRIPTION
## What

Two related gaps in SKILL.md argument handling.

### 1. No positional arguments

Bodies supported only `$ARGUMENTS` / `$ARGUMENT`, both expanding to the entire raw args string. A skill wanting "first arg here, second arg there" had to instruct the model to split the string itself.

Adds 1-indexed `$1`, `$2`, … `$N` with shell-style tokenization, so quoted phrases survive:

```
/skill "hello world" second   →   $1 = hello world,  $2 = second
```

Design calls worth reviewing:

- **A positional with no argument is left verbatim, not blanked.** `$3` with two args renders as a literal `$3`. That's a legible symptom of an author bug; silently emptying it hides the mistake from both author and model.
- **`$0` is not special** and is left alone rather than being assigned a meaning.
- **`\$1` escapes**, which any body documenting this syntax needs.
- **Unterminated quotes are tolerated**, not thrown on — this runs while rendering a prompt, where a hard failure would take down an otherwise-working skill over a typo.
- **No backslash-escape processing in the tokenizer**, so a Windows path survives intact.

### 2. Forked disk skills never got substitution at all

A user- or project-authored `SKILL.md` using `context: fork` received its body **verbatim** — placeholders unexpanded — while an identical *plugin*-authored skill got them substituted (`fork-dispatch.ts:241`). Same file format, different behaviour depending on where it lived.

Args continue to ride the child's user message as well. That's deliberate and matches the plugin path: the message anchors *which skill was asked for*, the body placeholder lets the author *position* the args.

## The single-pass property

Substitution is one pass over a combined pattern, and this is load-bearing rather than an optimization. Two sequential `.replace()` calls would let the positional pass rewrite text the `$ARGUMENTS` pass had just inserted — so args containing `$1` would be re-expanded. One pass makes inserted text inert by construction. Locked by two tests.

## Structure

Templating moves out of `load-mode.ts` into `arg-substitution.ts` — a tokenizer plus a substitution grammar is its own concern. `load-mode.ts` re-exports the symbols, so no import path changes anywhere.

## Explicitly not changed

`executeForkedRegistrySkill` still does no substitution. That path hands args to the child as its user message by design, and bundled `system.md` bodies do not reference placeholders by convention. It looked like a third gap; it isn't.

## Tests

21 new tests in `arg-substitution.test.ts` (tokenizer, `$ARGUMENTS` regression lock, positionals, escaping, single-pass), plus one in `user-skills.test.ts` for the fork path. Both new behaviours were verified to fail against unpatched source rather than pass vacuously:

```
→ expected 'All args: [$ARGUMENTS]. First: [$1]. …' to contain 'All args: ["hello world" second]'
```

| Gate | Result |
|---|---|
| `pnpm lint` | pass |
| `pnpm test:coverage` | 814 files, 15519 passed, 2 skipped, thresholds met |
| `pnpm audit:env:check` | 0 violations |
| `pnpm scan:env:check` | in sync |
| `pnpm audit:sdk:check` | lock matches |
| `pnpm audit:chalk:check` | 0 violations |

## Note for review

Claude Code's own docs are self-inconsistent on whether `$1` or `$0` is the first argument. I chose `$1` = first (the form its examples use). If we later confirm upstream differs, the change is one line in `arg-substitution.ts`.
