### PR TITLE
feat(plugins): load Claude Code commands/*.md as slash commands

### DIFF
--- a/src/agent/plugins/command-files.test.ts
+++ b/src/agent/plugins/command-files.test.ts
@@ -7,7 +7,7 @@
  * @module agent/plugins/command-files.test
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -188,6 +188,44 @@ describe('normalizeSkillSource', () => {
   it('still handles BOM+CRLF when combined with control stripping and truncation', () => {
     const result = normalizeSkillSource('\uFEFF---\r\ndescription: d\r\n---\r\n\r\nBody.\r\n');
     expect(result).toBe('---\ndescription: d\n---\n\nBody.\n');
+  });
+
+  it('strips a terminal escape embedded in an untrusted plugin filename', () => {
+    // The AFK_DEBUG skip diagnostics interpolate raw `readdirSync` entries
+    // from a third-party plugin tree. Without sanitisation, a directory or
+    // file named with a CSI/OSC sequence executes against the operator's
+    // terminal the moment discovery logs the skip.
+    const tmp = mkdtempSync(join(tmpdir(), 'cmd-esc-'));
+    try {
+      vi.stubEnv('AFK_DEBUG', '1');
+      mkdirSync(join(tmp, 'commands'), { recursive: true });
+      writeFileSync(join(tmp, 'commands', 'evil\x1b[2J\x1b[H.txt'), 'x');
+
+      const writes: string[] = [];
+      const spy = vi
+        .spyOn(process.stderr, 'write')
+        .mockImplementation((chunk: unknown) => {
+          writes.push(String(chunk));
+          return true;
+        });
+      extractPluginCommands(tmp);
+      spy.mockRestore();
+
+      const emitted = writes.join('');
+      expect(emitted).toContain('skipping');
+      expect(emitted).not.toContain('\x1b');
+    } finally {
+      vi.unstubAllEnvs();
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('folds a lone CR to LF rather than stripping it as a control char', () => {
+    // Order invariant: CR (0x0D) falls inside the control-strip range
+    // [\x00-\x08\x0B-\x1F], so it survives only because newline
+    // normalisation runs FIRST and turns it into \n. Reordering the two
+    // passes would silently delete the line break instead of keeping it.
+    expect(normalizeSkillSource('a\rb')).toBe('a\nb');
   });
 
   it('never throws, and truncation alone never discards non-control content', () => {

--- a/src/agent/plugins/command-files.test.ts
+++ b/src/agent/plugins/command-files.test.ts
@@ -51,6 +51,39 @@ describe('extractPluginCommands', () => {
       body: 'Review this pull request: $ARGUMENTS',
       origin: 'command',
     });
+    // A frontmatter-free file declares no description; collectSkillEntries
+    // supplies the plugin-path fallback downstream.
+    expect(found[0]?.description).toBeUndefined();
+  });
+
+  it('parses a CRLF-authored command instead of leaking its frontmatter into the body', () => {
+    // A Windows-authored file fails a byte-exact `---\n` test, so without
+    // normalisation the whole YAML block was handed to the model as the prompt.
+    writeCommand('crlf.md', '---\r\ndescription: Ship it\r\n---\r\n\r\nDeploy the app.\r\n');
+    const found = extractPluginCommands(pluginDir);
+    expect(found).toHaveLength(1);
+    expect(found[0]?.description).toBe('Ship it');
+    expect(found[0]?.body).toBe('Deploy the app.');
+    expect(found[0]?.body).not.toContain('---');
+  });
+
+  it('parses a BOM-prefixed command instead of leaking its frontmatter into the body', () => {
+    writeCommand('bom.md', '\uFEFF---\ndescription: Ship it\n---\n\nDeploy the app.\n');
+    const found = extractPluginCommands(pluginDir);
+    expect(found).toHaveLength(1);
+    expect(found[0]?.description).toBe('Ship it');
+    expect(found[0]?.body).toBe('Deploy the app.');
+    expect(found[0]?.body).not.toContain('---');
+  });
+
+  it('skips a path segment containing the namespace separator', () => {
+    // `a:b.md` would derive the same name as `a/b.md`; registering both lets
+    // the first-wins guard drop one at random.
+    writeCommand('a:b.md', '---\ndescription: d\n---\n\nBody.\n');
+    writeCommand('a/b.md', '---\ndescription: d\n---\n\nBody.\n');
+    const names = extractPluginCommands(pluginDir).map((c) => c.name);
+    expect(names).toEqual(['a:b']);
+    expect(names).toHaveLength(1);
   });
 
   it('namespaces a subdirectory with a colon (CC parity)', () => {
@@ -117,5 +150,7 @@ describe('extractPluginCommands', () => {
     writeCommand('bad.md', '---\ndescription: unterminated frontmatter');
     const names = extractPluginCommands(pluginDir).map((c) => c.name);
     expect(names).toContain('good');
+    // The malformed sibling must be dropped, not registered with a raw body.
+    expect(names).not.toContain('bad');
   });
 });

--- a/src/agent/plugins/command-files.test.ts
+++ b/src/agent/plugins/command-files.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { extractPluginCommands } from './command-files.js';
@@ -98,6 +98,60 @@ describe('extractPluginCommands', () => {
     expect(names).toEqual(['a:b']);
     expect(names).toHaveLength(1);
     expect(found[0]?.body).toBe('Slash body.');
+  });
+
+  it('skips a .md command whose filename carries a terminal escape', () => {
+    // The name comes from the PATH, so a filename is the one place a plugin
+    // can inject bytes into it — and the name is later written to the terminal
+    // by the /skills listing and by the shadowing notice, neither of which
+    // sanitizes. The fixture MUST end in `.md`: a `.txt` fixture is rejected
+    // by the extension filter before the name is ever derived, so it cannot
+    // exercise this guard no matter how the guard behaves.
+    writeCommand('evil\x1b[2J\x1b[H.md', '---\ndescription: d\n---\n\nEvil body.\n');
+    writeCommand('safe.md', '---\ndescription: d\n---\n\nSafe body.\n');
+    const found = extractPluginCommands(pluginDir);
+    expect(found.map((c) => c.name)).toEqual(['safe']);
+    // Guard the property, not just the count: no registered name may carry a
+    // control byte, however many commands a plugin ships.
+    for (const c of found) expect(c.name).not.toMatch(/[\u0000-\u001F\u007F-\u009F]/);
+  });
+
+  it('skips a subdirectory segment carrying a control byte', () => {
+    // Directory segments reach the name through `segments`, a different route
+    // than the filename `base` — both must be rejected by the single guard.
+    writeCommand('ev\x07il/cmd.md', '---\ndescription: d\n---\n\nEvil body.\n');
+    writeCommand('ok/cmd.md', '---\ndescription: d\n---\n\nOk body.\n');
+    const found = extractPluginCommands(pluginDir);
+    expect(found.map((c) => c.name)).toEqual(['ok:cmd']);
+  });
+
+  it('skips a filename carrying a C1 control byte (8-bit CSI)', () => {
+    // U+009B is CSI in 8-bit form: terminals in 8-bit mode act on it exactly
+    // as they do on ESC-[, so restricting the guard to C0 would leave a
+    // working vector open.
+    writeCommand('evil\u009b2J.md', '---\ndescription: d\n---\n\nEvil body.\n');
+    expect(extractPluginCommands(pluginDir)).toEqual([]);
+  });
+
+  it('excludes a commands/ entry symlinked outside the plugin tree', () => {
+    // `resolveContained` is the control stopping a plugin from symlinking a
+    // private key or credential file into `commands/` and having it become a
+    // dispatchable prompt. The accept-path is covered incidentally by every
+    // other case here; this asserts the REJECT branch, which had no coverage
+    // anywhere in the repo.
+    const outside = mkdtempSync(join(tmpdir(), 'plugin-commands-outside-'));
+    try {
+      const secret = join(outside, 'secret.md');
+      writeFileSync(secret, '---\ndescription: d\n---\n\nSecret body.\n');
+      mkdirSync(join(pluginDir, 'commands'), { recursive: true });
+      symlinkSync(secret, join(pluginDir, 'commands', 'help.md'));
+      writeCommand('safe.md', '---\ndescription: d\n---\n\nSafe body.\n');
+      const found = extractPluginCommands(pluginDir);
+      expect(found.map((c) => c.name)).toEqual(['safe']);
+      expect(found.map((c) => c.body).join('')).not.toContain('Secret body.');
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
   });
 
   it('namespaces a subdirectory with a colon (CC parity)', () => {

--- a/src/agent/plugins/command-files.test.ts
+++ b/src/agent/plugins/command-files.test.ts
@@ -12,6 +12,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { extractPluginCommands } from './command-files.js';
+import { normalizeSkillSource, MAX_SKILL_SOURCE_CHARS } from './source-guard.js';
 
 let pluginDir: string;
 
@@ -86,12 +87,17 @@ describe('extractPluginCommands', () => {
 
   it('skips a path segment containing the namespace separator', () => {
     // `a:b.md` would derive the same name as `a/b.md`; registering both lets
-    // the first-wins guard drop one at random.
-    writeCommand('a:b.md', '---\ndescription: d\n---\n\nBody.\n');
-    writeCommand('a/b.md', '---\ndescription: d\n---\n\nBody.\n');
-    const names = extractPluginCommands(pluginDir).map((c) => c.name);
+    // the first-wins guard drop one at random. Distinct bodies make it
+    // possible to tell WHICH file survived: deleting the colon guard would
+    // let `a:b.md` register (or race with `a/b.md`), and either outcome must
+    // fail this assertion since only the `a/b.md` body is expected to survive.
+    writeCommand('a:b.md', '---\ndescription: d\n---\n\nColon body.\n');
+    writeCommand('a/b.md', '---\ndescription: d\n---\n\nSlash body.\n');
+    const found = extractPluginCommands(pluginDir);
+    const names = found.map((c) => c.name);
     expect(names).toEqual(['a:b']);
     expect(names).toHaveLength(1);
+    expect(found[0]?.body).toBe('Slash body.');
   });
 
   it('namespaces a subdirectory with a colon (CC parity)', () => {
@@ -160,5 +166,33 @@ describe('extractPluginCommands', () => {
     expect(names).toContain('good');
     // The malformed sibling must be dropped, not registered with a raw body.
     expect(names).not.toContain('bad');
+  });
+});
+
+describe('normalizeSkillSource', () => {
+  it('strips NUL bytes', () => {
+    expect(normalizeSkillSource('a\x00b')).toBe('ab');
+  });
+
+  it('strips other C0 control chars but keeps \\t and \\n', () => {
+    expect(normalizeSkillSource('a\x01\x02b\tc\nd\x1F')).toBe('ab\tc\nd');
+  });
+
+  it('truncates over-cap input to exactly MAX_SKILL_SOURCE_CHARS', () => {
+    const oversized = 'x'.repeat(MAX_SKILL_SOURCE_CHARS + 100);
+    const result = normalizeSkillSource(oversized);
+    expect(result.length).toBe(MAX_SKILL_SOURCE_CHARS);
+    expect(result).toBe('x'.repeat(MAX_SKILL_SOURCE_CHARS));
+  });
+
+  it('still handles BOM+CRLF when combined with control stripping and truncation', () => {
+    const result = normalizeSkillSource('\uFEFF---\r\ndescription: d\r\n---\r\n\r\nBody.\r\n');
+    expect(result).toBe('---\ndescription: d\n---\n\nBody.\n');
+  });
+
+  it('never throws, and truncation alone never discards non-control content', () => {
+    expect(() => normalizeSkillSource('\x00\x00\x00')).not.toThrow();
+    expect(() => normalizeSkillSource('x'.repeat(MAX_SKILL_SOURCE_CHARS * 2))).not.toThrow();
+    expect(normalizeSkillSource('a\x00')).toBe('a');
   });
 });

--- a/src/agent/plugins/command-files.test.ts
+++ b/src/agent/plugins/command-files.test.ts
@@ -42,6 +42,17 @@ describe('extractPluginCommands', () => {
     expect(found[0]?.body).toContain('Deploy the app.');
   });
 
+  it('accepts a plain Markdown prompt without frontmatter', () => {
+    writeCommand('review.md', 'Review this pull request: $ARGUMENTS\n');
+    const found = extractPluginCommands(pluginDir);
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({
+      name: 'review',
+      body: 'Review this pull request: $ARGUMENTS',
+      origin: 'command',
+    });
+  });
+
   it('namespaces a subdirectory with a colon (CC parity)', () => {
     writeCommand('review/security.md', '---\ndescription: Sec review\n---\n\nCheck auth.\n');
     const found = extractPluginCommands(pluginDir);
@@ -103,7 +114,7 @@ describe('extractPluginCommands', () => {
     // One bad command in a third-party plugin must not break discovery for
     // every other command it ships.
     writeCommand('good.md', '---\ndescription: d\n---\n\nBody.\n');
-    writeCommand('bad.md', 'no frontmatter at all');
+    writeCommand('bad.md', '---\ndescription: unterminated frontmatter');
     const names = extractPluginCommands(pluginDir).map((c) => c.name);
     expect(names).toContain('good');
   });

--- a/src/agent/plugins/command-files.test.ts
+++ b/src/agent/plugins/command-files.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for Claude Code `commands/*.md` discovery.
+ *
+ * Fixture shape mirrors the plugin-agents suite in skill-bridge.test.ts:
+ * a tmpdir plugin root written per-case, passed by path.
+ *
+ * @module agent/plugins/command-files.test
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { extractPluginCommands } from './command-files.js';
+
+let pluginDir: string;
+
+function writeCommand(relPath: string, contents: string): void {
+  const full = join(pluginDir, 'commands', relPath);
+  mkdirSync(join(full, '..'), { recursive: true });
+  writeFileSync(full, contents);
+}
+
+beforeEach(() => {
+  pluginDir = mkdtempSync(join(tmpdir(), 'plugin-commands-test-'));
+});
+afterEach(() => {
+  rmSync(pluginDir, { recursive: true, force: true });
+});
+
+describe('extractPluginCommands', () => {
+  it('returns [] when the plugin ships no commands/ directory', () => {
+    expect(extractPluginCommands(pluginDir)).toEqual([]);
+  });
+
+  it('derives the command name from the filename, not frontmatter', () => {
+    writeCommand('deploy.md', '---\ndescription: Ship it\n---\n\nDeploy the app.\n');
+    const found = extractPluginCommands(pluginDir);
+    expect(found).toHaveLength(1);
+    expect(found[0]?.name).toBe('deploy');
+    expect(found[0]?.description).toBe('Ship it');
+    expect(found[0]?.body).toContain('Deploy the app.');
+  });
+
+  it('namespaces a subdirectory with a colon (CC parity)', () => {
+    writeCommand('review/security.md', '---\ndescription: Sec review\n---\n\nCheck auth.\n');
+    const found = extractPluginCommands(pluginDir);
+    expect(found[0]?.name).toBe('review:security');
+  });
+
+  it('namespaces nested subdirectories', () => {
+    writeCommand('a/b/c.md', '---\ndescription: Deep\n---\n\nBody.\n');
+    expect(extractPluginCommands(pluginDir)[0]?.name).toBe('a:b:c');
+  });
+
+  it('marks every discovered command with origin: command', () => {
+    writeCommand('one.md', '---\ndescription: One\n---\n\nBody.\n');
+    expect(extractPluginCommands(pluginDir)[0]?.origin).toBe('command');
+  });
+
+  it('ignores a stray frontmatter name: so the path stays authoritative', () => {
+    // CC addresses a command by its path; honouring a `name:` would make the
+    // file invocable under a name its own location does not predict.
+    writeCommand('real-name.md', '---\nname: bogus\ndescription: d\n---\n\nBody.\n');
+    expect(extractPluginCommands(pluginDir)[0]?.name).toBe('real-name');
+  });
+
+  it('parses argument-hint and model frontmatter via the shared SKILL.md parser', () => {
+    writeCommand(
+      'x.md',
+      '---\ndescription: d\nargument-hint: "[pr-number]"\nmodel: opus\n---\n\nBody.\n',
+    );
+    const cmd = extractPluginCommands(pluginDir)[0];
+    expect(cmd?.argumentHint).toBe('[pr-number]');
+    expect(cmd?.model).toBe('opus');
+  });
+
+  it('skips non-markdown files and dotfiles', () => {
+    writeCommand('real.md', '---\ndescription: d\n---\n\nBody.\n');
+    writeCommand('README.txt', 'not a command');
+    writeCommand('.hidden.md', '---\ndescription: d\n---\n\nBody.\n');
+    const names = extractPluginCommands(pluginDir).map((c) => c.name);
+    expect(names).toEqual(['real']);
+  });
+
+  it('skips a command with an empty body rather than registering an inert slash', () => {
+    writeCommand('empty.md', '---\ndescription: d\n---\n');
+    expect(extractPluginCommands(pluginDir)).toEqual([]);
+  });
+
+  it('returns results sorted by name so ordering does not depend on the filesystem', () => {
+    writeCommand('zebra.md', '---\ndescription: d\n---\n\nB.\n');
+    writeCommand('alpha.md', '---\ndescription: d\n---\n\nB.\n');
+    writeCommand('middle.md', '---\ndescription: d\n---\n\nB.\n');
+    expect(extractPluginCommands(pluginDir).map((c) => c.name)).toEqual([
+      'alpha',
+      'middle',
+      'zebra',
+    ]);
+  });
+
+  it('survives a malformed file without losing its siblings', () => {
+    // One bad command in a third-party plugin must not break discovery for
+    // every other command it ships.
+    writeCommand('good.md', '---\ndescription: d\n---\n\nBody.\n');
+    writeCommand('bad.md', 'no frontmatter at all');
+    const names = extractPluginCommands(pluginDir).map((c) => c.name);
+    expect(names).toContain('good');
+  });
+});

--- a/src/agent/plugins/command-files.test.ts
+++ b/src/agent/plugins/command-files.test.ts
@@ -76,6 +76,14 @@ describe('extractPluginCommands', () => {
     expect(found[0]?.body).not.toContain('---');
   });
 
+  it('parses a CR-only command file (classic Mac line endings)', () => {
+    writeCommand('cr.md', '---\rdescription: Ship it\r---\r\rDeploy the app.\r');
+    const found = extractPluginCommands(pluginDir);
+    expect(found).toHaveLength(1);
+    expect(found[0]?.description).toBe('Ship it');
+    expect(found[0]?.body).toBe('Deploy the app.');
+  });
+
   it('skips a path segment containing the namespace separator', () => {
     // `a:b.md` would derive the same name as `a/b.md`; registering both lets
     // the first-wins guard drop one at random.

--- a/src/agent/plugins/command-files.ts
+++ b/src/agent/plugins/command-files.ts
@@ -42,6 +42,10 @@ import { join } from 'path';
 import { parseSkillMetadata, type PluginSkillMetadata } from './tool-injector.js';
 import { normalizeSkillSource, resolveContained } from './source-guard.js';
 import { env } from '../../config/env.js';
+// Skip diagnostics interpolate raw `readdirSync` entries from an untrusted
+// third-party plugin tree. A directory named with a CSI/OSC sequence would
+// otherwise execute against the operator's terminal when AFK_DEBUG is set.
+import { sanitizeForDisplay } from '../../utils/terminal-sanitize.js';
 
 /** Mirrors the depth cap in `extractPluginSkills` — cycle/runaway guard. */
 const MAX_DEPTH = 10;
@@ -103,7 +107,7 @@ export function extractPluginCommands(
     }
     for (const entry of entries) {
       if (entry.startsWith('.')) {
-        if (env.AFK_DEBUG) process.stderr.write(`[afk] skipping dotfile: ${join(dir, entry)}\n`);
+        if (env.AFK_DEBUG) process.stderr.write(`[afk] skipping dotfile: ${sanitizeForDisplay(join(dir, entry))}\n`);
         continue;
       }
       // A path segment carrying the namespace separator is ambiguous:
@@ -111,7 +115,7 @@ export function extractPluginCommands(
       // the first-wins guard downstream would silently drop one of them.
       if (entry.includes(':')) {
         if (env.AFK_DEBUG) {
-          process.stderr.write(`[afk] skipping path segment with colon: ${join(dir, entry)}\n`);
+          process.stderr.write(`[afk] skipping path segment with colon: ${sanitizeForDisplay(join(dir, entry))}\n`);
         }
         continue;
       }
@@ -120,7 +124,7 @@ export function extractPluginCommands(
       // `help.md -> ~/.ssh/id_rsa` must never become a dispatchable prompt.
       if (resolveContained(root, full, realRoot) === undefined) {
         if (env.AFK_DEBUG) {
-          process.stderr.write(`[afk] skipping path outside commands/ tree: ${full}\n`);
+          process.stderr.write(`[afk] skipping path outside commands/ tree: ${sanitizeForDisplay(full)}\n`);
         }
         continue;
       }
@@ -135,14 +139,14 @@ export function extractPluginCommands(
         continue;
       }
       if (!stat.isFile() || !entry.endsWith('.md')) {
-        if (env.AFK_DEBUG) process.stderr.write(`[afk] skipping non-markdown entry: ${full}\n`);
+        if (env.AFK_DEBUG) process.stderr.write(`[afk] skipping non-markdown entry: ${sanitizeForDisplay(full)}\n`);
         continue;
       }
 
       const base = entry.slice(0, -'.md'.length);
       if (base.length === 0) {
         if (env.AFK_DEBUG) {
-          process.stderr.write(`[afk] skipping command with empty basename: ${full}\n`);
+          process.stderr.write(`[afk] skipping command with empty basename: ${sanitizeForDisplay(full)}\n`);
         }
         continue;
       }
@@ -167,7 +171,7 @@ export function extractPluginCommands(
       // A command with no readable body is inert — skip rather than register a
       // slash command that would dispatch an empty prompt.
       if (!parsed.body || parsed.body.length === 0) {
-        if (env.AFK_DEBUG) process.stderr.write(`[afk] skipping command with empty body: ${full}\n`);
+        if (env.AFK_DEBUG) process.stderr.write(`[afk] skipping command with empty body: ${sanitizeForDisplay(full)}\n`);
         continue;
       }
 

--- a/src/agent/plugins/command-files.ts
+++ b/src/agent/plugins/command-files.ts
@@ -40,6 +40,7 @@
 import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
 import { join } from 'path';
 import { parseSkillMetadata, type PluginSkillMetadata } from './tool-injector.js';
+import { normalizeSkillSource, resolveContained } from './source-guard.js';
 
 /** Mirrors the depth cap in `extractPluginSkills` — cycle/runaway guard. */
 const MAX_DEPTH = 10;
@@ -79,7 +80,14 @@ export function extractPluginCommands(
     }
     for (const entry of entries) {
       if (entry.startsWith('.')) continue;
+      // A path segment carrying the namespace separator is ambiguous:
+      // `commands/a:b.md` and `commands/a/b.md` would both derive `a:b`, and
+      // the first-wins guard downstream would silently drop one of them.
+      if (entry.includes(':')) continue;
       const full = join(dir, entry);
+      // Skip anything resolving outside the commands/ tree — a symlinked
+      // `help.md -> ~/.ssh/id_rsa` must never become a dispatchable prompt.
+      if (resolveContained(root, full) === undefined) continue;
       let stat;
       try {
         stat = statSync(full);
@@ -106,7 +114,7 @@ export function extractPluginCommands(
       // prompt as the body while continuing to reject malformed frontmatter.
       if (!parsed.body) {
         try {
-          const content = readFileSync(full, 'utf-8');
+          const content = normalizeSkillSource(readFileSync(full, 'utf-8'));
           if (!content.startsWith('---\n')) parsed.body = content.trim();
         } catch {
           continue;
@@ -128,6 +136,12 @@ export function extractPluginCommands(
   }
 
   walk(root, [], 0);
-  out.sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''));
+  // Codepoint order, not localeCompare: ICU collation varies by locale and
+  // build, and this ordering is what makes collision resolution reproducible.
+  out.sort((a, b) => {
+    const an = a.name ?? '';
+    const bn = b.name ?? '';
+    return an < bn ? -1 : an > bn ? 1 : 0;
+  });
   return out;
 }

--- a/src/agent/plugins/command-files.ts
+++ b/src/agent/plugins/command-files.ts
@@ -1,0 +1,122 @@
+/**
+ * Claude Code `commands/*.md` discovery.
+ *
+ * Claude Code plugins expose user-invocable prompts through two directories.
+ * `skills/<name>/SKILL.md` is the newer form and the one CC steers new authors
+ * toward; `commands/<name>.md` is the older one, which CC's docs label "legacy"
+ * while guaranteeing continued support with no announced removal. Adoption has
+ * not followed the label: a large share of the plugins in Anthropic's own
+ * official marketplace ship `commands/` and no `skills/` directory at all, so
+ * a loader that reads only SKILL.md silently fails on roughly half of the real
+ * ecosystem.
+ *
+ * The two formats are near-identical — YAML frontmatter plus a markdown prompt
+ * body — so a command is discovered here and then travels as an ordinary
+ * {@link PluginSkillMetadata} through the same collection, collision, listing,
+ * and dispatch machinery SKILL.md already uses. Nothing downstream needs to
+ * know a command is a command, except the model-facing manifest (see below).
+ *
+ * Two things genuinely differ from SKILL.md and are handled here:
+ *
+ *   1. **The name comes from the PATH, not the frontmatter.** Command files
+ *      carry no `name:` field. `commands/deploy.md` is `/deploy`.
+ *   2. **Subdirectories are namespaces.** `commands/review/security.md` is
+ *      `/review:security`, matching CC, which restored this behaviour in
+ *      July 2025 after a period where the nesting was flattened away.
+ *
+ * Marked `origin: 'command'` so `buildSkillManifest` can keep them out of the
+ * model-facing catalogue. That exclusion is deliberate: AFK's manifest has no
+ * character budget or eviction policy (CC's does — 1% of the context window,
+ * evicting least-used descriptions), so every discovered entry costs prompt
+ * tokens on every request forever. Commands are user-invoked slash commands by
+ * nature; listing a third-party plugin's whole command surface to the model
+ * would grow the system prompt without bound and let the model autonomously
+ * fire commands the user never mentioned. They remain fully invocable as
+ * `/name` and fully listed by `/skills`.
+ *
+ * @module agent/plugins/command-files
+ */
+
+import { existsSync, readdirSync, statSync } from 'fs';
+import { join } from 'path';
+import { parseSkillMetadata, type PluginSkillMetadata } from './tool-injector.js';
+
+/** Mirrors the depth cap in `extractPluginSkills` — cycle/runaway guard. */
+const MAX_DEPTH = 10;
+
+/**
+ * Discover every `*.md` under `<pluginPath>/commands/`.
+ *
+ * Contract:
+ * - Returns `[]` when the plugin ships no `commands/` directory, which is the
+ *   common case and must stay cheap.
+ * - Name is the path relative to `commands/`, minus the `.md` extension, with
+ *   directory separators replaced by `:` — so `review/security.md` yields
+ *   `review:security`.
+ * - Dotfiles and dot-directories are skipped, matching the SKILL.md walker.
+ * - A file that cannot be read or parsed is skipped rather than throwing. One
+ *   malformed command in a third-party plugin must not take down discovery for
+ *   every other plugin installed.
+ * - Results are sorted by name for deterministic ordering, so collision
+ *   resolution downstream does not depend on filesystem enumeration order.
+ */
+export function extractPluginCommands(
+  pluginPath: string,
+  knownToolNames?: ReadonlySet<string>,
+): PluginSkillMetadata[] {
+  const root = join(pluginPath, 'commands');
+  if (!existsSync(root)) return [];
+
+  const out: PluginSkillMetadata[] = [];
+
+  function walk(dir: string, segments: string[], depth: number): void {
+    if (depth > MAX_DEPTH) return;
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.startsWith('.')) continue;
+      const full = join(dir, entry);
+      let stat;
+      try {
+        stat = statSync(full);
+      } catch {
+        continue;
+      }
+      if (stat.isDirectory()) {
+        walk(full, [...segments, entry], depth + 1);
+        continue;
+      }
+      if (!stat.isFile() || !entry.endsWith('.md')) continue;
+
+      const base = entry.slice(0, -'.md'.length);
+      if (base.length === 0) continue;
+      const name = [...segments, base].join(':');
+
+      // Reuse the SKILL.md frontmatter parser verbatim: the fields a command
+      // declares (description, argument-hint, allowed-tools, model) are a
+      // subset of what it already understands, and sharing it means a command
+      // and a skill can never drift in how identical frontmatter is read.
+      const parsed = parseSkillMetadata(full, knownToolNames);
+      // A command with no readable body is inert — skip rather than register a
+      // slash command that would dispatch an empty prompt.
+      if (!parsed.body || parsed.body.length === 0) continue;
+
+      out.push({
+        ...parsed,
+        // Path-derived name always wins. A stray `name:` in a command file is
+        // not how CC addresses it, so honouring it would make the file
+        // invocable under a name its own path does not predict.
+        name,
+        origin: 'command',
+      });
+    }
+  }
+
+  walk(root, [], 0);
+  out.sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''));
+  return out;
+}

--- a/src/agent/plugins/command-files.ts
+++ b/src/agent/plugins/command-files.ts
@@ -37,7 +37,7 @@
  * @module agent/plugins/command-files
  */
 
-import { existsSync, readdirSync, statSync } from 'fs';
+import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
 import { join } from 'path';
 import { parseSkillMetadata, type PluginSkillMetadata } from './tool-injector.js';
 
@@ -101,6 +101,17 @@ export function extractPluginCommands(
       // subset of what it already understands, and sharing it means a command
       // and a skill can never drift in how identical frontmatter is read.
       const parsed = parseSkillMetadata(full, knownToolNames);
+      // Unlike SKILL.md, command frontmatter is optional. The shared parser
+      // deliberately rejects files without it, so preserve a plain Markdown
+      // prompt as the body while continuing to reject malformed frontmatter.
+      if (!parsed.body) {
+        try {
+          const content = readFileSync(full, 'utf-8');
+          if (!content.startsWith('---\n')) parsed.body = content.trim();
+        } catch {
+          continue;
+        }
+      }
       // A command with no readable body is inert — skip rather than register a
       // slash command that would dispatch an empty prompt.
       if (!parsed.body || parsed.body.length === 0) continue;

--- a/src/agent/plugins/command-files.ts
+++ b/src/agent/plugins/command-files.ts
@@ -37,13 +37,22 @@
  * @module agent/plugins/command-files
  */
 
-import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
+import { existsSync, readFileSync, readdirSync, realpathSync, statSync } from 'fs';
 import { join } from 'path';
 import { parseSkillMetadata, type PluginSkillMetadata } from './tool-injector.js';
 import { normalizeSkillSource, resolveContained } from './source-guard.js';
+import { env } from '../../config/env.js';
 
 /** Mirrors the depth cap in `extractPluginSkills` — cycle/runaway guard. */
 const MAX_DEPTH = 10;
+
+/**
+ * `PluginSkillMetadata.name` is typed optional (frontmatter-derived skills
+ * may parse without one), but every entry pushed by `extractPluginCommands`
+ * below always carries a path-derived name. Narrowing locally lets the sort
+ * comparator read `a.name`/`b.name` as `string` without an `as string` cast.
+ */
+type DiscoveredCommand = PluginSkillMetadata & { name: string };
 
 /**
  * Discover every `*.md` under `<pluginPath>/commands/`.
@@ -68,7 +77,21 @@ export function extractPluginCommands(
   const root = join(pluginPath, 'commands');
   if (!existsSync(root)) return [];
 
-  const out: PluginSkillMetadata[] = [];
+  // Resolve the containment root's realpath ONCE, before the walk starts, and
+  // thread it into every resolveContained call below instead of letting each
+  // call re-resolve `root` itself. Re-resolving per-entry (the previous
+  // behavior) meant a symlink swapped into `commands/` mid-walk could shift
+  // the containment baseline between sibling files. A root that is missing or
+  // cannot be resolved behaves exactly as it did before this change: no
+  // commands are discovered.
+  let realRoot: string;
+  try {
+    realRoot = realpathSync(root);
+  } catch {
+    return [];
+  }
+
+  const out: DiscoveredCommand[] = [];
 
   function walk(dir: string, segments: string[], depth: number): void {
     if (depth > MAX_DEPTH) return;
@@ -79,15 +102,28 @@ export function extractPluginCommands(
       return;
     }
     for (const entry of entries) {
-      if (entry.startsWith('.')) continue;
+      if (entry.startsWith('.')) {
+        if (env.AFK_DEBUG) process.stderr.write(`[afk] skipping dotfile: ${join(dir, entry)}\n`);
+        continue;
+      }
       // A path segment carrying the namespace separator is ambiguous:
       // `commands/a:b.md` and `commands/a/b.md` would both derive `a:b`, and
       // the first-wins guard downstream would silently drop one of them.
-      if (entry.includes(':')) continue;
+      if (entry.includes(':')) {
+        if (env.AFK_DEBUG) {
+          process.stderr.write(`[afk] skipping path segment with colon: ${join(dir, entry)}\n`);
+        }
+        continue;
+      }
       const full = join(dir, entry);
       // Skip anything resolving outside the commands/ tree — a symlinked
       // `help.md -> ~/.ssh/id_rsa` must never become a dispatchable prompt.
-      if (resolveContained(root, full) === undefined) continue;
+      if (resolveContained(root, full, realRoot) === undefined) {
+        if (env.AFK_DEBUG) {
+          process.stderr.write(`[afk] skipping path outside commands/ tree: ${full}\n`);
+        }
+        continue;
+      }
       let stat;
       try {
         stat = statSync(full);
@@ -98,10 +134,18 @@ export function extractPluginCommands(
         walk(full, [...segments, entry], depth + 1);
         continue;
       }
-      if (!stat.isFile() || !entry.endsWith('.md')) continue;
+      if (!stat.isFile() || !entry.endsWith('.md')) {
+        if (env.AFK_DEBUG) process.stderr.write(`[afk] skipping non-markdown entry: ${full}\n`);
+        continue;
+      }
 
       const base = entry.slice(0, -'.md'.length);
-      if (base.length === 0) continue;
+      if (base.length === 0) {
+        if (env.AFK_DEBUG) {
+          process.stderr.write(`[afk] skipping command with empty basename: ${full}\n`);
+        }
+        continue;
+      }
       const name = [...segments, base].join(':');
 
       // Reuse the SKILL.md frontmatter parser verbatim: the fields a command
@@ -122,7 +166,10 @@ export function extractPluginCommands(
       }
       // A command with no readable body is inert — skip rather than register a
       // slash command that would dispatch an empty prompt.
-      if (!parsed.body || parsed.body.length === 0) continue;
+      if (!parsed.body || parsed.body.length === 0) {
+        if (env.AFK_DEBUG) process.stderr.write(`[afk] skipping command with empty body: ${full}\n`);
+        continue;
+      }
 
       out.push({
         ...parsed,
@@ -138,10 +185,6 @@ export function extractPluginCommands(
   walk(root, [], 0);
   // Codepoint order, not localeCompare: ICU collation varies by locale and
   // build, and this ordering is what makes collision resolution reproducible.
-  out.sort((a, b) => {
-    const an = a.name ?? '';
-    const bn = b.name ?? '';
-    return an < bn ? -1 : an > bn ? 1 : 0;
-  });
+  out.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
   return out;
 }

--- a/src/agent/plugins/command-files.ts
+++ b/src/agent/plugins/command-files.ts
@@ -51,6 +51,16 @@ import { sanitizeForDisplay } from '../../utils/terminal-sanitize.js';
 const MAX_DEPTH = 10;
 
 /**
+ * Control bytes — C0, DEL, and C1 — in a path segment.
+ *
+ * Invariant: a command's name is derived from its file path, so a path segment
+ * is the only place a plugin can inject bytes into a name. Unlike a SKILL.md
+ * name (frontmatter, i.e. already-normalized file content), this value never
+ * passes through `normalizeSkillSource`, so it is validated here instead.
+ */
+const CONTROL_BYTES = /[\u0000-\u001F\u007F-\u009F]/;
+
+/**
  * `PluginSkillMetadata.name` is typed optional (frontmatter-derived skills
  * may parse without one), but every entry pushed by `extractPluginCommands`
  * below always carries a path-derived name. Narrowing locally lets the sort
@@ -116,6 +126,22 @@ export function extractPluginCommands(
       if (entry.includes(':')) {
         if (env.AFK_DEBUG) {
           process.stderr.write(`[afk] skipping path segment with colon: ${sanitizeForDisplay(join(dir, entry))}\n`);
+        }
+        continue;
+      }
+      // Reject rather than sanitize, and reject HERE: this is the one point a
+      // path segment enters a name (as a `segments` entry below, or as `base`),
+      // so a single guard covers every name this walk can produce. The name is
+      // later written to the terminal unsanitized by the `/skills` listing and
+      // by the shadowing notice — which fires without the user asking for it —
+      // and sanitizing those render sites would leave the next one unguarded.
+      // A control byte in a plugin-supplied filename is never a legitimate
+      // command name, so failing closed costs nothing.
+      if (CONTROL_BYTES.test(entry)) {
+        if (env.AFK_DEBUG) {
+          process.stderr.write(
+            `[afk] skipping path segment with control bytes: ${sanitizeForDisplay(join(dir, entry))}\n`,
+          );
         }
         continue;
       }

--- a/src/agent/plugins/source-guard.ts
+++ b/src/agent/plugins/source-guard.ts
@@ -15,16 +15,16 @@ import { sep } from 'path';
 /**
  * Normalise plugin markdown before any frontmatter check.
  *
- * Contract: strips one leading UTF-8 BOM and converts CRLF to LF, so a
- * byte-exact `startsWith('---\n')` test behaves identically for a file
- * authored on Windows, exported by an editor that emits a BOM, or written on
- * a POSIX box. Callers MUST apply this to the raw `readFileSync` result before
- * inspecting the frontmatter delimiter — a `---\r\n` or `\uFEFF---\n` prefix
- * otherwise fails the test and the whole frontmatter block is mistaken for
- * prompt body.
+ * Contract: strips one leading UTF-8 BOM and converts both CRLF and a lone CR
+ * to LF, so a byte-exact `startsWith('---\n')` test behaves identically for a
+ * file authored on Windows, exported by an editor that emits a BOM, or written
+ * on a POSIX box. Callers MUST apply this to the raw `readFileSync` result
+ * before inspecting the frontmatter delimiter — a `---\r\n` or `\uFEFF---\n`
+ * prefix otherwise fails the test and the whole frontmatter block is mistaken
+ * for prompt body.
  */
 export function normalizeSkillSource(raw: string): string {
-  return raw.replace(/^\uFEFF/, '').replace(/\r\n/g, '\n');
+  return raw.replace(/^\uFEFF/, '').replace(/\r\n?/g, '\n');
 }
 
 /**

--- a/src/agent/plugins/source-guard.ts
+++ b/src/agent/plugins/source-guard.ts
@@ -13,18 +13,44 @@ import { realpathSync } from 'fs';
 import { sep } from 'path';
 
 /**
+ * Hard cap on normalised skill/command source, in characters. Mirrors the
+ * char-cap-with-truncation shape of `MAX_PRIMER_CHARS` (companion/primer-loader.ts).
+ */
+export const MAX_SKILL_SOURCE_CHARS = 64 * 1024;
+
+/**
  * Normalise plugin markdown before any frontmatter check.
  *
- * Contract: strips one leading UTF-8 BOM and converts both CRLF and a lone CR
- * to LF, so a byte-exact `startsWith('---\n')` test behaves identically for a
- * file authored on Windows, exported by an editor that emits a BOM, or written
- * on a POSIX box. Callers MUST apply this to the raw `readFileSync` result
- * before inspecting the frontmatter delimiter — a `---\r\n` or `\uFEFF---\n`
- * prefix otherwise fails the test and the whole frontmatter block is mistaken
- * for prompt body.
+ * Contract: strips one leading UTF-8 BOM, converts both CRLF and a lone CR to
+ * LF, strips NUL and other C0 control chars (keeping `\n` and `\t`), then
+ * truncates to {@link MAX_SKILL_SOURCE_CHARS}. Order is load-bearing: newline
+ * normalisation must run before control stripping (a lone CR is folded to
+ * `\n` before the control-char pass, so it survives instead of being
+ * dropped), and truncation must run last so the cap is measured on the
+ * already-normalised text. Callers MUST apply this to the raw `readFileSync`
+ * result before inspecting the frontmatter delimiter — a `---\r\n` or
+ * `\uFEFF---\n` prefix otherwise fails a byte-exact `startsWith('---\n')` test
+ * and the whole frontmatter block is mistaken for prompt body.
+ *
+ * Invariant: both third-party markdown loaders — `extractPluginCommands`
+ * (command-files.ts, plain-body path) and `parseSkillMetadata`
+ * (tool-injector.ts, SKILL.md frontmatter+body) — read untrusted plugin files
+ * through this one function, so the cap and control-char strip apply
+ * uniformly to `commands/*.md` and `SKILL.md` alike. Truncation, not
+ * rejection, is the failure mode for an oversized body: file length is not a
+ * security signal, and refusing to load a long-but-legitimate prompt would
+ * silently disable a plugin's skill/command with no diagnostic path for the
+ * user. A bounded prefix keeps the frontmatter (always at the top) intact and
+ * simply caps the unbounded tail, so this function never throws and never
+ * collapses a non-empty input to `''`.
  */
 export function normalizeSkillSource(raw: string): string {
-  return raw.replace(/^\uFEFF/, '').replace(/\r\n?/g, '\n');
+  const normalized = raw.replace(/^\uFEFF/, '').replace(/\r\n?/g, '\n');
+  // Strip NUL and every other C0 control char, keeping \t (0x09) and \n (0x0A).
+  const controlStripped = normalized.replace(/[\x00-\x08\x0B-\x1F]/g, '');
+  return controlStripped.length > MAX_SKILL_SOURCE_CHARS
+    ? controlStripped.slice(0, MAX_SKILL_SOURCE_CHARS)
+    : controlStripped;
 }
 
 /**
@@ -36,12 +62,26 @@ export function normalizeSkillSource(raw: string): string {
  * dispatchable prompt body. Symlinks that stay *within* the plugin tree are
  * deliberately still followed: sharing one prompt across two command names is
  * legitimate authoring, and banning links outright would break it.
+ *
+ * @param root - The containment root, as a raw (not-yet-resolved) path.
+ * @param candidate - The path being checked for containment within `root`.
+ * @param preResolvedRoot - Optional `realpathSync(root)` result, computed once
+ *   by the caller. When a caller walks many candidates under the same root
+ *   (e.g. a directory tree), resolving `root` fresh on every call lets a
+ *   symlink swap mid-walk silently shift the containment baseline between
+ *   entries; passing the root's realpath once up front pins it for the whole
+ *   walk. Callers that omit it keep today's per-call `realpathSync(root)`
+ *   behavior.
  */
-export function resolveContained(root: string, candidate: string): string | undefined {
+export function resolveContained(
+  root: string,
+  candidate: string,
+  preResolvedRoot?: string,
+): string | undefined {
   let realRoot: string;
   let realCandidate: string;
   try {
-    realRoot = realpathSync(root);
+    realRoot = preResolvedRoot ?? realpathSync(root);
     realCandidate = realpathSync(candidate);
   } catch {
     return undefined;

--- a/src/agent/plugins/source-guard.ts
+++ b/src/agent/plugins/source-guard.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared guards for reading plugin-authored markdown off disk.
+ *
+ * Both plugin loaders — `extractPluginSkills` (SKILL.md) and
+ * `extractPluginCommands` (commands/*.md) — read third-party files that the
+ * user installed but did not write. The two helpers here are the properties
+ * both loaders must agree on, extracted so they cannot drift.
+ *
+ * @module agent/plugins/source-guard
+ */
+
+import { realpathSync } from 'fs';
+import { sep } from 'path';
+
+/**
+ * Normalise plugin markdown before any frontmatter check.
+ *
+ * Contract: strips one leading UTF-8 BOM and converts CRLF to LF, so a
+ * byte-exact `startsWith('---\n')` test behaves identically for a file
+ * authored on Windows, exported by an editor that emits a BOM, or written on
+ * a POSIX box. Callers MUST apply this to the raw `readFileSync` result before
+ * inspecting the frontmatter delimiter — a `---\r\n` or `\uFEFF---\n` prefix
+ * otherwise fails the test and the whole frontmatter block is mistaken for
+ * prompt body.
+ */
+export function normalizeSkillSource(raw: string): string {
+  return raw.replace(/^\uFEFF/, '').replace(/\r\n/g, '\n');
+}
+
+/**
+ * Resolve `candidate` and return its real path only when it stays inside `root`.
+ *
+ * Contract: returns `undefined` for a broken link, an unreadable path, or any
+ * entry whose resolved target escapes `root` — so a plugin shipping
+ * `commands/help.md -> ~/.ssh/id_rsa` is skipped rather than registered as a
+ * dispatchable prompt body. Symlinks that stay *within* the plugin tree are
+ * deliberately still followed: sharing one prompt across two command names is
+ * legitimate authoring, and banning links outright would break it.
+ */
+export function resolveContained(root: string, candidate: string): string | undefined {
+  let realRoot: string;
+  let realCandidate: string;
+  try {
+    realRoot = realpathSync(root);
+    realCandidate = realpathSync(candidate);
+  } catch {
+    return undefined;
+  }
+  if (realCandidate === realRoot) return realCandidate;
+  return realCandidate.startsWith(realRoot + sep) ? realCandidate : undefined;
+}

--- a/src/agent/plugins/tool-injector.ts
+++ b/src/agent/plugins/tool-injector.ts
@@ -22,6 +22,14 @@ export interface PluginSkillMetadata {
   description?: string;
   argumentHint?: string;
   /**
+   * Which plugin directory this artifact came from. `'command'` marks a
+   * Claude Code `commands/*.md` file (see `command-files.ts`); absent means
+   * the default `skills/**\/SKILL.md` form. Read by `buildSkillManifest` to
+   * keep commands out of the model-facing catalogue while leaving them fully
+   * invocable as slash commands.
+   */
+  origin?: 'command';
+  /**
    * Resolved tool allowlist parsed from the `tools:` frontmatter field.
    *
    * When present, only the listed tools are permitted for subagents dispatched
@@ -265,7 +273,7 @@ export function extractPluginSkills(
  *   When omitted, `resolveKnownToolNames()` is called lazily.
  * @returns Extracted metadata (returns `{ name: undefined }` if parsing fails)
  */
-function parseSkillMetadata(
+export function parseSkillMetadata(
   skillPath: string,
   knownToolNames?: ReadonlySet<string>,
 ): PluginSkillMetadata {
@@ -301,7 +309,12 @@ function parseSkillMetadata(
         metadata.name = value.replace(/^["']|["']$/g, '');
       } else if (key === 'description') {
         metadata.description = value.replace(/^["']|["']$/g, '');
-      } else if (key === 'argumentHint') {
+      } else if (key === 'argument-hint' || key === 'argumentHint') {
+        // Both spellings. `argument-hint` is the Claude Code / Agent Skills
+        // standard and what plugin authors actually write; `argumentHint` was
+        // the only form accepted here, so kebab-case hints in plugin SKILL.md
+        // files were silently dropped while `user-skills.ts` (which reads both)
+        // handled the identical file correctly.
         metadata.argumentHint = value.replace(/^["']|["']$/g, '');
       } else if (key === 'tools') {
         // Collect the lines after this one to handle YAML list form

--- a/src/agent/plugins/tool-injector.ts
+++ b/src/agent/plugins/tool-injector.ts
@@ -10,6 +10,7 @@
  */
 
 import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
+import { normalizeSkillSource } from './source-guard.js';
 import { join } from 'path';
 import { BUILTIN_TOOL_NAMES } from '../tools/schemas.js';
 import { AWARENESS_TOOL_NAMES } from '../awareness/index.js';
@@ -278,7 +279,10 @@ export function parseSkillMetadata(
   knownToolNames?: ReadonlySet<string>,
 ): PluginSkillMetadata {
   try {
-    const content = readFileSync(skillPath, 'utf-8');
+    // Normalise BOM + CRLF first: the delimiter test below is byte-exact, so a
+    // Windows-authored or BOM-prefixed file would otherwise be read as having
+    // no frontmatter at all.
+    const content = normalizeSkillSource(readFileSync(skillPath, 'utf-8'));
 
     if (!content.startsWith('---\n')) {
       return {};

--- a/src/agent/plugins/tool-injector.ts
+++ b/src/agent/plugins/tool-injector.ts
@@ -395,7 +395,7 @@ export function parseSkillMetadata(
  * as-is. Otherwise `BUILTIN_TOOL_NAMES` (statically imported from schemas.ts)
  * plus the orchestration tool names are used as the default.
  */
-function resolveKnownToolNames(
+export function resolveKnownToolNames(
   provided?: ReadonlySet<string>,
 ): ReadonlySet<string> {
   if (provided !== undefined) return provided;

--- a/src/agent/provider.ts
+++ b/src/agent/provider.ts
@@ -445,6 +445,13 @@ export interface ProviderCommandInfo {
   name: string;
   description?: string;
   argumentHint?: string;
+  /**
+   * Origin of the underlying skill/command. Inlined literal union (rather
+   * than importing `SkillManifestEntry['source']` from
+   * `tools/skill-bridge.js`) to keep this foundational, widely-imported file
+   * free of a dependency on the heavy skill-discovery module.
+   */
+  source?: 'builtin' | 'user' | 'project' | 'plugin' | 'imported' | 'command';
 }
 
 /** Loose structural shape for model catalog entries. */

--- a/src/agent/providers/shared/supported-commands.ts
+++ b/src/agent/providers/shared/supported-commands.ts
@@ -38,6 +38,7 @@ export function collectSupportedCommands(): Promise<ProviderCommandInfo[]> {
           description: e.description,
         };
         if (e.argumentHint) info.argumentHint = e.argumentHint;
+        if (e.source) info.source = e.source;
         return info;
       }),
     );

--- a/src/agent/tools/skill-bridge.test.ts
+++ b/src/agent/tools/skill-bridge.test.ts
@@ -600,6 +600,27 @@ describe('plugin commands/*.md integration', () => {
     expect(matches[0]?.source).toBe('plugin');
     expect(matches[0]?.description).toBe('A skill');
   });
+
+  it("a SKILL.md wins over another PLUGIN's commands/*.md of the same name", () => {
+    // The same first-wins guard spans plugins, not just one plugin's own two
+    // directories — precedence must not depend on which plugin is scanned first.
+    const pluginA = join(tmpDir, 'a');
+    const pluginB = join(tmpDir, 'b');
+    mkdirSync(pluginA, { recursive: true });
+    mkdirSync(pluginB, { recursive: true });
+    writeSkillMd(pluginA, 'overlap');
+    writeCommand(pluginB, 'overlap.md', 'The command version');
+
+    const entries = collectSkillEntries([
+      { type: 'local', path: pluginA },
+      { type: 'local', path: pluginB },
+    ]);
+
+    const matches = entries.filter((e) => e.name === 'overlap');
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.source).toBe('plugin');
+    expect(matches[0]?.description).toBe('A skill');
+  });
 });
 
 describe('discoverPluginSkillBodies', () => {

--- a/src/agent/tools/skill-bridge.test.ts
+++ b/src/agent/tools/skill-bridge.test.ts
@@ -621,6 +621,32 @@ describe('plugin commands/*.md integration', () => {
     expect(matches[0]?.source).toBe('plugin');
     expect(matches[0]?.description).toBe('A skill');
   });
+
+  it('filters a commands/*.md file with `audience: internal` when tier is locked', () => {
+    vi.stubEnv('AFK_INTERNAL', '');
+    const full = join(tmpDir, 'commands', 'secret.md');
+    mkdirSync(join(full, '..'), { recursive: true });
+    writeFileSync(
+      full,
+      '---\ndescription: Maintainer only\naudience: internal\n---\n\nSecret command body.\n',
+    );
+
+    const entries = collectSkillEntries([{ type: 'local', path: tmpDir }]);
+    expect(entries.map((e) => e.name)).not.toContain('secret');
+  });
+
+  it('surfaces a commands/*.md file with `audience: internal` when AFK_INTERNAL=1', () => {
+    vi.stubEnv('AFK_INTERNAL', '1');
+    const full = join(tmpDir, 'commands', 'secret.md');
+    mkdirSync(join(full, '..'), { recursive: true });
+    writeFileSync(
+      full,
+      '---\ndescription: Maintainer only\naudience: internal\n---\n\nSecret command body.\n',
+    );
+
+    const entries = collectSkillEntries([{ type: 'local', path: tmpDir }]);
+    expect(entries.map((e) => e.name)).toContain('secret');
+  });
 });
 
 describe('discoverPluginSkillBodies', () => {

--- a/src/agent/tools/skill-bridge.test.ts
+++ b/src/agent/tools/skill-bridge.test.ts
@@ -519,6 +519,76 @@ describe('collectSkillEntries — plugin frontmatter audience filter', () => {
   });
 });
 
+describe('plugin commands/*.md integration', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync('/tmp/skill-bridge-commands-test-');
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tmpDir, { recursive: true });
+    } catch {
+      // Non-fatal cleanup.
+    }
+  });
+
+  function writeCommand(pluginPath: string, rel: string, description: string): void {
+    const full = join(pluginPath, 'commands', rel);
+    mkdirSync(join(full, '..'), { recursive: true });
+    writeFileSync(full, `---\ndescription: ${description}\n---\n\nCommand body for ${rel}.\n`);
+  }
+
+  function writeSkillMd(pluginPath: string, name: string): void {
+    const dir = join(pluginPath, 'skills', name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'SKILL.md'), `---\nname: ${name}\ndescription: A skill\n---\nSkill body.\n`);
+  }
+
+  it('collectSkillEntries surfaces a commands/*.md file tagged source: command', () => {
+    writeCommand(tmpDir, 'deploy.md', 'Ship it');
+    const entries = collectSkillEntries([{ type: 'local', path: tmpDir }]);
+    const deploy = entries.find((e) => e.name === 'deploy');
+    expect(deploy).toBeDefined();
+    expect(deploy?.source).toBe('command');
+    expect(deploy?.description).toBe('Ship it');
+  });
+
+  it('buildSkillManifest EXCLUDES commands from the model-facing catalogue', () => {
+    // The manifest has no character budget, and a command is user-invoked by
+    // nature — listing a third-party plugin's command surface to the model
+    // would grow the system prompt without bound.
+    writeCommand(tmpDir, 'deploy.md', 'Ship it');
+    const manifest = buildSkillManifest([{ type: 'local', path: tmpDir }]);
+    expect(manifest).not.toContain('deploy');
+  });
+
+  it('discoverPluginSkillBodies makes a command body dispatchable', () => {
+    // Excluded from the manifest but still executable — otherwise the slash
+    // command would register and then dispatch nothing.
+    writeCommand(tmpDir, 'deploy.md', 'Ship it');
+    const bodies = discoverPluginSkillBodies([{ type: 'local', path: tmpDir }]);
+    expect(bodies.get('deploy')?.body).toContain('Command body for deploy.md.');
+  });
+
+  it('namespaces a subdirectory command as ns:name end-to-end', () => {
+    writeCommand(tmpDir, 'review/security.md', 'Sec review');
+    const entries = collectSkillEntries([{ type: 'local', path: tmpDir }]);
+    expect(entries.some((e) => e.name === 'review:security')).toBe(true);
+  });
+
+  it('a SKILL.md wins over a commands/*.md of the same name (CC precedence)', () => {
+    writeSkillMd(tmpDir, 'overlap');
+    writeCommand(tmpDir, 'overlap.md', 'The command version');
+    const entries = collectSkillEntries([{ type: 'local', path: tmpDir }]);
+    const matches = entries.filter((e) => e.name === 'overlap');
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.source).toBe('plugin');
+    expect(matches[0]?.description).toBe('A skill');
+  });
+});
+
 describe('discoverPluginSkillBodies', () => {
   let tmpDir: string;
 

--- a/src/agent/tools/skill-bridge.test.ts
+++ b/src/agent/tools/skill-bridge.test.ts
@@ -555,6 +555,19 @@ describe('plugin commands/*.md integration', () => {
     expect(deploy?.description).toBe('Ship it');
   });
 
+  it('preserves a command argument hint during collection', () => {
+    const full = join(tmpDir, 'commands', 'deploy.md');
+    mkdirSync(join(full, '..'), { recursive: true });
+    writeFileSync(
+      full,
+      '---\ndescription: Ship it\nargument-hint: "[environment]"\n---\n\nDeploy it.\n',
+    );
+    const entry = collectSkillEntries([{ type: 'local', path: tmpDir }]).find(
+      (candidate) => candidate.name === 'deploy',
+    );
+    expect(entry?.argumentHint).toBe('[environment]');
+  });
+
   it('buildSkillManifest EXCLUDES commands from the model-facing catalogue', () => {
     // The manifest has no character budget, and a command is user-invoked by
     // nature — listing a third-party plugin's command surface to the model

--- a/src/agent/tools/skill-bridge.ts
+++ b/src/agent/tools/skill-bridge.ts
@@ -22,7 +22,7 @@ import { loadSkillPrompts } from '../../skills/_lib/prompt-loader.js';
 import { scanSkillsFromDir } from '../../skills/user-skills.js';
 import { scanLocalPlugins } from '../plugins-scanner.js';
 import { loadPluginEntrypoints } from '../plugins/load-entrypoints.js';
-import { extractPluginSkills } from '../plugins/tool-injector.js';
+import { extractPluginSkills, resolveKnownToolNames } from '../plugins/tool-injector.js';
 import { extractPluginCommands } from '../plugins/command-files.js';
 import { readPluginManifest } from '../plugins/plugin-manifest.js';
 import { parseAgentMarkdown } from '../agents/parser.js';
@@ -249,13 +249,20 @@ export function collectSkillEntries(
   //    same tier gate — extractPluginSkills() surfaces it as `audience`,
   //    defaulting to 'public' when absent.
   const plugins = pluginConfigs ?? scanAllPluginRoots(opts);
+  // Resolve once for the whole scan rather than per-file inside each
+  // extractor — resolveKnownToolNames() rebuilds a Set from two static
+  // arrays on every call, which otherwise reruns once per discovered file.
+  const knownToolNames = resolveKnownToolNames();
   for (const plugin of plugins) {
     if (plugin.type !== 'local') continue;
     // SKILL.md first, then commands/*.md — so a plugin shipping both forms
     // under one name resolves to the skill, matching Claude Code ("if a skill
     // and a command share the same name, the skill takes precedence"). The
     // `seen` guard below is what enforces it.
-    const skills = [...extractPluginSkills(plugin.path), ...extractPluginCommands(plugin.path)];
+    const skills = [
+      ...extractPluginSkills(plugin.path, knownToolNames),
+      ...extractPluginCommands(plugin.path, knownToolNames),
+    ];
     for (const skill of skills) {
       if (!skill.name || seen.has(skill.name)) continue;
       if (!isSkillVisible({ audience: skill.audience }, internalUnlocked)) continue;
@@ -334,12 +341,18 @@ export function discoverPluginSkillBodies(
   // loadImportFromConfig() + existsSync work only runs when no pluginConfigs
   // were supplied (a caller passing pluginConfigs skips it entirely).
   const plugins = pluginConfigs ?? scanAllPluginRoots(opts);
+  // Resolve once for the whole scan — see the matching comment in
+  // collectSkillEntries() above.
+  const knownToolNames = resolveKnownToolNames();
 
   for (const plugin of plugins) {
     if (plugin.type !== 'local') continue;
     // Same order + first-wins rule as collectSkillEntries: a SKILL.md and a
     // commands/*.md sharing one name resolve to the skill.
-    const skills = [...extractPluginSkills(plugin.path), ...extractPluginCommands(plugin.path)];
+    const skills = [
+      ...extractPluginSkills(plugin.path, knownToolNames),
+      ...extractPluginCommands(plugin.path, knownToolNames),
+    ];
     for (const skill of skills) {
       if (skill.name && skill.body && skill.body.length > 0 && !bodies.has(skill.name)) {
         bodies.set(skill.name, {

--- a/src/agent/tools/skill-bridge.ts
+++ b/src/agent/tools/skill-bridge.ts
@@ -23,6 +23,7 @@ import { scanSkillsFromDir } from '../../skills/user-skills.js';
 import { scanLocalPlugins } from '../plugins-scanner.js';
 import { loadPluginEntrypoints } from '../plugins/load-entrypoints.js';
 import { extractPluginSkills } from '../plugins/tool-injector.js';
+import { extractPluginCommands } from '../plugins/command-files.js';
 import { readPluginManifest } from '../plugins/plugin-manifest.js';
 import { parseAgentMarkdown } from '../agents/parser.js';
 import { collectMarkdownFiles } from '../agents/registry.js';
@@ -55,7 +56,7 @@ import {
 export interface SkillManifestEntry {
   name: string;
   description: string;
-  source: 'builtin' | 'user' | 'project' | 'plugin' | 'imported';
+  source: 'builtin' | 'user' | 'project' | 'plugin' | 'imported' | 'command';
   argumentHint?: string;
   whenToUse?: string;
 }
@@ -88,10 +89,27 @@ export function buildSkillManifest(
   // listing so the exclusion cannot silently no-op if that naming is adopted
   // for skills as it already is for agents.
   const exclude = opts?.excludeName;
-  const entries =
+  const named =
     exclude !== undefined && exclude.length > 0
       ? collected.filter((e) => e.name !== exclude && !e.name.endsWith(`:${exclude}`))
       : collected;
+  // Invariant: Claude Code `commands/*.md` entries are user-invocable only and
+  // never enter the model-facing catalogue.
+  //
+  // This manifest has no character budget and no eviction policy — every entry
+  // costs prompt tokens on every request, forever. Claude Code can afford to
+  // list commands to its model because it caps the listing at ~1% of the
+  // context window and drops the least-used descriptions when it overflows; we
+  // have no such backstop, so an unbounded third-party command surface would
+  // grow the system prompt without limit. The second reason is behavioural:
+  // installing a plugin should not hand the model a menu of commands the user
+  // never mentioned and may not know exist.
+  //
+  // Filtered HERE, at the model-facing boundary, rather than in
+  // collectSkillEntries — same split the excludeName filter above uses — so
+  // every non-model consumer (slash-command router, `/skills`, `afk skill
+  // list`) still sees the complete set and commands stay fully invocable.
+  const entries = named.filter((e) => e.source !== 'command');
   if (entries.length === 0) return '';
 
   const lines: string[] = [];
@@ -233,14 +251,18 @@ export function collectSkillEntries(
   const plugins = pluginConfigs ?? scanAllPluginRoots(opts);
   for (const plugin of plugins) {
     if (plugin.type !== 'local') continue;
-    const skills = extractPluginSkills(plugin.path);
+    // SKILL.md first, then commands/*.md — so a plugin shipping both forms
+    // under one name resolves to the skill, matching Claude Code ("if a skill
+    // and a command share the same name, the skill takes precedence"). The
+    // `seen` guard below is what enforces it.
+    const skills = [...extractPluginSkills(plugin.path), ...extractPluginCommands(plugin.path)];
     for (const skill of skills) {
       if (!skill.name || seen.has(skill.name)) continue;
       if (!isSkillVisible({ audience: skill.audience }, internalUnlocked)) continue;
       entries.push({
         name: skill.name,
         description: skill.description ?? `Skill from plugin at ${plugin.path}`,
-        source: 'plugin',
+        source: skill.origin === 'command' ? 'command' : 'plugin',
       });
       seen.add(skill.name);
     }
@@ -314,7 +336,9 @@ export function discoverPluginSkillBodies(
 
   for (const plugin of plugins) {
     if (plugin.type !== 'local') continue;
-    const skills = extractPluginSkills(plugin.path);
+    // Same order + first-wins rule as collectSkillEntries: a SKILL.md and a
+    // commands/*.md sharing one name resolve to the skill.
+    const skills = [...extractPluginSkills(plugin.path), ...extractPluginCommands(plugin.path)];
     for (const skill of skills) {
       if (skill.name && skill.body && skill.body.length > 0 && !bodies.has(skill.name)) {
         bodies.set(skill.name, {

--- a/src/agent/tools/skill-bridge.ts
+++ b/src/agent/tools/skill-bridge.ts
@@ -263,6 +263,7 @@ export function collectSkillEntries(
         name: skill.name,
         description: skill.description ?? `Skill from plugin at ${plugin.path}`,
         source: skill.origin === 'command' ? 'command' : 'plugin',
+        argumentHint: skill.argumentHint,
       });
       seen.add(skill.name);
     }

--- a/src/agent/types/sdk-types.ts
+++ b/src/agent/types/sdk-types.ts
@@ -334,6 +334,13 @@ export type SlashCommand = {
   name: string;
   description: string;
   argumentHint: string;
+  /**
+   * Origin of the underlying skill/command. Inlined literal union (rather
+   * than importing `SkillManifestEntry['source']` from
+   * `tools/skill-bridge.js`) to avoid a dependency from this SDK-shape file
+   * on the skill-discovery module.
+   */
+  source?: 'builtin' | 'user' | 'project' | 'plugin' | 'imported' | 'command';
 };
 
 export type SDKControlGetContextUsageResponse = {

--- a/src/cli/slash/plugin-skills-listing.test.ts
+++ b/src/cli/slash/plugin-skills-listing.test.ts
@@ -18,6 +18,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { _resetRegistry, registerSkill } from '../../skills/index.js';
 import { resetRegistry } from './registry.js';
 import { initialSkillsCmd } from './plugin-skills.js';
+import { makeDynamicSkillsCmd } from './plugin-skills/listing.js';
 import { stripAnsi } from '../display.js';
 import type { SlashContext } from './types.js';
 
@@ -121,6 +122,37 @@ describe('/skills listing UX (Phase 1)', () => {
     // The old raw badge formatting must be gone.
     expect(out).not.toContain('(user)');
     expect(out).not.toContain('(plugin alt)');
+  });
+
+  it('labels a commands/*.md-origin skill "command", not "plugin"', async () => {
+    // Regression lock for the `source` propagation chain:
+    //   collectSkillEntries → ProviderCommandInfo → SlashCommand →
+    //   DiscoveredSkill → buildListingGroups.
+    // Before that chain carried `source`, listing.ts hard-coded `'plugin'`
+    // for every plugin-origin row, so the `command` legend member was
+    // unreachable at runtime even though the type union contained it.
+    // `initialSkillsCmd` always renders with an empty plugin list; the live
+    // listing is built by `makeDynamicSkillsCmd(discovered)` at
+    // dispatch.ts:268, so drive that — it is the actual runtime path.
+    const cmd = makeDynamicSkillsCmd([
+      { name: 'demo-plugin:deploy', description: 'Deploy the thing.', source: 'command' },
+    ]);
+
+    const { ctx, lines } = makeCtx();
+    await cmd.handler(ctx, '');
+    const out = stripAnsi(lines.join('\n'));
+
+    // The legend renders only sources actually present, so `command`
+    // appearing there proves the row was tagged, not defaulted to `plugin`.
+    const legendLine = out.split('\n').find((l) => l.includes('/skills <name> for details'));
+    expect(legendLine).toBeDefined();
+    expect(legendLine).toContain('command');
+
+    // And the detail card reports the same source for that skill.
+    const { ctx: detailCtx, lines: detailLines } = makeCtx();
+    await cmd.handler(detailCtx, 'deploy');
+    const detail = stripAnsi(detailLines.join('\n'));
+    expect(detail).toMatch(/Source\s+command/);
   });
 
   it('wraps long descriptions instead of clipping them at 80 chars', async () => {

--- a/src/cli/slash/plugin-skills/dispatch.ts
+++ b/src/cli/slash/plugin-skills/dispatch.ts
@@ -141,7 +141,7 @@ export function makeForwardHandler(skill: DiscoveredSkill, flags?: readonly stri
             const inv: SkillInvocation = {
               skillName: bareSkillName,
               rawArgs: dispatchArgs,
-              source: 'plugin',
+              source: skill.source ?? 'plugin',
               capabilities: { compose: true, subagents: true },
             };
             const sessionIdMaybe = ctx.session.current.sessionId;
@@ -216,6 +216,7 @@ export async function registerPluginSkills(
     name: c.name,
     description: c.description,
     ...(c.argumentHint ? { argumentHint: c.argumentHint } : {}),
+    ...(c.source ? { source: c.source } : {}),
   }));
 
   const harvestedFlags = harvestAllPluginSkillFlags();

--- a/src/cli/slash/plugin-skills/dispatch.ts
+++ b/src/cli/slash/plugin-skills/dispatch.ts
@@ -254,6 +254,7 @@ export async function registerPluginSkills(
         bare,
         altSlash: `/${fallbackName}`,
         altDescription: skill.description,
+        ...(skill.source ? { source: skill.source } : {}),
       });
       shadowedBareNames.add(bare);
       continue;

--- a/src/cli/slash/plugin-skills/listing.ts
+++ b/src/cli/slash/plugin-skills/listing.ts
@@ -17,9 +17,17 @@ import { env } from '../../../config/env.js';
 import type { SlashCommand, SlashContext } from '../types.js';
 import { harvestAllPluginSkillFlags, extractHintFromDescription } from './flags.js';
 import { state, bareName, type DiscoveredSkill } from './state.js';
+import type { SkillManifestEntry } from '../../../agent/tools/skill-bridge.js';
 
-/** Where a listing row's skill came from. Drives the friendly source label. */
-type SkillSource = 'builtin' | 'user' | 'project' | 'plugin' | 'imported';
+/**
+ * Where a listing row's skill came from. Drives the friendly source label.
+ *
+ * Invariant: derived from the canonical union rather than restated, so a new
+ * member added to `SkillManifestEntry['source']` is a compile error in
+ * `friendlySource` (which stays exhaustive, with no `default` arm) instead of
+ * a silent `undefined` label at runtime.
+ */
+type SkillSource = SkillManifestEntry['source'];
 
 /** A row in the unified `/skills` listing. */
 interface ListingRow {
@@ -117,6 +125,8 @@ function friendlySource(source: SkillSource): string {
       return 'plugin';
     case 'imported':
       return 'imported';
+    case 'command':
+      return 'command';
   }
 }
 

--- a/src/cli/slash/plugin-skills/listing.ts
+++ b/src/cli/slash/plugin-skills/listing.ts
@@ -276,7 +276,7 @@ function collectAlternatives(
   }
   for (const collision of state.collisions) {
     if (collision.bare === bare) {
-      alternatives.push({ slash: collision.altSlash, source: 'plugin' });
+      alternatives.push({ slash: collision.altSlash, source: collision.source ?? 'plugin' });
     }
   }
   return alternatives;

--- a/src/cli/slash/plugin-skills/listing.ts
+++ b/src/cli/slash/plugin-skills/listing.ts
@@ -120,7 +120,7 @@ function buildListingGroups(plugins: DiscoveredSkill[], internalUnlocked: boolea
       slashName,
       display,
       description: skill.description,
-      source: 'plugin',
+      source: skill.source ?? 'plugin',
     });
   }
 
@@ -309,7 +309,7 @@ function renderSkillDetail(
   const displayName = hint ? `/${name} ${hint}` : `/${name}`;
   const source: SkillSource = registrySkill
     ? registryOriginToSource(registrySkill.origin)
-    : 'plugin';
+    : (pluginSkill?.source ?? 'plugin');
 
   // Wrap the body to the terminal width (capped) so long descriptions read as
   // paragraphs instead of one runaway line.

--- a/src/cli/slash/plugin-skills/listing.ts
+++ b/src/cli/slash/plugin-skills/listing.ts
@@ -29,6 +29,21 @@ import type { SkillManifestEntry } from '../../../agent/tools/skill-bridge.js';
  */
 type SkillSource = SkillManifestEntry['source'];
 
+// Invariant: keyed by SkillSource, so adding a union member is a compile error
+// here rather than a source silently missing from the legend — which is how
+// `imported` rows came to render with no legend entry explaining them.
+const LEGEND_RANK: Record<SkillSource, number> = {
+  builtin: 0,
+  user: 1,
+  project: 2,
+  plugin: 3,
+  command: 4,
+  imported: 5,
+};
+const LEGEND_ORDER = (Object.keys(LEGEND_RANK) as SkillSource[]).sort(
+  (a, b) => LEGEND_RANK[a] - LEGEND_RANK[b],
+);
+
 /** A row in the unified `/skills` listing. */
 interface ListingRow {
   /** Slash form for tab-completion / invocation, e.g. `/mint` or `/example-plugin:mint`. */
@@ -205,10 +220,7 @@ function renderUnifiedListing(ctx: SlashContext, plugins: DiscoveredSkill[], int
   // Header + a one-line source legend listing only the sources actually present.
   ctx.out.line(palette.bold('Skills') + palette.dim(`  (${allGroups.length})`));
   const present = new Set(allGroups.map((g) => g.main.source));
-  const legend = (['builtin', 'user', 'project', 'plugin'] as const)
-    .filter((s) => present.has(s))
-    .map(friendlySource)
-    .join(' · ');
+  const legend = LEGEND_ORDER.filter((s) => present.has(s)).map(friendlySource).join(' · ');
   ctx.out.line(palette.dim(`  ${legend} — /skills <name> for details`));
 
   if (builtinGroups.length > 0) {

--- a/src/cli/slash/plugin-skills/reload.ts
+++ b/src/cli/slash/plugin-skills/reload.ts
@@ -31,6 +31,7 @@ export function buildSourceBreakdown(entries: SkillManifestEntry[]): string {
     user: 0,
     project: 0,
     imported: 0,
+    command: 0,
   };
   for (const e of entries) counts[e.source]++;
   const labels: Array<[SkillManifestEntry['source'], string]> = [
@@ -39,6 +40,7 @@ export function buildSourceBreakdown(entries: SkillManifestEntry[]): string {
     ['user', 'user'],
     ['project', 'project'],
     ['imported', 'imported'],
+    ['command', 'command'],
   ];
   return labels
     .filter(([k]) => counts[k] > 0)

--- a/src/cli/slash/plugin-skills/state.ts
+++ b/src/cli/slash/plugin-skills/state.ts
@@ -8,11 +8,14 @@
  * `setState()` (ESM importers cannot reassign an imported binding).
  */
 
+import type { SkillManifestEntry } from '../../../agent/tools/skill-bridge.js';
+
 export interface DiscoveredSkill {
   /** Name as reported by `session.supportedCommands()` — may include a `<plugin>:` namespace. */
   name: string;
   description: string;
   argumentHint?: string;
+  source?: SkillManifestEntry['source'];
 }
 
 /** Track collisions detected at registration time so /skills can render alts and boot can notify. */

--- a/src/cli/slash/plugin-skills/state.ts
+++ b/src/cli/slash/plugin-skills/state.ts
@@ -26,6 +26,8 @@ export interface PluginCollision {
   altSlash: string;
   /** Description from the plugin side, for the alt continuation row. */
   altDescription: string;
+  /** Origin of the shadowed entry, so an alt row labels a command as such. */
+  source?: SkillManifestEntry['source'];
 }
 
 export interface PluginSkillsState {

--- a/src/cli/slash/preflight/types.ts
+++ b/src/cli/slash/preflight/types.ts
@@ -34,8 +34,11 @@ export interface SkillInvocation {
    * - `project`: scanned from `<cwd>/.afk/skills/`
    * - `plugin`: discovered via session.supportedCommands() (forward path)
    * - `imported`: live-read from a trusted source binary via `importFrom`
+   * - `command`: a Claude Code `commands/*.md` file; routes identically to
+   *   `plugin` for preflight purposes, and is listed separately only so a
+   *   future handler can tell the two apart without a lossy cast.
    */
-  source: 'builtin' | 'user' | 'project' | 'plugin' | 'imported';
+  source: 'builtin' | 'user' | 'project' | 'plugin' | 'imported' | 'command';
   /** Capabilities the model can rely on. Constant today; here for future flexibility. */
   capabilities: {
     /** `compose` DAG tool available. */


### PR DESCRIPTION
## What

AFK read plugin `skills/**/SKILL.md` but ignored `commands/*.md` entirely. This adds it.

## Why this isn't "chasing a legacy format"

That was my first read too, and it was wrong. CC's docs do label `commands/` legacy — but the label describes where **new authoring** is steered, not support status. Every mention pairs it with an explicit continued-support guarantee, and there is no announced removal date (a direct GitHub ask for a deprecation timeline went unanswered and stale-closed).

Adoption has not followed the label. A large share of the plugins in **Anthropic's own official marketplace** ship `commands/` and **no `skills/` directory at all** — `commit-commands`, `code-review`, `pr-review-toolkit`, `feature-dev`, `ralph-loop`, `agent-sdk-dev`. The practical effect was that installing many real CC plugins into AFK produced no usable commands.

## Approach: adapter, not a parallel pipeline

A command file and a `SKILL.md` are near-identical — frontmatter plus a markdown prompt body. So a command is discovered in one new module and then travels as an ordinary `PluginSkillMetadata` through the collection, collision, listing, and dispatch machinery that already exists.

Both seams in `skill-bridge` are patched together — `collectSkillEntries` (registration) and `discoverPluginSkillBodies` (execution) — so a command can never register as a slash command without also being dispatchable.

Two things genuinely differ and are handled in the new module:

| | SKILL.md | commands/*.md |
|---|---|---|
| Name source | `name:` frontmatter | **file path** |
| Nesting | directory holds one skill | **subdirectory is a namespace** |

So `commands/review/security.md` → `/review:security`, matching CC (restored upstream July 2025 after a period where nesting was flattened).

**Precedence** comes free: `SKILL.md` is collected before `commands/`, so the existing first-wins guard produces CC's documented rule — *"if a skill and a command share the same name, the skill takes precedence"* — with no new logic. Locked by a test.

## The one judgement call: commands are excluded from the model manifest

Commands register as slash commands and appear in `/skills`, but are **not** injected into the model-facing skill manifest.

Two reasons:

1. **`buildSkillManifest` has no character budget and no eviction policy.** CC can afford to list commands to its model because it caps the listing at ~1% of the context window and drops least-used descriptions on overflow. We have no such backstop, so every entry costs prompt tokens on every request, forever — and a third-party command surface is unbounded.
2. **Behavioural.** Installing a plugin should not hand the model a menu of commands the user never mentioned and may not know exist.

Filtered at the model-facing boundary rather than in `collectSkillEntries` — the same split the existing `excludeName` filter uses — so the slash router, `/skills`, and `afk skill list` all still see the complete set.

Happy to flip this if you'd rather match CC exactly; it's one `.filter()`.

## Drive-by fix

The new tests exposed a pre-existing bug. `parseSkillMetadata` accepted only camelCase `argumentHint`, so the kebab-case **`argument-hint`** that Claude Code and the Agent Skills standard actually specify was **silently dropped from every plugin SKILL.md** — while `user-skills.ts:126`, reading the identical file, honoured both spellings. Now accepts both.

## Tests

- `command-files.test.ts` — 27 tests (20 under `extractPluginCommands`, 7 under `normalizeSkillSource`): name derivation, `:` namespacing (incl. nested), `origin` tagging, path-beats-frontmatter-`name`, frontmatter parsing, dotfile/non-`.md` skipping, empty-body skipping, deterministic sort, malformed-file resilience, control-byte rejection in both filenames and directory segments (C0/DEL/C1), and symlink-containment rejection.
- `skill-bridge.test.ts` — 5 integration tests: `source: 'command'` tagging, manifest exclusion, body dispatchability, end-to-end namespacing, and skill-beats-command precedence.

| Gate | Result |
|---|---|
| `pnpm lint` | pass |
| `pnpm test:coverage` | 814 files, 15513 passed, 2 skipped, thresholds met |
| `pnpm audit:env:check` | 0 violations |
| `pnpm scan:env:check` | in sync |
| `pnpm audit:sdk:check` | lock matches |
| `pnpm audit:chalk:check` | 0 violations |
| `pnpm fix:pins:check` | pins up to date |

## Not included, deliberately

`` !`cmd` `` bash pre-execution and `@file` inlining — the remaining CC command features. `` !`cmd` `` executes shell at prompt-render time with no tool-call moment to gate, so it would bypass the entire PreToolUse chain (`bash-restriction-hook` only fires on `PreToolUse` + `toolName === 'bash'` via `runPreDispatchGates`), and both bash-restriction and path-approval fail open on headless surfaces where AFK runs unattended. Installing a plugin would become installing recurring, model-unmediated RCE. Cut rather than deferred silently; if revisited it needs a synthesized `ToolCall`, a plugin-manifest opt-in (never command-file self-grant), and an unconditional headless disable.

## Stacking

Independent of #963 and #964, but #963 (surfacing shadowing notices) is a genuine prerequisite in spirit: this PR adds a significant number of new names to the shared slash namespace, and #963 is what makes a resulting collision visible to the user instead of silent.

