### PR TITLE
fix(redact): path-guard NAME=value replacers so non-secret paths survive capture (#949)

### DIFF
--- a/src/agent/prompt-dump.test.ts
+++ b/src/agent/prompt-dump.test.ts
@@ -654,6 +654,22 @@ describe('redactInlineSecrets', () => {
     expect(result).toBe(text);
   });
 
+  it.each([
+    'AUTH_TOKEN_PATH="/Users/me/.config/app/token.json"',
+    "AUTH_TOKEN_PATH='/Users/me/.config/app/token.json'",
+  ])('spares a quoted non-secret filesystem-path value (%s)', (text) => {
+    expect(redactInlineSecrets(text)).toBe(text);
+  });
+
+  it.each([
+    ['API_TOKEN', '/2wYZ01xPz7pQeC0mFkA/'],
+    ['PASSWORD', '/correct/horse/battery/staple'],
+  ])('still masks slash-prefixed secret %s values', (name, secret) => {
+    const result = redactInlineSecrets(`${name}=${secret}`);
+    expect(result).not.toContain(secret);
+    expect(result).toBe(`${name}=<REDACTED length=${secret.length}>`);
+  });
+
   it('STILL MASKS an AWS secret access key even though it is path-shaped (fail-safe)', () => {
     // wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY satisfies looksLikeFilesystemPath()
     // in isolation (contains '/', no '+'/'=', every segment under the 32-char

--- a/src/agent/prompt-dump.test.ts
+++ b/src/agent/prompt-dump.test.ts
@@ -636,4 +636,41 @@ describe('redactInlineSecrets', () => {
     const result = redactInlineSecrets(text);
     expect(result).toBe(text);
   });
+
+  // Issue #949: value-shape guard on the generic NAME=value rules — a
+  // filesystem-path value should survive even though the key name matches
+  // (`*_TOKEN`), but the guard must stay fail-safe against real secrets that
+  // happen to contain '/'.
+
+  it('spares a non-secret filesystem-path value (AUTH_TOKEN_PATH=/…)', () => {
+    const text = 'AUTH_TOKEN_PATH=/Users/me/.config/app/token.json';
+    const result = redactInlineSecrets(text);
+    expect(result).toBe(text);
+  });
+
+  it('spares a non-secret filesystem-path value with ~/ prefix', () => {
+    const text = 'CREDENTIAL_FILE_PATH=~/.config/app/credentials.json';
+    const result = redactInlineSecrets(text);
+    expect(result).toBe(text);
+  });
+
+  it('STILL MASKS an AWS secret access key even though it is path-shaped (fail-safe)', () => {
+    // wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY satisfies looksLikeFilesystemPath()
+    // in isolation (contains '/', no '+'/'=', every segment under the 32-char
+    // opaque-token threshold) — the path-prefix requirement ('/' or '~/') is what
+    // keeps this masked. Regressing this check unmasks a real credential shape.
+    const secret = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY';
+    const text = `AWS_SECRET_ACCESS_KEY=${secret}`;
+    const result = redactInlineSecrets(text);
+    expect(result).not.toContain(secret);
+    expect(result).toContain(`AWS_SECRET_ACCESS_KEY=<REDACTED length=${secret.length}>`);
+  });
+
+  it('still masks a high-entropy opaque token with no path shape', () => {
+    const secret = 'aB3xQ9zK7mN2pL5vR8tY1wC4dF6gH0jM';
+    const text = `API_TOKEN=${secret}`;
+    const result = redactInlineSecrets(text);
+    expect(result).not.toContain(secret);
+    expect(result).toContain(`API_TOKEN=<REDACTED length=${secret.length}>`);
+  });
 });

--- a/src/agent/prompt-dump.test.ts
+++ b/src/agent/prompt-dump.test.ts
@@ -662,8 +662,11 @@ describe('redactInlineSecrets', () => {
   });
 
   it.each([
+    // API_TOKEN has no suffix so `hasPathName` is false → redacted regardless of value shape.
     ['API_TOKEN', '/2wYZ01xPz7pQeC0mFkA/'],
-    ['PASSWORD', '/correct/horse/battery/staple'],
+    // SOME_PASSWORD has a 5-char prefix so it matches the {3,} quantifier guard, and the
+    // name does not have a PATH/FILE segment so `hasPathName` is false → redacted.
+    ['SOME_PASSWORD', '/correct/horse/battery/staple'],
   ])('still masks slash-prefixed secret %s values', (name, secret) => {
     const result = redactInlineSecrets(`${name}=${secret}`);
     expect(result).not.toContain(secret);
@@ -688,5 +691,116 @@ describe('redactInlineSecrets', () => {
     const result = redactInlineSecrets(text);
     expect(result).not.toContain(secret);
     expect(result).toContain(`API_TOKEN=<REDACTED length=${secret.length}>`);
+  });
+
+  // --- PR #968 Item 1: PATH_FILE bypass — passphrase-shaped values must be redacted ---
+
+  it('redacts MY_AUTH_TOKEN_FILE with an all-lowercase passphrase value (PR-968 path-signal guard)', () => {
+    // The hasPathSignal guard prevents passphrase-shaped values from slipping
+    // through the path exemption. MY_AUTH_TOKEN_FILE has a 3-char prefix (MY_),
+    // keyword TOKEN, and suffix _FILE (so hasPathName is true). Without the
+    // hasPathSignal check, /correct/horse/battery/staple would be spared because
+    // looksLikeFilesystemPath accepts short lowercase-only segments. With the
+    // guard, all-lowercase segments produce no path signal → value is redacted.
+    const passphrase = '/correct/horse/battery/staple';
+    const text = `MY_AUTH_TOKEN_FILE=${passphrase}`;
+    const result = redactInlineSecrets(text);
+    expect(result).not.toContain(passphrase);
+    expect(result).toContain('<REDACTED');
+  });
+
+  it('redacts MY_SECRET_KEY_FILE with an all-lowercase passphrase value', () => {
+    const passphrase = '/hunter/two/words/long';
+    const text = `MY_SECRET_KEY_FILE=${passphrase}`;
+    const result = redactInlineSecrets(text);
+    expect(result).not.toContain(passphrase);
+    expect(result).toContain('<REDACTED');
+  });
+
+  it('still spares AUTH_TOKEN_PATH with a real file path (hasPathSignal upholds existing exemption)', () => {
+    // /Users/me/.config/app/token.json: `Users` has uppercase, `.config` has dot —
+    // at least one segment passes the hasPathSignal test.
+    const text = 'AUTH_TOKEN_PATH=/Users/me/.config/app/token.json';
+    expect(redactInlineSecrets(text)).toBe(text);
+  });
+
+  it('still spares CREDENTIAL_FILE_PATH with a real file path with a hyphenated segment', () => {
+    const text = 'CREDENTIAL_FILE_PATH=/home/user/.config/my-app/creds.json';
+    expect(redactInlineSecrets(text)).toBe(text);
+  });
+
+  // --- PR #968 Item 2: quantifier {3,} revert — bare keywords must NOT match ---
+
+  it('does NOT redact bare KEY=<long value> (quantifier revert: prefix must be ≥3 chars)', () => {
+    // With [A-Za-z_]* the prefix was optional, letting `KEY=` match. Reverted to
+    // [A-Za-z_]{3,} so a bare keyword without a meaningful prefix is ignored.
+    const text = 'KEY=supersecretvalueatleast16chrs';
+    const result = redactInlineSecrets(text);
+    // 'KEY' alone has no qualifying prefix — should pass through unchanged
+    expect(result).toBe(text);
+  });
+
+  it('does NOT redact bare TOKEN=<long value> (uppercase variant, quantifier revert)', () => {
+    const text = 'TOKEN=supersecretvalueatleast16chrs';
+    const result = redactInlineSecrets(text);
+    expect(result).toBe(text);
+  });
+
+  it('does NOT redact bare SECRET=<long value>', () => {
+    const text = 'SECRET=supersecretvalueatleast16chrs';
+    const result = redactInlineSecrets(text);
+    expect(result).toBe(text);
+  });
+
+  it('DOES redact MY_KEY=<long value> (prefix ≥3 chars satisfies quantifier)', () => {
+    const secret = 'supersecretvalueatleast16chrs';
+    const text = `MY_KEY=${secret}`;
+    const result = redactInlineSecrets(text);
+    expect(result).not.toContain(secret);
+    expect(result).toContain('<REDACTED');
+  });
+});
+
+// --- PR #968 Item 4: looksLikeFilesystemPath unit tests ---
+
+import { looksLikeFilesystemPath } from './redact-secrets.js';
+
+describe('looksLikeFilesystemPath', () => {
+  it('returns true for a typical macOS home path', () => {
+    expect(looksLikeFilesystemPath('/Users/me/Projects/foo')).toBe(true);
+  });
+
+  it('returns false for a path with an opaque token segment (≥32 mixed alphanumeric chars)', () => {
+    // The long mixed-alphanumeric segment triggers the isOpaqueTokenSegment check.
+    expect(looksLikeFilesystemPath('/tmp/uploads/aB3xQ9zK7mN2pL5vR8tY1wC4dF6gH0jMExtra12345Extra')).toBe(false);
+  });
+
+  it('returns true for a value that looks path-shaped even if it could be an AWS key (name guard is separate)', () => {
+    // The function itself says yes — it is the NAME guard in pathGuardedRedact that
+    // keeps real AWS keys masked. This test documents the known residual gap so a
+    // future refactor does not accidentally tighten the wrong knob.
+    expect(looksLikeFilesystemPath('wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY')).toBe(true);
+  });
+
+  it('returns false for a pure string with no "/"', () => {
+    expect(looksLikeFilesystemPath('supersecretstring')).toBe(false);
+  });
+
+  it('returns false for a string containing "+"', () => {
+    expect(looksLikeFilesystemPath('/some/path+base64==')).toBe(false);
+  });
+
+  it('returns false for a string containing "="', () => {
+    expect(looksLikeFilesystemPath('/some/path=value')).toBe(false);
+  });
+
+  it('returns true for a Linux-style path with dotfile segments', () => {
+    expect(looksLikeFilesystemPath('/home/user/.config/app/settings.json')).toBe(true);
+  });
+
+  it('returns true for a short all-lowercase path (looksLikeFilesystemPath is permissive; path-signal guard sits above)', () => {
+    // looksLikeFilesystemPath itself returns true here; the hasPathSignal guard
+    // in pathGuardedRedact is the layer that rejects all-lowercase passphrase paths.
+    expect(looksLikeFilesystemPath('/correct/horse/battery/staple')).toBe(true);
   });
 });

--- a/src/agent/redact-secrets.ts
+++ b/src/agent/redact-secrets.ts
@@ -10,6 +10,12 @@
  *   - `session-ledger.ts`        — tool-input summary → events.jsonl (at-rest)
  *   - `telegram/streaming.ts`    — subagent tool-input summary → Telegram (egress)
  *
+ * `looksLikeFilesystemPath` is also exported standalone (not just used inside
+ * `redactSecrets`'s generic-token rule): `session/prompt-dump.ts`'s
+ * `NAME=value` replacers reuse it directly to spare path-shaped values from a
+ * key-name-only match (issue #949) — see that module for why key-name alone
+ * is unreliable evidence of a secret.
+ *
  * Intentionally pure — no I/O, no SDK imports — so any layer may depend on it.
  *
  * @module agent/redact-secrets
@@ -99,7 +105,7 @@ export function redactSecrets(text: string): string {
  * is preserved. The high-value NAMED secrets (sk-ant, Bearer, JWT, AWS) are
  * covered by the explicit rules that run first, regardless of path context.
  */
-function looksLikeFilesystemPath(run: string): boolean {
+export function looksLikeFilesystemPath(run: string): boolean {
   if (!run.includes('/') || /[+=]/.test(run)) return false;
   const isOpaqueTokenSegment = (seg: string): boolean =>
     seg.length >= 32 && !seg.includes('.') && /[A-Za-z]/.test(seg) && /[0-9]/.test(seg);

--- a/src/agent/session/prompt-dump.ts
+++ b/src/agent/session/prompt-dump.ts
@@ -12,6 +12,7 @@ import { env } from '../../config/env.js';
 import { mkdirSync, appendFileSync, existsSync } from 'fs';
 import { resolve } from 'path';
 import { dirname } from 'path';
+import { looksLikeFilesystemPath } from '../redact-secrets.js';
 
 export type PromptShape = 'string' | 'string[]' | 'preset' | 'undefined';
 
@@ -68,7 +69,32 @@ const SECRET_KEY_PATTERN = /key|token|secret|password|credential|auth/i;
  *   - Slack bot tokens: xoxb-*
  *   - Generic KEY=value pairs where the value looks like a high-entropy secret
  *     (≥16 chars of non-whitespace after the '=').
+ *
+ * Invariant (issue #949): matching on the key NAME alone with no check on
+ * the value's shape masks non-secret path values in full, e.g.
+ * `AUTH_TOKEN_PATH=/Users/me/.config/app/token.json`. `pathGuardedRedact`
+ * spares a value ONLY when it starts with `/` or `~/` AND
+ * `looksLikeFilesystemPath` also holds. The prefix check is required, not
+ * redundant: `looksLikeFilesystemPath` alone accepts
+ * `wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY` (an AWS secret access key —
+ * has `/`, no `+`/`=`, every segment under the 32-char opaque threshold),
+ * which would unmask a live credential. Path values start with `/`/`~/`
+ * virtually universally; secrets essentially never do. Ambiguous values —
+ * including any `/`-bearing value lacking that prefix — stay redacted.
  */
+function pathGuardedRedact(m: RegExpMatchArray): string {
+  // Both capture groups are structural requirements of the regexes this is used
+  // with (see the non-null-assertion comment below) — group 1 is the key name,
+  // group 2 is the value.
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const name = m[1]!;
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const value = m[2]!;
+  const hasPathPrefix = value.startsWith('/') || value.startsWith('~/');
+  if (hasPathPrefix && looksLikeFilesystemPath(value)) return `${name}=${value}`;
+  return `${name}=<REDACTED length=${value.length}>`;
+}
+
 const INLINE_SECRET_PATTERNS: Array<[RegExp, (m: RegExpMatchArray) => string]> = [
   // Anthropic key: sk-ant-... (up to 200 chars)
   [/sk-ant-[A-Za-z0-9_\-]{8,200}/g, (m) => `<REDACTED sk-ant length=${m[0].length}>`],
@@ -84,19 +110,14 @@ const INLINE_SECRET_PATTERNS: Array<[RegExp, (m: RegExpMatchArray) => string]> =
   [/\d{8,12}:[A-Za-z0-9_\-]{35}/g, (m) => `<REDACTED Telegram token length=${m[0].length}>`],
   // Generic TOKEN=<value ≥16 chars> — catches OPENAI_API_KEY=, TELEGRAM_BOT_TOKEN=, etc.
   // (The existing generic pattern already covers most of these; this is belt-and-suspenders
-  //  for lowercase variants, e.g. openai_api_key=...)
-  // Both capture groups are required by the regex structure: group 1 is [A-Za-z_]{3,}...
-  // and group 2 is [^\s]{16,}, so neither can be absent on a successful match.
-  // We assert (non-null assertion) rather than using ?? '' to avoid a misleading length=0
-  // in the redaction marker if the regex were ever changed to make groups optional.
+  //  for lowercase variants, e.g. openai_api_key=...) Both capture groups are required by
+  // the regex structure, so pathGuardedRedact's non-null assertions always hold.
   [/([A-Za-z_]{3,}(?:[Kk][Ee][Yy]|[Tt][Oo][Kk][Ee][Nn]|[Ss][Ee][Cc][Rr][Ee][Tt]|[Pp][Aa][Ss][Ss][Ww][Oo][Rr][Dd]|[Cc][Rr][Ee][Dd][Ee][Nn][Tt][Ii][Aa][Ll])[A-Za-z_]*)=([^\s]{16,})/g,
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    (m) => `${m[1]!}=<REDACTED length=${m[2]!.length}>`],
-  // Generic KEY=<high-entropy value> — UPPERCASE variant (kept for backward compat)
-  // Same invariant: both groups are structural requirements of the regex.
+    pathGuardedRedact],
+  // Generic KEY=<high-entropy value> — UPPERCASE variant (kept for backward compat). Same
+  // capture-group invariant as above.
   [/([A-Z_]{3,}(?:KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|AUTH)[A-Z_]*)=([^\s]{16,})/g,
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    (m) => `${m[1]!}=<REDACTED length=${m[2]!.length}>`],
+    pathGuardedRedact],
 ];
 
 /**

--- a/src/agent/session/prompt-dump.ts
+++ b/src/agent/session/prompt-dump.ts
@@ -73,14 +73,15 @@ const SECRET_KEY_PATTERN = /key|token|secret|password|credential|auth/i;
  * Invariant (issue #949): matching on the key NAME alone with no check on
  * the value's shape masks non-secret path values in full, e.g.
  * `AUTH_TOKEN_PATH=/Users/me/.config/app/token.json`. `pathGuardedRedact`
- * spares a value ONLY when it starts with `/` or `~/` AND
- * `looksLikeFilesystemPath` also holds. The prefix check is required, not
+ * spares a value ONLY when the variable name has a `PATH` or `FILE` segment,
+ * the optionally quoted value starts with `/` or `~/`, AND
+ * `looksLikeFilesystemPath` also holds. The name and prefix checks are required, not
  * redundant: `looksLikeFilesystemPath` alone accepts
  * `wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY` (an AWS secret access key —
  * has `/`, no `+`/`=`, every segment under the 32-char opaque threshold),
- * which would unmask a live credential. Path values start with `/`/`~/`
- * virtually universally; secrets essentially never do. Ambiguous values —
- * including any `/`-bearing value lacking that prefix — stay redacted.
+ * which would unmask a live credential. Requiring an explicit path-oriented
+ * name also keeps slash-prefixed passwords and tokens masked. Ambiguous values
+ * stay redacted.
  */
 function pathGuardedRedact(m: RegExpMatchArray): string {
   // Both capture groups are structural requirements of the regexes this is used
@@ -90,8 +91,16 @@ function pathGuardedRedact(m: RegExpMatchArray): string {
   const name = m[1]!;
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const value = m[2]!;
-  const hasPathPrefix = value.startsWith('/') || value.startsWith('~/');
-  if (hasPathPrefix && looksLikeFilesystemPath(value)) return `${name}=${value}`;
+  const quote = value[0];
+  const pathValue =
+    (quote === '"' || quote === "'") && value.at(-1) === quote
+      ? value.slice(1, -1)
+      : value;
+  const hasPathName = /(?:^|_)(?:PATH|FILE)(?:_|$)/i.test(name);
+  const hasPathPrefix = pathValue.startsWith('/') || pathValue.startsWith('~/');
+  if (hasPathName && hasPathPrefix && looksLikeFilesystemPath(pathValue)) {
+    return `${name}=${value}`;
+  }
   return `${name}=<REDACTED length=${value.length}>`;
 }
 
@@ -112,11 +121,11 @@ const INLINE_SECRET_PATTERNS: Array<[RegExp, (m: RegExpMatchArray) => string]> =
   // (The existing generic pattern already covers most of these; this is belt-and-suspenders
   //  for lowercase variants, e.g. openai_api_key=...) Both capture groups are required by
   // the regex structure, so pathGuardedRedact's non-null assertions always hold.
-  [/([A-Za-z_]{3,}(?:[Kk][Ee][Yy]|[Tt][Oo][Kk][Ee][Nn]|[Ss][Ee][Cc][Rr][Ee][Tt]|[Pp][Aa][Ss][Ss][Ww][Oo][Rr][Dd]|[Cc][Rr][Ee][Dd][Ee][Nn][Tt][Ii][Aa][Ll])[A-Za-z_]*)=([^\s]{16,})/g,
+  [/([A-Za-z_]*(?:[Kk][Ee][Yy]|[Tt][Oo][Kk][Ee][Nn]|[Ss][Ee][Cc][Rr][Ee][Tt]|[Pp][Aa][Ss][Ss][Ww][Oo][Rr][Dd]|[Cc][Rr][Ee][Dd][Ee][Nn][Tt][Ii][Aa][Ll])[A-Za-z_]*)=([^\s]{16,})/g,
     pathGuardedRedact],
   // Generic KEY=<high-entropy value> — UPPERCASE variant (kept for backward compat). Same
   // capture-group invariant as above.
-  [/([A-Z_]{3,}(?:KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|AUTH)[A-Z_]*)=([^\s]{16,})/g,
+  [/([A-Z_]*(?:KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|AUTH)[A-Z_]*)=([^\s]{16,})/g,
     pathGuardedRedact],
 ];
 

--- a/src/agent/session/prompt-dump.ts
+++ b/src/agent/session/prompt-dump.ts
@@ -98,7 +98,21 @@ function pathGuardedRedact(m: RegExpMatchArray): string {
       : value;
   const hasPathName = /(?:^|_)(?:PATH|FILE)(?:_|$)/i.test(name);
   const hasPathPrefix = pathValue.startsWith('/') || pathValue.startsWith('~/');
-  if (hasPathName && hasPathPrefix && looksLikeFilesystemPath(pathValue)) {
+  // Secondary guard: real filesystem paths almost always have at least one segment
+  // containing an uppercase letter, a digit, a dot, or a hyphen — characters that
+  // appear naturally in directory names (e.g. `Users`, `.config`, `token.json`,
+  // `my-app`) but are absent from all-lowercase passphrase strings like
+  // `/correct/horse/battery/staple`. Without this check a value such as
+  // `PASSWORD_FILE_PATH=/correct/horse/battery/staple` would slip through because
+  // all three existing guards pass: the name has `_PATH`, the value starts with `/`,
+  // and `looksLikeFilesystemPath` accepts short lowercase-only word segments.
+  // Requiring a positive path-signal ensures we only exempt values that look like
+  // genuine filesystem paths. The guard is intentionally loose — `/usr/local/bin`
+  // fails it (all lowercase, no digits/dots/hyphens), so those are redacted, which
+  // is the safe side when the name already matched a secret keyword.
+  const segments = pathValue.split('/').filter(Boolean);
+  const hasPathSignal = segments.some((s) => /[A-Z0-9.\-]/.test(s));
+  if (hasPathName && hasPathPrefix && hasPathSignal && looksLikeFilesystemPath(pathValue)) {
     return `${name}=${value}`;
   }
   return `${name}=<REDACTED length=${value.length}>`;
@@ -121,11 +135,11 @@ const INLINE_SECRET_PATTERNS: Array<[RegExp, (m: RegExpMatchArray) => string]> =
   // (The existing generic pattern already covers most of these; this is belt-and-suspenders
   //  for lowercase variants, e.g. openai_api_key=...) Both capture groups are required by
   // the regex structure, so pathGuardedRedact's non-null assertions always hold.
-  [/([A-Za-z_]*(?:[Kk][Ee][Yy]|[Tt][Oo][Kk][Ee][Nn]|[Ss][Ee][Cc][Rr][Ee][Tt]|[Pp][Aa][Ss][Ss][Ww][Oo][Rr][Dd]|[Cc][Rr][Ee][Dd][Ee][Nn][Tt][Ii][Aa][Ll])[A-Za-z_]*)=([^\s]{16,})/g,
+  [/([A-Za-z_]{3,}(?:[Kk][Ee][Yy]|[Tt][Oo][Kk][Ee][Nn]|[Ss][Ee][Cc][Rr][Ee][Tt]|[Pp][Aa][Ss][Ss][Ww][Oo][Rr][Dd]|[Cc][Rr][Ee][Dd][Ee][Nn][Tt][Ii][Aa][Ll])[A-Za-z_]*)=([^\s]{16,})/g,
     pathGuardedRedact],
   // Generic KEY=<high-entropy value> — UPPERCASE variant (kept for backward compat). Same
   // capture-group invariant as above.
-  [/([A-Z_]*(?:KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|AUTH)[A-Z_]*)=([^\s]{16,})/g,
+  [/([A-Z_]{3,}(?:KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|AUTH)[A-Z_]*)=([^\s]{16,})/g,
     pathGuardedRedact],
 ];
 


### PR DESCRIPTION
## Mechanism

`redactInlineSecrets` in `src/agent/session/prompt-dump.ts` (imported by both `subagent-output-capture.ts` and `subagent-prompt-capture.ts`) has two generic `NAME=value` redaction rules that match on **key name alone** — any key containing `key`/`token`/`secret`/`password`/`credential`/`auth`, with a value side of `[^\s]{16,}`. Because the check never inspects the value's shape, a filesystem path clears it: `AUTH_TOKEN_PATH=/Users/me/.config/app/token.json` was masked in full, even though the path only names a credential's *location*, not the credential itself.

## The fix

- `src/agent/redact-secrets.ts`: exported the existing `looksLikeFilesystemPath` helper (previously module-private), which already backs `redact-secrets.ts`'s own generic-token rule.
- `src/agent/session/prompt-dump.ts`: added `pathGuardedRedact`, wired through both `NAME=value` rules. It spares a value from redaction **only** when the value starts with `/` or `~/` **and** `looksLikeFilesystemPath(value)` also holds. Everything else — including any value that merely *contains* a `/` without that prefix — is still redacted.

## The AWS fail-safe finding, and how it's guarded

A naive port that gates purely on `looksLikeFilesystemPath(value)` (no prefix check) is a **regression that unmasks a real secret**: `looksLikeFilesystemPath('wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY')` — an AWS secret access key shape — returns `true` in isolation, because the value contains `/`, has no `+`/`=`, and every `/`-delimited segment is under the 32-char opaque-token threshold the helper uses.

The mitigation is the added prefix gate: `value.startsWith('/') || value.startsWith('~/')`. Env-var path values satisfy this virtually universally; secret values essentially never do. `AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/...` does not start with `/` or `~/`, so it fails the gate and stays redacted — confirmed by a dedicated regression test (see below).

## Test evidence

```
export PATH="$HOME/.nvm/versions/node/v24.11.0/bin:$PATH"
./node_modules/.bin/tsc --noEmit
# exit 0

./node_modules/.bin/vitest run src/agent/prompt-dump.test.ts
# Test Files  1 passed (1)
# Tests  49 passed (49)   (includes 4 new #949 regression tests)

./node_modules/.bin/vitest run \
  src/agent/session/subagent-output-capture.test.ts \
  src/agent/session/subagent-prompt-capture.test.ts \
  src/agent/session/subagent-prompt-capture-wiring.test.ts \
  src/agent/session/subagent-output-capture-wiring.test.ts \
  src/agent/daemon/queue-store.test.ts
# Test Files  5 passed (5)
# Tests  84 passed (84)
```

New tests added to `src/agent/prompt-dump.test.ts` (`redactInlineSecrets` describe block):
1. `AUTH_TOKEN_PATH=/Users/me/.config/app/token.json` **survives** unredacted.
2. `CREDENTIAL_FILE_PATH=~/.config/app/credentials.json` **survives** unredacted (`~/` prefix).
3. `AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY` **is still masked** — the critical fail-safe regression test.
4. A high-entropy opaque token with no path shape (`API_TOKEN=aB3xQ9zK7mN2pL5vR8tY1wC4dF6gH0jM`) **is still masked**.

## Files changed

- `src/agent/redact-secrets.ts` (+7/-1) — export `looksLikeFilesystemPath`.
- `src/agent/session/prompt-dump.ts` (+29/-14, 349 LOC total) — `pathGuardedRedact` helper, wired through both generic rules.
- `src/agent/prompt-dump.test.ts` (+37) — 4 new regression tests.

Closes #949. Unblocks #948.
