### PR TITLE
test(background-registry): replace fixed-sleep races with vi.waitFor polls (#917)

### DIFF
--- a/src/agent/background-registry.test.ts
+++ b/src/agent/background-registry.test.ts
@@ -752,28 +752,36 @@ describe('BackgroundAgentRegistry', () => {
       const handle = createStubHandle('sub-disk-hygiene');
       const job = registry.register({ handle, prompt, model: 'sonnet' });
 
-      await new Promise((r) => setTimeout(r, 100));
       const metaPath = path.join(bgTestTmpDir, 'state', 'bg', job.jobId, 'meta.json');
-      const rawMeta = fs.readFileSync(metaPath, 'utf8');
-      const meta = JSON.parse(rawMeta) as { label: string; promptHash: string };
-      expect(meta.label).toBe(prompt);
-      expect(meta.promptHash).toBe(createHash('sha256').update(prompt).digest('hex'));
-      expect(rawMeta).not.toContain(base64Sentinel);
+      // readFileSync throws ENOENT before the async writeMeta has landed the
+      // file; vi.waitFor retries on thrown error, so that's fine.
+      await vi.waitFor(
+        () => {
+          const rawMeta = fs.readFileSync(metaPath, 'utf8');
+          const meta = JSON.parse(rawMeta) as { label: string; promptHash: string };
+          expect(meta.label).toBe(prompt);
+          expect(meta.promptHash).toBe(createHash('sha256').update(prompt).digest('hex'));
+          expect(rawMeta).not.toContain(base64Sentinel);
+        },
+        { timeout: 2000 },
+      );
     });
 
     it('register() writes meta.json to disk with status=running', async () => {
       const handle = createStubHandle('sub-disk-1');
       const job = registry.register({ handle, prompt: 'disk job', model: 'haiku' });
 
-      // Allow the async writeMeta to settle
-      await new Promise((r) => setTimeout(r, 100));
-
       const { BgJobLogReader } = await import('./bg-job-log.js');
-      const meta = await BgJobLogReader.readMeta(job.jobId);
-      expect(meta).not.toBeNull();
-      expect(meta!.status).toBe('running');
-      expect(meta!.jobId).toBe(job.jobId);
-      expect(meta!.model).toBe('haiku');
+      await vi.waitFor(
+        async () => {
+          const meta = await BgJobLogReader.readMeta(job.jobId);
+          expect(meta).not.toBeNull();
+          expect(meta!.status).toBe('running');
+          expect(meta!.jobId).toBe(job.jobId);
+          expect(meta!.model).toBe('haiku');
+        },
+        { timeout: 2000 },
+      );
     });
 
     it('progress events flow to the disk writer', async () => {
@@ -786,22 +794,26 @@ describe('BackgroundAgentRegistry', () => {
         chunk: { type: 'content', content: 'hello' } as any,
       });
 
-      // Allow stream to flush
-      await new Promise((r) => setTimeout(r, 150));
-
+      // `writer.write()` is a synchronous in-memory queue append, so the
+      // progress event above is already durable — no sleep needed to bridge
+      // it. The poll below (after firing terminal) covers both events.
       const { BgJobLogReader } = await import('./bg-job-log.js');
 
       // We can't easily read mid-stream (writer is still open), but we can
       // verify the log file exists after firing terminal + close.
       handle.__fireTerminal(successResult('sub-disk-2', 'done'));
-      await new Promise((r) => setTimeout(r, 200));
 
-      const events = [];
-      for await (const e of BgJobLogReader.readEvents(job.jobId)) {
-        events.push(e);
-      }
-      // Should have at least the content event
-      expect(events.some((e) => e.type === 'chunk')).toBe(true);
+      await vi.waitFor(
+        async () => {
+          const events = [];
+          for await (const e of BgJobLogReader.readEvents(job.jobId)) {
+            events.push(e);
+          }
+          // Should have at least the content event
+          expect(events.some((e) => e.type === 'chunk')).toBe(true);
+        },
+        { timeout: 2000 },
+      );
     });
 
     it('text events feed appendTranscript()', () => {
@@ -825,15 +837,17 @@ describe('BackgroundAgentRegistry', () => {
 
       handle.__fireTerminal(successResult('sub-disk-4', 'completed output'));
 
-      // Allow the async writeMeta to settle
-      await new Promise((r) => setTimeout(r, 200));
-
       const { BgJobLogReader } = await import('./bg-job-log.js');
-      const meta = await BgJobLogReader.readMeta(job.jobId);
-      expect(meta).not.toBeNull();
-      expect(meta!.status).toBe('completed');
-      expect(meta!.endedAt).toBeDefined();
-      expect(meta!.endedAt).toBeGreaterThan(0);
+      await vi.waitFor(
+        async () => {
+          const meta = await BgJobLogReader.readMeta(job.jobId);
+          expect(meta).not.toBeNull();
+          expect(meta!.status).toBe('completed');
+          expect(meta!.endedAt).toBeDefined();
+          expect(meta!.endedAt).toBeGreaterThan(0);
+        },
+        { timeout: 2000 },
+      );
     });
 
     // PR#713 Wave-A A1(b): markTerminal persists `result.stopReason` into the
@@ -849,12 +863,15 @@ describe('BackgroundAgentRegistry', () => {
         stopReason: 'tool_use_loop_capped',
       });
 
-      await new Promise((r) => setTimeout(r, 200));
-
       const { BgJobLogReader } = await import('./bg-job-log.js');
-      const meta = await BgJobLogReader.readMeta(job.jobId);
-      expect(meta).not.toBeNull();
-      expect(meta!.stopReason).toBe('tool_use_loop_capped');
+      await vi.waitFor(
+        async () => {
+          const meta = await BgJobLogReader.readMeta(job.jobId);
+          expect(meta).not.toBeNull();
+          expect(meta!.stopReason).toBe('tool_use_loop_capped');
+        },
+        { timeout: 2000 },
+      );
     });
 
     it('terminal callback leaves meta.stopReason ABSENT when the result carries none', async () => {
@@ -864,9 +881,19 @@ describe('BackgroundAgentRegistry', () => {
       // successResult() never sets stopReason.
       handle.__fireTerminal(successResult('sub-disk-6', 'clean output'));
 
-      await new Promise((r) => setTimeout(r, 200));
-
       const { BgJobLogReader } = await import('./bg-job-log.js');
+      // Poll until the meta record reaches a terminal status FIRST. The
+      // initial "running" meta also lacks stopReason, so asserting
+      // toBeUndefined() without this guard would trivially pass against
+      // stale pre-completion state and mask the race instead of removing it.
+      await vi.waitFor(
+        async () => {
+          const polled = await BgJobLogReader.readMeta(job.jobId);
+          expect(polled?.status).toBe('completed');
+        },
+        { timeout: 2000 },
+      );
+
       const meta = await BgJobLogReader.readMeta(job.jobId);
       expect(meta).not.toBeNull();
       expect(meta!.stopReason).toBeUndefined();


### PR DESCRIPTION
## The race

`src/agent/background-registry.test.ts` had six `await new Promise((r) => setTimeout(r, N))` fixed sleeps in the persistent-log test suite (BgJobLogWriter disk I/O), each guarding an assertion that reads back a file/meta record written asynchronously. The sleep encodes an assumption — "N ms is always enough for the write to land" — that is only true on an unloaded machine. Under load (parallel test files, slower CI runners) the write can still be in flight when the sleep elapses, and the assertion reads stale or missing state. That's the flake in #917.

**A longer sleep is not the fix.** It only narrows the window where the assumption can fail — it doesn't remove the dependency on wall-clock timing being "enough," and it taxes every passing run (local and CI) with the same fixed delay regardless of how fast the write actually completes.

## The fix: poll on the actual condition

Replaced each fixed sleep with `vi.waitFor(() => { ...assertions... }, { timeout: 2000 })`. `vi.waitFor` (vitest 2.1.9) polls the callback on an interval (default 50ms) and retries on thrown error or rejected promise/assertion, resolving as soon as the callback passes or rejecting once the timeout elapses. This ties the wait to the actual condition (file exists + parses + matches) instead of a guessed duration, with a generous 2s ceiling so genuine failures still fail fast instead of hanging.

In-repo precedent for this exact pattern: `src/agent/tools/dispatcher.test.ts:301,323-326`.

## L790 — deleted, not converted

The sleep after `handle.__fireProgress()` guarded nothing async: `writer.write()` is a synchronous in-memory queue append, so there's no flush to bridge with a wait. That standalone 150ms sleep is deleted outright (comment left explaining why); the real assertion in that test is downstream of firing terminal, and is now covered by a single `vi.waitFor` wrapping the `readEvents()` loop.

## L867 — needed an extra guard, not a mechanical swap

The "leaves meta.stopReason ABSENT" test can't just poll `stopReason === undefined` — that's trivially true against the test's own initial "running" meta record, which also lacks `stopReason` before the terminal write ever lands. A naive swap would pass immediately without ever observing real terminal state, silently reintroducing the exact race under a different name. Fixed by polling `status === 'completed'` first inside the same `waitFor` callback, and only asserting `stopReason` once terminal state is confirmed reached.

## Verification

- `tsc --noEmit`: clean (exit 0).
- `vitest run src/agent/background-registry.test.ts` — 5 consecutive runs, 62/62 tests passing every time, 0 failures.
- No remaining `setTimeout`-based waits guard any assertion in this file (verified via grep post-edit).
- Test file only — no production code changes.

Closes #917
