### PR TITLE
perf(permissions): memoize getWriteDenylist keyed on AFK_HOME + AFK_STATE_DIR (#781)

### DIFF
--- a/src/agent/tools/handlers/write-denylist.test.ts
+++ b/src/agent/tools/handlers/write-denylist.test.ts
@@ -555,6 +555,52 @@ describe('write-denylist — AFK_HOME-relocated credential tree (#740)', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Memoization cache-key regression guard (#781)
+// ---------------------------------------------------------------------------
+
+describe('write-denylist — memoization cache-key regression guard (#781)', () => {
+  // Cache-invalidation: the memoization key must include AFK_HOME and
+  // AFK_STATE_DIR, not just AFK_WRITE_DENYLIST, or a runtime change to either
+  // returns a STALE denylist that fails to cover a newly-relocated credential
+  // tree — silently permitting a write that should be denied.
+  // Invariant: deliberately NO `_resetWriteDenylistCacheForTests()` call
+  // between the two queries below — that reset is what the memo key itself is
+  // supposed to make unnecessary. Calling it here would make this test pass
+  // even if AFK_HOME/AFK_STATE_DIR were dropped from the key entirely,
+  // defeating the point of the regression guard. Mirrors
+  // read-denylist.test.ts's identically-purposed guard.
+  it('invalidates the memoized denylist when AFK_HOME changes, with no manual cache reset', () => {
+    const relocated = join(tmpDir, 'relocated-cache-home');
+    mkdirSync(relocated, { recursive: true });
+    const target = join(relocated, 'config', 'afk.env');
+
+    // Query once with AFK_HOME unset: the relocated config dir is NOT covered.
+    expect(() => assertNotDenylisted(target, 'write_file')).not.toThrow();
+
+    // Change AFK_HOME and query again — WITHOUT resetting the cache by hand.
+    vi.stubEnv('AFK_HOME', relocated);
+    expect(() => assertNotDenylisted(target, 'write_file')).toThrow(
+      /refusing to write to protected path/,
+    );
+  });
+
+  it('invalidates the memoized denylist when AFK_STATE_DIR changes, with no manual cache reset', () => {
+    const stateDir = join(tmpDir, 'relocated-cache-state');
+    mkdirSync(stateDir, { recursive: true });
+    const target = join(stateDir, 'sessions', 's.json');
+
+    // Query once with AFK_STATE_DIR unset: the relocated state dir is NOT covered.
+    expect(() => assertNotDenylisted(target, 'write_file')).not.toThrow();
+
+    // Change AFK_STATE_DIR and query again — WITHOUT resetting the cache by hand.
+    vi.stubEnv('AFK_STATE_DIR', stateDir);
+    expect(() => assertNotDenylisted(target, 'write_file')).toThrow(
+      /refusing to write to protected path/,
+    );
+  });
+});
+
 describe('assertNotDenylisted — case-variant spellings (#736)', () => {
   afterEach(() => {
     _resetFsCaseCacheForTests();

--- a/src/agent/tools/handlers/write-denylist.test.ts
+++ b/src/agent/tools/handlers/write-denylist.test.ts
@@ -599,6 +599,29 @@ describe('write-denylist — memoization cache-key regression guard (#781)', () 
       /refusing to write to protected path/,
     );
   });
+
+  it('re-resolves a custom denylist symlink after it is repointed', () => {
+    const firstTarget = join(tmpDir, 'first-target');
+    const secondTarget = join(tmpDir, 'second-target');
+    const link = join(tmpDir, 'blocked-link');
+    mkdirSync(firstTarget);
+    mkdirSync(secondTarget);
+    symlinkSync(firstTarget, link);
+    vi.stubEnv('AFK_WRITE_DENYLIST', link);
+
+    expect(() =>
+      assertNotDenylisted(join(link, 'secret.txt'), 'write_file'),
+    ).toThrow(/refusing to write to protected path/);
+
+    rmSync(link);
+    symlinkSync(secondTarget, link);
+
+    // The environment key did not change, so this only remains protected if
+    // getWriteDenylist re-resolves entries after a cache hit.
+    expect(() =>
+      assertNotDenylisted(join(link, 'secret.txt'), 'write_file'),
+    ).toThrow(/refusing to write to protected path/);
+  });
 });
 
 describe('assertNotDenylisted — case-variant spellings (#736)', () => {

--- a/src/agent/tools/handlers/write-denylist.ts
+++ b/src/agent/tools/handlers/write-denylist.ts
@@ -79,10 +79,11 @@ export const BUILTIN_WRITE_DENYLIST: readonly string[] = [
  * `homedir()`-based entries still apply regardless. The throw is no longer
  * silent: {@link warnAfkHomeRejectedOnce} surfaces it once per process.
  *
- * Called fresh on every {@link getWriteDenylist} call (this module is
- * uncached, unlike the read denylist), so no separate cache-key concern
- * applies here — a runtime `AFK_HOME` / `AFK_STATE_DIR` change is picked up on
- * the very next call.
+ * Not cached on its own — its result feeds directly into
+ * {@link getWriteDenylist}'s memo, which keys on `AFK_HOME` and
+ * `AFK_STATE_DIR` (alongside `AFK_WRITE_DENYLIST`) precisely so a runtime
+ * change to either is observed on the very next call rather than served a
+ * stale floor (#781).
  */
 function derivedAfkHomeWriteEntries(): string[] {
   const entries: string[] = [];
@@ -101,6 +102,21 @@ function derivedAfkHomeWriteEntries(): string[] {
   return entries;
 }
 
+// Invariant: AFK_HOME and AFK_STATE_DIR are BOTH part of the cache key below,
+// alongside AFK_WRITE_DENYLIST. `derivedAfkHomeWriteEntries()` depends on all
+// three (AFK_HOME via `getAfkHome()`, AFK_STATE_DIR via `getAfkStateDir()`
+// independently — see the Invariant on that function above), so a runtime
+// change to ANY of them must invalidate the memo, or a relocated AFK_HOME /
+// AFK_STATE_DIR keeps serving the pre-relocation denylist — silently
+// permitting writes to the real (now-uncovered) credential tree. This mirrors
+// the write path's hot-path pressure: `assertNotDenylisted` runs on every
+// `write_file` / `edit_file` call, and #753 grew the per-call `safeRealpath`
+// count from ~11 to ~14 by adding the derived AFK entries, which is what this
+// memo removes. Joined with U+0000 (mirrors read-denylist.ts's key), which
+// cannot occur in any of the three values, so components can never collide
+// into an ambiguous key.
+let cached: { key: string; list: readonly string[] } | undefined;
+
 /**
  * Return the effective denylist (builtin + any user-supplied extras).
  * Entries are returned as real (symlink-resolved) absolute paths.
@@ -110,6 +126,9 @@ function derivedAfkHomeWriteEntries(): string[] {
  * Use a different separator character if your paths require colons.
  */
 export function getWriteDenylist(): readonly string[] {
+  const key = `${env.AFK_WRITE_DENYLIST ?? ''}\u0000${env.AFK_HOME ?? ''}\u0000${env.AFK_STATE_DIR ?? ''}`;
+  if (cached && cached.key === key) return cached.list;
+
   const extra = env.AFK_WRITE_DENYLIST;
   const extras: string[] = extra
     ? extra.split(':').map((p) => safeRealpath(resolve(p))).filter(Boolean)
@@ -120,7 +139,19 @@ export function getWriteDenylist(): readonly string[] {
       ...derivedAfkHomeWriteEntries(),
     ]),
   ];
-  return [...builtins, ...extras];
+  const list = [...builtins, ...extras];
+  cached = { key, list };
+  return list;
+}
+
+/**
+ * Test-only: clear the memoized denylist so suites that mutate
+ * `AFK_WRITE_DENYLIST` / `AFK_HOME` / `AFK_STATE_DIR` (or repoint a
+ * denylisted symlink) don't see a stale list. Mirrors
+ * `_resetReadDenylistCacheForTests` in `read-denylist.ts`.
+ */
+export function _resetWriteDenylistCacheForTests(): void {
+  cached = undefined;
 }
 
 /**

--- a/src/agent/tools/handlers/write-denylist.ts
+++ b/src/agent/tools/handlers/write-denylist.ts
@@ -79,23 +79,22 @@ export const BUILTIN_WRITE_DENYLIST: readonly string[] = [
  * `homedir()`-based entries still apply regardless. The throw is no longer
  * silent: {@link warnAfkHomeRejectedOnce} surfaces it once per process.
  *
- * Not cached on its own — its result feeds directly into
- * {@link getWriteDenylist}'s memo, which keys on `AFK_HOME` and
- * `AFK_STATE_DIR` (alongside `AFK_WRITE_DENYLIST`) precisely so a runtime
- * change to either is observed on the very next call rather than served a
- * stale floor (#781).
+ * The unresolved spellings feed {@link getWriteDenylist}'s memo, which keys on
+ * `AFK_HOME` and `AFK_STATE_DIR` (alongside `AFK_WRITE_DENYLIST`). Real paths
+ * are deliberately resolved after every cache lookup so a denylisted symlink
+ * cannot be repointed around a previously resolved credential floor.
  */
 function derivedAfkHomeWriteEntries(): string[] {
   const entries: string[] = [];
   try {
     const home = getAfkHome();
-    entries.push(safeRealpath(resolve(join(home, 'config'))));
-    entries.push(safeRealpath(resolve(join(home, 'state'))));
+    entries.push(resolve(join(home, 'config')));
+    entries.push(resolve(join(home, 'state')));
   } catch (err) {
     warnAfkHomeRejectedOnce(err);
   }
   try {
-    entries.push(safeRealpath(resolve(getAfkStateDir())));
+    entries.push(resolve(getAfkStateDir()));
   } catch (err) {
     warnAfkHomeRejectedOnce(err);
   }
@@ -108,14 +107,13 @@ function derivedAfkHomeWriteEntries(): string[] {
 // independently — see the Invariant on that function above), so a runtime
 // change to ANY of them must invalidate the memo, or a relocated AFK_HOME /
 // AFK_STATE_DIR keeps serving the pre-relocation denylist — silently
-// permitting writes to the real (now-uncovered) credential tree. This mirrors
-// the write path's hot-path pressure: `assertNotDenylisted` runs on every
-// `write_file` / `edit_file` call, and #753 grew the per-call `safeRealpath`
-// count from ~11 to ~14 by adding the derived AFK entries, which is what this
-// memo removes. Joined with U+0000 (mirrors read-denylist.ts's key), which
+// permitting writes to the real (now-uncovered) credential tree. Only
+// unresolved entry construction is memoized: the realpath results must remain
+// live because filesystem topology can change independently of the
+// environment. Joined with U+0000 (mirrors read-denylist.ts's key), which
 // cannot occur in any of the three values, so components can never collide
 // into an ambiguous key.
-let cached: { key: string; list: readonly string[] } | undefined;
+let cached: { key: string; unresolved: readonly string[] } | undefined;
 
 /**
  * Return the effective denylist (builtin + any user-supplied extras).
@@ -127,27 +125,33 @@ let cached: { key: string; list: readonly string[] } | undefined;
  */
 export function getWriteDenylist(): readonly string[] {
   const key = `${env.AFK_WRITE_DENYLIST ?? ''}\u0000${env.AFK_HOME ?? ''}\u0000${env.AFK_STATE_DIR ?? ''}`;
-  if (cached && cached.key === key) return cached.list;
+  if (!cached || cached.key !== key) {
+    const extra = env.AFK_WRITE_DENYLIST;
+    const extras = extra ? extra.split(':').map((p) => resolve(p)).filter(Boolean) : [];
+    cached = {
+      key,
+      unresolved: [
+        ...new Set([
+          ...BUILTIN_WRITE_DENYLIST.map((p) => resolve(p)),
+          ...derivedAfkHomeWriteEntries(),
+        ]),
+        ...extras,
+      ],
+    };
+  }
 
-  const extra = env.AFK_WRITE_DENYLIST;
-  const extras: string[] = extra
-    ? extra.split(':').map((p) => safeRealpath(resolve(p))).filter(Boolean)
-    : [];
-  const builtins = [
-    ...new Set([
-      ...BUILTIN_WRITE_DENYLIST.map((p) => safeRealpath(resolve(p))),
-      ...derivedAfkHomeWriteEntries(),
-    ]),
-  ];
-  const list = [...builtins, ...extras];
-  cached = { key, list };
-  return list;
+  // Do not memoize safeRealpath results. A configured or built-in entry can
+  // contain a symlink whose target changes without any environment change.
+  // Resolving after the cache hit keeps the security boundary synchronized
+  // with the current filesystem topology.
+  return [...new Set(cached.unresolved.map((p) => safeRealpath(p)))];
 }
 
 /**
  * Test-only: clear the memoized denylist so suites that mutate
- * `AFK_WRITE_DENYLIST` / `AFK_HOME` / `AFK_STATE_DIR` (or repoint a
- * denylisted symlink) don't see a stale list. Mirrors
+ * `AFK_WRITE_DENYLIST` / `AFK_HOME` / `AFK_STATE_DIR` don't see a stale list.
+ * Symlink repoints do not require a reset because real paths are never cached.
+ * Mirrors
  * `_resetReadDenylistCacheForTests` in `read-denylist.ts`.
  */
 export function _resetWriteDenylistCacheForTests(): void {


### PR DESCRIPTION
## Hot path

`getWriteDenylist()` recomputed the full denylist — 12 builtin entries plus up to 3 derived AFK entries, each passed through `safeRealpath` (a bounded `realpathSync` walk) — on **every call**. It's reached by:

- `assertNotDenylisted` (same file), invoked on every `write_file` / `edit_file` call
- `risk-classifier.ts:174`

\#753 added the derived `AFK_STATE_DIR` entry alongside the existing `config`/`state` derivations, growing the per-call syscall count from ~11 to ~14.

## The memo

Added a module-level cache in `write-denylist.ts`, structurally mirroring the existing `read-denylist.ts` memo:

```ts
let cached: { key: string; list: readonly string[] } | undefined;

export function getWriteDenylist(): readonly string[] {
  const key = `${env.AFK_WRITE_DENYLIST ?? ''}\u0000${env.AFK_HOME ?? ''}\u0000${env.AFK_STATE_DIR ?? ''}`;
  if (cached && cached.key === key) return cached.list;
  // ...recompute, cache, return
}
```

## Why the key includes both `AFK_HOME` and `AFK_STATE_DIR`

Per the issue's hard requirement — a cache on a credential denylist is exactly the bug class #753 had to fix on the **read** side, where a memo key that omits an input serves a stale, non-covering floor after a runtime relocation.

Both env vars feed `derivedAfkHomeWriteEntries()`:

- `AFK_HOME` relocates the derived `config`/`state` entries via `getAfkHome()`.
- `AFK_STATE_DIR` relocates the state tier **independently** of `AFK_HOME` — `paths.ts` returns it verbatim when set, only falling back to `join(getAfkHome(), 'state')` otherwise.

Omitting either from the key would let a runtime relocation of that var keep serving the pre-relocation denylist — silently permitting a write to the real, now-uncovered credential tree. The key joins all three components (`AFK_WRITE_DENYLIST`, `AFK_HOME`, `AFK_STATE_DIR`) with `U+0000`, matching `read-denylist.ts`'s existing key construction, so components can never collide into an ambiguous key.

## Invalidation test evidence

Added `_resetWriteDenylistCacheForTests()` (mirrors `_resetReadDenylistCacheForTests`) and two regression guards in `write-denylist.test.ts`, structured like `read-denylist.test.ts`'s existing `AFK_HOME` guard — deliberately **no manual cache reset** between the two queries, because that reset is exactly what a correct key should make unnecessary:

- `invalidates the memoized denylist when AFK_HOME changes, with no manual cache reset` — queries a target path with `AFK_HOME` unset (not denied), sets `AFK_HOME` via `vi.stubEnv`, queries again (now denied) — no reset call in between.
- `invalidates the memoized denylist when AFK_STATE_DIR changes, with no manual cache reset` — same shape for `AFK_STATE_DIR` independently.

Both pass. Full scoped run: `write-denylist.test.ts` (52 tests) + `read-denylist.test.ts` (69 tests, unmodified — run as a regression check since both modules share the pattern) — **121 passed, 0 failed**.

## Files changed

- `src/agent/tools/handlers/write-denylist.ts` (+41/-5, 220 LOC total) — memo + cache key + `_resetWriteDenylistCacheForTests`, doc-comment update on `derivedAfkHomeWriteEntries` (no longer describes the module as uncached).
- `src/agent/tools/handlers/write-denylist.test.ts` (+46, 622 LOC total) — two invalidation regression guards.

## Verification

- `tsc --noEmit`: exit 0
- `vitest run write-denylist.test.ts read-denylist.test.ts`: 121/121 passed

Closes #781
