### PR TITLE
fix(cli): name the unrecognized command instead of blaming its flag (#710)

### DIFF
--- a/src/cli/commands/interactive.ts
+++ b/src/cli/commands/interactive.ts
@@ -35,6 +35,7 @@ import {
   resolveWorktreeDisposition,
   resolveWorktreeExitPolicy,
 } from './interactive/worktree-disposition.js';
+import { installUnknownCommandGuard } from './interactive/unknown-command-guard.js';
 
 export { formatToolResultLine } from './interactive/tool-lane.js';
 
@@ -188,7 +189,7 @@ export function startupHintLine(): string {
 }
 
 export function registerInteractiveCommand(program: Command): void {
-  program
+  const interactiveCmd = program
     .command('interactive', { isDefault: true })
     .description('Start interactive chat session')
     .argument(
@@ -893,6 +894,12 @@ export function registerInteractiveCommand(program: Command): void {
 
       await runReplLoop(ctx, transcript, turnState, handleSigint);
     });
+
+  // Issue #710 mode 1: name the unrecognized COMMAND, not its trailing flag,
+  // when a mistyped subcommand (e.g. `afk config_set env X --unset`) falls
+  // through to this default command. See unknown-command-guard.ts for the
+  // full mechanism and the documented residual gap (mode 2).
+  installUnknownCommandGuard(interactiveCmd, program);
 }
 
 /**

--- a/src/cli/commands/interactive/unknown-command-guard.test.ts
+++ b/src/cli/commands/interactive/unknown-command-guard.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Issue #710 mode 1: a mistyped subcommand (`afk config_set env X --unset`)
+ * blamed its trailing flag (`error: unknown option '--unset'`) instead of
+ * naming the unrecognized command. These tests exercise the guard directly
+ * against real commander `Command` instances (no mocking of interactive.ts's
+ * heavy bootstrap chain needed — the guard is a pure commander-level concern).
+ */
+
+import { describe, expect, it } from 'vitest';
+import { Command } from 'commander';
+import { isUnrecognizedCommandToken, installUnknownCommandGuard } from './unknown-command-guard.js';
+
+/** Build a minimal program shaped like the real CLI: a default `interactive`
+ * command plus a couple of named sibling subcommands, with the guard wired
+ * in exactly as `registerInteractiveCommand` does. */
+function buildProgram(): Command {
+  const program = new Command();
+  program.name('afk').exitOverride();
+
+  const interactiveCmd = program
+    .command('interactive', { isDefault: true })
+    .argument('[input...]')
+    .option('--model <model>', 'model')
+    .action(() => {
+      /* no-op: presence of a call is asserted via captured state below */
+    });
+  program.commands.find((c) => c.name() === 'interactive')?.alias('i');
+
+  program
+    .command('config')
+    .description('config stuff')
+    .action(() => undefined);
+
+  installUnknownCommandGuard(interactiveCmd, program);
+  return program;
+}
+
+describe('isUnrecognizedCommandToken', () => {
+  const program = buildProgram();
+
+  it('flags a plain mistyped token', () => {
+    expect(isUnrecognizedCommandToken('config_set', program)).toBe(true);
+  });
+
+  it('does not flag a registered command name', () => {
+    expect(isUnrecognizedCommandToken('config', program)).toBe(false);
+  });
+
+  it('does not flag a registered alias', () => {
+    expect(isUnrecognizedCommandToken('i', program)).toBe(false);
+  });
+
+  it('does not flag a leading slash (documented slash-command launch path)', () => {
+    expect(isUnrecognizedCommandToken('/review', program)).toBe(false);
+  });
+
+  it('does not flag a leading dash (the token IS the unknown flag itself)', () => {
+    expect(isUnrecognizedCommandToken('--badflag', program)).toBe(false);
+  });
+
+  it('does not flag undefined or empty', () => {
+    expect(isUnrecognizedCommandToken(undefined, program)).toBe(false);
+    expect(isUnrecognizedCommandToken('', program)).toBe(false);
+  });
+});
+
+describe('installUnknownCommandGuard — end-to-end via commander parse', () => {
+  it('names the unrecognized command, not the trailing flag, for `config_set env X --unset`', async () => {
+    const program = buildProgram();
+    let caught: unknown;
+    try {
+      await program.parseAsync(['node', 'afk', 'config_set', 'env', 'X', '--unset']);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    const message = (caught as Error).message;
+    expect(message).toContain("unknown command 'config_set'");
+    expect(message).not.toContain("unknown option '--unset'");
+  });
+
+  it('leaves the bare-prompt path untouched (`afk "do a thing"`)', async () => {
+    const program = buildProgram();
+    // No flags at all → unknownOption never fires → guard never engages →
+    // the default `interactive` action runs normally (no throw).
+    await expect(
+      program.parseAsync(['node', 'afk', 'do a thing']),
+    ).resolves.toBeDefined();
+  });
+
+  it('leaves the documented `afk /review` slash-command path untouched', async () => {
+    const program = buildProgram();
+    await expect(
+      program.parseAsync(['node', 'afk', '/review']),
+    ).resolves.toBeDefined();
+  });
+
+  it('leaves a genuinely bad flag on the bare invocation blaming the flag (unchanged behavior)', async () => {
+    const program = buildProgram();
+    let caught: unknown;
+    try {
+      await program.parseAsync(['node', 'afk', '--badflag']);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain("unknown option '--badflag'");
+  });
+
+  it('leaves a genuinely bad flag after the alias blaming the flag (unchanged behavior)', async () => {
+    const program = buildProgram();
+    let caught: unknown;
+    try {
+      await program.parseAsync(['node', 'afk', 'i', '--badflag']);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain("unknown option '--badflag'");
+  });
+
+  it('still boots the interactive action for an unrecognized bare token with no flags (mode 2, deliberately unfixed)', async () => {
+    const program = buildProgram();
+    // `zzzbogus` never reaches unknownOption (no unknown flag present), so
+    // the guard cannot and does not intercept it — this documents the
+    // residual gap rather than asserting a fix for it.
+    await expect(
+      program.parseAsync(['node', 'afk', 'zzzbogus']),
+    ).resolves.toBeDefined();
+  });
+});

--- a/src/cli/commands/interactive/unknown-command-guard.ts
+++ b/src/cli/commands/interactive/unknown-command-guard.ts
@@ -1,0 +1,73 @@
+import type { Command } from 'commander';
+
+/**
+ * True when `token` looks like a mistyped subcommand rather than the
+ * legitimate first token of a bare-prompt or slash-command REPL launch.
+ *
+ * Guards, in order:
+ *   - `undefined`/empty: no positional token at all (e.g. `afk --badflag`
+ *     with nothing before the flag) — nothing to name.
+ *   - Leading `/`: a documented, load-bearing slash-command launch path
+ *     (`afk /review`) — never reinterpret as a bad command name.
+ *   - Leading `-`: the token IS the (mis-set) unknown flag itself surfacing
+ *     as `args[0]` (e.g. `afk --badflag`) — the original flag-blaming
+ *     message is correct there.
+ *   - Already a registered command/alias name: unreachable in practice
+ *     (commander dispatches a matched name to that command's own
+ *     `_parseCommand` before the default command ever sees it) but kept as
+ *     a defensive check so this function's contract stands alone.
+ */
+export function isUnrecognizedCommandToken(
+  token: string | undefined,
+  program: Command,
+): token is string {
+  if (token === undefined || token.length === 0) return false;
+  if (token.startsWith('/') || token.startsWith('-')) return false;
+  return !program.commands.some((cmd) => cmd.name() === token || cmd.aliases().includes(token));
+}
+
+/**
+ * Issue #710, mode 1: a mistyped subcommand (`afk config_set env X --unset`)
+ * blames its trailing flag (`error: unknown option '--unset'`) instead of
+ * naming the unrecognized command. Root cause: `interactive.ts` registers
+ * `interactive` as commander's default command with `.argument('[input...]')`,
+ * so commander's `_parseCommand` dispatches ANY unrecognized leading token to
+ * `interactive` before `unknownCommand()` ever gets a chance to fire — the
+ * default command's own `unknownOption()` fires first instead, blaming
+ * whatever flag happens to be unknown.
+ *
+ * Fix: monkey-patch `unknownOption` on the specific dispatched Command
+ * instance (`interactiveCmd`) so it names the real culprit — the
+ * unrecognized leading token, available as `this.args[0]` inside
+ * `unknownOption()` — before falling back to the stock flag-blaming message.
+ * `configureOutput` was considered and rejected: it only observes the
+ * already-formatted error string, not the original argv token, so it cannot
+ * distinguish "mistyped command" from "genuinely bad flag on a valid
+ * command/bare prompt".
+ *
+ * Deliberately NOT fixed here (see issue #710 mode 2): a bare unknown token
+ * with no flags at all (`afk zzzbogus`) still boots a full interactive
+ * session instead of erroring, because commander never calls
+ * `unknownOption`/`unknownCommand` in that path at all — there's no unknown
+ * flag to intercept. Closing that gap would require a "did you mean"
+ * near-miss heuristic, which was measured (Levenshtein ≤3 against registered
+ * command names) to false-positive on ordinary one-word prompts (`stats`,
+ * `grace`, `confirm`, `log`, `plan`, `commit`, `where`, …) at a 14–16/20 rate,
+ * even tightened to ≤2 with a canonical-names-only pool it was still 8/20 —
+ * hard-erroring on a legitimate prompt is a worse regression than the bug
+ * being fixed, so that half is intentionally out of scope.
+ */
+export function installUnknownCommandGuard(interactiveCmd: Command, program: Command): void {
+  const patchTarget = interactiveCmd as Command & { unknownOption(flag: string): void };
+  const originalUnknownOption = patchTarget.unknownOption.bind(patchTarget);
+  patchTarget.unknownOption = function guardedUnknownOption(flag: string): void {
+    const firstToken = patchTarget.args[0];
+    if (isUnrecognizedCommandToken(firstToken, program)) {
+      patchTarget.error(`error: unknown command '${firstToken}'`, {
+        code: 'commander.unknownCommand',
+      });
+      return;
+    }
+    originalUnknownOption(flag);
+  };
+}


### PR DESCRIPTION
## Issue

#710 identifies two distinct ways a mistyped `afk` subcommand misleads the user:

1. **Flag-blaming**: `afk config_set env X --unset` (a typo of `afk config set env X --unset`) surfaces `error: unknown option '--unset'` — the user is told their *flag* is bad, when the real problem is that `config_set` isn't a registered command at all.
2. **Silent boot**: a bare unrecognized token with no flags, e.g. `afk zzzbogus`, boots a full interactive REPL session instead of erroring, because nothing in that path ever fires an "unknown command" check.

## What this PR fixes (mode 1 only)

Root cause: `interactive` is registered as commander's *default* command (`.command('interactive', { isDefault: true })` with `.argument('[input...]')`). Commander's `_parseCommand` dispatches any unrecognized leading token to that default command **before** `unknownCommand()` ever gets a chance to fire. The default command's own `unknownOption()` then fires on whatever flag happens to be unknown, blaming the flag instead of the command.

Fix: `installUnknownCommandGuard` (new file: `src/cli/commands/interactive/unknown-command-guard.ts`) monkey-patches `unknownOption` on the dispatched `interactive` Command instance. Inside that hook, `this.args[0]` holds the *original* first token — when it isn't a registered command/alias and doesn't start with `/` or `-`, the guard raises `unknown command '<token>'` instead of falling through to the flag-blaming message.

`configureOutput` was considered and rejected as the interception point: it only observes the already-formatted error string, not the original argv token, so it can't distinguish "mistyped command" from "a genuinely bad flag on a valid command/bare prompt."

**Before:**
```
$ afk config_set env X --unset
error: unknown option '--unset'
```

**After:**
```
$ afk config_set env X --unset
error: unknown command 'config_set'
```

### Zero regression risk on adjacent paths

- `afk /review` — a documented, load-bearing slash-command launch path — is explicitly exempted (leading `/`) and untouched.
- `afk --badflag` — the token *is* the bad flag itself (leading `-`) — keeps today's flag-blaming message unchanged.
- `afk "do a thing"` — a bare prompt with no unknown flag — never reaches `unknownOption` at all, so the guard never engages; REPL boots exactly as before.

All four behaviors (the fix + the three unchanged paths) are covered by a new test file, `unknown-command-guard.test.ts` (12 tests), plus the existing `interactive.resume.test.ts` and `index-integration.test.ts` suites still pass unmodified.

## Residual gap — mode 2 is NOT fixed here

A bare unrecognized token with **no flags at all** (`afk zzzbogus`) still boots a full interactive session instead of erroring. This is a different code path: commander never calls `unknownOption`/`unknownCommand` when there's no unknown flag to trip on, so this guard — which hooks `unknownOption` — structurally cannot intercept it.

Closing that gap would require a "did you mean" near-miss heuristic comparing the typed token against registered command names. That heuristic was built and empirically tested against real prompt words before this PR, and hard-errors too often to ship:

- At Levenshtein distance ≤3 against all registered command names: **14–16 false positives out of 20** ordinary one-word prompts, including `stats`→`status`, `grace`/`brace`/`track`→`trace`, `confirm`→`config`, `log`→`login`, `plan`→`plugin`, `commit`→`config`, `where`→`queue`.
- Tightened to ≤2 with a canonical-names-only pool: still **8/20** false positives.

Hard-erroring on someone's legitimate one-word prompt (a real, common `afk "one word"` usage pattern) is a worse regression than the bug being fixed. That half of #710 is intentionally left open — the false-positive data above is left for the maintainer to decide whether a different heuristic, an allowlist, or another approach entirely is worth the complexity.

## Verification

- `./node_modules/.bin/tsc --noEmit` — exit 0
- `./node_modules/.bin/vitest run src/cli/commands/interactive/unknown-command-guard.test.ts` — 12/12 passed
- `./node_modules/.bin/vitest run src/cli/commands/interactive.resume.test.ts src/cli/index-integration.test.ts` — 11/11 passed (no regression)
- Manual smoke test via `tsx src/cli/index.ts`:
  - `config_set env X --unset` → `error: unknown command 'config_set'` ✓
  - `--badflag` (bare) → `error: unknown option '--badflag'` (unchanged) ✓
  - `"do a thing"` → proceeds into REPL boot (unchanged) ✓
  - `/review` → proceeds into REPL boot, reaches app-level slash-command resolution unchanged ✓

Refs #710
