### PR TITLE
fix(paths): warn once per malformed env var instead of once globally (#780)

### DIFF
--- a/src/agent/tools/afk-home-warn.ts
+++ b/src/agent/tools/afk-home-warn.ts
@@ -9,34 +9,48 @@
  * defect: an operator who typo'd `AFK_HOME` ran on a silently reduced floor
  * with no diagnostic anywhere in the process.
  *
- * Invariant: the warning is latched to fire at most ONCE per process, not once
- * per call. These derivations sit on the read/write hot path — `getReadDenylist`
- * is consulted on every typed read and `getWriteDenylist` on every
+ * Invariant: the warning is latched to fire at most ONCE PER DISTINCT
+ * malformed value, not once per call and not once globally. These
+ * derivations sit on the read/write hot path — `getReadDenylist` is
+ * consulted on every typed read and `getWriteDenylist` on every
  * `write_file`/`edit_file` — so a per-call warn would emit thousands of
  * identical lines and become its own denial-of-service on the operator's
- * terminal. The latch is module-scope state, which is why this lives in its own
- * module: all four call sites must share ONE latch, and a per-file copy would
- * warn once per file instead.
+ * terminal. A single process-wide boolean over-corrected: `AFK_HOME` and
+ * `AFK_STATE_DIR` are derived independently (see `write-denylist.ts`) so both
+ * can be malformed in the same process, and a shared boolean let the first
+ * one consume the only warning, leaving the second silent. The latch is
+ * therefore a `Set` keyed on the thrown message text (which already embeds
+ * which variable and what value it rejected — see below) so each distinct
+ * malformed value gets its own one-time warning while an unchanged malformed
+ * value still warns only once. The latch is module-scope state, which is why
+ * this lives in its own module: all four call sites must share ONE latch, and
+ * a per-file copy would warn once per file instead.
  *
  * @module agent/tools/afk-home-warn
  */
 
-let warned = false;
+const warnedReasons = new Set<string>();
 
 /**
- * Emit a single warn-level line naming the rejected env value, then latch.
+ * Emit a warn-level line naming the rejected env value, once per distinct
+ * malformed value.
  *
  * Contract: never throws (a diagnostic must not become the failure it reports),
  * never alters control flow, and returns void. The rejected value is carried in
  * the thrown message from `paths.ts` (`... got: <value>`), so it is surfaced
- * without this module re-reading the environment.
+ * without this module re-reading the environment. That message text (which
+ * already embeds the offending variable name — `AFK_HOME must be...` vs.
+ * `AFK_STATE_DIR must be...`) is also the latch key: a second, independently
+ * malformed variable produces a different message and warns; the same
+ * malformed variable read again on a later call produces the same message and
+ * stays silent.
  *
  * @param err The error thrown by `getAfkHome()` / `getAfkStateDir()`.
  */
 export function warnAfkHomeRejectedOnce(err: unknown): void {
-  if (warned) return;
-  warned = true;
   const reason = err instanceof Error ? err.message : String(err);
+  if (warnedReasons.has(reason)) return;
+  warnedReasons.add(reason);
   console.warn(
     `[afk-home] Malformed AFK home/state env var ignored while deriving the ` +
       `credential floor: ${reason}. The relocated tree is NOT protected — the ` +
@@ -49,9 +63,9 @@ export function warnAfkHomeRejectedOnce(err: unknown): void {
  *
  * Contract: production code must never call this. Without it a test asserting
  * the warn would depend on suite ordering — whichever spec touched a malformed
- * env var first would consume the single latch and every later assertion would
- * see silence.
+ * env var first would consume the latch for that reason string and a later
+ * assertion expecting the same message to fire again would see silence.
  */
 export function resetAfkHomeWarnLatchForTests(): void {
-  warned = false;
+  warnedReasons.clear();
 }

--- a/src/agent/tools/handlers/write-denylist.test.ts
+++ b/src/agent/tools/handlers/write-denylist.test.ts
@@ -553,6 +553,44 @@ describe('write-denylist — AFK_HOME-relocated credential tree (#740)', () => {
       resetAfkHomeWarnLatchForTests();
     }
   });
+
+  // #780: the latch used to be a single process-wide boolean, so the FIRST
+  // malformed var consumed it and a second, independently-malformed var
+  // stayed silent. An operator who typo'd both AFK_HOME and AFK_STATE_DIR
+  // fixed one, re-ran, and only then learned about the other. The latch is
+  // now keyed per distinct rejected value, so both warn.
+  it('warns for BOTH vars when AFK_HOME and AFK_STATE_DIR are both malformed (#780)', () => {
+    resetAfkHomeWarnLatchForTests();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      vi.stubEnv('AFK_HOME', 'relative/not-absolute-home');
+      vi.stubEnv('AFK_STATE_DIR', 'relative/not-absolute-state');
+
+      getWriteDenylist();
+
+      expect(warn).toHaveBeenCalledTimes(2);
+      const messages = warn.mock.calls.map((call) => call[0]);
+      expect(messages.some((m) => typeof m === 'string' && m.includes('AFK_HOME'))).toBe(true);
+      expect(messages.some((m) => typeof m === 'string' && m.includes('AFK_STATE_DIR'))).toBe(
+        true,
+      );
+      expect(
+        messages.some((m) => typeof m === 'string' && m.includes('relative/not-absolute-home')),
+      ).toBe(true);
+      expect(
+        messages.some((m) => typeof m === 'string' && m.includes('relative/not-absolute-state')),
+      ).toBe(true);
+
+      // Repeated reads must not re-warn for either already-seen value — the
+      // once-per-var de-duplication this fix must preserve.
+      getWriteDenylist();
+      getWriteDenylist();
+      expect(warn).toHaveBeenCalledTimes(2);
+    } finally {
+      warn.mockRestore();
+      resetAfkHomeWarnLatchForTests();
+    }
+  });
 });
 
 describe('assertNotDenylisted — case-variant spellings (#736)', () => {


### PR DESCRIPTION
## The latch

`warnAfkHomeRejectedOnce` (`src/agent/tools/afk-home-warn.ts`) guards a
one-time operator diagnostic that fires when `getAfkHome()` /
`getAfkStateDir()` reject a malformed `AFK_HOME` or `AFK_STATE_DIR`. It was
keyed on a single module-level boolean:

```ts
let warned = false;

export function warnAfkHomeRejectedOnce(err: unknown): void {
  if (warned) return;
  warned = true;
  ...
}
```

## The double-typo scenario

`derivedAfkHomeWriteEntries` (`src/agent/tools/handlers/write-denylist.ts`)
derives `AFK_HOME` and `AFK_STATE_DIR` in two independent `try` blocks
specifically so one bad value can't drop the other's denylist entries — which
means both can genuinely throw in the same process. With a single boolean
latch, whichever one threw first consumed the only warning. An operator who
typo'd **both** `AFK_HOME` and `AFK_STATE_DIR` was told about one, fixed it,
re-ran, and only then learned about the other — a double typo was
half-diagnosed.

## The fix

Replace the boolean with a `Set<string>` keyed on the thrown error message
text. The message already embeds both the variable name and the rejected
value (e.g. `AFK_HOME must be an absolute path that is not /, got: ...`), so
it's a natural per-variable key with no extra plumbing:

```ts
const warnedReasons = new Set<string>();

export function warnAfkHomeRejectedOnce(err: unknown): void {
  const reason = err instanceof Error ? err.message : String(err);
  if (warnedReasons.has(reason)) return;
  warnedReasons.add(reason);
  console.warn(...);
}
```

Each distinct malformed value now warns exactly once. `resetAfkHomeWarnLatchForTests()` clears the Set instead of resetting a boolean, so the existing test contract (`write-denylist.test.ts` asserting exact call counts) is unchanged.

## Files changed

- `src/agent/tools/afk-home-warn.ts` (71 lines) — boolean → `Set<string>` latch, updated doc comments explaining the per-variable rationale.
- `src/agent/tools/handlers/write-denylist.test.ts` (614 lines) — new regression test for the double-typo scenario.

## Test evidence

New test `warns for BOTH vars when AFK_HOME and AFK_STATE_DIR are both malformed (#780)`:
- Stubs both `AFK_HOME` and `AFK_STATE_DIR` to malformed (relative) values.
- Calls `getWriteDenylist()` once → asserts `console.warn` fired **twice**, one message containing `AFK_HOME` + the rejected value, one containing `AFK_STATE_DIR` + its rejected value.
- Calls `getWriteDenylist()` twice more → asserts warn count is still 2 (no re-warn for either already-seen value — the once-per-var de-duplication is preserved, not spammed).

Existing test `warns once when a malformed AFK_HOME is rejected` (single-var case) still passes unmodified — confirms a single malformed var still warns exactly once across repeated reads.

```
./node_modules/.bin/tsc --noEmit                                          → exit 0
./node_modules/.bin/vitest run src/agent/tools/handlers/write-denylist.test.ts → 51 passed
./node_modules/.bin/vitest run src/agent/tools/handlers/read-denylist.test.ts  → 69 passed (shares the same latch module; unaffected)
```

## Risks

- Latch key is the full error message string rather than the variable name explicitly — if `paths.ts` ever changes the thrown message to no longer embed the variable name, the per-variable behavior would degrade silently (still correct for "same value → warn once", but would lose per-variable distinction between two vars that happened to throw identically-worded messages, which isn't currently possible since each variable's message names itself explicitly).
- Set grows unbounded across process lifetime, but is bounded by the number of *distinct* malformed values a long-lived process could ever see (in practice ≤2 env vars, each fixed at most a handful of times per process) — not a real memory concern.

## Not checked

- `afk-home-refs.ts` and `root-validation.ts` call sites (`src/agent/tools/hooks/`, `src/agent/tools/subagent/`) were not individually re-tested — they call the same shared `warnAfkHomeRejectedOnce`/latch and are covered transitively by this fix, but I did not add call-site-specific tests for them.

Closes #780
