### PR TITLE
fix(agents): surface a warning when a malformed agent file is discarded (#752)

### DIFF
--- a/src/agent/session/wire-executors.ts
+++ b/src/agent/session/wire-executors.ts
@@ -206,7 +206,10 @@ export function wireExecutors(opts: WireExecutorsOptions): WiredExecutors {
   //    dispatch at every depth.
   const agentRegistry = loadAgentRegistry({
     ...cwdOpt,
-    pluginAgents: discoverPluginAgents(),
+    // Same sink both scanners report through: a malformed plugin agent file
+    // now warns exactly like a malformed user/project one (#752) instead of
+    // vanishing silently ahead of the merge below.
+    pluginAgents: discoverPluginAgents(undefined, agentRegistryWarn),
     ...(agentRegistryWarn !== undefined ? { warn: agentRegistryWarn } : {}),
   });
 

--- a/src/agent/session/wire-executors.ts
+++ b/src/agent/session/wire-executors.ts
@@ -181,6 +181,10 @@ export function wireExecutors(opts: WireExecutorsOptions): WiredExecutors {
   const skillTraceOpt = skillTraceWriter !== undefined ? { traceWriter: skillTraceWriter } : {};
   const apiKeyOpt = apiKey !== undefined ? { apiKey } : {};
   const bgRegistryOpt = backgroundRegistry !== undefined ? { backgroundRegistry } : {};
+  // Match loadAgentRegistry's default sink so plugin discovery remains audible
+  // on non-interactive surfaces that do not provide a boot-warning collector.
+  const registryWarn =
+    agentRegistryWarn ?? ((message: string) => process.stderr.write(message + '\n'));
   // Session-static snapshot shared by all root executors and inherited by
   // descendants. Do not resolve inside execute(): sibling calls must not see
   // different caps if the process environment changes during the session.
@@ -209,8 +213,8 @@ export function wireExecutors(opts: WireExecutorsOptions): WiredExecutors {
     // Same sink both scanners report through: a malformed plugin agent file
     // now warns exactly like a malformed user/project one (#752) instead of
     // vanishing silently ahead of the merge below.
-    pluginAgents: discoverPluginAgents(undefined, agentRegistryWarn),
-    ...(agentRegistryWarn !== undefined ? { warn: agentRegistryWarn } : {}),
+    pluginAgents: discoverPluginAgents(undefined, registryWarn),
+    warn: registryWarn,
   });
 
   // 4. Shared by the `agent` and `skill` executors so plugin skill children

--- a/src/agent/tools/skill-bridge.test.ts
+++ b/src/agent/tools/skill-bridge.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtempSync, writeFileSync, rmSync, mkdirSync, chmodSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import {
   buildSkillManifest,
@@ -30,6 +30,18 @@ import { _resetPluginScanCache } from '../plugins-scanner.js';
 import { getPluginsDir } from '../../paths.js';
 import type { RegisteredAgent } from '../agents/types.js';
 
+const fsMocks = vi.hoisted(() => ({
+  readFileSync: vi.fn(),
+  realReadFileSync: undefined as typeof import('node:fs').readFileSync | undefined,
+}));
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  fsMocks.realReadFileSync = actual.readFileSync;
+  fsMocks.readFileSync.mockImplementation(actual.readFileSync);
+  return { ...actual, readFileSync: fsMocks.readFileSync };
+});
+
 // ---------------------------------------------------------------------------
 // File-level isolation: redirect AFK_HOME + cwd before every test so the
 // disk scan inside collectSkillEntries() always finds an empty skills dir.
@@ -41,6 +53,7 @@ let _isolatedCwd: string;
 let _origCwd: string;
 
 beforeEach(() => {
+  fsMocks.readFileSync.mockImplementation(fsMocks.realReadFileSync!);
   _isolatedAfkHome = mkdtempSync('/tmp/skill-bridge-test-afkhome-');
   _isolatedCwd = mkdtempSync('/tmp/skill-bridge-test-cwd-');
   _origCwd = process.cwd();
@@ -780,20 +793,23 @@ describe('discoverPluginAgents', () => {
     writeManifest(pluginA, 'demo');
     const dir = join(pluginA, 'agents');
     mkdirSync(dir, { recursive: true });
-    const unreadablePath = join(dir, 'locked.md');
+    const unreadablePath = join(dir, '\x1B]0;pwned\x07locked.md');
     writeAgentFile(pluginA, 'ok.md', 'works');
     writeFileSync(unreadablePath, '---\nname: locked\ndescription: d\n---\nbody\n');
-    chmodSync(unreadablePath, 0o000);
+    fsMocks.readFileSync.mockImplementation((path, options) => {
+      if (path === unreadablePath) {
+        throw new Error(`EACCES: permission denied, open '${unreadablePath}'`);
+      }
+      return fsMocks.realReadFileSync!(path, options);
+    });
 
     const warn = vi.fn();
-    try {
-      const agents = discoverPluginAgents([{ type: 'local', path: pluginA }], warn);
-      expect(agents.map((a) => a.name)).toEqual(['demo:works']);
-      expect(warn).toHaveBeenCalledWith(expect.stringContaining('cannot read'));
-      expect(warn).toHaveBeenCalledWith(expect.stringContaining(unreadablePath));
-    } finally {
-      chmodSync(unreadablePath, 0o644); // restore so afterEach's rmSync can clean up
-    }
+    const agents = discoverPluginAgents([{ type: 'local', path: pluginA }], warn);
+    expect(agents.map((a) => a.name)).toEqual(['demo:works']);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('cannot read'));
+    const message = warn.mock.calls[0]?.[0] as string;
+    expect(message).not.toContain('\x1B');
+    expect(message).not.toContain('\x07');
   });
 
   it('sanitizes an escape-sequence-bearing file path before it reaches warn', () => {

--- a/src/agent/tools/skill-bridge.test.ts
+++ b/src/agent/tools/skill-bridge.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync, chmodSync } from 'node:fs';
 import { join } from 'node:path';
 import {
   buildSkillManifest,
@@ -28,6 +28,7 @@ import {
 import { registerSkill, _resetRegistry } from '../../skills/index.js';
 import { _resetPluginScanCache } from '../plugins-scanner.js';
 import { getPluginsDir } from '../../paths.js';
+import type { RegisteredAgent } from '../agents/types.js';
 
 // ---------------------------------------------------------------------------
 // File-level isolation: redirect AFK_HOME + cwd before every test so the
@@ -742,6 +743,78 @@ describe('discoverPluginAgents', () => {
     writeAgentFile(pluginA, 'ok.md', 'works');
     const agents = discoverPluginAgents([{ type: 'local', path: pluginA }]);
     expect(agents.map((a) => a.name)).toEqual(['demo:works']);
+  });
+
+  // Regression (#752): parseAgentMarkdown's warn callback was never passed at
+  // this call site, so a malformed plugin agent file vanished with zero
+  // diagnostics — the agent simply didn't exist, and nothing said why. This
+  // pins that the discard is now audible (naming the file and the parser's
+  // reason) while remaining non-fatal: the rest of the plugin's agents still
+  // load and discovery never throws.
+  it('warns naming the file and parse reason when a plugin agent file is malformed, and still skips it non-fatally', () => {
+    const pluginA = join(tmpDir, 'plugin-a');
+    writeManifest(pluginA, 'demo');
+    const dir = join(pluginA, 'agents');
+    mkdirSync(dir, { recursive: true });
+    const brokenPath = join(dir, 'broken.md');
+    writeFileSync(brokenPath, 'no frontmatter at all');
+    writeAgentFile(pluginA, 'ok.md', 'works');
+
+    const warn = vi.fn();
+    let agents: RegisteredAgent[] = [];
+    expect(() => {
+      agents = discoverPluginAgents([{ type: 'local', path: pluginA }], warn);
+    }).not.toThrow();
+
+    // Non-fatal: the valid sibling agent still loads.
+    expect(agents.map((a) => a.name)).toEqual(['demo:works']);
+    // Audible: warn names the offending file and the parser's specific reason.
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('missing frontmatter (file must start with ---)'),
+    );
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(brokenPath));
+  });
+
+  it('warns rather than silently skipping an unreadable plugin agent file', () => {
+    const pluginA = join(tmpDir, 'plugin-a');
+    writeManifest(pluginA, 'demo');
+    const dir = join(pluginA, 'agents');
+    mkdirSync(dir, { recursive: true });
+    const unreadablePath = join(dir, 'locked.md');
+    writeAgentFile(pluginA, 'ok.md', 'works');
+    writeFileSync(unreadablePath, '---\nname: locked\ndescription: d\n---\nbody\n');
+    chmodSync(unreadablePath, 0o000);
+
+    const warn = vi.fn();
+    try {
+      const agents = discoverPluginAgents([{ type: 'local', path: pluginA }], warn);
+      expect(agents.map((a) => a.name)).toEqual(['demo:works']);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('cannot read'));
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining(unreadablePath));
+    } finally {
+      chmodSync(unreadablePath, 0o644); // restore so afterEach's rmSync can clean up
+    }
+  });
+
+  it('sanitizes an escape-sequence-bearing file path before it reaches warn', () => {
+    const pluginA = join(tmpDir, 'plugin-a');
+    writeManifest(pluginA, 'demo');
+    const dir = join(pluginA, 'agents');
+    mkdirSync(dir, { recursive: true });
+    // ESC ] 0 ; ... BEL is an OSC window-title sequence — a real escape family
+    // sanitizeForDisplay strips (terminal-sanitize.ts), not just cosmetic text.
+    const escapeyName = '\x1B]0;pwned\x07evil.md';
+    writeFileSync(join(dir, escapeyName), 'no frontmatter at all');
+
+    const warn = vi.fn();
+    discoverPluginAgents([{ type: 'local', path: pluginA }], warn);
+
+    expect(warn).toHaveBeenCalled();
+    for (const call of warn.mock.calls) {
+      const message = call[0] as string;
+      expect(message).not.toContain('\x1B');
+      expect(message).not.toContain('\x07');
+    }
   });
 
   it('returns empty for a plugin with no agents/ dir', () => {

--- a/src/agent/tools/skill-bridge.ts
+++ b/src/agent/tools/skill-bridge.ts
@@ -27,6 +27,7 @@ import { readPluginManifest } from '../plugins/plugin-manifest.js';
 import { parseAgentMarkdown } from '../agents/parser.js';
 import { collectMarkdownFiles } from '../agents/registry.js';
 import type { RegisteredAgent } from '../agents/types.js';
+import { sanitizeForDisplay } from '../../utils/terminal-sanitize.js';
 import { SubagentManager } from '../subagent.js';
 import { describeFailure } from '../subagent/result.js';
 import {
@@ -350,10 +351,17 @@ export function discoverPluginSkillBodies(
  * Cross-scope precedence (plugin < user < project < config) is applied by
  * {@link import('../agents/registry.js').loadAgentRegistry}, which merges the
  * returned list just above the builtins. Read/parse failures are contained
- * per-file: one malformed agent never blocks the rest.
+ * per-file: one malformed agent never blocks the rest — but is reported via
+ * `warn`, mirroring {@link import('../agents/registry.js').loadAgentRegistry}'s
+ * scan-warning contract (`registry.ts`'s `scanScope`) so a broken plugin agent
+ * file fails as audibly as a broken user/project one instead of vanishing
+ * without a trace (#752). `filePath` is repo- or operator-controlled (plugins
+ * can live in a cloned project's tree), so it is routed through
+ * `sanitizeForDisplay` before interpolation rather than embedded raw.
  */
 export function discoverPluginAgents(
   pluginConfigs?: SdkPluginConfig[],
+  warn: (message: string) => void = () => {},
 ): RegisteredAgent[] {
   const plugins = pluginConfigs ?? scanAllPluginRoots();
   const agents: RegisteredAgent[] = [];
@@ -363,14 +371,16 @@ export function discoverPluginAgents(
     const pluginName = readPluginManifest(plugin.path).name;
     if (pluginName === null) continue;
     for (const filePath of collectMarkdownFiles(join(plugin.path, 'agents'))) {
+      const safePath = sanitizeForDisplay(filePath);
       let content: string;
       try {
         content = readFileSync(filePath, 'utf8');
-      } catch {
+      } catch (err) {
+        warn(`[afk] agents: cannot read ${safePath}: ${err instanceof Error ? err.message : String(err)}`);
         continue; // unreadable file — contained, skip
       }
-      const parsed = parseAgentMarkdown(content);
-      if (parsed === undefined) continue; // malformed frontmatter — skip
+      const parsed = parseAgentMarkdown(content, (msg) => warn(`[afk] agents: ${safePath}: ${msg}`));
+      if (parsed === undefined) continue; // malformed frontmatter — skip (warned above)
       const qualifiedName = `${pluginName}:${parsed.name}`;
       if (seen.has(qualifiedName)) continue; // first plugin wins
       seen.add(qualifiedName);

--- a/src/agent/tools/skill-bridge.ts
+++ b/src/agent/tools/skill-bridge.ts
@@ -376,7 +376,8 @@ export function discoverPluginAgents(
       try {
         content = readFileSync(filePath, 'utf8');
       } catch (err) {
-        warn(`[afk] agents: cannot read ${safePath}: ${err instanceof Error ? err.message : String(err)}`);
+        const safeError = sanitizeForDisplay(err instanceof Error ? err.message : String(err));
+        warn(`[afk] agents: cannot read ${safePath}: ${safeError}`);
         continue; // unreadable file — contained, skip
       }
       const parsed = parseAgentMarkdown(content, (msg) => warn(`[afk] agents: ${safePath}: ${msg}`));


### PR DESCRIPTION
## The silent discard

`discoverPluginAgents` (`src/agent/tools/skill-bridge.ts`) reads each candidate plugin agent file and drops it on two paths without a word:

- unreadable file → `continue` (no warning)
- `parseAgentMarkdown(content)` returns `undefined` → `continue` (no warning)

`parseAgentMarkdown` is built to report *why* it rejected a file — its second parameter is a `warn` callback that **defaults to a no-op**. The old call site (`parseAgentMarkdown(content)`) never passed one, so every diagnostic (`'missing frontmatter (file must start with ---)'`, `'unterminated frontmatter (no closing ---)'`, etc.) fell into the default no-op and was lost. The non-plugin scanner in the same codebase (`loadAgentRegistry`'s `scanScope`, `registry.ts:182`) already threads `warn` through correctly — the plugin scanner just never matched that contract.

Net effect: a plugin author ships `agents/reviewer.md` with a typo'd frontmatter delimiter, the agent silently doesn't exist, and `agent_type: "my-plugin:reviewer"` later fails with "unknown agent" nowhere near the actual cause.

## Where the callback was dropped

`src/agent/tools/skill-bridge.ts` — `discoverPluginAgents`:
- the unreadable-file `catch` block used a bare `continue`
- `parseAgentMarkdown(content)` was called with no second argument

## The fix

- `discoverPluginAgents` now accepts an optional `warn` callback (defaults to a no-op, matching `parseAgentMarkdown`'s own default) and threads it into `parseAgentMarkdown(content, (msg) => warn(...))`, mirroring `registry.ts:182`'s shape.
- The unreadable-file path now also warns (`cannot read <path>: <error message>`), matching `registry.ts`'s handling of the same failure class.
- `src/agent/session/wire-executors.ts` — the one production call site — now passes the existing `agentRegistryWarn` option through: `discoverPluginAgents(undefined, agentRegistryWarn)`. This is the same sink `loadAgentRegistry` already receives, which the REPL routes to `ctx.bootWarnings` (PR #751) so it survives the startup screen clear. `chat.ts`, `daemon.ts`, and `telegram/session-anthropic.ts` all reach `discoverPluginAgents` only indirectly through `wireExecutors`, so this one wiring point covers every surface.
- Containment is unchanged: a malformed or unreadable file is still skipped via `continue`, never thrown, and never blocks discovery of the plugin's other agents.

This issue is scoped to the *emission* of the warning (never produced → now produced). It does not touch #745 (warning produced but erased by the REPL clear, already fixed in PR #751).

## Sanitization note (re: #747)

Plugin agent directories can live inside a cloned repository, so `filePath` is not fully operator-controlled. Per the issue's guidance and in the spirit of #747 (which hardens this same warning class across `registry.ts`), the path is passed through the repo's existing `sanitizeForDisplay` helper (`src/utils/terminal-sanitize.ts`) before interpolation, rather than embedded raw. This PR does **not** implement #747 itself (that issue covers `registry.ts`'s five pre-existing sites) — it just avoids introducing a sixth raw-path warning that would contradict it.

## Test evidence

Four new cases added to the `discoverPluginAgents` describe block in `src/agent/tools/skill-bridge.test.ts`:
1. A malformed file (no frontmatter) warns naming the file and the parser's specific reason; the call does not throw; a valid sibling agent in the same plugin still loads.
2. An unreadable file (`chmod 0o000`) warns with `cannot read <path>`; the valid sibling agent still loads.
3. A filename containing a raw ANSI/OSC escape sequence never reaches `warn()` unescaped — pins the `sanitizeForDisplay` routing.

## Verification

- `./node_modules/.bin/tsc --noEmit` → exit 0
- `./node_modules/.bin/vitest run src/agent/tools/skill-bridge.test.ts src/agent/agents/registry.test.ts src/agent/agents/parser.test.ts` → **100 passed**, 0 failed

## Confirmed still non-fatal

Both new tests assert the plugin's other, valid agent still loads after the broken file is discovered — the skip remains a `continue`, not a throw, in both the read-failure and parse-failure paths.

## Risks

- None expected to existing behavior for well-formed agent files. Warning volume increases only when a plugin actually ships a broken or unreadable agent file — previously invisible, now visible.
- Surfaces that don't wire `agentRegistryWarn` fall back to the no-op default (unchanged pre-existing behavior for those paths, since `discoverPluginAgents()` with no second argument is still valid).

## What I did not check

- Did not audit `src/agent/plugins-scanner.ts` or the skill-body scanner for the same missing-warn pattern — out of scope for this issue (that's plugin *skill* discovery, not agent discovery).
- Did not implement #747's fix to the five pre-existing `registry.ts` sites — only ensured this new call site doesn't add a sixth unsanitized one.
- Did not add an integration test exercising the REPL's `ctx.bootWarnings` end-to-end for a plugin agent (existing wiring test coverage for `agentRegistryWarn` already covers that this option reaches `loadAgentRegistry`'s `warn`; this PR extends the same option to also reach `discoverPluginAgents`).

Closes #752
