### PR TITLE
fix(bg-job): bound stopReason at a single chokepoint instead of 6 call sites (#717)

### DIFF
--- a/src/agent/background-registry.test.ts
+++ b/src/agent/background-registry.test.ts
@@ -871,6 +871,30 @@ describe('BackgroundAgentRegistry', () => {
       expect(meta).not.toBeNull();
       expect(meta!.stopReason).toBeUndefined();
     });
+
+    // #717 regression: `writeMeta`'s spread was the one write site (of six)
+    // that persisted `result.stopReason` raw, bypassing `boundedStopReason`
+    // (applied at the three telemetry emits above and at the two
+    // foreground-promotion.ts emits). A provider-supplied stopReason over 64
+    // chars must land in meta.json bounded, exactly like every sibling site.
+    it('terminal callback truncates an over-long stopReason to 64 chars before persisting to meta.json', async () => {
+      const longReason = 'z'.repeat(200);
+      const handle = createStubHandle('sub-disk-7');
+      const job = registry.register({ handle, prompt: 'unbounded job', model: 'sonnet' });
+
+      handle.__fireTerminal({
+        ...successResult('sub-disk-7', 'partial output'),
+        stopReason: longReason,
+      });
+
+      await new Promise((r) => setTimeout(r, 200));
+
+      const { BgJobLogReader } = await import('./bg-job-log.js');
+      const meta = await BgJobLogReader.readMeta(job.jobId);
+      expect(meta).not.toBeNull();
+      expect(meta!.stopReason).toBe('z'.repeat(64) + '…');
+      expect(meta!.stopReason!.length).toBe(65);
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/src/agent/background-registry.ts
+++ b/src/agent/background-registry.ts
@@ -59,7 +59,7 @@ import { BgJobLogWriter } from './bg-job-log.js';
 import type { BgJobMeta } from './bg-job-log.js';
 import { getBgJobsRoot, getBgJobDir } from '../paths.js';
 import { appendRoutingDecision } from './routing-telemetry.js';
-import { truncate } from './tools/subagent/failure-payload.js';
+import { boundedStopReason } from './tools/subagent/failure-payload.js';
 import { resolveMaxConcurrentBackgroundJobs } from '../config/concurrency.js';
 
 export type BackgroundJobStatus = 'running' | 'completed' | 'failed' | 'cancelled';
@@ -121,18 +121,6 @@ export const MAX_TRANSCRIPT_TAIL_BYTES = 4096;
  */
 function emitRoutingTelemetry(entry: Parameters<typeof appendRoutingDecision>[0]): void {
   void appendRoutingDecision(entry).catch(() => {});
-}
-
-/**
- * Cap `stopReason` before it rides into a telemetry row. On the
- * OpenAI-compatible path `stopReason` is provider-controlled free text
- * (`providers/openai-compatible/translate.ts`, `responses-translate.ts`),
- * not a bounded enum, so — like the sibling free-form telemetry fields — it
- * must not be emitted uncapped. Preserves omit-when-absent: `undefined` stays
- * `undefined`, never `''`.
- */
-function boundedStopReason(stopReason: string | undefined): string | undefined {
-  return stopReason !== undefined ? truncate(stopReason, 64) : undefined;
 }
 
 /**
@@ -680,7 +668,12 @@ export class BackgroundAgentRegistry extends EventEmitter<BackgroundRegistryEven
         // after this job's in-memory entry is TTL-evicted) can reconstruct
         // the same partial-result labeling the in-memory replay applies —
         // see BgJobMeta.stopReason. Omitted (not undefined/null) when absent.
-        ...(result.stopReason !== undefined ? { stopReason: result.stopReason } : {}),
+        // Bounded via the shared chokepoint (see failure-payload.ts) — this
+        // was the one write site (of six) that persisted the raw,
+        // provider-controlled value uncapped (#717).
+        ...(boundedStopReason(result.stopReason) !== undefined
+          ? { stopReason: boundedStopReason(result.stopReason) }
+          : {}),
       }).then(() => writer.close());
     }
 

--- a/src/agent/tools/subagent/failure-payload.test.ts
+++ b/src/agent/tools/subagent/failure-payload.test.ts
@@ -19,6 +19,7 @@ vi.mock('../../routing-telemetry.js', () => ({ appendRoutingDecision }));
 import {
   emitTelemetry,
   truncate,
+  boundedStopReason,
   measurePartial,
   buildFailurePayload,
   type StructuredFailurePayload,
@@ -60,6 +61,36 @@ describe('truncate', () => {
 
   it('handles the empty string', () => {
     expect(truncate('', 240)).toBe('');
+  });
+});
+
+// #717: `boundedStopReason` is the single chokepoint every stopReason write
+// site (telemetry emits in background-registry.ts and foreground-promotion.ts,
+// plus the durable meta.json write in background-registry.ts) must call.
+// Before this fix, the 64-char bound was hand-duplicated at five sites and
+// silently omitted at a sixth (the meta.json persist) — pinning the helper
+// directly here guards the invariant at its source rather than only at each
+// call site.
+describe('boundedStopReason', () => {
+  it('returns undefined unchanged (omit-when-absent preserved)', () => {
+    expect(boundedStopReason(undefined)).toBeUndefined();
+  });
+
+  it('passes through a stopReason at or under 64 chars unchanged', () => {
+    const short = 'tool_use_loop_capped';
+    expect(boundedStopReason(short)).toBe(short);
+  });
+
+  it('leaves an exactly-64-char stopReason untouched (boundary, no ellipsis)', () => {
+    const atCap = 'r'.repeat(64);
+    expect(boundedStopReason(atCap)).toBe(atCap);
+  });
+
+  it('truncates a stopReason over 64 chars to 64 chars + ellipsis', () => {
+    const long = 'x'.repeat(200);
+    const result = boundedStopReason(long);
+    expect(result).toBe('x'.repeat(64) + '…');
+    expect(result!.length).toBe(65);
   });
 });
 

--- a/src/agent/tools/subagent/failure-payload.ts
+++ b/src/agent/tools/subagent/failure-payload.ts
@@ -30,6 +30,28 @@ export function truncate(s: string, max = 240): string {
   return s.length <= max ? s : s.slice(0, max) + '…';
 }
 
+/**
+ * Maximum length applied to `stopReason` everywhere it is persisted or
+ * emitted. On the OpenAI-compatible path `stopReason` is provider-controlled
+ * free text (`providers/openai-compatible/translate.ts`,
+ * `responses-translate.ts`), not a bounded enum, so it must never ride
+ * uncapped into a telemetry row or a durable artifact.
+ */
+const MAX_STOP_REASON_CHARS = 64;
+
+/**
+ * Single chokepoint for bounding `stopReason` before it leaves the process
+ * boundary (telemetry emit or `meta.json` persistence). Every call site that
+ * touches `SubagentResult.stopReason` downstream of the fork/promotion layer
+ * must route through this helper instead of inlining its own
+ * `truncate(x, 64)` — a hand-duplicated bound is how the unbounded
+ * `writeMeta` site (#717) went unnoticed for three of its four siblings.
+ * Preserves omit-when-absent: `undefined` stays `undefined`, never `''`.
+ */
+export function boundedStopReason(stopReason: string | undefined): string | undefined {
+  return stopReason !== undefined ? truncate(stopReason, MAX_STOP_REASON_CHARS) : undefined;
+}
+
 /** Measure partial output size without serializing large structures repeatedly. */
 export function measurePartial(partial: unknown): number | undefined {
   if (partial === undefined || partial === null) return undefined;

--- a/src/agent/tools/subagent/foreground-promotion.ts
+++ b/src/agent/tools/subagent/foreground-promotion.ts
@@ -27,7 +27,7 @@ import type { TraceWriter } from '../../trace/index.js';
 import { emitQueuedUserMessage } from '../../trace/emit.js';
 import type { ToolResult } from '../types.js';
 import type { PromotedSubagentInfo } from '../subagent-executor.js';
-import { emitTelemetry, truncate, measurePartial, buildFailurePayload } from './failure-payload.js';
+import { emitTelemetry, truncate, boundedStopReason, measurePartial, buildFailurePayload } from './failure-payload.js';
 import { appendInjectContext } from './inject-context.js';
 import { claimQueuedNote, type QueuedNoteClaim } from './queued-note.js';
 import { teardownIsolatedWorktree, describePreserveReason } from '../handlers/worktree-managed.js';
@@ -298,12 +298,11 @@ export async function runForegroundWithPromotion(args: RunForegroundArgs): Promi
         status: result.status,
         duration_ms: Date.now() - startedAt,
         content_chars: content.length,
-        // Capped like the sibling free-form telemetry fields (error_message,
-        // schema_error below): on the OpenAI-compatible path stopReason is
-        // provider-controlled free text (translate.ts / responses-translate.ts),
-        // not a bounded enum, so it must not ride into telemetry uncapped.
-        // Omit-when-absent preserved: `undefined` stays `undefined`, never ''.
-        stop_reason: result.stopReason !== undefined ? truncate(result.stopReason, 64) : undefined,
+        // Bounded via the shared chokepoint (see failure-payload.ts) rather
+        // than an inline `truncate(x, 64)` — that duplication (this site,
+        // its failure-path sibling below, and background-registry.ts) is how
+        // the sixth call site drifted unbounded (#717).
+        stop_reason: boundedStopReason(result.stopReason),
         depth,
         tool_call_count: trace?.toolCalls.length,
         // Preserve `false` ("confirmed absent") distinctly from `undefined`
@@ -348,9 +347,8 @@ export async function runForegroundWithPromotion(args: RunForegroundArgs): Promi
         ? truncate(result.schemaError.message)
         : undefined,
       partial_output_chars: measurePartial(result.partialOutput),
-      // Capped — see the completed-path comment above for why (provider
-      // free text on the OpenAI-compatible path, not a bounded enum).
-      stop_reason: result.stopReason !== undefined ? truncate(result.stopReason, 64) : undefined,
+      // Bounded via the shared chokepoint — see the completed-path comment above.
+      stop_reason: boundedStopReason(result.stopReason),
       depth,
       // Mirror trace fields on the failure path — failed subagents are the
       // highest-value debugging target and benefit most from this signal.


### PR DESCRIPTION
## Summary

Fixes #717 — `stopReason` was persisted unbounded to a background job's `meta.json`, one of six write sites.

**The unbounded site:** `background-registry.ts:685` (pre-fix line number) spread `result.stopReason` raw into the `writer.writeMeta(...)` call that closes out a terminal job. Its three sibling telemetry emits in the same file (`completed`/`failed`/`cancelled`) each called a private `boundedStopReason()` helper that truncates to 64 chars; two more inline `truncate(result.stopReason, 64)` calls lived in `foreground-promotion.ts`. The `writeMeta` spread was the only one of the six that never bounded the value — a provider-supplied `stopReason` (free text on the OpenAI-compatible path, not a bounded enum) could land verbatim in a durable on-disk artifact.

## Why not a sixth duplicate clamp

Five hand-duplicated 64-char bounds plus one omission *is* the defect. Patching the sixth site with its own `truncate(x, 64)` literal would leave the codebase with six independent copies of the same invariant — the exact shape that let this one go unnoticed. Any future call site touching `stopReason` would have no structural reason to know the bound exists, and could just as easily be the seventh miss.

## Fix

Hoisted the bound into a single exported chokepoint, `boundedStopReason()` in `src/agent/tools/subagent/failure-payload.ts` (a module already imported by both files touching `stopReason`). All six sites now call it:

- `background-registry.ts`: the `writeMeta` spread (the previously-unbounded site) + the three telemetry emits (completed/failed/cancelled).
- `foreground-promotion.ts`: the completed and failed telemetry emits.

**Duplicates removed:** the private `boundedStopReason()` copy in `background-registry.ts` (13 lines, including its doc comment) is deleted — the shared helper in `failure-payload.ts` now covers it. The two inline `truncate(result.stopReason, 64)` call sites in `foreground-promotion.ts` were replaced with calls to the shared helper (not removed as standalone duplicates, since they were single expressions, not a second function definition — but they now share one implementation instead of three).

Net result: exactly one place in the codebase computes the 64-char stopReason bound (`failure-payload.ts`), and every write site (telemetry or disk) is bounded by construction.

## Files changed

- `src/agent/tools/subagent/failure-payload.ts` (+22) — new exported `boundedStopReason()` chokepoint + `MAX_STOP_REASON_CHARS` constant.
- `src/agent/background-registry.ts` (+9/-15, net -6) — removed the private duplicate helper, fixed the unbounded `writeMeta` call, switched the three existing telemetry emits to import the shared helper.
- `src/agent/tools/subagent/foreground-promotion.ts` (+8/-10, net -2) — both inline `truncate(x, 64)` call sites now call the shared helper.
- `src/agent/tools/subagent/failure-payload.test.ts` (+31) — new `describe('boundedStopReason', ...)` block: absent stays absent, at-cap (64 chars) passes through unchanged, over-cap truncates to 64 + ellipsis.
- `src/agent/background-registry.test.ts` (+24) — new regression test driving the real `markTerminal` → `writeMeta` path with a 200-char `stopReason`, asserting the persisted `meta.json` value is truncated to 64 chars + ellipsis. This is the path that was unbounded before this change; it's the test that would have failed pre-fix.

(Per scope guard: kept the `background-registry.test.ts` edit to one small, additive test block alongside the existing sibling tests, matching PR #969's post-merge conventions in that file — did not restructure or touch unrelated tests.)

## Test evidence

```
./node_modules/.bin/tsc --noEmit
# exit 0, no output

./node_modules/.bin/vitest run src/agent/background-registry.test.ts \
  src/agent/tools/subagent/failure-payload.test.ts \
  src/agent/tools/subagent/foreground-promotion.test.ts \
  src/agent/bg-job-log.test.ts

 ✓ src/agent/tools/subagent/failure-payload.test.ts (37 tests)
 ✓ src/agent/bg-job-log.test.ts (13 tests)
 ✓ src/agent/tools/subagent/foreground-promotion.test.ts (5 tests)
 ✓ src/agent/background-registry.test.ts (63 tests)

 Test Files  4 passed (4)
      Tests  118 passed (118)
```

## Risks

- Low. The bound was already applied at 5 of 6 sites with 64 chars — this only closes the sixth. No behavior change for any `stopReason` under 64 chars (the overwhelming common case per the issue's own telemetry finding).
- `readMeta` (`bg-job-log.ts`) still does a bare `JSON.parse` cast, and the sole disk consumer (`bgsub.ts:253`) gates on an exact-match `isIncompleteStopReason` check — both noted as out-of-scope hygiene items in the issue, not touched here.

## Not checked

- Did not audit call sites outside `src/agent/` (e.g. CLI/daemon paths) for further `stopReason` handling — the issue's own evidence table scoped the defect to these two files, and `rg` for `truncate(.*stopReason.*64` (post-fix) confirms exactly one implementation remains.
- Did not run the full test suite (per hard constraint — bare `pnpm test` is prohibited in this workspace); ran the four scoped files exercising every touched line.

Closes #717
