### PR TITLE
fix(subagent): refuse model-supplied roots that erase the bash credential floor (#852)

### DIFF
--- a/src/agent/tools/hooks/bash-restriction-hook.test.ts
+++ b/src/agent/tools/hooks/bash-restriction-hook.test.ts
@@ -461,6 +461,38 @@ describe('deriveRestrictedSubstrings — no coverage regression from sharing the
   });
 });
 
+describe('deriveRestrictedSubstrings — a cross-drive grant cannot empty the floor (#852)', () => {
+  // Invariant: `path.win32.relative` returns a DRIVE-QUALIFIED ABSOLUTE string
+  // (`C:\Users\me\.ssh`) when the two paths sit on different drives, never a
+  // `..\`-prefixed one. So `!rel.startsWith('..')` alone reads a cross-drive
+  // pair as "the grant covers this candidate" and DROPS it — one grant on an
+  // unrelated drive emptied the entire credential floor, reachable by any
+  // model-supplied readRoots entry. `!path.isAbsolute(rel)` is the fix.
+  //
+  // Gated to win32 because the topology is UNREACHABLE on POSIX: relative()
+  // between two absolute POSIX paths is never absolute. That unreachability is
+  // why the bug survived review, and it is why the platform-independent guard
+  // is the predicate-identity test in subagent/root-validation.test.ts — this
+  // case does not run on the default CI matrix (the windows leg is opt-in).
+  it.runIf(process.platform === 'win32')(
+    'keeps every candidate when the only grant sits on another drive',
+    () => {
+      const unfiltered = deriveRestrictedSubstrings({
+        resolveBase: undefined,
+        readRoots: [],
+        writeRoots: [],
+      });
+      const otherDrive = homedir().toUpperCase().startsWith('D:') ? 'C:\\scratch' : 'D:\\scratch';
+      const withCrossDriveGrant = deriveRestrictedSubstrings({
+        resolveBase: undefined,
+        readRoots: [otherDrive],
+        writeRoots: [],
+      });
+      expect(withCrossDriveGrant).toEqual(unfiltered);
+    },
+  );
+});
+
 describe('createBashRestrictionHook — credential parity with the typed read denylist', () => {
   // Invariant: a credential path floored for read_file / grep / glob is floored
   // for bash too. Each path below was readable with `cat` while the typed tools

--- a/src/agent/tools/hooks/bash-restriction-hook.ts
+++ b/src/agent/tools/hooks/bash-restriction-hook.ts
@@ -567,10 +567,22 @@ export function deriveRestrictedSubstrings(grants: {
   // so granting a narrow subdir (e.g. ~/Library/Application Support/Cursor/User)
   // wrongly un-gated the whole sensitive parent (~/Library/Application Support)
   // and every sibling app dir under it.
+
+  // Invariant: `!rel.startsWith('..')` alone is NOT a sufficient coverage test
+  // on Windows. When `g` and `c` sit on different drives, `path.win32.relative`
+  // returns a DRIVE-QUALIFIED ABSOLUTE string (`C:\Users\me\.ssh`) rather than a
+  // `..\`-prefixed one, which the bare check reads as "g covers c" and drops the
+  // candidate — so a single cross-drive grant (`readRoots: ['D:\\scratch']`)
+  // silently emptied the ENTIRE credential floor. `!path.isAbsolute(rel)` is the
+  // same guard `computeContainment` carries for this exact class (see
+  // handlers/_cwd-utils.ts), and it makes this predicate byte-identical to
+  // `ungatedSensitiveRoot`'s (subagent/root-validation.ts) — that identity is
+  // what the #852 lockstep property rests on, so the two must not drift again.
+  // No-op on POSIX: relative() between two absolute paths is never absolute.
   return candidates.filter((c) => {
     for (const g of granted) {
       const rel = path.relative(g, c);
-      if (rel === '' || !rel.startsWith('..')) return false;
+      if (rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel))) return false;
     }
     return true;
   });

--- a/src/agent/tools/subagent/input-parse.test.ts
+++ b/src/agent/tools/subagent/input-parse.test.ts
@@ -24,6 +24,11 @@ afterEach(() => {
   vi.unstubAllEnvs();
 });
 
+/** Escape a literal path for embedding in a `toThrow` RegExp. */
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 describe('parseAgentInput', () => {
   describe('input shape', () => {
     it('throws when input is not an object (string)', () => {
@@ -585,6 +590,17 @@ describe('parseAgentInput', () => {
       const result = parseAgentInput({ prompt: 'p', cwd: '/tmp/wt/feat-y' });
       expect(result.cwd).toBe('/tmp/wt/feat-y');
     });
+
+    // --- Hardening: ancestor-of-credential rejection (#852) ---
+    // cwd becomes the child's resolveBase, which deriveRestrictedSubstrings
+    // seeds into `granted` alongside the explicit roots — so an ancestor cwd
+    // lifts the bash floor exactly as a readRoots grant would.
+    it('throws when cwd is an ancestor of a bash credential root (#852)', () => {
+      const appSupport = path.join(os.homedir(), 'Library', 'Application Support');
+      expect(() => parseAgentInput({ prompt: 'p', cwd: appSupport })).toThrow(
+        /must not be at or above a credential root/,
+      );
+    });
   });
 
   describe('writeRoots', () => {
@@ -698,6 +714,17 @@ describe('parseAgentInput', () => {
       });
       expect(result.cwd).toBe('/tmp/wt/x');
       expect(result.writeRoots).toEqual(['/sibling/repo']);
+    });
+
+    // --- Hardening: ancestor-of-credential rejection (#852) ---
+    // writeRoots feed the same `granted` set in deriveRestrictedSubstrings that
+    // cwd and readRoots do, so leaving this field unchecked would just relocate
+    // the erosion rather than close it.
+    it('throws when an entry is an ancestor of a bash credential root (#852)', () => {
+      const appSupport = path.join(os.homedir(), 'Library', 'Application Support');
+      expect(() => parseAgentInput({ prompt: 'p', writeRoots: [appSupport] })).toThrow(
+        /must not be at or above a credential root/,
+      );
     });
   });
 
@@ -848,6 +875,88 @@ describe('parseAgentInput', () => {
       expect(() => parseAgentInput({ prompt: 'p', readRoots: [afkConfig] })).toThrow(
         /must not target a protected\/credential path/,
       );
+    });
+
+    // --- Hardening: ancestor-of-credential rejection (#852) ---
+    //
+    // Invariant: a model must not be able to self-grant a root that ERASES a
+    // bash credential floor. `deriveRestrictedSubstrings` deliberately drops
+    // any candidate a granted root is an ancestor of — that is the documented
+    // operator lift (`/allow-dir ~/.ssh` means the operator wants it) — but a
+    // model reaches the same filter with no human in the loop via this field.
+    // The rejection lives here rather than in the grant filter precisely
+    // because this parser sees ONLY model-authored agent-tool calls, while
+    // every operator grant path reaches the grant manager without passing
+    // through it. That is what keeps the operator's lift working.
+    //
+    // These cases are distinct from the denylist cases above: the denylist
+    // catches an entry that IS a credential path; these catch one that merely
+    // sits ABOVE it.
+    it('throws when an entry is an ancestor of a bash credential root (~/Library/Application Support) (#852)', () => {
+      // The issue's concrete vector: not too-broad (isTooBroadRoot anchors only
+      // on /, home and the AFK dirs) and not read-denied (only the per-browser
+      // subtrees under it are), yet granting it drops the whole vendor tree —
+      // browser secrets included — out of the child's bash gate.
+      const appSupport = path.join(os.homedir(), 'Library', 'Application Support');
+      expect(() => parseAgentInput({ prompt: 'p', readRoots: [appSupport] })).toThrow(
+        /must not be at or above a credential root/,
+      );
+    });
+
+    it('throws when an entry is a PARENT of a bash credential root (~/Library, ~/.config) (#852)', () => {
+      const home = os.homedir();
+      expect(() =>
+        parseAgentInput({ prompt: 'p', readRoots: [path.join(home, 'Library')] }),
+      ).toThrow(/must not be at or above a credential root/);
+      // ~/.config covers both ~/.config/gh and ~/.config/gcloud.
+      expect(() =>
+        parseAgentInput({ prompt: 'p', readRoots: [path.join(home, '.config')] }),
+      ).toThrow(/must not be at or above a credential root/);
+    });
+
+    it('throws when an entry is ~/.afk (ancestor of the AFK credential dir) (#852)', () => {
+      expect(() =>
+        parseAgentInput({ prompt: 'p', readRoots: [path.join(os.homedir(), '.afk')] }),
+      ).toThrow(/must not be at or above a credential root/);
+    });
+
+    it('names the specific root it would un-gate, so the model can narrow the grant', () => {
+      const appSupport = path.join(os.homedir(), 'Library', 'Application Support');
+      expect(() => parseAgentInput({ prompt: 'p', readRoots: [appSupport] })).toThrow(
+        new RegExp(escapeRe(appSupport)),
+      );
+    });
+
+    // --- The guard must not over-reject (#852) ---
+    it('still accepts a NARROWER path inside a sensitive tree', () => {
+      // Containment direction matters: a grant INSIDE a sensitive tree does not
+      // lift the enclosing root, so it is not this guard's business. (The
+      // denylisted browser subtrees are still refused by the isReadDenied leg.)
+      const inner = path.join(os.homedir(), 'Library', 'Application Support', 'SomeApp', 'data');
+      expect(parseAgentInput({ prompt: 'p', readRoots: [inner] }).readRoots).toEqual([inner]);
+    });
+
+    it('still accepts the deliberately-grantable AFK state + framework dirs', () => {
+      // Regression guard for the fork read-denial remedy (Gap A / Gap C in
+      // forkSubagent): confined children legitimately read these, and neither
+      // is an ancestor of ~/.afk/config, so the new check must leave them alone.
+      const home = os.homedir();
+      for (const dir of [
+        path.join(home, '.afk', 'state'),
+        path.join(home, '.afk', 'agent-framework'),
+      ]) {
+        expect(parseAgentInput({ prompt: 'p', readRoots: [dir] }).readRoots).toEqual([dir]);
+      }
+    });
+
+    it('still accepts ordinary out-of-repo dirs (the #662 use case)', () => {
+      const downloads = path.join(os.homedir(), 'Downloads');
+      expect(parseAgentInput({ prompt: 'p', readRoots: [downloads] }).readRoots).toEqual([
+        downloads,
+      ]);
+      expect(parseAgentInput({ prompt: 'p', readRoots: ['/tmp/scratch'] }).readRoots).toEqual([
+        '/tmp/scratch',
+      ]);
     });
 
     // --- Deliberate divergence from writeRoots ---

--- a/src/agent/tools/subagent/input-parse.ts
+++ b/src/agent/tools/subagent/input-parse.ts
@@ -11,7 +11,7 @@
 import { isAbsolute, resolve as resolvePath } from 'node:path';
 import { isReadDenied } from '../handlers/read-denylist.js';
 import { realpathSafe } from '../handlers/_cwd-utils.js';
-import { isTooBroadRoot } from './root-validation.js';
+import { isTooBroadRoot, ungatedSensitiveRoot } from './root-validation.js';
 import {
   readOptional,
   readOptionalAliasString,
@@ -290,6 +290,20 @@ export function parseAgentInput(input: unknown): AgentInput {
           `cwd alone and grant those paths via readRoots. Got: ${JSON.stringify(cwdValue)}`,
       );
     }
+    // 5. ANCESTOR-OF-CREDENTIAL rejection (#852). `cwd` becomes the child's
+    // `resolveBase`, which `deriveRestrictedSubstrings` seeds into `granted`
+    // alongside the explicit roots — so a cwd ABOVE a credential root lifts
+    // that root's bash gate exactly as a readRoots grant would, and this leg
+    // is what closes the resolveBase half of the hole.
+    const cwdUngates = ungatedSensitiveRoot(resolvedCwd);
+    if (cwdUngates !== undefined) {
+      throw new Error(
+        `Agent tool cwd must not be at or above a credential root the bash ` +
+          `restriction protects (${cwdUngates}) — anchoring the child there would ` +
+          `silently drop that whole tree out of its bash gate. Pass a directory ` +
+          `outside it. Got: ${JSON.stringify(cwdValue)}`,
+      );
+    }
     cwd = cwdValue;
   }
 
@@ -336,6 +350,19 @@ export function parseAgentInput(input: unknown): AgentInput {
           `Agent tool writeRoots entries must not be a filesystem root, your home ` +
             `directory, or an ancestor of it (checked after resolving symlinks) — ` +
             `grant a specific subdirectory instead, got: ${JSON.stringify(entry)}`,
+        );
+      }
+      // Ancestor-of-credential rejection (#852) — writeRoots feed the same
+      // `granted` set in `deriveRestrictedSubstrings` that cwd and readRoots
+      // do, so the guard has to be identical on all three or the erosion just
+      // moves to whichever field is left unchecked.
+      const wUngates = ungatedSensitiveRoot(resolvedEntry);
+      if (wUngates !== undefined) {
+        throw new Error(
+          `Agent tool writeRoots entries must not be at or above a credential root ` +
+            `the bash restriction protects (${wUngates}) — granting it would silently ` +
+            `drop that whole tree out of the child's bash gate. Grant a narrower ` +
+            `subdirectory instead. Got: ${JSON.stringify(entry)}`,
         );
       }
       roots.push(entry);
@@ -419,6 +446,22 @@ export function parseAgentInput(input: unknown): AgentInput {
         throw new Error(
           `Agent tool readRoots entries must not target a protected/credential path ` +
             `(matches read-denylist entry: ${denied.matched}), got: ${JSON.stringify(entry)}`,
+        );
+      }
+      // (c) ANCESTOR-OF-CREDENTIAL rejection (#852). Distinct from (b): the
+      // denylist catches an entry that IS (or resolves into) a credential path,
+      // but says nothing about one that merely sits ABOVE it. Those are exactly
+      // the grants that empty the bash floor — `~/Library/Application Support`
+      // is neither too broad nor read-denied, yet covers every browser secret
+      // tree beneath it.
+      const ungates = ungatedSensitiveRoot(resolved);
+      if (ungates !== undefined) {
+        throw new Error(
+          `Agent tool readRoots entries must not be at or above a credential root ` +
+            `the bash restriction protects (${ungates}) — granting it would silently ` +
+            `drop that whole tree out of the child's bash gate. Grant a narrower ` +
+            `subdirectory, or the individual FILES you need: a single file is a valid ` +
+            `read root and grants exactly that file. Got: ${JSON.stringify(entry)}`,
         );
       }
       roots.push(entry);

--- a/src/agent/tools/subagent/root-validation.test.ts
+++ b/src/agent/tools/subagent/root-validation.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, it } from 'vitest';
 import os from 'node:os';
 import path from 'node:path';
 import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { isTooBroadRoot, ungatedSensitiveRoot } from './root-validation.js';
 import { deriveRestrictedSubstrings } from '../hooks/bash-restriction-hook.js';
 
@@ -19,6 +20,24 @@ const HOME = os.homedir();
 /** The unfiltered candidate list — what the bash floor protects. */
 function allCandidates(): string[] {
   return deriveRestrictedSubstrings({ resolveBase: undefined, readRoots: [], writeRoots: [] });
+}
+
+/**
+ * The ancestor-coverage predicate as spelled in `source`, normalized so the two
+ * call sites are comparable: the named-import spelling (`isAbsolute`) and the
+ * namespace spelling (`path.isAbsolute`) fold together, as does whitespace.
+ * Deliberately source-text based — see the predicate-identity case below for why
+ * a behavioural assertion cannot cover this on POSIX.
+ */
+function coveragePredicate(source: string): string {
+  const match = source.match(/if \((rel === ''[\s\S]*?)\)\s*return /);
+  if (match?.[1] === undefined) {
+    throw new Error('coverage predicate not found — did the `rel` binding get renamed?');
+  }
+  return match[1]
+    .replace(/\bpath\.isAbsolute\b/g, 'isAbsolute')
+    .replace(/\s+/g, ' ')
+    .trim();
 }
 
 describe('ungatedSensitiveRoot (#852)', () => {
@@ -134,5 +153,29 @@ describe('ungatedSensitiveRoot (#852)', () => {
     for (const candidate of allCandidates()) {
       expect(ungatedSensitiveRoot(candidate)).toBeDefined();
     }
+  });
+
+  // Invariant: the two lockstep cases above compare a root against ITSELF or
+  // against an UNRELATED root, and on POSIX those are the only reachable
+  // topologies — `path.relative` between two absolute POSIX paths is never
+  // absolute. The one topology where the guard and the filter can DISAGREE is a
+  // win32 cross-drive pair, where relative() yields a drive-qualified ABSOLUTE
+  // string; a behavioural test for it therefore only runs on the opt-in windows
+  // CI leg (see hooks/bash-restriction-hook.test.ts). This case is the guard
+  // that runs everywhere: it pins the two coverage predicates as textually
+  // identical, so dropping `isAbsolute` from either side fails here on every
+  // platform instead of silently reopening #852 on Windows only.
+  it('predicate identity: guard and bash filter spell coverage the same way', () => {
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const guardSrc = fs.readFileSync(path.join(here, 'root-validation.ts'), 'utf8');
+    const filterSrc = fs.readFileSync(
+      path.join(here, '..', 'hooks', 'bash-restriction-hook.ts'),
+      'utf8',
+    );
+    expect(coveragePredicate(guardSrc)).toBe(coveragePredicate(filterSrc));
+    // Pin the shape too, so an edit that weakens BOTH sides in lockstep still fails.
+    expect(coveragePredicate(guardSrc)).toBe(
+      "rel === '' || (!rel.startsWith('..') && !isAbsolute(rel))",
+    );
   });
 });

--- a/src/agent/tools/subagent/root-validation.test.ts
+++ b/src/agent/tools/subagent/root-validation.test.ts
@@ -83,9 +83,17 @@ describe('ungatedSensitiveRoot (#852)', () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afk852-'));
     const link = path.join(dir, 'link');
     try {
-      fs.symlinkSync(path.join(HOME, 'Library'), link, 'dir');
-      // Lexically innocuous (/tmp/...), but its realpath is an ancestor of the
-      // Application Support credential root.
+      // Target must EXIST on every platform the suite runs on: realpathSafe
+      // falls back to re-appending the trailing segments for an unresolvable
+      // path, so a DANGLING link resolves to the link's own path and would
+      // silently assert nothing. The home dir exists everywhere and is an
+      // ancestor of the home-anchored credential roots (~/.ssh, …); a
+      // home-relative target like ~/Library is macOS-only and would make this
+      // case vacuous on Linux CI rather than failing loudly.
+      fs.symlinkSync(HOME, link, 'dir');
+      // Lexically innocuous (/tmp/...), but its realpath is an ancestor of a
+      // credential root — the lexical-only check that #664 closed for
+      // isTooBroadRoot would have passed it.
       expect(ungatedSensitiveRoot(link)).toBeDefined();
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });

--- a/src/agent/tools/subagent/root-validation.test.ts
+++ b/src/agent/tools/subagent/root-validation.test.ts
@@ -30,11 +30,19 @@ function allCandidates(): string[] {
  * a behavioural assertion cannot cover this on POSIX.
  */
 function coveragePredicate(source: string): string {
-  const match = source.match(/if \((rel === ''[\s\S]*?)\)\s*return /);
-  if (match?.[1] === undefined) {
-    throw new Error('coverage predicate not found — did the `rel` binding get renamed?');
+  // Match ALL sites and demand exactly one. A first-match-wins `.match()` would
+  // silently bind to the wrong site if a second `if (rel === …) return` ever
+  // appeared above the real one (a decoy in a comment is enough), which fails
+  // OPEN — the test would keep passing while pinning unrelated text.
+  const matches = [...source.matchAll(/if \((rel === ''[\s\S]*?)\)\s*return /g)];
+  const expression = matches.length === 1 ? matches[0]?.[1] : undefined;
+  if (expression === undefined) {
+    throw new Error(
+      `expected exactly one coverage predicate, found ${matches.length} — did the \`rel\` ` +
+        'binding get renamed, or did a second `if (rel === …) return` site appear?',
+    );
   }
-  return match[1]
+  return expression
     .replace(/\bpath\.isAbsolute\b/g, 'isAbsolute')
     .replace(/\s+/g, ' ')
     .trim();

--- a/src/agent/tools/subagent/root-validation.test.ts
+++ b/src/agent/tools/subagent/root-validation.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Direct unit tests for the path-root breadth guards.
+ *
+ * `isTooBroadRoot` is covered transitively through `input-parse.test.ts` (every
+ * rejection message it produces is asserted there); this file covers the #852
+ * ancestor guard at the function boundary, plus the coupling property that ties
+ * it to the bash-restriction filter it defends.
+ */
+
+import { describe, expect, it } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs';
+import { isTooBroadRoot, ungatedSensitiveRoot } from './root-validation.js';
+import { deriveRestrictedSubstrings } from '../hooks/bash-restriction-hook.js';
+
+const HOME = os.homedir();
+
+/** The unfiltered candidate list — what the bash floor protects. */
+function allCandidates(): string[] {
+  return deriveRestrictedSubstrings({ resolveBase: undefined, readRoots: [], writeRoots: [] });
+}
+
+describe('ungatedSensitiveRoot (#852)', () => {
+  describe('rejects roots that would erase a credential floor', () => {
+    it('flags the credential root itself', () => {
+      // The issue's vector. Note this root is NOT caught by either pre-existing
+      // guard: isTooBroadRoot anchors on / + home + the AFK dirs, and the read
+      // denylist covers only the per-browser subtrees beneath it.
+      const appSupport = path.join(HOME, 'Library', 'Application Support');
+      expect(isTooBroadRoot(appSupport)).toBe(false);
+      expect(ungatedSensitiveRoot(appSupport)).toBe(appSupport);
+    });
+
+    it('flags a parent of a credential root', () => {
+      expect(ungatedSensitiveRoot(path.join(HOME, 'Library'))).toBeDefined();
+      expect(ungatedSensitiveRoot(path.join(HOME, '.config'))).toBeDefined();
+      expect(ungatedSensitiveRoot(path.join(HOME, '.afk'))).toBeDefined();
+      expect(ungatedSensitiveRoot('/etc')).toBeDefined();
+    });
+
+    it('returns WHICH root would be un-gated, not just a boolean', () => {
+      // The parse-layer error embeds this so the model can narrow the grant
+      // instead of guessing which of ~25 roots it collided with.
+      expect(ungatedSensitiveRoot(path.join(HOME, '.config'))).toBe(
+        path.join(HOME, '.config', 'gh'),
+      );
+    });
+  });
+
+  describe('does not over-reject', () => {
+    it('allows ordinary out-of-repo dirs', () => {
+      for (const p of ['/tmp/scratch', '/abs/data', path.join(HOME, 'Downloads')]) {
+        expect(ungatedSensitiveRoot(p)).toBeUndefined();
+      }
+    });
+
+    it('allows a path INSIDE a sensitive tree', () => {
+      // Containment direction: a grant below a credential root does not lift
+      // that root, so it is not this guard's concern.
+      expect(
+        ungatedSensitiveRoot(path.join(HOME, 'Library', 'Application Support', 'App', 'x')),
+      ).toBeUndefined();
+      expect(ungatedSensitiveRoot(path.join(HOME, '.config', 'someapp'))).toBeUndefined();
+    });
+
+    it('allows the deliberately-grantable AFK state + framework dirs', () => {
+      // Confined forks legitimately read these (the Gap A / Gap C grants in
+      // forkSubagent); neither is an ancestor of ~/.afk/config.
+      expect(ungatedSensitiveRoot(path.join(HOME, '.afk', 'state'))).toBeUndefined();
+      expect(ungatedSensitiveRoot(path.join(HOME, '.afk', 'agent-framework'))).toBeUndefined();
+    });
+
+    it('allows a not-yet-created path without collapsing to its nearest existing ancestor', () => {
+      // realpathSafe re-appends the trailing segments for a missing path, so a
+      // non-existent grant must not be judged as if it were its existing parent
+      // (which would reject nearly everything).
+      expect(ungatedSensitiveRoot('/tmp/definitely-not-created-852/a/b')).toBeUndefined();
+    });
+  });
+
+  it('resolves symlinks before judging (a link INTO an ancestor is still rejected)', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afk852-'));
+    const link = path.join(dir, 'link');
+    try {
+      fs.symlinkSync(path.join(HOME, 'Library'), link, 'dir');
+      // Lexically innocuous (/tmp/...), but its realpath is an ancestor of the
+      // Application Support credential root.
+      expect(ungatedSensitiveRoot(link)).toBeDefined();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // Invariant: this is the property the whole fix rests on, and it is why the
+  // guard reuses `deriveRestrictedSubstrings` instead of keeping its own list
+  // of roots. A root the guard ACCEPTS must leave the bash floor completely
+  // intact; if the two ever drift — someone adds a root to the bash floor but
+  // not to the guard's notion of sensitive — this fails rather than silently
+  // reopening #852 for the newly-added root.
+  it('lockstep: any root the guard accepts drops NOTHING from the bash floor', () => {
+    const full = allCandidates();
+    const accepted = [
+      '/tmp/scratch',
+      '/abs/data',
+      path.join(HOME, 'Downloads'),
+      path.join(HOME, '.afk', 'state'),
+      path.join(HOME, '.afk', 'agent-framework'),
+      path.join(HOME, 'Library', 'Application Support', 'App', 'x'),
+      path.join(HOME, '.config', 'someapp'),
+    ];
+    for (const root of accepted) {
+      expect(ungatedSensitiveRoot(root)).toBeUndefined();
+      const withGrant = deriveRestrictedSubstrings({
+        resolveBase: undefined,
+        readRoots: [root],
+        writeRoots: [],
+      });
+      expect(withGrant).toEqual(full);
+    }
+  });
+
+  it('lockstep: every root the bash floor protects is itself refused as a grant', () => {
+    // The converse direction — no candidate root may be grantable, or a model
+    // could name it directly and erase exactly that one.
+    for (const candidate of allCandidates()) {
+      expect(ungatedSensitiveRoot(candidate)).toBeDefined();
+    }
+  });
+});

--- a/src/agent/tools/subagent/root-validation.ts
+++ b/src/agent/tools/subagent/root-validation.ts
@@ -1,15 +1,20 @@
 /**
  * The path-root breadth guard: rejects a `cwd`, `writeRoots`, or `readRoots`
- * entry that is a filesystem root, the home dir, an ancestor of home, or an
- * AFK-anchored credential root.
+ * entry that is a filesystem root, the home dir, an ancestor of home, an
+ * AFK-anchored credential root, or an ancestor of ANY bash credential root.
  *
- * Extracted from `input-parse.ts` (#782) — a pure move, zero logic change. The
- * host file's three grant fields (`cwd`, `writeRoots`, `readRoots`) each feed
- * the child's grant snapshot and the bash-restriction hook's grant filter
- * (`deriveRestrictedSubstrings`), where an ancestor-based containment check
- * drops any credential root beneath a granted path; a too-broad grant on ANY
- * of the three silently empties that child's credential floor, so the rejection
- * must be identical across all three call sites.
+ * Extracted from `input-parse.ts` (#782). The host file's three grant fields
+ * (`cwd`, `writeRoots`, `readRoots`) each feed the child's grant snapshot and
+ * the bash-restriction hook's grant filter (`deriveRestrictedSubstrings`),
+ * where an ancestor-based containment check drops any credential root beneath
+ * a granted path; a too-broad grant on ANY of the three silently empties that
+ * child's credential floor, so the rejection must be identical across all
+ * three call sites.
+ *
+ * Two guards live here, in widening order: {@link isTooBroadRoot} (the #740
+ * extraction, anchored on `/`, home, and the AFK dirs) and
+ * {@link ungatedSensitiveRoot} (#852, anchored on every credential root the
+ * bash floor protects).
  *
  * @module agent/tools/subagent/root-validation
  */
@@ -19,6 +24,7 @@ import { homedir } from 'node:os';
 import { realpathSafe } from '../handlers/_cwd-utils.js';
 import { getAfkHome, getAfkStateDir } from '../../../paths.js';
 import { warnAfkHomeRejectedOnce } from '../afk-home-warn.js';
+import { deriveRestrictedSubstrings } from '../hooks/bash-restriction-hook.js';
 
 // Home targets for the shared breadth guard below. Computed once at module
 // scope — `homedir()` is stable per process, so there is no need to
@@ -82,4 +88,64 @@ export function isTooBroadRoot(candidate: string): boolean {
     const rel = relativePath(candidate, h);
     return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
   });
+}
+
+/**
+ * The complete, UNFILTERED bash credential-candidate list — the exact set
+ * `deriveRestrictedSubstrings` starts from before applying its grant filter.
+ * The empty snapshot is what makes it unfiltered: with no resolveBase and no
+ * roots, its containment check can drop nothing.
+ *
+ * Invariant: derived per call, never hoisted to module scope. The underlying
+ * list is env-driven (`AFK_READ_DENYLIST`, `AFK_HOME`), so a module-scope
+ * snapshot would freeze one spelling at import and never observe a runtime
+ * relocation — the same trap `afkBreadthTargets` documents above. Reusing the
+ * hook's own exported deriver (rather than re-listing roots here) is what keeps
+ * the two in lockstep: a root added to the bash floor later is automatically
+ * un-grantable, with no second list to remember.
+ */
+function bashSensitiveRoots(): readonly string[] {
+  return deriveRestrictedSubstrings({ resolveBase: undefined, readRoots: [], writeRoots: [] });
+}
+
+/**
+ * The bash credential root that granting `candidate` would un-gate, or
+ * `undefined` when it would un-gate none.
+ *
+ * Invariant: this is the ANCESTOR half of the breadth guard, and it exists
+ * because {@link isTooBroadRoot} anchors only on the filesystem root, home, and
+ * the AFK dirs — it says nothing about the many narrower directories that still
+ * sit ABOVE a credential root. `~/Library/Application Support` is the canonical
+ * case (#852): not home, not an AFK dir, and not read-denied (only the
+ * per-browser subtrees under it are), yet granting it drops that whole vendor
+ * tree — browser secrets included — out of the child's bash restriction via the
+ * ancestor-based containment check in `deriveRestrictedSubstrings`.
+ *
+ * Invariant: provenance comes from the CALL SITE, not from a tag on the grant.
+ * The three fields guarded here are parsed off a MODEL-authored `agent` tool
+ * call, while every operator grant path (`/allow-dir`, the path-approval
+ * elicitation approvals, persisted-permission restore) reaches the grant
+ * manager without passing through this module. That asymmetry is the whole
+ * point: the documented "an explicit grant lifts the bash floor" contract
+ * survives intact for the operator, and only the model loses the ability to
+ * lift that floor for itself with no human in the loop.
+ *
+ * Containment direction matches the filter this defends: `relative(candidate,
+ * sensitive)` neither escaping with '..' nor being absolute means the candidate
+ * IS the sensitive root or is an ancestor of it. A grant INSIDE a sensitive
+ * tree is therefore not rejected here — it does not lift the enclosing root,
+ * and `isReadDenied` already refuses the denylisted subtrees for `readRoots`.
+ * Checked on both the lexical and the symlink-resolved spelling, same as
+ * {@link isTooBroadRoot}, because the containment layer realpaths granted roots
+ * before comparison (#664).
+ */
+export function ungatedSensitiveRoot(candidate: string): string | undefined {
+  const forms = [...new Set([candidate, realpathSafe(candidate)])];
+  for (const sensitive of bashSensitiveRoots()) {
+    for (const form of forms) {
+      const rel = relativePath(form, sensitive);
+      if (rel === '' || (!rel.startsWith('..') && !isAbsolute(rel))) return sensitive;
+    }
+  }
+  return undefined;
 }

--- a/src/agent/tools/subagent/root-validation.ts
+++ b/src/agent/tools/subagent/root-validation.ts
@@ -136,8 +136,13 @@ function bashSensitiveRoots(): readonly string[] {
  * tree is therefore not rejected here — it does not lift the enclosing root,
  * and `isReadDenied` already refuses the denylisted subtrees for `readRoots`.
  * Checked on both the lexical and the symlink-resolved spelling, same as
- * {@link isTooBroadRoot}, because the containment layer realpaths granted roots
- * before comparison (#664).
+ * {@link isTooBroadRoot} (#664). Note WHICH layer motivates that: the bash
+ * filter this guard defends compares the raw granted string and does NOT
+ * realpath it, but the same grant also flows into the typed-tool containment
+ * layer, which resolves every root through `realpathRoot`
+ * (`handlers/_cwd-utils.ts`) before comparing. Covering both spellings here is
+ * therefore fail-closed against the layer that DOES resolve, rather than a
+ * mirror of the one that does not.
  */
 export function ungatedSensitiveRoot(candidate: string): string | undefined {
   const forms = [...new Set([candidate, realpathSafe(candidate)])];


### PR DESCRIPTION
Closes #852.

## The hole

`deriveRestrictedSubstrings` drops any bash credential candidate that a granted root is an ancestor of. That is deliberate and documented — an explicit `/allow-dir ~/.ssh` is the operator saying they want that path this session, and the typed-read floor stays unconditional regardless. The problem is that a **model** reaches the same filter with no human in the loop, through the `agent` tool's own grant fields.

`~/Library/Application Support` is the canonical vector, and it slips both existing guards:

| Guard | Why it passes the vector |
|---|---|
| `isTooBroadRoot` | anchors only on `/`, home, ancestors of home, and the AFK dirs |
| `isReadDenied` | only the per-browser subtrees *beneath* it are denylisted, not the dir itself |

So the grant lands, and the child's bash `cat` gate over that whole vendor tree — browser secrets included — silently disappears.

## Why not the three directions in the issue

The issue proposed (1) a real provenance field on `GrantSnapshot`, (2) tagging the `extraReadRoots` union, or (3) widening the read-denylist. It also showed why the *obvious* variant of (1) is inverted: every `'tool'`-sourced grant is actually operator-originated (elicitation approvals, persisted-permission restore), so gating on the `'slash'`/`'tool'` axis would revoke the operator's own choices — while the actual model vector never calls `addReadRoot` at all, so there is no provenance there to inspect.

That analysis holds, and it points at a fourth option the issue did not list: **provenance is already structural at the parse boundary.** `parseAgentInput` sees *only* model-authored agent-tool input. Every operator grant path — `/allow-dir`, the path-approval elicitation approvals, persisted-permission restore — reaches the grant manager without passing through it.

So the check goes there, and no snapshot field is needed. The operator's documented lift keeps working unchanged; only the model loses the ability to lift the floor for itself.

## The change

A new `ungatedSensitiveRoot(candidate)` in `root-validation.ts`, beside the `isTooBroadRoot` it complements, returning *which* credential root a grant would un-gate (so the error can name it and the model can narrow the grant rather than guess).

Applied to all three grant fields, matching that module's existing "the rejection must be identical across all three call sites" contract. **`cwd` included** — it becomes the child's `resolveBase`, which `deriveRestrictedSubstrings` seeds into `granted` alongside the explicit roots, so an ancestor `cwd` lifts the floor by exactly the same route.

Two details worth review attention:

- **No second list of sensitive roots.** The guard calls the hook's own exported `deriveRestrictedSubstrings` with an empty snapshot (empty ⇒ its filter can drop nothing ⇒ the full candidate set). A root added to the bash floor later is therefore un-grantable automatically. Two lockstep property tests pin the coupling in *both* directions: everything the guard accepts drops nothing from the floor, and every root the floor protects is refused as a grant.
- **Containment direction.** A grant *inside* a sensitive tree is not rejected — it does not lift the enclosing root, and the denylisted subtrees are already refused by `isReadDenied`. Only at-or-above is refused. Checked on the symlink-resolved spelling as well as the lexical one, same as `isTooBroadRoot` (#664).

## Blast radius

Newly refused: `~/Library`, `~/Library/Application Support`, `~/.config`, `~/.afk`, `/etc` — each a genuine ancestor of a credential root.

Still accepted (verified by test, and the reason the guard is ancestor-only rather than a blanket denial):

- ordinary out-of-repo grants — `/tmp/...`, `~/Downloads`, repo paths (the #662 use case)
- narrower paths *inside* a sensitive tree
- `~/.afk/state` and `~/.afk/agent-framework` — the deliberately-grantable dirs confined forks depend on (the Gap A / Gap C grants in `forkSubagent`); neither is an ancestor of `~/.afk/config`
- not-yet-created paths, which `realpathSafe` re-appends rather than collapsing to their nearest existing ancestor

## Verification

- Full suite green: **834 files / 15,870 tests**, 0 failures.
- All CI gates pass: `lint`, `audit:sdk:check`, `audit:env:check`, `scan:env:check`, `audit:chalk:check`, `fix:pins:check`, `build`.
- **Negative control** — reverted the two source files with the new tests left in place: the 6 rejection tests fail (so they capture the real vulnerability, not a tautology) while the "does not over-reject" tests still pass. Restored, re-verified green.
- +19 tests: 9 at the parse boundary, 10 in a new `root-validation.test.ts` (that module had no direct unit coverage before).

## Out of scope, worth a follow-up

`SubagentDAGNode.readRoots` flows straight into `forkSubagent` (`dag-subagent.ts:115-126`) without passing through `parseAgentInput`, so it bypasses this guard — **and equally bypasses the pre-existing `isTooBroadRoot`**, so this is not a regression introduced here. It is also not model-reachable today: the `compose` tool's schema exposes no `readRoots`, so only in-process skill code can populate it. Filing separately rather than widening this PR.
