### PR TITLE
fix(observability): surface first artifact-write failure per subsystem without AFK_DEBUG (#850)

### DIFF
--- a/src/agent/session/subagent-output-capture.ts
+++ b/src/agent/session/subagent-output-capture.ts
@@ -32,7 +32,7 @@ import { join } from 'node:path';
 import { env } from '../../config/env.js';
 import { getSubagentOutputsDir } from '../../paths.js';
 import type { OutputEvent } from '../types/session-types.js';
-import { debugLog } from '../../utils/debug.js';
+import { reportArtifactFailure } from '../../utils/artifact-failure-reporter.js';
 import { redactInlineSecrets } from './prompt-dump.js';
 import { truncateToBytes } from './subagent-prompt-capture.js';
 
@@ -186,7 +186,16 @@ export function createSubagentOutputRecorder(
         await appendFile(file, body, { encoding: 'utf8', mode: 0o600 });
       })
       .catch((err: unknown) => {
-        debugLog(`subagent-output-capture failed: ${String(err)}`);
+        // Dedup key: the witness session label — `createSubagentOutputRecorder`
+        // returns null unless `shouldCaptureSubagentOutput` confirms it's
+        // defined, so one first-failure warning covers this whole child's
+        // transcript, not one per appended record. See #850.
+        reportArtifactFailure(
+          'subagent-output-capture',
+          input.sessionId ?? 'unknown',
+          'write',
+          err,
+        );
       });
   };
 
@@ -253,7 +262,12 @@ export function createSubagentOutputRecorder(
           wroteSayThisTurn = false;
         }
       } catch (err) {
-        debugLog(`subagent-output-capture observe failed: ${String(err)}`);
+        reportArtifactFailure(
+          'subagent-output-capture',
+          input.sessionId ?? 'unknown',
+          'observe',
+          err,
+        );
       }
     },
     end(reason: string): void {
@@ -261,7 +275,12 @@ export function createSubagentOutputRecorder(
         flushSaid();
         write(buildRecord('end', { reason }));
       } catch (err) {
-        debugLog(`subagent-output-capture end failed: ${String(err)}`);
+        reportArtifactFailure(
+          'subagent-output-capture',
+          input.sessionId ?? 'unknown',
+          'end',
+          err,
+        );
       }
     },
   };

--- a/src/agent/session/subagent-prompt-capture.ts
+++ b/src/agent/session/subagent-prompt-capture.ts
@@ -28,7 +28,7 @@ import { join } from 'node:path';
 
 import { env } from '../../config/env.js';
 import { getPromptsDir } from '../../paths.js';
-import { debugLog } from '../../utils/debug.js';
+import { reportArtifactFailure } from '../../utils/artifact-failure-reporter.js';
 import { redactInlineSecrets } from './prompt-dump.js';
 
 /**
@@ -171,6 +171,14 @@ export async function captureSubagentPrompt(input: CaptureSubagentPromptInput): 
     // a pre-planted symlink at the target path.
     await writeFile(file, doc, { encoding: 'utf8', mode: 0o600, flag: 'wx' });
   } catch (err) {
-    debugLog(`subagent-prompt-capture failed: ${String(err)}`);
+    // Dedup key: the witness session label (shouldCapture guarantees it's
+    // defined by the time any of the above can throw) — one first-failure
+    // warning per session, not per captured prompt. See #850.
+    reportArtifactFailure(
+      'subagent-prompt-capture',
+      input.sessionId ?? 'unknown',
+      'captureSubagentPrompt',
+      err,
+    );
   }
 }

--- a/src/agent/trace/emit.test.ts
+++ b/src/agent/trace/emit.test.ts
@@ -17,11 +17,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { resetArtifactFailureReporterForTests } from '../../utils/artifact-failure-reporter.js';
 import { emitSessionPhase, emitAbort, emitToolCall } from './emit.js';
-import { InMemoryTraceWriter, type TraceWriter } from './writer.js';
+import { InMemoryTraceWriter } from './writer.js';
 import type { TraceWriter } from './index.js';
 
-/** A writer whose `write()` always rejects, with a real (fixed) trace path
- *  so it can serve as a stable dedup key across multiple calls. */
+/**
+ * A writer whose `write()` always rejects. `tracePath` is cosmetic content
+ * for `getTracePath()` only — post-fix, `reportArtifactFailure`'s dedup key
+ * is the writer INSTANCE itself, matched by identity, so multiple distinct
+ * writers may safely share the identical `tracePath` (exercised below) and
+ * still isolate correctly. Pre-fix, the dedup key was `getTracePath()`'s
+ * return value, so every existing call to this helper used a unique
+ * `tracePath` per test — isolation between writers passed, but only
+ * because no two tests' writers ever shared a path, not because the
+ * dedup logic was actually keyed on the right thing.
+ */
 function makeFailingWriter(tracePath: string, message: string): TraceWriter {
   const inner = new InMemoryTraceWriter();
   return {
@@ -80,8 +89,9 @@ describe('emit* — #850 first-failure-visible-without-AFK_DEBUG', () => {
   });
 
   // AC3: a forced write failure emits the signal EXACTLY ONCE per dedup key
-  // (here, the writer's trace path) — not zero times, not once per call. A
-  // wedged writer (every call fails identically) must not flood stderr.
+  // (post-fix: the writer INSTANCE, matched by identity) — not zero times,
+  // not once per call. A wedged writer (every call fails identically) must
+  // not flood stderr.
   it('emits the visible signal exactly once per writer even across many failing calls', async () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     try {
@@ -102,6 +112,93 @@ describe('emit* — #850 first-failure-visible-without-AFK_DEBUG', () => {
     try {
       await expect(emitSessionPhase(undefined, { phase: 'session_init_start' })).resolves.toBeUndefined();
       expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  // Regression for the CI TypeError this fix closes: a writer that has NO
+  // `getTracePath` method at all (a partial/test-double TraceWriter — e.g.
+  // McpManager's traceWriter mock in src/telegram/mcp-session.test.ts) must
+  // not crash `emitSessionPhase` when its `write()` also fails. Pre-fix,
+  // the catch block called `writer.getTracePath()` to build the dedup key,
+  // which threw `TypeError: writer.getTracePath is not a function` from
+  // INSIDE the catch — an unhandled rejection that reddened CI. This test
+  // MUST fail against the pre-fix code (it either throws or emitSessionPhase
+  // rejects, either way violating the never-throw contract).
+  it('never throws when the writer has no getTracePath method at all (CI TypeError regression)', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const writer = {
+        write: async () => {
+          throw new Error('boom');
+        },
+      } as unknown as TraceWriter;
+
+      await expect(emitSessionPhase(writer, { phase: 'session_init_start' })).resolves.toBeUndefined();
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      const msg = errorSpy.mock.calls[0]?.[0];
+      expect(String(msg)).toContain('session_phase');
+      expect(String(msg)).toContain('boom');
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  // Regression for the shared-sentinel suppression bug: two SEPARATE writer
+  // instances that both return the identical getTracePath() value (mimicking
+  // InMemoryTraceWriter's shared 'in-memory://trace' sentinel — see
+  // agent/trace/writer.ts) and both fail must each get their own visible
+  // warning. Pre-fix (path-string dedup key), the second writer's failure
+  // would have been silently swallowed into debugLog because its path
+  // collided with the first writer's already-latched key.
+  it('warns once PER WRITER even when two distinct writers share the identical getTracePath() value', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const sharedPath = 'in-memory://trace';
+      const writerOne = makeFailingWriter(sharedPath, 'writer one failure');
+      const writerTwo = makeFailingWriter(sharedPath, 'writer two failure');
+
+      await emitSessionPhase(writerOne, { phase: 'session_init_start' });
+      await emitSessionPhase(writerTwo, { phase: 'session_init_start' });
+
+      expect(errorSpy).toHaveBeenCalledTimes(2);
+      const firstMsg = String(errorSpy.mock.calls[0]?.[0]);
+      const secondMsg = String(errorSpy.mock.calls[1]?.[0]);
+      expect(firstMsg).toContain('writer one failure');
+      expect(secondMsg).toContain('writer two failure');
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  // Regression for the traceDedupKey self-recursion defect (superseded helper,
+  // never shipped past PR #979 review): `traceDedupKey` called ITSELF instead
+  // of `writer.getTracePath()` in its true branch, so every writer — including
+  // ones correctly implementing getTracePath — recursed until `RangeError:
+  // Maximum call stack size exceeded`, which its own catch swallowed into the
+  // single sentinel key 'unknown-trace'. Two writers with DIFFERENT
+  // getTracePath() values would therefore have collapsed onto that one shared
+  // key, so only the FIRST writer's failure anywhere in the process was ever
+  // visible — the second would have been silently downgraded to debugLog.
+  // Identity-based keying never reads getTracePath() at all, so it is immune:
+  // distinct instances are always distinct keys regardless of what (if
+  // anything) their accessor returns.
+  it('does not collapse distinct writers onto one dedup key (traceDedupKey recursion regression)', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const writerOne = makeFailingWriter('/tmp/afk-850-recursion-a/trace.jsonl', 'writer A failure');
+      const writerTwo = makeFailingWriter('/tmp/afk-850-recursion-b/trace.jsonl', 'writer B failure');
+
+      await emitSessionPhase(writerOne, { phase: 'session_init_start' });
+      await emitSessionPhase(writerTwo, { phase: 'session_init_start' });
+
+      expect(errorSpy).toHaveBeenCalledTimes(2);
+      const firstMsg = String(errorSpy.mock.calls[0]?.[0]);
+      const secondMsg = String(errorSpy.mock.calls[1]?.[0]);
+      expect(firstMsg).toContain('writer A failure');
+      expect(secondMsg).toContain('writer B failure');
     } finally {
       errorSpy.mockRestore();
     }

--- a/src/agent/trace/emit.test.ts
+++ b/src/agent/trace/emit.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for the #850 fix: trace `emit*` helpers must surface a swallowed
+ * write failure to the operator without requiring `AFK_DEBUG=1`, while
+ * preserving the never-throw fire-and-forget contract documented in this
+ * module's header.
+ *
+ * Uses `emitSessionPhase` as the representative call site — all eleven
+ * `emit*` functions share the identical `try { await writer.write(...) }
+ * catch (err) { reportArtifactFailure(...) }` shape, so one forced-failure
+ * exercise here validates the shared pattern without duplicating the same
+ * assertion eleven times.
+ *
+ * @module agent/trace/emit.test
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { resetArtifactFailureReporterForTests } from '../../utils/artifact-failure-reporter.js';
+import { emitSessionPhase, emitAbort } from './emit.js';
+import { InMemoryTraceWriter } from './writer.js';
+import type { TraceWriter } from './index.js';
+
+/** A writer whose `write()` always rejects, with a real (fixed) trace path
+ *  so it can serve as a stable dedup key across multiple calls. */
+function makeFailingWriter(tracePath: string, message: string): TraceWriter {
+  const inner = new InMemoryTraceWriter();
+  return {
+    write: () => Promise.reject(new Error(message)),
+    getTracePath: () => tracePath,
+    seal: (payload) => inner.seal(payload),
+    close: () => inner.close(),
+  };
+}
+
+describe('emit* — #850 first-failure-visible-without-AFK_DEBUG', () => {
+  beforeEach(() => {
+    resetArtifactFailureReporterForTests();
+  });
+
+  afterEach(() => {
+    resetArtifactFailureReporterForTests();
+  });
+
+  // AC1: enabling an observability feature that then fails produces at
+  // least one operator-visible signal WITHOUT AFK_DEBUG=1.
+  it('surfaces a write failure via console.error with AFK_DEBUG unset', async () => {
+    const originalDebug = process.env['AFK_DEBUG'];
+    delete process.env['AFK_DEBUG'];
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const writer = makeFailingWriter('/tmp/afk-850-a/trace.jsonl', 'EACCES: permission denied');
+
+      await emitSessionPhase(writer, { phase: 'session_init_start' });
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      const msg = errorSpy.mock.calls[0]?.[0];
+      expect(String(msg)).toContain('session_phase');
+      expect(String(msg)).toContain('EACCES');
+    } finally {
+      if (originalDebug !== undefined) process.env['AFK_DEBUG'] = originalDebug;
+      errorSpy.mockRestore();
+    }
+  });
+
+  // AC2: no turn can be failed by an artifact write. A rejecting writer must
+  // never cause emitSessionPhase (or any emit* helper) to throw/reject.
+  it('never rejects even when the writer throws on every call (never-throw contract)', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const writer = makeFailingWriter('/tmp/afk-850-b/trace.jsonl', 'ENOSPC: no space left on device');
+
+      await expect(emitSessionPhase(writer, { phase: 'loop_end', durationMs: 5 })).resolves.toBeUndefined();
+      await expect(emitAbort(writer, { origin: 'user_signal', cascadedTo: [] })).resolves.toBeUndefined();
+      // Repeat calls — still must never throw, matching the fire-and-forget
+      // contract callers rely on (`void emitSessionPhase(...)`).
+      await expect(emitSessionPhase(writer, { phase: 'loop_end', durationMs: 5 })).resolves.toBeUndefined();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  // AC3: a forced write failure emits the signal EXACTLY ONCE per dedup key
+  // (here, the writer's trace path) — not zero times, not once per call. A
+  // wedged writer (every call fails identically) must not flood stderr.
+  it('emits the visible signal exactly once per writer even across many failing calls', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const writer = makeFailingWriter('/tmp/afk-850-c/trace.jsonl', 'EROFS: read-only file system');
+
+      await emitSessionPhase(writer, { phase: 'session_init_start' });
+      await emitSessionPhase(writer, { phase: 'loop_end', durationMs: 1 });
+      await emitAbort(writer, { origin: 'user_signal', cascadedTo: [] });
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('does not surface anything when the writer is undefined (no-op path unaffected)', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      await expect(emitSessionPhase(undefined, { phase: 'session_init_start' })).resolves.toBeUndefined();
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+});

--- a/src/agent/trace/emit.test.ts
+++ b/src/agent/trace/emit.test.ts
@@ -16,8 +16,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { resetArtifactFailureReporterForTests } from '../../utils/artifact-failure-reporter.js';
-import { emitSessionPhase, emitAbort } from './emit.js';
-import { InMemoryTraceWriter } from './writer.js';
+import { emitSessionPhase, emitAbort, emitToolCall } from './emit.js';
+import { InMemoryTraceWriter, type TraceWriter } from './writer.js';
 import type { TraceWriter } from './index.js';
 
 /** A writer whose `write()` always rejects, with a real (fixed) trace path
@@ -105,5 +105,47 @@ describe('emit* — #850 first-failure-visible-without-AFK_DEBUG', () => {
     } finally {
       errorSpy.mockRestore();
     }
+  });
+});
+
+describe('#850 regression — the reporter must not become the failure it reports', () => {
+  it('does not reject when a failing writer lacks getTracePath', async () => {
+    // Reproduces the CI unhandled rejection: `reportArtifactFailure` guards its
+    // own body, but its ARGUMENTS are evaluated first, so `writer.getTracePath()`
+    // at the call site threw on a partial writer double and escaped as an
+    // unhandled rejection. 4 of these failed the full suite while every test
+    // still "passed".
+    const partialWriter = {
+      write: async () => {
+        throw new Error('disk full');
+      },
+    } as unknown as TraceWriter;
+
+    await expect(
+      emitSessionPhase(partialWriter, { phase: 'bootstrap_start' }),
+    ).resolves.toBeUndefined();
+    await expect(
+      emitToolCall(partialWriter, {
+        phase: 'started',
+        toolUseId: 'tu-1',
+        name: 'bash',
+        inputBytes: 4,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('does not reject when getTracePath itself throws', async () => {
+    const hostileWriter = {
+      write: async () => {
+        throw new Error('disk full');
+      },
+      getTracePath: () => {
+        throw new Error('path resolution blew up');
+      },
+    } as unknown as TraceWriter;
+
+    await expect(
+      emitSessionPhase(hostileWriter, { phase: 'bootstrap_start' }),
+    ).resolves.toBeUndefined();
   });
 });

--- a/src/agent/trace/emit.ts
+++ b/src/agent/trace/emit.ts
@@ -6,9 +6,16 @@
  *   1. **No-op when writer is undefined.** Emission sites never need to
  *      guard with `if (writer)` — call the helper unconditionally.
  *
- *   2. **Errors are swallowed.** A broken trace writer must never crash
- *      an active session. Failures are logged via `debugLog` so they
- *      surface during debugging but never propagate to the caller.
+ *   2. **Errors are swallowed but not silent (#850).** A broken trace
+ *      writer must never crash an active session, so every failure is
+ *      caught here — but the FIRST failure per writer is also surfaced to
+ *      stderr unconditionally via `reportArtifactFailure` (subsequent
+ *      failures for the same writer fall back to `debugLog`), so an
+ *      operator who turns on tracing does not get silence when it is
+ *      completely broken. `writer.getTracePath()` is the dedup key: it is
+ *      unique per session/writer instance and these functions take no
+ *      `sessionId` parameter, so it identifies "this failing sink" without
+ *      threading a new parameter through eleven call sites.
  *
  * This keeps emission sites readable — no try/catch noise around every
  * trace write — while preserving the invariant that the witness layer
@@ -17,7 +24,7 @@
  * @module agent/trace/emit
  */
 
-import { debugLog } from '../../utils/debug.js';
+import { reportArtifactFailure } from '../../utils/artifact-failure-reporter.js';
 import type {
   AbortPayload,
   BackgroundAgentPayload,
@@ -42,7 +49,7 @@ export async function emitToolCall(
   try {
     await writer.write({ kind: 'tool_call', payload });
   } catch (err) {
-    debugLog(`trace.emit tool_call failed: ${stringifyError(err)}`);
+    reportArtifactFailure('trace.emit', writer.getTracePath(), 'tool_call', err);
   }
 }
 
@@ -54,7 +61,7 @@ export async function emitHookDecision(
   try {
     await writer.write({ kind: 'hook_decision', payload });
   } catch (err) {
-    debugLog(`trace.emit hook_decision failed: ${stringifyError(err)}`);
+    reportArtifactFailure('trace.emit', writer.getTracePath(), 'hook_decision', err);
   }
 }
 
@@ -66,7 +73,7 @@ export async function emitSubagentLifecycle(
   try {
     await writer.write({ kind: 'subagent_lifecycle', payload });
   } catch (err) {
-    debugLog(`trace.emit subagent_lifecycle failed: ${stringifyError(err)}`);
+    reportArtifactFailure('trace.emit', writer.getTracePath(), 'subagent_lifecycle', err);
   }
 }
 
@@ -78,7 +85,7 @@ export async function emitBackgroundAgent(
   try {
     await writer.write({ kind: 'background_agent', payload });
   } catch (err) {
-    debugLog(`trace.emit background_agent failed: ${stringifyError(err)}`);
+    reportArtifactFailure('trace.emit', writer.getTracePath(), 'background_agent', err);
   }
 }
 
@@ -90,7 +97,7 @@ export async function emitBudget(
   try {
     await writer.write({ kind: 'budget', payload });
   } catch (err) {
-    debugLog(`trace.emit budget failed: ${stringifyError(err)}`);
+    reportArtifactFailure('trace.emit', writer.getTracePath(), 'budget', err);
   }
 }
 
@@ -102,7 +109,7 @@ export async function emitAbort(
   try {
     await writer.write({ kind: 'abort', payload });
   } catch (err) {
-    debugLog(`trace.emit abort failed: ${stringifyError(err)}`);
+    reportArtifactFailure('trace.emit', writer.getTracePath(), 'abort', err);
   }
 }
 
@@ -114,7 +121,7 @@ export async function emitCompaction(
   try {
     await writer.write({ kind: 'compaction', payload });
   } catch (err) {
-    debugLog(`trace.emit compaction failed: ${stringifyError(err)}`);
+    reportArtifactFailure('trace.emit', writer.getTracePath(), 'compaction', err);
   }
 }
 
@@ -126,7 +133,7 @@ export async function emitClosure(
   try {
     await writer.write({ kind: 'closure', payload });
   } catch (err) {
-    debugLog(`trace.emit closure failed: ${stringifyError(err)}`);
+    reportArtifactFailure('trace.emit', writer.getTracePath(), 'closure', err);
   }
 }
 
@@ -138,7 +145,7 @@ export async function emitClaim(
   try {
     await writer.write({ kind: 'claim', payload });
   } catch (err) {
-    debugLog(`trace.emit claim failed: ${stringifyError(err)}`);
+    reportArtifactFailure('trace.emit', writer.getTracePath(), 'claim', err);
   }
 }
 
@@ -150,7 +157,7 @@ export async function emitBrowserEvent(
   try {
     await writer.write({ kind: 'browser_event', payload });
   } catch (err) {
-    debugLog(`trace.emit browser_event failed: ${stringifyError(err)}`);
+    reportArtifactFailure('trace.emit', writer.getTracePath(), 'browser_event', err);
   }
 }
 
@@ -162,7 +169,7 @@ export async function emitQueuedUserMessage(
   try {
     await writer.write({ kind: 'queued_user_message', payload });
   } catch (err) {
-    debugLog(`trace.emit queued_user_message failed: ${stringifyError(err)}`);
+    reportArtifactFailure('trace.emit', writer.getTracePath(), 'queued_user_message', err);
   }
 }
 
@@ -174,11 +181,6 @@ export async function emitSessionPhase(
   try {
     await writer.write({ kind: 'session_phase', payload });
   } catch (err) {
-    debugLog(`trace.emit session_phase failed: ${stringifyError(err)}`);
+    reportArtifactFailure('trace.emit', writer.getTracePath(), 'session_phase', err);
   }
-}
-
-function stringifyError(err: unknown): string {
-  if (err instanceof Error) return err.message;
-  return String(err);
 }

--- a/src/agent/trace/emit.ts
+++ b/src/agent/trace/emit.ts
@@ -12,10 +12,14 @@
  *      stderr unconditionally via `reportArtifactFailure` (subsequent
  *      failures for the same writer fall back to `debugLog`), so an
  *      operator who turns on tracing does not get silence when it is
- *      completely broken. `traceDedupKey(writer)` is the dedup key: it is
- *      unique per session/writer instance and these functions take no
- *      `sessionId` parameter, so it identifies "this failing sink" without
- *      threading a new parameter through eleven call sites.
+ *      completely broken. The `writer` INSTANCE itself is the dedup key,
+ *      matched by identity (see `reportArtifactFailure`'s `WeakMap`) rather
+ *      than by calling a trace-path accessor on it — a partial/test-double
+ *      writer need not implement that accessor, and the in-memory writer
+ *      returns the same sentinel path for every instance, so a path-derived
+ *      key was neither safe nor unique. Identity requires no `sessionId`
+ *      parameter on these functions and needs no plumbing through any of
+ *      the twelve call sites below.
  *
  * This keeps emission sites readable — no try/catch noise around every
  * trace write — while preserving the invariant that the witness layer
@@ -41,22 +45,6 @@ import type {
   TraceWriter,
 } from './index.js';
 
-// Contract: this derivation runs INSIDE a catch block, so it must never throw.
-// `reportArtifactFailure` guards its own body, but its arguments are evaluated
-// before it is entered — so calling `traceDedupKey(writer)` directly at the
-// call site put the one unguarded expression on the failure path. A writer
-// double, or a partial TraceWriter from an SDK consumer, that lacks the method
-// then converted a swallowed write failure into an unhandled rejection: the
-// diagnostic becoming the failure it reports, which is precisely the
-// never-throw contract this reporter exists to uphold (#850).
-function traceDedupKey(writer: TraceWriter): string {
-  try {
-    return typeof writer.getTracePath === 'function' ? traceDedupKey(writer) : 'unknown-trace';
-  } catch {
-    return 'unknown-trace';
-  }
-}
-
 export async function emitToolCall(
   writer: TraceWriter | undefined,
   payload: ToolCallPayload,
@@ -65,7 +53,7 @@ export async function emitToolCall(
   try {
     await writer.write({ kind: 'tool_call', payload });
   } catch (err) {
-    reportArtifactFailure('trace.emit', traceDedupKey(writer), 'tool_call', err);
+    reportArtifactFailure('trace.emit', writer, 'tool_call', err);
   }
 }
 
@@ -77,7 +65,7 @@ export async function emitHookDecision(
   try {
     await writer.write({ kind: 'hook_decision', payload });
   } catch (err) {
-    reportArtifactFailure('trace.emit', traceDedupKey(writer), 'hook_decision', err);
+    reportArtifactFailure('trace.emit', writer, 'hook_decision', err);
   }
 }
 
@@ -89,7 +77,7 @@ export async function emitSubagentLifecycle(
   try {
     await writer.write({ kind: 'subagent_lifecycle', payload });
   } catch (err) {
-    reportArtifactFailure('trace.emit', traceDedupKey(writer), 'subagent_lifecycle', err);
+    reportArtifactFailure('trace.emit', writer, 'subagent_lifecycle', err);
   }
 }
 
@@ -101,7 +89,7 @@ export async function emitBackgroundAgent(
   try {
     await writer.write({ kind: 'background_agent', payload });
   } catch (err) {
-    reportArtifactFailure('trace.emit', traceDedupKey(writer), 'background_agent', err);
+    reportArtifactFailure('trace.emit', writer, 'background_agent', err);
   }
 }
 
@@ -113,7 +101,7 @@ export async function emitBudget(
   try {
     await writer.write({ kind: 'budget', payload });
   } catch (err) {
-    reportArtifactFailure('trace.emit', traceDedupKey(writer), 'budget', err);
+    reportArtifactFailure('trace.emit', writer, 'budget', err);
   }
 }
 
@@ -125,7 +113,7 @@ export async function emitAbort(
   try {
     await writer.write({ kind: 'abort', payload });
   } catch (err) {
-    reportArtifactFailure('trace.emit', traceDedupKey(writer), 'abort', err);
+    reportArtifactFailure('trace.emit', writer, 'abort', err);
   }
 }
 
@@ -137,7 +125,7 @@ export async function emitCompaction(
   try {
     await writer.write({ kind: 'compaction', payload });
   } catch (err) {
-    reportArtifactFailure('trace.emit', traceDedupKey(writer), 'compaction', err);
+    reportArtifactFailure('trace.emit', writer, 'compaction', err);
   }
 }
 
@@ -149,7 +137,7 @@ export async function emitClosure(
   try {
     await writer.write({ kind: 'closure', payload });
   } catch (err) {
-    reportArtifactFailure('trace.emit', traceDedupKey(writer), 'closure', err);
+    reportArtifactFailure('trace.emit', writer, 'closure', err);
   }
 }
 
@@ -161,7 +149,7 @@ export async function emitClaim(
   try {
     await writer.write({ kind: 'claim', payload });
   } catch (err) {
-    reportArtifactFailure('trace.emit', traceDedupKey(writer), 'claim', err);
+    reportArtifactFailure('trace.emit', writer, 'claim', err);
   }
 }
 
@@ -173,7 +161,7 @@ export async function emitBrowserEvent(
   try {
     await writer.write({ kind: 'browser_event', payload });
   } catch (err) {
-    reportArtifactFailure('trace.emit', traceDedupKey(writer), 'browser_event', err);
+    reportArtifactFailure('trace.emit', writer, 'browser_event', err);
   }
 }
 
@@ -185,7 +173,7 @@ export async function emitQueuedUserMessage(
   try {
     await writer.write({ kind: 'queued_user_message', payload });
   } catch (err) {
-    reportArtifactFailure('trace.emit', traceDedupKey(writer), 'queued_user_message', err);
+    reportArtifactFailure('trace.emit', writer, 'queued_user_message', err);
   }
 }
 
@@ -197,6 +185,6 @@ export async function emitSessionPhase(
   try {
     await writer.write({ kind: 'session_phase', payload });
   } catch (err) {
-    reportArtifactFailure('trace.emit', traceDedupKey(writer), 'session_phase', err);
+    reportArtifactFailure('trace.emit', writer, 'session_phase', err);
   }
 }

--- a/src/agent/trace/emit.ts
+++ b/src/agent/trace/emit.ts
@@ -12,7 +12,7 @@
  *      stderr unconditionally via `reportArtifactFailure` (subsequent
  *      failures for the same writer fall back to `debugLog`), so an
  *      operator who turns on tracing does not get silence when it is
- *      completely broken. `writer.getTracePath()` is the dedup key: it is
+ *      completely broken. `traceDedupKey(writer)` is the dedup key: it is
  *      unique per session/writer instance and these functions take no
  *      `sessionId` parameter, so it identifies "this failing sink" without
  *      threading a new parameter through eleven call sites.
@@ -41,6 +41,22 @@ import type {
   TraceWriter,
 } from './index.js';
 
+// Contract: this derivation runs INSIDE a catch block, so it must never throw.
+// `reportArtifactFailure` guards its own body, but its arguments are evaluated
+// before it is entered — so calling `traceDedupKey(writer)` directly at the
+// call site put the one unguarded expression on the failure path. A writer
+// double, or a partial TraceWriter from an SDK consumer, that lacks the method
+// then converted a swallowed write failure into an unhandled rejection: the
+// diagnostic becoming the failure it reports, which is precisely the
+// never-throw contract this reporter exists to uphold (#850).
+function traceDedupKey(writer: TraceWriter): string {
+  try {
+    return typeof writer.getTracePath === 'function' ? traceDedupKey(writer) : 'unknown-trace';
+  } catch {
+    return 'unknown-trace';
+  }
+}
+
 export async function emitToolCall(
   writer: TraceWriter | undefined,
   payload: ToolCallPayload,
@@ -49,7 +65,7 @@ export async function emitToolCall(
   try {
     await writer.write({ kind: 'tool_call', payload });
   } catch (err) {
-    reportArtifactFailure('trace.emit', writer.getTracePath(), 'tool_call', err);
+    reportArtifactFailure('trace.emit', traceDedupKey(writer), 'tool_call', err);
   }
 }
 
@@ -61,7 +77,7 @@ export async function emitHookDecision(
   try {
     await writer.write({ kind: 'hook_decision', payload });
   } catch (err) {
-    reportArtifactFailure('trace.emit', writer.getTracePath(), 'hook_decision', err);
+    reportArtifactFailure('trace.emit', traceDedupKey(writer), 'hook_decision', err);
   }
 }
 
@@ -73,7 +89,7 @@ export async function emitSubagentLifecycle(
   try {
     await writer.write({ kind: 'subagent_lifecycle', payload });
   } catch (err) {
-    reportArtifactFailure('trace.emit', writer.getTracePath(), 'subagent_lifecycle', err);
+    reportArtifactFailure('trace.emit', traceDedupKey(writer), 'subagent_lifecycle', err);
   }
 }
 
@@ -85,7 +101,7 @@ export async function emitBackgroundAgent(
   try {
     await writer.write({ kind: 'background_agent', payload });
   } catch (err) {
-    reportArtifactFailure('trace.emit', writer.getTracePath(), 'background_agent', err);
+    reportArtifactFailure('trace.emit', traceDedupKey(writer), 'background_agent', err);
   }
 }
 
@@ -97,7 +113,7 @@ export async function emitBudget(
   try {
     await writer.write({ kind: 'budget', payload });
   } catch (err) {
-    reportArtifactFailure('trace.emit', writer.getTracePath(), 'budget', err);
+    reportArtifactFailure('trace.emit', traceDedupKey(writer), 'budget', err);
   }
 }
 
@@ -109,7 +125,7 @@ export async function emitAbort(
   try {
     await writer.write({ kind: 'abort', payload });
   } catch (err) {
-    reportArtifactFailure('trace.emit', writer.getTracePath(), 'abort', err);
+    reportArtifactFailure('trace.emit', traceDedupKey(writer), 'abort', err);
   }
 }
 
@@ -121,7 +137,7 @@ export async function emitCompaction(
   try {
     await writer.write({ kind: 'compaction', payload });
   } catch (err) {
-    reportArtifactFailure('trace.emit', writer.getTracePath(), 'compaction', err);
+    reportArtifactFailure('trace.emit', traceDedupKey(writer), 'compaction', err);
   }
 }
 
@@ -133,7 +149,7 @@ export async function emitClosure(
   try {
     await writer.write({ kind: 'closure', payload });
   } catch (err) {
-    reportArtifactFailure('trace.emit', writer.getTracePath(), 'closure', err);
+    reportArtifactFailure('trace.emit', traceDedupKey(writer), 'closure', err);
   }
 }
 
@@ -145,7 +161,7 @@ export async function emitClaim(
   try {
     await writer.write({ kind: 'claim', payload });
   } catch (err) {
-    reportArtifactFailure('trace.emit', writer.getTracePath(), 'claim', err);
+    reportArtifactFailure('trace.emit', traceDedupKey(writer), 'claim', err);
   }
 }
 
@@ -157,7 +173,7 @@ export async function emitBrowserEvent(
   try {
     await writer.write({ kind: 'browser_event', payload });
   } catch (err) {
-    reportArtifactFailure('trace.emit', writer.getTracePath(), 'browser_event', err);
+    reportArtifactFailure('trace.emit', traceDedupKey(writer), 'browser_event', err);
   }
 }
 
@@ -169,7 +185,7 @@ export async function emitQueuedUserMessage(
   try {
     await writer.write({ kind: 'queued_user_message', payload });
   } catch (err) {
-    reportArtifactFailure('trace.emit', writer.getTracePath(), 'queued_user_message', err);
+    reportArtifactFailure('trace.emit', traceDedupKey(writer), 'queued_user_message', err);
   }
 }
 
@@ -181,6 +197,6 @@ export async function emitSessionPhase(
   try {
     await writer.write({ kind: 'session_phase', payload });
   } catch (err) {
-    reportArtifactFailure('trace.emit', writer.getTracePath(), 'session_phase', err);
+    reportArtifactFailure('trace.emit', traceDedupKey(writer), 'session_phase', err);
   }
 }

--- a/src/utils/artifact-failure-reporter.test.ts
+++ b/src/utils/artifact-failure-reporter.test.ts
@@ -103,4 +103,88 @@ describe('reportArtifactFailure', () => {
       errorSpy.mockRestore();
     }
   });
+
+  // Object dedup keys are latched by IDENTITY (WeakMap), not by structural
+  // equality or by calling anything on them. Two distinct object keys must
+  // each get their own first-failure warning; the same object reused twice
+  // must warn only once — exactly like the string-keyed behavior above.
+  it('latches object dedup keys by identity: distinct objects each warn once, the same object warns only once', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const sinkA = {};
+      const sinkB = {};
+
+      reportArtifactFailure('trace.emit', sinkA, 'tool_call', new Error('EACCES'));
+      reportArtifactFailure('trace.emit', sinkB, 'tool_call', new Error('EACCES'));
+      // Same instance as sinkA again — must NOT produce a third warning.
+      reportArtifactFailure('trace.emit', sinkA, 'abort', new Error('EACCES'));
+
+      expect(errorSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  // Never-throw on a hostile key: the reporter must identify an object
+  // dedup key ONLY by identity, never by touching its members. A key whose
+  // `getTracePath` throws on access (getter) or on call proves the reporter
+  // never reads or invokes anything on the object it was handed.
+  it('never touches members of an object dedup key, even a hostile one that throws on access', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const hostileKey = {
+        get getTracePath(): never {
+          throw new Error('accessing getTracePath must never happen');
+        },
+      };
+
+      expect(() =>
+        reportArtifactFailure('x', hostileKey, 'y', new Error('e')),
+      ).not.toThrow();
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+
+      // A second failure on the SAME hostile key must fall back to debugLog,
+      // not warn again — proving the identity latch recognized it.
+      reportArtifactFailure('x', hostileKey, 'y', new Error('e2'));
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  // The string-keyed latch is bounded (FIFO eviction), not an unbounded
+  // leak. Report enough distinct string keys to overflow the cap, then
+  // re-report the very first key: it must warn visibly again, proving its
+  // entry was evicted rather than retained forever. Asserted purely through
+  // observable re-warning — no reach into internal Map size.
+  it('bounds the string-keyed latch: overflowing it evicts the oldest entry, which then warns again', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const firstKey = 'session-0000';
+      reportArtifactFailure('bounded-latch', firstKey, 'write', new Error('e'));
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+
+      // Push 300 more distinct keys through the same subsystem — well past
+      // the internal cap — none of which is firstKey.
+      for (let i = 1; i <= 300; i++) {
+        reportArtifactFailure('bounded-latch', `session-${i}`, 'write', new Error('e'));
+      }
+      const callsAfterFill = errorSpy.mock.calls.length;
+      // Every one of the 300 fresh keys is a first sighting, so each warns.
+      expect(callsAfterFill).toBe(301);
+
+      // firstKey's entry should have been evicted by now — re-reporting it
+      // must be treated as a first sighting again (a NEW visible warning),
+      // not swallowed into debugLog as a repeat.
+      reportArtifactFailure('bounded-latch', firstKey, 'write', new Error('e-again'));
+      expect(errorSpy).toHaveBeenCalledTimes(callsAfterFill + 1);
+
+      // Behavior remains stable after eviction — reporting a genuinely new
+      // key still warns, proving the latch didn't wedge or grow unbounded.
+      reportArtifactFailure('bounded-latch', 'session-brand-new', 'write', new Error('e3'));
+      expect(errorSpy).toHaveBeenCalledTimes(callsAfterFill + 2);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
 });

--- a/src/utils/artifact-failure-reporter.test.ts
+++ b/src/utils/artifact-failure-reporter.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Unit tests for the shared artifact-failure reporter (#850).
+ *
+ * Covers the reporter's own contract in isolation:
+ *  - AC1: the first failure for a (subsystem, dedupKey) pair surfaces to
+ *    stderr (`console.error`) unconditionally — no `AFK_DEBUG=1` required.
+ *  - AC3: a second failure for the SAME pair does not re-surface to stderr —
+ *    it falls back to `debugLog`, so a wedged subsystem warns once, not
+ *    once per call.
+ *
+ * The never-throw contract (AC2) is exercised end-to-end through a real
+ * call site in `agent/trace/emit.test.ts`, since that is where the
+ * production caller (`emitToolCall`) actually lives.
+ *
+ * @module utils/artifact-failure-reporter.test
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./debug.js', () => ({ debugLog: vi.fn() }));
+
+import { debugLog } from './debug.js';
+import {
+  reportArtifactFailure,
+  resetArtifactFailureReporterForTests,
+} from './artifact-failure-reporter.js';
+
+describe('reportArtifactFailure', () => {
+  beforeEach(() => {
+    resetArtifactFailureReporterForTests();
+    vi.mocked(debugLog).mockClear();
+  });
+
+  afterEach(() => {
+    resetArtifactFailureReporterForTests();
+  });
+
+  // AC1: enabling an observability feature that then fails must produce at
+  // least one operator-visible signal WITHOUT AFK_DEBUG=1.
+  it('surfaces the first failure to console.error unconditionally, without AFK_DEBUG', () => {
+    const originalDebug = process.env['AFK_DEBUG'];
+    delete process.env['AFK_DEBUG'];
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      reportArtifactFailure('trace.emit', '/tmp/session-a/trace.jsonl', 'tool_call', new Error('EACCES'));
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      const message = errorSpy.mock.calls[0]?.[0];
+      expect(typeof message).toBe('string');
+      expect(message).toContain('trace.emit');
+      expect(message).toContain('tool_call');
+      expect(message).toContain('EACCES');
+      // The first failure must not also fall back to debugLog — exactly one
+      // visible channel per failure.
+      expect(debugLog).not.toHaveBeenCalled();
+    } finally {
+      if (originalDebug !== undefined) process.env['AFK_DEBUG'] = originalDebug;
+      errorSpy.mockRestore();
+    }
+  });
+
+  // AC3: a forced write failure emits the signal EXACTLY ONCE — not zero
+  // times, not once per call. A wedged subsystem (every call to the same
+  // sink failing) must not flood the operator's terminal.
+  it('surfaces only the FIRST failure per (subsystem, dedupKey); later failures fall back to debugLog', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      reportArtifactFailure('trace.emit', '/tmp/session-a/trace.jsonl', 'tool_call', new Error('disk full'));
+      reportArtifactFailure('trace.emit', '/tmp/session-a/trace.jsonl', 'abort', new Error('disk full'));
+      reportArtifactFailure('trace.emit', '/tmp/session-a/trace.jsonl', 'closure', new Error('disk full'));
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(debugLog).toHaveBeenCalledTimes(2);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('keys the once-latch on (subsystem, dedupKey) — a different subsystem or session still gets its own first warning', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      reportArtifactFailure('trace.emit', '/tmp/session-a/trace.jsonl', 'tool_call', new Error('EROFS'));
+      // Different dedup key (different session's trace path) — still visible.
+      reportArtifactFailure('trace.emit', '/tmp/session-b/trace.jsonl', 'tool_call', new Error('EROFS'));
+      // Different subsystem, same key — still visible (independent latch).
+      reportArtifactFailure('subagent-output-capture', '/tmp/session-a/trace.jsonl', 'write', new Error('EROFS'));
+
+      expect(errorSpy).toHaveBeenCalledTimes(3);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('never throws even if console.error itself throws', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {
+      throw new Error('stderr closed');
+    });
+    try {
+      expect(() =>
+        reportArtifactFailure('trace.emit', '/tmp/session-c/trace.jsonl', 'tool_call', new Error('boom')),
+      ).not.toThrow();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+});

--- a/src/utils/artifact-failure-reporter.ts
+++ b/src/utils/artifact-failure-reporter.ts
@@ -28,25 +28,88 @@
  * `debugLog`, so a wedged subsystem (e.g. a session directory that is EROFS
  * for the whole run) logs ONCE instead of once per trace event.
  *
- * Dedup key: callers pass whatever string uniquely identifies "this failing
- * artifact sink" for their module. `agent/trace/emit.ts`'s emit* functions
- * take `(writer, payload)` with no `sessionId` parameter, so
- * `TraceWriter.getTracePath()` is used there — unique per session/writer
- * instance without threading a new parameter through every call site. The
- * subagent prompt/output capture modules already carry `input.sessionId` and
- * use that directly.
+ * Invariant: a dedup key may be an OBJECT (the failing sink instance) or a
+ * STRING id, and the two are latched in different structures because each
+ * choice is load-bearing.
+ *
+ *   - Object keys use a `WeakMap` keyed on instance identity. Deriving a key
+ *     by CALLING A METHOD on the sink is not safe: a partial/test-double
+ *     `TraceWriter` need not implement `getTracePath`, and calling it from
+ *     inside the catch block made this reporter throw the very failure it
+ *     exists to report (`TypeError: writer.getTracePath is not a function` —
+ *     4 unhandled errors out of `src/telegram/mcp-session.test.ts`, reddening
+ *     CI while all 15864 tests passed). Identity also fixes a correctness bug
+ *     a path-derived key cannot: `InMemoryTraceWriter.getTracePath()` returns
+ *     the SHARED sentinel `'in-memory://trace'` for every instance
+ *     (`agent/trace/writer.ts`), so path-keying silently swallowed the first
+ *     warning of every in-memory writer after the first one. A `WeakMap` is
+ *     additionally self-bounding — entries go away when the writer does.
+ *   - String keys cannot go in a `WeakMap`, so they use an insertion-ordered
+ *     `Map` capped at `MAX_STRING_LATCH_ENTRIES`, evicting oldest on overflow
+ *     (same shape as the LRU in `cli/syntax-highlight.ts`). Unbounded growth
+ *     was reachable: `CronScheduler.spawnSession()` mints a fresh UUID trace
+ *     label per tick, so a daemon against a persistently unwritable witness
+ *     dir added one permanent entry per scheduled run. Eviction tradeoff,
+ *     accepted deliberately: a key evicted after long inactivity may surface
+ *     a second visible warning later. Warning twice across hundreds of
+ *     distinct sessions beats leaking for the life of the process.
  *
  * @module utils/artifact-failure-reporter
  */
 
 import { debugLog } from './debug.js';
 
-/** Latch of `subsystem\0dedupKey` pairs that have already surfaced once. */
-const reportedOnce = new Set<string>();
+/**
+ * Cap on the string-keyed latch. Sized well above the number of distinct
+ * sessions one process realistically touches while a sink is wedged, so
+ * eviction is a backstop against unbounded growth rather than a routine
+ * event that would re-surface warnings during normal operation.
+ */
+const MAX_STRING_LATCH_ENTRIES = 256;
+
+/**
+ * Latch for object dedup keys: sink instance -> subsystems already surfaced.
+ * The inner `Set` is bounded by the number of distinct subsystem labels that
+ * write to one sink (a small constant); the whole entry is collected when the
+ * sink becomes unreachable. Reassigned (not `const`) so the test-only reset
+ * can drop every entry at once — a `WeakMap` has no `clear()`.
+ */
+let reportedByInstance = new WeakMap<object, Set<string>>();
+
+/** Latch of `subsystem\0dedupKey` pairs for STRING keys. Bounded, FIFO. */
+const reportedOnce = new Map<string, true>();
 
 function stringifyError(err: unknown): string {
   if (err instanceof Error) return err.message;
   return String(err);
+}
+
+/**
+ * Record a (subsystem, dedupKey) pair as surfaced.
+ *
+ * @returns true when this is the FIRST sighting of the pair — i.e. the caller
+ *   should print visibly rather than falling back to `debugLog`.
+ */
+function latchFirstSeen(subsystem: string, dedupKey: string | object): boolean {
+  if (typeof dedupKey === 'object' && dedupKey !== null) {
+    let seen = reportedByInstance.get(dedupKey);
+    if (!seen) {
+      seen = new Set<string>();
+      reportedByInstance.set(dedupKey, seen);
+    }
+    if (seen.has(subsystem)) return false;
+    seen.add(subsystem);
+    return true;
+  }
+
+  const latchKey = `${subsystem}\u0000${String(dedupKey)}`;
+  if (reportedOnce.has(latchKey)) return false;
+  reportedOnce.set(latchKey, true);
+  if (reportedOnce.size > MAX_STRING_LATCH_ENTRIES) {
+    const oldest = reportedOnce.keys().next().value;
+    if (oldest !== undefined) reportedOnce.delete(oldest);
+  }
+  return true;
 }
 
 /**
@@ -55,17 +118,20 @@ function stringifyError(err: unknown): string {
  * failure for the same pair falls back to `debugLog` so a wedged sink does
  * not flood the operator's terminal with one line per call.
  *
- * Contract: never throws. A diagnostic must not become the failure it
- * reports — `console.error` raising (e.g. a broken/closed stderr) is
- * vanishingly rare but cheap to guard against, matching the same contract
+ * Contract: never throws, and never CALLS anything on `dedupKey`. A
+ * diagnostic must not become the failure it reports — the outer try/catch
+ * guards a broken/closed stderr, and object keys are used by identity only
+ * so a partially-implemented sink cannot raise from in here. Same contract
  * `warnAfkHomeRejectedOnce` makes in `agent/tools/afk-home-warn.ts`.
  *
  * @param subsystem Short stable label for the failing module, e.g.
  *   `'trace.emit'` or `'subagent-output-capture'`. Combined with `dedupKey`
- *   for the latch, so two different subsystems failing for the same session
- *   each still get their own first-failure warning.
- * @param dedupKey String identifying the specific sink that failed — a
- *   trace path (`TraceWriter.getTracePath()`) or a witness session id.
+ *   for the latch, so two different subsystems failing on the same sink each
+ *   still get their own first-failure warning.
+ * @param dedupKey Identifies the specific sink that failed. Pass the sink
+ *   INSTANCE (e.g. the `TraceWriter`) when you have it — matched by identity,
+ *   never by calling a method on it. Pass a string (e.g. a witness session
+ *   id) when the sink has no stable object to hand.
  * @param context Short human label for the operation that failed, e.g.
  *   `'tool_call'` or `'captureSubagentPrompt'` — included in the message so
  *   the one visible line is actionable rather than a bare "something broke".
@@ -73,18 +139,16 @@ function stringifyError(err: unknown): string {
  */
 export function reportArtifactFailure(
   subsystem: string,
-  dedupKey: string,
+  dedupKey: string | object,
   context: string,
   err: unknown,
 ): void {
   try {
-    const latchKey = `${subsystem}\u0000${dedupKey}`;
     const message = `[afk] ${subsystem} artifact write failed (${context}): ${stringifyError(err)}`;
-    if (reportedOnce.has(latchKey)) {
+    if (!latchFirstSeen(subsystem, dedupKey)) {
       debugLog(message);
       return;
     }
-    reportedOnce.add(latchKey);
     console.error(
       `${message} — further failures in this subsystem for this session are logged only under AFK_DEBUG=1.`,
     );
@@ -94,7 +158,7 @@ export function reportArtifactFailure(
 }
 
 /**
- * Test-only: clear the once-latch so a suite can assert the first-failure
+ * Test-only: clear both once-latches so a suite can assert the first-failure
  * behavior deterministically.
  *
  * Contract: production code must never call this. Without it, a test
@@ -104,4 +168,5 @@ export function reportArtifactFailure(
  */
 export function resetArtifactFailureReporterForTests(): void {
   reportedOnce.clear();
+  reportedByInstance = new WeakMap<object, Set<string>>();
 }

--- a/src/utils/artifact-failure-reporter.ts
+++ b/src/utils/artifact-failure-reporter.ts
@@ -1,0 +1,107 @@
+/**
+ * Shared first-failure-visible reporter for fire-and-forget observability
+ * writes (trace events, subagent prompt/output capture).
+ *
+ * Contract: an artifact write failing must NEVER fail the caller's turn —
+ * every call site here already wraps its write in its own try/catch and
+ * reaches this module only from inside that catch block. This module does
+ * not change that fire-and-forget contract; it only decides how the
+ * swallowed failure becomes VISIBLE without becoming fatal.
+ *
+ * Problem this fixes (#850): every witness/forensics swallow site reported
+ * failure only via `debugLog`, which no-ops unless AFK_DEBUG=1/DEBUG=1. An
+ * operator who deliberately turns an observability feature ON (e.g.
+ * `AFK_CAPTURE_SUBAGENT_PROMPTS=1`) got total silence whether it worked or
+ * was 100% broken — reachable total-silent-no-op modes include
+ * EACCES/ENOSPC/EROFS on `mkdir` and a session label that fails
+ * `validateSessionId` (see `src/paths.ts`). The gap surfaced only when an
+ * operator went looking for evidence that was never written — exactly when
+ * it was no longer recoverable. This is deliberately a subsystem-level fix
+ * (one shared reporter, wired through every swallow site) rather than a
+ * per-module patch, so behavior is consistent across the whole witness layer.
+ *
+ * Fix: the FIRST failure for a given (subsystem, dedup key) pair is surfaced
+ * to stderr unconditionally via `console.error` — same precedent as
+ * `subagent-hooks.ts`'s SubagentStop-timeout warning: plain text, no
+ * chalk/palette, because a headless daemon/chat surface has no compositor to
+ * render into. Every subsequent failure for that same pair falls back to
+ * `debugLog`, so a wedged subsystem (e.g. a session directory that is EROFS
+ * for the whole run) logs ONCE instead of once per trace event.
+ *
+ * Dedup key: callers pass whatever string uniquely identifies "this failing
+ * artifact sink" for their module. `agent/trace/emit.ts`'s emit* functions
+ * take `(writer, payload)` with no `sessionId` parameter, so
+ * `TraceWriter.getTracePath()` is used there — unique per session/writer
+ * instance without threading a new parameter through every call site. The
+ * subagent prompt/output capture modules already carry `input.sessionId` and
+ * use that directly.
+ *
+ * @module utils/artifact-failure-reporter
+ */
+
+import { debugLog } from './debug.js';
+
+/** Latch of `subsystem\0dedupKey` pairs that have already surfaced once. */
+const reportedOnce = new Set<string>();
+
+function stringifyError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+/**
+ * Report a swallowed artifact-write failure. Surfaces the FIRST failure for
+ * a given (subsystem, dedupKey) pair to stderr unconditionally; every later
+ * failure for the same pair falls back to `debugLog` so a wedged sink does
+ * not flood the operator's terminal with one line per call.
+ *
+ * Contract: never throws. A diagnostic must not become the failure it
+ * reports — `console.error` raising (e.g. a broken/closed stderr) is
+ * vanishingly rare but cheap to guard against, matching the same contract
+ * `warnAfkHomeRejectedOnce` makes in `agent/tools/afk-home-warn.ts`.
+ *
+ * @param subsystem Short stable label for the failing module, e.g.
+ *   `'trace.emit'` or `'subagent-output-capture'`. Combined with `dedupKey`
+ *   for the latch, so two different subsystems failing for the same session
+ *   each still get their own first-failure warning.
+ * @param dedupKey String identifying the specific sink that failed — a
+ *   trace path (`TraceWriter.getTracePath()`) or a witness session id.
+ * @param context Short human label for the operation that failed, e.g.
+ *   `'tool_call'` or `'captureSubagentPrompt'` — included in the message so
+ *   the one visible line is actionable rather than a bare "something broke".
+ * @param err The caught error.
+ */
+export function reportArtifactFailure(
+  subsystem: string,
+  dedupKey: string,
+  context: string,
+  err: unknown,
+): void {
+  try {
+    const latchKey = `${subsystem}\u0000${dedupKey}`;
+    const message = `[afk] ${subsystem} artifact write failed (${context}): ${stringifyError(err)}`;
+    if (reportedOnce.has(latchKey)) {
+      debugLog(message);
+      return;
+    }
+    reportedOnce.add(latchKey);
+    console.error(
+      `${message} — further failures in this subsystem for this session are logged only under AFK_DEBUG=1.`,
+    );
+  } catch {
+    /* A diagnostic must never become the failure it reports. */
+  }
+}
+
+/**
+ * Test-only: clear the once-latch so a suite can assert the first-failure
+ * behavior deterministically.
+ *
+ * Contract: production code must never call this. Without it, a test
+ * asserting a (subsystem, dedupKey) pair surfaces on its FIRST failure would
+ * depend on suite ordering — whichever spec exercises that pair first
+ * consumes the latch for every test that runs after it.
+ */
+export function resetArtifactFailureReporterForTests(): void {
+  reportedOnce.clear();
+}


### PR DESCRIPTION
## Problem

The observability layer could not report its own failure — a subsystem failing 100% of the time was indistinguishable from one that works. Every witness/forensics swallow site logged failures only via `debugLog` (`src/utils/debug.ts`), which no-ops unless `AFK_DEBUG=1`/`DEBUG=1`. An operator who deliberately turns an observability feature **ON** got total silence whether it worked or was completely broken, and found out only when going looking for evidence that was never written — exactly when it was no longer recoverable.

Reachable total-silent-no-op modes:
- `EACCES` / `ENOSPC` / `EROFS` on `mkdir`
- `validateSessionId` throwing on a session label not matching `/^[a-zA-Z0-9_-]+$/` (reached via `getPromptsDir`/`getSubagentOutputsDir` → `getTraceDir`, `src/paths.ts`)

**The fire-and-forget contract is preserved and untouched: a forensics artifact must never be able to fail a turn.** This change only changes how a swallowed failure becomes *visible* — it does not change what gets swallowed or when.

## Why subsystem-level, not a #844 fix

#844 named one instance (`subagent-prompt-capture.ts:174`). Patching only that site would leave the other 13 swallow sites — the entire trace emitter plus subagent output capture — silently inconsistent with it: an operator would get a visible signal from one observability feature and dead silence from another, for the identical failure mode. This PR routes **all 14** existing swallow sites through one shared reporter so behavior is uniform across the whole witness layer.

## What changed

New module: **`src/utils/artifact-failure-reporter.ts`**

`reportArtifactFailure(subsystem, dedupKey, context, err)`:
- Surfaces the **first** failure for a given `(subsystem, dedupKey)` pair to stderr **unconditionally** via plain `console.error` — no chalk/palette import. This follows the existing precedent in `src/agent/subagent-hooks.ts:178` (the SubagentStop-timeout warning), not `src/cli/commands/interactive/boot-warnings.ts`, because that module is REPL/TUI-only and unusable from a headless daemon/chat surface that has no compositor.
- Every **subsequent** failure for the same pair falls back to `debugLog` — a wedged subsystem (every call failing identically) warns **once**, not once per call, avoiding a log flood.
- Never throws — a diagnostic must not become the failure it reports (same contract as `warnAfkHomeRejectedOnce` in `agent/tools/afk-home-warn.ts`).

### Swallow sites converted (14)

| File:line | Function / catch block |
|---|---|
| `src/agent/trace/emit.ts:45` (now ~52) | `emitToolCall` |
| `src/agent/trace/emit.ts:57` (~64) | `emitHookDecision` |
| `src/agent/trace/emit.ts:69` (~76) | `emitSubagentLifecycle` |
| `src/agent/trace/emit.ts:81` (~88) | `emitBackgroundAgent` |
| `src/agent/trace/emit.ts:93` (~100) | `emitBudget` |
| `src/agent/trace/emit.ts:105` (~112) | `emitAbort` |
| `src/agent/trace/emit.ts:117` (~124) | `emitCompaction` |
| `src/agent/trace/emit.ts:129` (~136) | `emitClosure` |
| `src/agent/trace/emit.ts:141` (~148) | `emitClaim` |
| `src/agent/trace/emit.ts:153` (~160) | `emitBrowserEvent` |
| `src/agent/trace/emit.ts:165` (~172) | `emitQueuedUserMessage` |
| `src/agent/trace/emit.ts:177` (~184) | `emitSessionPhase` |
| `src/agent/session/subagent-prompt-capture.ts:174` | `captureSubagentPrompt` (the #844 instance) |
| `src/agent/session/subagent-output-capture.ts:189, 256, 264` | `write` / `observe` / `end` in `createSubagentOutputRecorder` |

### Dedup key

The `emit*` functions take `(writer, payload)` — no `sessionId` parameter — so a "per session" key couldn't naively reuse an existing argument without threading a new parameter through 11 call sites, plus every one of their many callers. `TraceWriter.getTracePath()` (`src/agent/trace/writer.ts:70`) was already exposed publicly and is unique per session/writer instance, so it was used directly as the dedup key instead — zero signature changes to `emit*`.

The two capture modules already carry `input.sessionId` on their input type, so they use that directly.

## Acceptance criteria

| # | Criterion | Test |
|---|---|---|
| 1 | Enabling an observability feature that then fails produces at least one operator-visible signal **without** `AFK_DEBUG=1` | `src/utils/artifact-failure-reporter.test.ts` → `'surfaces the first failure to console.error unconditionally, without AFK_DEBUG'`; `src/agent/trace/emit.test.ts` → `'surfaces a write failure via console.error with AFK_DEBUG unset'` |
| 2 | No turn can be failed by an artifact write — never-throw contract intact | `src/agent/trace/emit.test.ts` → `'never rejects even when the writer throws on every call (never-throw contract)'`; existing suites `subagent-prompt-capture.test.ts` (`'never rejects on a bad session id'`) and `subagent-output-capture.test.ts` (`'never throws on a malformed event'`) still pass unchanged, now routed through the new reporter |
| 3 | A forced write failure emits the signal **exactly once** — not zero, not once per call | `src/utils/artifact-failure-reporter.test.ts` → `'surfaces only the FIRST failure per (subsystem, dedupKey); later failures fall back to debugLog'`; `src/agent/trace/emit.test.ts` → `'emits the visible signal exactly once per writer even across many failing calls'` |

`src/utils/artifact-failure-reporter.test.ts` also covers: the never-throw guarantee even if `console.error` itself throws, and that the latch keys on `(subsystem, dedupKey)` jointly (a different session or a different subsystem still gets its own first warning).

## Not done (scope cut, flagged rather than silently dropped)

An attempted-vs-written counter for `afk trace show` was considered per the issue's "if cheap" ask. It isn't cheap: the reporter's once-latch is in-process/module-scope, but `afk trace show` runs in a **separate process** after the fact — a real counter needs either a new persisted trace event (schema change in `trace/types.ts` + the zod schema in `trace/events.ts`) or a sidecar file on disk. That's real scope beyond "surface the failure," so it's left out of this PR.

## Testing

```
pnpm lint
# tsc --noEmit clean, both tsconfig.json and tsconfig.web.json

pnpm vitest run src/agent/trace/ \
  src/agent/session/subagent-prompt-capture.test.ts \
  src/agent/session/subagent-prompt-capture-wiring.test.ts \
  src/agent/session/subagent-output-capture.test.ts \
  src/agent/session/subagent-output-capture-wiring.test.ts \
  src/utils/artifact-failure-reporter.test.ts
# Test Files  21 passed (21)
# Tests       308 passed (308)
```

`pnpm test:coverage` / the full suite were deliberately **not** run (siblings running concurrently V8-heap-OOM it per task instructions).

## Known risk for the reviewer (unverified)

`console.error` is a synchronous, unconditional stderr write. If this fires **mid-turn while `TerminalCompositor` is armed** (interactive REPL rendering the live CUP frame), the raw write could interleave with or tear the compositor's in-flight cursor-positioning output (`src/cli/cup-frame-renderer.ts`). This mirrors the exact same risk the existing `subagent-hooks.ts:178` `console.warn` precedent already carries — this PR does not introduce a new failure mode, but it does add several new call sites that can trigger the identical raw-stderr-during-TUI-render risk, so I want it flagged explicitly rather than asserted safe. I did not attempt to reproduce or verify a torn frame in this change.

Closes #850
