### PR TITLE
fix(openai-compatible): rebuild the Environment block on cwd re-anchor (#876)

### DIFF
--- a/src/agent/providers/openai-compatible/index.ts
+++ b/src/agent/providers/openai-compatible/index.ts
@@ -214,13 +214,21 @@ export class OpenAICompatibleProvider implements ModelProvider {
     let dispatcher: ToolDispatcher;
     const modelName = typeof config.model === 'string' ? config.model : String(config.model);
 
+    // Mutable cwd cell (#876 fix) — a per-query local, NOT a class field:
+    // `buildDispatcher`'s own cwd param is closed-over per-call for the same
+    // reason (see its docstring) — a class field would let concurrent
+    // sessions sharing the module-level `openaiCompatibleProvider` singleton
+    // race on cwd. `getCwd` below reads THIS cell instead of the closed-over
+    // `config.cwd`, and `rebuildEnvironmentBlock` (defined further down, once
+    // every fragment it needs exists) updates it before re-deriving the
+    // workspace snapshot and the `# Environment` block, so a mid-query
+    // `setCwd()` (query.ts) is reflected in `get_runtime_state` AND the
+    // system prompt the next turn sees — not just the dispatcher's resolve base.
+    let _currentCwd = config.cwd ?? process.cwd();
+
     const runtimeStateSource: RuntimeStateSource = buildRuntimeStateSource({
       surface: this.providerOpts.surface ?? 'cli',
-      // Behaviour-preserving: this provider builds the source per query, so
-      // `config.cwd` is frozen at query construction. Its `setCwd` only re-bases
-      // the dispatcher (query.ts) without rebuilding this source or the system
-      // prompt, so mid-query `get_runtime_state` cwd is stale until #876.
-      getCwd: () => config.cwd ?? process.cwd(),
+      getCwd: () => _currentCwd,
       modelName,
       providerName: PROVIDER_NAME,
       permissionMode,
@@ -294,6 +302,7 @@ export class OpenAICompatibleProvider implements ModelProvider {
       baseURL?: string;
       toolDispatcher?: ToolDispatcher;
       onPermissionMode?: (mode: string) => void;
+      onCwdChange?: (cwd: string) => void;
       mcpManager?: import('../../mcp/index.js').McpManager;
       sessionIdOverride?: string;
     } = {};
@@ -328,32 +337,26 @@ export class OpenAICompatibleProvider implements ModelProvider {
       model: modelName,
     });
 
-    // Phase 2 — add `# Environment` block to the system prompt.
-    const envFragment = formatEnvironmentFragment({
-      cwd: config.cwd ?? process.cwd(),
-      ...(config.sessionId !== undefined ? { sessionId: config.sessionId } : {}),
-      surface: this.providerOpts.surface ?? 'cli',
-      ...(config.depth !== undefined ? { depth: config.depth } : {}),
-      ...(config.maxDepth !== undefined ? { maxDepth: config.maxDepth } : {}),
-      workspace: runtimeStateSource.getWorkspace(),
-    });
-    // Assemble the full provider-side system prompt so non-Anthropic sessions
-    // (this provider backs the REPL when the model is gpt-*/o*/local org/model)
-    // receive the SAME fragments as anthropic-direct — tool conventions, the
-    // interactive slash-command / bash-passthrough / background-subagent
-    // guidance, the memory prompt, and the skill manifest. Previously this
-    // provider sent only `userSystem + env`, so on a non-Anthropic REPL the
-    // model was never told what the `<background-subagent-result>` (and
-    // slash/bash) envelopes mean. The tool/memory fragments are resolved via
-    // the shared helpers in tools/system-prompt.ts so the set cannot drift from
-    // anthropic-direct. Ordering mirrors AnthropicDirectProvider.query():
-    // [toolBase, userSystem?, memoryPrompt, hotMemory?, env, manifest?]. The
-    // `# Agent AFK` doctrine + operator overlay (`existingSys`) is placed EARLY
-    // — right after the tool conventions and before the cross-session memory
-    // (instructions + hot-memory project context) and the skill manifest. Hot
-    // memory rides `config.hotMemory` (a dedicated field), not prepended into
-    // systemPrompt, so it can sit after the memory instructions rather than
-    // ahead of the doctrine.
+    // Invariant: assemble the full provider-side system prompt so non-Anthropic
+    // sessions (this provider backs the REPL when the model is gpt-*/o*/local
+    // org/model) receive the SAME fragments as anthropic-direct — tool
+    // conventions, the interactive slash-command / bash-passthrough /
+    // background-subagent guidance, the memory prompt, and the skill manifest.
+    // Previously this provider sent only `userSystem + env`, so on a
+    // non-Anthropic REPL the model was never told what the
+    // `<background-subagent-result>` (and slash/bash) envelopes mean. The
+    // tool/memory fragments are resolved via the shared helpers in
+    // tools/system-prompt.ts so the set cannot drift from anthropic-direct.
+    // Ordering mirrors AnthropicDirectProvider.query(): [toolBase, userSystem?,
+    // memoryPrompt, hotMemory?, env, manifest?]. The `# Agent AFK` doctrine +
+    // operator overlay (`existingSys`) is placed EARLY — right after the tool
+    // conventions and before the cross-session memory (instructions +
+    // hot-memory project context) and the skill manifest. Hot memory rides
+    // `config.hotMemory` (a dedicated field), not prepended into systemPrompt,
+    // so it can sit after the memory instructions rather than ahead of the
+    // doctrine. `envFragment` is the ONLY cwd-dependent piece — see
+    // `assembleSystemPrompt`/`rebuildEnvironmentBlock` below (#876) for why the
+    // rest are computed once and treated as stable across a cwd re-anchor.
     const toolBase = resolveToolSystemPrompt(config.isSkillDispatch);
     const memoryPrompt = resolveMemorySystemPrompt(this.providerOpts.readOnlyMemory);
     // Invariant: kept in lockstep with anthropic-direct's call site. Two
@@ -376,16 +379,57 @@ export class OpenAICompatibleProvider implements ModelProvider {
     const hotMemory = typeof config.hotMemory === 'string' ? config.hotMemory : '';
     const existingSys =
       typeof config.systemPrompt === 'string' ? config.systemPrompt : undefined;
-    const systemParts = [toolBase];
-    if (existingSys !== undefined && existingSys.length > 0) systemParts.push(existingSys);
-    systemParts.push(memoryPrompt);
-    if (hotMemory.length > 0) systemParts.push(hotMemory);
-    systemParts.push(envFragment);
-    if (manifest.length > 0) systemParts.push(manifest);
+
+    // Contract: given the cwd-dependent `# Environment` fragment, return the
+    // full joined system prompt over the STABLE fragments captured above.
+    // Used both for the initial build and for every #876 rebuild, so the two
+    // can never drift out of ordering sync with each other.
+    const assembleSystemPrompt = (envFragment: string): string => {
+      const parts = [toolBase];
+      if (existingSys !== undefined && existingSys.length > 0) parts.push(existingSys);
+      parts.push(memoryPrompt);
+      if (hotMemory.length > 0) parts.push(hotMemory);
+      parts.push(envFragment);
+      if (manifest.length > 0) parts.push(manifest);
+      return parts.join('\n\n');
+    };
+
+    // Phase 2 — the `# Environment` block. Reads `_currentCwd` (the mutable
+    // cell, not the closed-over `config.cwd`) so a post-construction call
+    // picks up whatever `rebuildEnvironmentBlock` last wrote there.
+    const buildEnvFragment = (): string =>
+      formatEnvironmentFragment({
+        cwd: _currentCwd,
+        ...(config.sessionId !== undefined ? { sessionId: config.sessionId } : {}),
+        surface: this.providerOpts.surface ?? 'cli',
+        ...(config.depth !== undefined ? { depth: config.depth } : {}),
+        ...(config.maxDepth !== undefined ? { maxDepth: config.maxDepth } : {}),
+        workspace: runtimeStateSource.getWorkspace(),
+      });
+
     const patchedConfig: typeof config = {
       ...config,
-      systemPrompt: systemParts.join('\n\n'),
+      systemPrompt: assembleSystemPrompt(buildEnvFragment()),
     };
+
+    // Invariant (#876): `setCwd()` (query.ts) invokes this so a mid-session
+    // cwd re-anchor refreshes BOTH the `get_runtime_state` tool (already live
+    // via the `getCwd` cell) and the system prompt's `# Environment` block —
+    // previously only the dispatcher's resolve base moved, leaving the model
+    // reading a stale directory for the rest of the session. Ordering is
+    // load-bearing: `_currentCwd` is updated FIRST, then `buildEnvFragment()`
+    // re-reads `getWorkspace()` — which itself resolves through the same
+    // cell — so updating after the read would compute the workspace snapshot
+    // for the OLD directory (mirrors anthropic-direct's cwd-dependents.ts
+    // ordering invariant). `patchedConfig.systemPrompt` is reassigned IN
+    // PLACE (the same object `OpenAICompatibleQuery` holds as `this.opts.config`
+    // by reference), so the next turn's `buildMessages` call picks up the new
+    // string with no further plumbing.
+    const rebuildEnvironmentBlock = (newCwd: string): void => {
+      _currentCwd = newCwd;
+      patchedConfig.systemPrompt = assembleSystemPrompt(buildEnvFragment());
+    };
+    buildOpts.onCwdChange = rebuildEnvironmentBlock;
 
     return buildQueryFromConfig(patchedConfig, args.prompt, buildOpts);
   }

--- a/src/agent/providers/openai-compatible/query.test.ts
+++ b/src/agent/providers/openai-compatible/query.test.ts
@@ -1806,7 +1806,7 @@ describe('OpenAICompatibleQuery — ProviderQuery surface', () => {
     q.close();
   });
 
-  it('get_runtime_state cwd is frozen to the query config cwd (#876 characterization)', async () => {
+  it('get_runtime_state cwd follows a mid-query setCwd() re-anchor (#876 fix)', async () => {
     const provider = new OpenAICompatibleProvider();
     const q = provider.query({
       prompt: makeControlledPromptStream().stream,
@@ -1823,10 +1823,34 @@ describe('OpenAICompatibleQuery — ProviderQuery surface', () => {
     });
 
     const snapshot = JSON.parse(result.content) as { self: { cwd: string } };
-    expect(snapshot.self.cwd).toBe('/query-cwd');
-    // #876 gap: unlike the dispatcher resolve base, awareness cwd does not follow
-    // a mid-query setCwd() on openai-compatible until that provider is fixed.
-    expect(snapshot.self.cwd).not.toBe('/mid-query-cwd');
+    // #876 fix: `get_runtime_state` now reads the live cwd cell that
+    // `setCwd()` updates, not the value `config.cwd` was constructed with.
+    expect(snapshot.self.cwd).toBe('/mid-query-cwd');
+    expect(snapshot.self.cwd).not.toBe('/query-cwd');
+    q.close();
+  });
+
+  it('setCwd() rebuilds the `# Environment` block in the system prompt (#876 fix)', () => {
+    const provider = new OpenAICompatibleProvider();
+    const q = provider.query({
+      prompt: makeControlledPromptStream().stream,
+      config: baseConfig({ cwd: '/query-cwd' }),
+    });
+
+    const configRef = (q as unknown as { opts: { config: AgentConfig } }).opts.config;
+    expect(typeof configRef.systemPrompt).toBe('string');
+    expect(configRef.systemPrompt as string).toContain('/query-cwd');
+    expect(configRef.systemPrompt as string).not.toContain('/mid-query-cwd');
+
+    q.setCwd('/mid-query-cwd');
+
+    // Same config object reference — `buildMessages` reads `this.opts.config`
+    // by reference each turn, so reassigning `systemPrompt` in place (rather
+    // than replacing the whole config object) is what makes the next turn
+    // pick up the rebuilt block with no further plumbing.
+    expect((q as unknown as { opts: { config: AgentConfig } }).opts.config).toBe(configRef);
+    expect(configRef.systemPrompt as string).toContain('/mid-query-cwd');
+    expect(configRef.systemPrompt as string).not.toContain('/query-cwd');
     q.close();
   });
 

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -177,6 +177,15 @@ export interface OpenAICompatibleQueryOptions {
    * `setAllowAll()`). Supplied by `OpenAICompatibleProvider.query()`.
    */
   onPermissionMode?: (mode: string) => void;
+  /**
+   * Provider callback invoked by `setCwd()` to rebuild the `# Environment`
+   * block after a cwd re-anchor (#876). Rewrites `opts.config.systemPrompt`
+   * in place on the provider side; `buildMessages` reads `this.opts.config`
+   * by reference each turn, so no further plumbing is needed here beyond
+   * calling it. Supplied by `OpenAICompatibleProvider.query()`; absent for
+   * callers (tests, external-dispatcher branch) that never re-anchor cwd.
+   */
+  onCwdChange?: (cwd: string) => void;
   /** Optional MCP manager — populates `session.init` and `mcpServerStatus()`. */
   mcpManager?: import('../../mcp/index.js').McpManager;
   /**
@@ -233,6 +242,7 @@ export class OpenAICompatibleQuery implements ProviderQuery {
   private readonly initSessionId: string;
   private readonly toolDispatcher: ToolDispatcher | undefined;
   private readonly onPermissionMode?: (mode: string) => void;
+  private readonly onCwdChange?: (cwd: string) => void;
   /** Pre-computed tool catalog — recomputed only if dispatcher.toolDefs changes (it doesn't today). */
   private readonly openAITools: OpenAIFunctionTool[] | undefined;
   /** Which wire this session speaks: Chat Completions (default) or Responses. */
@@ -302,6 +312,7 @@ export class OpenAICompatibleQuery implements ProviderQuery {
     this.currentPermissionMode = normalizePermissionMode(opts.config.permissionMode);
     this.toolDispatcher = opts.toolDispatcher;
     this.onPermissionMode = opts.onPermissionMode;
+    this.onCwdChange = opts.onCwdChange;
     this.traceWriter = opts.traceWriter;
     this.autoCompactThreshold = resolveAutoCompactThreshold(opts.config.autoCompact);
 
@@ -1125,6 +1136,12 @@ export class OpenAICompatibleQuery implements ProviderQuery {
 
   setCwd(cwd: string): void {
     this.toolDispatcher?.setResolveBase?.(cwd);
+    // #876: also rebuild the `# Environment` block (awareness cwd + system
+    // prompt), which the dispatcher rebase above does not touch. Order vs.
+    // the rebase above is not load-bearing — the two update independent
+    // state — but the rebuild ITSELF has an internal ordering invariant; see
+    // `rebuildEnvironmentBlock` in openai-compatible/index.ts.
+    this.onCwdChange?.(cwd);
   }
 
   async supportedCommands(): Promise<ProviderCommandInfo[]> {
@@ -1246,6 +1263,7 @@ export function buildQueryFromConfig(
     baseURL?: string;
     toolDispatcher?: ToolDispatcher;
     onPermissionMode?: (mode: string) => void;
+    onCwdChange?: (cwd: string) => void;
     mcpManager?: import('../../mcp/index.js').McpManager;
     useResponsesApi?: boolean;
     /**
@@ -1289,6 +1307,7 @@ export function buildQueryFromConfig(
   if (options.baseURL !== undefined) opts.baseURL = options.baseURL;
   if (options.toolDispatcher !== undefined) opts.toolDispatcher = options.toolDispatcher;
   if (options.onPermissionMode !== undefined) opts.onPermissionMode = options.onPermissionMode;
+  if (options.onCwdChange !== undefined) opts.onCwdChange = options.onCwdChange;
   if (options.mcpManager !== undefined) opts.mcpManager = options.mcpManager;
   if (options.useResponsesApi !== undefined) opts.useResponsesApi = options.useResponsesApi;
   // Thread traceWriter from AgentConfig so witness events are emitted for


### PR DESCRIPTION
## Root cause

`OpenAICompatibleProvider.query()` built `runtimeStateSource.getCwd` as
`() => config.cwd ?? process.cwd()` — closed over the immutable `config.cwd`.
The `# Environment` fragment was built once via `formatEnvironmentFragment`
and baked into `patchedConfig.systemPrompt` as a frozen string.
`OpenAICompatibleQuery.setCwd()` only called `toolDispatcher.setResolveBase()`
— it never touched the awareness cwd or the system prompt. `messages.ts`
re-reads that frozen string every turn, refreshing only the date via
`refreshEnvironmentDate`.

Net effect: a mid-session cwd re-anchor moved the dispatcher's file-tool
resolve base, but `get_runtime_state` and the model-visible `# Environment`
block kept reporting the original directory for the rest of the session.

## Fix

Mirrors anthropic-direct's `cwd-dependents.ts` / `system-prompt.ts`
(`assembleSystemPrompt` / `buildStableSystemPrefix`) pattern, including the
ordering invariant that cwd is updated **before** the workspace read.

- **`index.ts`** — added a mutable `_currentCwd` cell (query-scoped local,
  not a class field, so concurrent sessions sharing the provider singleton
  don't race on cwd). `runtimeStateSource.getCwd` now reads that cell instead
  of the closed-over `config.cwd`. `assembleSystemPrompt(envFragment)` factors
  the stable, cwd-independent fragments (tool base, operator overlay, memory
  prompt, hot memory, skill manifest) out of what was previously one inline
  join, so the initial build and every later rebuild share the same ordering.
  `rebuildEnvironmentBlock(newCwd)` updates the cell **first**, then re-reads
  `runtimeStateSource.getWorkspace()` (which itself resolves through the same
  cell) before re-rendering the fragment, and reassigns
  `patchedConfig.systemPrompt` **in place**. The callback is threaded out via
  `buildOpts.onCwdChange`.
- **`query.ts`** — `OpenAICompatibleQueryOptions.onCwdChange` + a constructor
  field carry the callback. `setCwd()` now calls both the existing
  `toolDispatcher.setResolveBase()` and the new `this.onCwdChange?.(cwd)`.
  `buildQueryFromConfig` forwards `options.onCwdChange` through.
- **`query.test.ts`** — **flipped** the `#876 characterization` test
  (previously asserting the frozen/broken cwd) to assert the fixed behavior,
  and added a second test confirming `setCwd()` rebuilds the system prompt's
  `# Environment` block **in place** (same `config` object reference, new cwd
  string present, old cwd string absent).

Why reassigning `config.systemPrompt` is sufficient: `buildMessages` reads
`this.opts.config` **by reference** every turn, so the next turn picks up the
rebuilt string automatically — no further plumbing needed.

## Test evidence

```
./node_modules/.bin/tsc --noEmit
# exit 0

./node_modules/.bin/vitest run src/agent/providers/openai-compatible/query.test.ts
# Test Files  1 passed (1)
#      Tests  97 passed (97)
```

## Scope

Only the three files named in the issue. No changes to
`src/cli/git-status-sampler.ts` or
`src/cli/commands/interactive/bootstrap-surface.ts` (owned by #973).

## Risks

- `_currentCwd` is a per-`query()`-call local, matching the existing
  per-call closure pattern for `buildDispatcher`'s own `cwd` param — a
  concurrent multi-session process (daemon, Telegram bot) cannot cross-talk
  cwd between sessions.
- `rebuildEnvironmentBlock` re-renders the whole system prompt string (not
  just the fragment) on every `setCwd()` call; this is the same cost the
  initial build already pays once per query, so it's a re-occurrence, not a
  new cost class, and `setCwd()` is not a hot-path call.

## Not checked

- Did not re-verify anthropic-direct's own cwd-rebuild path — only mirrored
  its documented pattern per the issue's instructions.
- Did not run the full test suite (explicitly out of scope per the
  instructions — `pnpm test` is unsafe to run from a worktree).

Closes #876
