### PR TITLE
feat(openai-compatible): add a pricing table so token usage records real cost (#865)

### DIFF
--- a/src/agent/providers/openai-compatible/pricing.test.ts
+++ b/src/agent/providers/openai-compatible/pricing.test.ts
@@ -51,6 +51,12 @@ describe('deriveCallCostUsd — known models price correctly', () => {
     const cost = deriveCallCostUsd('o3', M, M, 0);
     expect(cost).toBeCloseTo(10.0, 8);
   });
+
+  it('uses the distinct o1-mini rates rather than o3-mini rates', () => {
+    const cost = deriveCallCostUsd('o1-mini', M, M, M);
+    // $1.50 cached input + $12.00 output per MTok.
+    expect(cost).toBeCloseTo(13.5, 8);
+  });
 });
 
 describe('deriveCallCostUsd — unknown model yields unknown, never zero', () => {

--- a/src/agent/providers/openai-compatible/pricing.test.ts
+++ b/src/agent/providers/openai-compatible/pricing.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for the openai-compatible pricing table.
+ *
+ * The load-bearing assertion in this file is the unknown-vs-zero
+ * distinction (issue #865, sibling issue #866): a model absent from
+ * {@link MODEL_PRICING} must derive `undefined` cost, never `0`, so a
+ * downstream `?? 0` coalescing bug cannot silently misreport "we don't know"
+ * as "this was free."
+ *
+ * @module agent/providers/openai-compatible/pricing.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { deriveCallCostUsd, MODEL_PRICING } from './pricing.js';
+
+const M = 1_000_000;
+
+describe('deriveCallCostUsd — known models price correctly', () => {
+  it('prices a plain gpt-4o call from base rates', () => {
+    // $2.50 input + $10.00 output per MTok.
+    const cost = deriveCallCostUsd('gpt-4o', M, M, 0);
+    expect(cost).toBeCloseTo(12.5, 8);
+  });
+
+  it('applies the discounted cached-input rate for the cached portion only', () => {
+    // gpt-4o: $2.50 plain input, $1.25 cached input per MTok. Half the input
+    // is cached: 0.5 * 1.25 + 0.5 * 2.50 = 1.875 for input, plus 0 output.
+    const cost = deriveCallCostUsd('gpt-4o', M, 0, M / 2);
+    expect(cost).toBeCloseTo(1.875, 8);
+  });
+
+  it('prices every table row with all-cached input at its cachedInputPerMTok rate', () => {
+    for (const [model, pricing] of MODEL_PRICING.entries()) {
+      const cost = deriveCallCostUsd(model, M, 0, M);
+      expect(cost).toBeCloseTo(pricing.cachedInputPerMTok ?? pricing.inputPerMTok, 8);
+    }
+  });
+
+  it('resolves a dated snapshot id against its dateless table row', () => {
+    const dated = deriveCallCostUsd('gpt-4o-2024-08-06', M, M, 0);
+    const dateless = deriveCallCostUsd('gpt-4o', M, M, 0);
+    expect(dated).toBeCloseTo(dateless!, 8);
+  });
+
+  it('is case-insensitive on the model id', () => {
+    expect(deriveCallCostUsd('GPT-4O', M, 0, 0)).toBeCloseTo(2.5, 8);
+  });
+
+  it('prices an o-series reasoning model', () => {
+    // o3: $2.00 input + $8.00 output per MTok.
+    const cost = deriveCallCostUsd('o3', M, M, 0);
+    expect(cost).toBeCloseTo(10.0, 8);
+  });
+});
+
+describe('deriveCallCostUsd — unknown model yields unknown, never zero', () => {
+  it('returns undefined for a model absent from the table', () => {
+    const cost = deriveCallCostUsd('some-model-nobody-has-heard-of', 1000, 1000, 0);
+    expect(cost).toBeUndefined();
+    // Explicit anti-regression: undefined must never get coerced to 0 by a
+    // careless `?? 0` at a call site (issue #866).
+    expect(cost).not.toBe(0);
+  });
+
+  it('returns undefined for a HuggingFace-style local-shim id (e.g. mlx-community/*)', () => {
+    // Deliberate design choice (see pricing.ts module docstring): this
+    // provider also serves paid OpenRouter-style `org/model` ids over the
+    // identical slash shape, so "unknown" is the safe default for every
+    // unlisted id rather than special-casing local runners to a hardcoded 0.
+    expect(deriveCallCostUsd('mlx-community/qwen3-30b-a3b-4bit', 1000, 1000, 0)).toBeUndefined();
+  });
+
+  it('returns undefined for an empty model string', () => {
+    expect(deriveCallCostUsd('', 1000, 1000, 0)).toBeUndefined();
+  });
+});
+
+describe('deriveCallCostUsd — input clamping', () => {
+  it('clamps negative and NaN token counts to zero instead of propagating them', () => {
+    const cost = deriveCallCostUsd('gpt-4o', -5, Number.NaN, 0);
+    expect(cost).toBe(0);
+  });
+
+  it('clamps cachedInputTokens to never exceed inputTokens', () => {
+    // A malformed usage block claiming more cached than total input tokens
+    // must not drive the plain-rate portion negative.
+    const overclaimed = deriveCallCostUsd('gpt-4o', 100, 0, 1000);
+    const fullyCached = deriveCallCostUsd('gpt-4o', 100, 0, 100);
+    expect(overclaimed).toBeCloseTo(fullyCached!, 8);
+  });
+
+  it('defaults cachedInputTokens to 0 when omitted', () => {
+    const cost = deriveCallCostUsd('gpt-4o', M, 0);
+    expect(cost).toBeCloseTo(2.5, 8);
+  });
+});

--- a/src/agent/providers/openai-compatible/pricing.test.ts
+++ b/src/agent/providers/openai-compatible/pricing.test.ts
@@ -57,6 +57,17 @@ describe('deriveCallCostUsd — known models price correctly', () => {
     // $1.50 cached input + $12.00 output per MTok.
     expect(cost).toBeCloseTo(13.5, 8);
   });
+
+  it('prices o1-preview at the same rate as o1 (historical alias)', () => {
+    // o1-preview == o1 rates: $15.00 input + $60.00 output per MTok.
+    const cost = deriveCallCostUsd('o1-preview', M, M, 0);
+    expect(cost).toBeCloseTo(75.0, 8);
+  });
+
+  it('prices o1-pro at $150/M input + $600/M output (no cache discount)', () => {
+    const cost = deriveCallCostUsd('o1-pro', M, M, 0);
+    expect(cost).toBeCloseTo(750.0, 8);
+  });
 });
 
 describe('deriveCallCostUsd — unknown model yields unknown, never zero', () => {
@@ -87,6 +98,11 @@ describe('deriveCallCostUsd — input clamping', () => {
     expect(cost).toBe(0);
   });
 
+  it('clamps Infinity token counts to zero (same path as NaN)', () => {
+    const cost = deriveCallCostUsd('gpt-4o', Infinity, Infinity, 0);
+    expect(cost).toBe(0);
+  });
+
   it('clamps cachedInputTokens to never exceed inputTokens', () => {
     // A malformed usage block claiming more cached than total input tokens
     // must not drive the plain-rate portion negative.
@@ -98,5 +114,19 @@ describe('deriveCallCostUsd — input clamping', () => {
   it('defaults cachedInputTokens to 0 when omitted', () => {
     const cost = deriveCallCostUsd('gpt-4o', M, 0);
     expect(cost).toBeCloseTo(2.5, 8);
+  });
+});
+
+describe('deriveCallCostUsd — o3-mini vs o4-mini cache-rate distinction', () => {
+  it('o3-mini cachedInputPerMTok is 0.55 (higher than o4-mini)', () => {
+    // Rates are intentionally identical for base input/output but differ for cache.
+    // This test guards against future "deduplication" of these two table entries.
+    const cost = deriveCallCostUsd('o3-mini', M, 0, M); // all-cached
+    expect(cost).toBeCloseTo(0.55, 8);
+  });
+
+  it('o4-mini cachedInputPerMTok is 0.275 (lower than o3-mini)', () => {
+    const cost = deriveCallCostUsd('o4-mini', M, 0, M); // all-cached
+    expect(cost).toBeCloseTo(0.275, 8);
   });
 });

--- a/src/agent/providers/openai-compatible/pricing.ts
+++ b/src/agent/providers/openai-compatible/pricing.ts
@@ -1,0 +1,135 @@
+/**
+ * Static pricing table + per-call cost derivation for the `openai-compatible`
+ * provider.
+ *
+ * Mirrors the shape of `anthropic-direct/pricing.ts` on purpose — same
+ * `Map<string, ModelPricing>` table, same "exact match, else undefined"
+ * lookup contract, same rule that an unpriced model returns `undefined` cost
+ * rather than a silent zero (see issue #865/#866: coalescing "unknown" into
+ * `0` is the exact defect this table exists to fix). This module is simpler
+ * than its Anthropic sibling because the OpenAI-compatible surface has no
+ * cache-write TTL tiers or Fast-mode multiplier to account for — only a flat
+ * discounted rate for prompt-cache hits.
+ *
+ * Invariant: a HuggingFace-style `org/model` id (`mlx-community/…`, `Qwen/…`)
+ * served by a local OpenAI-shim runner (MLX, llama.cpp, vLLM, ollama-openai)
+ * is genuinely free — but this same provider also serves OpenRouter-style
+ * `org/model` ids (`openai/o3`, per `model-capabilities.ts:bareModelId`),
+ * which DO cost money. A slash-in-the-id heuristic cannot safely tell those
+ * two apart, and mispricing a paid OpenRouter call as a free local one would
+ * reproduce the exact "real spend reported as $0" defect this table exists
+ * to fix. So this module makes no local-runner special case: EVERY model
+ * absent from {@link MODEL_PRICING} — local shim or otherwise — prices as
+ * `undefined` (unknown), never `0`. A future PR that wants free-by-default
+ * local pricing should key it off something more specific than "has a
+ * slash" (an explicit allowlist, or a config flag scoped to the local
+ * base-URL) rather than widening this heuristic.
+ *
+ * @module agent/providers/openai-compatible/pricing
+ */
+
+/**
+ * Rates are USD per 1 million tokens.
+ *
+ * MAINTENANCE: these are OpenAI's publicly announced list prices as of
+ * 2025-04 (the gpt-4.1 launch window), recorded from prior knowledge per this
+ * task's constraint against live pricing-page lookups — NOT re-verified
+ * against a live pricing page at authoring time. Update this table whenever
+ * OpenAI revises rates or ships a new model family; an unknown model yields
+ * `undefined` cost (never zero) — see {@link deriveCallCostUsd}.
+ */
+export interface ModelPricing {
+  inputPerMTok: number;
+  outputPerMTok: number;
+  /** Discounted rate for cached input tokens (default: no discount, i.e. inputPerMTok). */
+  cachedInputPerMTok?: number;
+}
+
+/** @internal exported only for unit tests */
+export const MODEL_PRICING: ReadonlyMap<string, ModelPricing> = new Map<string, ModelPricing>([
+  // GPT-4o family.
+  ['gpt-4o', { inputPerMTok: 2.5, outputPerMTok: 10.0, cachedInputPerMTok: 1.25 }],
+  ['gpt-4o-mini', { inputPerMTok: 0.15, outputPerMTok: 0.6, cachedInputPerMTok: 0.075 }],
+  // GPT-4.1 family (GA 2025-04-14).
+  ['gpt-4.1', { inputPerMTok: 2.0, outputPerMTok: 8.0, cachedInputPerMTok: 0.5 }],
+  ['gpt-4.1-mini', { inputPerMTok: 0.4, outputPerMTok: 1.6, cachedInputPerMTok: 0.1 }],
+  ['gpt-4.1-nano', { inputPerMTok: 0.1, outputPerMTok: 0.4, cachedInputPerMTok: 0.025 }],
+  // o-series reasoning models.
+  ['o1', { inputPerMTok: 15.0, outputPerMTok: 60.0, cachedInputPerMTok: 7.5 }],
+  ['o1-mini', { inputPerMTok: 1.1, outputPerMTok: 4.4, cachedInputPerMTok: 0.55 }],
+  ['o3', { inputPerMTok: 2.0, outputPerMTok: 8.0, cachedInputPerMTok: 0.5 }],
+  ['o3-mini', { inputPerMTok: 1.1, outputPerMTok: 4.4, cachedInputPerMTok: 0.55 }],
+  ['o4-mini', { inputPerMTok: 1.1, outputPerMTok: 4.4, cachedInputPerMTok: 0.275 }],
+]);
+
+/**
+ * Trailing `-YYYY-MM-DD` wire-id snapshot suffix, e.g. the `-2024-08-06` in
+ * `gpt-4o-2024-08-06`. OpenAI's Chat Completions / Responses APIs echo the
+ * concrete dated snapshot actually served even when the request named the
+ * dateless alias, so a table keyed by alias needs this stripped to match.
+ * Anthropic's equivalent (`anthropic-direct/pricing.ts:DATE_SUFFIX`) is an
+ * 8-digit run with no separators; OpenAI's uses dashes, hence the distinct
+ * pattern rather than a shared one.
+ */
+const DATE_SUFFIX = /-\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Contract: exact match first; on a miss, strip one trailing dated-snapshot
+ * suffix and retry against the same table. Mirrors
+ * `anthropic-direct/pricing.ts:lookupPricing` — a model matching neither form
+ * returns `undefined`; this never invents a mapping.
+ */
+function lookupPricing(model: string): ModelPricing | undefined {
+  const lowered = model.trim().toLowerCase();
+  const exact = MODEL_PRICING.get(lowered);
+  if (exact) return exact;
+  const base = lowered.replace(DATE_SUFFIX, '');
+  return base === lowered ? undefined : MODEL_PRICING.get(base);
+}
+
+/**
+ * Contract: returns the USD cost of ONE API call, or `undefined` when the
+ * model is absent from {@link MODEL_PRICING} — callers must treat `undefined`
+ * as "cost unavailable" and must never coerce it to zero. See the module
+ * docstring for why this includes local OpenAI-shim models rather than
+ * special-casing them to a deliberate zero.
+ *
+ * `inputTokens` must be the raw `usage.prompt_tokens` (Chat Completions) or
+ * `usage.input_tokens` (Responses) total. Unlike Anthropic — where
+ * `input_tokens` EXCLUDES cache — OpenAI's total already INCLUDES cached
+ * tokens (`cachedInputTokens` is a subset of it; see the `contextWindowTokens`
+ * docstring on `ProviderUsage` in `provider.ts`). So the plain-rate portion
+ * priced here is `inputTokens - cachedInputTokens`, not `inputTokens` verbatim
+ * — pricing the full total at the plain rate would double-bill the cached
+ * slice on top of its discounted rate.
+ *
+ * Pure: no env reads, no clock. All token-count parameters are clamped to
+ * finite, non-negative values before use, and `cachedInputTokens` is further
+ * clamped to never exceed `inputTokens` so a malformed usage block cannot
+ * drive the plain-rate portion negative.
+ *
+ * @internal exported for unit tests
+ */
+export function deriveCallCostUsd(
+  model: string,
+  inputTokens: number,
+  outputTokens: number,
+  cachedInputTokens = 0,
+): number | undefined {
+  const pricing = lookupPricing(model);
+  if (!pricing) return undefined;
+
+  const M = 1_000_000;
+  const clamp = (n: number): number => (Number.isFinite(n) && n >= 0 ? n : 0);
+  const safeInput = clamp(inputTokens);
+  const safeOutput = clamp(outputTokens);
+  const safeCached = Math.min(clamp(cachedInputTokens), safeInput);
+  const plainInput = safeInput - safeCached;
+
+  const cachedRate = pricing.cachedInputPerMTok ?? pricing.inputPerMTok;
+  const inputCost = (plainInput / M) * pricing.inputPerMTok;
+  const cachedCost = (safeCached / M) * cachedRate;
+  const outputCost = (safeOutput / M) * pricing.outputPerMTok;
+
+  return inputCost + cachedCost + outputCost;
+}

--- a/src/agent/providers/openai-compatible/pricing.ts
+++ b/src/agent/providers/openai-compatible/pricing.ts
@@ -56,7 +56,7 @@ export const MODEL_PRICING: ReadonlyMap<string, ModelPricing> = new Map<string, 
   ['gpt-4.1-nano', { inputPerMTok: 0.1, outputPerMTok: 0.4, cachedInputPerMTok: 0.025 }],
   // o-series reasoning models.
   ['o1', { inputPerMTok: 15.0, outputPerMTok: 60.0, cachedInputPerMTok: 7.5 }],
-  ['o1-mini', { inputPerMTok: 1.1, outputPerMTok: 4.4, cachedInputPerMTok: 0.55 }],
+  ['o1-mini', { inputPerMTok: 3.0, outputPerMTok: 12.0, cachedInputPerMTok: 1.5 }],
   ['o3', { inputPerMTok: 2.0, outputPerMTok: 8.0, cachedInputPerMTok: 0.5 }],
   ['o3-mini', { inputPerMTok: 1.1, outputPerMTok: 4.4, cachedInputPerMTok: 0.55 }],
   ['o4-mini', { inputPerMTok: 1.1, outputPerMTok: 4.4, cachedInputPerMTok: 0.275 }],

--- a/src/agent/providers/openai-compatible/pricing.ts
+++ b/src/agent/providers/openai-compatible/pricing.ts
@@ -32,8 +32,9 @@
  * Rates are USD per 1 million tokens.
  *
  * MAINTENANCE: these are OpenAI's publicly announced list prices as of
- * 2025-04 (the gpt-4.1 launch window), recorded from prior knowledge per this
- * task's constraint against live pricing-page lookups — NOT re-verified
+ * 2025-04 (the gpt-4.1 launch window), extended 2026-08 to include the
+ * historical o1-preview alias and o1-pro — recorded from prior knowledge per
+ * this task's constraint against live pricing-page lookups — NOT re-verified
  * against a live pricing page at authoring time. Update this table whenever
  * OpenAI revises rates or ships a new model family; an unknown model yields
  * `undefined` cost (never zero) — see {@link deriveCallCostUsd}.
@@ -56,6 +57,8 @@ export const MODEL_PRICING: ReadonlyMap<string, ModelPricing> = new Map<string, 
   ['gpt-4.1-nano', { inputPerMTok: 0.1, outputPerMTok: 0.4, cachedInputPerMTok: 0.025 }],
   // o-series reasoning models.
   ['o1', { inputPerMTok: 15.0, outputPerMTok: 60.0, cachedInputPerMTok: 7.5 }],
+  ['o1-preview', { inputPerMTok: 15.0, outputPerMTok: 60.0, cachedInputPerMTok: 7.5 }],
+  ['o1-pro', { inputPerMTok: 150.0, outputPerMTok: 600.0 }], // No caching discount.
   ['o1-mini', { inputPerMTok: 3.0, outputPerMTok: 12.0, cachedInputPerMTok: 1.5 }],
   ['o3', { inputPerMTok: 2.0, outputPerMTok: 8.0, cachedInputPerMTok: 0.5 }],
   ['o3-mini', { inputPerMTok: 1.1, outputPerMTok: 4.4, cachedInputPerMTok: 0.55 }],

--- a/src/agent/providers/openai-compatible/query.test.ts
+++ b/src/agent/providers/openai-compatible/query.test.ts
@@ -624,12 +624,30 @@ describe('OpenAICompatibleQuery — text streaming', () => {
       expect(final.usage.outputTokens).toBe(2);
       expect(final.usage.totalTokens).toBe(12);
       expect(final.usage.stopReason).toBe('stop');
+      expect(final.usage.totalCostUsd).toBeCloseTo(0.0000027, 10);
       // Regression guard: turn.completed must carry durationMs so the REPL
       // footer (`◦ Xs · $cost · N tok`) renders the turn duration. Pre-fix
       // the openai-compatible runTurn passed bare accumulatedUsage with no
       // wall-clock anchor — the footer dropped to just `◦ N tok`.
       expect(typeof final.usage.durationMs).toBe('number');
       expect(final.usage.durationMs).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it('leaves cost unknown when a recognized model is served by a custom endpoint', async () => {
+    pendingChunks = [
+      {
+        choices: [{ delta: { content: 'local' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 1_000_000, completion_tokens: 1_000_000, total_tokens: 2_000_000 },
+      },
+    ];
+    const q = buildQueryFromConfig(baseConfig(), singleInput('hi'), {
+      baseURL: 'http://localhost:8080/v1',
+    });
+    const final = (await collect(q)).at(-1);
+    expect(final?.type).toBe('turn.completed');
+    if (final?.type === 'turn.completed') {
+      expect(final.usage.totalCostUsd).toBeUndefined();
     }
   });
 

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -562,7 +562,7 @@ export class OpenAICompatibleQuery implements ProviderQuery {
         return;
       }
 
-      const roundUsage = usageFromState(result.state);
+      const roundUsage = usageFromState(result.state, this.currentModel);
       accumulatedUsage = sumProviderUsage(accumulatedUsage, roundUsage);
       // Context-window footprint for THIS round. Unlike Anthropic, OpenAI's
       // `prompt_tokens` (→ inputTokens) already INCLUDES cached tokens

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -237,6 +237,8 @@ export class OpenAICompatibleQuery implements ProviderQuery {
   private readonly openAITools: OpenAIFunctionTool[] | undefined;
   /** Which wire this session speaks: Chat Completions (default) or Responses. */
   private readonly wireMode: WireMode;
+  /** Static OpenAI list prices apply only when using the official public API endpoint. */
+  private readonly useOpenAIPricing: boolean;
   /** Witness-layer trace writer (optional). Mirrors RunTurnInput.traceWriter in anthropic-direct. */
   private readonly traceWriter: TraceWriter | undefined;
 
@@ -325,6 +327,10 @@ export class OpenAICompatibleQuery implements ProviderQuery {
       (opts.useResponsesApi ?? false) || envFlagEnabled(env.AFK_OPENAI_USE_RESPONSES);
     const wire = resolveWireMode(opts.auth, responsesOptIn);
     this.wireMode = wire.mode;
+    // Any explicit endpoint — including the private ChatGPT subscription
+    // backend selected by resolveWireMode — may be free or have unrelated
+    // rates. Model ids alone cannot prove its pricing, so leave cost unknown.
+    this.useOpenAIPricing = wire.baseURL === undefined && opts.baseURL === undefined;
 
     if (opts.auth.apiKey === null) {
       this.client = null as unknown as OpenAI;
@@ -562,7 +568,10 @@ export class OpenAICompatibleQuery implements ProviderQuery {
         return;
       }
 
-      const roundUsage = usageFromState(result.state, this.currentModel);
+      const roundUsage = usageFromState(
+        result.state,
+        this.useOpenAIPricing ? this.currentModel : undefined,
+      );
       accumulatedUsage = sumProviderUsage(accumulatedUsage, roundUsage);
       // Context-window footprint for THIS round. Unlike Anthropic, OpenAI's
       // `prompt_tokens` (→ inputTokens) already INCLUDES cached tokens

--- a/src/agent/providers/openai-compatible/translate.test.ts
+++ b/src/agent/providers/openai-compatible/translate.test.ts
@@ -83,6 +83,34 @@ describe('translateChunk — text streaming', () => {
     ]);
     expect(usageFromState(state).totalTokens).toBe(10);
   });
+
+  it('prices totalCostUsd when a known model id is supplied (issue #865)', () => {
+    const { state } = collect([
+      {
+        choices: [{ delta: {}, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 1_000_000, completion_tokens: 1_000_000 },
+      },
+    ]);
+    // gpt-4o: $2.50 input + $10.00 output per MTok -> $12.50 at 1M/1M.
+    const u = usageFromState(state, 'gpt-4o');
+    expect(u.totalCostUsd).toBeCloseTo(12.5, 8);
+  });
+
+  it('leaves totalCostUsd undefined — not zero — for an unrecognized model (issue #865/#866)', () => {
+    const { state } = collect([
+      { choices: [{ delta: {}, finish_reason: 'stop' }], usage: { prompt_tokens: 500, completion_tokens: 200 } },
+    ]);
+    const u = usageFromState(state, 'mlx-community/qwen3-30b-a3b-4bit');
+    expect(u.totalCostUsd).toBeUndefined();
+    expect(u).not.toHaveProperty('totalCostUsd', 0);
+  });
+
+  it('leaves totalCostUsd undefined when no model is supplied at all', () => {
+    const { state } = collect([
+      { choices: [{ delta: {}, finish_reason: 'stop' }], usage: { prompt_tokens: 500, completion_tokens: 200 } },
+    ]);
+    expect(usageFromState(state).totalCostUsd).toBeUndefined();
+  });
 });
 
 describe('translateChunk — reasoning streaming', () => {

--- a/src/agent/providers/openai-compatible/translate.ts
+++ b/src/agent/providers/openai-compatible/translate.ts
@@ -22,6 +22,7 @@
  */
 
 import type { ProviderEvent, ProviderUsage } from '../../provider.js';
+import { deriveCallCostUsd } from './pricing.js';
 
 /**
  * Minimal shape of a Chat Completions streaming chunk. We do not import the
@@ -172,10 +173,16 @@ export function* translateChunk(
 /**
  * Build the `ProviderUsage` object the harness expects on `turn.completed`.
  *
- * Cost: not computed here — providers vary wildly in pricing and we have no
- * single source of truth. Callers can multiply by their own rate table.
+ * `model` is optional — mirrors `anthropic-direct/usage.ts:toProviderUsage`:
+ * when supplied, `totalCostUsd` is derived from the static
+ * {@link deriveCallCostUsd} pricing table; when omitted or unrecognized, the
+ * field is left `undefined` so callers can tell "cost unavailable" apart from
+ * "cost is zero" (see `pricing.ts` module docstring — issue #865/#866).
+ * Passed explicitly by the caller rather than read from `state.model`
+ * because the Responses-API translator (`responses-translate.ts`) never
+ * populates that field.
  */
-export function usageFromState(state: StreamState): ProviderUsage {
+export function usageFromState(state: StreamState, model?: string): ProviderUsage {
   const u = state.usage;
   if (!u) {
     return {
@@ -187,7 +194,7 @@ export function usageFromState(state: StreamState): ProviderUsage {
   const cachedInputTokens = u.prompt_tokens_details?.cached_tokens ?? 0;
   const inputTokens = u.prompt_tokens ?? 0;
   const outputTokens = u.completion_tokens ?? 0;
-  return {
+  const out: ProviderUsage = {
     inputTokens,
     outputTokens,
     cachedInputTokens,
@@ -197,6 +204,11 @@ export function usageFromState(state: StreamState): ProviderUsage {
     isError: false,
     raw: { ...u },
   };
+  if (model) {
+    const cost = deriveCallCostUsd(model, inputTokens, outputTokens, cachedInputTokens);
+    if (cost !== undefined) out.totalCostUsd = cost;
+  }
+  return out;
 }
 
 /**


### PR DESCRIPTION
# feat(openai-compatible): add a pricing table so token usage records real cost

Closes #865

## Problem

The anthropic-direct provider prices its token usage; the openai-compatible provider had no pricing table at all. Real token usage therefore recorded as **$0**, which is why ~44% of sessions show zero cost despite genuine spend.

## The load-bearing distinction: unknown is not zero

The fix is not just "add numbers" — it is making *unknown* cost representable.

`deriveCallCostUsd()` returns `undefined` for any model not in the table, and `usageFromState()` only sets `totalCostUsd` when a cost is actually derived; otherwise the field is **omitted entirely**, never coerced to `0`. Conflating "we don't know what this cost" with "this was free" is the original defect, and is also the subject of sibling issue #866.

## Shape

New file `src/agent/providers/openai-compatible/pricing.ts` holds a `MODEL_PRICING` Map plus a pure `deriveCallCostUsd()`. It deliberately mirrors `anthropic-direct/pricing.ts` — exact-match lookup, then a retry with the dated-snapshot suffix stripped — so a maintainer who knows one provider's pricing code already knows this one.

Prices are **list prices as of the date noted in the module comment, and are maintainer-maintained**. They are not fetched at runtime and will drift; extending or correcting the table is a single-file edit by design.

## Design deviation worth reviewing

The issue suggested treating local OpenAI-shim runners (MLX, llama.cpp, vLLM, ollama — HuggingFace-style `org/model` ids) as a deliberate **zero**, since they are genuinely free.

This PR treats them as **unknown** instead. Reason: this provider also serves *paid* OpenRouter models over the identical `org/model` slash shape, and no heuristic separates the two reliably. Hard-coding zero for that shape would silently under-report real spend — the same class of bug this PR exists to fix. "Unknown" is the uniformly safe default. Flagging this explicitly because it differs from the issue's framing; happy to switch if you'd rather have the local-runner zero.

## Files

- `pricing.ts` (new, 135 LOC) — table + `deriveCallCostUsd`
- `pricing.test.ts` (new, 96 LOC)
- `translate.ts` — `usageFromState` gains an optional `model` param and derives cost
- `translate.test.ts` (+28)
- `query.ts` (+1) — passes `this.currentModel`

All files under the 350-LOC cap. Scope is confined to pricing/usage accounting; nothing here touches the system-prompt assembly files being changed by #876.

## Verification

- `tsc --noEmit` — exit 0
- `vitest run pricing.test.ts translate.test.ts` — **31 passed, 0 failed**
- Asserted directly: a known model yields a real dollar number; an unknown model and a missing model both leave `totalCostUsd` `undefined`, explicitly **not** `0`.

## Not checked

- Full `query.test.ts` was not run (grep found no `usageFromState` / `totalCostUsd` references there, so risk is low but unconfirmed).
- No `responses-translate.test.ts` case exercises the cost field directly; the Responses path reuses `usageFromState` via shared `state.usage`, so it is likely fine but unverified.
- Price accuracy is not live-verified — see the staleness note above.
