### PR TITLE
fix(tools): tell the model an invented tool does not exist, not that it lacks permission

### DIFF
--- a/src/agent/tools/dispatcher.test.ts
+++ b/src/agent/tools/dispatcher.test.ts
@@ -178,6 +178,27 @@ describe('SessionToolDispatcher', () => {
       expect(result.content).not.toContain('Unknown tool');
     });
 
+    it.each([
+      ['agent', 'subagentExecutor'],
+      ['skill', 'skillExecutor'],
+      ['compose', 'composeExecutor'],
+    ] as const)(
+      'preserves the allowlist message for the executor-backed %s tool',
+      async (toolName, executorOption) => {
+        const configured = makeDispatcher({
+          handlers: new Map(),
+          schemas: [],
+          permissions: { allowedTools: [] },
+          [executorOption]: mockExecutor(),
+        });
+        // Executor-backed tools intentionally have no entries in the handler map.
+        const result = await configured.execute(makeCall({ name: toolName, input: {} }));
+        expect(result.isError).toBe(true);
+        expect(result.content).toContain('is not in the configured allowlist');
+        expect(result.content).not.toContain('Unknown tool');
+      },
+    );
+
     it('keeps failureClass permission-denied for the unregistered case', async () => {
       const dispatcher = makeSplitDispatcher();
       const result = await dispatcher.execute(

--- a/src/agent/tools/dispatcher.test.ts
+++ b/src/agent/tools/dispatcher.test.ts
@@ -123,6 +123,70 @@ describe('SessionToolDispatcher', () => {
     expect(result.content).toContain('Unknown tool');
   });
 
+  describe('allowlist denial of an unregistered (hallucinated) tool name', () => {
+    // `bash` is REGISTERED but not allowlisted (a real permission decision);
+    // read_file/edit_file are both registered and allowed.
+    function makeSplitDispatcher() {
+      const pick = (n: string) => builtinToolSchemas.find((s) => s.name === n)!;
+      return new SessionToolDispatcher({
+        handlers: new Map([
+          ['read_file', echoHandler()],
+          ['edit_file', echoHandler()],
+          ['bash', echoHandler()],
+        ]),
+        schemas: [pick('read_file'), pick('edit_file'), pick('bash')],
+        permissions: { allowedTools: ['read_file', 'edit_file'] },
+      });
+    }
+
+    it('tells the model the tool does not exist instead of blaming the allowlist', async () => {
+      const dispatcher = makeSplitDispatcher();
+      const result = await dispatcher.execute(
+        makeCall({ name: 'str_replace_based_edit_tool', input: {} }),
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('Unknown tool "str_replace_based_edit_tool"');
+      expect(result.content).toContain('does not exist in this session');
+      // The misleading message is what caused models to re-emit the phantom name.
+      expect(result.content).not.toContain('not in the configured allowlist');
+    });
+
+    it('enumerates the callable tools and warns against retrying the phantom name', async () => {
+      const dispatcher = makeSplitDispatcher();
+      const result = await dispatcher.execute(
+        makeCall({ name: 'str_replace_based_edit_tool', input: {} }),
+      );
+      expect(result.content).toContain('read_file');
+      expect(result.content).toContain('edit_file');
+      expect(result.content).toContain('Do NOT retry');
+    });
+
+    it('does NOT advertise a registered-but-denied tool in the suggestion list', async () => {
+      // Mirrors the `toolDefs` contract: never show the model a tool the gate rejects.
+      const dispatcher = makeSplitDispatcher();
+      const result = await dispatcher.execute(
+        makeCall({ name: 'str_replace_based_edit_tool', input: {} }),
+      );
+      expect(result.content).not.toContain('bash');
+    });
+
+    it('preserves the allowlist message for a REGISTERED but denied tool', async () => {
+      const dispatcher = makeSplitDispatcher();
+      const result = await dispatcher.execute(makeCall({ name: 'bash', input: {} }));
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('is not in the configured allowlist');
+      expect(result.content).not.toContain('Unknown tool');
+    });
+
+    it('keeps failureClass permission-denied for the unregistered case', async () => {
+      const dispatcher = makeSplitDispatcher();
+      const result = await dispatcher.execute(
+        makeCall({ name: 'str_replace_based_edit_tool', input: {} }),
+      );
+      expect(result.failureClass).toBe('permission-denied');
+    });
+  });
+
   it('catches handler throws and returns isError', async () => {
     const throwing: ToolHandler = async () => {
       throw new Error('handler kaboom');

--- a/src/agent/tools/dispatcher.test.ts
+++ b/src/agent/tools/dispatcher.test.ts
@@ -185,6 +185,41 @@ describe('SessionToolDispatcher', () => {
       );
       expect(result.failureClass).toBe('permission-denied');
     });
+
+    it('does not leak non-allowlisted handlers when an ALLOWLISTED tool has no handler', async () => {
+      // Reachable in production: `exit_plan_mode` is statically allowlisted by
+      // topLevelSurfaceAllowedTools but only registered while in plan mode.
+      // This path passes the permission gate and fails the handler lookup.
+      const pick = (n: string) => builtinToolSchemas.find((s) => s.name === n)!;
+      const dispatcher = new SessionToolDispatcher({
+        handlers: new Map([
+          ['read_file', echoHandler()],
+          ['bash', echoHandler()],
+        ]),
+        schemas: [pick('read_file'), pick('bash')],
+        // 'write_file' is allowlisted but never registered; bash is registered
+        // but NOT allowlisted, so it must not appear in the suggestion list.
+        permissions: { allowedTools: ['read_file', 'write_file'] },
+      });
+      const result = await dispatcher.execute(makeCall({ name: 'write_file', input: {} }));
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('Unknown tool "write_file"');
+      expect(result.content).toContain('read_file');
+      expect(result.content).not.toContain('bash');
+    });
+
+    it('omits the dangling "listed above" pointer when no schema survives the allowlist', async () => {
+      const dispatcher = new SessionToolDispatcher({
+        handlers: new Map([['echo', echoHandler()]]),
+        schemas: [],
+        permissions: { allowedTools: ['echo', 'ghost'] },
+      });
+      const result = await dispatcher.execute(makeCall({ name: 'ghost', input: {} }));
+      expect(result.content).toContain('Unknown tool "ghost"');
+      expect(result.content).toContain('Do NOT retry');
+      expect(result.content).not.toContain('listed above');
+      expect(result.content).not.toContain('Available tools:');
+    });
   });
 
   it('catches handler throws and returns isError', async () => {

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -1314,7 +1314,9 @@ export class SessionToolDispatcher implements ToolDispatcher {
     // Handler lookup
     const handler = this.handlers.get(call.name);
     if (!handler) {
-      return { content: this.unknownToolMessage(call.name), isError: true };
+      const msg = this.unknownToolMessage(call.name);
+      await this.emitPreToolUseBlock(call.name, msg);
+      return { content: msg, isError: true, failureClass: 'permission-denied' };
     }
 
     let result: ToolResult;

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -555,6 +555,43 @@ export class SessionToolDispatcher implements ToolDispatcher {
   }
 
   /**
+   * Model-visible reason text for an allowlist denial.
+   *
+   * Invariant: the permission gate runs BEFORE the handler lookup in
+   * `executeCoreInner`, so a name the model INVENTED is rejected here as an
+   * allowlist denial and never reaches that branch's `Unknown tool "X".
+   * Available tools: ...` enumeration. Because every surface configures an
+   * allowlist (`CHILD_ALLOWED_TOOLS` / `topLevelSurfaceAllowedTools`), that
+   * enumeration was unreachable for exactly the case it was written for, and
+   * the model instead saw a denial that reads like "you lack permission" — no
+   * signal that the tool does not exist. Models carry a strong post-training
+   * prior for Anthropic's native tool names (e.g. `str_replace_based_edit_tool`,
+   * the text-editor tool this codebase does not implement) and re-emit them
+   * under long edit-heavy runs, burning a round each time.
+   *
+   * A missing handler is the discriminator: registered-but-denied is a real
+   * permission decision and keeps its original message, while an unregistered
+   * name does not exist at all and gets the tool list instead. Suggestions come
+   * from `toolDefs` (NOT `handlers`) to honour the contract on that getter —
+   * never show the model a tool the gate will reject.
+   *
+   * `failureClass` stays `permission-denied` at the call site: it is a trace
+   * union consumed by receipt/detector code, and widening it is out of scope
+   * for a message fix.
+   */
+  private denialReason(toolName: string, permissionReason: string | undefined): string {
+    if (this.handlers.has(toolName)) {
+      return permissionReason ?? `Tool "${toolName}" is not permitted`;
+    }
+    const available = this.toolDefs.map((s) => s.name).join(', ');
+    return (
+      `Unknown tool "${toolName}" — it does not exist in this session. ` +
+      `Available tools: ${available}. ` +
+      `Do NOT retry "${toolName}" or a variant of it; use one of the tools listed above.`
+    );
+  }
+
+  /**
    * Read-only-skill bash gate. Returns an isError {@link ToolResult} when the
    * dispatcher is in `readOnlyBash` mode AND `call` is a `bash` invocation
    * whose command classifies as MUTATING; otherwise returns `null` (allow).
@@ -870,7 +907,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
     // 2. Permission check
     const permResult = checkToolPermission(call.name, this.permissions);
     if (!permResult.allowed) {
-      const reason = permResult.reason ?? `Tool "${call.name}" is not permitted`;
+      const reason = this.denialReason(call.name, permResult.reason);
       await this.emitPreToolUseBlock(call.name, reason);
       return { content: reason, isError: true, failureClass: 'permission-denied' };
     }

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -583,12 +583,34 @@ export class SessionToolDispatcher implements ToolDispatcher {
     if (this.handlers.has(toolName)) {
       return permissionReason ?? `Tool "${toolName}" is not permitted`;
     }
+    return this.unknownToolMessage(toolName);
+  }
+
+  /**
+   * Contract: the single model-visible phrasing for "this tool does not exist",
+   * shared by the permission gate (a name absent from BOTH the allowlist and
+   * the handler map) and the handler lookup in `executeCoreInner` (a name that
+   * IS allowlisted but has no registered handler — reachable in production via
+   * `exit_plan_mode`, which `topLevelSurfaceAllowedTools` lists statically but
+   * which is only registered while in plan mode, and via an MCP tool whose
+   * server dropped after the allowlist snapshot).
+   *
+   * Suggestions come from `toolDefs`, never `handlers`: the handler map can
+   * hold tools the gate will reject, and advertising one just buys a denial on
+   * the next turn. `toolDefs` is exactly what was shown to the model, so it is
+   * the only honest answer to "what may I call instead".
+   */
+  private unknownToolMessage(toolName: string): string {
     const available = this.toolDefs.map((s) => s.name).join(', ');
-    return (
-      `Unknown tool "${toolName}" — it does not exist in this session. ` +
-      `Available tools: ${available}. ` +
-      `Do NOT retry "${toolName}" or a variant of it; use one of the tools listed above.`
-    );
+    // An empty listing means no schema survived the allowlist filter — the
+    // model was shown nothing, so pointing at "the tools listed above" would be
+    // a dangling reference.
+    const guidance =
+      available.length > 0
+        ? `Available tools: ${available}. Do NOT retry "${toolName}" or a variant of it; ` +
+          `use one of the tools listed above.`
+        : `Do NOT retry "${toolName}" or a variant of it.`;
+    return `Unknown tool "${toolName}" — it does not exist in this session. ${guidance}`;
   }
 
   /**
@@ -1279,10 +1301,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
     // Handler lookup
     const handler = this.handlers.get(call.name);
     if (!handler) {
-      return {
-        content: `Unknown tool "${call.name}". Available tools: ${[...this.handlers.keys()].join(', ')}`,
-        isError: true,
-      };
+      return { content: this.unknownToolMessage(call.name), isError: true };
     }
 
     let result: ToolResult;

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -569,9 +569,12 @@ export class SessionToolDispatcher implements ToolDispatcher {
    * the text-editor tool this codebase does not implement) and re-emit them
    * under long edit-heavy runs, burning a round each time.
    *
-   * A missing handler is the discriminator: registered-but-denied is a real
-   * permission decision and keeps its original message, while an unregistered
-   * name does not exist at all and gets the tool list instead. Suggestions come
+   * A missing registration is the discriminator: registered-but-denied is a
+   * real permission decision and keeps its original message, while an
+   * unregistered name does not exist at all and gets the tool list instead.
+   * Registrations include both ordinary handlers and the executor-backed
+   * `agent`, `skill`, and `compose` tools, which are routed before handler
+   * lookup in `executeCoreInner`. Suggestions come
    * from `toolDefs` (NOT `handlers`) to honour the contract on that getter —
    * never show the model a tool the gate will reject.
    *
@@ -580,10 +583,20 @@ export class SessionToolDispatcher implements ToolDispatcher {
    * for a message fix.
    */
   private denialReason(toolName: string, permissionReason: string | undefined): string {
-    if (this.handlers.has(toolName)) {
+    if (this.isRegisteredTool(toolName)) {
       return permissionReason ?? `Tool "${toolName}" is not permitted`;
     }
     return this.unknownToolMessage(toolName);
+  }
+
+  /** Whether this session has an implementation for a tool, regardless of permission. */
+  private isRegisteredTool(toolName: string): boolean {
+    return (
+      this.handlers.has(toolName) ||
+      (toolName === 'agent' && this.subagentExecutor !== undefined) ||
+      (toolName === 'skill' && this.skillExecutor !== undefined) ||
+      (toolName === 'compose' && this.composeExecutor !== undefined)
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary

Subagents kept emitting `str_replace_based_edit_tool` and getting back:

```
Tool "str_replace_based_edit_tool" is not in the configured allowlist
```

That name is not a hallucination. It is a **real Anthropic tool name** — the text editor tool, types `text_editor_20250429` / `text_editor_20250728`, Claude 4 and later. This project does not implement it (it ships `edit_file`), but the models carry a strong post-training prior for the native name and re-emit it during long, edit-heavy runs.

The message they got back is the problem. `SessionToolDispatcher` has two rejection paths:

| Gate | Message |
|---|---|
| Permission check (`runPreDispatchGates`) | `Tool "X" is not in the configured allowlist` |
| Handler lookup (`executeCoreInner`) | `Unknown tool "X". Available tools: ...` |

The permission gate runs **first** and returns early. Since every surface configures an allowlist (`CHILD_ALLOWED_TOOLS`, `topLevelSurfaceAllowedTools`), a name the model invented always short-circuits there — so the branch that would have told it the tool does not exist, and named the real ones, was **structurally unreachable for exactly the case it was written for**. It only ever fired for a name that *is* allowlisted but has no handler.

So the model saw what looks like a permissions problem, had no signal the tool was fictional, and no list of what to use instead. Each attempt burns a round against `max_tool_use_iterations` and feeds the repeat-failure guard.

This is the same failure shape already documented in `top-level-allowlist.ts` — where `get_runtime_state` and `exit_plan_mode` were rejected as "not in the configured allowlist" while visibly callable. That fix centralized the list; the message masking itself was never addressed.

### Commit 1 — discriminate "does not exist" from "not permitted"

Handler presence is the discriminator. A **registered-but-denied** tool is a real permission decision and keeps its original message and `failureClass` untouched. An **unregistered** name now gets the callable-tool list plus an explicit do-not-retry instruction.

`failureClass` deliberately stays `permission-denied`: it is a trace union consumed by receipt/detector code, and widening it is out of scope for a message fix.

### Commit 2 — stop the unknown-tool message leaking non-allowlisted handlers

The handler-lookup branch enumerated raw `this.handlers.keys()`, which can contain tools the gate will reject — suggesting one just buys a denial next turn. This path is reachable in production, not theoretical: `exit_plan_mode` is listed statically by `topLevelSurfaceAllowedTools` but only registered while in plan mode, and an MCP tool whose server dropped after the allowlist snapshot hits the same branch.

Both sites now share one `unknownToolMessage()` helper sourced from `toolDefs`, honouring the contract already written on that getter — *never show the model a tool the permission gate will reject* — so the two can no longer drift.

### Why not just implement the tool

Considered and rejected:

- **Breaks the provider-agnostic contract.** `text_editor_20250728` is an Anthropic-typed tool with no OpenAI equivalent. There is no precedent — no native tool type is passed anywhere today. The child tool surface would silently differ by provider.
- **It is not one duplicate, it is three.** The tool dispatches on a `command` field spanning `view` → `read_file`, `create` → `write_file`, `str_replace`/`insert` → `edit_file`, making tool selection *more* nondeterministic.
- **Anthropic-versioned schema.** The name already changed once (`str_replace_editor` → `str_replace_based_edit_tool`) and `undo_edit` was dropped in `20250429`.
- **The pain does not justify it.** Local telemetry shows ~44 occurrences total, self-correcting to `edit_file` within 1–3 calls essentially every time.

The message fix also generalizes: it repairs the whole class, so any mistyped or invented tool name self-corrects — including whatever a future model generation invents.

## How was this tested?

- `pnpm lint` — clean.
- `pnpm test` — **833/833 files, 15864 passed, 2 skipped.** Baseline at `8ba6e2cd` is 15857 passed; the delta is exactly the 7 net-new tests here.
- `pnpm build`, `audit:sdk:check`, `audit:env:check`, `scan:env:check`, `audit:chalk:check`, `fix:pins:check` — all pass.
- 7 net-new tests. This path previously had **no coverage** for allowlist denial; the pre-existing "returns isError for unknown tool" test covers the other branch and still passes unchanged.

Tests cover: the phantom name no longer blamed on the allowlist; the callable-tool list and do-not-retry guidance; a registered-but-denied tool keeping its original message (the safety property); `failureClass` preserved; the non-leak guarantee on the allowlisted-but-unregistered path; and the empty-listing edge.

One full-suite run showed a failure in `subagent-output-capture-wiring.test.ts` — verified pre-existing and unrelated: it passes in isolation, a stashed pristine-`HEAD` baseline passed 833/833, and re-running with this diff restored passed 833/833.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/) — see [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] No secrets, tokens, or private paths in the diff
