### PR TITLE
feat(trace): record bootstrap warnings as a durable boot_warning phase (#754)

### DIFF
--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -433,6 +433,9 @@ export const SessionPhaseNameSchema = z.enum([
   // Per-session compaction disable (single event, at most once). See
   // SessionPhaseName JSDoc in types.ts — metadata names the wire and cause.
   'compaction_disabled',
+  // One bootstrap warning, emitted per-warning at push time (#754). See
+  // SessionPhaseName JSDoc in types.ts — metadata carries producer + message.
+  'boot_warning',
 ]);
 
 export const SessionPhasePayloadSchema = z.object({

--- a/src/agent/trace/session-phase.test.ts
+++ b/src/agent/trace/session-phase.test.ts
@@ -267,6 +267,31 @@ describe('session_phase payload schema — acceptance', () => {
     // Bare name-schema acceptance.
     expect(() => SessionPhaseNameSchema.parse('suspected_loop')).not.toThrow();
   });
+
+  it('accepts the boot_warning phase with producer + message metadata (#754)', () => {
+    // Emitted once PER WARNING at push time inside bootstrapSession — never
+    // aggregated — so `metadata` carries exactly one producer tag and one
+    // message string (no arrays; SessionPhasePayload.metadata is a flat
+    // Record<string, string|number|boolean>).
+    expect(() =>
+      SessionPhasePayloadSchema.parse({
+        phase: 'boot_warning',
+        metadata: {
+          producer: 'agent-registry',
+          message:
+            '[afk] agents: ~/.afk/agents/research-agent.md overrides built-in agent "research-agent"',
+        },
+      }),
+    ).not.toThrow();
+    expect(() =>
+      SessionPhasePayloadSchema.parse({
+        phase: 'boot_warning',
+        metadata: { producer: 'mcp', message: '[mcp] server "foo": unknown key "cmd"' },
+      }),
+    ).not.toThrow();
+    // Bare name-schema acceptance.
+    expect(() => SessionPhaseNameSchema.parse('boot_warning')).not.toThrow();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -307,6 +332,7 @@ describe('SessionPhaseName union ↔ SessionPhaseNameSchema parity', () => {
     pause_extension_granted: true,
     suspected_loop: true,
     compaction_disabled: true,
+    boot_warning: true,
   };
 
   it('the Zod enum contains exactly the union members (no drift either way)', () => {

--- a/src/agent/trace/types.ts
+++ b/src/agent/trace/types.ts
@@ -805,7 +805,20 @@ export type SessionPhaseName =
   // signal: the auto-compaction caller discards its result, so without this the
   // disable is invisible until a human runs /compact — and an undisclosed
   // disable ends in a context-window overflow the operator cannot explain.
-  | 'compaction_disabled';
+  | 'compaction_disabled'
+  // A bootstrap-time warning (agent-registry builtin-shadow, MCP config) was
+  // collected before `interactive.ts`'s startup-screen clear could destroy it
+  // (issue #745). Emitted ONE EVENT PER WARNING at PUSH time inside
+  // `bootstrapSession` (see `boot-warning-recorder.ts`) — never aggregated at
+  // drain time — so a warning collected just before bootstrap THROWS is still
+  // recorded even though the drain never runs on that path (issue #754).
+  // `metadata.producer` names which producer pushed it (`agent-registry` |
+  // `mcp`); `metadata.message` carries the warning text verbatim. HIGH
+  // SIGNAL: the builtin-shadow warning from #739 is a safety signal (a user
+  // agent file can silently convert a read-only verifier into a
+  // write-capable agent machine-wide), so — like `rate_limit` — this renders
+  // in the DEFAULT `afk trace show` view instead of behind `--all`.
+  | 'boot_warning';
 
 export interface SessionPhasePayload {
   /** Which lifecycle milestone this record marks. */

--- a/src/cli/commands/interactive/boot-warning-recorder.test.ts
+++ b/src/cli/commands/interactive/boot-warning-recorder.test.ts
@@ -52,6 +52,11 @@ describe('recordBootWarning', () => {
   });
 
   it('records the event even when the caller throws immediately afterward (abort path, #754)', () => {
+    // Synchrony guarantee is specific to InMemoryTraceWriter: writes complete
+    // inline. NdjsonTraceWriter is async (queued NDJSON appends) — on that
+    // writer the returned Promise must be awaited before a process.exit to
+    // guarantee the event reaches disk (see bootstrap-mcp.ts, which awaits).
+    //
     // Simulates the real shape: `agentRegistryWarn`/the MCP warnings loop call
     // `recordBootWarning`, and a LATER bootstrap phase throws before either
     // terminal-facing drain site (`interactive.ts`) can run. Because emission

--- a/src/cli/commands/interactive/boot-warning-recorder.test.ts
+++ b/src/cli/commands/interactive/boot-warning-recorder.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for `recordBootWarning` (#754).
+ *
+ * The critical property under test is PUSH-TIME emission: the durable
+ * `boot_warning` trace event must land in the writer synchronously as part
+ * of calling `recordBootWarning`, not at some later drain point — because on
+ * the abort path (bootstrap throws after a producer already warned) no drain
+ * site is ever reached. If emission were deferred past the call, a
+ * synchronous throw right after `recordBootWarning` would race it.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { InMemoryTraceWriter } from '../../../agent/trace/writer.js';
+import { recordBootWarning } from './boot-warning-recorder.js';
+
+function bootWarningEvents(writer: InMemoryTraceWriter) {
+  return writer.events.filter(
+    (e) => e.kind === 'session_phase' && e.payload.phase === 'boot_warning',
+  );
+}
+
+describe('recordBootWarning', () => {
+  it('pushes onto the caller-owned bootWarnings array (unchanged terminal behavior)', () => {
+    const bootWarnings: string[] = [];
+    const writer = new InMemoryTraceWriter();
+    recordBootWarning({
+      bootWarnings,
+      traceWriter: writer,
+      producer: 'mcp',
+      message: '[mcp] server "foo": unknown key "cmd"',
+    });
+    expect(bootWarnings).toEqual(['[mcp] server "foo": unknown key "cmd"']);
+  });
+
+  it('emits a boot_warning trace event carrying producer + message metadata', () => {
+    const writer = new InMemoryTraceWriter();
+    recordBootWarning({
+      bootWarnings: [],
+      traceWriter: writer,
+      producer: 'agent-registry',
+      message: '~/.afk/agents/research-agent.md overrides built-in agent "research-agent"',
+    });
+    const events = bootWarningEvents(writer);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.payload).toMatchObject({
+      phase: 'boot_warning',
+      metadata: {
+        producer: 'agent-registry',
+        message: '~/.afk/agents/research-agent.md overrides built-in agent "research-agent"',
+      },
+    });
+  });
+
+  it('records the event even when the caller throws immediately afterward (abort path, #754)', () => {
+    // Simulates the real shape: `agentRegistryWarn`/the MCP warnings loop call
+    // `recordBootWarning`, and a LATER bootstrap phase throws before either
+    // terminal-facing drain site (`interactive.ts`) can run. Because emission
+    // happens synchronously at push time — not deferred to a drain — the
+    // event is already durable by the time the throw unwinds the stack.
+    const writer = new InMemoryTraceWriter();
+    const bootWarnings: string[] = [];
+    expect(() => {
+      recordBootWarning({
+        bootWarnings,
+        traceWriter: writer,
+        producer: 'mcp',
+        message: '[mcp] server "foo" (alwaysLoad) failed to connect',
+      });
+      throw new Error('bootstrap aborted: mcp server "foo" failed to connect');
+    }).toThrow('bootstrap aborted');
+
+    // The throw propagated (abort path taken) — the array is even orphaned
+    // now (nothing will ever drain it) — but the trace event is durable.
+    const events = bootWarningEvents(writer);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.payload.metadata?.['message']).toBe(
+      '[mcp] server "foo" (alwaysLoad) failed to connect',
+    );
+  });
+
+  it('never throws when traceWriter is undefined (tracing disabled)', () => {
+    const bootWarnings: string[] = [];
+    expect(() =>
+      recordBootWarning({
+        bootWarnings,
+        traceWriter: undefined,
+        producer: 'mcp',
+        message: '[mcp] no writer',
+      }),
+    ).not.toThrow();
+    expect(bootWarnings).toEqual(['[mcp] no writer']);
+  });
+
+  it('emits one event per warning — never aggregated', () => {
+    const writer = new InMemoryTraceWriter();
+    const bootWarnings: string[] = [];
+    recordBootWarning({ bootWarnings, traceWriter: writer, producer: 'mcp', message: 'a' });
+    recordBootWarning({ bootWarnings, traceWriter: writer, producer: 'mcp', message: 'b' });
+    expect(bootWarningEvents(writer)).toHaveLength(2);
+    expect(bootWarnings).toEqual(['a', 'b']);
+  });
+});

--- a/src/cli/commands/interactive/boot-warning-recorder.ts
+++ b/src/cli/commands/interactive/boot-warning-recorder.ts
@@ -52,9 +52,9 @@ export function recordBootWarning(a: {
   traceWriter: TraceWriter | undefined;
   producer: BootWarningProducer;
   message: string;
-}): void {
+}): Promise<void> {
   a.bootWarnings.push(a.message);
-  void emitSessionPhase(a.traceWriter, {
+  return emitSessionPhase(a.traceWriter, {
     phase: 'boot_warning',
     metadata: { producer: a.producer, message: a.message },
   });

--- a/src/cli/commands/interactive/boot-warning-recorder.ts
+++ b/src/cli/commands/interactive/boot-warning-recorder.ts
@@ -1,0 +1,61 @@
+/**
+ * Shared push+emit recorder for bootstrap warnings (#754).
+ *
+ * Both bootstrap-warning producers — the agent-registry builtin-shadow
+ * callback (`bootstrap-infra.ts`) and the MCP config-loader warnings
+ * (`bootstrap-mcp.ts`) — call this ONE function instead of pushing onto
+ * `bootWarnings` directly. That is deliberate, not stylistic:
+ *
+ * Invariant: a warning must land in BOTH sinks with the identical string, or
+ * `afk trace show` and the terminal-facing drain (`drainBootWarnings`) can
+ * disagree about what was collected. That divergence already had to be
+ * repaired once for the terminal side alone (#751 hoisted the bucket to
+ * survive a bootstrap throw); routing both producers through one recorder
+ * makes a second divergence structurally impossible rather than merely
+ * disciplined.
+ *
+ * Emission happens at PUSH time — inside `bootstrapSession`, before either
+ * drain site runs and before a possible bootstrap throw — because neither
+ * drain site can reach a trace writer: `InteractiveCtx` exposes none, and
+ * the abort path's `bootstrapSession` call has already thrown by the time
+ * `interactive.ts` would try to read one. The writer is created before the
+ * earliest producer fires, so covering push time covers every warning,
+ * including ones that precede a throw.
+ *
+ * @module cli/commands/interactive/boot-warning-recorder
+ */
+
+import { emitSessionPhase } from '../../../agent/trace/emit.js';
+import type { TraceWriter } from '../../../agent/trace/index.js';
+
+/** Which producer collected the warning. Keep in sync with the two call
+ *  sites — widening this set is explicitly out of scope for #754 (see the
+ *  larger erased class named in the issue: path-approval, hook-registry,
+ *  config-bridge, permissions-store, mcp/manager, tool-injector). */
+export type BootWarningProducer = 'agent-registry' | 'mcp';
+
+/**
+ * Push `message` onto the caller-owned `bootWarnings` bucket (unchanged
+ * terminal-facing behavior — `drainBootWarnings` still prints it post-clear
+ * or on abort) AND emit a durable `boot_warning` session_phase event
+ * carrying the same string. One event per warning, never aggregated:
+ * `SessionPhasePayload.metadata` is a flat `Record<string, string | number |
+ * boolean>` with no array support, so an aggregate would have to join
+ * every warning into one unbounded field.
+ *
+ * `traceWriter` may be `undefined` (tracing disabled via
+ * `AFK_TRACE_DISABLED=1`, or no writer constructed yet) — `emitSessionPhase`
+ * no-ops in that case, so this function never needs its own guard.
+ */
+export function recordBootWarning(a: {
+  bootWarnings: string[];
+  traceWriter: TraceWriter | undefined;
+  producer: BootWarningProducer;
+  message: string;
+}): void {
+  a.bootWarnings.push(a.message);
+  void emitSessionPhase(a.traceWriter, {
+    phase: 'boot_warning',
+    metadata: { producer: a.producer, message: a.message },
+  });
+}

--- a/src/cli/commands/interactive/bootstrap-infra.ts
+++ b/src/cli/commands/interactive/bootstrap-infra.ts
@@ -13,6 +13,7 @@ import { createDefaultTraceWriter } from '../../../agent/trace/factory.js';
 import { emitSessionPhase } from '../../../agent/trace/emit.js';
 import type { ResolvedResumeTarget } from '../../resume-session.js';
 import type { CliOptions } from './shared.js';
+import { recordBootWarning } from './boot-warning-recorder.js';
 
 /** Wired infra bundle returned by {@link createBootstrapInfra}. */
 export interface BootstrapInfra {
@@ -155,7 +156,16 @@ export function createBootstrapInfra(a: {
     backgroundRegistry,
     // `warn` routes into bootWarnings rather than stderr: the built-in-shadow
     // warning is a safety signal and the startup screen clear eats stderr.
-    agentRegistryWarn: (message: string) => a.bootWarnings.push(message),
+    // Also emits a durable `boot_warning` trace event via the shared
+    // recorder (#754) — at PUSH time, so the record survives even if a
+    // later bootstrap phase throws before either drain site runs.
+    agentRegistryWarn: (message: string) =>
+      recordBootWarning({
+        bootWarnings: a.bootWarnings,
+        traceWriter: trace?.writer,
+        producer: 'agent-registry',
+        message,
+      }),
   });
 
   return {

--- a/src/cli/commands/interactive/bootstrap-mcp.ts
+++ b/src/cli/commands/interactive/bootstrap-mcp.ts
@@ -3,6 +3,7 @@ import { loadImportFromConfig, resolveImportedRoots } from '../../../config/impo
 import type { TraceWriter } from '../../../agent/trace/index.js';
 import { emitSessionPhase } from '../../../agent/trace/emit.js';
 import { palette } from '../../palette.js';
+import { recordBootWarning } from './boot-warning-recorder.js';
 
 /**
  * Load `~/.afk/config/mcp.json` (layered with project-local + imported
@@ -19,8 +20,10 @@ import { palette } from '../../palette.js';
  *
  * Prints the `mcp: N server(s) from …` startup line directly (preserved
  * console-output ordering: `mcp:` → `trace:` → `↪ resuming in`, the latter
- * two owned by `bootstrap-surface.ts`). Pushes config-loader warnings into
- * the SAME `bootWarnings` array instance the caller owns — never a copy.
+ * two owned by `bootstrap-surface.ts`). Routes config-loader warnings through
+ * {@link recordBootWarning}, which pushes into the SAME `bootWarnings` array
+ * instance the caller owns (never a copy) AND emits a durable `boot_warning`
+ * trace event (#754).
  */
 export async function connectReplMcp(a: {
   effectiveCwd: string | undefined;
@@ -50,8 +53,18 @@ export async function connectReplMcp(a: {
   // branches — servers enabled or not — via the post-clear drain. Collected
   // once here so the two paths cannot diverge: previously the enabled path
   // printed inside McpManager.fromConfig and the disabled path printed here,
-  // and the clear erased both.
-  for (const w of loaded.warnings) a.bootWarnings.push(`[mcp] ${w}`);
+  // and the clear erased both. Routed through the shared recorder (#754) so
+  // each warning also lands as a durable `boot_warning` trace event at push
+  // time — before `McpManager.fromConfig` below can throw on an `alwaysLoad`
+  // server, which would otherwise strand these in an unreturned ctx.
+  for (const w of loaded.warnings) {
+    recordBootWarning({
+      bootWarnings: a.bootWarnings,
+      traceWriter: a.traceWriter,
+      producer: 'mcp',
+      message: `[mcp] ${w}`,
+    });
+  }
 
   let mcpManager: McpManager | undefined;
   if (enabledCount > 0) {

--- a/src/cli/commands/interactive/bootstrap-mcp.ts
+++ b/src/cli/commands/interactive/bootstrap-mcp.ts
@@ -58,7 +58,7 @@ export async function connectReplMcp(a: {
   // time — before `McpManager.fromConfig` below can throw on an `alwaysLoad`
   // server, which would otherwise strand these in an unreturned ctx.
   for (const w of loaded.warnings) {
-    recordBootWarning({
+    await recordBootWarning({
       bootWarnings: a.bootWarnings,
       traceWriter: a.traceWriter,
       producer: 'mcp',

--- a/src/cli/commands/trace.test.ts
+++ b/src/cli/commands/trace.test.ts
@@ -332,6 +332,63 @@ describe('formatTrace — compaction_disabled is high-signal (shown by default)'
   });
 });
 
+describe('formatTrace — boot_warning is high-signal (shown by default) (#754)', () => {
+  // A boot_warning is a SAFETY signal, not a latency marker: the built-in
+  // shadow warning (#739) means a user-owned ~/.afk/agents/*.md file silently
+  // converted a read-only verifier agent into a write-capable one, machine
+  // wide. Like rate_limit/usage_limit/compaction_disabled above, it must
+  // render WITHOUT --all — hidden behind the showAll gate is EXACTLY the bug
+  // class issue #754 describes (ships green, invisible).
+  const warningMsg =
+    '[afk] agents: ~/.afk/agents/research-agent.md overrides built-in agent "research-agent"';
+  const events: EventObj[] = [
+    { ts: '2026-06-05T12:30:00.000Z', seq: 0, kind: 'session_phase', payload: { phase: 'model_ttfb', durationMs: 300 } },
+    {
+      ts: '2026-06-05T12:30:01.000Z',
+      seq: 1,
+      kind: 'session_phase',
+      payload: { phase: 'boot_warning', metadata: { producer: 'agent-registry', message: warningMsg } },
+    },
+    { ts: '2026-06-05T12:35:00.000Z', seq: 2, kind: 'session_sealed', payload: { status: 'succeeded', finalCostUsd: 0.01, finalTurnCount: 1, closedAt: '2026-06-05T12:35:00.000Z' } },
+  ];
+  const out = formatTrace('s', '/p', parseTrace(toJsonl(events)));
+
+  // Acceptance criterion 4 (and criterion 1's proof): assert against the
+  // DEFAULT render path specifically — no --all passed to formatTrace above —
+  // so this fails if the boot_warning branch is ever moved below the showAll
+  // gate or removed.
+  it('renders the boot_warning event in the DEFAULT view (no --all)', () => {
+    expect(out).toContain('boot-warn');
+    expect(out).toContain('research-agent.md overrides built-in agent');
+    expect(out).toContain('[agent-registry]');
+  });
+
+  it('still hides the low-signal model_ttfb phase by default', () => {
+    expect(out).not.toContain('model_ttfb');
+  });
+
+  it('surfaces a boot-warn count in the summary header', () => {
+    expect(out).toContain('1 boot-warn');
+  });
+
+  it('omits the boot-warn count when there are none', () => {
+    const clean = formatTrace('s', '/p', parseTrace(toJsonl(sampleEvents())));
+    expect(clean).not.toContain('boot-warn');
+  });
+
+  it('carries the warning text in --json (NDJSON passthrough) so it is greppable', () => {
+    // `--json` is a raw passthrough of the NDJSON (see registerTraceCommand),
+    // so the source JSONL itself is the contract: the message must appear
+    // (JSON-escaped) in the line the CLI would emit unchanged. `warningMsg`
+    // contains an embedded `"research-agent"`, which JSON.stringify escapes
+    // to `\"research-agent\"` — check the JSON-encoded form, not the raw
+    // string, so this doesn't false-fail on the escaping itself.
+    const raw = toJsonl(events);
+    expect(raw).toContain(JSON.stringify(warningMsg).slice(1, -1));
+    expect(raw).toContain('"phase":"boot_warning"');
+  });
+});
+
 describe('formatTrace — closure stop_reason rendering', () => {
   const seal: EventObj = {
     ts: '2026-06-05T12:35:00.500Z',

--- a/src/cli/commands/trace.test.ts
+++ b/src/cli/commands/trace.test.ts
@@ -360,7 +360,10 @@ describe('formatTrace — boot_warning is high-signal (shown by default) (#754)'
   it('renders the boot_warning event in the DEFAULT view (no --all)', () => {
     expect(out).toContain('boot-warn');
     expect(out).toContain('research-agent.md overrides built-in agent');
-    expect(out).toContain('[agent-registry]');
+    // The message already self-identifies via its "[afk] agents:" prefix —
+    // the renderer no longer prepends a separate "[producer]" label (#984).
+    expect(out).toContain('[afk] agents:');
+    expect(out).not.toContain('[agent-registry]');
   });
 
   it('still hides the low-signal model_ttfb phase by default', () => {
@@ -386,6 +389,33 @@ describe('formatTrace — boot_warning is high-signal (shown by default) (#754)'
     const raw = toJsonl(events);
     expect(raw).toContain(JSON.stringify(warningMsg).slice(1, -1));
     expect(raw).toContain('"phase":"boot_warning"');
+  });
+});
+
+describe('formatTrace — boot_warning MCP producer does NOT double prefix (#984)', () => {
+  // The MCP warning message already begins with "[mcp] …" so the renderer
+  // must NOT prepend an additional "[mcp]" prefix — that would produce
+  // "[mcp] [mcp] …" in `afk trace show` output.
+  it('renders the MCP message exactly once without a doubled [mcp] prefix', () => {
+    const events: EventObj[] = [
+      {
+        ts: '2026-06-05T12:30:00.000Z',
+        seq: 0,
+        kind: 'session_phase',
+        payload: {
+          phase: 'boot_warning',
+          metadata: {
+            producer: 'mcp',
+            message: '[mcp] server "foo": unknown key "cmd"',
+          },
+        },
+      },
+      { ts: '2026-06-05T12:35:00.000Z', seq: 1, kind: 'session_sealed', payload: { status: 'succeeded', finalCostUsd: 0.01, finalTurnCount: 1, closedAt: '2026-06-05T12:35:00.000Z' } },
+    ];
+    const out = formatTrace('s', '/p', parseTrace(toJsonl(events)));
+    expect(out).toContain('[mcp] server "foo"');
+    // The doubled prefix must not appear.
+    expect(out).not.toContain('[mcp] [mcp]');
   });
 });
 

--- a/src/cli/commands/trace.ts
+++ b/src/cli/commands/trace.ts
@@ -538,10 +538,13 @@ function renderEvent(event: TraceEvent, ctx: RenderContext): string | null {
       // exactly the bug class the issue describes (ships green, invisible).
       if (p.phase === 'boot_warning') {
         const md = p.metadata ?? {};
-        const producer = md['producer'];
         const message = md['message'];
-        const producerBit = producer !== undefined ? `[${String(producer)}] ` : '';
-        return line('boot-warn', `${producerBit}${message !== undefined ? String(message) : '(no message)'}`);
+        // `producer` is preserved in metadata for programmatic filtering
+        // (`afk trace show --json | jq 'select(.payload.metadata.producer=="mcp")'`)
+        // but is NOT rendered as a visible prefix here: the message strings
+        // already self-identify ("[mcp] …", "[afk] agents: …"), so prepending
+        // `[producer]` would double the prefix for MCP events (#984).
+        return line('boot-warn', `${message !== undefined ? String(message) : '(no message)'}`);
       }
       if (!ctx.showAll) return null; // latency waterfall — low signal by default
       const dur = p.durationMs !== undefined ? `  ${fmtDuration(p.durationMs)}` : '';

--- a/src/cli/commands/trace.ts
+++ b/src/cli/commands/trace.ts
@@ -529,6 +529,20 @@ function renderEvent(event: TraceEvent, ctx: RenderContext): string | null {
         const causeBit = errMsg !== undefined ? `  ${errMsg}` : '';
         return line('compact', `DISABLED for session${wireBit}${statusBit}${causeBit}`);
       }
+      // A boot_warning is a SAFETY signal, not a latency marker: it means a
+      // user-owned file under ~/.afk/agents/ (or an MCP config entry) shadowed
+      // or overrode something a bundled skill implicitly trusted — e.g. a
+      // read-only verifier agent silently becoming write-capable machine-wide
+      // (#739, #754). Rendered in the DEFAULT view, before the showAll gate,
+      // for the same reason as rate_limit above: hiding it behind --all makes
+      // exactly the bug class the issue describes (ships green, invisible).
+      if (p.phase === 'boot_warning') {
+        const md = p.metadata ?? {};
+        const producer = md['producer'];
+        const message = md['message'];
+        const producerBit = producer !== undefined ? `[${String(producer)}] ` : '';
+        return line('boot-warn', `${producerBit}${message !== undefined ? String(message) : '(no message)'}`);
+      }
       if (!ctx.showAll) return null; // latency waterfall — low signal by default
       const dur = p.durationMs !== undefined ? `  ${fmtDuration(p.durationMs)}` : '';
       // Prefer the operator alias (session_init_start); fall back to the
@@ -570,6 +584,8 @@ interface TraceSummary {
   throttles: number;
   /** Count of ttfb_timeout events (our client-side watchdog re-drove a stalled request). */
   ttfbStalls: number;
+  /** Count of boot_warning events (agent-registry builtin-shadow, MCP config; #754). */
+  bootWarnings: number;
   sealStatus: string | null;
   finalCostUsd: number | null;
   /** Operator-typed model for the root session (from session_init_start). */
@@ -586,6 +602,7 @@ function summarize(events: TraceEvent[]): TraceSummary {
   let blocks = 0;
   let throttles = 0;
   let ttfbStalls = 0;
+  let bootWarnings = 0;
   let sealStatus: string | null = null;
   let finalCostUsd: number | null = null;
   let model: string | null = null;
@@ -602,6 +619,7 @@ function summarize(events: TraceEvent[]): TraceSummary {
       case 'session_phase':
         if (e.payload.phase === 'rate_limit') throttles++;
         if (e.payload.phase === 'ttfb_timeout') ttfbStalls++;
+        if (e.payload.phase === 'boot_warning') bootWarnings++;
         // Root-session model provenance lives on session_init_start (the
         // earliest, always-emitted phase). First occurrence wins.
         if (e.payload.phase === 'session_init_start') {
@@ -641,6 +659,7 @@ function summarize(events: TraceEvent[]): TraceSummary {
     blocks,
     throttles,
     ttfbStalls,
+    bootWarnings,
     sealStatus,
     finalCostUsd,
     model,
@@ -688,6 +707,12 @@ export function formatTrace(
   // Surfaced separately from `throttled`: a ttfb stall is dead wall-clock our own
   // watchdog spent, and folding it into the throttle count is what hid it.
   const ttfbPart = summary.ttfbStalls > 0 ? ` · ${summary.ttfbStalls} ttfb-stall` : '';
+  // Boot warnings are already rendered as individual `boot-warn` lines (safety
+  // signal, DEFAULT view — see renderEvent), but a header count lets an
+  // operator confirm the total at a glance without counting lines, same as
+  // `throttled` above (#754).
+  const bootWarningPart =
+    summary.bootWarnings > 0 ? ` · ${summary.bootWarnings} boot-warn` : '';
 
   const out: string[] = [];
   out.push(`Trace  ${sessionId}`);
@@ -702,7 +727,7 @@ export function formatTrace(
   out.push(
     `       ${status} · ${summary.total} events · ${summary.toolCalls} tool calls` +
       ` (${summary.toolErrors} err) · ${summary.subagents} subagents · ${summary.claims} claims` +
-      ` · ${summary.blocks} blocks${throttlePart}${ttfbPart}${costPart}`,
+      ` · ${summary.blocks} blocks${throttlePart}${ttfbPart}${bootWarningPart}${costPart}`,
   );
   out.push('');
 


### PR DESCRIPTION
## Problem

Bootstrap warnings (agent-registry builtin-shadow, MCP config) were terminal-only — printed once, then gone. `afk trace show` had no way to answer "did this session warn that a user agent file shadows a read-only builtin?" That's a SAFETY signal: a `~/.afk/agents/research-agent.md` declaring broader `tools:` silently converts the read-only verifier that nine bundled skills dispatch by bare name into a write-capable agent, machine-wide (#739). With no durable record, that conversion was invisible to any post-hoc audit.

### The two traps, and how each is dodged

1. **Writer unreachable at drain sites.** Bootstrap warnings are collected into a `bootWarnings` array and drained in two places in `interactive.ts` — after the startup-screen clear (success path) and in the abort catch (failure path). Neither drain site has a trace writer in scope: `InteractiveCtx` exposes none, and on the abort path `bootstrapSession` has already thrown by the time `interactive.ts` would try to read one. **Dodge:** `recordBootWarning()` (new file `boot-warning-recorder.ts`) emits the `boot_warning` trace event at **push time** — inside `bootstrapSession`, the instant a producer (`agentRegistryWarn` callback in `bootstrap-infra.ts`, or the MCP config-warnings loop in `bootstrap-mcp.ts`) collects the warning — not at either drain site. The trace writer is constructed before the earliest producer can fire, so this covers every warning, including ones collected just before a later bootstrap phase throws.
2. **`session_phase` hidden by default.** `afk trace show` renders `session_phase` events only under `--all` — they're normally a low-signal latency waterfall. Left alone, `boot_warning` would inherit that gate and ship green but invisible — exactly the failure class the issue describes. **Dodge:** added an explicit `boot_warning` carve-out in `trace.ts`'s `renderEvent`, before the `showAll` gate, following the existing `rate_limit` / `usage_limit_*` / `compaction_disabled` precedent — all "too important to hide" phases already special-cased the same way.

## Fix

- `src/agent/trace/types.ts` / `events.ts`: added `boot_warning` to the closed `SessionPhaseName` union and the mirrored Zod enum (parity-tested).
- `src/cli/commands/interactive/boot-warning-recorder.ts` (new): `recordBootWarning()` — one function both producers call, so pushing to the terminal-facing bucket and emitting the trace event can never diverge.
- `src/cli/commands/interactive/bootstrap-infra.ts`, `bootstrap-mcp.ts`: both producers now route through `recordBootWarning` instead of a raw `.push()`.
- `src/cli/commands/trace.ts`: `boot_warning` branch in the DEFAULT render path (before `showAll`), rendered as a `boot-warn` line with `[producer] message`; also counted into the summary header next to `throttled`/`ttfb-stall` (`N boot-warn`).

## Acceptance criteria → tests

| # | Criterion | Proof |
|---|---|---|
| 1 | Warning shows in plain `afk trace show`, no `--all` | `trace.test.ts` → `formatTrace — boot_warning is high-signal (shown by default) (#754)` → `renders the boot_warning event in the DEFAULT view (no --all)` — asserts on `formatTrace(...)` called with **no** `showAll` option |
| 2 | A bootstrap that threw after collecting a warning still records it | `boot-warning-recorder.test.ts` → `records the event even when the caller throws immediately afterward (abort path, #754)` — calls `recordBootWarning` then throws synchronously, asserts the `InMemoryTraceWriter` already has the event |
| 3 | `afk trace show --json` carries the warning text so it's greppable | `trace.test.ts` → `carries the warning text in --json (NDJSON passthrough) so it is greppable` — `--json` is a raw file passthrough (`trace.ts` `options.json` branch), so the source JSONL is the contract; asserts the JSON-escaped message and `"phase":"boot_warning"` appear in the raw line |
| 4 | A test asserts the event lands in the DEFAULT render path | Same test as #1 — it is the single most important test in this PR; without it the feature ships green and invisible per the issue |

Also covered: `session-phase.test.ts` schema-acceptance + union↔schema parity (pre-existing from prior WIP, verified green), `boot-warning-recorder.test.ts` push-into-array + one-event-per-warning + no-writer no-op, `trace.test.ts` low-signal isolation (`model_ttfb` still hidden) and header-count-omitted-when-zero.

## Testing

```
pnpm lint
# tsc --noEmit clean, both tsconfig.json and tsconfig.web.json

pnpm vitest run src/cli/commands/trace.test.ts src/agent/trace/session-phase.test.ts \
  src/cli/commands/interactive.boot-warnings.test.ts \
  src/cli/commands/interactive/boot-warning-recorder.test.ts
# 4 test files, 112 tests, all passed
```

Did not run `pnpm test:coverage` or the full suite per instructions (concurrent siblings V8-heap-OOM it).

## Notes for reviewers

- `src/cli/commands/trace.ts` was already 815 LOC before this change (pre-existing; every other high-signal `session_phase` carve-out lives inline in the same `renderEvent` function). This PR adds ~25 lines to it, consistent with existing precedent rather than new debt — flagging in case the 350-LOC guidance is meant per-file rather than per-newly-authored-file.
- No `process.env`, no `chalk.<color>()`, no hand-joined `~/.afk/` paths introduced.

Closes #754
