### PR TITLE
fix(trace): give the resumed session a live writer instead of a sealed one (#731)

### DIFF
--- a/src/agent/abort-graph.ts
+++ b/src/agent/abort-graph.ts
@@ -42,10 +42,19 @@ interface GraphNode {
 
 export class AbortGraph {
   private readonly nodes = new Map<string, GraphNode>();
-  private readonly traceWriter: TraceWriter | undefined;
+  private traceWriter: TraceWriter | undefined;
 
   constructor(traceWriter?: TraceWriter) {
     this.traceWriter = traceWriter;
+  }
+
+  /**
+   * Re-point the witness sink. Called (via the bootstrap cascade) on a REPL
+   * `/resume` so abort records emitted after the swap go to the live writer
+   * rather than the outgoing session's sealed one (#985).
+   */
+  setTraceWriter(writer: TraceWriter | undefined): void {
+    this.traceWriter = writer;
   }
 
   register(id: string, controller: AbortController): void {

--- a/src/agent/background-registry.ts
+++ b/src/agent/background-registry.ts
@@ -184,7 +184,10 @@ export class BackgroundAgentRegistry extends EventEmitter<BackgroundRegistryEven
    *  test workers (vitest runs files concurrently) don't produce
    *  colliding jobIds that share the same on-disk `bg/` directory. */
   private counter = Math.floor(Math.random() * 65536);
-  private readonly traceWriter: TraceWriter | undefined;
+  // Not readonly: a REPL `/resume` hands this long-lived registry a fresh
+  // writer via `setTraceWriter`, because the outgoing session sealed the one
+  // captured at construction (#731).
+  private traceWriter: TraceWriter | undefined;
   private readonly maxConcurrentJobs: number;
 
   constructor(options: BackgroundRegistryOptions = {}) {
@@ -201,6 +204,19 @@ export class BackgroundAgentRegistry extends EventEmitter<BackgroundRegistryEven
       5000,
     );
     sweepTimer.unref();
+  }
+
+  /**
+   * Re-point the writer this registry emits background-job lifecycle events
+   * into.
+   *
+   * Contract: called (via the bootstrap cascade) on a REPL `/resume`, where
+   * the outgoing session sealed the writer captured at construction. Jobs
+   * already in flight keep emitting into whatever writer they hold; only
+   * events emitted by the registry after this call use `writer` (#731).
+   */
+  setTraceWriter(writer: TraceWriter | undefined): void {
+    this.traceWriter = writer;
   }
 
   /**

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -226,6 +226,7 @@ export class SubagentManager {
    */
   setTraceWriter(writer: TraceWriter | undefined): void {
     this.parentTraceWriter = writer;
+    this.abortGraph.setTraceWriter(writer);
   }
 
   /**

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -114,7 +114,10 @@ export class SubagentManager {
   // manager lifetime. `undefined` value = resolved-and-there-is-none, so the
   // Map's `.has()` distinguishes "not yet resolved" from "resolved to none".
   private readonly worktreeMainRootCache = new Map<string, string | undefined>();
-  private readonly parentTraceWriter: TraceWriter | undefined;
+  // Not readonly: a REPL `/resume` swaps the session out from under this
+  // long-lived manager and hands it a fresh writer via `setTraceWriter`,
+  // because the outgoing session sealed the one captured here (#731).
+  private parentTraceWriter: TraceWriter | undefined;
   private readonly parentSurface: Surface | undefined;
   private readonly abortGraph: AbortGraph;
   private readonly rootId: string;
@@ -208,6 +211,21 @@ export class SubagentManager {
     // the cache (#441). setCwd is rare (born-named worktree creation on turn 1),
     // so forcing one re-resolution on the next fork costs nothing.
     this.worktreeMainRootCache.delete(cwd);
+  }
+
+  /**
+   * Re-point the writer inherited by future forks.
+   *
+   * Contract: mirrors {@link SubagentManager.setCwd} — existing in-flight
+   * children keep the writer they were forked with; only forks dispatched
+   * after this call inherit `writer`. Called (via the bootstrap cascade) on a
+   * REPL `/resume`, where the outgoing session seals the writer this manager
+   * captured at construction; without the re-point, every post-resume fork
+   * would emit its lifecycle events into a sealed writer and be silently
+   * dropped (#731).
+   */
+  setTraceWriter(writer: TraceWriter | undefined): void {
+    this.parentTraceWriter = writer;
   }
 
   /**

--- a/src/agent/tools/compose-executor.ts
+++ b/src/agent/tools/compose-executor.ts
@@ -541,6 +541,15 @@ export class ComposeExecutor {
     this.currentCwd = cwd;
   }
 
+  /**
+   * Re-point the trace writer compose DAG nodes inherit, after a REPL
+   * `/resume` replaced the session that owned the previous writer. Only nodes
+   * dispatched after this call use `writer` (#731).
+   */
+  setTraceWriter(writer: TraceWriter | undefined): void {
+    this.ctx.traceWriter = writer;
+  }
+
   async execute(call: ToolCall): Promise<ToolResult> {
     if (call.signal.aborted) {
       return { content: 'Compose tool call aborted', isError: true };

--- a/src/agent/tools/skill-executor.ts
+++ b/src/agent/tools/skill-executor.ts
@@ -31,6 +31,7 @@ import { buildSkillMaxDepthRefusal } from './skill-depth-message.js';
 import { appendRoutingDecision } from '../routing-telemetry.js';
 import { isTrustedSkill } from '../_lib/trusted-skill-registry.js';
 import { emitTrustedSkillComplete, emitTrustedSkillStart } from '../_lib/trusted-skill-events.js';
+import type { TraceWriter } from '../trace/writer.js';
 import type { SkillExecutorContext, SkillExecutorInternals, SkillInput } from './skill-executor/types.js';
 import { isGateSkill, sessionIdentity, truncateTelemetryString } from './skill-executor/telemetry.js';
 import { executeLoadedPluginSkill, executeLoadedRegistrySkill } from './skill-executor/load-mode.js';
@@ -103,6 +104,15 @@ export class SkillExecutor {
   setCwd(cwd: string): void {
     this.currentCwd = cwd;
     this.pluginBodies = null;
+  }
+
+  /**
+   * Re-point the trace writer skill forks inherit, after a REPL `/resume`
+   * replaced the session that owned the previous writer. Only forks dispatched
+   * after this call use `writer`; in-flight ones keep theirs (#731).
+   */
+  setTraceWriter(writer: TraceWriter | undefined): void {
+    this.ctx.traceWriter = writer;
   }
 
   /**

--- a/src/agent/tools/subagent-executor.ts
+++ b/src/agent/tools/subagent-executor.ts
@@ -314,6 +314,18 @@ export class SubagentExecutor implements SubagentControl {
   }
 
   /**
+   * Re-point the trace writer forked sub-agents inherit, after a REPL
+   * `/resume` replaced the session that owned the previous writer. Mirrors
+   * {@link SubagentExecutor.setCwd}: updates this executor's context AND the
+   * root manager that dispatches depth-1 forks, so the whole `agent`-tool tree
+   * follows the resumed session's live writer instead of the sealed one (#731).
+   */
+  setTraceWriter(writer: TraceWriter | undefined): void {
+    this.ctx.traceWriter = writer;
+    this.ctx.subagentManager.setTraceWriter(writer);
+  }
+
+  /**
    * The `agent` tool definition this executor's owning provider should
    * advertise. With a non-empty named-agent registry, the definition gains
    * the `agent_type` input property and an "Available agent types" listing

--- a/src/agent/trace/factory.ts
+++ b/src/agent/trace/factory.ts
@@ -21,6 +21,7 @@
 
 import { env } from '../../config/env.js';
 import { randomUUID } from 'node:crypto';
+import { readFileSync, existsSync } from 'node:fs';
 import { getTraceDir } from '../../paths.js';
 import { NdjsonTraceWriter, type TraceWriter } from './writer.js';
 
@@ -61,6 +62,26 @@ export interface CreatedTraceWriter {
  * still writes the directory + a `session_sealed` line (the seal goes
  * through the same enqueue path).
  */
+/**
+ * Read the last non-empty line of an NDJSON trace file and return its `seq`
+ * value, or `undefined` when the file is absent, empty, or unparseable.
+ * Synchronous because it runs once per resume before any async work starts.
+ */
+function readLastSeq(tracePath: string): number | undefined {
+  if (!existsSync(tracePath)) return undefined;
+  const content = readFileSync(tracePath, 'utf8');
+  const lines = content.split('\n').filter((l) => l.trim().length > 0);
+  if (lines.length === 0) return undefined;
+  try {
+    const lastLine = lines[lines.length - 1] ?? '';
+    const last = JSON.parse(lastLine) as Record<string, unknown>;
+    const seq = last['seq'];
+    return typeof seq === 'number' ? seq : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export function createDefaultTraceWriter(
   options: CreateDefaultTraceWriterOptions = {},
 ): CreatedTraceWriter | null {
@@ -68,7 +89,12 @@ export function createDefaultTraceWriter(
 
   const sessionLabel = options.sessionLabel ?? randomUUID();
   const traceDir = getTraceDir(sessionLabel);
-  const writer = new NdjsonTraceWriter({ traceDir });
+  const tracePath = `${traceDir}/trace.jsonl`;
+  const lastSeq = readLastSeq(tracePath);
+  const writer = new NdjsonTraceWriter({
+    traceDir,
+    ...(lastSeq !== undefined ? { startSeq: lastSeq + 1 } : {}),
+  });
   return {
     writer,
     tracePath: writer.getTracePath(),

--- a/src/agent/trace/writer.ts
+++ b/src/agent/trace/writer.ts
@@ -87,6 +87,12 @@ export interface TraceWriter {
 export interface NdjsonTraceWriterOptions {
   /** Per-session trace directory. Will be created if absent. */
   traceDir: string;
+  /**
+   * First `seq` value this writer will use. Defaults to 0.
+   * Pass `lastSeq + 1` when resuming an existing trace file so the
+   * new writer's events continue the file's monotonic sequence.
+   */
+  startSeq?: number;
 }
 
 /**
@@ -155,7 +161,7 @@ function ensureExitBackstop(): void {
 export class NdjsonTraceWriter implements TraceWriter {
   private readonly traceDir: string;
   private readonly tracePath: string;
-  private seq = 0;
+  private seq: number;
   private sealed = false;
   /**
    * Invariant (#171): flips to `true` only once a terminal `session_sealed`
@@ -176,6 +182,7 @@ export class NdjsonTraceWriter implements TraceWriter {
   constructor(options: NdjsonTraceWriterOptions) {
     this.traceDir = options.traceDir;
     this.tracePath = join(this.traceDir, 'trace.jsonl');
+    this.seq = options.startSeq ?? 0;
   }
 
   /** Absolute path to the JSONL file this writer appends to. */

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -6,6 +6,8 @@ import { ContextSampler } from '../../context-sampler.js';
 import { ensurePluginEntrypointsLoaded } from '../../../agent/tools/skill-bridge.js';
 import type { ResolvedResumeTarget } from '../../resume-session.js';
 import { emitSessionPhase } from '../../../agent/trace/emit.js';
+import { createDefaultTraceWriter } from '../../../agent/trace/factory.js';
+import type { TraceWriter } from '../../../agent/trace/writer.js';
 import { performResumeSwap, resumeConfigFor } from './resume-swap.js';
 import { resolveBootstrapConfig } from './bootstrap-config.js';
 import { createBootstrapInfra } from './bootstrap-infra.js';
@@ -167,6 +169,23 @@ export async function bootstrapSession(
   // requestResume delegates to performResumeSwap (resume-swap.ts).
   // The sharedDeps + model-precedence resolution lives here; the swap
   // sequence itself is tested independently via the exported function.
+  // Invariant: a REPL `/resume` must hand the incoming session a LIVE writer,
+  // and the swap's own ordering is what makes that mandatory. performResumeSwap
+  // closes the outgoing session (step 5) BEFORE the pointer flip (step 6), and
+  // closing is what seals the writer — so any writer shared with the outgoing
+  // session is already sealed by the time the incoming session is current.
+  // NdjsonTraceWriter.write() throws on a sealed writer and emit.ts swallows the
+  // rejection, so the resumed session's every turn, tool call, and subagent
+  // dispatch would vanish with no error, no warning, and no marker in the trace
+  // (#731). Each built session therefore gets its OWN writer here, and the
+  // long-lived executors/managers — constructed once at bootstrap and never
+  // rebuilt across a swap — are re-pointed at it in `onSwapped`, AFTER the flip
+  // commits. Ordering matters both ways: build-time is too early to cascade
+  // (the swap can still roll back and leave the original session current), and
+  // anywhere after `onSwapped` is too late (the first post-resume fork may
+  // already have been dispatched into the sealed writer).
+  let pendingTraceWriter: TraceWriter | undefined;
+
   const requestResume = (target: ResolvedResumeTarget) => {
     // Clear the trusted-skill ledger so the resumed session starts with a
     // clean slate. The ledger accumulates per-session run statistics
@@ -196,16 +215,39 @@ export async function bootstrapSession(
         // settled just before it may already sit in the notifier's buffer
         // and would otherwise inject into the resumed session's first turn.
         ctx.clearBgResultBuffer?.();
+        // Re-point every long-lived holder of the outgoing (now sealed) writer
+        // at the incoming session's live one. These are built once in
+        // createBootstrapInfra and survive the swap, so without this the
+        // resumed session's own turns would be traced while its `agent` /
+        // skill / compose dispatches silently vanished (#731). Mirrors the
+        // `setCwd` cascade in dispatcher.ts. `undefined` when tracing is
+        // disabled (AFK_TRACE_DISABLED=1), which correctly propagates "no
+        // writer" rather than leaving the sealed one in place.
+        subagentExecutor.setTraceWriter(pendingTraceWriter);
+        skillExecutor.setTraceWriter(pendingTraceWriter);
+        composeExecutor.setTraceWriter(pendingTraceWriter);
+        rootManager.setTraceWriter(pendingTraceWriter);
+        backgroundRegistry.setTraceWriter(pendingTraceWriter);
       },
-      buildSession: (t) => buildAgentSession({
-        ...sharedDeps,
-        model: t.stored?.model ?? sharedDeps.model,
-        resumeConfig: resumeConfigFor(t),
-        // Preserve the LIVE permission mode across a model swap (e.g. the user
-        // toggled /bypass after startup) rather than resetting to the initial
-        // config value carried in sharedDeps.
-        permissionMode: stats.permissionMode,
-      }),
+      buildSession: (t) => {
+        // Resuming session X appends to X's own trace directory, matching how
+        // a launch-time `--resume` labels its writer in createBootstrapInfra.
+        // The label is the witness directory name, not the SDK session id.
+        const resumedLabel = t.stored?.sessionId;
+        pendingTraceWriter = createDefaultTraceWriter(
+          resumedLabel !== undefined ? { sessionLabel: resumedLabel } : {},
+        )?.writer;
+        return buildAgentSession({
+          ...sharedDeps,
+          model: t.stored?.model ?? sharedDeps.model,
+          resumeConfig: resumeConfigFor(t),
+          // Preserve the LIVE permission mode across a model swap (e.g. the user
+          // toggled /bypass after startup) rather than resetting to the initial
+          // config value carried in sharedDeps.
+          permissionMode: stats.permissionMode,
+          traceWriter: pendingTraceWriter,
+        });
+      },
     });
   };
 

--- a/src/cli/commands/interactive/resume-trace-writer.test.ts
+++ b/src/cli/commands/interactive/resume-trace-writer.test.ts
@@ -23,6 +23,7 @@ import { mkdtempSync, rmSync, readFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { NdjsonTraceWriter, type TraceWriter } from '../../../agent/trace/writer.js';
+import { AbortGraph } from '../../../agent/abort-graph.js';
 import { SubagentManager } from '../../../agent/subagent.js';
 import { BackgroundAgentRegistry } from '../../../agent/background-registry.js';
 import { SubagentExecutor } from '../../../agent/tools/subagent-executor.js';
@@ -134,5 +135,63 @@ describe('#731 — setTraceWriter cascade re-points long-lived holders', () => {
     const ctx = { traceWriter: makeWriter('a') as TraceWriter | undefined };
     new ComposeExecutor(ctx as never).setTraceWriter(undefined);
     expect(ctx.traceWriter).toBeUndefined();
+  });
+
+  it('AbortGraph accepts setTraceWriter without throwing', () => {
+    const graph = new AbortGraph(makeWriter('ag-a'));
+    const next = makeWriter('ag-b');
+    expect(() => graph.setTraceWriter(next)).not.toThrow();
+    expect(() => graph.setTraceWriter(undefined)).not.toThrow();
+  });
+
+  it('SubagentManager.setTraceWriter cascades to the abort graph', () => {
+    const setTraceWriter = vi.fn();
+    // Patch AbortGraph's prototype so we can verify the call without
+    // constructing a real subagent runner.
+    const original = AbortGraph.prototype.setTraceWriter;
+    AbortGraph.prototype.setTraceWriter = setTraceWriter;
+    try {
+      const manager = new SubagentManager({ traceWriter: makeWriter('sm-a') });
+      const next = makeWriter('sm-b');
+      manager.setTraceWriter(next);
+      expect(setTraceWriter).toHaveBeenCalledWith(next);
+    } finally {
+      AbortGraph.prototype.setTraceWriter = original;
+    }
+  });
+});
+
+describe('#985 — resumed writer continues seq from where outgoing left off', () => {
+  it('a second NdjsonTraceWriter on the same traceDir with startSeq produces monotonic seq numbers', async () => {
+    const traceDir = join(tmpRoot, 'resumed');
+
+    // First writer — writes two events (seq 0, seq 1), then seals (seq 2).
+    const first = new NdjsonTraceWriter({ traceDir });
+    await first.write(sampleEvent());
+    await first.write(sampleEvent());
+    await first.seal({ reason: 'session_end' });
+
+    // Read the last seq from the sealed file.
+    const lines = readFileSync(join(traceDir, 'trace.jsonl'), 'utf8')
+      .split('\n')
+      .filter((l) => l.trim().length > 0);
+    const lastSeq: number = JSON.parse(lines[lines.length - 1]).seq as number;
+
+    // Second writer — starts at lastSeq + 1.
+    const second = new NdjsonTraceWriter({ traceDir, startSeq: lastSeq + 1 });
+    await second.write(sampleEvent());
+    await second.write(sampleEvent());
+    await second.close();
+
+    // Verify all seq values across the combined file are strictly increasing.
+    const allLines = readFileSync(join(traceDir, 'trace.jsonl'), 'utf8')
+      .split('\n')
+      .filter((l) => l.trim().length > 0);
+    const seqs = allLines.map((l) => (JSON.parse(l) as { seq: number }).seq);
+    for (let i = 1; i < seqs.length; i++) {
+      expect(seqs[i]).toBeGreaterThan(seqs[i - 1]);
+    }
+    // And the second writer's first event directly follows lastSeq.
+    expect(seqs[lines.length]).toBe(lastSeq + 1);
   });
 });

--- a/src/cli/commands/interactive/resume-trace-writer.test.ts
+++ b/src/cli/commands/interactive/resume-trace-writer.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Regression tests for #731 — a REPL `/resume` silently blacking out the
+ * resumed session's witness trace.
+ *
+ * The bug: the REPL allocated ONE TraceWriter for the whole process and
+ * threaded that same instance into the swap-built session. `performResumeSwap`
+ * closes the outgoing session (which seals the writer) BEFORE the pointer flip,
+ * so the incoming session inherited a sealed writer. `write()` throws on a
+ * sealed writer and `emit.ts` swallows the rejection, so every subsequent turn,
+ * tool call, and subagent dispatch vanished with no error and no marker.
+ *
+ * Two properties are covered here, matching the two halves of the fix:
+ *   1. The seam itself, against a REAL NdjsonTraceWriter (not a stub): sealing
+ *      the outgoing writer must not disable the incoming session's own writer.
+ *   2. The `setTraceWriter` cascade: the executors/managers/registry built once
+ *      at bootstrap and never rebuilt across a swap must re-point at the live
+ *      writer, or post-resume `agent` / skill / compose dispatches keep writing
+ *      into the sealed one.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { NdjsonTraceWriter, type TraceWriter } from '../../../agent/trace/writer.js';
+import { SubagentManager } from '../../../agent/subagent.js';
+import { BackgroundAgentRegistry } from '../../../agent/background-registry.js';
+import { SubagentExecutor } from '../../../agent/tools/subagent-executor.js';
+import { SkillExecutor } from '../../../agent/tools/skill-executor.js';
+import { ComposeExecutor } from '../../../agent/tools/compose-executor.js';
+
+let tmpRoot: string;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'afk-731-'));
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+function makeWriter(label: string): NdjsonTraceWriter {
+  return new NdjsonTraceWriter({ traceDir: join(tmpRoot, label) });
+}
+
+/** A minimal `tool_call` event — enough to exercise the write path. */
+function sampleEvent() {
+  return {
+    kind: 'tool_call' as const,
+    payload: {
+      phase: 'started' as const,
+      toolUseId: 'tu-1',
+      name: 'bash',
+      inputBytes: 12,
+    },
+  };
+}
+
+describe('#731 — resumed session gets a live writer, not the sealed one', () => {
+  it('sealing the outgoing writer does NOT disable the incoming session\'s writer', async () => {
+    // The outgoing session owns writer A; the incoming session owns writer B.
+    const outgoing = makeWriter('outgoing');
+    const incoming = makeWriter('incoming');
+
+    await outgoing.write(sampleEvent());
+
+    // performResumeSwap step 5: closing the outgoing session seals ITS writer.
+    await outgoing.seal({ reason: 'session_end' });
+
+    // Pre-fix, incoming === outgoing, so this write threw and was swallowed.
+    await expect(outgoing.write(sampleEvent())).rejects.toThrow(/sealed/);
+    await expect(incoming.write(sampleEvent())).resolves.toBeUndefined();
+
+    // The incoming session's records are actually on disk, in their own file.
+    expect(incoming.getTracePath()).not.toBe(outgoing.getTracePath());
+    expect(existsSync(incoming.getTracePath())).toBe(true);
+    const body = readFileSync(incoming.getTracePath(), 'utf8');
+    expect(body).toContain('"kind":"tool_call"');
+  });
+
+  it('a resumed label writes into that session\'s own witness directory', async () => {
+    // Resuming session X appends to X's directory — mirrors how a launch-time
+    // `--resume` labels its writer in createBootstrapInfra.
+    const resumed = makeWriter('resumed-session-id');
+    await resumed.write(sampleEvent());
+    expect(resumed.getTracePath()).toContain('resumed-session-id');
+  });
+});
+
+describe('#731 — setTraceWriter cascade re-points long-lived holders', () => {
+  it('SubagentManager accepts a new writer for future forks', () => {
+    const manager = new SubagentManager({ traceWriter: makeWriter('a') });
+    const next = makeWriter('b');
+    // Contract: re-pointing never throws and never disturbs in-flight children.
+    expect(() => manager.setTraceWriter(next)).not.toThrow();
+    expect(() => manager.setTraceWriter(undefined)).not.toThrow();
+  });
+
+  it('BackgroundAgentRegistry accepts a new writer', () => {
+    const registry = new BackgroundAgentRegistry({ traceWriter: makeWriter('a') });
+    expect(() => registry.setTraceWriter(makeWriter('b'))).not.toThrow();
+  });
+
+  it('SubagentExecutor re-points its own ctx AND the root manager', () => {
+    const setTraceWriter = vi.fn();
+    const ctx = {
+      subagentManager: { setCwd: vi.fn(), setTraceWriter },
+      traceWriter: makeWriter('a') as TraceWriter | undefined,
+    };
+    const executor = new SubagentExecutor(ctx as never);
+    const next = makeWriter('b');
+
+    executor.setTraceWriter(next);
+
+    // Both halves matter: depth-2+ forks read ctx.traceWriter, depth-1 forks
+    // are dispatched by the root manager.
+    expect(ctx.traceWriter).toBe(next);
+    expect(setTraceWriter).toHaveBeenCalledWith(next);
+  });
+
+  it('SkillExecutor and ComposeExecutor re-point their ctx writer', () => {
+    const skillCtx = { traceWriter: makeWriter('a') as TraceWriter | undefined };
+    const composeCtx = { traceWriter: makeWriter('a') as TraceWriter | undefined };
+    const next = makeWriter('b');
+
+    new SkillExecutor(skillCtx as never).setTraceWriter(next);
+    new ComposeExecutor(composeCtx as never).setTraceWriter(next);
+
+    expect(skillCtx.traceWriter).toBe(next);
+    expect(composeCtx.traceWriter).toBe(next);
+  });
+
+  it('propagates undefined when tracing is disabled rather than keeping the sealed writer', () => {
+    const ctx = { traceWriter: makeWriter('a') as TraceWriter | undefined };
+    new ComposeExecutor(ctx as never).setTraceWriter(undefined);
+    expect(ctx.traceWriter).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem

After a REPL `/resume`, the resumed session writes **zero** records to the witness trace. The trace file ends at the outgoing session's `session_sealed` row, and everything the user does afterwards — every turn, tool call, and subagent dispatch — is silently dropped.

Corroboration from the issue: across **12,252** trace files on disk, `session_sealed` is the last row in **all 4,872** traces that contain it — 0 exceptions. Once a writer seals, nothing is ever recorded again, so there was no path by which the post-`/resume` records could be landing elsewhere.

## Root cause

The REPL allocates one `TraceWriter` for the whole process and threads that same instance into the swap-built session:

- `src/cli/commands/interactive/bootstrap.ts:126` — `traceWriter: trace?.writer` goes into `sharedDeps`
- the `requestResume` `buildSession` closure spreads that same writer into the replacement session

`performResumeSwap` then closes the outgoing session *before* the pointer flip:

- `src/cli/commands/interactive/resume-swap.ts:163` — step 5, `await deps.sessionRef.current.close()` (the outgoing session owns the seal, so this seals the shared writer)
- `resume-swap.ts:168` — step 6, atomic pointer flip to the new session

From step 6 onward the current session holds a **sealed** writer. `NdjsonTraceWriter.write()` throws on a sealed writer (`src/agent/trace/writer.ts:187-189`) and `emit.ts` swallows the rejection, so the loss is completely silent — no warning, no degraded-mode marker, nothing in the trace to indicate records are missing.

### The complication the issue does not mention

Patching only `AgentConfig.traceWriter` is **not** sufficient. `SubagentManager`, `BackgroundAgentRegistry`, and the subagent / skill / compose executors are constructed once in `createBootstrapInfra` / `wireExecutors` and hold the writer in their own fields. They are never rebuilt on resume, so a fresh writer on the session alone would fix the resumed session's own turns while leaving post-resume `agent` / `skill` / `compose` dispatches writing into the sealed writer — the same silent drop, one layer down.

## Fix

**1 — a fresh writer per built session** (`bootstrap.ts`). The resume closure calls `createDefaultTraceWriter()` and passes the result as the new session's `traceWriter`. The writer is labelled with the resumed session's id, so it appends to that session's own witness directory — mirroring how a launch-time `--resume` labels its writer in `createBootstrapInfra`.

**2 — a `setTraceWriter` cascade**, mirroring the existing `setCwd` cascade in `dispatcher.ts`. Added to `SubagentManager`, `BackgroundAgentRegistry`, `SubagentExecutor` (which also re-points the root manager, as its `setCwd` does), `SkillExecutor`, and `ComposeExecutor`. Invoked from `onSwapped`.

### Ordering (recorded as an `// Invariant:` at the site)

The cascade point is not arbitrary — it is pinned on both sides:

- **Build time is too early.** The swap can still roll back (`waitForInitialization` rejects), which would leave the original session current with its executors re-pointed at a writer belonging to a session that was closed.
- **Anything after `onSwapped` is too late.** The first post-resume fork may already have been dispatched into the sealed writer.

`onSwapped` fires after the pointer flip commits, which is the only window satisfying both.

A rollback now also seals only the replacement session's own writer, leaving the survivor's untouched — previously the two were the same object.

## Tradeoff

`/resume` now splits one REPL run across two trace files, so `afk trace show` no longer shows the whole run in one file. This is accepted deliberately: a resume **is** a new session with a new id, so it earns its own trace file (direction 1 in the issue).

Directions 2 and 3 — transfer seal ownership at the pointer flip, or defer the outgoing seal — both require a real ownership-handoff API that **#732** (the `TraceSink` / owner-handle type split) is expected to provide, and the issue notes direction 2 "probably wants to land after that". Building a second runtime gate now is precisely the pattern #732 exists to delete. Direction 2 remains the end state once #732 lands.

I did **not** implement the outgoing→successor breadcrumb: it needs a new `SessionPhaseName` value plus a mirrored Zod enum entry, which is schema surface disproportionate to a nicety, and PR #984 (#754) is concurrently adding a value to that same closed union. Left out rather than silently bundled.

## Testing

```
pnpm lint
# tsc --noEmit clean, both tsconfig.json and tsconfig.web.json

pnpm vitest run src/cli/commands/interactive/resume-trace-writer.test.ts \
  src/cli/commands/interactive/resume-swap.test.ts
# 2 files, 53 tests passed

pnpm vitest run src/agent/subagent.test.ts src/agent/background-registry.test.ts \
  src/agent/tools/subagent-executor.test.ts src/agent/tools/compose-executor.test.ts \
  src/agent/tools/skill-executor.test.ts
# 5 files, 441 tests passed
```

New `src/cli/commands/interactive/resume-trace-writer.test.ts` drives a **real `NdjsonTraceWriter`** against a temp dir — not a stub — so it tests the actual seam:

- sealing the outgoing writer rejects further writes to it, while the incoming writer still accepts them and its records land on disk in a distinct file;
- a resumed label writes into that session's own witness directory;
- all five long-lived holders re-point, including `SubagentExecutor` cascading to the root manager;
- `undefined` propagates when tracing is disabled (`AFK_TRACE_DISABLED=1`) rather than leaving the sealed writer in place.

Did not run `pnpm test:coverage` or the full suite (concurrent sibling worktrees V8-heap-OOM it); CI covers both.

## Reviewer notes

- In-flight children keep the writer they were forked with — the cascade only affects forks dispatched after the swap. That matches `setCwd`'s documented contract and avoids mutating a child mid-run.
- `readonly` was dropped on `SubagentManager.parentTraceWriter` and `BackgroundAgentRegistry.traceWriter`; both now carry a comment naming the resume swap as the reason.

Closes #731
