### PR TITLE
test(trace): cover tool_call conditional spreads through both provider dispatch paths (#633)

### DIFF
--- a/src/agent/providers/anthropic-direct/loop.trace.test.ts
+++ b/src/agent/providers/anthropic-direct/loop.trace.test.ts
@@ -366,6 +366,161 @@ describe('loop.ts runTurn — witness-layer tool_call emission', () => {
       expect('subagentId' in tc.payload).toBe(false);
     }
   });
+
+  // Issue #633: circuitBreaker, failureClass, batchIndex, and batchSize are
+  // conditional spreads in buildToolCallCompletedPayload (providers/shared/
+  // tool-call-trace.ts) that were previously exercised only by the builder's
+  // own isolated unit test — never through a real provider dispatch path.
+  // These three tests drive runTurn end to end so a future edit that drops
+  // one of these spreads at the anthropic-direct call site fails here.
+  it('includes circuitBreaker, failureClass, batchIndex, and batchSize on tool_call.completed when the ToolResult carries them', async () => {
+    const { InMemoryTraceWriter } = await import('../../trace/writer.js');
+    const writer = new InMemoryTraceWriter();
+
+    let callIdx = 0;
+    const streams = [
+      () => fromArray(makeToolUseStream('tu_meta_1', 'search', '{"q":"hello"}')),
+      () => fromArray(makeTextStream('done', 'end_turn')),
+    ];
+    const client: AnthropicClientLike = {
+      messages: {
+        create: vi.fn(() => streams[callIdx++ % streams.length]!()),
+      },
+    };
+    const dispatcher = makeDispatcher(async () => ({
+      content: 'search result',
+      isError: true,
+      circuitBreaker: true,
+      failureClass: 'repeat-failure',
+      batchIndex: 1,
+      batchSize: 3,
+    }));
+
+    await collect(
+      runTurn({
+        client,
+        messages: [{ role: 'user', content: 'search please' }],
+        system: null,
+        tools: [{ name: 'search', input_schema: { type: 'object' } }],
+        toolDispatcher: dispatcher,
+        model: 'claude-test',
+        maxTokens: 1024,
+        headers: {},
+        signal: new AbortController().signal,
+        ctx,
+        traceWriter: writer,
+      }),
+    );
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const toolCalls = writer.events.filter((e) => e.kind === 'tool_call');
+    expect(toolCalls).toHaveLength(2);
+    if (toolCalls[1]?.kind !== 'tool_call' || toolCalls[1].payload.phase !== 'completed') {
+      throw new Error('unreachable');
+    }
+    expect(toolCalls[1].payload.circuitBreaker).toBe(true);
+    expect(toolCalls[1].payload.failureClass).toBe('repeat-failure');
+    expect(toolCalls[1].payload.batchIndex).toBe(1);
+    expect(toolCalls[1].payload.batchSize).toBe(3);
+  });
+
+  it('omits circuitBreaker, failureClass, batchIndex, and batchSize from tool_call.completed when the ToolResult lacks them', async () => {
+    const { InMemoryTraceWriter } = await import('../../trace/writer.js');
+    const writer = new InMemoryTraceWriter();
+
+    let callIdx = 0;
+    const streams = [
+      () => fromArray(makeToolUseStream('tu_meta_2', 'search', '{"q":"hello"}')),
+      () => fromArray(makeTextStream('done', 'end_turn')),
+    ];
+    const client: AnthropicClientLike = {
+      messages: {
+        create: vi.fn(() => streams[callIdx++ % streams.length]!()),
+      },
+    };
+    const dispatcher = makeDispatcher(async () => ({
+      content: 'search result',
+      isError: false,
+    }));
+
+    await collect(
+      runTurn({
+        client,
+        messages: [{ role: 'user', content: 'search please' }],
+        system: null,
+        tools: [{ name: 'search', input_schema: { type: 'object' } }],
+        toolDispatcher: dispatcher,
+        model: 'claude-test',
+        maxTokens: 1024,
+        headers: {},
+        signal: new AbortController().signal,
+        ctx,
+        traceWriter: writer,
+      }),
+    );
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const toolCalls = writer.events.filter((e) => e.kind === 'tool_call');
+    expect(toolCalls).toHaveLength(2);
+    if (toolCalls[1]?.kind !== 'tool_call' || toolCalls[1].payload.phase !== 'completed') {
+      throw new Error('unreachable');
+    }
+    expect('circuitBreaker' in toolCalls[1].payload).toBe(false);
+    expect('failureClass' in toolCalls[1].payload).toBe(false);
+    expect('batchIndex' in toolCalls[1].payload).toBe(false);
+    expect('batchSize' in toolCalls[1].payload).toBe(false);
+  });
+
+  it('omits batchIndex and batchSize from tool_call.completed when only batchIndex is present (both-or-neither guard)', async () => {
+    const { InMemoryTraceWriter } = await import('../../trace/writer.js');
+    const writer = new InMemoryTraceWriter();
+
+    let callIdx = 0;
+    const streams = [
+      () => fromArray(makeToolUseStream('tu_meta_3', 'search', '{"q":"hello"}')),
+      () => fromArray(makeTextStream('done', 'end_turn')),
+    ];
+    const client: AnthropicClientLike = {
+      messages: {
+        create: vi.fn(() => streams[callIdx++ % streams.length]!()),
+      },
+    };
+    const dispatcher = makeDispatcher(async () => ({
+      content: 'search result',
+      isError: false,
+      batchIndex: 2,
+      // batchSize intentionally omitted — the builder requires BOTH to be
+      // numbers before spreading either onto the payload.
+    }));
+
+    await collect(
+      runTurn({
+        client,
+        messages: [{ role: 'user', content: 'search please' }],
+        system: null,
+        tools: [{ name: 'search', input_schema: { type: 'object' } }],
+        toolDispatcher: dispatcher,
+        model: 'claude-test',
+        maxTokens: 1024,
+        headers: {},
+        signal: new AbortController().signal,
+        ctx,
+        traceWriter: writer,
+      }),
+    );
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const toolCalls = writer.events.filter((e) => e.kind === 'tool_call');
+    expect(toolCalls).toHaveLength(2);
+    if (toolCalls[1]?.kind !== 'tool_call' || toolCalls[1].payload.phase !== 'completed') {
+      throw new Error('unreachable');
+    }
+    expect('batchIndex' in toolCalls[1].payload).toBe(false);
+    expect('batchSize' in toolCalls[1].payload).toBe(false);
+  });
 });
 
 describe('loop.ts runTurn — render-only diff sidecar', () => {

--- a/src/agent/providers/openai-compatible/query.test.ts
+++ b/src/agent/providers/openai-compatible/query.test.ts
@@ -3128,6 +3128,134 @@ describe('OpenAICompatibleQuery — witness-layer trace emission', () => {
     expect('subagentId' in completed.payload).toBe(false);
   });
 
+  // Issue #633: circuitBreaker, failureClass, batchIndex, and batchSize are
+  // conditional spreads in buildToolCallCompletedPayload (providers/shared/
+  // tool-call-trace.ts) that were previously exercised only by the builder's
+  // own isolated unit test — never through a real provider dispatch path.
+  // These three tests drive the openai-compatible dispatch path
+  // (query/dispatch-append.ts) end to end so a future edit that drops one of
+  // these spreads at this call site fails here.
+  it('includes circuitBreaker, failureClass, batchIndex, and batchSize on tool_call.completed when the ToolResult carries them', async () => {
+    const { InMemoryTraceWriter } = await import('../../trace/writer.js');
+    const writer = new InMemoryTraceWriter();
+
+    installToolThenTextClient('call_search_meta_1', 'search', '{"q":"hello"}');
+
+    const { dispatcher } = makeDispatcherForPR2();
+    (dispatcher as unknown as { handlers: Map<string, unknown> }).handlers?.set(
+      'search',
+      async () => ({
+        content: 'search result',
+        isError: true,
+        circuitBreaker: true,
+        failureClass: 'repeat-failure',
+        batchIndex: 1,
+        batchSize: 3,
+      }),
+    );
+
+    const q = new OpenAICompatibleQuery({
+      auth: { apiKey: 'sk-test', source: 'env:OPENAI_API_KEY' },
+      model: 'gpt-4o-mini',
+      synthesizedSessionId: 'test-session-meta-1',
+      promptStream: singleInput('search please'),
+      config: { model: 'gpt-4o-mini', apiKey: 'sk-test' } as AgentConfig,
+      toolDispatcher: dispatcher,
+      traceWriter: writer,
+    });
+
+    await collect(q);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const toolCallEvents = writer.events.filter((e) => e.kind === 'tool_call');
+    expect(toolCallEvents).toHaveLength(2);
+    const completed = toolCallEvents[1];
+    if (completed?.kind !== 'tool_call' || completed.payload.phase !== 'completed') {
+      throw new Error('unreachable');
+    }
+    expect(completed.payload.circuitBreaker).toBe(true);
+    expect(completed.payload.failureClass).toBe('repeat-failure');
+    expect(completed.payload.batchIndex).toBe(1);
+    expect(completed.payload.batchSize).toBe(3);
+  });
+
+  it('omits circuitBreaker, failureClass, batchIndex, and batchSize from tool_call.completed when the ToolResult lacks them', async () => {
+    const { InMemoryTraceWriter } = await import('../../trace/writer.js');
+    const writer = new InMemoryTraceWriter();
+
+    installToolThenTextClient('call_search_meta_2', 'search', '{"q":"hello"}');
+
+    const { dispatcher } = makeDispatcherForPR2();
+    (dispatcher as unknown as { handlers: Map<string, unknown> }).handlers?.set(
+      'search',
+      async () => ({ content: 'search result' }),
+    );
+
+    const q = new OpenAICompatibleQuery({
+      auth: { apiKey: 'sk-test', source: 'env:OPENAI_API_KEY' },
+      model: 'gpt-4o-mini',
+      synthesizedSessionId: 'test-session-meta-2',
+      promptStream: singleInput('search please'),
+      config: { model: 'gpt-4o-mini', apiKey: 'sk-test' } as AgentConfig,
+      toolDispatcher: dispatcher,
+      traceWriter: writer,
+    });
+
+    await collect(q);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const toolCallEvents = writer.events.filter((e) => e.kind === 'tool_call');
+    expect(toolCallEvents).toHaveLength(2);
+    const completed = toolCallEvents[1];
+    if (completed?.kind !== 'tool_call' || completed.payload.phase !== 'completed') {
+      throw new Error('unreachable');
+    }
+    expect('circuitBreaker' in completed.payload).toBe(false);
+    expect('failureClass' in completed.payload).toBe(false);
+    expect('batchIndex' in completed.payload).toBe(false);
+    expect('batchSize' in completed.payload).toBe(false);
+  });
+
+  it('omits batchIndex and batchSize from tool_call.completed when only batchIndex is present (both-or-neither guard)', async () => {
+    const { InMemoryTraceWriter } = await import('../../trace/writer.js');
+    const writer = new InMemoryTraceWriter();
+
+    installToolThenTextClient('call_search_meta_3', 'search', '{"q":"hello"}');
+
+    const { dispatcher } = makeDispatcherForPR2();
+    (dispatcher as unknown as { handlers: Map<string, unknown> }).handlers?.set(
+      'search',
+      async () => ({
+        content: 'search result',
+        batchIndex: 2,
+        // batchSize intentionally omitted — the builder requires BOTH to be
+        // numbers before spreading either onto the payload.
+      }),
+    );
+
+    const q = new OpenAICompatibleQuery({
+      auth: { apiKey: 'sk-test', source: 'env:OPENAI_API_KEY' },
+      model: 'gpt-4o-mini',
+      synthesizedSessionId: 'test-session-meta-3',
+      promptStream: singleInput('search please'),
+      config: { model: 'gpt-4o-mini', apiKey: 'sk-test' } as AgentConfig,
+      toolDispatcher: dispatcher,
+      traceWriter: writer,
+    });
+
+    await collect(q);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const toolCallEvents = writer.events.filter((e) => e.kind === 'tool_call');
+    expect(toolCallEvents).toHaveLength(2);
+    const completed = toolCallEvents[1];
+    if (completed?.kind !== 'tool_call' || completed.payload.phase !== 'completed') {
+      throw new Error('unreachable');
+    }
+    expect('batchIndex' in completed.payload).toBe(false);
+    expect('batchSize' in completed.payload).toBe(false);
+  });
+
   // Issue #612: when the query runs inside a forked child, `config.subagentId`
   // is set at the fork site (subagent.ts) and must flow onto every tool_call
   // trace event so the child's work is attributable in the shared parent trace.


### PR DESCRIPTION
## Summary

Test-coverage-only change. Closes #633.

`buildToolCallCompletedPayload` (`src/agent/providers/shared/tool-call-trace.ts:89-92`) carries three conditional spreads — `circuitBreaker` (only when `=== true`), `failureClass` (only when truthy), and `batchIndex`+`batchSize` (only when BOTH are numbers). Before this PR they were exercised only by the builder's own isolated unit test, never through either provider's real dispatch path — a future edit that dropped one of these fields at a dispatch call site would still pass the suite.

Added three tests to **each** provider's trace-emission test file, driving the real dispatch path end to end (never calling `buildToolCallCompletedPayload` directly):

1. **Positive case** — dispatcher returns a `ToolResult` with `circuitBreaker: true`, `failureClass: 'repeat-failure'`, `batchIndex: 1`, `batchSize: 3`; asserts the emitted `tool_call` `completed` payload carries all four.
2. **Negative case** — `ToolResult` lacks all of them; asserts each key is absent (`'key' in payload === false`), not just falsy.
3. **Guard case** — `batchIndex` present without `batchSize`; asserts neither key appears on the payload, matching the builder's `typeof result.batchIndex === 'number' && typeof result.batchSize === 'number'` guard.

Files touched:
- `src/agent/providers/anthropic-direct/loop.trace.test.ts` — 3 new tests added to the existing `'loop.ts runTurn — witness-layer tool_call emission'` describe block, following the file's own established convention (`makeDispatcher` + scripted tool-use/text stream + `runTurn` + drain microtasks + filter `writer.events` for `kind === 'tool_call'`).
- `src/agent/providers/openai-compatible/query.test.ts` — 3 new tests added to the `'OpenAICompatibleQuery — witness-layer trace emission'` describe block, following the file's own convention (`installToolThenTextClient` + `makeDispatcherForPR2()` + overriding the handler map via `dispatcher.handlers?.set(...)`).

No production code changed — see mutation-check result below for why this is not just a green-by-construction test.

Both test files already exceed the repo's 350-LOC guideline (now 703 lines and 3549 lines respectively) — pre-existing before this PR, not something this change set out to fix. Flagging per the issue's instruction rather than refactoring them.

## How was this tested?

**Mutation check (required by the issue):** Temporarily changed line 89 of `tool-call-trace.ts` from
```ts
...(result.circuitBreaker === true ? { circuitBreaker: true } : {}),
```
to
```ts
...(false ? { circuitBreaker: true } : {}),
```
Re-ran both touched test files — the new **positive-case** test in each file went RED (`expected undefined to be true` on `payload.circuitBreaker`), while all other tests (12/13 and 99/100) stayed green. Reverted the one-line change; `git diff` / `git status` on `tool-call-trace.ts` confirmed a byte-for-byte clean revert (no diff, not in `git status`, not part of the committed diff). Re-ran both files again — full green. This confirms the new tests actually exercise the conditional spread through the real dispatch path rather than passing unconditionally.

**Lint:**
```
pnpm lint
> tsc --noEmit && tsc --noEmit -p tsconfig.web.json
```
Clean, no errors.

**Targeted test runs (only the two touched files, per issue instructions — full suite not run):**
```
pnpm test src/agent/providers/anthropic-direct/loop.trace.test.ts
 ✓ 13 tests passed (10 pre-existing + 3 new)

pnpm test src/agent/providers/openai-compatible/query.test.ts
 ✓ 100 tests passed (97 pre-existing + 3 new)
```

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes (both touched files; full suite intentionally not run per issue scope)
- [x] Commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/) — see [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] No secrets, tokens, or private paths in the diff
