### PR TITLE
feat(models): make claude-sonnet-4-6 the default sonnet model (+ correct its 1M/128k limits)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ afk chat "refactor this" --model gpt-5.5
 |---|---|---|
 | `local` | *(empty — you configure)* | Point at Ollama, LM Studio, or any OpenAI-compatible shim via `AFK_MODEL_LOCAL` + `AFK_MODEL_LOCAL_BASE_URL` |
 | `small` | `claude-haiku-4-5-20251001` | Cheapest/fastest Anthropic tier |
-| `medium` | `claude-sonnet-5` | General-use default |
+| `medium` | `claude-sonnet-4-6` | General-use default |
 | `large` | `claude-opus-5` | Most capable |
 
 The `haiku`/`sonnet`/`opus`/`fable` handles are **fixed identities**, not tier

--- a/docs/model-slots.md
+++ b/docs/model-slots.md
@@ -87,7 +87,7 @@ An unconfigured install behaves exactly as before this feature:
 | -------- | ------------------------------- | ------------------------- |
 | `local`  | `` (empty — user-configured)    | —                         |
 | `small`  | `claude-haiku-4-5-20251001`     | `haiku`                   |
-| `medium` | `claude-sonnet-5`             | `sonnet`, `sonnet_1m`     |
+| `medium` | `claude-sonnet-4-6`          | `sonnet`, `sonnet_1m`     |
 | `large`  | `claude-opus-5`                 | `opus`, `opus_1m`         |
 
 ## Identity aliases vs. capability tiers

--- a/src/agent/model-limits.test.ts
+++ b/src/agent/model-limits.test.ts
@@ -201,33 +201,47 @@ describe('maxOutputTokensFor — retired-but-Active Opus pin', () => {
 
 describe('claude-sonnet-4-6 — explicit limit pins (A/B baseline vs claude-sonnet-5)', () => {
   // Invariant: 4.6 is not a first-class alias but IS reachable by raw wire id and
-  // already priced (providers/anthropic-direct/pricing.ts). Both values below
-  // equal the fallbacks they replace, so these tests pin INTENT, not a behaviour
-  // change: they fail if someone edits DEFAULT_MAX_OUTPUT / DEFAULT_CONTEXT_LIMIT
-  // or "upgrades" 4.6 to Sonnet 5's 1M window, either of which would silently
-  // invalidate a 4.6-vs-5 A/B comparison.
-  it('pins the 64k output ceiling (first-party: the Sonnet 5 entry says "up from 64k on Sonnet 4.6")', () => {
-    expect(maxOutputTokensFor('claude-sonnet-4-6')).toBe(64_000);
-    // Contrast: the Sonnet 5 sibling is double. An A/B that silently gave 4.6
-    // Sonnet 5's ceiling would compare two different output budgets.
+  // already priced (providers/anthropic-direct/pricing.ts). Both pins below now
+  // DIFFER from the fallbacks they replace, so they guard real behaviour: 4.6
+  // shares Sonnet 5's 1M window and 128k output ceiling, and inheriting either
+  // fallback (200k context / 64k output) would under-report a live capability.
+  it('pins the 128k output ceiling — the same as Sonnet 5, not half of it', () => {
+    // First-party: migration guide, 4.6 → 5 — "128k max output tokens
+    // (unchanged): Claude Sonnet 5 supports up to 128k output tokens, the same as
+    // Claude Sonnet 4.6." A prior revision read Sonnet 5's "up from 64k on Sonnet
+    // 4.6" comment as first-party and pinned 64k; that comment was itself wrong.
+    expect(maxOutputTokensFor('claude-sonnet-4-6')).toBe(128_000);
     expect(maxOutputTokensFor('claude-sonnet-5')).toBe(128_000);
+    // Guard the specific regression: 4.6 must not silently inherit the 64k
+    // DEFAULT_MAX_OUTPUT fallback.
+    expect(maxOutputTokensFor('claude-sonnet-4-6')).not.toBe(64_000);
   });
 
-  it('pins the 200k context window — NOT Sonnet 5 1M (this repo sends no 1M beta header)', () => {
-    // 1M on the 4.x line requires a `context-1m` beta this codebase never sends:
-    // composeBetaHeader (providers/anthropic-direct/beta-headers.ts) emits a
-    // closed set (OAuth, effort, extended-cache-ttl, fast-mode). Over-reporting
-    // here would suppress auto-compaction and cause hard API errors mid-run.
-    expect(contextLimitFor('claude-sonnet-4-6')).toBe(200_000);
+  it('pins the native 1M context window — GA, no `context-1m` beta header needed', () => {
+    // A prior revision pinned 200k, reasoning that 1M on the 4.x line required a
+    // `context-1m` beta this repo never sends. Stale: 1M is GA and per Anthropic
+    // "you don't need a beta header" for any model with a 1M window — and Sonnet
+    // 4.6 is named in that list. No beta entry was added to composeBetaHeader for
+    // this, because none is required.
+    expect(contextLimitFor('claude-sonnet-4-6')).toBe(1_000_000);
     expect(contextLimitFor('claude-sonnet-5')).toBe(1_000_000);
   });
 
-  it('takes NO auto-compact budget entry: 200k is its real window, not a cap (haiku precedent)', () => {
-    // MODEL_AUTOCOMPACT_BUDGET exists to cap a 1M window down to a 200k working
-    // budget. 4.6's window IS 200k, so an entry would be Math.min(200k, 200k) —
-    // a no-op that falsely implies a larger window is being throttled. Same
-    // reasoning as haiku above, which is deliberately absent from the table.
+  it('takes the same 200k auto-compact budget as its Sonnet 5 sibling', () => {
+    // Now that the window is truthfully 1M, the budget entry does real work:
+    // Math.min(1M, 200k) bounds cost/latency on a long raw-wire-id session while
+    // the status line still reports the true 1M window.
     expect(autoCompactLimitFor('claude-sonnet-4-6')).toBe(200_000);
-    expect(autoCompactLimitFor('claude-sonnet-4-6')).toBe(contextLimitFor('claude-sonnet-4-6'));
+    expect(autoCompactLimitFor('claude-sonnet-5')).toBe(200_000);
+    // The budget is a policy cap, NOT the window — they must now diverge.
+    expect(autoCompactLimitFor('claude-sonnet-4-6')).not.toBe(
+      contextLimitFor('claude-sonnet-4-6'),
+    );
+  });
+
+  it('the explicit `_1m` opt-in still bypasses the budget for a 4.6 session', () => {
+    // `sonnet_1m` short-circuits on the literal suffix BEFORE wire-id resolution,
+    // so the opt-out survives regardless of which id the sonnet family points at.
+    expect(autoCompactLimitFor('sonnet_1m')).toBe(1_000_000);
   });
 });

--- a/src/agent/model-limits.ts
+++ b/src/agent/model-limits.ts
@@ -42,17 +42,19 @@ export const MODEL_MAX_OUTPUT_TOKENS: Record<string, number> = {
   // DEFAULT_MAX_OUTPUT fallback. (Alias lineage, for git blame: 'claude-opus-4-6'
   // → 4-7 on 2026-04, 4-7 → 4-8 on 2026-05-28, 4-8 → opus-5 on 2026-07-24.)
   'claude-opus-4-8': 128_000,
-  // Claude Sonnet 5 (GA 2026-06): 128k max output (up from 64k on Sonnet 4.6).
+  // Claude Sonnet 5 (GA 2026-06): 128k max output — the SAME ceiling as Sonnet
+  // 4.6, not an increase over it.
   'claude-sonnet-5': 128_000,
-  // 'claude-sonnet-4-6' is not a first-class alias (MODEL_MAP.sonnet resolves to
-  // claude-sonnet-5) but stays reachable by its raw wire id (`--model
-  // claude-sonnet-4-6`, a config or env override) and is already priced in
-  // providers/anthropic-direct/pricing.ts. 64k is first-party per the Sonnet 5
-  // entry above — "up from 64k on Sonnet 4.6". That equals DEFAULT_MAX_OUTPUT,
-  // so this pin is a runtime no-op today; its value is making the number
-  // intentional and test-pinned rather than an accident of the fallback, so a
-  // future change to DEFAULT_MAX_OUTPUT cannot silently move 4.6's ceiling.
-  'claude-sonnet-4-6': 64_000,
+  // Claude Sonnet 4.6: 128k max output. Not a first-class alias (MODEL_MAP.sonnet
+  // resolves to claude-sonnet-5) but reachable by its raw wire id (`--model
+  // claude-sonnet-4-6`, a config or env override) and already priced in
+  // providers/anthropic-direct/pricing.ts. First-party source — the migration
+  // guide's 4.6 → 5 section: "128k max output tokens (unchanged): Claude Sonnet 5
+  // supports up to 128k output tokens, the same as Claude Sonnet 4.6."
+  // <https://platform.claude.com/docs/en/about-claude/models/migration-guide>
+  // Unlike the previous 64k value, this pin is NOT a runtime no-op: it doubles
+  // the DEFAULT_MAX_OUTPUT (64k) fallback 4.6 would otherwise inherit.
+  'claude-sonnet-4-6': 128_000,
   'claude-haiku-4-5-20251001': 64_000,
   // Claude Fable 5 (Mythos-class, GA 2026-06-09): 128k max output.
   'claude-fable-5': 128_000,
@@ -143,18 +145,18 @@ export const MODEL_CONTEXT_LIMITS: Record<string, number> = {
   // Claude Opus 5 (GA 2026-07-24): native 1M window. Base `opus` still
   // auto-compacts early via MODEL_AUTOCOMPACT_BUDGET (cost/latency policy).
   'claude-opus-5': 1_000_000,
-  // Claude Sonnet 4.6: 200k. Deliberately NOT 1M — the native-1M/"no smaller
-  // variant" claim above is specific to Sonnet 5. The 4.x line served 200k by
-  // default with 1M only behind a `context-1m` beta header, and this repo never
-  // sends one: composeBetaHeader (providers/anthropic-direct/beta-headers.ts)
-  // emits a closed set — OAuth entries, effort, extended-cache TTL, fast-mode —
-  // and no 1M beta string exists anywhere in src/. So 200k is correct BY
-  // CONSTRUCTION for every request this codebase can issue, regardless of what
-  // the API might serve behind a header we do not send. This equals the
-  // Anthropic DEFAULT_CONTEXT_LIMIT fallback, so the pin is a no-op today; it
-  // guards the asymmetry — under-reporting only compacts early, over-reporting
-  // suppresses compaction and yields hard API errors mid-run.
-  'claude-sonnet-4-6': 200_000,
+  // Claude Sonnet 4.6: native 1M window, GA — no beta header required. An earlier
+  // revision pinned this at 200k on the premise that the 4.x line gated 1M behind
+  // a `context-1m` beta this repo never sends. That premise was stale: 1M is now
+  // generally available, and per Anthropic "For every model with a 1M-token
+  // context window, 1M is the default: you don't need a beta header, and
+  // long-context requests are billed at standard pricing."
+  // <https://platform.claude.com/docs/en/build-with-claude/context-windows>
+  // That page names Sonnet 4.6 in the 1M list; the launch post's "1M in beta"
+  // wording predates GA and is what the stale pin was derived from. Cost/latency
+  // throttling of the base alias belongs in MODEL_AUTOCOMPACT_BUDGET below — this
+  // table stays truthful about the wire capability.
+  'claude-sonnet-4-6': 1_000_000,
   // OpenAI flagship + cost-tier models (windows per OpenAI platform docs
   // as of 2026-Q1). Listed here so the openai-compatible provider's
   // getContextUsage() returns an accurate percentage instead of the
@@ -264,6 +266,12 @@ const MODEL_AUTOCOMPACT_BUDGET: Record<string, number> = {
   // long base-`opus` sessions. `opus_1m` bypasses this via the `_1m`
   // short-circuit in autoCompactLimitFor.
   'claude-opus-5': 200_000,
+  // Sonnet 4.6 also ships a native 1M window (see MODEL_CONTEXT_LIMITS), so it
+  // takes the same 200k working budget as its Sonnet 5 sibling: a raw
+  // `claude-sonnet-4-6` session reports the truthful 1M window on the status line
+  // while keeping the same cost/latency-bounded compaction trigger. `sonnet_1m`
+  // bypasses this via the `_1m` short-circuit in autoCompactLimitFor.
+  'claude-sonnet-4-6': 200_000,
 };
 
 /**

--- a/src/agent/providers/anthropic-direct/oneshot.test.ts
+++ b/src/agent/providers/anthropic-direct/oneshot.test.ts
@@ -235,7 +235,7 @@ describe('oneShotCompletion (T21 + T22)', () => {
   it('(T22b) resolves all canonical short aliases (opus/sonnet/haiku)', async () => {
     const cases: Array<[string, string]> = [
       ['opus', 'claude-opus-5'],
-      ['sonnet', 'claude-sonnet-5'],
+      ['sonnet', 'claude-sonnet-4-6'],
       ['haiku', 'claude-haiku-4-5-20251001'],
     ];
     for (const [alias, fullId] of cases) {

--- a/src/agent/providers/anthropic-direct/provider-runtime.ts
+++ b/src/agent/providers/anthropic-direct/provider-runtime.ts
@@ -67,7 +67,10 @@ import { buildProviderQuery } from './provider-query-build.js';
 export { resolveUserSystem } from './provider-query-setup.js';
 
 const PROVIDER_NAME = 'anthropic-direct';
-const DEFAULT_MODEL = 'claude-sonnet-5';
+// Keep in sync with CLAUDE_SONNET_ID (session/model-slots.ts) — the fallback for
+// a query that arrives with no model should match what the `sonnet` alias and the
+// `medium` tier resolve to.
+const DEFAULT_MODEL = 'claude-sonnet-4-6';
 
 /**
  * Direct Anthropic SDK provider. Construction is cheap; the real per-session

--- a/src/agent/providers/anthropic-direct/query-options.ts
+++ b/src/agent/providers/anthropic-direct/query-options.ts
@@ -25,9 +25,14 @@ import type { HookRegistry } from '../../hooks.js';
  */
 const STARTER_MODELS: ReadonlyArray<{ value: string; displayName: string; description: string }> = [
   {
+    value: 'claude-sonnet-4-6',
+    displayName: 'Claude Sonnet 4.6',
+    description: 'Balanced Claude — recommended default (1M context, 128k output)',
+  },
+  {
     value: 'claude-sonnet-5',
     displayName: 'Claude Sonnet 5',
-    description: 'Latest balanced Claude — recommended default',
+    description: 'Newer balanced Claude — adaptive thinking, new tokenizer',
   },
   {
     value: 'claude-opus-5',

--- a/src/agent/session/model-slots.ts
+++ b/src/agent/session/model-slots.ts
@@ -92,7 +92,15 @@ export type ModelSlots = Record<SlotName, ModelSlotBinding>;
  * identity handles) so a tier default and its namesake alias can never drift.
  */
 export const CLAUDE_HAIKU_ID = 'claude-haiku-4-5-20251001';
-export const CLAUDE_SONNET_ID = 'claude-sonnet-5';
+// Claude Sonnet 4.6 — the `sonnet`/`sonnet_1m` aliases and the `medium` tier
+// default all follow this constant. Deliberately NOT Sonnet 5: 4.6 is the better
+// fit for this harness's agentic + subagent workloads, and its tokenizer packs
+// ~30% more text into the same window (Sonnet 5's tokenizer emits ~30% more
+// tokens for identical input, so its 1M holds proportionally less). Both models
+// are 1M context / 128k output (see model-limits.ts), so this is a lateral move
+// in capability, not a downgrade. To go back to Sonnet 5, revert this one line
+// plus the matching provider-runtime.ts DEFAULT_MODEL and STARTER_MODELS entries.
+export const CLAUDE_SONNET_ID = 'claude-sonnet-4-6';
 // Claude Opus 5 (GA 2026-07-24) — dateless wire id, itself a pinned snapshot
 // (post-4.6 naming convention). Bumped from claude-opus-4-8; the `opus`/`opus_1m`
 // aliases and the `large` tier default follow this constant. To roll back to 4.8,

--- a/src/cli/commands/trace.test.ts
+++ b/src/cli/commands/trace.test.ts
@@ -401,9 +401,9 @@ describe('formatTrace — root model provenance header', () => {
     const out = formatTrace(
       's',
       '/p',
-      parseTrace(toJsonl([initStart('sonnet', 'claude-sonnet-5'), seal])),
+      parseTrace(toJsonl([initStart('sonnet', 'claude-sonnet-4-6'), seal])),
     );
-    expect(out).toContain('Model  sonnet → claude-sonnet-5');
+    expect(out).toContain('Model  sonnet → claude-sonnet-4-6');
   });
 
   it('renders the model once (no arrow) when alias === resolved (raw passthrough)', () => {
@@ -422,7 +422,7 @@ describe('formatTrace — root model provenance header', () => {
     const out = formatTrace(
       's',
       '/p',
-      parseTrace(toJsonl([initStart('sonnet', 'claude-sonnet-5'), seal])),
+      parseTrace(toJsonl([initStart('sonnet', 'claude-sonnet-4-6'), seal])),
       { showAll: true },
     );
     expect(out).toMatch(/session_init_start.*sonnet/);

--- a/src/cli/config.test.ts
+++ b/src/cli/config.test.ts
@@ -105,8 +105,8 @@ describe('Config Loader', () => {
     it('should return correct model IDs', () => {
       expect(getModelId('opus')).toBe('claude-opus-5');
       expect(getModelId('opus_1m')).toBe('claude-opus-5');
-      expect(getModelId('sonnet')).toBe('claude-sonnet-5');
-      expect(getModelId('sonnet_1m')).toBe('claude-sonnet-5');
+      expect(getModelId('sonnet')).toBe('claude-sonnet-4-6');
+      expect(getModelId('sonnet_1m')).toBe('claude-sonnet-4-6');
       expect(getModelId('haiku')).toBe('claude-haiku-4-5-20251001');
       expect(getModelId('fable')).toBe('claude-fable-5');
     });

--- a/website/content/docs/configuration/model-slots.mdx
+++ b/website/content/docs/configuration/model-slots.mdx
@@ -18,7 +18,7 @@ An unconfigured install uses these defaults:
 |------|-----------------|----------------|
 | `local` | _(unset — configure via `AFK_MODEL_LOCAL`)_ | — |
 | `small` | `claude-haiku-4-5-20251001` | `haiku` |
-| `medium` | `claude-sonnet-5` | `sonnet`, `sonnet_1m` |
+| `medium` | `claude-sonnet-4-6` | `sonnet`, `sonnet_1m` |
 | `large` | `claude-opus-5` | `opus`, `opus_1m` |
 
 **Note:** These default model IDs reflect the latest available models as of this writing. As new versions ship, these defaults are updated in the codebase (`src/agent/session/model-slots.ts`). You can override any slot via environment variables (`AFK_MODEL_SMALL`, `AFK_MODEL_MEDIUM`, `AFK_MODEL_LARGE`) or `afk.config.json` — see [Configuring slots](/docs/configuration/model-slots#configuring-slots-in-afkconfigjson) for details.

--- a/website/content/docs/configuration/overview.mdx
+++ b/website/content/docs/configuration/overview.mdx
@@ -144,7 +144,7 @@ an object with optional provider credentials.
 {
   "models": {
     "small": "claude-haiku-4-5-20251001",
-    "medium": "claude-sonnet-5",
+    "medium": "claude-sonnet-4-6",
     "large": {
       "id": "claude-opus-5",
       "name": "big",


### PR DESCRIPTION
Makes `claude-sonnet-4-6` the default Sonnet model, and corrects the two limit pins that had to be fixed first for that to be safe.

Two commits, reviewable independently:

1. **`59e1ccb5`** — `fix(model-limits)`: correct 4.6's context window and output ceiling.
2. **`1998922f`** — `feat(models)`: point `sonnet` / `sonnet_1m` / `medium` at 4.6.

Commit 1 is a genuine prerequisite: with 4.6 still pinned at 200k, flipping the constant would have made `contextLimitFor('sonnet')` report 200k and broken the alias's own regression test.

## Commit 1 — the limit pins were wrong

| | before | after |
|---|---|---|
| context window | `200_000` | `1_000_000` |
| max output | `64_000` | `128_000` |

**The 1M window is GA and needs no beta header.** The 200k pin was defended by a comment arguing 1M on the 4.x line sits behind a `context-1m` beta this repo never sends, so 200k was "correct BY CONSTRUCTION." The construction argument was sound; its premise was stale. Per [Anthropic's context-windows doc](https://platform.claude.com/docs/en/build-with-claude/context-windows), which names Sonnet 4.6 in the 1M list:

> For every model with a 1M-token context window, 1M is the default: you don't need a beta header, and long-context requests are billed at standard pricing.

The `anthropic.com` launch post still says "1M token context window in beta" — that predates GA and is the likely origin of the pin. **No entry was added to `composeBetaHeader`, because none is required.**

**128k output, not 64k.** The 64k pin was inferred from the `claude-sonnet-5` entry's own comment, "128k max output (up from 64k on Sonnet 4.6)" — which was itself wrong. Per the [migration guide](https://platform.claude.com/docs/en/about-claude/models/migration-guide):

> **128k max output tokens (unchanged):** Claude Sonnet 5 supports up to 128k output tokens, the same as Claude Sonnet 4.6.

The misleading Sonnet 5 comment is corrected in the same commit so the bad inference is not re-derivable. A `MODEL_AUTOCOMPACT_BUDGET` entry (200k) is added for 4.6, matching the policy already applied to `claude-sonnet-5` and `claude-opus-5` — now that the window is truthfully 1M, that entry does real work.

## Commit 2 — 4.6 becomes the default Sonnet

```
/model sonnet    -> claude-sonnet-4-6   ctx=1,000,000  compactAt=  200,000  maxOut=128,000
/model sonnet_1m -> claude-sonnet-4-6   ctx=1,000,000  compactAt=1,000,000  maxOut=128,000
/model medium    -> claude-sonnet-4-6   ctx=1,000,000  compactAt=  200,000  maxOut=128,000
/model opus      -> claude-opus-5       (unchanged)
/model haiku     -> claude-haiku-4-5-20251001 (unchanged)
```

`sonnet_1m` keeps its distinct meaning: same wire model, but the `_1m` suffix bypasses the 200k working budget for the full 1M window.

**Why a code change rather than config:** `sonnet` and `sonnet_1m` are `DIRECT_MODEL_ALIASES` entries, deliberately *not* rebindable by slot config — `models.medium` / `AFK_MODEL_MEDIUM` only move the capability tiers. Every subagent dispatched with `model: 'sonnet'` (research-agent, git-investigator, compose nodes) tracks this constant and nothing else, so flipping it is the only mechanism that retargets them.

**Capability is lateral, not a downgrade:** after commit 1, both models are 1M context / 128k output. Sonnet 5's tokenizer emits ~30% more tokens for identical input, so 4.6's 1M window holds proportionally more real text.

**Cost:** 4.6 is $3/$15 per MTok; Sonnet 5 is on introductory $2/$10 **through 2026-08-31**, then $3/$15. So this is ~50% more per token for the remainder of August — but only ~15% per equivalent content once the tokenizer difference is accounted for, and at parity from September 1.

**Thinking routing is deliberately untouched.** `requiresAdaptiveThinking` matches `(opus|sonnet)-5`, not `-4-6`, so a 4.6 session uses manual extended thinking (`{type:'enabled'}`) rather than adaptive. Not a break — 4.6 accepts manual extended thinking; the 400 error only appears going 4.6 → 5 — and it reproduces the behaviour this repo had before `da492d45` flipped the default the other way.

`AFK_MODEL_MEDIUM`'s registry example stays `claude-sonnet-5`: still a valid id, and it now illustrates binding the tier to something other than the default, which avoids regenerating the CI-gated `docs/env-registry.{json,md}` pair for a cosmetic string.

## Verification

- `pnpm lint` clean (`tsc --noEmit`, both projects).
- Full suite: **15971 passed**, 1 failure in `write-denylist.test.ts` (a `/tmp` symlink `rmSync` case) that is **pre-existing and unrelated** — it fails identically with this branch stashed, and that file does not import `model-limits`. Test count is unchanged across the flip, i.e. zero regressions.
- All five audit gates pass: `audit:sdk:check`, `audit:env:check`, `scan:env:check`, `audit:chalk:check`, `fix:pins:check`.
- Resolution table above produced by executing the real resolver, not by reading the constants.

## Deliberately out of scope

`pricing.ts` lists `claude-sonnet-5` at $3/$15, but its introductory rate is $2/$10 until 2026-08-31 — so AFK currently over-reports Sonnet 5 spend by ~50%. Unrelated to this diff; worth its own issue.
