### PR TITLE
feat(hooks): two-tier OBSERVE/BLOCK split in safe-destruct PreToolUse detector

### DIFF
--- a/src/agent/safe-destruct-detect.test.ts
+++ b/src/agent/safe-destruct-detect.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for the two-tier safe-destruct detector.
  *
- * Four contracts:
+ * Five contracts:
  *   1. `detectDestructiveCommands` matches every curated pattern and does NOT
  *      flag common-but-safe near-misses.
  *   2. OBSERVE patterns return `decision: 'approve'` (never block).
@@ -65,6 +65,10 @@ describe('detectDestructiveCommands', () => {
     ['git clean --force -x', 'git-clean-force'],
     ['git push --force origin main', 'git-push-force'],
     ['git push -f', 'git-push-force'],
+    ['git -C /tmp/repo reset --hard HEAD', 'git-reset-hard'],
+    ['git --work-tree=/tmp/w reset --hard', 'git-reset-hard'],
+    ['git -C /other push --force origin main', 'git-push-force'],
+    ['git --git-dir=.git clean -fd', 'git-clean-force'],
     ['dd if=/x.img of=/dev/sda bs=1M', 'dd-to-device'],
     ['mkfs.ext4 /dev/sdb1', 'mkfs'],
     ['echo boot > /dev/sda', 'redirect-to-block-device'],
@@ -87,6 +91,8 @@ describe('detectDestructiveCommands', () => {
     ['git status'],
     ['git commit -m "wip"'],
     ['git push origin main'], // no force
+    ['git push --force-with-lease origin main'], // safe lease variant
+    ['git push --force-with-lease=origin/main origin main'], // =<refname> form
     ['git branch -d merged'], // lowercase -d is the safe delete
     ['ls -la /var'],
     ['npm install'],

--- a/src/agent/safe-destruct-detect.test.ts
+++ b/src/agent/safe-destruct-detect.test.ts
@@ -1,14 +1,20 @@
 /**
- * Tests for the observe-only safe-destruct detector (Wave 1, gate-migration).
+ * Tests for the two-tier safe-destruct detector.
  *
- * Three contracts:
- *   1. `detectDestructiveCommands` matches the curated catastrophic patterns
- *      and — critically for calibration — does NOT flag common-but-safe near
- *      misses (`rm -r build/`, `rm -f lock`, `git branch -d`, `truncate -s 0`).
- *   2. The hook returns an `approve` catch-record (never a block) only on a
- *      `bash` PreToolUse with a destructive command; `{}` otherwise.
- *   3. It is wired into the default registry and, dispatched end-to-end, passes
- *      the command through (no throw) while recording `decision: 'approve'`.
+ * Four contracts:
+ *   1. `detectDestructiveCommands` matches every curated pattern and does NOT
+ *      flag common-but-safe near-misses.
+ *   2. OBSERVE patterns return `decision: 'approve'` (never block).
+ *   3. BLOCK patterns return `decision: 'block'` with a reason that names the
+ *      pattern id.
+ *   4. When a single compound command matches both tiers, BLOCK wins.
+ *   5. Registry wiring: the hook is registered exactly once, produces approve
+ *      for OBSERVE patterns, and throws HookBlockedError for BLOCK patterns.
+ *
+ * Note on the former 'NEVER blocks' test (~line 97-101 in the old file):
+ *   It used `rm -rf / --no-preserve-root` as the fixture — that pattern moved
+ *   to the BLOCK tier. The test has been split into two: one asserting OBSERVE
+ *   patterns still approve, one asserting BLOCK patterns now block.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -18,6 +24,7 @@ import {
   detectDestructiveCommands,
   SAFE_DESTRUCT_DETECT_REASON_PREFIX,
 } from './safe-destruct-detect.js';
+import { HookBlockedError } from '../utils/errors.js';
 import { createDefaultHookRegistry } from './default-hook-registry.js';
 
 function preCtx(command: string, toolName = 'bash'): HookContext {
@@ -25,7 +32,12 @@ function preCtx(command: string, toolName = 'bash'): HookContext {
   return ctx;
 }
 
+// ---------------------------------------------------------------------------
+// detectDestructiveCommands — pattern matching
+// ---------------------------------------------------------------------------
+
 describe('detectDestructiveCommands', () => {
+  // ── OBSERVE patterns ───────────────────────────────────────────────────────
   it.each([
     ['rm -rf /tmp/foo', 'rm-recursive-force'],
     ['rm -fr build', 'rm-recursive-force'],
@@ -34,29 +46,40 @@ describe('detectDestructiveCommands', () => {
     ['rm -r -f dir', 'rm-recursive-force-split'],
     ['rm -f -r dir', 'rm-recursive-force-split'],
     ['rm --recursive --force dir', 'rm-recursive-force-long'],
-    ['rm -rf --no-preserve-root /', 'rm-no-preserve-root'],
-    ['git reset --hard HEAD~3', 'git-reset-hard'],
-    ['git clean -fd', 'git-clean-force'],
-    ['git push --force origin main', 'git-push-force'],
-    ['git push -f', 'git-push-force'],
     ['git branch -D feature', 'git-branch-force-delete'],
-    ['dd if=/x.img of=/dev/sda bs=1M', 'dd-to-device'],
-    ['mkfs.ext4 /dev/sdb1', 'mkfs'],
-    ['echo boot > /dev/sda', 'redirect-to-block-device'],
     ["find . -name '*.log' -delete", 'find-delete'],
     ['find . -exec rm {} +', 'find-delete'],
-    ['shred -u secret.key', 'shred'],
-    ["psql -c 'DROP DATABASE prod'", 'sql-drop-truncate-delete'],
-    ["mysql -e 'TRUNCATE TABLE users'", 'sql-drop-truncate-delete'],
-    ["psql -c 'DELETE FROM orders'", 'sql-drop-truncate-delete'],
     ['docker system prune -af', 'docker-destructive'],
     ['docker rm -f web', 'docker-destructive'],
     ['kubectl delete pod api-0', 'kubectl-delete'],
-    ['terraform destroy -auto-approve', 'terraform-destroy'],
-  ])('flags %j → %s', (command, expectedId) => {
+    ["psql -c 'DELETE FROM orders'", 'sql-delete-from'],
+  ])('OBSERVE: flags %j → %s', (command, expectedId) => {
     expect(detectDestructiveCommands(command)).toContain(expectedId);
   });
 
+  // ── BLOCK patterns ─────────────────────────────────────────────────────────
+  it.each([
+    ['rm -rf --no-preserve-root /', 'rm-no-preserve-root'],
+    ['git reset --hard HEAD~3', 'git-reset-hard'],
+    ['git clean -fd', 'git-clean-force'],
+    ['git clean --force -x', 'git-clean-force'],
+    ['git push --force origin main', 'git-push-force'],
+    ['git push -f', 'git-push-force'],
+    ['dd if=/x.img of=/dev/sda bs=1M', 'dd-to-device'],
+    ['mkfs.ext4 /dev/sdb1', 'mkfs'],
+    ['echo boot > /dev/sda', 'redirect-to-block-device'],
+    ['shred -u secret.key', 'shred'],
+    ["psql -c 'DROP DATABASE prod'", 'sql-drop-truncate'],
+    ["mysql -e 'TRUNCATE TABLE users'", 'sql-drop-truncate'],
+    ["psql -c 'DROP TABLE foo'", 'sql-drop-truncate'],
+    ["psql -c 'DROP SCHEMA public'", 'sql-drop-truncate'],
+    ["psql -c 'DROP INDEX idx_name'", 'sql-drop-truncate'],
+    ['terraform destroy -auto-approve', 'terraform-destroy'],
+  ])('BLOCK: flags %j → %s', (command, expectedId) => {
+    expect(detectDestructiveCommands(command)).toContain(expectedId);
+  });
+
+  // ── benign commands — must match nothing ────────────────────────────────────
   it.each([
     ['rm file.txt'], // no recursive/force
     ['rm -r build'], // recursive only — deliberately NOT flagged
@@ -82,22 +105,68 @@ describe('detectDestructiveCommands', () => {
     expect(ids).toContain('rm-recursive-force');
     expect(ids).toContain('git-push-force');
   });
+
+  it('sql-drop-truncate-delete id no longer exists; split ids are sql-drop-truncate and sql-delete-from', () => {
+    // Verify the split: old monolithic id is gone; both new ids fire correctly.
+    const drop = detectDestructiveCommands("DROP TABLE users");
+    expect(drop).toContain('sql-drop-truncate');
+    expect(drop).not.toContain('sql-drop-truncate-delete');
+
+    const del = detectDestructiveCommands('DELETE FROM orders WHERE id=1');
+    expect(del).toContain('sql-delete-from');
+    expect(del).not.toContain('sql-drop-truncate-delete');
+  });
 });
 
-describe('createSafeDestructDetect (observe-only hook)', () => {
+// ---------------------------------------------------------------------------
+// createSafeDestructDetect — hook decisions
+// ---------------------------------------------------------------------------
+
+describe('createSafeDestructDetect (two-tier hook)', () => {
   const hook = createSafeDestructDetect();
 
-  it('returns an approve catch-record with the stable reason prefix on a destructive bash command', () => {
-    const decision = hook(preCtx('rm -rf /tmp/x'));
+  // ── OBSERVE patterns must approve ─────────────────────────────────────────
+  it.each([
+    ['rm -rf /tmp/x', 'rm-recursive-force'],
+    ['rm -r -f /tmp/x', 'rm-recursive-force-split'],
+    ['rm --recursive --force /tmp/x', 'rm-recursive-force-long'],
+    ['git branch -D stale', 'git-branch-force-delete'],
+    ["find . -name '*.tmp' -delete", 'find-delete'],
+    ['docker system prune -af', 'docker-destructive'],
+    ['kubectl delete pod api-0', 'kubectl-delete'],
+    ['DELETE FROM sessions WHERE expired=1', 'sql-delete-from'],
+  ])('OBSERVE pattern %s returns approve, not block', (command, _id) => {
+    const decision: HookDecision = hook(preCtx(command));
     expect(decision.decision).toBe('approve');
+    expect(decision.decision).not.toBe('block');
     expect(decision.reason).toContain(SAFE_DESTRUCT_DETECT_REASON_PREFIX);
-    expect(decision.reason).toContain('rm-recursive-force');
   });
 
-  it('NEVER blocks — no block decision, no continue:false (the interpreter-eval lesson)', () => {
-    const decision: HookDecision = hook(preCtx('rm -rf / --no-preserve-root'));
-    expect(decision.decision).not.toBe('block');
-    expect(decision.continue).not.toBe(false);
+  // ── BLOCK patterns must block and name the pattern id ────────────────────
+  it.each([
+    ['rm -rf --no-preserve-root /', 'rm-no-preserve-root'],
+    ['git reset --hard HEAD', 'git-reset-hard'],
+    ['git clean -fd .', 'git-clean-force'],
+    ['git push --force origin main', 'git-push-force'],
+    ['dd if=/dev/zero of=/dev/sda', 'dd-to-device'],
+    ['mkfs.ext4 /dev/sdb1', 'mkfs'],
+    ['echo x > /dev/sda', 'redirect-to-block-device'],
+    ['shred -u key.pem', 'shred'],
+    ["psql -c 'DROP DATABASE prod'", 'sql-drop-truncate'],
+    ["mysql -e 'TRUNCATE TABLE users'", 'sql-drop-truncate'],
+    ['terraform destroy -auto-approve', 'terraform-destroy'],
+  ])('BLOCK pattern %s returns block decision naming %s', (command, expectedPatternId) => {
+    const decision: HookDecision = hook(preCtx(command));
+    expect(decision.decision).toBe('block');
+    expect(decision.reason).toContain(expectedPatternId);
+  });
+
+  // ── BLOCK wins when both tiers match in one compound command ─────────────
+  it('block wins over approve when a compound command matches both tiers', () => {
+    // rm -rf → OBSERVE; git push --force → BLOCK
+    const decision: HookDecision = hook(preCtx('rm -rf build && git push --force origin main'));
+    expect(decision.decision).toBe('block');
+    expect(decision.reason).toContain('git-push-force');
   });
 
   it('passes through benign bash commands', () => {
@@ -121,18 +190,33 @@ describe('createSafeDestructDetect (observe-only hook)', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Registry wiring
+// ---------------------------------------------------------------------------
+
 describe('safe-destruct-detect wiring in the default registry', () => {
-  it('is registered and records approve (without blocking) for a destructive bash call', async () => {
+  it('is registered and records approve (without blocking) for an OBSERVE-tier destructive bash call', async () => {
     const { registry } = createDefaultHookRegistry(undefined, 'cli');
     const ctx: PreToolUseContext = {
       event: 'PreToolUse',
       toolName: 'bash',
       input: { command: 'rm -rf /tmp/scratch' },
     };
-    // Must not throw (a block would throw HookBlockedError through dispatch).
+    // Must not throw — OBSERVE tier passes through.
     const decision = await registry.dispatch(ctx);
     expect(decision.decision).toBe('approve');
     expect(decision.reason).toContain(SAFE_DESTRUCT_DETECT_REASON_PREFIX);
+  });
+
+  it('throws HookBlockedError for a BLOCK-tier destructive bash call through the default registry', async () => {
+    const { registry } = createDefaultHookRegistry(undefined, 'cli');
+    const ctx: PreToolUseContext = {
+      event: 'PreToolUse',
+      toolName: 'bash',
+      input: { command: 'terraform destroy -auto-approve' },
+    };
+    // BLOCK tier must throw HookBlockedError.
+    await expect(registry.dispatch(ctx)).rejects.toBeInstanceOf(HookBlockedError);
   });
 
   it('leaves benign bash calls untouched through the default registry', async () => {

--- a/src/agent/safe-destruct-detect.ts
+++ b/src/agent/safe-destruct-detect.ts
@@ -103,13 +103,19 @@ export function createSafeDestructDetect(): (context: HookContext) => HookDecisi
     // Precedence: if ANY matched pattern is BLOCK-tier, the entire command is
     // blocked. A compound command containing even one unrecoverable sub-operation
     // must not pass through because it is mixed with a recoverable one.
+    //
+    // Invariant: when multiple BLOCK patterns match in one compound command, the
+    // first BLOCK in DESTRUCTIVE_PATTERNS table order wins. Only that pattern's
+    // blockReason is reported. This is deliberate: the pattern table is ordered
+    // by importance (most dangerous operations first), so the first hit is the
+    // highest-priority signal and the most actionable reason for the agent.
     const patternMap = new Map(DESTRUCTIVE_PATTERNS.map((p) => [p.id, p]));
     for (const id of matchedIds) {
       const pattern = patternMap.get(id);
       if (pattern?.tier === 'block') {
         return {
           decision: 'block',
-          reason: pattern.blockReason ?? `safe-destruct: blocked [${id}] — unrecoverable operation.`,
+          reason: pattern.blockReason,
         };
       }
     }

--- a/src/agent/safe-destruct-detect.ts
+++ b/src/agent/safe-destruct-detect.ts
@@ -1,127 +1,77 @@
 /**
- * Safe-destruct detector — an **observe-only** PreToolUse hook.
+ * Safe-destruct detector — a two-tier PreToolUse hook.
  *
  * Migrates the detection half of the `safe-destruct` gate-skill into
  * deterministic harness code (Wave 1 of the friction-substrate / gate-migration
  * program — `.afk/plans/friction-substrate-and-gate-migration.md`). It watches
  * `bash` commands for a curated set of catastrophic / irreversible operations
- * (`rm -rf`, `git reset --hard`, `DROP DATABASE`, `dd of=/dev/*`, `mkfs`,
- * `terraform destroy`, ...) and, on a match, emits a witnessed catch-record —
- * **without blocking the command**.
+ * and routes each matched pattern to one of two tiers:
  *
- * # Why observe-only (the interpreter-eval lesson)
+ *   OBSERVE — returns `decision: 'approve'` (never blocks). High-volume routine
+ *     operations or recoverable ones where a hard block would generate 326-class
+ *     friction (see `safe-destruct-patterns.ts` for the calibration invariant).
+ *
+ *   BLOCK — returns `decision: 'block'` with a human-readable reason string.
+ *     Reserved for unrecoverable or externally-irreversible operations that are
+ *     never inner-loop for a well-behaved agent.
+ *
+ * # Precedence rule
+ *
+ * When a single compound command matches patterns from both tiers, BLOCK wins.
+ * The precedence is deliberate and explicit — a command that contains even one
+ * unrecoverable sub-operation must not slip through because it is mixed with a
+ * recoverable one.
+ *
+ * # Why observe exists at all (the interpreter-eval lesson)
  *
  * This whole program exists because an over-firing PreToolUse *hard block* (the
  * interpreter-eval guard) generated 18 nights of self-inflicted friction. The
- * plan's de-risking rule is therefore "injectContext-first, shadow-window
- * before enforcing". PreToolUse cannot `injectContext` — the harness honors that
- * field only for `SubagentStop` / `UserPromptSubmit` (see `hooks.ts`) — and a
- * hard block would repeat the exact mistake. So slice 1 changes ZERO behavior:
- * it only records that a destructive command was attempted. The records are the
- * shadow window; a later slice uses their real-world frequency per pattern to
- * calibrate which (if any) warrant a block or nudge.
+ * plan's de-risking rule is "injectContext-first, shadow-window before
+ * enforcing". PreToolUse cannot `injectContext` — the harness honors that field
+ * only for `SubagentStop` / `UserPromptSubmit` (see `hooks.ts`) — so the OBSERVE
+ * tier records attempts without blocking, building the shadow-window dataset. A
+ * later slice uses real-world frequency per pattern to re-calibrate tiers.
  *
- * # How the catch-record is emitted (the `approve` outcome)
+ * # How the approve catch-record is emitted
  *
- * A PreToolUse handler can only `block` or pass; passing (`{}`) is not
- * witnessed with a reason. To emit a filterable catch-record while letting the
- * command run, this hook returns the otherwise-unused `decision: 'approve'`
- * outcome with a structured `reason`. `approve`:
- *   - is behaviorally identical to unset — `isBlocking()` (`hook-registry.ts`)
- *     checks only `block` / `continue:false`, so the command proceeds and the
- *     other PreToolUse gates (afk-mode, bash-restriction, ...) still run;
- *   - is recorded by `dispatchPreToolUse` as a `hook_decision` event carrying
- *     the `reason` (`subagent-hooks.ts`), which is the Wave-4 substrate signal;
- *   - is IGNORED by the mechanical friction detectors (they count `block`
- *     outcomes / error `failureClass`es — see `improve/scan/detectors`), so
- *     these observations never masquerade as new friction.
- * No existing hook returns `approve`, so `decision === 'approve'` cleanly
- * isolates safe-destruct observations in the trace.
+ * A PreToolUse handler can only `block` or pass; passing (`{}`) is not witnessed
+ * with a reason. To emit a filterable catch-record while letting the command run,
+ * OBSERVE patterns return `decision: 'approve'` with a structured reason:
+ *   - behaviorally identical to unset — `isBlocking()` checks only `block` /
+ *     `continue:false`, so the command proceeds and other PreToolUse gates still
+ *     run;
+ *   - recorded by `dispatchPreToolUse` as a `hook_decision` event carrying the
+ *     `reason`, which is the Wave-4 substrate signal;
+ *   - IGNORED by friction detectors (they count `block` outcomes / error
+ *     `failureClass`es), so observations never masquerade as new friction.
  *
  * Registered unconditionally on ALL surfaces (including headless/autonomous,
- * where destructive actions are most dangerous and least observed) precisely
- * because it never blocks — it is safe everywhere.
+ * where destructive actions are most dangerous and least observed) — OBSERVE
+ * patterns are safe everywhere; BLOCK patterns fire before irreversible damage.
  *
  * @module agent/safe-destruct-detect
  */
 
 import type { HookContext, HookDecision } from './hooks.js';
+import { DESTRUCTIVE_PATTERNS } from './safe-destruct-patterns.js';
 
 /**
- * Stable prefix on the emitted `reason`. Exported so the telemetry substrate,
- * tests, and `afk trace show` can match safe-destruct observations by prefix.
+ * Stable prefix on OBSERVE reason strings. Exported so telemetry, tests, and
+ * `afk trace show` can isolate safe-destruct observations by prefix.
+ *
+ * BLOCK reasons are pattern-specific (see `safe-destruct-patterns.ts`) and do
+ * not share this prefix — they are the agent's only feedback and must be
+ * self-contained.
  */
 export const SAFE_DESTRUCT_DETECT_REASON_PREFIX =
   'safe-destruct observe-only: destructive-command attempt';
 
 /**
- * Curated destructive / irreversible command patterns.
+ * Return the ids of every destructive pattern the command matches.
+ * Returns an empty array when none match.
  *
- * Calibration bias: high-signal only. Operations that are catastrophic AND
- * rarely a legitimate agent action. Recursive-only deletes (`rm -r build/`) are
- * deliberately NOT flagged — common and usually safe; only recursive+force
- * (no prompt, no recovery) is. Each regex avoids nested quantifiers so the scan
- * is linear (no ReDoS); `[^|&;\n]*` bounds a match to a single command segment.
- *
- * Reused by the future block/nudge slice — keep it the single source of truth.
- */
-const DESTRUCTIVE_PATTERNS: readonly { readonly id: string; readonly re: RegExp }[] = [
-  // --- rm: recursive AND force (irrecoverable, no prompt) ---------------------
-  // One flag cluster containing both r and f (`-rf`, `-fr`, `-rfv`, `-Rf`, ...).
-  { id: 'rm-recursive-force', re: /\brm\s+-(?=[a-z]*r)(?=[a-z]*f)[a-z]+/i },
-  // Recursive and force in separate flag tokens (`rm -r -f`, `rm -f -r`).
-  {
-    id: 'rm-recursive-force-split',
-    re: /\brm\s+-[a-z]*r[a-z]*\s+-[a-z]*f|\brm\s+-[a-z]*f[a-z]*\s+-[a-z]*r/i,
-  },
-  // Long-form, both flags present in either order.
-  {
-    id: 'rm-recursive-force-long',
-    re: /\brm\s+[^|&;\n]*--recursive\b[^|&;\n]*--force\b|\brm\s+[^|&;\n]*--force\b[^|&;\n]*--recursive\b/i,
-  },
-  // The explicit "yes, wipe /" escape hatch — always catastrophic.
-  { id: 'rm-no-preserve-root', re: /\brm\b[^|&;\n]*--no-preserve-root\b/i },
-
-  // --- git: history / worktree destroyers ------------------------------------
-  { id: 'git-reset-hard', re: /\bgit\s+reset\s+--hard\b/i },
-  { id: 'git-clean-force', re: /\bgit\s+clean\s+-[a-z]*f|\bgit\s+clean\s+[^|&;\n]*--force\b/i },
-  {
-    id: 'git-push-force',
-    re: /\bgit\s+push\b[^|&;\n]*--force\b|\bgit\s+push\b[^|&;\n]*(?<![\w-])-f\b/i,
-  },
-  // Case-sensitive: `-D` force-deletes a branch; `-d` refuses on unmerged.
-  { id: 'git-branch-force-delete', re: /\bgit\s+branch\s+[^|&;\n]*-D\b/ },
-
-  // --- filesystem / raw device -----------------------------------------------
-  // Writing to a real device node (excludes the harmless pseudo-devices).
-  {
-    id: 'dd-to-device',
-    re: /\bof=\/dev\/(?!null\b|zero\b|random\b|urandom\b|stdout\b|stderr\b|tty\b)\S/i,
-  },
-  { id: 'mkfs', re: /\bmkfs(\.\w+)?\b/i },
-  { id: 'redirect-to-block-device', re: />\s*\/dev\/(sd|nvme|hd|disk|mmcblk|vd)\w*/i },
-  { id: 'find-delete', re: /\bfind\b[^|&;\n]*-delete\b|\bfind\b[^|&;\n]*-exec\s+rm\b/i },
-  { id: 'shred', re: /\bshred\b/i },
-
-  // --- SQL --------------------------------------------------------------------
-  {
-    id: 'sql-drop-truncate-delete',
-    re: /\b(drop\s+(table|database|schema|index)\b|truncate\s+table\b|delete\s+from\b)/i,
-  },
-
-  // --- infra / containers -----------------------------------------------------
-  {
-    id: 'docker-destructive',
-    re: /\bdocker\s+(system\s+prune|volume\s+(rm|prune)|image\s+prune|container\s+prune|network\s+prune)\b|\bdocker\b[^|&;\n]*\brmi?\s+[^|&;\n]*-f/i,
-  },
-  { id: 'kubectl-delete', re: /\bkubectl\s+delete\b/i },
-  { id: 'terraform-destroy', re: /\bterraform\s+destroy\b/i },
-];
-
-/**
- * Return the ids of every destructive pattern the command matches (empty when
- * none). Pure and stateless — no global-flag regexes, so `.test()` is safe to
- * call repeatedly. Exported for the block/nudge slice and for tests.
+ * Pure and stateless — no global-flag regexes, safe to call repeatedly.
+ * Exported for tests and for a future block/nudge slice.
  */
 export function detectDestructiveCommands(command: string): string[] {
   if (!command) return [];
@@ -133,11 +83,10 @@ export function detectDestructiveCommands(command: string): string[] {
 }
 
 /**
- * Create the observe-only safe-destruct PreToolUse hook.
+ * Create the two-tier safe-destruct PreToolUse hook.
  *
  * Stateless (no dedup): every destructive attempt is a distinct data point —
- * an agent looping on `rm -rf x` is exactly the signal the shadow window wants
- * to surface, so occurrences are not collapsed.
+ * an agent looping on `rm -rf x` is the signal the shadow window wants to see.
  */
 export function createSafeDestructDetect(): (context: HookContext) => HookDecision {
   return function safeDestructDetect(context: HookContext): HookDecision {
@@ -148,15 +97,27 @@ export function createSafeDestructDetect(): (context: HookContext) => HookDecisi
     const command = typeof input?.['command'] === 'string' ? input['command'] : '';
     if (!command) return {};
 
-    const matched = detectDestructiveCommands(command);
-    if (matched.length === 0) return {};
+    const matchedIds = detectDestructiveCommands(command);
+    if (matchedIds.length === 0) return {};
 
-    // approve == allow (never blocks; see module header) but carries a reason
-    // that lands as a `hook_decision` catch-record for the reasoning-failure
-    // substrate.
+    // Precedence: if ANY matched pattern is BLOCK-tier, the entire command is
+    // blocked. A compound command containing even one unrecoverable sub-operation
+    // must not pass through because it is mixed with a recoverable one.
+    const patternMap = new Map(DESTRUCTIVE_PATTERNS.map((p) => [p.id, p]));
+    for (const id of matchedIds) {
+      const pattern = patternMap.get(id);
+      if (pattern?.tier === 'block') {
+        return {
+          decision: 'block',
+          reason: pattern.blockReason ?? `safe-destruct: blocked [${id}] — unrecoverable operation.`,
+        };
+      }
+    }
+
+    // All matched patterns are OBSERVE-tier: record the attempt, allow through.
     return {
       decision: 'approve',
-      reason: `${SAFE_DESTRUCT_DETECT_REASON_PREFIX} [${matched.join(', ')}]`,
+      reason: `${SAFE_DESTRUCT_DETECT_REASON_PREFIX} [${matchedIds.join(', ')}]`,
     };
   };
 }

--- a/src/agent/safe-destruct-patterns.ts
+++ b/src/agent/safe-destruct-patterns.ts
@@ -1,0 +1,211 @@
+/**
+ * Curated destructive / irreversible command pattern table for the safe-destruct
+ * PreToolUse hook.
+ *
+ * Pulled into its own module to keep `safe-destruct-detect.ts` under the
+ * project-wide 350-LOC ceiling after the two-tier (OBSERVE / BLOCK) split.
+ *
+ * @module agent/safe-destruct-patterns
+ */
+
+/**
+ * Tier assignment for a destructive pattern.
+ *
+ * - `'observe'` — hook records the attempt but always returns `decision:
+ *   'approve'`. Used for high-volume routine operations or recoverable ones
+ *   where a hard block would create 326-class friction.
+ * - `'block'` — hook returns `decision: 'block'` with a human-readable reason.
+ *   Reserved for unrecoverable or externally-irreversible operations that are
+ *   never inner-loop for a well-behaved agent.
+ */
+export type PatternTier = 'observe' | 'block';
+
+export interface DestructivePattern {
+  readonly id: string;
+  readonly re: RegExp;
+  readonly tier: PatternTier;
+  /**
+   * Required when tier === 'block'. The reason string surfaces directly to the
+   * agent through HookBlockedError → tool result content. It must:
+   *   (a) name the matched pattern id,
+   *   (b) say in one clause why it is blocked (unrecoverable / external),
+   *   (c) name the recoverable alternative or the explicit way to proceed.
+   */
+  readonly blockReason?: string;
+}
+
+// Invariant: Tier calibration is a measured constraint, not a preference.
+//
+// Five weeks of catch-records (359 approve events, 165 sessions) show:
+//
+//   rm-recursive-force:    326 firings (91%) — routine cleanup in cron jobs
+//   git-branch-force-delete: 13
+//   git-push-force:           6
+//   git-reset-hard:           5
+//   everything else:          0
+//
+// A blanket block would have stopped ~326 legitimate operations. Tiers encode
+// the calibration outcome: OBSERVE for high-volume / recoverable operations,
+// BLOCK for unrecoverable or externally-irreversible ones that are never
+// inner-loop. The rationale for each controversial assignment is inline below.
+// Do NOT move a pattern from OBSERVE to BLOCK without re-measuring firing rates;
+// the asymmetry is intentional, not an oversight.
+//
+// Pattern ids are stable public identifiers used by telemetry, tests, and the
+// trace substrate. Changing an id breaks deduplication across the 165-session
+// history. New ids are append-only.
+export const DESTRUCTIVE_PATTERNS: readonly DestructivePattern[] = [
+  // ── rm: recursive AND force (irrecoverable, no prompt) ─────────────────────
+  //
+  // Invariant: stays OBSERVE despite being destructive because of the measured
+  // 326-firing base rate (91% of all catch-records). Promoting to BLOCK would
+  // have blocked 91% of legitimate operations across the shadow window. A
+  // future re-calibration can revisit this if the rate drops significantly, but
+  // any change must be measured, not assumed. The commit objects and most build
+  // artifacts are reproducible; the irrecoverability risk is accepted.
+  {
+    id: 'rm-recursive-force',
+    re: /\brm\s+-(?=[a-z]*r)(?=[a-z]*f)[a-z]+/i,
+    tier: 'observe',
+  },
+  // Recursive and force in separate flag tokens (`rm -r -f`, `rm -f -r`).
+  {
+    id: 'rm-recursive-force-split',
+    re: /\brm\s+-[a-z]*r[a-z]*\s+-[a-z]*f|\brm\s+-[a-z]*f[a-z]*\s+-[a-z]*r/i,
+    tier: 'observe',
+  },
+  // Long-form, both flags present in either order.
+  {
+    id: 'rm-recursive-force-long',
+    re: /\brm\s+[^|&;\n]*--recursive\b[^|&;\n]*--force\b|\brm\s+[^|&;\n]*--force\b[^|&;\n]*--recursive\b/i,
+    tier: 'observe',
+  },
+  // The explicit "yes, wipe /" escape hatch — always catastrophic.
+  {
+    id: 'rm-no-preserve-root',
+    re: /\brm\b[^|&;\n]*--no-preserve-root\b/i,
+    tier: 'block',
+    blockReason:
+      'safe-destruct: blocked [rm-no-preserve-root] — explicit root-wipe flag, irrecoverable; remove the --no-preserve-root flag, or target a non-root path instead.',
+  },
+
+  // ── git: history / worktree destroyers ─────────────────────────────────────
+  //
+  // git reset --hard: BLOCK — discards uncommitted work permanently. Measured
+  // at 5 firings in 5 weeks, so it is not inner-loop.
+  {
+    id: 'git-reset-hard',
+    re: /\bgit\s+reset\s+--hard\b/i,
+    tier: 'block',
+    blockReason:
+      'safe-destruct: blocked [git-reset-hard] — discards all uncommitted changes irrecoverably; commit or run "git stash" first, or re-run with the discard intent stated explicitly.',
+  },
+  // git clean -f: BLOCK — removes untracked files with no recovery path.
+  {
+    id: 'git-clean-force',
+    re: /\bgit\s+clean\s+-[a-z]*f|\bgit\s+clean\s+[^|&;\n]*--force\b/i,
+    tier: 'block',
+    blockReason:
+      'safe-destruct: blocked [git-clean-force] — deletes untracked files irrecoverably; use "git clean -n" (dry-run) to preview, then proceed with the intent stated explicitly.',
+  },
+  // git push --force: BLOCK — rewrites remote history, potentially for all
+  // consumers. Measured at 6 firings in 5 weeks; not inner-loop.
+  {
+    id: 'git-push-force',
+    re: /\bgit\s+push\b[^|&;\n]*--force\b|\bgit\s+push\b[^|&;\n]*(?<![\w-])-f\b/i,
+    tier: 'block',
+    blockReason:
+      'safe-destruct: blocked [git-push-force] — rewrites remote history, permanently destructive for all branch consumers; prefer "--force-with-lease" or coordinate with collaborators first.',
+  },
+  // Invariant: git branch -D stays OBSERVE because only the ref is deleted —
+  // the commit objects survive in the reflog for at least 30 days by default.
+  // Recovery: `git reflog` + `git checkout -b <name> <sha>`. Measured at 13
+  // firings in 5 weeks; promoting to BLOCK would have been the #2 largest
+  // friction source after rm-recursive-force.
+  // Case-sensitive: `-D` force-deletes; `-d` refuses on unmerged.
+  { id: 'git-branch-force-delete', re: /\bgit\s+branch\s+[^|&;\n]*-D\b/, tier: 'observe' },
+
+  // ── filesystem / raw device ─────────────────────────────────────────────────
+  {
+    id: 'dd-to-device',
+    re: /\bof=\/dev\/(?!null\b|zero\b|random\b|urandom\b|stdout\b|stderr\b|tty\b)\S/i,
+    tier: 'block',
+    blockReason:
+      'safe-destruct: blocked [dd-to-device] — writing directly to a block device is irrecoverable; verify the target path is a file, not a device node.',
+  },
+  {
+    id: 'mkfs',
+    re: /\bmkfs(\.\w+)?\b/i,
+    tier: 'block',
+    blockReason:
+      'safe-destruct: blocked [mkfs] — formats a filesystem, irrecoverably destroying all data on the target device; confirm the device path and proceed only with explicit intent.',
+  },
+  {
+    id: 'redirect-to-block-device',
+    re: />\s*\/dev\/(sd|nvme|hd|disk|mmcblk|vd)\w*/i,
+    tier: 'block',
+    blockReason:
+      'safe-destruct: blocked [redirect-to-block-device] — shell redirect to a block device overwrites raw sectors irrecoverably; redirect to a file path instead.',
+  },
+  // Invariant: find -delete stays OBSERVE because most usages target build
+  // artifacts and temp files (zero firings in 5 weeks suggests it is rare but
+  // routine when it does appear); state is typically reproducible from source.
+  {
+    id: 'find-delete',
+    re: /\bfind\b[^|&;\n]*-delete\b|\bfind\b[^|&;\n]*-exec\s+rm\b/i,
+    tier: 'observe',
+  },
+  {
+    id: 'shred',
+    re: /\bshred\b/i,
+    tier: 'block',
+    blockReason:
+      'safe-destruct: blocked [shred] — overwrites file data irrecoverably, bypassing the filesystem; use "rm" if secure deletion is not required, or proceed with the intent stated explicitly.',
+  },
+
+  // ── SQL ─────────────────────────────────────────────────────────────────────
+  //
+  // Split from the former monolithic `sql-drop-truncate-delete` id:
+  //   - sql-drop-truncate: DDL destructors → BLOCK (schema changes are external
+  //     / unrecoverable without a backup).
+  //   - sql-delete-from: DML row removal → OBSERVE (routine in development SQL;
+  //     zero firings in 5 weeks confirm it is not a high-risk inner-loop op in
+  //     this agent's usage profile, and transactions often wrap it).
+  {
+    id: 'sql-drop-truncate',
+    re: /\b(drop\s+(table|database|schema|index)\b|truncate\s+table\b)/i,
+    tier: 'block',
+    blockReason:
+      'safe-destruct: blocked [sql-drop-truncate] — DDL destructor removes schema objects or all rows without a transaction rollback path; back up or use a migration with a down step, then proceed with the intent stated explicitly.',
+  },
+  {
+    id: 'sql-delete-from',
+    re: /\bdelete\s+from\b/i,
+    tier: 'observe',
+  },
+
+  // ── infra / containers ───────────────────────────────────────────────────────
+  //
+  // Invariant: docker-destructive and kubectl-delete stay OBSERVE because their
+  // state is typically declarative and re-creatable from manifests / Dockerfiles.
+  // `kubectl delete pod` is inner-loop for many operators (pod restarts); a
+  // block here would be the #3 largest friction source. Zero firings in 5 weeks
+  // is consistent with rare-but-routine usage.
+  {
+    id: 'docker-destructive',
+    re: /\bdocker\s+(system\s+prune|volume\s+(rm|prune)|image\s+prune|container\s+prune|network\s+prune)\b|\bdocker\b[^|&;\n]*\brmi?\s+[^|&;\n]*-f/i,
+    tier: 'observe',
+  },
+  { id: 'kubectl-delete', re: /\bkubectl\s+delete\b/i, tier: 'observe' },
+  // Invariant: terraform-destroy stays BLOCK because it tears down real external
+  // infrastructure (VMs, load balancers, DNS records, databases) that cannot be
+  // reconstructed by re-running plan — re-apply creates new resources with new
+  // IDs / IPs, breaking dependent systems. It is never an inner-loop operation.
+  {
+    id: 'terraform-destroy',
+    re: /\bterraform\s+destroy\b/i,
+    tier: 'block',
+    blockReason:
+      'safe-destruct: blocked [terraform-destroy] — tears down live external infrastructure irrecoverably (new apply creates new resources, not the same ones); run "terraform plan -destroy" to preview, then proceed with explicit intent.',
+  },
+];

--- a/src/agent/safe-destruct-patterns.ts
+++ b/src/agent/safe-destruct-patterns.ts
@@ -20,19 +20,16 @@
  */
 export type PatternTier = 'observe' | 'block';
 
-export interface DestructivePattern {
-  readonly id: string;
-  readonly re: RegExp;
-  readonly tier: PatternTier;
-  /**
-   * Required when tier === 'block'. The reason string surfaces directly to the
-   * agent through HookBlockedError → tool result content. It must:
-   *   (a) name the matched pattern id,
-   *   (b) say in one clause why it is blocked (unrecoverable / external),
-   *   (c) name the recoverable alternative or the explicit way to proceed.
-   */
-  readonly blockReason?: string;
-}
+/**
+ * Required when tier === 'block'. The reason string surfaces directly to the
+ * agent through HookBlockedError → tool result content. It must:
+ *   (a) name the matched pattern id,
+ *   (b) say in one clause why it is blocked (unrecoverable / external),
+ *   (c) name the recoverable alternative or the explicit way to proceed.
+ */
+export type DestructivePattern =
+  | { readonly id: string; readonly re: RegExp; readonly tier: 'observe' }
+  | { readonly id: string; readonly re: RegExp; readonly tier: 'block'; readonly blockReason: string };
 
 // Invariant: Tier calibration is a measured constraint, not a preference.
 //
@@ -54,6 +51,11 @@ export interface DestructivePattern {
 // Pattern ids are stable public identifiers used by telemetry, tests, and the
 // trace substrate. Changing an id breaks deduplication across the 165-session
 // history. New ids are append-only.
+// Known constraint: regex-based detection cannot distinguish executable commands
+// from quoted/echoed mentions (e.g. `echo 'git reset --hard'`, `grep
+// 'terraform destroy'`). OBSERVE-tier false positives are noisy but harmless;
+// BLOCK-tier false positives are a known cost accepted for safety — they fire
+// rarely in practice and the agent can explain the context to the operator.
 export const DESTRUCTIVE_PATTERNS: readonly DestructivePattern[] = [
   // ── rm: recursive AND force (irrecoverable, no prompt) ─────────────────────
   //
@@ -95,7 +97,7 @@ export const DESTRUCTIVE_PATTERNS: readonly DestructivePattern[] = [
   // at 5 firings in 5 weeks, so it is not inner-loop.
   {
     id: 'git-reset-hard',
-    re: /\bgit\s+reset\s+--hard\b/i,
+    re: /\bgit\s+(?:(?:-{2}[\w-]+(?:=\S+)?|-[A-Za-z](?:\s+\S+)?)\s+)*reset\s+--hard\b/i,
     tier: 'block',
     blockReason:
       'safe-destruct: blocked [git-reset-hard] — discards all uncommitted changes irrecoverably; commit or run "git stash" first. This hook cannot be self-bypassed: if the destruction is genuinely intended, stop and ask the operator to run it.',
@@ -103,7 +105,7 @@ export const DESTRUCTIVE_PATTERNS: readonly DestructivePattern[] = [
   // git clean -f: BLOCK — removes untracked files with no recovery path.
   {
     id: 'git-clean-force',
-    re: /\bgit\s+clean\s+-[a-z]*f|\bgit\s+clean\s+[^|&;\n]*--force\b/i,
+    re: /\bgit\s+(?:(?:-{2}[\w-]+(?:=\S+)?|-[A-Za-z](?:\s+\S+)?)\s+)*clean\s+-[a-z]*f|\bgit\s+(?:(?:-{2}[\w-]+(?:=\S+)?|-[A-Za-z](?:\s+\S+)?)\s+)*clean\s+[^|&;\n]*--force\b/i,
     tier: 'block',
     blockReason:
       'safe-destruct: blocked [git-clean-force] — deletes untracked files irrecoverably; use "git clean -n" (dry-run) to preview. This hook cannot be self-bypassed: if the destruction is genuinely intended, stop and ask the operator to run it.',
@@ -112,7 +114,7 @@ export const DESTRUCTIVE_PATTERNS: readonly DestructivePattern[] = [
   // consumers. Measured at 6 firings in 5 weeks; not inner-loop.
   {
     id: 'git-push-force',
-    re: /\bgit\s+push\b[^|&;\n]*--force\b|\bgit\s+push\b[^|&;\n]*(?<![\w-])-f\b/i,
+    re: /\bgit\s+(?:(?:-{2}[\w-]+(?:=\S+)?|-[A-Za-z](?:\s+\S+)?)\s+)*push\b[^|&;\n]*--force(?!-)|\bgit\s+(?:(?:-{2}[\w-]+(?:=\S+)?|-[A-Za-z](?:\s+\S+)?)\s+)*push\b[^|&;\n]*(?<![\w-])-f\b/i,
     tier: 'block',
     blockReason:
       'safe-destruct: blocked [git-push-force] — rewrites remote history, permanently destructive for all branch consumers; prefer "--force-with-lease" or coordinate with collaborators first.',
@@ -171,6 +173,9 @@ export const DESTRUCTIVE_PATTERNS: readonly DestructivePattern[] = [
   //   - sql-delete-from: DML row removal → OBSERVE (routine in development SQL;
   //     zero firings in 5 weeks confirm it is not a high-risk inner-loop op in
   //     this agent's usage profile, and transactions often wrap it).
+  //
+  // Exception: the old `sql-drop-truncate-delete` id had 0 firings in the
+  // 5-week shadow window, so no trace data is orphaned by the split.
   {
     id: 'sql-drop-truncate',
     re: /\b(drop\s+(table|database|schema|index)\b|truncate\s+table\b)/i,

--- a/src/agent/safe-destruct-patterns.ts
+++ b/src/agent/safe-destruct-patterns.ts
@@ -98,7 +98,7 @@ export const DESTRUCTIVE_PATTERNS: readonly DestructivePattern[] = [
     re: /\bgit\s+reset\s+--hard\b/i,
     tier: 'block',
     blockReason:
-      'safe-destruct: blocked [git-reset-hard] — discards all uncommitted changes irrecoverably; commit or run "git stash" first, or re-run with the discard intent stated explicitly.',
+      'safe-destruct: blocked [git-reset-hard] — discards all uncommitted changes irrecoverably; commit or run "git stash" first. This hook cannot be self-bypassed: if the destruction is genuinely intended, stop and ask the operator to run it.',
   },
   // git clean -f: BLOCK — removes untracked files with no recovery path.
   {
@@ -106,7 +106,7 @@ export const DESTRUCTIVE_PATTERNS: readonly DestructivePattern[] = [
     re: /\bgit\s+clean\s+-[a-z]*f|\bgit\s+clean\s+[^|&;\n]*--force\b/i,
     tier: 'block',
     blockReason:
-      'safe-destruct: blocked [git-clean-force] — deletes untracked files irrecoverably; use "git clean -n" (dry-run) to preview, then proceed with the intent stated explicitly.',
+      'safe-destruct: blocked [git-clean-force] — deletes untracked files irrecoverably; use "git clean -n" (dry-run) to preview. This hook cannot be self-bypassed: if the destruction is genuinely intended, stop and ask the operator to run it.',
   },
   // git push --force: BLOCK — rewrites remote history, potentially for all
   // consumers. Measured at 6 firings in 5 weeks; not inner-loop.
@@ -138,7 +138,7 @@ export const DESTRUCTIVE_PATTERNS: readonly DestructivePattern[] = [
     re: /\bmkfs(\.\w+)?\b/i,
     tier: 'block',
     blockReason:
-      'safe-destruct: blocked [mkfs] — formats a filesystem, irrecoverably destroying all data on the target device; confirm the device path and proceed only with explicit intent.',
+      'safe-destruct: blocked [mkfs] — formats a filesystem, irrecoverably destroying all data on the target device; confirm the device path. This hook cannot be self-bypassed: if the destruction is genuinely intended, stop and ask the operator to run it.',
   },
   {
     id: 'redirect-to-block-device',
@@ -160,7 +160,7 @@ export const DESTRUCTIVE_PATTERNS: readonly DestructivePattern[] = [
     re: /\bshred\b/i,
     tier: 'block',
     blockReason:
-      'safe-destruct: blocked [shred] — overwrites file data irrecoverably, bypassing the filesystem; use "rm" if secure deletion is not required, or proceed with the intent stated explicitly.',
+      'safe-destruct: blocked [shred] — overwrites file data irrecoverably, bypassing the filesystem; use "rm" if secure deletion is not required. This hook cannot be self-bypassed: if the destruction is genuinely intended, stop and ask the operator to run it.',
   },
 
   // ── SQL ─────────────────────────────────────────────────────────────────────
@@ -176,7 +176,7 @@ export const DESTRUCTIVE_PATTERNS: readonly DestructivePattern[] = [
     re: /\b(drop\s+(table|database|schema|index)\b|truncate\s+table\b)/i,
     tier: 'block',
     blockReason:
-      'safe-destruct: blocked [sql-drop-truncate] — DDL destructor removes schema objects or all rows without a transaction rollback path; back up or use a migration with a down step, then proceed with the intent stated explicitly.',
+      'safe-destruct: blocked [sql-drop-truncate] — DDL destructor removes schema objects or all rows without a transaction rollback path; back up or use a migration with a down step. This hook cannot be self-bypassed: if the destruction is genuinely intended, stop and ask the operator to run it.',
   },
   {
     id: 'sql-delete-from',
@@ -206,6 +206,6 @@ export const DESTRUCTIVE_PATTERNS: readonly DestructivePattern[] = [
     re: /\bterraform\s+destroy\b/i,
     tier: 'block',
     blockReason:
-      'safe-destruct: blocked [terraform-destroy] — tears down live external infrastructure irrecoverably (new apply creates new resources, not the same ones); run "terraform plan -destroy" to preview, then proceed with explicit intent.',
+      'safe-destruct: blocked [terraform-destroy] — tears down live external infrastructure irrecoverably (new apply creates new resources, not the same ones); run "terraform plan -destroy" to preview. This hook cannot be self-bypassed: if the destruction is genuinely intended, stop and ask the operator to run it.',
   },
 ];


### PR DESCRIPTION
## What

Splits `safe-destruct-detect`'s flat pattern table into two tiers. OBSERVE keeps returning `decision: 'approve'` (never blocks, emits a catch-record). BLOCK returns `decision: 'block'` with an actionable reason. One hook, one registration — `registry.count('PreToolUse') === 3` is unchanged.

This is the first slice of the gate-migration program that actually **enforces** anything. Both shipped detectors (#492, #524) have been observe-only, which meant a gate-class skill was replaced by a silent logger.

## Why these tiers — the calibration is measured, not preferred

The detector has been logging for five weeks. Its own catch-records (359 `approve` events across 165 sessions, from `~/.afk/state/witness/**/trace.jsonl`):

| pattern | firings | share |
|---|---|---|
| `rm-recursive-force` | 326 | 91% |
| `git-branch-force-delete` | 13 | 4% |
| `git-push-force` | 6 | 2% |
| `git-reset-hard` | 5 | 1% |
| everything else | 0 | — |

Two things fall out of that distribution:

1. **A blanket promotion to block was never viable.** It would have blocked ~326 legitimate operations — the `rm -rf` firings are concentrated in recurring cron jobs (`pr-review-sweep`, `weekly-recap`), i.e. routine cleanup, dozens per run.
2. **The dangerous set is the low-volume tail.** Roughly 29 events in five weeks, about one every 1.5 days. That is cheap to gate.

So the split is by *recoverability*, not by how alarming the command looks.

| tier | patterns |
|---|---|
| **BLOCK** (unrecoverable or externally irreversible, never inner-loop) | `rm-no-preserve-root`, `git-reset-hard`, `git-clean-force`, `git-push-force`, `dd-to-device`, `mkfs`, `redirect-to-block-device`, `shred`, `sql-drop-truncate`, `terraform-destroy` |
| **OBSERVE** (high-volume routine, or recoverable) | `rm-recursive-force` (+ `-split`, `-long`), `git-branch-force-delete`, `find-delete`, `docker-destructive`, `kubectl-delete`, `sql-delete-from` |

The judgment calls a reviewer will question, each recorded as an `// Invariant:` comment beside the pattern so a future reader does not "fix" them:

- **`rm -rf` stays OBSERVE despite being destructive** — purely the 326-firing base rate. This is the whole point of the PR.
- **`git branch -D` stays OBSERVE** — only the ref is lost; the commit objects survive in the reflog.
- **`docker`/`kubectl` stay OBSERVE** — that state is typically declarative and re-creatable, and `kubectl delete pod` is inner-loop for many users.
- **`terraform destroy` blocks** — it tears down real external infrastructure and is never inner-loop.

`sql-drop-truncate-delete` is **split** into `sql-drop-truncate` (BLOCK) and `sql-delete-from` (OBSERVE). The old id bundled DDL destructors with `DELETE FROM`, which is routine development SQL and must not block. That id had 0 firings, so no telemetry history is affected.

## Block reasons are load-bearing

A PreToolUse block reaches the agent only as `dispatcher.ts`'s tool result — `{ content: 'Tool "bash" blocked by PreToolUse hook: <reason>', isError: true }`. That string is the entire interface, and the agent can retry next turn, so each reason names the pattern, why it is blocked, and the real alternative:

> `safe-destruct: blocked [git-reset-hard] — discards all uncommitted changes irrecoverably; commit or run "git stash" first. This hook cannot be self-bypassed: if the destruction is genuinely intended, stop and ask the operator to run it.`

The second commit exists because the first draft ended six reasons with "proceed with the intent stated explicitly." There is no intent-based bypass, so an agent following that advice would re-run the identical command and be blocked again — a loop. A constraint the agent can talk itself past is not a constraint; the reasons now say so plainly and route the genuine case to the operator.

## Precedence

A compound command matching both tiers resolves to BLOCK (`git reset --hard && rm -rf build` blocks). Tested explicitly — one unrecoverable sub-operation must not slip through by being mixed with a recoverable one.

## Structure

`DESTRUCTIVE_PATTERNS` moved to a new `src/agent/safe-destruct-patterns.ts` to keep both files under the 350-LOC limit (detector 123, patterns 211, tests 233).

## Verification

- `pnpm lint` clean (`tsc --noEmit`, both projects)
- `pnpm test src/agent/safe-destruct-detect.test.ts` — 74 passed (one positive case per pattern per tier, plus the precedence case and the registry-wiring variants)
- `pnpm test src/agent/hooks/config-bridge.test.ts` — 19 passed, PreToolUse count assertion intact
- `pnpm test src/agent/default-hook-registry.test.ts` — 6 passed
- `pnpm audit:env:check`, `scan:env:check`, `audit:sdk:check`, `audit:chalk:check`, `fix:pins:check` — all OK

No existing assertion was weakened. The previous `NEVER blocks` test used `rm -rf / --no-preserve-root`, a target that moves to BLOCK; it was split into per-tier cases rather than deleted.

## Follow-ups, deliberately not in this PR

- `release-boundary-detect` is still observe-only. `npm publish` is the strongest remaining block candidate — externally irreversible, 5 firings in five weeks.
- Re-measure before moving anything OBSERVE → BLOCK. The asymmetry is the design.
