### PR TITLE
fix(model-limits): opus 4.6/4.7/4.8 serve native 1M windows and 128k output

### DIFF
--- a/src/agent/model-limits.test.ts
+++ b/src/agent/model-limits.test.ts
@@ -186,16 +186,41 @@ describe('maxOutputTokensFor — retired-but-Active Opus pin', () => {
     // miss the table and fall to the 64k DEFAULT_MAX_OUTPUT — halving the real
     // 128k output cap. This guards that regression.
     expect(maxOutputTokensFor('claude-opus-4-8')).toBe(128_000);
+    // Same reasoning, same ceiling, for the other two Active 1M-window opus
+    // generations — both were missing and inheriting the 64k fallback.
+    expect(maxOutputTokensFor('claude-opus-4-7')).toBe(128_000);
+    expect(maxOutputTokensFor('claude-opus-4-6')).toBe(128_000);
     // The new default resolves correctly too.
     expect(maxOutputTokensFor('claude-opus-5')).toBe(128_000);
     expect(maxOutputTokensFor('opus')).toBe(128_000);
   });
 
-  it('reports opus-4-8 true 200k context window via the raw wire id', () => {
-    // No explicit MODEL_CONTEXT_LIMITS entry: the Anthropic DEFAULT_CONTEXT_LIMIT
-    // (200k) fallback already yields opus-4-8's real window, so no regression on
-    // the context path — documented here so the pin stays fully usable.
-    expect(contextLimitFor('claude-opus-4-8')).toBe(200_000);
+  it('reports the true 1M context window for the 4.6/4.7/4.8 opus wire ids', () => {
+    // Invariant: this assertion previously pinned 200k, on the stated premise that
+    // "the DEFAULT_CONTEXT_LIMIT (200k) fallback already yields opus-4-8's real
+    // window." That premise was wrong. Anthropic's context-windows page lists Opus
+    // 5, Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 5 and Sonnet 4.6 as 1M-window models
+    // with 1M as the default and no beta header required, so relying on the
+    // fallback under-reported all three opus generations by 5x.
+    // <https://platform.claude.com/docs/en/build-with-claude/context-windows>
+    expect(contextLimitFor('claude-opus-4-8')).toBe(1_000_000);
+    expect(contextLimitFor('claude-opus-4-7')).toBe(1_000_000);
+    expect(contextLimitFor('claude-opus-4-6')).toBe(1_000_000);
+    // Opus 4.5 is absent from that 1M list, so it must KEEP the 200k fallback —
+    // this is the negative control proving the fix is list-derived, not blanket.
+    expect(contextLimitFor('claude-opus-4-5-20251101')).toBe(200_000);
+  });
+
+  it('keeps the 200k working budget for the 1M opus wire ids (no cost regression)', () => {
+    // Contract: correcting the WINDOW must not move the COMPACTION TRIGGER. These
+    // sessions compacted at 200k before the window fix; without matching
+    // MODEL_AUTOCOMPACT_BUDGET entries they would have jumped to 1M — a real
+    // cost/latency change smuggled in behind a bookkeeping correction. `opus_1m`
+    // remains the explicit opt-in to the full window.
+    expect(autoCompactLimitFor('claude-opus-4-8')).toBe(200_000);
+    expect(autoCompactLimitFor('claude-opus-4-7')).toBe(200_000);
+    expect(autoCompactLimitFor('claude-opus-4-6')).toBe(200_000);
+    expect(autoCompactLimitFor('opus_1m')).toBe(1_000_000);
   });
 });
 

--- a/src/agent/model-limits.ts
+++ b/src/agent/model-limits.ts
@@ -42,6 +42,16 @@ export const MODEL_MAX_OUTPUT_TOKENS: Record<string, number> = {
   // DEFAULT_MAX_OUTPUT fallback. (Alias lineage, for git blame: 'claude-opus-4-6'
   // → 4-7 on 2026-04, 4-7 → 4-8 on 2026-05-28, 4-8 → opus-5 on 2026-07-24.)
   'claude-opus-4-8': 128_000,
+  // Opus 4.7 and 4.6 take the same 128k ceiling for the same reason, and both are
+  // likewise Active (retirement not sooner than 2027-04-16 / 2027-02-05). The rule
+  // is capability-derived, not per-model generosity: "A single request to any model
+  // with a 1M-token context window can generate up to 128k output tokens
+  // (`max_tokens`)" — and that page's 1M list names Opus 4.8, 4.7 AND 4.6.
+  // <https://platform.claude.com/docs/en/build-with-claude/context-windows>
+  // Both were absent here, so maxOutputTokensFor() silently halved them to the 64k
+  // DEFAULT_MAX_OUTPUT — the exact failure the 4.8 comment above warns about.
+  'claude-opus-4-7': 128_000,
+  'claude-opus-4-6': 128_000,
   // Claude Sonnet 5 (GA 2026-06): 128k max output — the SAME ceiling as Sonnet
   // 4.6, not an increase over it.
   'claude-sonnet-5': 128_000,
@@ -145,6 +155,19 @@ export const MODEL_CONTEXT_LIMITS: Record<string, number> = {
   // Claude Opus 5 (GA 2026-07-24): native 1M window. Base `opus` still
   // auto-compacts early via MODEL_AUTOCOMPACT_BUDGET (cost/latency policy).
   'claude-opus-5': 1_000_000,
+  // Opus 4.8 / 4.7 / 4.6: native 1M windows, no beta header — the same
+  // context-windows page cited below for Sonnet 4.6 names all three opus
+  // generations in its 1M list, and all three are Active per the deprecation
+  // table (retirement not sooner than 2027-05-28 / 2027-04-16 / 2027-02-05).
+  // All three were missing here and inherited DEFAULT_CONTEXT_LIMIT (200k),
+  // under-reporting a 1M window by 5x. That direction is the safe one — early
+  // compaction, not mid-run API errors — but it silently truncated usable
+  // context on models the user explicitly selected by wire id. Opus 4.5 is
+  // deliberately NOT listed: it is absent from the docs' 1M list, so the 200k
+  // fallback is correct for it.
+  'claude-opus-4-8': 1_000_000,
+  'claude-opus-4-7': 1_000_000,
+  'claude-opus-4-6': 1_000_000,
   // Claude Sonnet 4.6: native 1M window, GA — no beta header required. An earlier
   // revision pinned this at 200k on the premise that the 4.x line gated 1M behind
   // a `context-1m` beta this repo never sends. That premise was stale: 1M is now
@@ -272,6 +295,15 @@ const MODEL_AUTOCOMPACT_BUDGET: Record<string, number> = {
   // while keeping the same cost/latency-bounded compaction trigger. `sonnet_1m`
   // bypasses this via the `_1m` short-circuit in autoCompactLimitFor.
   'claude-sonnet-4-6': 200_000,
+  // Opus 4.8 / 4.7 / 4.6 now report truthful 1M windows, so they need the same
+  // 200k working budget as every other 1M model here. Without these entries the
+  // context-limit correction above would have silently raised their compaction
+  // trigger 5x — turning a bookkeeping fix into a real cost/latency regression on
+  // sessions that were previously compacting at 200k. `opus_1m` bypasses this via
+  // the `_1m` short-circuit; a raw wire id keeps the bounded budget.
+  'claude-opus-4-8': 200_000,
+  'claude-opus-4-7': 200_000,
+  'claude-opus-4-6': 200_000,
 };
 
 /**

--- a/src/agent/providers/anthropic-direct/context-limit-1m.test.ts
+++ b/src/agent/providers/anthropic-direct/context-limit-1m.test.ts
@@ -73,10 +73,16 @@ describe('getContextUsage — 1M-context aliases', () => {
   });
 
   it('falls back to the 200k Anthropic default for an unknown/retired wire id', async () => {
-    // A bare wire id that is in no limits table (e.g. the retired
-    // claude-opus-4-8) and carries no requestedModel hint falls back to the
-    // conservative 200k Anthropic default.
-    const query = makeQuery({ model: 'claude-opus-4-8' });
+    // A bare wire id that is in no limits table and carries no requestedModel
+    // hint falls back to the conservative 200k Anthropic default.
+    //
+    // Invariant: this case previously used `claude-opus-4-8` as its example of a
+    // "retired" id. That was wrong twice over — 4.8 is Active per Anthropic's
+    // deprecation table AND it is a 1M-window model, so it now has explicit
+    // entries and no longer exercises the fallback at all. The example is now
+    // claude-opus-4-1-20250805, which Anthropic genuinely retired on 2026-08-05.
+    // <https://platform.claude.com/docs/en/about-claude/model-deprecations>
+    const query = makeQuery({ model: 'claude-opus-4-1-20250805' });
     const usage = await query.getContextUsage();
     expect(usage.maxTokens).toBe(200_000);
   });

--- a/src/agent/tools/schema-classification.test.ts
+++ b/src/agent/tools/schema-classification.test.ts
@@ -10,7 +10,9 @@
  *   3. dispatcher.ts SAFE_TOOLS was a hand-maintained mirror.
  *   4. Schedule tools fell through to 'other'.
  *   5. CLAUDE_SHORT_ALIASES included 'auto' which was absent from MODEL_MAP.
- *   6. model-limits.ts listed retired 'claude-opus-4-6'.
+ *   6. model-limits.ts listed 'claude-opus-4-6' — believed retired at the time,
+ *      in fact Active until 2027-02-05. Guard #6 is now inverted: the entry must
+ *      be PRESENT. See the test body for the deprecation-table citation.
  *
  * If any of these invariants regresses a test here will fail.
  *
@@ -135,10 +137,19 @@ describe('schema-as-source-of-truth: model-limits coverage', () => {
     }
   });
 
-  it('claude-opus-4-6 (retired) is NOT in MODEL_MAX_OUTPUT_TOKENS', () => {
-    // Regression guard: the retired model was removed in the
-    // schema-as-source-of-truth refactor and must stay removed.
-    expect('claude-opus-4-6' in MODEL_MAX_OUTPUT_TOKENS).toBe(false);
+  it('claude-opus-4-6 (Active, not retired) IS in MODEL_MAX_OUTPUT_TOKENS', () => {
+    // Invariant: this assertion was inverted until 2026-08-10. The
+    // schema-as-source-of-truth refactor removed the entry as a "retired model"
+    // and pinned that removal here, but the premise was false: Anthropic's
+    // deprecation table lists claude-opus-4-6 as Active with retirement "not
+    // sooner than February 5, 2027", and the models actually retired from that
+    // era are claude-opus-4-1-20250805 and claude-opus-4-20250514.
+    // <https://platform.claude.com/docs/en/about-claude/model-deprecations>
+    // The wire id was always reachable (`--model claude-opus-4-6`); the missing
+    // entry only made maxOutputTokensFor() under-report it as 64k instead of
+    // 128k. Keep this pinned so the false-retirement removal cannot recur.
+    expect('claude-opus-4-6' in MODEL_MAX_OUTPUT_TOKENS).toBe(true);
+    expect(MODEL_MAX_OUTPUT_TOKENS['claude-opus-4-6']).toBe(128_000);
   });
 });
 


### PR DESCRIPTION
`claude-opus-4-6` was never retired. Anthropic's [deprecation table](https://platform.claude.com/docs/en/about-claude/model-deprecations) lists it as **Active**, retirement *"not sooner than February 5, 2027"*. The models actually retired from that era are `claude-opus-4-1-20250805` and `claude-opus-4-20250514`.

A prior refactor removed 4.6 from the limits tables as a *"retired model"* and pinned that removal with a regression test — freezing a false premise into a guard. Auditing the whole opus row against first-party docs turned up **three** Active models with wrong limits, not one.

## The wire id was never blocked

`--model claude-opus-4-6` has always worked. `resolveModelInput` passes an unrecognized wire id through unchanged, so the missing table entries never gated access — they only made AFK **silently under-report** the model. That is why this went unnoticed: no error, just a 200k status line on a 1M model and a halved output ceiling.

## What was wrong

Per [context-windows](https://platform.claude.com/docs/en/build-with-claude/context-windows), which names Opus 5, **Opus 4.8, Opus 4.7, Opus 4.6**, Sonnet 5 and Sonnet 4.6 in its 1M list:

> For every model with a 1M-token context window, 1M is the default: you don't need a beta header, and long-context requests are billed at standard pricing.

> A single request to any model with a 1M-token context window can generate up to 128k output tokens (`max_tokens`).

| model | context before | after | max output before | after |
|---|---|---|---|---|
| `claude-opus-4-8` | 200k | **1M** | 128k | 128k |
| `claude-opus-4-7` | 200k | **1M** | 64k | **128k** |
| `claude-opus-4-6` | 200k | **1M** | 64k | **128k** |

All three inherited `DEFAULT_CONTEXT_LIMIT` (200k), under-reporting a 1M window by 5×. Two of them also inherited `DEFAULT_MAX_OUTPUT` (64k) — exactly the failure mode the existing `claude-opus-4-8` comment warns about, reproduced on its two siblings.

`claude-opus-4-5-20251101` is **deliberately untouched**: it is absent from the docs' 1M list, so its 200k fallback is correct. It is asserted as a negative control, so the fix is provably list-derived rather than a blanket bump.

## The trap: window ≠ compaction trigger

Correcting `MODEL_CONTEXT_LIMITS` alone would have raised these models' auto-compaction trigger from 200k to 1M — a real cost/latency regression smuggled in behind a bookkeeping fix. Matching `MODEL_AUTOCOMPACT_BUDGET` entries keep all three compacting at 200k exactly as before, consistent with the policy already applied to `claude-opus-5`, `claude-sonnet-5`, and `claude-sonnet-4-6`. `opus_1m` remains the explicit opt-in to the full window. A new test pins this.

## Three false-premise sites corrected

1. **`schema-classification.test.ts`** asserted 4.6 must be *absent* (*"retired … must stay removed"*). Inverted to assert presence at 128k, carrying the deprecation-table citation so the removal cannot recur. The module docstring's invariant list is updated to match.
2. **`model-limits.test.ts`** pinned `contextLimitFor('claude-opus-4-8')` at 200k, stating the fallback *"already yields opus-4-8's real window."* It does not. Now pins 1M for all three, plus the 4.5 negative control and the new compaction-budget guard.
3. **`context-limit-1m.test.ts`** used `claude-opus-4-8` as its example of an *"unknown/retired wire id"* exercising the 200k fallback — wrong twice over, since 4.8 is Active **and** now has explicit entries, meaning that case had stopped testing a fallback at all. Swapped to `claude-opus-4-1-20250805`, genuinely retired 2026-08-05.

## Net capability

`claude-opus-4-6` becomes the only opus offering **raw extended thinking** (`{type:'enabled'}` with an explicit `budget_tokens`) together with a **1M context window** — every opus from 4.7 up is force-routed to adaptive by `requiresAdaptiveThinking` (`resolve-params.ts:28`). Verified by executing the real resolvers:

```
claude-opus-4-6 — context 1,000,000 · maxOut 128,000 · compactAt 200,000 (opus_1m -> 1,000,000)
thinking: {"type":"enabled","budget_tokens":60000,"display":"summarized"}   <- raw, budget preserved
```

## Verification

- `pnpm lint` clean (`tsc --noEmit`, both projects).
- Full suite **15975 passed**; the single failure is `write-denylist.test.ts` (a `/tmp` symlink `rmSync` case) which is **pre-existing and unrelated** — it reproduces in isolation and that file contains zero references to `model-limits`.
- Before/after tables produced by **executing** `contextLimitFor` / `maxOutputTokensFor` / `autoCompactLimitFor`, not by reading the constants.

## Out of scope

`requiresAdaptiveThinking`'s `isOpus47Plus` regex is `/opus-4-(7|[89])/`, so a hypothetical `claude-opus-4-10` would fall back to manual thinking and take a 400. Not reachable today; worth its own issue.
