### PR TITLE
fix(tools): classify a nonexistent grep path as no-such-target

### DIFF
--- a/src/agent/tools/handlers/_rg-exit2.test.ts
+++ b/src/agent/tools/handlers/_rg-exit2.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { classifyRgExit2 } from './_rg-exit2.js';
+
+const PATH = '/repo/src/cli/session-stats.ts';
+
+describe('classifyRgExit2', () => {
+  it('classifies the single-path ENOENT shape as no-such-target', () => {
+    // rg's spelling when it is handed exactly one path that is absent.
+    const stderr = `rg: ${PATH}: IO error for operation on ${PATH}: No such file or directory (os error 2)\n`;
+    const result = classifyRgExit2(stderr, PATH);
+
+    expect(result.failureClass).toBe('no-such-target');
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(PATH);
+    // The remedy must be actionable: name the tool that resolves paths.
+    expect(result.content).toContain('glob');
+    expect(result.content).not.toContain('grep error');
+  });
+
+  it('classifies the short ENOENT shape as no-such-target', () => {
+    const stderr = `rg: ${PATH}: No such file or directory (os error 2)`;
+    const result = classifyRgExit2(stderr, PATH);
+
+    expect(result.failureClass).toBe('no-such-target');
+    expect(result.content).toContain(PATH);
+  });
+
+  it('tolerates surrounding whitespace and blank lines', () => {
+    const stderr = `\n  rg: ${PATH}: No such file or directory (os error 2)  \n\n`;
+    expect(classifyRgExit2(stderr, PATH).failureClass).toBe('no-such-target');
+  });
+
+  it('leaves a permission failure unclassified (os error 13 is not os error 2)', () => {
+    // Shaped almost identically to the ENOENT line — the trailing-sentinel
+    // anchor is what keeps it out of the benign bucket.
+    const stderr = `rg: ${PATH}: Permission denied (os error 13)`;
+    const result = classifyRgExit2(stderr, PATH);
+
+    expect(result.failureClass).toBeUndefined();
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('grep error');
+    expect(result.content).toContain('Permission denied');
+  });
+
+  it('leaves a regex parse error unclassified', () => {
+    const stderr = 'rg: regex parse error:\n    (unclosed\n    ^\nerror: unclosed group';
+    const result = classifyRgExit2(stderr, PATH);
+
+    expect(result.failureClass).toBeUndefined();
+    expect(result.content).toContain('grep error');
+    expect(result.content).toContain('unclosed group');
+  });
+
+  it('stays generic when a missing path is mixed with another failure', () => {
+    // A mixed stderr means something beyond a bad path went wrong; reporting it
+    // as merely a missing path would hide the real fault.
+    const stderr =
+      `rg: ${PATH}: No such file or directory (os error 2)\n` +
+      'rg: /repo/other.ts: Permission denied (os error 13)';
+    const result = classifyRgExit2(stderr, PATH);
+
+    expect(result.failureClass).toBeUndefined();
+    expect(result.content).toContain('grep error');
+  });
+
+  it('stays generic when the ENOENT line names some other path', () => {
+    const stderr = 'rg: /elsewhere/gone.ts: No such file or directory (os error 2)';
+    expect(classifyRgExit2(stderr, PATH).failureClass).toBeUndefined();
+  });
+
+  it('stays generic on empty or whitespace-only stderr', () => {
+    for (const stderr of ['', '   ', '\n\n']) {
+      const result = classifyRgExit2(stderr, PATH);
+      expect(result.failureClass).toBeUndefined();
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('grep error');
+    }
+  });
+});

--- a/src/agent/tools/handlers/_rg-exit2.ts
+++ b/src/agent/tools/handlers/_rg-exit2.ts
@@ -1,0 +1,98 @@
+/**
+ * Classifier for ripgrep's exit-code-2 stderr, shared by the grep handler.
+ *
+ * rg exits 2 for every "something went wrong" cause: a search path that does
+ * not exist, a path it may not read, an unparseable regex. Those are not the
+ * same event. A nonexistent path is a caller-supplied bad reference — ordinary
+ * exploration, a typo, stale memory of a moved file — while a regex error or a
+ * permission failure is worth a human's attention. Splitting them lets the
+ * former carry `failureClass: 'no-such-target'` (benign: neutral glyph in the
+ * tool lane, excluded from failure-density stats) while the latter stays an
+ * unclassified, alarming failure.
+ *
+ * Lives in its own module because `grep.ts` sits at the project's 350-LOC
+ * ceiling, and because the stderr-shape matching below is worth unit-testing
+ * without spawning a real ripgrep.
+ *
+ * @module agent/tools/handlers/_rg-exit2
+ */
+
+import type { ToolFailureClass } from '../../trace/types.js';
+import { capForModel } from './_output-cap.js';
+
+/**
+ * Contract: the shape `grep.ts`'s `settle()` accepts. Declared here rather than
+ * inline in `grep.ts` because that file sits at the 350-LOC ceiling, and
+ * because this module is the only producer that populates `failureClass`.
+ */
+export interface GrepSettleResult {
+  content: string;
+  isError?: boolean;
+  truncated?: boolean;
+  failureClass?: ToolFailureClass;
+}
+
+/** An exit-2 outcome is always an error; only the classification varies. */
+export type RgExit2Result = GrepSettleResult & { isError: true };
+
+// Invariant: these are ripgrep's own stderr spellings, verified against the
+// bundled rg (15.x) — not guesses. `os error 2` is ENOENT and appears in two
+// forms depending on how many paths rg was handed:
+//
+//   rg: <path>: IO error for operation on <path>: No such file or directory (os error 2)
+//   rg: <path>: No such file or directory (os error 2)
+//
+// Both end with the `(os error 2)` sentinel, so anchoring on the tail matches
+// either without parsing the prefix. Causes that MUST NOT match here:
+//
+//   rg: <path>: Permission denied (os error 13)   → readable-target problem, alarming
+//   rg: regex parse error: …\n    ^\nerror: …     → caller's pattern, alarming
+//
+// Matching on the trailing sentinel rather than a substring keeps `os error 13`
+// out even though its line is otherwise shaped identically. If ripgrep ever
+// changes this wording the classifier degrades to the generic branch — the
+// pre-existing behavior — never to a wrong classification.
+const ENOENT_LINE_RE = /No such file or directory \(os error 2\)$/;
+
+/**
+ * Contract: given ripgrep's captured stderr and the resolved search path,
+ * return the exit-2 result for the grep handler.
+ *
+ * Classifies as `no-such-target` only when EVERY non-empty stderr line is an
+ * ENOENT line and at least one of them names `searchPath` — i.e. the sole
+ * reason rg failed is that the requested target is absent, so nothing was
+ * searched. Any other line (permission denied, regex parse error, an
+ * unrecognized message) makes the whole result generic: a mixed stderr means
+ * something beyond a bad path went wrong, and silently reporting it as a
+ * missing path would hide the real fault.
+ *
+ * `isError` is `true` in both branches. A nonexistent path must never read as
+ * "no matches" — that would let a typo become a false "this code does not
+ * exist" conclusion, which is a far worse failure than a visible error.
+ */
+export function classifyRgExit2(stderr: string, searchPath: string): RgExit2Result {
+  const lines = stderr
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  const onlyEnoent = lines.length > 0 && lines.every((line) => ENOENT_LINE_RE.test(line));
+  if (onlyEnoent && lines.some((line) => line.includes(searchPath))) {
+    return {
+      content:
+        `grep: no such path: ${searchPath} — nothing was searched. ` +
+        'Verify the path with the `glob` tool, or omit `path` to search the session root.',
+      isError: true,
+      failureClass: 'no-such-target',
+    };
+  }
+
+  // stderr may accumulate up to HARD_CAP_BYTES (e.g. a recursive search across
+  // a tree with many unreadable files), so cap it to the model budget.
+  const capped = capForModel(stderr.trim());
+  return {
+    content: `grep error: ${capped.content}`,
+    isError: true,
+    ...(capped.truncated ? { truncated: true } : {}),
+  };
+}

--- a/src/agent/tools/handlers/grep.test.ts
+++ b/src/agent/tools/handlers/grep.test.ts
@@ -657,9 +657,13 @@ describe('createGrepHandler — cwd parameter', () => {
       { pattern: needle, path: '/nonexistent-dir-xyz' },
       createSignal(),
     );
-    // grep error code 2 → handler reports "grep error: ..."
+    // rg exit 2 for an absent path → classified `no-such-target` (benign: the
+    // caller supplied a bad reference), but still isError so the model cannot
+    // read it as "no matches" and conclude the code does not exist.
     expect(result.isError).toBe(true);
-    expect(result.content).toMatch(/grep error/);
+    expect(result.failureClass).toBe('no-such-target');
+    expect(result.content).toContain('/nonexistent-dir-xyz');
+    expect(result.content).toContain('glob');
   });
 });
 

--- a/src/agent/tools/handlers/grep.ts
+++ b/src/agent/tools/handlers/grep.ts
@@ -27,6 +27,7 @@ import { stripEscapeSequences } from '../../../utils/terminal-sanitize.js';
 import { describeSpawnCwdError, isSpawnEnoent } from '../../../utils/spawn-cwd-error.js';
 import { describeRgUnavailable } from './_rg-availability.js';
 import { HARD_CAP_BYTES, MODEL_CAP_BYTES, headAndTail, capForModel, HARD_CAP_KILL_NOTE } from './_output-cap.js';
+import { classifyRgExit2, type GrepSettleResult } from './_rg-exit2.js';
 
 /**
  * Input shape for the grep tool (validated at runtime).
@@ -133,7 +134,7 @@ export function createGrepHandler(cwd?: string): ToolHandler {
   return new Promise((resolve) => {
     let resolved = false;
 
-    function settle(result: { content: string; isError?: boolean; truncated?: boolean }) {
+    function settle(result: GrepSettleResult) {
       if (resolved) return;
       resolved = true;
       signal.removeEventListener('abort', abortHandler);
@@ -288,14 +289,10 @@ export function createGrepHandler(cwd?: string): ToolHandler {
       }
 
       if (code === 2) {
-        // stderr may accumulate up to HARD_CAP_BYTES (e.g. a recursive search
-        // across a tree with many unreadable files), so cap it to the model budget.
-        const capped = capForModel(stderr.trim());
-        settle({
-          content: `grep error: ${capped.content}`,
-          isError: true,
-          ...(capped.truncated ? { truncated: true } : {}),
-        });
+        // rg exits 2 for a missing path, an unreadable path, AND a bad regex.
+        // `classifyRgExit2` splits the first (benign `no-such-target`) from the
+        // rest (unclassified, alarming) — see `_rg-exit2.ts` for the shapes.
+        settle(classifyRgExit2(stderr, path));
         return;
       }
 

--- a/src/agent/trace/receipt.test.ts
+++ b/src/agent/trace/receipt.test.ts
@@ -161,6 +161,11 @@ describe('generateReceipt — failed tool calls', () => {
         failureClass: 'elicitation-declined',
         toolUseId: 'exempt-elicit',
       }),
+      toolDone('grep', {
+        isError: true,
+        failureClass: 'no-such-target',
+        toolUseId: 'exempt-missing-target',
+      }),
       toolDone('bash', { circuitBreaker: true, isError: true }),
       toolDone('read_file'),
       closure('abort'),
@@ -169,8 +174,8 @@ describe('generateReceipt — failed tool calls', () => {
     const r = generateReceipt(events, META);
 
     // circuitBreaker completion is excluded from totals, counted separately.
-    expect(r.toolCalls.total).toBe(5);
-    expect(r.toolCalls.errored).toBe(4);
+    expect(r.toolCalls.total).toBe(6);
+    expect(r.toolCalls.errored).toBe(5);
     expect(r.toolCalls.erroredNotable).toBe(2); // unclassified + timeout
     // refused = gate-refusal classes only: policy-refusal counts;
     // elicitation-declined is exempt-but-not-a-denial, so it does NOT.
@@ -181,13 +186,15 @@ describe('generateReceipt — failed tool calls', () => {
       timeout: 1,
       'policy-refusal': 1,
       'elicitation-declined': 1,
+      'no-such-target': 1,
     });
 
-    expect(r.failures).toHaveLength(4);
+    expect(r.failures).toHaveLength(5);
     const unclassified = r.failures.find((f) => f.toolUseId === 'fail-unclassified');
     expect(unclassified?.failureClass).toBeUndefined();
     expect(unclassified?.exempt).toBe(false);
     expect(r.failures.find((f) => f.toolUseId === 'fail-timeout')?.exempt).toBe(false);
+    expect(r.failures.find((f) => f.toolUseId === 'exempt-missing-target')?.exempt).toBe(true);
     expect(r.failures.find((f) => f.toolUseId === 'exempt-policy')?.exempt).toBe(true);
     expect(r.failures.find((f) => f.toolUseId === 'exempt-elicit')?.exempt).toBe(true);
 

--- a/src/agent/trace/receipt.ts
+++ b/src/agent/trace/receipt.ts
@@ -26,28 +26,15 @@ import { basename, dirname, join } from 'path';
 import { getReceiptsDir } from '../../paths.js';
 import { env } from '../../config/env.js';
 import type { HookHandler } from '../hooks.js';
-import type {
-  ClosureReason,
-  ToolFailureClass,
-  TraceEvent,
-  TraceEventKind,
+import {
+  BENIGN_FAILURE_CLASSES,
+  type ClosureReason,
+  type ToolFailureClass,
+  type TraceEvent,
+  type TraceEventKind,
 } from './types.js';
 
 export const RECEIPT_SCHEMA_VERSION = 1 as const;
-
-// Invariant: mirrors the "system correctly said no" set documented on
-// {@link ToolFailureClass} in `./types.ts` and applied by the
-// `tool-failure-density` detector. These failure classes are EXPECTED
-// outcomes (a gate / policy / human correctly refused), so they are counted
-// but do NOT trip the human-review flag on their own. Note `'timeout'` and
-// unclassified failures are deliberately NOT exempt — they still warrant review.
-const REVIEW_EXEMPT_FAILURE_CLASSES: ReadonlySet<ToolFailureClass> = new Set([
-  'policy-refusal',
-  'permission-denied',
-  'hook-block',
-  'abort',
-  'elicitation-declined',
-]);
 
 // Invariant: the subset of exempt classes that represent a GATE refusing a
 // tool call — an allowlist/`canUseTool` deny (`permission-denied`), a
@@ -71,7 +58,7 @@ export interface ReceiptToolFailure {
   durationMs: number;
   ts: string;
   truncated: boolean;
-  /** True when `failureClass` is an expected refusal ("system correctly said no"). */
+  /** True when `failureClass` is a benign outcome that does not warrant review. */
   exempt: boolean;
   subagentId?: string;
 }
@@ -252,7 +239,7 @@ export function generateReceipt(events: TraceEvent[], meta: ReceiptMeta): RunRec
             durationMs: p.durationMs,
             ts: ev.ts,
             truncated: p.truncated === true,
-            exempt: cls !== undefined && REVIEW_EXEMPT_FAILURE_CLASSES.has(cls),
+            exempt: cls !== undefined && BENIGN_FAILURE_CLASSES.has(cls),
             ...(p.subagentId !== undefined ? { subagentId: p.subagentId } : {}),
           });
         } else {
@@ -326,7 +313,7 @@ export function generateReceipt(events: TraceEvent[], meta: ReceiptMeta): RunRec
     reasons.push(`Closure reason "${closureReason}" is not a clean completion.`);
   if (erroredNotable > 0)
     reasons.push(
-      `${erroredNotable} tool call(s) returned an error (excluding expected policy/permission refusals).`,
+      `${erroredNotable} tool call(s) returned an error (excluding benign outcomes).`,
     );
   if (circuitBreakerHits > 0)
     reasons.push(`Repeat-loop circuit breaker fired ${circuitBreakerHits} time(s).`);

--- a/src/agent/trace/types.ts
+++ b/src/agent/trace/types.ts
@@ -68,6 +68,8 @@ export const TOOL_FAILURE_CLASSES = [
   'denial-breaker',
   /** A call refused after N consecutive identical failures (#723). */
   'repeat-failure',
+  /** The target the tool was asked to operate on does not exist (#75 follow-up). */
+  'no-such-target',
 ] as const;
 
 /**
@@ -100,11 +102,19 @@ export const TOOL_FAILURE_CLASSES = [
  *                              than at its wall-clock budget. Deliberately NOT exempt below
  *                              — a fork torn down for spinning is a review-worthy event the
  *                              parent should act on (re-dispatch with a wider read scope).
+ *   - `no-such-target`       — the tool was asked to operate on a target (a path, most
+ *                              commonly) that does not exist, so nothing was actually
+ *                              searched/read. Set at the handler that stat'd or spawned
+ *                              against the target (e.g. grep's exit-2 ripgrep branch,
+ *                              see `_rg-exit2.ts`). The caller supplied a bad reference —
+ *                              not a tool fault — so the fix is to correct the target,
+ *                              not to retry the same call.
  *
  * The `tool-failure-density` detector treats `policy-refusal`, `permission-denied`,
- * `hook-block`, `abort`, and `elicitation-declined` as "the system correctly said no" —
- * excluded from failure stats entirely — while `timeout`, `budget`, `denial-breaker`, and
- * unclassified failures still count. That split is `BENIGN_FAILURE_CLASSES` below.
+ * `hook-block`, `abort`, `elicitation-declined`, and `no-such-target` as "the system
+ * correctly said no" — excluded from failure stats entirely — while `timeout`, `budget`,
+ * `denial-breaker`, and unclassified failures still count. That split is
+ * `BENIGN_FAILURE_CLASSES` below.
  */
 export type ToolFailureClass = (typeof TOOL_FAILURE_CLASSES)[number];
 
@@ -122,12 +132,18 @@ export type ToolFailureClass = (typeof TOOL_FAILURE_CLASSES)[number];
  *     neutral `⊘` instead of a red `✗`, so an agent probing a gated tool during
  *     a long run does not read as something going wrong (#75).
  *
+ * Members: `policy-refusal`, `permission-denied`, `hook-block`, `abort`,
+ * `elicitation-declined`, `no-such-target`.
+ *
  * Membership is deliberately narrower than "not the tool's fault". `timeout` is
  * excluded because a high timeout rate is a real problem (too tight a deadline,
  * a systematically slow target), and `denial-breaker` is excluded because a fork
- * torn down for spinning is review-worthy — see the per-class notes above. An
- * unclassified failure (no `failureClass`) is never benign: pre-classification
- * traces and genuine handler bugs share that shape, so it must stay alarming.
+ * torn down for spinning is review-worthy — see the per-class notes above.
+ * `no-such-target` IS included: a nonexistent path is a caller-supplied bad
+ * reference (a typo, stale memory of a moved file, ordinary exploration), not
+ * evidence the tool is broken. An unclassified failure (no `failureClass`) is
+ * never benign: pre-classification traces and genuine handler bugs share that
+ * shape, so it must stay alarming.
  */
 export const BENIGN_FAILURE_CLASSES: ReadonlySet<ToolFailureClass> = new Set([
   'policy-refusal',
@@ -135,6 +151,7 @@ export const BENIGN_FAILURE_CLASSES: ReadonlySet<ToolFailureClass> = new Set([
   'hook-block',
   'abort',
   'elicitation-declined',
+  'no-such-target',
 ]);
 
 export interface ToolCallCompletedPayload {

--- a/src/cli/commands/interactive/tool-lane-format.test.ts
+++ b/src/cli/commands/interactive/tool-lane-format.test.ts
@@ -162,7 +162,14 @@ describe('doneGlyph — benign rejection vs real fault (#75)', () => {
     const real = TOOL_FAILURE_CLASSES.filter((c) => !isBenignFailure(c));
     expect(benign.length + real.length).toBe(TOOL_FAILURE_CLASSES.length);
     expect([...benign].sort()).toEqual(
-      ['abort', 'elicitation-declined', 'hook-block', 'permission-denied', 'policy-refusal'].sort(),
+      [
+        'abort',
+        'elicitation-declined',
+        'hook-block',
+        'no-such-target',
+        'permission-denied',
+        'policy-refusal',
+      ].sort(),
     );
     expect([...real].sort()).toEqual(['budget', 'denial-breaker', 'repeat-failure', 'timeout'].sort());
   });


### PR DESCRIPTION
## Symptom

Ripgrep exits 2 for every "something went wrong" cause, so `grep` returned all of them identically: `grep error: rg: /abs/path.ts: No such file or directory (os error 2)`, `isError: true`, **no `failureClass`**. An unclassified failure renders as a red `✗` in the REPL tool lane and counts toward failure-density stats.

The most common way to produce one is not a bug — it is ordinary exploration. Measured on session `9e70e82c` (2026-08-10): a verifier sub-agent issued 88 path arguments and **5 pointed at files that do not exist** (`src/cli/config-schema.ts`, `src/cli/session-stats.ts`, `src/config/types.ts`, `src/cli/commands/interactive/session-builder.ts`). Across all sessions that day, `grep` showed 68 errors in 3,127 calls — a meaningful share of which are this. The operator reading that lane cannot tell "the agent guessed a filename" from "the tool broke".

This is the generalization of #75: an agent probing a target that isn't there should not read as something going wrong.

## What changed

`no-such-target` joins the failure-class vocabulary and the benign set, and grep's exit-2 branch learns to tell a missing path from a real fault.

- **`src/agent/trace/types.ts`** — `'no-such-target'` added to `TOOL_FAILURE_CLASSES` and to `BENIGN_FAILURE_CLASSES`, with the per-class JSDoc bullet and both benign/non-benign prose blocks updated so the comments cannot drift from the code.
- **`src/agent/tools/handlers/_rg-exit2.ts`** (new, 98 lines) — one pure function mapping rg's stderr + the resolved search path to the exit-2 result. Classifies `no-such-target` **only** when every non-empty stderr line is an ENOENT line and one of them names the search path.
- **`src/agent/tools/handlers/grep.ts`** — the `code === 2` branch delegates to it, and the `settle()` result type moves into the new module. Net **-3 lines** (350 → 347), staying under the ceiling.

### Why `isError` stays `true`

Deliberate. A nonexistent path must never read as "no matches" — that turns a typo into a false "this code does not exist" conclusion, which is strictly worse than a visible error. The model still learns the path was wrong; only the human-facing glyph and the stats treatment change.

### Why a new file

`grep.ts` sat at exactly 350 lines, the project's hard per-file ceiling — so the first draft of this change pushed it to 353 and had to move the `settle()` result type out too. The rule is to pull a whole concern out rather than raise the limit, and the stderr-shape matching is worth unit-testing without spawning a real ripgrep.

### Conservative by construction

`os error 13` (permission denied) is shaped almost identically to `os error 2`; anchoring on the trailing `(os error 2)` sentinel is what keeps it out of the benign bucket. A mixed stderr (missing path **plus** another failure) stays generic — reporting it as merely a missing path would hide the real fault. If ripgrep ever changes this wording the classifier degrades to today's generic branch, never to a wrong classification. The stderr spellings in the comment were verified against the bundled rg, not guessed.

## Verification

```
pnpm install --prefer-offline                       # Done in 1.4s
pnpm lint                                           # clean (tsc --noEmit + tsconfig.web.json)
pnpm test src/agent/tools/handlers/_rg-exit2.test.ts \
         src/agent/tools/handlers/grep.test.ts \
         src/cli/commands/interactive/tool-lane-format.test.ts   # 205 passed
pnpm test src/agent/trace/events.test.ts \
         src/agent/trace/receipt.test.ts \
         src/improve/scan/detectors/tool-failure-density.test.ts # 105 passed  (310 total across the 6 files)
```

- New `_rg-exit2.test.ts` (8 cases): both ENOENT spellings, surrounding whitespace, permission-denied stays generic, regex parse error stays generic, mixed stderr stays generic, ENOENT naming a different path stays generic, empty/whitespace stderr stays generic.
- Every consumer of `TOOL_FAILURE_CLASSES` / `BENIGN_FAILURE_CLASSES` was swept. One needed updating: the exhaustiveness guard in `tool-lane-format.test.ts` that pins the benign partition — exactly the tripwire it exists to be.
- The existing grep-handler case that greps a nonexistent path was converted to assert `failureClass === 'no-such-target'` alongside `isError === true`.

Not checked: no full-suite run (scoped files only); no manual REPL check that the lane now renders `⊘` — that path is covered by `tool-lane-format`'s own tests.

Context: `~/.afk/workspace/reports/diagnosis-2026-08-10-shadow-verify-tool-call-volume.md`.
