### PR TITLE
ci: make 350-line filesize check advisory (non-blocking)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         # a baselined path that no longer exists — so the baseline can shrink but
         # never silently slacken into a parking lot. Regenerate with
         # `pnpm audit:filesize:update`; never hand-edit it.
-        run: pnpm audit:filesize:check
+        run: pnpm audit:filesize:check || true
 
       - name: Audit the 350-line ceiling on files this PR touches
         # Touch-trigger: a change that modifies a still-oversized baselined file


### PR DESCRIPTION
Append `|| true` to the full-repo `pnpm audit:filesize:check` step so it
logs violations but no longer fails the workflow.

The per-PR touch-trigger step (line 83) was already advisory — this brings
the full-repo step in line.

The check still runs and prints any ceiling violations in the CI log for
visibility; it just won't block merges.
