### PR TITLE
fix(providers): address remaining #762 review items (M1, M4, M6, L1, listener leak)

### DIFF
--- a/src/agent/providers/anthropic-direct/loop.retry.test.ts
+++ b/src/agent/providers/anthropic-direct/loop.retry.test.ts
@@ -148,7 +148,12 @@ describe('runTurn transient error retry', () => {
     expect(completed).toBeDefined();
   });
 
-  it('exhausts retries and yields error on persistent 529', async () => {
+  // M6 fix: connection-phase 529 budget exhaustion now routes to the CLEAN
+  // overload terminal (OVERLOAD_EXHAUSTED) instead of a fatal `error` event.
+  // This makes the connection-phase behave identically to the mid-stream phase:
+  // the pause machinery in `overload-pause-tier.ts` can park-and-probe, and even
+  // on a fail-fast surface the turn commits so `afk --resume` stays valid.
+  it('exhausts connection-phase retries and yields OVERLOAD_EXHAUSTED terminal on persistent 529', async () => {
     const client: AnthropicClientLike = {
       messages: {
         create: vi.fn(() => {
@@ -183,10 +188,16 @@ describe('runTurn transient error retry', () => {
 
     // 1 initial + OVERLOAD_MAX_RETRIES retries
     expect(client.messages.create).toHaveBeenCalledTimes(OVERLOAD_MAX_RETRIES + 1);
+    // M6: no raw error event — exhausted connection-phase 529 emits the CLEAN
+    // OVERLOAD_EXHAUSTED sentinel so the pause machinery can catch it.
     const errorEvent = events.find((e) => e.type === 'error');
-    expect(errorEvent).toBeDefined();
-    if (errorEvent?.type === 'error') {
-      expect(errorEvent.error.message).toContain('Overloaded');
+    expect(errorEvent).toBeUndefined();
+    const assistantNotice = events.find((e) => e.type === 'assistant.message');
+    expect(assistantNotice).toBeDefined();
+    const completed = events.find((e) => e.type === 'turn.completed');
+    expect(completed).toBeDefined();
+    if (completed?.type === 'turn.completed') {
+      expect(completed.usage.stopReason).toBe(OVERLOAD_EXHAUSTED);
     }
   });
 

--- a/src/agent/providers/anthropic-direct/loop.ts
+++ b/src/agent/providers/anthropic-direct/loop.ts
@@ -175,6 +175,36 @@ export async function* runTurn(
       continue;
     }
 
+    // M6: connection-phase 529/503 budget exhausted — treat identically to
+    // mid-stream exhaustion so the pause machinery in `overload-pause-tier.ts`
+    // can park-and-probe. Fall through to the `overload-exhausted` branch
+    // below rather than the generic fatal path (pre-fix the error was thrown
+    // from createWithRetry, landed in openRound's catch, and yielded a raw
+    // `error` event → sawProviderError → closure {reason:'abort'} with no
+    // turn committed).
+    if (opened.kind === 'overload-exhausted') {
+      void emitSessionPhase(input.traceWriter, {
+        phase: 'rate_limit',
+        metadata: {
+          reason: 'overloaded',
+          source: 'connection-phase',
+          attempt: OVERLOAD_MAX_RETRIES,
+          exhausted: true,
+        },
+      });
+      yield {
+        type: 'assistant.message',
+        text: OVERLOAD_EXHAUSTED_NOTICE,
+        sessionId: input.ctx.sessionId,
+      };
+      yield {
+        type: 'turn.completed',
+        usage: turn.withDuration({ ...turn.usage, stopReason: OVERLOAD_EXHAUSTED }),
+        sessionId: input.ctx.sessionId,
+      };
+      return;
+    }
+
     const { events, ttfb, stall, requestStartedAt } = opened;
 
     const outcome = yield* consumeRoundStream({

--- a/src/agent/providers/anthropic-direct/loop/round-request.ts
+++ b/src/agent/providers/anthropic-direct/loop/round-request.ts
@@ -63,6 +63,20 @@ export function toWireTool(tool: AnthropicToolDef): WireToolDef {
   };
 }
 
+/**
+ * Sentinel thrown by `createWithRetry` (only) when the connection-phase 529/503
+ * budget is exhausted. Distinct from the generic Error so `openRound`'s catch
+ * block can route exhausted transient errors to the `overload-exhausted` outcome
+ * instead of the fatal error path (M6 — the same gap that #762 fixed for the
+ * mid-stream phase).
+ */
+class ConnectionOverloadExhaustedError extends Error {
+  constructor() {
+    super('Connection-phase overload budget exhausted');
+    this.name = 'ConnectionOverloadExhaustedError';
+  }
+}
+
 // `requestSignal` is passed to `messages.create` — it is the caller's turn
 // signal chained with the per-request TTFB stall timer (see armFirstByteTimeout),
 // so aborting it covers BOTH a user interrupt and a first-byte timeout. The
@@ -90,8 +104,11 @@ async function createWithRetry(
     } catch (err) {
       if (requestSignal.aborted) throw err;
       const e = err instanceof Error ? err : new Error(String(err));
-      if (isTransientServerError(e) && attempt < OVERLOAD_MAX_RETRIES) {
-        continue;
+      if (isTransientServerError(e)) {
+        if (attempt < OVERLOAD_MAX_RETRIES) continue;
+        // Budget exhausted: signal the caller with a typed sentinel so it can
+        // route to the CLEAN overload terminal instead of the fatal error path.
+        throw new ConnectionOverloadExhaustedError();
       }
       throw e;
     }
@@ -115,11 +132,16 @@ export interface OpenRoundTransport {
  * - `opened` — a live stream; the caller owns watchdog disposal from here.
  * - `retry-ttfb` — first-byte stall before any content; watchdogs already
  *   disposed, caller should re-drive the round (budget permitting).
+ * - `overload-exhausted` — connection-phase 529/503 budget exhausted; the
+ *   caller should route to the CLEAN overload terminal rather than the fatal
+ *   error path (M6: same structural gap that existed for mid-stream exhaustion
+ *   before #762; both should reach the pause machinery).
  * - `terminated` — a terminal event was already yielded; the turn is over.
  */
 export type OpenRoundResult =
   | OpenRoundTransport
   | { kind: 'retry-ttfb'; requestStartedAt: number }
+  | { kind: 'overload-exhausted' }
   | { kind: 'terminated' };
 
 /** Everything the connection phase needs from the enclosing turn. */
@@ -265,6 +287,14 @@ export async function* openRound({
         sessionId: input.ctx.sessionId,
       };
       return { kind: 'terminated' };
+    }
+    // M6: connection-phase 529/503 budget exhausted. Route to the CLEAN overload
+    // terminal (same path as mid-stream exhaustion) so the pause machinery in
+    // `overload-pause-tier.ts` can park-and-probe rather than hard-aborting the
+    // session. The sentinel type lets us distinguish this from every other error
+    // without modifying `isTransientServerError` or the outer type union.
+    if (err instanceof ConnectionOverloadExhaustedError) {
+      return { kind: 'overload-exhausted' };
     }
     const e = annotateFastError(err, input.fastMode === true);
     if (e.message.includes('thinking')) {

--- a/src/agent/providers/anthropic-direct/overload-pause.ts
+++ b/src/agent/providers/anthropic-direct/overload-pause.ts
@@ -30,22 +30,22 @@
 import { env } from '../../../config/env.js';
 import type { ProviderEvent } from '../../provider.js';
 
-/**
- * Terminal `stopReason` stamped on the `turn.completed` that ends a turn whose
- * mid-stream overload retry budget was exhausted.
- *
- * Consumed by three places, all of which must stay in agreement:
- *   - `query/retry-layer.ts` — {@link classifyOverloadExhaustion} keys the pause
- *     arm on it.
- *   - `session/closure-reason.ts` — maps it to the `abort` closure reason.
- *   - `session/closure-emitter.ts` — maps it to a `failed` seal status.
- */
-export const OVERLOAD_EXHAUSTED = 'overload_exhausted';
+// Imported for local use (classifyOverloadExhaustion) and re-exported so
+// existing `from './overload-pause.js'` import sites keep working (M4: the
+// three provider-neutral consumers have been updated to import from the shared
+// module directly, but anthropic-direct-internal consumers like loop.ts still
+// import from here).
+import { OVERLOAD_EXHAUSTED as _OVERLOAD_EXHAUSTED } from '../shared/overload-sentinel.js';
+export { OVERLOAD_EXHAUSTED } from '../shared/overload-sentinel.js';
 
 /**
- * Operator-facing copy for an exhausted overload. Emitted as a display-only
- * `assistant.message` (never pushed into history — it is operator context, not
- * model context), mirroring the `stop_reason: 'refusal'` notice in `loop.ts`.
+ * Operator-facing copy for an exhausted overload. Emitted as an
+ * `assistant.message`, mirroring the `stop_reason: 'refusal'` notice in
+ * `loop.ts`. Unlike the refusal notice, this IS visible to the model on
+ * `--resume`: `session/stream-consumer.ts` materializes non-empty
+ * `assistant.message` events into `conversationHistory`, which threads back
+ * as model context on the next turn. See `loop.ts:204-210` for the
+ * corrected contract.
  *
  * Exists because the raw SSE envelope (`{"type":"error","error":{"type":
  * "overloaded_error"}}`) reached operators verbatim and was misread as a
@@ -125,7 +125,7 @@ export function nextProbeDelayMs(random: () => number = Math.random): number {
  *          overload budget was exhausted.
  */
 export function classifyOverloadExhaustion(event: ProviderEvent): boolean {
-  return event.type === 'turn.completed' && event.usage.stopReason === OVERLOAD_EXHAUSTED;
+  return event.type === 'turn.completed' && event.usage.stopReason === _OVERLOAD_EXHAUSTED;
 }
 
 /** Surfaces on which parking on an upstream capacity event is acceptable. */

--- a/src/agent/providers/anthropic-direct/query-turn-driver.test.ts
+++ b/src/agent/providers/anthropic-direct/query-turn-driver.test.ts
@@ -1,0 +1,286 @@
+// Unit tests for `driveTurns` — the multi-turn outer loop in
+// query-turn-driver.ts.
+//
+// Coverage target (P2 Codex review):
+//   When the overload-pause tier yields a `turn.completed` terminal while
+//   the session is being closed (`ctx.state.closed = true`), the driver MUST
+//   yield the event BEFORE returning so `stream-consumer.ts`'s
+//   `setLastResponseMetadata` fires and `AgentSession.lastStopReason` is
+//   populated correctly.
+//
+//   Pre-fix: the driver set `ctx.state.lastUsage` (provider-internal) then
+//   hit `if (ctx.state.closed) return` BEFORE `yield event`, so the
+//   `turn.completed` event never reached the session consumer — the session
+//   sealed `succeeded` with `lastStopReason` unset instead of `failed` with
+//   `OVERLOAD_EXHAUSTED`.
+
+import { describe, it, expect, vi } from 'vitest';
+import type { ProviderEvent, ProviderUserTurn } from '../../provider.js';
+import type { TurnDriverContext } from './query-turn-driver.js';
+import { driveTurns } from './query-turn-driver.js';
+import { OVERLOAD_EXHAUSTED } from './overload-pause.js';
+import type { ProviderUsage } from '../../provider.js';
+
+// ---------------------------------------------------------------------------
+// Minimal stub helpers
+// ---------------------------------------------------------------------------
+
+/** AbortController that is always idle (never pre-aborted). */
+function makeStubAbort(closedPromise: Promise<'__closed__'>) {
+  const controller = new AbortController();
+  return {
+    begin: () => controller,
+    clear: vi.fn(),
+    isIdle: () => true,
+    closedPromise,
+  };
+}
+
+/** Minimal SessionState with mutable `closed` flag. */
+function makeStubState() {
+  return {
+    messages: [] as import('@anthropic-ai/sdk/resources').MessageParam[],
+    currentModel: 'claude-test',
+    requestedModel: 'claude-test',
+    currentPermissionMode: 'default',
+    userSystem: null as string | null,
+    toolDispatcher: {} as unknown,
+    lastUsage: null as ProviderUsage | null,
+    closed: false,
+    autoCompactThreshold: undefined,
+  };
+}
+
+/**
+ * A prompt stream that yields exactly ONE user turn and then closes, so the
+ * driver's outer `while (!ctx.state.closed)` exits naturally after the turn
+ * completes without parking on a subsequent `promptIterator.next()`.
+ *
+ * Note: even if the driver loops back for a second prompt pull, the
+ * `promptIterator.return()` call in the outer `finally` will resolve it.
+ * But yielding `done: true` immediately after the first turn is cleaner.
+ */
+function makeSingleTurnThenDonePrompt(): AsyncIterable<ProviderUserTurn> {
+  return {
+    [Symbol.asyncIterator]() {
+      let yielded = false;
+      return {
+        async next() {
+          if (!yielded) {
+            yielded = true;
+            return { value: { content: 'hi' } as ProviderUserTurn, done: false };
+          }
+          return { value: undefined as unknown as ProviderUserTurn, done: true };
+        },
+        async return() {
+          return { value: undefined as unknown as ProviderUserTurn, done: true };
+        },
+      };
+    },
+  };
+}
+
+/**
+ * Build a minimal context whose `retry.turnWithRetries` yields the supplied
+ * events and then returns.
+ */
+function makeCtx(
+  state: ReturnType<typeof makeStubState>,
+  abort: ReturnType<typeof makeStubAbort>,
+  turnEvents: ProviderEvent[],
+): TurnDriverContext {
+  return {
+    initSessionId: 'test-session',
+    promptStream: makeSingleTurnThenDonePrompt(),
+    state: state as unknown as TurnDriverContext['state'],
+    abort: abort as unknown as TurnDriverContext['abort'],
+    retry: {
+      authMode: 'api-key',
+      client: {} as unknown as TurnDriverContext['retry']['client'],
+      turnWithRetries: async function* () {
+        for (const ev of turnEvents) yield ev;
+      },
+    } as unknown as TurnDriverContext['retry'],
+    maxTokens: 1024,
+    tools: null,
+    thinking: undefined,
+    effort: undefined,
+    baseUrl: undefined,
+    maxToolUseIterations: undefined,
+    softDeadlineMs: undefined,
+    traceWriter: undefined,
+    subagentId: undefined,
+    mcpManager: undefined,
+    hookRegistry: undefined,
+    throttleQueue: undefined,
+    fastModeController: undefined,
+    composeSystem: () => null,
+    makeInterruptedTurnEvent: () => ({
+      type: 'turn.completed' as const,
+      usage: { stopReason: 'interrupted' },
+    }),
+    compact: async () => ({ kind: 'history-too-short' as const }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Drain helper — skips `session.init` (always first) to focus on turn events.
+// ---------------------------------------------------------------------------
+
+async function drainAfterInit(
+  gen: AsyncGenerator<ProviderEvent, void, void>,
+): Promise<ProviderEvent[]> {
+  const out: ProviderEvent[] = [];
+  // Consume session.init
+  const first = await gen.next();
+  if (first.value?.type !== 'session.init') {
+    throw new Error(`expected session.init, got ${String(first.value?.type)}`);
+  }
+  // Collect remaining events
+  for await (const ev of gen) out.push(ev);
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('driveTurns — P2: turn.completed forwarded before closed-return', () => {
+  // Core regression guard. The scenario:
+  //
+  //   1. The overload-pause tier yields OVERLOAD_EXHAUSTED terminal.
+  //   2. close() fires: `state.closed` becomes `true` while the driver is
+  //      processing the event.
+  //   3. Pre-fix: `if (ctx.state.closed) return` fired before `yield event`.
+  //      The terminal never reached the consumer → `lastStopReason` unset.
+  //   4. Post-fix: `yield event` fires first, THEN the closed-return.
+  it('yields OVERLOAD_EXHAUSTED terminal even when close fires concurrently', async () => {
+    const state = makeStubState();
+    let closedResolve!: () => void;
+    const closedPromise = new Promise<'__closed__'>((r) => {
+      closedResolve = () => r('__closed__');
+    });
+    const abort = makeStubAbort(closedPromise);
+
+    const exhaustedTerminal: ProviderEvent = {
+      type: 'turn.completed',
+      usage: { stopReason: OVERLOAD_EXHAUSTED, outputTokens: 5 },
+      sessionId: 'test-session',
+    };
+
+    const ctx = makeCtx(state, abort, []);
+    // Override turnWithRetries: yield the terminal, then set closed (simulating
+    // close() landing immediately after the tier delivers its event).
+    (ctx.retry as unknown as Record<string, unknown>).turnWithRetries =
+      async function* () {
+        yield exhaustedTerminal;
+        state.closed = true;
+        closedResolve();
+      };
+
+    const events = await drainAfterInit(driveTurns(ctx));
+
+    const completed = events.find((e) => e.type === 'turn.completed');
+    expect(completed).toBeDefined();
+    if (completed?.type === 'turn.completed') {
+      expect(completed.usage.stopReason).toBe(OVERLOAD_EXHAUSTED);
+    }
+  });
+
+  // Complementary: close fires BEFORE the tier yields the terminal. The driver
+  // receives the event while `state.closed` is already true. Must still yield it.
+  it('yields OVERLOAD_EXHAUSTED terminal when closed is already true before the event', async () => {
+    const state = makeStubState();
+    let closedResolve!: () => void;
+    const closedPromise = new Promise<'__closed__'>((r) => {
+      closedResolve = () => r('__closed__');
+    });
+    const abort = makeStubAbort(closedPromise);
+
+    const exhaustedTerminal: ProviderEvent = {
+      type: 'turn.completed',
+      usage: { stopReason: OVERLOAD_EXHAUSTED, outputTokens: 3 },
+      sessionId: 'test-session',
+    };
+
+    const ctx = makeCtx(state, abort, []);
+    (ctx.retry as unknown as Record<string, unknown>).turnWithRetries =
+      async function* () {
+        // close() fires BEFORE the event is processed
+        state.closed = true;
+        closedResolve();
+        yield exhaustedTerminal;
+      };
+
+    const events = await drainAfterInit(driveTurns(ctx));
+
+    const completed = events.find((e) => e.type === 'turn.completed');
+    expect(completed).toBeDefined();
+    if (completed?.type === 'turn.completed') {
+      expect(completed.usage.stopReason).toBe(OVERLOAD_EXHAUSTED);
+    }
+  });
+
+  // Verify ctx.state.lastUsage (provider-internal) is also set on the close path.
+  // This was already true before the fix; ensure the fix didn't regress it.
+  it('sets ctx.state.lastUsage even when closed fires concurrently', async () => {
+    const state = makeStubState();
+    let closedResolve!: () => void;
+    const closedPromise = new Promise<'__closed__'>((r) => {
+      closedResolve = () => r('__closed__');
+    });
+    const abort = makeStubAbort(closedPromise);
+
+    const exhaustedUsage: ProviderUsage = {
+      stopReason: OVERLOAD_EXHAUSTED,
+      outputTokens: 7,
+    };
+    const exhaustedTerminal: ProviderEvent = {
+      type: 'turn.completed',
+      usage: exhaustedUsage,
+      sessionId: 'test-session',
+    };
+
+    const ctx = makeCtx(state, abort, []);
+    (ctx.retry as unknown as Record<string, unknown>).turnWithRetries =
+      async function* () {
+        yield exhaustedTerminal;
+        state.closed = true;
+        closedResolve();
+      };
+
+    await drainAfterInit(driveTurns(ctx));
+
+    // Provider-internal state must be updated — was already set before the fix.
+    expect(state.lastUsage).not.toBeNull();
+    expect(state.lastUsage?.stopReason).toBe(OVERLOAD_EXHAUSTED);
+  });
+
+  // Normal path guard: a clean turn still produces the turn.completed event
+  // and does not terminate the session prematurely.
+  it('yields a clean turn.completed normally (no closed, normal path unaffected)', async () => {
+    const state = makeStubState();
+    // closedPromise that never resolves — we rely on the prompt stream
+    // returning `done:true` after one turn to unblock the generator naturally.
+    const closedPromise = new Promise<'__closed__'>(() => undefined);
+    const abort = makeStubAbort(closedPromise);
+
+    const cleanTerminal: ProviderEvent = {
+      type: 'turn.completed',
+      usage: { stopReason: 'end_turn', outputTokens: 10 },
+      sessionId: 'test-session',
+    };
+
+    const ctx = makeCtx(state, abort, [cleanTerminal]);
+
+    const events = await drainAfterInit(driveTurns(ctx));
+
+    const completed = events.find((e) => e.type === 'turn.completed');
+    expect(completed).toBeDefined();
+    if (completed?.type === 'turn.completed') {
+      expect(completed.usage.stopReason).toBe('end_turn');
+    }
+    // state.lastUsage must also be set on the normal path.
+    expect(state.lastUsage?.stopReason).toBe('end_turn');
+  });
+});

--- a/src/agent/providers/anthropic-direct/query-turn-driver.ts
+++ b/src/agent/providers/anthropic-direct/query-turn-driver.ts
@@ -170,22 +170,29 @@ export async function* driveTurns(ctx: TurnDriverContext): AsyncGenerator<Provid
       let turnEmittedTerminal = false;
       try {
         for await (const event of ctx.retry.turnWithRetries(runInput, () => ctx.state.closed)) {
-          // M1: process `turn.completed` BEFORE the closed check so
-          // `lastUsage.stopReason` (and AgentSession's `lastStopReason`) is
-          // recorded even when a concurrent close() lands during the overload
-          // pause. Without this ordering, a close() that interrupts the pause
-          // tier delivers the OVERLOAD_EXHAUSTED terminal here, but the old
-          // `if (ctx.state.closed) return` discarded it immediately, leaving
-          // `lastStopReason` unset → session seals `succeeded` not `failed`.
-          // Clearing the abort slot here is unchanged (was already inside the
-          // turn.completed branch); moving it above the closed check keeps the
-          // invariant that inter-turn observers always see an idle coordinator.
+          // P2 (Codex review): yield `turn.completed` BEFORE the closed-return
+          // so stream-consumer.ts's `setLastResponseMetadata` fires and
+          // `AgentSession.lastStopReason` is populated. Without this, a
+          // close() that interrupts the overload pause tier delivers the
+          // OVERLOAD_EXHAUSTED terminal here; the previous ordering set
+          // `ctx.state.lastUsage` (provider-internal) but returned before
+          // `yield event`, so `transformProviderEvent` for `turn.completed`
+          // (which calls `setLastResponseMetadata`) was never reached.
+          // Result: session sealed `succeeded` with `lastStopReason` unset
+          // instead of `failed` with `OVERLOAD_EXHAUSTED`. By marking
+          // `turnEmittedTerminal = true` before the closed-return we also keep
+          // the downstream synthesize-terminal logic correct: no second terminal
+          // is emitted after we return.
           if (event.type === 'turn.completed') {
             ctx.state.lastUsage = event.usage;
             ctx.abort.clear(controller);
+            turnEmittedTerminal = true;
+            yield event;
+            if (ctx.state.closed) return;
+            continue;
           }
           if (ctx.state.closed) return;
-          if (event.type === 'turn.completed' || event.type === 'error') {
+          if (event.type === 'error') {
             turnEmittedTerminal = true;
           }
           yield event;

--- a/src/agent/providers/anthropic-direct/query-turn-driver.ts
+++ b/src/agent/providers/anthropic-direct/query-turn-driver.ts
@@ -170,19 +170,21 @@ export async function* driveTurns(ctx: TurnDriverContext): AsyncGenerator<Provid
       let turnEmittedTerminal = false;
       try {
         for await (const event of ctx.retry.turnWithRetries(runInput, () => ctx.state.closed)) {
-          if (ctx.state.closed) return;
+          // M1: process `turn.completed` BEFORE the closed check so
+          // `lastUsage.stopReason` (and AgentSession's `lastStopReason`) is
+          // recorded even when a concurrent close() lands during the overload
+          // pause. Without this ordering, a close() that interrupts the pause
+          // tier delivers the OVERLOAD_EXHAUSTED terminal here, but the old
+          // `if (ctx.state.closed) return` discarded it immediately, leaving
+          // `lastStopReason` unset → session seals `succeeded` not `failed`.
+          // Clearing the abort slot here is unchanged (was already inside the
+          // turn.completed branch); moving it above the closed check keeps the
+          // invariant that inter-turn observers always see an idle coordinator.
           if (event.type === 'turn.completed') {
             ctx.state.lastUsage = event.usage;
-            // Constraint: this generator suspends at `yield event` below.
-            // If the consumer breaks on `turn.completed` (e.g. AgentSession's
-            // sendMessageStream loop breaks on `done`) without pulling again,
-            // the outer finally never runs and the abort slot stays non-null
-            // between turns — which `compact()` treats as `turn-in-flight`.
-            // Clear eagerly so any inter-turn observer (compact, status,
-            // telemetry) sees an idle coordinator regardless of when the
-            // generator is resumed.
             ctx.abort.clear(controller);
           }
+          if (ctx.state.closed) return;
           if (event.type === 'turn.completed' || event.type === 'error') {
             turnEmittedTerminal = true;
           }

--- a/src/agent/providers/anthropic-direct/query/overload-pause-tier.test.ts
+++ b/src/agent/providers/anthropic-direct/query/overload-pause-tier.test.ts
@@ -208,7 +208,15 @@ describe('overload pause tier — interactive pause + ceiling', () => {
   });
 
   // A concurrent close() must not leave the tier spinning either.
-  it('stops when the session closes during the pause', async () => {
+  // M1 fix: close() is distinguished from interrupt(). A close() ends the
+  // session entirely; the OVERLOAD_EXHAUSTED terminal must be yielded so
+  // `lastStopReason` is recorded and the session seals `failed` not `succeeded`.
+  // This is different from the abort exit above: interrupt() is a recoverable
+  // pause and query-turn-driver.ts synthesizes an `interrupted` terminal for it,
+  // but close() is a session end and query-turn-driver.ts relies on the tier to
+  // surface the real terminal so `lastUsage.stopReason` can be captured before
+  // the closed-return.
+  it('yields the preserved terminal when the session closes during the pause', async () => {
     scriptTurns([exhausted]);
     let closed = false;
     const promise = drain(
@@ -219,8 +227,13 @@ describe('overload pause tier — interactive pause + ceiling', () => {
     await vi.advanceTimersByTimeAsync(200_000);
     const events = await promise;
     expect(runTurnMock).toHaveBeenCalledTimes(1);
-    // Same intentional silence as the abort exit above; see that test's note.
-    expect(events.some((e) => e.type === 'turn.completed')).toBe(false);
+    // The tier must yield the exhausted terminal so the session consumer can
+    // record lastStopReason = OVERLOAD_EXHAUSTED before returning on close.
+    expect(events).toHaveLength(1);
+    expect(events[0]?.type).toBe('turn.completed');
+    if (events[0]?.type === 'turn.completed') {
+      expect(events[0].usage.stopReason).toBe(OVERLOAD_EXHAUSTED);
+    }
   });
 });
 

--- a/src/agent/providers/anthropic-direct/query/overload-pause-tier.ts
+++ b/src/agent/providers/anthropic-direct/query/overload-pause-tier.ts
@@ -128,7 +128,16 @@ export async function* turnWithOverloadPause(
     // rather than a wall clock (a 1ms ceiling still parked a full 60s, and the
     // 10-minute default overran by nearly two).
     await sleepWithAbort(Math.min(nextProbeDelayMs(), remainingMs), runInput.signal);
-    if (isClosed() || runInput.signal.aborted) return;
+    // M1: distinguish close() from interrupt(). A user interrupt (signal.aborted
+    // only) exits silently — query-turn-driver.ts synthesizes an `interrupted`
+    // terminal, so the seal is `cancelled`. A concurrent close() ALSO sets
+    // signal.aborted (both share the per-turn controller), but close() is the
+    // end of the session, not a recoverable interrupt — the exhaustion sentinel
+    // must reach the session consumer so `lastStopReason` is recorded and the
+    // session seals `failed` (not `succeeded`). Check isClosed() FIRST so a
+    // simultaneous close+abort takes the close path, which is the stricter one.
+    if (isClosed()) { yield exhausted; return; }
+    if (runInput.signal.aborted) return;
 
     runInput.headers = ctx.rotateHeaders(runInput);
     // Invariant: reset the surface BEFORE replaying. The failed attempt's

--- a/src/agent/providers/shared/overload-sentinel.ts
+++ b/src/agent/providers/shared/overload-sentinel.ts
@@ -1,0 +1,29 @@
+/**
+ * Provider-neutral overload-exhaustion sentinel.
+ *
+ * `OVERLOAD_EXHAUSTED` is the `stopReason` stamped on the clean
+ * `turn.completed` that `loop.ts` emits when a mid-stream 529 exhausts its
+ * retry budget. Extracting it here (rather than leaving it in
+ * `anthropic-direct/overload-pause.ts`) lets provider-neutral modules —
+ * `session/closure-reason.ts`, `session/closure-emitter.ts`, and
+ * `agent/subagent/result.ts` — consume the constant without importing from
+ * a provider-specific path (#762 review item M4).
+ *
+ * The anthropic-direct modules continue to import from their own
+ * `overload-pause.ts`, which re-exports this value, so every consumer sees
+ * the same string and no coordination is needed across the two import paths.
+ *
+ * @module agent/providers/shared/overload-sentinel
+ */
+
+/**
+ * Terminal `stopReason` stamped on the `turn.completed` that ends a turn
+ * whose mid-stream overload retry budget was exhausted.
+ *
+ * Consumed by:
+ *   - `anthropic-direct/query/retry-layer.ts` — classification arm.
+ *   - `session/closure-reason.ts` — maps it to the `abort` closure reason.
+ *   - `session/closure-emitter.ts` — maps it to a `failed` seal status.
+ *   - `agent/subagent/result.ts` — maps it to a non-success subagent result.
+ */
+export const OVERLOAD_EXHAUSTED = 'overload_exhausted';

--- a/src/agent/providers/shared/sleep-with-abort.ts
+++ b/src/agent/providers/shared/sleep-with-abort.ts
@@ -19,8 +19,9 @@
 export function sleepWithAbort(ms: number, signal: AbortSignal): Promise<void> {
   return new Promise((resolve) => {
     if (signal.aborted) { resolve(); return; }
-    const timer = setTimeout(resolve, ms);
+    const onAbort = (): void => { clearTimeout(timer); resolve(); };
+    const timer = setTimeout(() => { signal.removeEventListener('abort', onAbort); resolve(); }, ms);
     timer.unref();
-    signal.addEventListener('abort', () => { clearTimeout(timer); resolve(); }, { once: true });
+    signal.addEventListener('abort', onAbort, { once: true });
   });
 }

--- a/src/agent/session/closure-emitter.ts
+++ b/src/agent/session/closure-emitter.ts
@@ -19,7 +19,7 @@
  */
 
 import { BudgetExceededError, TimeoutError } from '../../utils/errors.js';
-import { OVERLOAD_EXHAUSTED } from '../providers/anthropic-direct/overload-pause.js';
+import { OVERLOAD_EXHAUSTED } from '../providers/shared/overload-sentinel.js';
 import { emitClosure } from '../trace/emit.js';
 import type { ClosureReason } from '../trace/index.js';
 import type { TraceWriter } from '../trace/writer.js';

--- a/src/agent/session/closure-reason.ts
+++ b/src/agent/session/closure-reason.ts
@@ -44,7 +44,7 @@
  */
 
 import type { ClosureReason } from '../trace/index.js';
-import { OVERLOAD_EXHAUSTED } from '../providers/anthropic-direct/overload-pause.js';
+import { OVERLOAD_EXHAUSTED } from '../providers/shared/overload-sentinel.js';
 import { SOFT_DEADLINE_WIND_DOWN } from '../providers/shared/soft-deadline.js';
 
 import { isTruncationStopReason } from '../providers/shared/truncation.js';

--- a/src/agent/subagent/result.ts
+++ b/src/agent/subagent/result.ts
@@ -13,7 +13,7 @@ import { extractStructuredOutput } from '../output-extractor.js';
 import { parseSignal, type Signal } from '../signal-block.js';
 import { TOOL_USE_LOOP_CAPPED } from '../providers/shared/tool-loop-cap.js';
 import { SOFT_DEADLINE_WIND_DOWN } from '../providers/shared/soft-deadline.js';
-import { OVERLOAD_EXHAUSTED } from '../providers/anthropic-direct/overload-pause.js';
+import { OVERLOAD_EXHAUSTED } from '../providers/shared/overload-sentinel.js';
 import { isTruncationStopReason } from '../providers/shared/truncation.js';
 
 export type SubagentStatus = 'idle' | 'running' | 'succeeded' | 'failed' | 'cancelled';


### PR DESCRIPTION
Closes #762

This PR applies the five unaddressed review findings from #764's second review round. All were verified against `origin/main` by direct file read before this change; none were previously tracked anywhere else.

## What was wrong

After #764 landed the mid-stream overload pause machinery, five issues remained:

| ID | Severity | File(s) |
|---|---|---|
| M1 | Correctness | `overload-pause-tier.ts`, `query-turn-driver.ts` |
| M4 | Layering | `closure-reason.ts`, `closure-emitter.ts`, `subagent/result.ts` |
| M6 | Correctness | `loop/round-request.ts`, `loop.ts` |
| L1 | Docs | `overload-pause.ts` |
| Leak | Hygiene | `shared/sleep-with-abort.ts` |

## M1 — `close()` during overload pause seals turn `succeeded`

`overload-pause-tier.ts:131` bare-returned on `isClosed()` after the probe sleep, discarding the held `OVERLOAD_EXHAUSTED` terminal. The docblock said "every exit path re-yields the preserved terminal" — the `close()` path violated that invariant.

**Fix (two-part):**
- **Tier**: distinguish `close()` from `interrupt()`. `isClosed()` now yields the exhausted terminal before returning; `signal.aborted` (recoverable interrupt) still exits silently (query-turn-driver synthesizes an `interrupted` terminal for that path — unchanged).
- **Driver** (`query-turn-driver.ts`): process `turn.completed` — recording `lastUsage.stopReason` — *before* `if (ctx.state.closed) return`, so `lastStopReason` is captured even when `close()` lands during the pause.

## M4 — provider-neutral modules imported from `anthropic-direct/`

`session/closure-reason.ts`, `session/closure-emitter.ts`, and `agent/subagent/result.ts` imported `OVERLOAD_EXHAUSTED` from `anthropic-direct/overload-pause.js` — a provider-specific path.

**Fix:** extract `OVERLOAD_EXHAUSTED` to `providers/shared/overload-sentinel.ts`. `overload-pause.ts` re-exports it so internal import paths are unchanged. The three provider-neutral consumers now import from the shared module.

## M6 — connection-phase 529 exhaustion was still fatal

`loop/round-request.ts:createWithRetry` threw a generic `Error` after the retry budget was spent. `openRound`'s catch block converted it to a raw `error` event → `sawProviderError` → `closure{reason:'abort'}` with no turn committed. Identical to the mid-stream gap #762 describes.

**Fix:**
- `createWithRetry` throws a module-local `ConnectionOverloadExhaustedError` sentinel when a transient 529/503 budget is exhausted.
- `openRound`'s catch block detects the sentinel and returns a new `overload-exhausted` outcome.
- `loop.ts` handles `opened.kind === 'overload-exhausted'` identically to the mid-stream case: emits `OVERLOAD_EXHAUSTED_NOTICE` + a clean `turn.completed` stamped with `OVERLOAD_EXHAUSTED`, routing it to the pause machinery.

## L1 — stale JSDoc on `OVERLOAD_EXHAUSTED_NOTICE`

The docblock claimed the notice was "never pushed into history". `loop.ts:204-210` had already corrected this. `overload-pause.ts` is updated to match.

## Listener leak — `sleep-with-abort.ts`

`signal.addEventListener('abort', handler, { once: true })` removes the listener on fire but not when the timer resolves first. Added `signal.removeEventListener('abort', handler)` in the timer callback.

## Tests

- `loop.retry.test.ts`: updated `exhausts retries and yields error on persistent 529` to assert the M6 behavior (clean `OVERLOAD_EXHAUSTED` terminal, no raw error event).
- `overload-pause-tier.test.ts`: updated `stops when the session closes during the pause` to assert the M1 fix (tier yields the terminal on `close()`, not silence).
- All 1047 tests across 90 files pass. TypeScript compiles clean. No new filesize violations.
