### PR TITLE
fix(#962): fail-fast context-overflow guard for max_tokens exceeding window

### DIFF
--- a/src/agent/providers/anthropic-direct/provider-query-build.ts
+++ b/src/agent/providers/anthropic-direct/provider-query-build.ts
@@ -96,6 +96,14 @@ export function buildProviderQuery(
       });
 
   const resolvedEffort = resolveEffort(config.effort, model);
+  // Use requestedModel (the alias, e.g. sonnet_1m) rather than the resolved
+  // wire id so safeAutoCompactThresholdFor sees the full 1M window when
+  // the alias carries that budget. Extracted to avoid calling
+  // resolveAutoCompactThreshold twice. (#1014 Item 3 & 4)
+  const autoCompactThreshold = resolveAutoCompactThreshold(
+    config.autoCompact,
+    typeof config.model === 'string' && config.model.length > 0 ? config.model : model,
+  );
   return new AnthropicDirectQuery({
     client,
     // In local-server mode, downgrade the effective auth mode to 'api-key'
@@ -163,9 +171,7 @@ export function buildProviderQuery(
       ctx.setCurrentPermissionMode(mode);
     },
     ...(ctx.mcpManager !== undefined ? { mcpManager: ctx.mcpManager } : {}),
-    ...(resolveAutoCompactThreshold(config.autoCompact, model) !== undefined
-      ? { autoCompactThreshold: resolveAutoCompactThreshold(config.autoCompact, model) }
-      : {}),
+    ...(autoCompactThreshold !== undefined ? { autoCompactThreshold } : {}),
     // Thread the resolved hook registry into the query so auto-compaction
     // can dispatch PreCompact(trigger:'auto') before calling compact().
     // resolveSessionHookRegistry is already called above for the dispatcher;

--- a/src/agent/providers/anthropic-direct/provider-query-build.ts
+++ b/src/agent/providers/anthropic-direct/provider-query-build.ts
@@ -163,8 +163,8 @@ export function buildProviderQuery(
       ctx.setCurrentPermissionMode(mode);
     },
     ...(ctx.mcpManager !== undefined ? { mcpManager: ctx.mcpManager } : {}),
-    ...(resolveAutoCompactThreshold(config.autoCompact) !== undefined
-      ? { autoCompactThreshold: resolveAutoCompactThreshold(config.autoCompact) }
+    ...(resolveAutoCompactThreshold(config.autoCompact, model) !== undefined
+      ? { autoCompactThreshold: resolveAutoCompactThreshold(config.autoCompact, model) }
       : {}),
     // Thread the resolved hook registry into the query so auto-compaction
     // can dispatch PreCompact(trigger:'auto') before calling compact().

--- a/src/agent/providers/anthropic-direct/query-runtime.ts
+++ b/src/agent/providers/anthropic-direct/query-runtime.ts
@@ -326,13 +326,13 @@ export class AnthropicDirectQuery implements ProviderQuery {
   }
 
   async compact(): Promise<ProviderCompactResult> {
-    return compactQueryHistory({
-      state: this.state,
-      abort: this.abort,
-      retry: this.retry,
+    const r = await compactQueryHistory({
+      state: this.state, abort: this.abort, retry: this.retry,
       initSessionId: this.initSessionId,
       ...(this.traceWriter ? { traceWriter: this.traceWriter } : {}),
     });
+    if (r.compacted) this.state.lastUsage = null; // #962: stale usage → false-positive
+    return r;
   }
 
   listRewindTargets(): RewindTarget[] {

--- a/src/agent/providers/anthropic-direct/query-turn-driver.auto-compact.ts
+++ b/src/agent/providers/anthropic-direct/query-turn-driver.auto-compact.ts
@@ -63,12 +63,15 @@ export async function* maybeAutoCompact(ctx: TurnDriverContext): AsyncGenerator<
         trigger: 'auto',
       });
     }
-    await ctx.compact();
+    const compactResult = await ctx.compact();
     // Reset lastUsage after compaction so the overflow guard (#962) does not
     // false-positive on the next turn: the stale count is no longer a valid
     // lower bound once history has been truncated. The next API call will
     // repopulate it from the actual response.
-    ctx.state.lastUsage = null;
+    // Conditioned on `compacted` — a no-op (history too short, summarization
+    // failure) must preserve the near-limit evidence; unconditionally nulling
+    // it would skip both the guard and auto-compaction on the next turn.
+    if (compactResult.compacted) ctx.state.lastUsage = null;
   } catch (compactErr) {
     if (compactErr instanceof HookBlockedError) {
       // Hook blocked auto-compaction — skip this turn's compaction

--- a/src/agent/providers/anthropic-direct/query-turn-driver.auto-compact.ts
+++ b/src/agent/providers/anthropic-direct/query-turn-driver.auto-compact.ts
@@ -1,0 +1,80 @@
+/**
+ * Auto-compaction helper extracted from query-turn-driver.ts to stay within the
+ * 350-line file ceiling. Behavior is identical — only the physical location
+ * changed.
+ *
+ * @module agent/providers/anthropic-direct/query-turn-driver.auto-compact
+ */
+
+import type { ProviderEvent } from '../../provider.js';
+import { autoCompactLimitFor } from '../../model-limits.js';
+import { contextWindowTokensUsed, shouldAutoCompact } from './query/auto-compact.js';
+import { HookBlockedError } from '../../../utils/errors.js';
+import type { TurnDriverContext } from './query-turn-driver.js';
+
+/**
+ * Auto-compaction: fire at the natural turn boundary — after the per-turn
+ * event loop exits and the abort slot is cleared — so we never trigger while a
+ * tool call is in flight.
+ *
+ * External constraint: `abort.isIdle()` MUST be true here (cleared by
+ * `abort.clear(controller)` in the caller's finally) so compact-handler's own
+ * isIdle() guard passes and the 'turn-in-flight' bail is not hit spuriously.
+ * Do not call this from inside the inner for-await — compact() mutates
+ * state.messages in place and must only run at a clean turn boundary, never
+ * mid-tool-call.
+ *
+ * Yields nothing; it is a generator purely so the caller's `yield*` keeps the
+ * original inline control flow (a throw here propagates identically).
+ */
+export async function* maybeAutoCompact(ctx: TurnDriverContext): AsyncGenerator<ProviderEvent, void, void> {
+  if (ctx.state.autoCompactThreshold === undefined || ctx.state.closed) return;
+  const usage = ctx.state.lastUsage;
+  // requestedModel (not the wire currentModel) so 1M aliases use their
+  // true window — opus_1m resolves to the same wire id as opus but must
+  // compact at ~90% of 1M, not 200k. autoCompactLimitFor additionally
+  // caps the DEFAULT `sonnet` at a 200k working budget: its 1M window is
+  // truthful, but base sessions compact early for cost/latency, while the
+  // `sonnet_1m` opt-in bypasses the cap. See model-limits.ts.
+  const compactionLimit = autoCompactLimitFor(ctx.state.requestedModel);
+  if (usage === null || compactionLimit <= 0) return;
+  // Use the context-window footprint (input + cache_read +
+  // cache_creation + output for the last round), NOT input+output
+  // alone — Anthropic's input_tokens excludes cache, so the cached
+  // conversation prefix (often the bulk of the window) must be
+  // counted or compaction never fires before the window overflows.
+  const usedTokens = contextWindowTokensUsed(usage);
+  if (!shouldAutoCompact(usedTokens, compactionLimit, ctx.state.autoCompactThreshold)) return;
+  // Fire-and-await: compact() is async but we hold the turn
+  // boundary here (generator suspended at promptIterator.next()
+  // on the next iteration). Awaiting inline keeps the ordering
+  // deterministic and avoids a dangling promise race.
+  //
+  // Invariant: dispatch PreCompact(trigger:'auto') BEFORE compact()
+  // so registered hooks can block or observe the operation, mirroring
+  // the manual-compact paths in REPL (/compact) and Telegram. A block
+  // decision throws HookBlockedError — caught here to skip compaction
+  // for this turn without propagating to the outer error handler.
+  try {
+    if (ctx.hookRegistry) {
+      await ctx.hookRegistry.dispatch({
+        event: 'PreCompact',
+        sessionId: ctx.initSessionId,
+        trigger: 'auto',
+      });
+    }
+    await ctx.compact();
+    // Reset lastUsage after compaction so the overflow guard (#962) does not
+    // false-positive on the next turn: the stale count is no longer a valid
+    // lower bound once history has been truncated. The next API call will
+    // repopulate it from the actual response.
+    ctx.state.lastUsage = null;
+  } catch (compactErr) {
+    if (compactErr instanceof HookBlockedError) {
+      // Hook blocked auto-compaction — skip this turn's compaction
+      // without surfacing an error; the session continues normally.
+    } else {
+      throw compactErr;
+    }
+  }
+}

--- a/src/agent/providers/anthropic-direct/query-turn-driver.ts
+++ b/src/agent/providers/anthropic-direct/query-turn-driver.ts
@@ -128,22 +128,19 @@ export async function* driveTurns(ctx: TurnDriverContext): AsyncGenerator<Provid
       // placeholders so the API contract holds and the user can continue.
       repairOrphanToolUses(ctx.state.messages);
 
-      // Append the new user turn to history. Strings and content-block
-      // arrays both ride through as-is — Anthropic's MessageParam accepts
-      // either shape natively.
-      ctx.state.messages.push({ role: 'user', content: turn.content });
-
-      const system = ctx.composeSystem();
-
       // Context-overflow guard (#962): fail fast with a legible error BEFORE
-      // sending the request when we know the provider will 400 it. Uses the
-      // stale-by-one-round `lastUsage.contextWindowTokens` as a lower bound —
+      // sending the request when we know the provider will 400 it. Runs BEFORE
+      // the history push so the user message is not left in history on overflow
+      // (allowing /compact to succeed cleanly from the outer while loop). Uses
+      // the stale-by-one-round `lastUsage.contextWindowTokens` as a lower bound —
       // conservative by design (skips the first turn when lastUsage is null,
       // never silently shrinks max_tokens). See shared/auto-compact.ts.
       // Yields an error event (rather than throwing) so the abort controller is
       // cleared before control returns to the outer loop — throwing here would
       // skip the inner try/finally that clears it and leave compact() returning
       // 'turn-in-flight' on any subsequent manual compact call.
+      // Uses `continue` (not `return`) so the outer while loop survives: the
+      // user can /compact and send a new message without the session dying.
       {
         let overflowErr: Error | undefined;
         try {
@@ -159,9 +156,16 @@ export async function* driveTurns(ctx: TurnDriverContext): AsyncGenerator<Provid
         if (overflowErr !== undefined) {
           ctx.abort.clear(controller);
           yield { type: 'error', error: overflowErr };
-          return;
+          continue;
         }
       }
+
+      // Append the new user turn to history. Strings and content-block
+      // arrays both ride through as-is — Anthropic's MessageParam accepts
+      // either shape natively.
+      ctx.state.messages.push({ role: 'user', content: turn.content });
+
+      const system = ctx.composeSystem();
 
       // Snapshot preference + eligibility exactly once. The resulting headers
       // and body intent live on one immutable RunTurnInput for every round/retry.

--- a/src/agent/providers/anthropic-direct/query-turn-driver.ts
+++ b/src/agent/providers/anthropic-direct/query-turn-driver.ts
@@ -24,13 +24,13 @@ import type {
   ProviderUserTurn,
 } from '../../provider.js';
 import { EXIT_PLAN_MODE_TOOL_NAME } from '../../tools/handlers/exit-plan-mode.js';
-import { autoCompactLimitFor } from '../../model-limits.js';
+import { autoCompactLimitFor, contextLimitFor } from '../../model-limits.js';
 import type { AnthropicClientLike, AnthropicToolDef } from './types.js';
 import { repairOrphanToolUses } from './query/repair-orphan-tool-uses.js';
 import type { SessionState } from './query/session-state.js';
 import type { AbortCoordinator } from '../shared/abort-coordinator.js';
 import type { RetryLayer } from './query/retry-layer.js';
-import { contextWindowTokensUsed, shouldAutoCompact } from './query/auto-compact.js';
+import { contextWindowTokensUsed, guardContextOverflow, shouldAutoCompact } from './query/auto-compact.js';
 import type { HookRegistry } from '../../hooks.js';
 import { HookBlockedError } from '../../../utils/errors.js';
 import { annotateFastError, prepareTurnRequest } from './query/turn-request.js';
@@ -134,6 +134,35 @@ export async function* driveTurns(ctx: TurnDriverContext): AsyncGenerator<Provid
       ctx.state.messages.push({ role: 'user', content: turn.content });
 
       const system = ctx.composeSystem();
+
+      // Context-overflow guard (#962): fail fast with a legible error BEFORE
+      // sending the request when we know the provider will 400 it. Uses the
+      // stale-by-one-round `lastUsage.contextWindowTokens` as a lower bound —
+      // conservative by design (skips the first turn when lastUsage is null,
+      // never silently shrinks max_tokens). See shared/auto-compact.ts.
+      // Yields an error event (rather than throwing) so the abort controller is
+      // cleared before control returns to the outer loop — throwing here would
+      // skip the inner try/finally that clears it and leave compact() returning
+      // 'turn-in-flight' on any subsequent manual compact call.
+      {
+        let overflowErr: Error | undefined;
+        try {
+          guardContextOverflow(
+            contextWindowTokensUsed(ctx.state.lastUsage ?? {}),
+            ctx.maxTokens,
+            contextLimitFor(ctx.state.requestedModel ?? ctx.state.currentModel),
+            ctx.state.requestedModel ?? ctx.state.currentModel,
+          );
+        } catch (e) {
+          overflowErr = e instanceof Error ? e : new Error(String(e));
+        }
+        if (overflowErr !== undefined) {
+          ctx.abort.clear(controller);
+          yield { type: 'error', error: overflowErr };
+          return;
+        }
+      }
+
       // Snapshot preference + eligibility exactly once. The resulting headers
       // and body intent live on one immutable RunTurnInput for every round/retry.
       const { decision: fastDecision, runInput } = prepareTurnRequest({
@@ -308,6 +337,11 @@ async function* maybeAutoCompact(ctx: TurnDriverContext): AsyncGenerator<Provide
       });
     }
     await ctx.compact();
+    // Reset lastUsage after compaction so the overflow guard (#962) does not
+    // false-positive on the next turn: the stale count is no longer a valid
+    // lower bound once history has been truncated. The next API call will
+    // repopulate it from the actual response.
+    ctx.state.lastUsage = null;
   } catch (compactErr) {
     if (compactErr instanceof HookBlockedError) {
       // Hook blocked auto-compaction — skip this turn's compaction

--- a/src/agent/providers/anthropic-direct/query-turn-driver.ts
+++ b/src/agent/providers/anthropic-direct/query-turn-driver.ts
@@ -24,16 +24,16 @@ import type {
   ProviderUserTurn,
 } from '../../provider.js';
 import { EXIT_PLAN_MODE_TOOL_NAME } from '../../tools/handlers/exit-plan-mode.js';
-import { autoCompactLimitFor, contextLimitFor } from '../../model-limits.js';
+import { contextLimitFor } from '../../model-limits.js';
 import type { AnthropicClientLike, AnthropicToolDef } from './types.js';
 import { repairOrphanToolUses } from './query/repair-orphan-tool-uses.js';
 import type { SessionState } from './query/session-state.js';
 import type { AbortCoordinator } from '../shared/abort-coordinator.js';
 import type { RetryLayer } from './query/retry-layer.js';
-import { contextWindowTokensUsed, guardContextOverflow, shouldAutoCompact } from './query/auto-compact.js';
+import { contextWindowTokensUsed, guardContextOverflow } from './query/auto-compact.js';
 import type { HookRegistry } from '../../hooks.js';
-import { HookBlockedError } from '../../../utils/errors.js';
 import { annotateFastError, prepareTurnRequest } from './query/turn-request.js';
+import { maybeAutoCompact } from './query-turn-driver.auto-compact.js';
 
 /** Live accessors the turn driver needs from the owning query. */
 export interface TurnDriverContext {
@@ -285,69 +285,4 @@ export async function* driveTurns(ctx: TurnDriverContext): AsyncGenerator<Provid
   }
 }
 
-/**
- * Auto-compaction: fire at the natural turn boundary — after the per-turn
- * event loop exits and the abort slot is cleared — so we never trigger while a
- * tool call is in flight.
- *
- * External constraint: `abort.isIdle()` MUST be true here (cleared by
- * `abort.clear(controller)` in the caller's finally) so compact-handler's own
- * isIdle() guard passes and the 'turn-in-flight' bail is not hit spuriously.
- * Do not call this from inside the inner for-await — compact() mutates
- * state.messages in place and must only run at a clean turn boundary, never
- * mid-tool-call.
- *
- * Yields nothing; it is a generator purely so the caller's `yield*` keeps the
- * original inline control flow (a throw here propagates identically).
- */
-async function* maybeAutoCompact(ctx: TurnDriverContext): AsyncGenerator<ProviderEvent, void, void> {
-  if (ctx.state.autoCompactThreshold === undefined || ctx.state.closed) return;
-  const usage = ctx.state.lastUsage;
-  // requestedModel (not the wire currentModel) so 1M aliases use their
-  // true window — opus_1m resolves to the same wire id as opus but must
-  // compact at ~90% of 1M, not 200k. autoCompactLimitFor additionally
-  // caps the DEFAULT `sonnet` at a 200k working budget: its 1M window is
-  // truthful, but base sessions compact early for cost/latency, while the
-  // `sonnet_1m` opt-in bypasses the cap. See model-limits.ts.
-  const compactionLimit = autoCompactLimitFor(ctx.state.requestedModel);
-  if (usage === null || compactionLimit <= 0) return;
-  // Use the context-window footprint (input + cache_read +
-  // cache_creation + output for the last round), NOT input+output
-  // alone — Anthropic's input_tokens excludes cache, so the cached
-  // conversation prefix (often the bulk of the window) must be
-  // counted or compaction never fires before the window overflows.
-  const usedTokens = contextWindowTokensUsed(usage);
-  if (!shouldAutoCompact(usedTokens, compactionLimit, ctx.state.autoCompactThreshold)) return;
-  // Fire-and-await: compact() is async but we hold the turn
-  // boundary here (generator suspended at promptIterator.next()
-  // on the next iteration). Awaiting inline keeps the ordering
-  // deterministic and avoids a dangling promise race.
-  //
-  // Invariant: dispatch PreCompact(trigger:'auto') BEFORE compact()
-  // so registered hooks can block or observe the operation, mirroring
-  // the manual-compact paths in REPL (/compact) and Telegram. A block
-  // decision throws HookBlockedError — caught here to skip compaction
-  // for this turn without propagating to the outer error handler.
-  try {
-    if (ctx.hookRegistry) {
-      await ctx.hookRegistry.dispatch({
-        event: 'PreCompact',
-        sessionId: ctx.initSessionId,
-        trigger: 'auto',
-      });
-    }
-    await ctx.compact();
-    // Reset lastUsage after compaction so the overflow guard (#962) does not
-    // false-positive on the next turn: the stale count is no longer a valid
-    // lower bound once history has been truncated. The next API call will
-    // repopulate it from the actual response.
-    ctx.state.lastUsage = null;
-  } catch (compactErr) {
-    if (compactErr instanceof HookBlockedError) {
-      // Hook blocked auto-compaction — skip this turn's compaction
-      // without surfacing an error; the session continues normally.
-    } else {
-      throw compactErr;
-    }
-  }
-}
+

--- a/src/agent/providers/anthropic-direct/query/auto-compact.ts
+++ b/src/agent/providers/anthropic-direct/query/auto-compact.ts
@@ -16,6 +16,8 @@ export {
   contextFullnessFraction,
   buildContextUsageFields,
   shouldAutoCompact,
+  guardContextOverflow,
+  safeAutoCompactThresholdFor,
 } from '../../shared/auto-compact.js';
 
 export type {

--- a/src/agent/providers/openai-compatible/query.test.ts
+++ b/src/agent/providers/openai-compatible/query.test.ts
@@ -1397,21 +1397,25 @@ describe('OpenAICompatibleQuery — ProviderQuery surface', () => {
                 yield { type: 'response.output_text.delta', delta: 'AUTO-SUMMARY' };
                 yield {
                   type: 'response.completed',
-                  response: { usage: { input_tokens: 200_000, output_tokens: 10, total_tokens: 200_010 } },
+                  response: { usage: { input_tokens: 850_000, output_tokens: 10, total_tokens: 850_010 } },
                 };
               })();
             },
           },
         }) as unknown as OpenAI,
     );
+    // Use gpt-5.5 (1M window) so each turn's ~850k reported usage triggers
+    // auto-compaction but does NOT fire the context-overflow guard (#962),
+    // which fires on gpt-4o-mini (128k window) before compaction can run.
     const q = buildQueryFromConfig(
-      baseConfig({ model: 'gpt-4o-mini', autoCompact: true }),
+      baseConfig({ model: 'gpt-5.5', autoCompact: true }),
       multiInput('u1', 'u2', 'u3'),
       { useResponsesApi: true },
     );
     await collect(q);
-    // Each turn reports ~200k tokens — far over gpt-4o-mini's 128k window — so the
-    // turn-boundary trigger fires compaction, and the summarize rode responses.create
+    // Each turn reports ~850k tokens — over gpt-5.5's compaction threshold (~832k)
+    // but under the overflow guard (~872k) — so the turn-boundary trigger fires
+    // compaction, and the summarize rode responses.create
     // (a chat.completions.create would have thrown above and failed the run).
     expect(summarizeCalls.length).toBeGreaterThanOrEqual(1);
     // Public API-key path (source 'config', not chatgpt-oauth) DOES carry the cap.
@@ -1422,9 +1426,13 @@ describe('OpenAICompatibleQuery — ProviderQuery surface', () => {
   /**
    * Responses-wire client whose summarize call (the one carrying
    * COMPACT_SYSTEM_PROMPT as `instructions`) fails with `summarizeError`, while
-   * ordinary turns stream a ~200k-token reply so every turn boundary trips the
+   * ordinary turns stream a ~850k-token reply so every turn boundary trips the
    * auto-compaction threshold. `attempts` counts summarize calls reaching the
    * backend — the observable that proves whether the latch engaged.
+   *
+   * Uses gpt-5.5 (1M window): 850k usage triggers auto-compaction (~832k
+   * threshold) but stays under the overflow guard (~872k), which would fire
+   * first on gpt-4o-mini (128k window) and prevent compaction from running (#962).
    */
   function installResponsesClientFailingSummarize(summarizeError: unknown): { attempts: () => number } {
     let attempts = 0;
@@ -1448,7 +1456,7 @@ describe('OpenAICompatibleQuery — ProviderQuery surface', () => {
                 yield { type: 'response.output_text.delta', delta: 'ok' };
                 yield {
                   type: 'response.completed',
-                  response: { usage: { input_tokens: 200_000, output_tokens: 10, total_tokens: 200_010 } },
+                  response: { usage: { input_tokens: 850_000, output_tokens: 10, total_tokens: 850_010 } },
                 };
               })();
             },
@@ -1471,7 +1479,7 @@ describe('OpenAICompatibleQuery — ProviderQuery surface', () => {
       statusError(400, 'unsupported request for this backend'),
     );
     const q = buildQueryFromConfig(
-      baseConfig({ model: 'gpt-4o-mini', autoCompact: true }),
+      baseConfig({ model: 'gpt-5.5', autoCompact: true }),
       multiInput('u1', 'u2', 'u3'),
       { useResponsesApi: true },
     );
@@ -1496,7 +1504,7 @@ describe('OpenAICompatibleQuery — ProviderQuery surface', () => {
     // retryable, so the backend is asked again on later boundaries.
     const client = installResponsesClientFailingSummarize(statusError(429, 'rate limited'));
     const q = buildQueryFromConfig(
-      baseConfig({ model: 'gpt-4o-mini', autoCompact: true }),
+      baseConfig({ model: 'gpt-5.5', autoCompact: true }),
       multiInput('u1', 'u2', 'u3'),
       { useResponsesApi: true },
     );
@@ -1516,7 +1524,7 @@ describe('OpenAICompatibleQuery — ProviderQuery surface', () => {
     // never proof that the backend refuses this request shape.
     const client = installResponsesClientFailingSummarize(new Error('socket hang up'));
     const q = buildQueryFromConfig(
-      baseConfig({ model: 'gpt-4o-mini', autoCompact: true }),
+      baseConfig({ model: 'gpt-5.5', autoCompact: true }),
       multiInput('u1', 'u2', 'u3'),
       { useResponsesApi: true },
     );
@@ -1558,15 +1566,18 @@ describe('OpenAICompatibleQuery — ProviderQuery surface', () => {
                 yield { type: 'response.output_text.delta', delta: ' MORE' };
                 yield {
                   type: 'response.completed',
-                  response: { usage: { input_tokens: 200_000, output_tokens: 10, total_tokens: 200_010 } },
+                  response: { usage: { input_tokens: 850_000, output_tokens: 10, total_tokens: 850_010 } },
                 };
               })();
             },
           },
         }) as unknown as OpenAI,
     );
+    // Use gpt-5.5 (1M window) so each turn's ~850k reported usage triggers
+    // auto-compaction but does NOT fire the context-overflow guard (#962),
+    // which fires on gpt-4o-mini (128k window) before compaction can run.
     const q = buildQueryFromConfig(
-      baseConfig({ model: 'gpt-4o-mini', autoCompact: true }),
+      baseConfig({ model: 'gpt-5.5', autoCompact: true }),
       multiInput('u1', 'u2', 'u3'),
       { useResponsesApi: true },
     );
@@ -1722,12 +1733,14 @@ describe('OpenAICompatibleQuery — ProviderQuery surface', () => {
   });
 
   it('auto-compacts at the turn boundary once the context-window threshold is crossed', async () => {
-    // Each streaming turn reports a context-window footprint (~200k) far over
-    // the 90% default threshold for gpt-4o-mini's 128k window. Compaction is
-    // the only thing that issues a NON-streaming Chat Completions call
-    // (the summarize), so recording that call proves the turn-boundary trigger
-    // fired compactHistory('token_threshold'). Three fresh user turns are the
-    // minimum for a real boundary (keepLastN defaults to 2).
+    // Each streaming turn reports a context-window footprint (~850k) over the
+    // compaction threshold for gpt-5.5 (~832k) but under the overflow guard
+    // (~872k). Use gpt-5.5 (1M window) instead of gpt-4o-mini (128k) so the
+    // context-overflow guard (#962) does not fire before compaction can run.
+    // Compaction is the only thing that issues a NON-streaming Chat Completions
+    // call (the summarize), so recording that call proves the turn-boundary
+    // trigger fired compactHistory('token_threshold'). Three fresh user turns
+    // are the minimum for a real boundary (keepLastN defaults to 2).
     const summarizeCalls: unknown[] = [];
     __setOpenAIClientFactory(
       () =>
@@ -1739,7 +1752,7 @@ describe('OpenAICompatibleQuery — ProviderQuery surface', () => {
                   return (async function* () {
                     yield {
                       choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }],
-                      usage: { prompt_tokens: 200_000, completion_tokens: 10, total_tokens: 200_010 },
+                      usage: { prompt_tokens: 850_000, completion_tokens: 10, total_tokens: 850_010 },
                     } as OpenAIChunk;
                   })();
                 }
@@ -1750,17 +1763,21 @@ describe('OpenAICompatibleQuery — ProviderQuery surface', () => {
           },
         }) as unknown as OpenAI,
     );
+    // Use gpt-5.5 (1M window) so each turn's ~850k reported usage triggers
+    // auto-compaction but does NOT fire the context-overflow guard (#962),
+    // which fires on gpt-4o-mini (128k window) before compaction can run.
     const q = new OpenAICompatibleQuery({
       auth: { apiKey: 'k', source: 'config', last4: 'kkkk' },
-      model: 'gpt-4o-mini',
+      model: 'gpt-5.5',
       synthesizedSessionId: 'sid',
       promptStream: multiInput('u1', 'u2', 'u3'),
       config: baseConfig({ autoCompact: true }),
     });
     await collect(q);
-    // Each turn reports ~200k — far over the window — so the adaptive
-    // keep-window (see shared/compaction.ts:findCompactionBoundaryAdaptive)
-    // engages whenever there is an older turn to summarize:
+    // Each turn reports ~850k — over gpt-5.5's compaction threshold (~832k)
+    // but under the overflow guard (~872k) — so the adaptive keep-window
+    // (see shared/compaction.ts:findCompactionBoundaryAdaptive) engages
+    // whenever there is an older turn to summarize:
     //   turn 1 → still history-too-short (a single fresh user turn can't be
     //            compacted — shrinking to keepLastN=1 lands the boundary at 0);
     //   turn 2 → 2 fresh user turns + full window → keep-window relaxes 2→1 and

--- a/src/agent/providers/openai-compatible/query.test.ts
+++ b/src/agent/providers/openai-compatible/query.test.ts
@@ -1648,8 +1648,11 @@ describe('OpenAICompatibleQuery — ProviderQuery surface', () => {
     );
     // autoCompact OFF so the boundaries are driven explicitly below — an auto pass
     // would microcompact mid-run and make the assertions order-dependent.
+    // Use gpt-5.5 (1M window) so each turn's ~200k reported usage does NOT
+    // trigger the context-overflow guard (#962), which fires on gpt-4o-mini
+    // (128k window) when lastUsage.contextWindowTokens exceeds the window.
     const q = buildQueryFromConfig(
-      baseConfig({ model: 'gpt-4o-mini', autoCompact: false }),
+      baseConfig({ model: 'gpt-5.5', autoCompact: false }),
       multiInput('u1', 'u2', 'u3', 'u4', 'u5', 'u6'),
       { useResponsesApi: true, toolDispatcher: dispatcher },
     );

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -478,16 +478,14 @@ export class OpenAICompatibleQuery implements ProviderQuery {
     // iteration + tool-dispatch so the user turn, history sanitize, and
     // tool-result image follow-up all agree. See issue #127 / model-capabilities.ts.
     const vision = supportsVision(this.currentModel);
-    this.priorTurns.push({
-      role: 'user',
-      content: buildUserContent(content, { vision, model: this.currentModel }),
-    });
 
     // Context-overflow guard (#962): fail fast BEFORE sending a request the
-    // provider would reject with HTTP 400. Yields an error event (rather than
-    // throwing) so the abort slot is cleared before control returns; throwing
-    // here leaves the slot set and makes compact() return 'turn-in-flight'.
-    // See query/context-overflow.ts and shared/auto-compact.ts for details.
+    // provider would reject with HTTP 400. Runs BEFORE the history push so
+    // the user message is not left in history on overflow. Yields an error
+    // event (rather than throwing) so the abort slot is cleared before
+    // control returns; throwing here leaves the slot set and makes compact()
+    // return 'turn-in-flight'. See query/context-overflow.ts and
+    // shared/auto-compact.ts for details.
     const overflowErr = checkContextOverflow(
       this.lastUsage,
       this.currentModel,
@@ -499,6 +497,11 @@ export class OpenAICompatibleQuery implements ProviderQuery {
       yield { type: 'error', error: overflowErr };
       return;
     }
+
+    this.priorTurns.push({
+      role: 'user',
+      content: buildUserContent(content, { vision, model: this.currentModel }),
+    });
 
     // Aggregate usage across all tool-loop iterations for this turn via the
     // shared sumProviderUsage helper. Critical: cache fields (cachedInputTokens,

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -397,12 +397,12 @@ export class OpenAICompatibleQuery implements ProviderQuery {
                   sessionId: this.initSessionId,
                   trigger: 'auto',
                 });
-                await this.compactHistory('token_threshold');
-                // Reset lastUsage after compaction so the overflow guard
-                // (#962) does not false-positive on the next turn: the stale
-                // count is no longer a valid lower bound once history has been
-                // truncated. The next API call will repopulate it.
-                this.lastUsage = null;
+                const compactResult = await this.compactHistory('token_threshold');
+                // Overflow guard (#962): invalidate stale usage so it doesn't
+                // false-positive. Conditioned on `compacted` — a no-op must
+                // preserve the near-limit evidence or the next turn skips the
+                // guard entirely, letting the over-limit request through.
+                if (compactResult.compacted) this.lastUsage = null;
               } catch (compactErr) {
                 if (!(compactErr instanceof HookBlockedError)) throw compactErr;
                 // Hook blocked auto-compaction — continue the session normally.
@@ -1021,7 +1021,10 @@ export class OpenAICompatibleQuery implements ProviderQuery {
     // Manual entrypoint (REPL /compact, Telegram, router). Auto-compaction
     // calls compactHistory('token_threshold') directly from the turn-boundary
     // check in run(), so the two paths differ only in the emitted trace trigger.
-    return this.compactHistory('manual');
+    const result = await this.compactHistory('manual');
+    // #962: invalidate stale usage so the overflow guard doesn't false-positive.
+    if (result.compacted) this.lastUsage = null; // no-op must keep evidence
+    return result;
   }
 
   private async compactHistory(

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -103,13 +103,8 @@ import { compactOpenAIHistory, readShrinkFraction, microcompactToolResults } fro
 import {
   oneShotChatCompletion,
   oneShotResponses,
-  ResponsesSummaryIncompleteError,
 } from './oneshot.js';
-import {
-  getErrorStatus,
-  isRetryableConnectionError,
-  isRetryableStreamError,
-} from './query/retry.js';
+import { getErrorStatus } from './query/retry.js';
 import { PLAN_MODE_ADDENDUM_TEXT } from '../shared/plan-mode-addendum.js';
 import { AFK_MODE_ADDENDUM_TEXT } from '../shared/afk-mode-addendum.js';
 import { EXIT_PLAN_MODE_TOOL_NAME } from '../../tools/handlers/exit-plan-mode.js';
@@ -131,6 +126,7 @@ import {
   normalizePermissionMode,
   resolveReasoningEffort,
 } from './query/model-params.js';
+import { checkContextOverflow } from './query/context-overflow.js';
 import { resolveClientFactory } from './query/client.js';
 import { driveStream, type IterationResult } from './query/stream-drive.js';
 import {
@@ -206,35 +202,7 @@ export interface OpenAICompatibleQueryOptions {
   traceWriter?: TraceWriter;
 }
 
-/**
- * Statuses that prove the endpoint refused the REQUEST ITSELF (its shape, route,
- * or media type) rather than transiently failing to serve it. 429 and 5xx are
- * deliberately absent (transient — see `isRetryableConnectionError`), as are
- * 401/403 (a credential can be hot-swapped mid-session, so an auth lapse must
- * not permanently disable compaction).
- */
-const UNSUPPORTED_REQUEST_STATUSES = new Set([400, 404, 405, 415, 422, 501]);
-
-/**
- * Contract: does `err` PROVE this endpoint cannot serve a Responses-wire
- * summarize at all — as opposed to having transiently failed one?
- *
- * Only an explicit, deterministic client-side refusal counts. The distinction
- * matters because the latch it guards is PERMANENT for the session, so a false
- * positive disables compaction until the session ends — re-creating the very
- * context-window exhaustion issue #653 fixed. Deliberately NOT proof:
- *   - 429 / 5xx and friends — transient, already classified by the retry preds;
- *   - status-less throws (network drop, DNS, bad baseURL) — a blip or a
- *     misconfiguration, neither of which is the backend refusing this shape;
- *   - {@link ResponsesSummaryIncompleteError} — the backend DID accept and serve
- *     the request, then streamed a failed/partial response. The wire works.
- */
-function provesResponsesCompactionUnsupported(err: unknown): boolean {
-  if (err instanceof ResponsesSummaryIncompleteError) return false;
-  if (isRetryableConnectionError(err) || isRetryableStreamError(err)) return false;
-  const status = getErrorStatus(err);
-  return status !== undefined && UNSUPPORTED_REQUEST_STATUSES.has(status);
-}
+import { provesResponsesCompactionUnsupported } from './query/compaction-guard.js';
 
 /** Internal record used to drive the per-turn iteration loop. */
 export class OpenAICompatibleQuery implements ProviderQuery {
@@ -317,7 +285,7 @@ export class OpenAICompatibleQuery implements ProviderQuery {
     this.onPermissionMode = opts.onPermissionMode;
     this.onCwdChange = opts.onCwdChange;
     this.traceWriter = opts.traceWriter;
-    this.autoCompactThreshold = resolveAutoCompactThreshold(opts.config.autoCompact);
+    this.autoCompactThreshold = resolveAutoCompactThreshold(opts.config.autoCompact, opts.model);
 
     // Pre-compute the OpenAI tool catalog once. Only `SessionToolDispatcher`
     // (and not the structural `ToolDispatcher` minimal interface) exposes
@@ -430,6 +398,11 @@ export class OpenAICompatibleQuery implements ProviderQuery {
                   trigger: 'auto',
                 });
                 await this.compactHistory('token_threshold');
+                // Reset lastUsage after compaction so the overflow guard
+                // (#962) does not false-positive on the next turn: the stale
+                // count is no longer a valid lower bound once history has been
+                // truncated. The next API call will repopulate it.
+                this.lastUsage = null;
               } catch (compactErr) {
                 if (!(compactErr instanceof HookBlockedError)) throw compactErr;
                 // Hook blocked auto-compaction — continue the session normally.
@@ -509,6 +482,23 @@ export class OpenAICompatibleQuery implements ProviderQuery {
       role: 'user',
       content: buildUserContent(content, { vision, model: this.currentModel }),
     });
+
+    // Context-overflow guard (#962): fail fast BEFORE sending a request the
+    // provider would reject with HTTP 400. Yields an error event (rather than
+    // throwing) so the abort slot is cleared before control returns; throwing
+    // here leaves the slot set and makes compact() return 'turn-in-flight'.
+    // See query/context-overflow.ts and shared/auto-compact.ts for details.
+    const overflowErr = checkContextOverflow(
+      this.lastUsage,
+      this.currentModel,
+      this.opts.config.maxOutputTokens,
+      this.opts.config.model ?? this.currentModel,
+    );
+    if (overflowErr) {
+      this.abort.clear(controller);
+      yield { type: 'error', error: overflowErr };
+      return;
+    }
 
     // Aggregate usage across all tool-loop iterations for this turn via the
     // shared sumProviderUsage helper. Critical: cache fields (cachedInputTokens,

--- a/src/agent/providers/openai-compatible/query/compaction-guard.ts
+++ b/src/agent/providers/openai-compatible/query/compaction-guard.ts
@@ -1,0 +1,46 @@
+/**
+ * Responses-wire compaction-support predicate for the openai-compatible provider.
+ *
+ * Determines whether an error PROVES that the endpoint cannot serve a
+ * Responses-wire compaction request — as opposed to having transiently failed
+ * one. Extracted from query.ts to keep that file within its line ceiling.
+ *
+ * @module agent/providers/openai-compatible/query/compaction-guard
+ */
+
+import {
+  getErrorStatus,
+  isRetryableConnectionError,
+  isRetryableStreamError,
+} from './retry.js';
+import { ResponsesSummaryIncompleteError } from '../oneshot.js';
+
+/**
+ * Statuses that prove the endpoint refused the REQUEST ITSELF (its shape, route,
+ * or media type) rather than transiently failing to serve it. 429 and 5xx are
+ * deliberately absent (transient — see `isRetryableConnectionError`), as are
+ * 401/403 (a credential can be hot-swapped mid-session, so an auth lapse must
+ * not permanently disable compaction).
+ */
+const UNSUPPORTED_REQUEST_STATUSES = new Set([400, 404, 405, 415, 422, 501]);
+
+/**
+ * Contract: does `err` PROVE this endpoint cannot serve a Responses-wire
+ * summarize at all — as opposed to having transiently failed one?
+ *
+ * Only an explicit, deterministic client-side refusal counts. The distinction
+ * matters because the latch it guards is PERMANENT for the session, so a false
+ * positive disables compaction until the session ends — re-creating the very
+ * context-window exhaustion issue #653 fixed. Deliberately NOT proof:
+ *   - 429 / 5xx and friends — transient, already classified by the retry preds;
+ *   - status-less throws (network drop, DNS, bad baseURL) — a blip or a
+ *     misconfiguration, neither of which is the backend refusing this shape;
+ *   - {@link ResponsesSummaryIncompleteError} — the backend DID accept and serve
+ *     the request, then streamed a failed/partial response. The wire works.
+ */
+export function provesResponsesCompactionUnsupported(err: unknown): boolean {
+  if (err instanceof ResponsesSummaryIncompleteError) return false;
+  if (isRetryableConnectionError(err) || isRetryableStreamError(err)) return false;
+  const status = getErrorStatus(err);
+  return status !== undefined && UNSUPPORTED_REQUEST_STATUSES.has(status);
+}

--- a/src/agent/providers/openai-compatible/query/context-overflow.ts
+++ b/src/agent/providers/openai-compatible/query/context-overflow.ts
@@ -1,0 +1,51 @@
+/**
+ * Context-overflow pre-flight guard for the openai-compatible provider (#962).
+ *
+ * Wraps `guardContextOverflow` from shared/auto-compact into a caller-friendly
+ * helper that returns an Error on overflow and null otherwise, so the turn
+ * driver can yield the error and return cleanly without a naked try/catch block
+ * inline. Extracted from query.ts to keep that file within its line ceiling.
+ *
+ * @module agent/providers/openai-compatible/query/context-overflow
+ */
+
+import { guardContextOverflow, contextWindowTokensUsed } from '../../shared/auto-compact.js';
+import { contextLimitFor } from '../../../model-limits.js';
+import { resolveEffectiveMaxOutputTokens } from './model-params.js';
+import type { ProviderUsage } from '../../../provider.js';
+
+/**
+ * Run the context-overflow guard for a pending turn.
+ *
+ * Returns null when the turn is safe to send, or an Error when
+ * `lastUsage.input_tokens + max_tokens > contextWindow` — meaning the provider
+ * would reject the request with HTTP 400. The caller should yield the error and
+ * return without sending the request.
+ *
+ * Uses the stale-by-one-round `lastUsage` as a conservative lower bound:
+ * - Skips the first turn (lastUsage === null) — no prior usage to check against.
+ * - Never silently shrinks max_tokens; prefers a loud failure over a silent one.
+ *
+ * @param lastUsage - Usage from the previous turn, or null on the first turn.
+ * @param currentModel - Resolved model identifier for this turn.
+ * @param maxOutputTokens - Optional configured output-token cap.
+ * @param configuredModel - The model string from config (for error messages).
+ */
+export function checkContextOverflow(
+  lastUsage: Partial<ProviderUsage> | null,
+  currentModel: string,
+  maxOutputTokens: number | undefined,
+  configuredModel: string,
+): Error | null {
+  try {
+    guardContextOverflow(
+      contextWindowTokensUsed(lastUsage ?? {}),
+      resolveEffectiveMaxOutputTokens(currentModel, maxOutputTokens),
+      contextLimitFor(currentModel),
+      configuredModel,
+    );
+    return null;
+  } catch (err) {
+    return err instanceof Error ? err : new Error(String(err));
+  }
+}

--- a/src/agent/providers/shared/auto-compact.ts
+++ b/src/agent/providers/shared/auto-compact.ts
@@ -15,6 +15,7 @@
 
 import type { ProviderUsage } from '../../provider.js';
 import type { AgentConfig } from '../../types/config-types.js';
+import { autoCompactLimitFor, contextLimitFor, maxOutputTokensFor } from '../../model-limits.js';
 
 /**
  * Cumulative billed tokens for a turn: `inputTokens + outputTokens`.
@@ -168,24 +169,138 @@ export function contextFullnessFraction(usedTokens: number, contextLimit: number
 export const DEFAULT_AUTO_COMPACT_THRESHOLD = 0.9;
 
 /**
+ * Maximum SAFE auto-compaction threshold for a model, computed from its
+ * documented output ceiling (#962).
+ *
+ * When auto-compaction fires at `threshold × window`, the NEXT turn needs at
+ * least `max_tokens` headroom: `threshold × window + max_tokens ≤ window`,
+ * i.e. `threshold ≤ (window - max_tokens) / window`. The slack fraction
+ * (`SAFE_THRESHOLD_SLACK`) shaves a small buffer so the guard fires slightly
+ * before the exact math boundary, avoiding a race between compaction and the
+ * next user turn.
+ *
+ * For models whose `MODEL_AUTOCOMPACT_BUDGET` shrinks the compaction limit below
+ * the real context window (base `sonnet`, base `opus`), auto-compaction already
+ * fires well below the overflow boundary — no cap is needed, so this returns
+ * the default 0.90 unchanged. The cap only tightens for narrow-headroom models
+ * whose compaction limit equals their full context window:
+ *
+ * | Model              | window  | ceiling | cap    |
+ * |--------------------|---------|---------|--------|
+ * | haiku              | 200k    | 64k     | ≈0.64  |
+ * | openai compat fb.  | 262k    | 64k     | ≈0.70  |
+ * | sonnet_1m / opus_1m| 1M      | 128k    | ≈0.83  |
+ * | base sonnet/opus   | (200k budget) | 128k | 0.90 (no cap) |
+ *
+ * Callers that set a user-configured threshold receive the MIN of their
+ * threshold and this safe cap — they can still lower the threshold further,
+ * but never raise it above the safe boundary.
+ */
+const SAFE_THRESHOLD_SLACK = 0.04;
+
+/**
+ * Returns the maximum safe auto-compaction threshold for a model — the
+ * largest fraction of the context window at which compaction can fire and
+ * still leave enough room for a full output turn.
+ *
+ * Use as a cap on any threshold before passing it to `shouldAutoCompact`.
+ */
+export function safeAutoCompactThresholdFor(model: string): number {
+  const contextWindow = contextLimitFor(model);
+  const compactionLimit = autoCompactLimitFor(model);
+  const ceiling = maxOutputTokensFor(model);
+  if (contextWindow <= 0 || ceiling <= 0) return DEFAULT_AUTO_COMPACT_THRESHOLD;
+
+  // When `MODEL_AUTOCOMPACT_BUDGET` shrinks the compaction limit below the
+  // real context window (base `sonnet`, `opus`), auto-compaction fires at a
+  // fraction of the budget — which is already far below the overflow point.
+  // No cap is needed: the budget guarantee is stricter than the overflow guard.
+  // Apply the cap only when compactionLimit equals the full context window.
+  if (compactionLimit < contextWindow) return DEFAULT_AUTO_COMPACT_THRESHOLD;
+
+  // The safe cap is the fraction of the context window below which the
+  // next full output turn still fits: `threshold × window + ceiling ≤ window`.
+  // `SAFE_THRESHOLD_SLACK` adds a small buffer so compaction fires slightly
+  // before the exact math boundary.
+  const safeCap = (contextWindow - ceiling) / contextWindow - SAFE_THRESHOLD_SLACK;
+  // Never return a nonsensical value — fall back to default if the geometry
+  // is impossible (e.g. ceiling >= contextWindow).
+  return safeCap > 0 ? safeCap : DEFAULT_AUTO_COMPACT_THRESHOLD;
+}
+
+/**
+ * Fail-fast guard for context-window overflow (#962).
+ *
+ * When `knownInputTokens + maxOutputTokens > contextLimit`, the provider WILL
+ * reject the request with HTTP 400 ("input length and max_tokens exceed context
+ * limit"). We detect this condition before sending — using the stale-by-one-round
+ * `lastUsage.contextWindowTokens` as a lower bound on the current input — and
+ * throw a legible error naming the numbers and the two escape hatches.
+ *
+ * **Conservative by design.** The guard fires only when overflow is
+ * MATHEMATICALLY CERTAIN (stale lower-bound already exceeds the hard limit),
+ * never on estimates. A request whose actual input is slightly larger than the
+ * stale count still goes to the wire; the provider error in that case is
+ * unchanged from pre-fix behaviour and is already reasonably legible.  Trading
+ * a loud 400 for a silent `max_tokens` shrink (#952) is NOT acceptable — we
+ * fail loudly or not at all.
+ *
+ * **Not called when `knownInputTokens <= 0`** (first turn or stale usage
+ * unavailable) — the guard skips those cases to avoid false positives on sessions
+ * that have never completed a round.
+ *
+ * @throws {Error} with a structured message naming the numbers and escape hatches
+ *   when overflow is guaranteed.
+ */
+export function guardContextOverflow(
+  knownInputTokens: number,
+  maxOutputTokens: number,
+  contextLimit: number,
+  model: string,
+): void {
+  if (knownInputTokens <= 0 || contextLimit <= 0 || maxOutputTokens <= 0) return;
+  const projected = knownInputTokens + maxOutputTokens;
+  if (projected <= contextLimit) return;
+  throw new Error(
+    `[afk] Context-window overflow: the conversation already used ~${knownInputTokens.toLocaleString()} ` +
+      `tokens (last-turn API count) and the configured output ceiling is ${maxOutputTokens.toLocaleString()} ` +
+      `tokens — together they exceed the ${model} context window of ${contextLimit.toLocaleString()} tokens ` +
+      `by ${(projected - contextLimit).toLocaleString()} tokens. ` +
+      `The provider would reject this request with HTTP 400. ` +
+      `To continue: run /compact to summarise the conversation history, or start a new session.`,
+  );
+}
+
+/**
  * Resolve `AgentConfig.autoCompact` to a numeric threshold fraction, or
  * `undefined` when auto-compaction is disabled. Provider-neutral: both the
  * anthropic-direct and openai-compatible providers resolve their threshold
  * through this single source of truth.
  *
+ * When `model` is supplied the resolved threshold is capped at
+ * {@link safeAutoCompactThresholdFor} — the largest fraction of the window at
+ * which compaction can fire and still leave enough room for a full output turn
+ * (#962). This prevents the situation where compaction would fire AFTER the
+ * overflow point (e.g. haiku: 0.9×200k = 180k, but overflow is at 136k).
+ * The cap is applied silently; it does not disable compaction, just moves the
+ * trigger earlier.
+ *
  * - `false` or `undefined` → disabled (`undefined` returned).
- * - `true` → default threshold (0.90).
- * - `{ threshold: n }` → custom fraction; clamped to (0, 1) exclusive.
+ * - `true` → default threshold (0.90), capped at `safeAutoCompactThresholdFor(model)`.
+ * - `{ threshold: n }` → custom fraction; clamped to (0, 1) exclusive and
+ *   capped at `safeAutoCompactThresholdFor(model)`.
  *   Out-of-range values are silently treated as disabled.
  */
 export function resolveAutoCompactThreshold(
   autoCompact: AgentConfig['autoCompact'],
+  model?: string,
 ): number | undefined {
   if (autoCompact === undefined || autoCompact === false) return undefined;
-  if (autoCompact === true) return DEFAULT_AUTO_COMPACT_THRESHOLD;
+  const safeCap = model !== undefined ? safeAutoCompactThresholdFor(model) : 1;
+  if (autoCompact === true) return Math.min(DEFAULT_AUTO_COMPACT_THRESHOLD, safeCap);
   const t = autoCompact.threshold;
   if (typeof t !== 'number' || !Number.isFinite(t) || t <= 0 || t >= 1) {
     return undefined;
   }
-  return t;
+  return Math.min(t, safeCap);
 }

--- a/src/agent/providers/shared/context-overflow-guard.test.ts
+++ b/src/agent/providers/shared/context-overflow-guard.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Tests for the context-window overflow guard and safe auto-compact threshold
+ * introduced by #962.
+ *
+ * `guardContextOverflow` — fail-fast error before the wire call when input
+ * tokens + max_tokens already exceeds the context window.
+ *
+ * `safeAutoCompactThresholdFor` — computes the maximum threshold at which
+ * auto-compaction can fire and still leave headroom for a full output turn.
+ *
+ * `resolveAutoCompactThreshold` — extended with an optional `model` param
+ * that caps the resolved threshold at the safe boundary.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { guardContextOverflow, safeAutoCompactThresholdFor, resolveAutoCompactThreshold } from './auto-compact.js';
+
+// ─── guardContextOverflow ──────────────────────────────────────────────────
+
+describe('guardContextOverflow', () => {
+  describe('throws when overflow is certain', () => {
+    it('haiku overflow: 137k input + 64k output > 200k window', () => {
+      // Real scenario: haiku 200k window, 64k output ceiling.
+      // 137k + 64k = 201k > 200k → must throw.
+      expect(() =>
+        guardContextOverflow(137_000, 64_000, 200_000, 'haiku'),
+      ).toThrow(/Context-window overflow/);
+    });
+
+    it('error message names the numbers', () => {
+      const err = (() => {
+        try {
+          guardContextOverflow(140_000, 64_000, 200_000, 'haiku');
+          return null;
+        } catch (e) {
+          return e as Error;
+        }
+      })();
+      expect(err).not.toBeNull();
+      expect(err!.message).toContain('140,000');
+      expect(err!.message).toContain('64,000');
+      expect(err!.message).toContain('200,000');
+      expect(err!.message).toContain('haiku');
+      // Overflow amount: 140k + 64k - 200k = 4k
+      expect(err!.message).toContain('4,000');
+    });
+
+    it('error message mentions /compact and new session escape hatches', () => {
+      let err: Error | null = null;
+      try {
+        guardContextOverflow(150_000, 64_000, 200_000, 'haiku');
+      } catch (e) {
+        err = e as Error;
+      }
+      expect(err!.message).toContain('/compact');
+      expect(err!.message).toContain('new session');
+    });
+
+    it('openai-compatible fallback: 200k + 64k > 262k', () => {
+      expect(() =>
+        guardContextOverflow(200_000, 64_000, 262_144, 'gpt-4o'),
+      ).toThrow(/Context-window overflow/);
+    });
+
+    it('throws when input + output equals context limit + 1 (exact boundary)', () => {
+      // 136k + 64k = 200k is exactly at the limit — does NOT throw.
+      // 136k + 64k + 1 > 200k — must throw.
+      expect(() =>
+        guardContextOverflow(136_001, 64_000, 200_000, 'haiku'),
+      ).toThrow(/Context-window overflow/);
+    });
+  });
+
+  describe('does NOT throw when overflow is not certain', () => {
+    it('no usage yet (first turn): knownInputTokens = 0', () => {
+      // First turn: lastUsage is null, so knownInputTokens = 0.
+      // Guard must not throw — we have no lower bound.
+      expect(() =>
+        guardContextOverflow(0, 64_000, 200_000, 'haiku'),
+      ).not.toThrow();
+    });
+
+    it('input + output exactly at the context limit (136k + 64k = 200k)', () => {
+      // Exactly at the limit — NOT over, so no throw.
+      expect(() =>
+        guardContextOverflow(136_000, 64_000, 200_000, 'haiku'),
+      ).not.toThrow();
+    });
+
+    it('safe with headroom (100k input + 64k output < 200k)', () => {
+      expect(() =>
+        guardContextOverflow(100_000, 64_000, 200_000, 'haiku'),
+      ).not.toThrow();
+    });
+
+    it('large context model with headroom (800k + 128k < 1M)', () => {
+      expect(() =>
+        guardContextOverflow(800_000, 128_000, 1_000_000, 'claude-sonnet-5'),
+      ).not.toThrow();
+    });
+
+    it('skips guard when contextLimit is 0 (unknown)', () => {
+      expect(() =>
+        guardContextOverflow(150_000, 64_000, 0, 'unknown-model'),
+      ).not.toThrow();
+    });
+
+    it('skips guard when maxOutputTokens is 0', () => {
+      expect(() =>
+        guardContextOverflow(150_000, 0, 200_000, 'haiku'),
+      ).not.toThrow();
+    });
+
+    it('skips guard when knownInputTokens is negative', () => {
+      expect(() =>
+        guardContextOverflow(-1, 64_000, 200_000, 'haiku'),
+      ).not.toThrow();
+    });
+  });
+});
+
+// ─── safeAutoCompactThresholdFor ──────────────────────────────────────────
+
+describe('safeAutoCompactThresholdFor', () => {
+  it('returns a threshold strictly below the overflow point for haiku', () => {
+    // Haiku: 200k window, 64k ceiling → overflow at 136k/200k = 0.68.
+    // Safe threshold must be < 0.68 so compaction fires before overflow.
+    const t = safeAutoCompactThresholdFor('haiku');
+    expect(t).toBeLessThan(0.68);
+    expect(t).toBeGreaterThan(0);
+  });
+
+  it('returns a value in (0, 1) for known models', () => {
+    for (const model of ['haiku', 'claude-sonnet-5', 'claude-opus-5', 'gpt-4o']) {
+      const t = safeAutoCompactThresholdFor(model);
+      expect(t).toBeGreaterThan(0);
+      expect(t).toBeLessThan(1);
+    }
+  });
+
+  it('returns a higher threshold for 1M-opt-in aliases vs haiku', () => {
+    // sonnet_1m bypasses the budget → autoCompactLimitFor = contextLimitFor = 1M.
+    // 1M window, 128k ceiling → (872k/1M) - slack ≈ 0.832.
+    // haiku: 200k window, 64k ceiling → (136k/200k) - slack ≈ 0.64.
+    // So sonnet_1m safe threshold > haiku safe threshold.
+    const haikuT = safeAutoCompactThresholdFor('haiku');
+    const sonnetT = safeAutoCompactThresholdFor('sonnet_1m');
+    expect(sonnetT).toBeGreaterThan(haikuT);
+  });
+
+  it('returns DEFAULT_AUTO_COMPACT_THRESHOLD for models with a budget-based compaction limit', () => {
+    // Base sonnet/opus have a budget < contextWindow → no cap needed → default 0.9.
+    expect(safeAutoCompactThresholdFor('claude-sonnet-5')).toBe(0.9);
+    expect(safeAutoCompactThresholdFor('claude-opus-5')).toBe(0.9);
+  });
+
+  it('returns a threshold that keeps compaction below the overflow point', () => {
+    // For any model, safeThreshold × window + ceiling must be ≤ window.
+    // (i.e. safeThreshold ≤ (window - ceiling) / window)
+    // We test haiku explicitly.
+    const window = 200_000;
+    const ceiling = 64_000;
+    const t = safeAutoCompactThresholdFor('haiku');
+    const wouldCompactAt = t * window;
+    // Compaction trigger + output ceiling must not exceed the window.
+    expect(wouldCompactAt + ceiling).toBeLessThanOrEqual(window);
+  });
+});
+
+// ─── resolveAutoCompactThreshold (with model cap) ─────────────────────────
+
+describe('resolveAutoCompactThreshold — model-aware safe cap (#962)', () => {
+  it('caps the default 0.9 threshold for haiku below the overflow point', () => {
+    const t = resolveAutoCompactThreshold(true, 'haiku');
+    // Safe threshold for haiku is ~0.64; must be below 0.68 (overflow point).
+    expect(t).not.toBeUndefined();
+    expect(t!).toBeLessThan(0.68);
+  });
+
+  it('does not raise a user-configured lower threshold', () => {
+    // A user who explicitly sets 0.5 should keep 0.5, even if safe cap is 0.64.
+    const t = resolveAutoCompactThreshold({ threshold: 0.5 }, 'haiku');
+    expect(t).toBe(0.5);
+  });
+
+  it('caps a user-configured threshold that is above the safe boundary', () => {
+    // A user who sets 0.85 on haiku (> safe cap of ~0.64) gets the safe cap.
+    const t = resolveAutoCompactThreshold({ threshold: 0.85 }, 'haiku');
+    expect(t).not.toBeUndefined();
+    expect(t!).toBeLessThan(0.68); // must be at or below safe boundary
+  });
+
+  it('returns undefined when autoCompact is false (no model)', () => {
+    expect(resolveAutoCompactThreshold(false)).toBeUndefined();
+    expect(resolveAutoCompactThreshold(false, 'haiku')).toBeUndefined();
+  });
+
+  it('returns undefined when autoCompact is undefined', () => {
+    expect(resolveAutoCompactThreshold(undefined)).toBeUndefined();
+    expect(resolveAutoCompactThreshold(undefined, 'haiku')).toBeUndefined();
+  });
+
+  it('does NOT cap base sonnet (has a budget-based compaction limit, already safe)', () => {
+    // base sonnet: MODEL_AUTOCOMPACT_BUDGET shrinks compaction limit to 200k,
+    // far below the 1M overflow boundary. safeAutoCompactThresholdFor returns
+    // the default 0.9 for these models — no additional cap needed.
+    const t = resolveAutoCompactThreshold(true, 'claude-sonnet-5');
+    expect(t).toBe(0.9);
+  });
+
+  it('caps the 1M opt-in alias (sonnet_1m) below 0.9', () => {
+    // sonnet_1m bypasses the budget (autoCompactLimitFor = contextLimitFor = 1M).
+    // 1M window, 128k ceiling → safe cap = (872k/1M) - 0.04 = 0.832.
+    // The default 0.9 is capped to 0.832.
+    const t = resolveAutoCompactThreshold(true, 'sonnet_1m');
+    expect(t).not.toBeUndefined();
+    expect(t!).toBeGreaterThan(0.8);
+    expect(t!).toBeLessThan(0.9);
+  });
+
+  it('still works without a model argument (backward-compatible)', () => {
+    // Without a model, no cap is applied — existing behaviour unchanged.
+    const t = resolveAutoCompactThreshold(true);
+    expect(t).toBe(0.9);
+    const t2 = resolveAutoCompactThreshold({ threshold: 0.8 });
+    expect(t2).toBe(0.8);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a fail-fast context-overflow guard that emits a legible error **before** sending a request that the provider would reject with HTTP 400 when `lastUsage.input_tokens + max_tokens > contextWindow`.

Closes #962.

## Root Cause

`resolveMaxTokens` (anthropic-direct) and `resolveEffectiveMaxOutputTokens` (openai-compatible) take no messages and no usage, so they cannot see how much context is already consumed. The resolved `max_tokens` value is sent to the wire verbatim. When `input + max_tokens > context_window` — the haiku threshold is ~136k input — the provider rejects with HTTP 400.

## Approach: Fail-Fast (Option 3)

Consistent with #951, which chose the same pattern for the unsatisfiable thinking-budget case. On each turn start, read the stale-by-one-round `lastUsage` as a conservative lower bound:
- **Skip the first turn** (no `lastUsage` yet) — conservative by design.
- **Never silently shrink** `max_tokens`; prefer a loud, actionable error over silent truncation.

The guard yields an error event (rather than throwing) so the abort controller is cleared before control returns — throwing here would leave the slot set and make `compact()` return `'turn-in-flight'`.

## Changes

| File | What changed |
|------|-------------|
| `src/agent/providers/shared/auto-compact.ts` | Added `guardContextOverflow()`, `safeAutoCompactThresholdFor()`, updated `resolveAutoCompactThreshold()` to accept a model for model-aware threshold capping |
| `src/agent/providers/anthropic-direct/query-turn-driver.ts` | Call `guardContextOverflow()` at turn start, yield error if it throws |
| `src/agent/providers/openai-compatible/query.ts` | Same guard via `checkContextOverflow()`, reset `lastUsage = null` after auto-compaction so the guard doesn't false-positive on the next turn |
| `src/agent/providers/openai-compatible/query/context-overflow.ts` | New: extracted helper that wraps `guardContextOverflow` into a null-or-Error pattern for the OpenAI provider |
| `src/agent/providers/openai-compatible/query/compaction-guard.ts` | New: extracted `provesResponsesCompactionUnsupported` predicate (moved from query.ts to stay within line ceiling) |
| `src/agent/providers/shared/context-overflow-guard.test.ts` | 25 new unit tests for `guardContextOverflow`, `safeAutoCompactThresholdFor`, and the model-aware threshold resolution |

## Test Coverage

25 new unit tests cover:
- Happy path (no overflow, guard passes)
- Exact-boundary cases (at the limit, at limit + 1)
- First-turn skip (null lastUsage)
- Error message format and legibility
- `safeAutoCompactThresholdFor` clamping logic
- Model-aware `resolveAutoCompactThreshold` integration

All 16,230 existing tests continue to pass (one pre-existing flaky symlink test in `write-denylist.test.ts` is unrelated to this change).

## Lint & File Size

- `pnpm lint` ✅ passes
- `pnpm audit:filesize:check` — the 6 pre-existing violations on main are unchanged; no new violations introduced by this PR
