### PR TITLE
fix(tools): clarify skill tool description for load vs fork modes

### DIFF
--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -473,9 +473,13 @@ export const skillTool: AnthropicToolDef = {
   // dispatch state, so adjacent skill calls in one turn can run in parallel.
   concurrencySafe: true,
   description:
-    'Invoke a registered skill by name. Skills are specialized capabilities ' +
-    'that dispatch subagents with domain-specific prompts. Check the system ' +
-    'prompt for the list of available skills and their descriptions.',
+    'Invoke a registered skill by name. A skill either forks an isolated ' +
+    'subagent or loads its instructions into your current context for you ' +
+    'to execute directly — the mode is fixed per-skill, not per-call. ' +
+    'To run a skill N times in parallel with isolation, dispatch N ' +
+    'subagents (via `agent` or `compose`) that each call `skill` once. ' +
+    'Check the system prompt for the list of available skills and their ' +
+    'descriptions.',
   input_schema: {
     type: 'object',
     properties: {

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -468,9 +468,14 @@ export const agentTool: AnthropicToolDef = {
 export const skillTool: AnthropicToolDef = {
   name: 'skill',
   category: 'skill',
-  // Concurrency-safe like `agent`/`compose`: each skill dispatch forks its own
-  // SubagentManager with unique, per-call session ids and shares no mutable
-  // dispatch state, so adjacent skill calls in one turn can run in parallel.
+  // Concurrency-safe like `agent`/`compose`: all three execution paths share
+  // no mutable dispatch state across concurrent calls.
+  //   fork   — each dispatch constructs a fresh SubagentManager with a unique
+  //            per-call session id.
+  //   load   — the load-path functions are pure: read-only `internals()`
+  //            snapshot, disk I/O + string substitution, no shared state.
+  //   inline — handlers receive immutable args from ctx; any subagents they
+  //            spawn are per-invocation.
   concurrencySafe: true,
   description:
     'Invoke a registered skill by name. A skill either forks an isolated ' +

--- a/src/agent/tools/skill-bridge.ts
+++ b/src/agent/tools/skill-bridge.ts
@@ -126,7 +126,7 @@ export function buildSkillManifest(
   return [
     'Available skills (invoke via the `skill` tool):',
     '',
-    "Each skill either dispatches one or more context-isolated subagents (delegation — preserves the main session's context) or loads its instructions directly into your current context (`load` mode). Calling `skill` is the entry point for both; the executor picks the mode per skill. Prefer a skill over inline investigation when the task shape matches.",
+    "Each skill either forks an isolated subagent (delegation — preserves the main session's context) or loads its instructions directly into your current context for you to execute directly. The mode is fixed per-skill, not per-call. To run a skill N times in parallel with isolation, dispatch N subagents (via `agent` or `compose`) that each call `skill` once. Prefer a skill over inline investigation when the task shape matches.",
     '',
     ...lines,
   ].join('\n');


### PR DESCRIPTION
## Problem

The `skill` tool description says *"Skills are specialized capabilities that dispatch subagents with domain-specific prompts"* — but this is only true for `context: fork` skills. Most skills (including `review`) are `context: load` and inject their instructions into the caller's context window without forking any subagent.

This caused an agent asked to "use parallel subagents to /review 37 38 and 39" to call `skill(review)` three times in the same turn, expecting three isolated subagent forks. Instead it got the review SKILL.md body injected into its own context three times — zero isolation, the instructions competing for attention, and the agent left to manually orchestrate all three reviews in-series.

## Fix

Update the tool description to:
- Explain that a skill **either forks an isolated subagent or loads instructions into the current context** — the mode is per-skill, not per-call
- Give the correct pattern for parallel isolated execution: **dispatch N subagents (via `agent` or `compose`) that each call `skill` once**

## Verification

- `pnpm lint` ✅
- `pnpm build` ✅  
- `pnpm test src/agent/tools/skill-executor.test.ts` — 91 tests passed ✅
