### PR TITLE
feat(telegram): native topics routing (step 6) + cross-surface CLI/daemon registration (step 7)

### DIFF
--- a/src/agent/daemon/scheduler.ts
+++ b/src/agent/daemon/scheduler.ts
@@ -27,6 +27,7 @@ import { dequeueNext } from './queue-store.js';
 import { getQueueDir } from '../../paths.js';
 import type { ScheduledTask as CronTask } from 'node-cron';
 import { AgentSession } from '../session/agent-session.js';
+import { registerSurfaceSession } from '../session/register-surface-session.js';
 import { createDefaultHookRegistry } from '../default-hook-registry.js';
 import { loadHooksConfig } from '../hooks/config-loader.js';
 import { createDefaultTraceWriter } from '../trace/factory.js';
@@ -395,12 +396,14 @@ export class CronScheduler {
     let session: AgentSession | null = null;
     let memoryStore: MemoryStore | null = null;
     let mcpManager: McpManager | null = null;
+    let disposeRegistration: (() => void) | null = null;
     this.idleDetector.increment();
     try {
       const spawned = await this.spawnSession(task.taskId);
       session = spawned.session;
       memoryStore = spawned.memoryStore;
       mcpManager = spawned.mcpManager ?? null;
+      disposeRegistration = spawned.dispose;
       const response = await session.sendMessage(task.command);
       const responseText = redactInlineSecrets(response.content);
       // "Done"-verification probe (opt-in via injected `doneUnverifiedProbe`,
@@ -448,6 +451,9 @@ export class CronScheduler {
           // already-closed sessions throw; ignore.
         }
       }
+      // Archive the cross-surface registry handle (frees its key) so the
+      // long-running daemon never accumulates handles. Best-effort.
+      disposeRegistration?.();
       if (mcpManager) {
         try {
           await mcpManager.disconnectAll();
@@ -645,6 +651,8 @@ export class CronScheduler {
     session: AgentSession;
     memoryStore: MemoryStore;
     mcpManager?: McpManager;
+    /** Archive the cross-surface registry handle. Called by runOnce on close. */
+    dispose: () => void;
   }> {
     // Derive a unique-per-tick sessionId (daemonTraceLabel appends a random
     // suffix, so each tick gets its own label) so hook commands receive a
@@ -770,7 +778,20 @@ export class CronScheduler {
       const session = this.options.sessionFactory
         ? this.options.sessionFactory(config)
         : new AgentSession(injectCompanionPrimer(injectHotMemory(config)));
-      return { session, memoryStore, ...(mcpManager !== undefined ? { mcpManager } : {}) };
+      // Step 7: register the daemon session in the cross-surface registry.
+      // Best-effort; dispose() (archive) is invoked by runOnce on session close
+      // so the long-running daemon never accumulates registry handles.
+      const registration = registerSurfaceSession(session, {
+        surface: 'daemon',
+        model: config.model,
+        cwd: agentCwd,
+      });
+      return {
+        session,
+        memoryStore,
+        dispose: registration.dispose,
+        ...(mcpManager !== undefined ? { mcpManager } : {}),
+      };
     } catch (err) {
       if (mcpManager) {
         await mcpManager.disconnectAll().catch(() => undefined);

--- a/src/agent/session/register-surface-session.test.ts
+++ b/src/agent/session/register-surface-session.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { registerSurfaceSession } from './register-surface-session.js';
+import { createSessionRegistry, type SessionRegistry } from './session-registry.js';
+
+/** Session with the SDK id known up front. */
+function fixedSession(sessionId?: string): { sessionId?: string; waitForInitialization(): Promise<void> } {
+  return { sessionId, async waitForInitialization() { /* immediate */ } };
+}
+
+/** Session whose SDK id only becomes available AFTER initialization (the late-bind case). */
+class LateSession {
+  private _id: string | undefined;
+  get sessionId(): string | undefined {
+    return this._id;
+  }
+  async waitForInitialization(): Promise<void> {
+    this._id = 'sdk-late';
+  }
+}
+
+describe('registerSurfaceSession', () => {
+  it('registers a handle with the surface/model and an up-front SDK id', () => {
+    const registry = createSessionRegistry();
+    const { handle } = registerSurfaceSession(fixedSession('sdk-1'), {
+      surface: 'cli',
+      model: 'sonnet',
+      sdkSessionId: 'sdk-1',
+      name: 'my-repl',
+      cwd: '/repo',
+      registry,
+    });
+    expect(handle?.surface).toBe('cli');
+    expect(handle?.model).toBe('sonnet');
+    expect(handle?.name).toBe('my-repl');
+    expect(handle?.cwd).toBe('/repo');
+    expect(handle?.sdkSessionId).toBe('sdk-1');
+    // Keyed on + reverse-lookupable by the SDK id.
+    expect(registry.resolve('cli', 'sdk-1')?.id).toBe(handle?.id);
+    expect(registry.getBySdkSessionId('sdk-1')?.id).toBe(handle?.id);
+  });
+
+  it('attaches the SDK id lazily once the session initializes', async () => {
+    const registry = createSessionRegistry();
+    const { handle } = registerSurfaceSession(new LateSession(), {
+      surface: 'daemon',
+      model: 'sonnet',
+      registry,
+    });
+    expect(handle?.sdkSessionId).toBeUndefined(); // not known at registration time
+    // Flush the waitForInitialization().then() microtask chain.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(registry.getBySdkSessionId('sdk-late')?.id).toBe(handle?.id);
+  });
+
+  it('uses a unique generated key per session when no SDK id is known', () => {
+    const registry = createSessionRegistry();
+    const a = registerSurfaceSession(fixedSession(), { surface: 'cli', model: 'sonnet', registry });
+    const b = registerSurfaceSession(fixedSession(), { surface: 'cli', model: 'sonnet', registry });
+    // Distinct handles, no key collision (both registered successfully).
+    expect(a.handle?.id).toBeDefined();
+    expect(b.handle?.id).toBeDefined();
+    expect(a.handle?.id).not.toBe(b.handle?.id);
+  });
+
+  it('dispose archives the handle and frees its key (idempotent)', () => {
+    const registry = createSessionRegistry();
+    const { handle, dispose } = registerSurfaceSession(fixedSession('sdk-x'), {
+      surface: 'cli',
+      model: 'sonnet',
+      sdkSessionId: 'sdk-x',
+      registry,
+    });
+    expect(registry.resolve('cli', 'sdk-x')?.id).toBe(handle?.id);
+    dispose();
+    expect(registry.resolve('cli', 'sdk-x')).toBeUndefined(); // key freed
+    expect(() => dispose()).not.toThrow(); // idempotent
+  });
+
+  it('is best-effort: a throwing registry never propagates', () => {
+    const throwing = {
+      create() {
+        throw new Error('boom');
+      },
+    } as unknown as SessionRegistry;
+    const reg = registerSurfaceSession(fixedSession(), { surface: 'cli', model: 'sonnet', registry: throwing });
+    expect(reg.handle).toBeUndefined();
+    expect(() => reg.dispose()).not.toThrow();
+  });
+});

--- a/src/agent/session/register-surface-session.ts
+++ b/src/agent/session/register-surface-session.ts
@@ -1,0 +1,123 @@
+/**
+ * Cross-surface session registration (step 7 of the session-registry effort).
+ *
+ * Registers a top-level session — the CLI REPL and the daemon scheduler — in the
+ * process-wide {@link sessionRegistry}, so they appear in the surface-agnostic
+ * index alongside the Telegram adapter's sessions. This closes the loop from the
+ * registry foundation to every user-facing surface.
+ *
+ * Invariant: registration and disposal are BEST-EFFORT — they must never throw
+ * into the caller. A registry hiccup can never break or abort a live session;
+ * the cross-surface index is auxiliary, not load-bearing.
+ *
+ * The SDK session id is late-bound (undefined until the provider emits it
+ * mid-first-turn — see session-registry.ts). When it is already known at
+ * registration (e.g. a CLI `--resume` target) it is passed up front and used as
+ * the binding key; otherwise it is attached asynchronously after
+ * `waitForInitialization()`, best-effort.
+ *
+ * Lifecycle: process-scoped surfaces (the CLI REPL — one process, one session)
+ * need no disposal: the in-memory registry dies with the process. Long-lived
+ * surfaces (the daemon — many sessions per process) MUST call `dispose()` on
+ * session close so the handle is archived and its binding key freed, preventing
+ * unbounded handle growth.
+ *
+ * @module agent/session/register-surface-session
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { AgentModelInput } from '../types.js';
+import {
+  sessionRegistry,
+  type SessionRegistry,
+  type SessionHandle,
+  type SessionSurface,
+} from './session-registry.js';
+
+/** Minimal session shape needed for late SDK-session-id attachment. The
+ *  init result is awaited but unused, so its type is intentionally `unknown`
+ *  (AgentSession resolves SessionMetadata; a stub may resolve void). */
+interface RegisterableSession {
+  readonly sessionId?: string;
+  waitForInitialization?(): Promise<unknown>;
+}
+
+export interface RegisterSurfaceSessionOptions {
+  surface: SessionSurface;
+  model: AgentModelInput;
+  cwd?: string;
+  name?: string;
+  /** SDK session id when already known (e.g. a --resume target); else attached lazily. */
+  sdkSessionId?: string;
+  /** Registry to register in. Defaults to the process-wide singleton (tests inject a fresh one). */
+  registry?: SessionRegistry;
+}
+
+export interface SurfaceSessionRegistration {
+  /** The created handle, or undefined when registration failed (best-effort). */
+  handle: SessionHandle | undefined;
+  /** Archive the handle (frees its binding key). Idempotent + best-effort — call on close for long-lived surfaces. */
+  dispose(): void;
+}
+
+const NOOP_REGISTRATION: SurfaceSessionRegistration = { handle: undefined, dispose: () => {} };
+
+/**
+ * Register a top-level session in the cross-surface registry. Returns the handle
+ * (or undefined on failure) plus a best-effort `dispose()` that archives it.
+ */
+export function registerSurfaceSession(
+  session: RegisterableSession,
+  opts: RegisterSurfaceSessionOptions,
+): SurfaceSessionRegistration {
+  const registry = opts.registry ?? sessionRegistry;
+
+  let handle: SessionHandle | undefined;
+  try {
+    handle = registry.create({
+      surface: opts.surface,
+      model: opts.model,
+      // Key on the SDK id when known (meaningful, reverse-lookupable); else a
+      // unique opaque key — CLI/daemon have no external routing key like a chatId.
+      key: opts.sdkSessionId ?? `${opts.surface}:${randomUUID()}`,
+      ...(opts.cwd !== undefined ? { cwd: opts.cwd } : {}),
+      ...(opts.name !== undefined ? { name: opts.name } : {}),
+      ...(opts.sdkSessionId !== undefined ? { sdkSessionId: opts.sdkSessionId } : {}),
+    });
+  } catch {
+    // Registration is auxiliary; never surface a registry error to the session.
+    return NOOP_REGISTRATION;
+  }
+
+  const id = handle.id;
+
+  // Late-bind the SDK session id once the provider emits it (best-effort, non-blocking).
+  if (opts.sdkSessionId === undefined && typeof session.waitForInitialization === 'function') {
+    void session
+      .waitForInitialization()
+      .then(() => {
+        const sid = session.sessionId;
+        if (sid) {
+          try {
+            registry.attachSdkSessionId(id, sid);
+          } catch {
+            /* best-effort */
+          }
+        }
+      })
+      .catch(() => {
+        /* best-effort — init failure is handled by the session itself */
+      });
+  }
+
+  return {
+    handle,
+    dispose: () => {
+      try {
+        registry.archive(id);
+      } catch {
+        /* best-effort — already archived / unknown id */
+      }
+    },
+  };
+}

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -1,4 +1,5 @@
 import { MemoryStore } from '../../../agent/memory/index.js';
+import { registerSurfaceSession } from '../../../agent/session/register-surface-session.js';
 import type { SlashContext } from '../../slash/types.js';
 import type { SessionRef } from '../../../agent/session-ref.js';
 import type { CliOptions, InteractiveCtx } from './shared.js';
@@ -135,6 +136,19 @@ export async function bootstrapSession(
   const session = buildAgentSession(sharedDeps);
   // Populate sessionRef (declared above deferredParent so the proxy works).
   sessionRef.current = session;
+
+  // Step 7: register this REPL session in the cross-surface session registry so
+  // it appears alongside Telegram/daemon sessions. Best-effort (never throws).
+  // Process-scoped — the in-memory registry dies with the REPL — so no dispose
+  // is wired here (unlike the long-running daemon, which archives on close).
+  registerSurfaceSession(session, {
+    surface: 'cli',
+    model: sharedDeps.model,
+    ...(sharedDeps.cwd !== undefined ? { cwd: sharedDeps.cwd } : {}),
+    ...(resumeTarget?.stored?.sessionId !== undefined
+      ? { sdkSessionId: resumeTarget.stored.sessionId }
+      : {}),
+  });
 
   // Witness layer: wire the subagent-success rollup so the rootManager's
   // foreground forks accumulate token/cost data into the parent session's

--- a/src/telegram/afk-two-way-roundtrip.test.ts
+++ b/src/telegram/afk-two-way-roundtrip.test.ts
@@ -46,8 +46,8 @@ function sleep(ms: number): Promise<void> {
  * two pending-resolver maps `makeTelegramElicitationHandler` populates.
  */
 function makeElicitStubs(chatId: number) {
-  const pendingElicitations = new Map<number, (text: string) => void>();
-  const ledgerOriginatedPendingChats = new Set<number>();
+  const pendingElicitations = new Map<string, (text: string) => void>();
+  const ledgerOriginatedPendingChats = new Set<string>();
   const sentMessages: string[] = [];
   const bot = {
     action: vi.fn(),
@@ -107,7 +107,7 @@ describe('two-way AFK round-trip (real daemon ↔ real REPL over one ledger)', (
 
     // The daemon tail should observe the elicitation and install the resolver.
     await sleep(300);
-    const resolver = pendingElicitations.get(chatId);
+    const resolver = pendingElicitations.get(String(chatId));
     expect(resolver).toBeDefined();
 
     // Operator answers on the phone. The daemon signs + writes back the response;

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -29,6 +29,7 @@ import { readLivePresenceFiles } from '../agent/awareness/presence.js';
 import { readSessionKey, signAbortRequest, freshChannelId } from '../agent/afk-channel.js';
 import { SessionLedgerWriter } from '../agent/session-ledger.js';
 import { splitLongMessage } from './formatter.js';
+import { routeFromCtx, sendOptions } from './route.js';
 
 /**
  * Bot configuration options
@@ -114,34 +115,34 @@ export class TelegramBot {
     this.bot.command('start', (ctx) => handleStart(ctx));
     this.bot.command('help', (ctx) => handleHelp(ctx, this.sessionManager));
     this.bot.command('clear', async (ctx) => {
-      const chatId = ctx.chat?.id;
-      if (!chatId) {
+      const route = routeFromCtx(ctx);
+      if (!route) {
         await ctx.reply(formatError('Could not identify chat'));
         return;
       }
-      const session = await this.sessionManager.getSession(chatId);
+      const session = await this.sessionManager.getSession(route);
       if (session.state !== 'idle') {
-        this.messageHandler.enqueueClear(chatId, ctx);
+        this.messageHandler.enqueueClear(route, ctx);
         await ctx.reply('Clear queued.');
       } else {
         await handleClear(ctx, this.sessionManager, this.registeredCommandChats, this.log.bind(this));
       }
     });
     this.bot.command('compact', async (ctx) => {
-      const chatId = ctx.chat?.id;
-      if (!chatId) {
+      const route = routeFromCtx(ctx);
+      if (!route) {
         await ctx.reply(formatError('Could not identify chat'));
         return;
       }
-      const session = await this.sessionManager.getSession(chatId);
+      const session = await this.sessionManager.getSession(route);
       if (session.state !== 'idle') {
-        this.messageHandler.enqueueCompact(chatId, ctx);
+        this.messageHandler.enqueueCompact(route, ctx);
         await ctx.reply('Compact queued.');
       } else {
         try {
           await handleCompact(ctx, this.sessionManager, this.log.bind(this));
         } finally {
-          this.messageHandler.drainQueue(chatId).catch(err => this.log('Drain error:', err));
+          this.messageHandler.drainQueue(route).catch(err => this.log('Drain error:', err));
         }
       }
     });
@@ -182,11 +183,15 @@ export class TelegramBot {
     // written by every top-level AgentSession (CLI REPL, daemon, one-shot),
     // so this is the CLI→Telegram half of cross-surface continuity.
     this.bot.command('watch', async (ctx) => {
-      const chatId = ctx.chat?.id;
-      if (!chatId) {
+      const route = routeFromCtx(ctx);
+      if (!route) {
         await ctx.reply(formatError('Could not identify chat'));
         return;
       }
+      const { chatId } = route;
+      // Pin the streamed watch output to the topic /watch was invoked from
+      // (General omits message_thread_id → default delivery, byte-identical).
+      const watchThreadOpts = sendOptions(route);
       const text = (ctx.message && 'text' in ctx.message ? ctx.message.text : '') ?? '';
       const arg = text.split(/\s+/).slice(1).join(' ').trim();
       try {
@@ -203,7 +208,7 @@ export class TelegramBot {
         }
         const send = async (msg: string): Promise<void> => {
           for (const part of splitLongMessage(msg)) {
-            await ctx.telegram.sendMessage(chatId, part);
+            await ctx.telegram.sendMessage(chatId, part, watchThreadOpts);
           }
         };
         this.watchManager.start(chatId, sessionId, send);
@@ -316,14 +321,16 @@ export class TelegramBot {
           ? (ctx.callbackQuery as { data: string }).data
           : '';
       const alias = data.replace('afk:m:', '') as AgentModelInput;
-      const chatId = ctx.chat?.id;
-      if (!chatId || !alias) return;
+      // routeFromCtx reads the thread id off callbackQuery.message (the §11 fix),
+      // so a /model tap inside a topic switches THAT topic's session, not General.
+      const route = routeFromCtx(ctx);
+      if (!route || !alias) return;
 
       // Validate alias is a known short alias (prevents arbitrary string injection)
       if (!(MODEL_ALIASES_HINT as readonly string[]).includes(alias)) return;
 
       try {
-        await this.sessionManager.switchModel(chatId, alias);
+        await this.sessionManager.switchModel(route, alias);
         const confirmText = formatModelSwitch(alias);
         await ctx.editMessageText(confirmText).catch(() => ctx.reply(confirmText));
       } catch (err) {
@@ -501,14 +508,14 @@ export class TelegramBot {
   }
 
   async handleClear(ctx: Context): Promise<void> {
-    const chatId = ctx.chat?.id;
-    if (!chatId) {
+    const route = routeFromCtx(ctx);
+    if (!route) {
       await ctx.reply(formatError('Could not identify chat'));
       return;
     }
-    const session = await this.sessionManager.getSession(chatId);
+    const session = await this.sessionManager.getSession(route);
     if (session.state !== 'idle') {
-      this.messageHandler.enqueueClear(chatId, ctx);
+      this.messageHandler.enqueueClear(route, ctx);
       await ctx.reply('Clear queued.');
     } else {
       return handleClear(ctx, this.sessionManager, this.registeredCommandChats, this.log.bind(this));

--- a/src/telegram/elicitation-handler.test.ts
+++ b/src/telegram/elicitation-handler.test.ts
@@ -86,10 +86,14 @@ interface MockCallbackCtx {
 // Test factory helpers
 // ---------------------------------------------------------------------------
 
-/** Build a minimal mock MessageHandler with a real pendingElicitations map. */
+/**
+ * Build a minimal mock MessageHandler with a real pendingElicitations map.
+ * The map is keyed by routeKey (string). For the General route these tests use
+ * (CHAT_ID with no topic), the key is String(CHAT_ID) — see ROUTE_KEY below.
+ */
 function makeMockMessageHandler() {
   return {
-    pendingElicitations: new Map<number, (text: string) => void>(),
+    pendingElicitations: new Map<string, (text: string) => void>(),
   };
 }
 
@@ -101,6 +105,8 @@ function makeMockBot() {
 }
 
 const CHAT_ID = 12345;
+/** routeKey for the General route used across these tests (String(CHAT_ID)). */
+const ROUTE_KEY = String(CHAT_ID);
 
 /** Build an AbortController wired with a controllable signal. */
 function makeAbort() {
@@ -207,10 +213,12 @@ function simulateTextReply(
   chatId: number,
   text: string,
 ) {
-  const resolver = messageHandler.pendingElicitations.get(chatId);
+  // Map is keyed by routeKey; a bare chatId here is a General route → String(chatId).
+  const rk = String(chatId);
+  const resolver = messageHandler.pendingElicitations.get(rk);
   if (!resolver) throw new Error(`No pending elicitation for chat ${chatId}`);
   // MessageHandler.handle() deletes the entry before calling the resolver.
-  messageHandler.pendingElicitations.delete(chatId);
+  messageHandler.pendingElicitations.delete(rk);
   resolver(text);
 }
 
@@ -319,7 +327,7 @@ describe('H2: abort-mid-question (text wait)', () => {
     // Allow the handler to register the pending elicitation
     await Promise.resolve();
 
-    expect(messageHandler.pendingElicitations.has(CHAT_ID)).toBe(true);
+    expect(messageHandler.pendingElicitations.has(ROUTE_KEY)).toBe(true);
 
     // Now abort
     ac.abort();
@@ -341,7 +349,7 @@ describe('H2: abort-mid-question (text wait)', () => {
     ac.abort();
     await resultPromise;
 
-    expect(messageHandler.pendingElicitations.has(CHAT_ID)).toBe(false);
+    expect(messageHandler.pendingElicitations.has(ROUTE_KEY)).toBe(false);
   });
 
   it('abort during number wait resolves with { action: "decline" }', async () => {
@@ -377,7 +385,7 @@ describe('H2: number type — re-prompt on invalid then accept on valid', () => 
     // Allow handler to register and send initial prompt
     await Promise.resolve();
 
-    expect(messageHandler.pendingElicitations.has(CHAT_ID)).toBe(true);
+    expect(messageHandler.pendingElicitations.has(ROUTE_KEY)).toBe(true);
 
     // Send invalid input
     simulateTextReply(messageHandler, CHAT_ID, 'not-a-number');
@@ -389,10 +397,11 @@ describe('H2: number type — re-prompt on invalid then accept on valid', () => 
     expect(sendMessage).toHaveBeenCalledWith(
       CHAT_ID,
       expect.stringMatching(/valid number/i),
+      {},
     );
 
     // Handler re-registered a new interceptor
-    expect(messageHandler.pendingElicitations.has(CHAT_ID)).toBe(true);
+    expect(messageHandler.pendingElicitations.has(ROUTE_KEY)).toBe(true);
 
     // Now send valid number
     simulateTextReply(messageHandler, CHAT_ID, '42');
@@ -417,8 +426,9 @@ describe('H2: number type — re-prompt on invalid then accept on valid', () => 
     expect(sendMessage).toHaveBeenCalledWith(
       CHAT_ID,
       expect.stringMatching(/enter a number/i),
+      {},
     );
-    expect(messageHandler.pendingElicitations.has(CHAT_ID)).toBe(true);
+    expect(messageHandler.pendingElicitations.has(ROUTE_KEY)).toBe(true);
 
     // Clean up: cancel so the promise settles
     simulateTextReply(messageHandler, CHAT_ID, ':cancel');
@@ -442,8 +452,9 @@ describe('H2: number type — re-prompt on invalid then accept on valid', () => 
     expect(sendMessage).toHaveBeenCalledWith(
       CHAT_ID,
       expect.stringMatching(/\u2265 10|>=\s*10|≥\s*10/),
+      {},
     );
-    expect(messageHandler.pendingElicitations.has(CHAT_ID)).toBe(true);
+    expect(messageHandler.pendingElicitations.has(ROUTE_KEY)).toBe(true);
 
     // Clean up
     simulateTextReply(messageHandler, CHAT_ID, ':cancel');
@@ -466,6 +477,7 @@ describe('H2: number type — re-prompt on invalid then accept on valid', () => 
     expect(sendMessage).toHaveBeenCalledWith(
       CHAT_ID,
       expect.stringMatching(/\u2264 100|<=\s*100|≤\s*100/),
+      {},
     );
 
     simulateTextReply(messageHandler, CHAT_ID, ':cancel');
@@ -641,7 +653,7 @@ describe('H2: sendMessage failure → decline', () => {
     const ac = makeAbort();
     await handler(textRequest(), { signal: ac.signal });
 
-    expect(messageHandler.pendingElicitations.has(CHAT_ID)).toBe(false);
+    expect(messageHandler.pendingElicitations.has(ROUTE_KEY)).toBe(false);
   });
 
   it('confirm type: sendMessage failure resolves { action: "decline" }', async () => {
@@ -789,7 +801,7 @@ describe('H1: abort race in re-prompt path', () => {
     // Allow the handler to register the initial interceptor
     await Promise.resolve();
 
-    expect(messageHandler.pendingElicitations.has(CHAT_ID)).toBe(true);
+    expect(messageHandler.pendingElicitations.has(ROUTE_KEY)).toBe(true);
 
     // Trigger invalid input → enters the re-prompt branch → sets resolved=false
     // → fires sendMessage (which aborts inside mock) → guard fires → no .set()
@@ -801,7 +813,7 @@ describe('H1: abort race in re-prompt path', () => {
 
     // The H1 guard must have prevented re-registration
     expect(repromptSendCount).toBeGreaterThanOrEqual(1);
-    expect(messageHandler.pendingElicitations.has(CHAT_ID)).toBe(false);
+    expect(messageHandler.pendingElicitations.has(ROUTE_KEY)).toBe(false);
 
     // Give the promise a chance to settle (it may or may not, depending on
     // microtask ordering; we just verify it does not hang the test).
@@ -835,7 +847,7 @@ describe('H1: abort race in re-prompt path', () => {
 
     await Promise.resolve();
 
-    expect(messageHandler.pendingElicitations.has(CHAT_ID)).toBe(true);
+    expect(messageHandler.pendingElicitations.has(ROUTE_KEY)).toBe(true);
 
     // '1abc' is an invalid multi_choice index → re-prompt path → H1 race
     simulateTextReply(messageHandler, CHAT_ID, '1abc');
@@ -844,7 +856,7 @@ describe('H1: abort race in re-prompt path', () => {
     await Promise.resolve();
 
     expect(repromptSendCount).toBeGreaterThanOrEqual(1);
-    expect(messageHandler.pendingElicitations.has(CHAT_ID)).toBe(false);
+    expect(messageHandler.pendingElicitations.has(ROUTE_KEY)).toBe(false);
 
     await Promise.race([
       resultPromise,
@@ -877,8 +889,9 @@ describe('M2/M3: multi_choice — invalid index format → re-prompt', () => {
     expect(sendMessage).toHaveBeenCalledWith(
       CHAT_ID,
       expect.stringMatching(/invalid selection/i),
+      {},
     );
-    expect(messageHandler.pendingElicitations.has(CHAT_ID)).toBe(true);
+    expect(messageHandler.pendingElicitations.has(ROUTE_KEY)).toBe(true);
 
     // Clean up
     simulateTextReply(messageHandler, CHAT_ID, ':cancel');
@@ -905,6 +918,7 @@ describe('M2/M3: multi_choice — invalid index format → re-prompt', () => {
     expect(sendMessage).toHaveBeenCalledWith(
       CHAT_ID,
       expect.stringMatching(/invalid selection/i),
+      {},
     );
 
     simulateTextReply(messageHandler, CHAT_ID, ':cancel');
@@ -930,6 +944,7 @@ describe('M2/M3: multi_choice — invalid index format → re-prompt', () => {
     expect(sendMessage).toHaveBeenCalledWith(
       CHAT_ID,
       expect.stringMatching(/invalid selection/i),
+      {},
     );
 
     simulateTextReply(messageHandler, CHAT_ID, ':cancel');
@@ -1086,8 +1101,9 @@ describe('text type — :cancel and allow_skip', () => {
     expect(sendMessage).toHaveBeenCalledWith(
       CHAT_ID,
       expect.stringMatching(/please enter a response|:cancel/i),
+      {},
     );
-    expect(messageHandler.pendingElicitations.has(CHAT_ID)).toBe(true);
+    expect(messageHandler.pendingElicitations.has(ROUTE_KEY)).toBe(true);
 
     simulateTextReply(messageHandler, CHAT_ID, ':cancel');
     const result = await resultPromise;
@@ -1173,7 +1189,7 @@ describe('resolved guard — no double-resolve', () => {
     await Promise.resolve();
 
     // Pull the resolver directly to simulate simultaneous delivery
-    const resolver = messageHandler.pendingElicitations.get(CHAT_ID)!;
+    const resolver = messageHandler.pendingElicitations.get(ROUTE_KEY)!;
     messageHandler.pendingElicitations.delete(CHAT_ID);
 
     // Call resolver twice (race simulation)

--- a/src/telegram/elicitation-handler.test.ts
+++ b/src/telegram/elicitation-handler.test.ts
@@ -1190,7 +1190,7 @@ describe('resolved guard — no double-resolve', () => {
 
     // Pull the resolver directly to simulate simultaneous delivery
     const resolver = messageHandler.pendingElicitations.get(ROUTE_KEY)!;
-    messageHandler.pendingElicitations.delete(CHAT_ID);
+    messageHandler.pendingElicitations.delete(ROUTE_KEY);
 
     // Call resolver twice (race simulation)
     resolver('first');

--- a/src/telegram/elicitation-handler.ts
+++ b/src/telegram/elicitation-handler.ts
@@ -23,6 +23,7 @@ import { Markup, Telegraf } from 'telegraf';
 import type { ElicitationHandler } from '../agent/elicitation-router.js';
 import type { ElicitationRequest, ElicitationResult } from '../agent/types/sdk-types.js';
 import type { MessageHandler } from './handlers/message.js';
+import { type TelegramRoute, routeKey, sendOptions } from './route.js';
 import {
   buildElicitationCallback,
   parseElicitationCallback,
@@ -70,33 +71,43 @@ function truncateLabel(label: string, maxBytes = 64): string {
  *
  * @param messageHandler - The message handler instance (for `pendingElicitations`).
  * @param bot - The Telegraf bot instance (for `bot.action` registration).
- * @param chatId - The Telegram chat ID to send questions to.
+ * @param target - The route to send questions to, or a bare chatId (General
+ *   topic). The route's key isolates the pending-elicitation entry from other
+ *   topics, and `sendOptions(route)` pins prompts/keyboards to the topic thread.
  * @param opts.ledgerOriginated - When true, every text-intercept entry also
- *   registers the chatId in `messageHandler.ledgerOriginatedPendingChats` so
+ *   registers the route in `messageHandler.ledgerOriginatedPendingChats` so
  *   the message handler's idle-guard fires the resolver even with no active
- *   AgentSession for this chat (the REPL session runs in a separate process).
+ *   AgentSession for this route (the REPL session runs in a separate process).
  */
 export function makeTelegramElicitationHandler(
   messageHandler: MessageHandler,
   bot: Telegraf,
-  chatId: number,
+  target: TelegramRoute | number,
   opts?: { ledgerOriginated?: boolean },
 ): ElicitationHandler {
+  // Normalize: a bare chatId is that chat's General topic. `key` isolates the
+  // pending entry per route (leak fix); `chatId` + `threadOpts` drive sends so
+  // a topic's prompt lands in the topic, not General.
+  const route: TelegramRoute = typeof target === 'number' ? { chatId: target } : target;
+  const chatId = route.chatId;
+  const key = routeKey(route);
+  const threadOpts = sendOptions(route);
+
   // Contract: ledgerOriginated elicitations bypass the session-state guard in
   // MessageHandler.handle() — the resolver fires on the next text reply
-  // regardless of whether an AgentSession exists for this chat.
+  // regardless of whether an AgentSession exists for this route.
   const ledgerOriginated = opts?.ledgerOriginated ?? false;
 
   // Helpers that keep pendingElicitations and ledgerOriginatedPendingChats in
   // sync. All text-intercept registrations and deletions must use these instead
   // of touching the maps directly, so the bypass set never drifts from reality.
   function setPending(resolver: (text: string) => void): void {
-    messageHandler.pendingElicitations.set(chatId, resolver);
-    if (ledgerOriginated) messageHandler.ledgerOriginatedPendingChats.add(chatId);
+    messageHandler.pendingElicitations.set(key, resolver);
+    if (ledgerOriginated) messageHandler.ledgerOriginatedPendingChats.add(key);
   }
   function deletePending(): void {
-    messageHandler.pendingElicitations.delete(chatId);
-    if (ledgerOriginated) messageHandler.ledgerOriginatedPendingChats.delete(chatId);
+    messageHandler.pendingElicitations.delete(key);
+    if (ledgerOriginated) messageHandler.ledgerOriginatedPendingChats.delete(key);
   }
   /**
    * H3: Single dispatch table for confirm/choice elicitations.
@@ -213,7 +224,7 @@ export function makeTelegramElicitationHandler(
           if (choiceIndex === CUSTOM_ENTRY_SENTINEL_INDEX) {
             resolved = false; // re-arm for the text intercept
             inCustomTextWait = true;
-            bot.telegram.sendMessage(chatId, '✍️ Please type your custom answer:').catch(() => {});
+            bot.telegram.sendMessage(chatId, '✍️ Please type your custom answer:', threadOpts).catch(() => {});
             if (options.signal.aborted) { resolve({ action: 'decline' }); return; }
             setPending((text: string) => {
               if (resolved) return;
@@ -242,9 +253,10 @@ export function makeTelegramElicitationHandler(
           }
         });
 
-        // Send the keyboard message
+        // Send the keyboard message (pinned to the route's topic thread).
         bot.telegram.sendMessage(chatId, displayText, {
           parse_mode: 'HTML',
+          ...threadOpts,
           reply_markup: Markup.inlineKeyboard(buttons).reply_markup,
         }).catch(() => {
           if (!resolved) {
@@ -266,8 +278,8 @@ export function makeTelegramElicitationHandler(
         resolved = true;
         // M6: log abandoned-entry cleanup so diagnostic traces surface if the
         // re-prompt race (H1) or an unanticipated path leaves a stale entry.
-        if (messageHandler.pendingElicitations.has(chatId)) {
-          console.warn('[elicitation-handler] abort: cleaning up stale pendingElicitation for chatId', chatId);
+        if (messageHandler.pendingElicitations.has(key)) {
+          console.warn('[elicitation-handler] abort: cleaning up stale pendingElicitation for route', key);
         }
         deletePending();
         resolve({ action: 'decline' });
@@ -301,7 +313,7 @@ export function makeTelegramElicitationHandler(
           if (trimmed === '' && !request.allowSkip) {
             resolved = false;
             isFirstPrompt = false;
-            bot.telegram.sendMessage(chatId, '❌ Please enter a number.').catch(() => {});
+            bot.telegram.sendMessage(chatId, '❌ Please enter a number.', threadOpts).catch(() => {});
             // H1: abort guard — if abort fired between `resolved = false` and `.set()`,
             // the promise is already settled; skip re-registration to avoid a dangling intercept.
             if (options.signal.aborted) return;
@@ -315,7 +327,7 @@ export function makeTelegramElicitationHandler(
             // Re-prompt: re-register and ask again
             resolved = false;
             isFirstPrompt = false;
-            bot.telegram.sendMessage(chatId, '❌ Please enter a valid number.').catch(() => {});
+            bot.telegram.sendMessage(chatId, '❌ Please enter a valid number.', threadOpts).catch(() => {});
             // H1: abort guard before re-registration.
             if (options.signal.aborted) return;
             setPending(handleText);
@@ -326,7 +338,7 @@ export function makeTelegramElicitationHandler(
           if (request.min !== undefined && n < request.min) {
             resolved = false;
             isFirstPrompt = false;
-            bot.telegram.sendMessage(chatId, `❌ Value must be ≥ ${request.min}.`).catch(() => {});
+            bot.telegram.sendMessage(chatId, `❌ Value must be ≥ ${request.min}.`, threadOpts).catch(() => {});
             // H1: abort guard before re-registration.
             if (options.signal.aborted) return;
             setPending(handleText);
@@ -337,7 +349,7 @@ export function makeTelegramElicitationHandler(
           if (request.max !== undefined && n > request.max) {
             resolved = false;
             isFirstPrompt = false;
-            bot.telegram.sendMessage(chatId, `❌ Value must be ≤ ${request.max}.`).catch(() => {});
+            bot.telegram.sendMessage(chatId, `❌ Value must be ≤ ${request.max}.`, threadOpts).catch(() => {});
             // H1: abort guard before re-registration.
             if (options.signal.aborted) return;
             setPending(handleText);
@@ -373,6 +385,7 @@ export function makeTelegramElicitationHandler(
               bot.telegram.sendMessage(
                 chatId,
                 `❌ Invalid selection. Enter comma-separated numbers between 1 and ${choices.length}.`,
+                threadOpts,
               ).catch(() => {});
               // H1: abort guard before re-registration.
               if (options.signal.aborted) return;
@@ -391,7 +404,7 @@ export function makeTelegramElicitationHandler(
         if (trimmed === '' && !request.allowSkip) {
           resolved = false;
           isFirstPrompt = false;
-          bot.telegram.sendMessage(chatId, '❌ Please enter a response (or type :cancel to skip).').catch(() => {});
+          bot.telegram.sendMessage(chatId, '❌ Please enter a response (or type :cancel to skip).', threadOpts).catch(() => {});
           // H1: abort guard before re-registration.
           if (options.signal.aborted) return;
           setPending(handleText);
@@ -433,13 +446,13 @@ export function makeTelegramElicitationHandler(
         }
       }
 
-      bot.telegram.sendMessage(chatId, promptText, { parse_mode: 'HTML' }).catch(() => {
+      bot.telegram.sendMessage(chatId, promptText, { parse_mode: 'HTML', ...threadOpts }).catch(() => {
         if (!resolved) {
           resolved = true;
           options.signal.removeEventListener('abort', onAbort);
           // M6: log sendMessage failure so callers can diagnose silent declines
           // without a visible error (e.g., MarkdownV2 parse failure, network error).
-          console.warn('[elicitation-handler] sendMessage failed; declining elicitation for chatId', chatId);
+          console.warn('[elicitation-handler] sendMessage failed; declining elicitation for route', key);
           deletePending();
           resolve({ action: 'decline' });
         }

--- a/src/telegram/handlers/commands.ts
+++ b/src/telegram/handlers/commands.ts
@@ -32,6 +32,7 @@ import {
 import type { AgentModelInput } from '../../agent/types.js';
 import { slugifySessionName } from '../../cli/session-name.js';
 import { formatResumeCommand } from '../../cli/resume-command.js';
+import { routeFromCtx } from '../route.js';
 
 type LogFn = (...args: unknown[]) => void;
 
@@ -51,15 +52,16 @@ export async function handleClear(
   registeredCommandChats: Set<number>,
   log: LogFn
 ): Promise<void> {
-  const chatId = ctx.chat?.id;
-  if (!chatId) {
+  const route = routeFromCtx(ctx);
+  if (!route) {
     await ctx.reply(formatError('Could not identify chat'));
     return;
   }
 
   try {
-    await sessionManager.resetSession(chatId);
-    registeredCommandChats.delete(chatId);
+    await sessionManager.resetSession(route);
+    // Command re-registration is chat-scoped (setMyCommands per chat).
+    registeredCommandChats.delete(route.chatId);
     await ctx.reply(formatClear());
   } catch (error) {
     log('Clear error:', error);
@@ -77,14 +79,14 @@ export async function handleCompact(
   sessionManager: SessionManager,
   log: LogFn
 ): Promise<void> {
-  const chatId = ctx.chat?.id;
-  if (!chatId) {
+  const route = routeFromCtx(ctx);
+  if (!route) {
     await ctx.reply(formatError('Could not identify chat'));
     return;
   }
 
   try {
-    const session = await sessionManager.getSession(chatId);
+    const session = await sessionManager.getSession(route);
     const hookRegistry = session.hookRegistry;
     // Keep the "typing…" indicator alive across the PreCompact hook and the
     // model-call compaction, which can outlast the ~5s one-shot expiry.
@@ -130,8 +132,8 @@ export async function handleModelSwitch(
   sessionManager: SessionManager,
   log: LogFn
 ): Promise<void> {
-  const chatId = ctx.chat?.id;
-  if (!chatId) {
+  const route = routeFromCtx(ctx);
+  if (!route) {
     await ctx.reply(formatError('Could not identify chat'));
     return;
   }
@@ -140,7 +142,7 @@ export async function handleModelSwitch(
   const args = text.split(/\s+/).slice(1);
 
   if (args.length === 0) {
-    const currentModel = sessionManager.getModel(chatId);
+    const currentModel = sessionManager.getModel(route);
     const buttons = MODEL_ALIASES_HINT.map(alias => [
       Markup.button.callback(
         isModelAvailable(alias) ? alias : `${alias} — needs sign-in`,
@@ -189,7 +191,7 @@ export async function handleModelSwitch(
   }
 
   try {
-    await sessionManager.switchModel(chatId, model);
+    await sessionManager.switchModel(route, model);
     await ctx.reply(formatModelSwitch(model));
   } catch (error) {
     log('Model switch error:', error);
@@ -238,8 +240,8 @@ export async function handleCwd(
   sessionManager: SessionManager,
   log: LogFn,
 ): Promise<void> {
-  const chatId = ctx.chat?.id;
-  if (!chatId) {
+  const route = routeFromCtx(ctx);
+  if (!route) {
     await ctx.reply(formatError('Could not identify chat'));
     return;
   }
@@ -254,7 +256,7 @@ export async function handleCwd(
   // which would orphan a streaming turn. Match the switchModel precedent
   // (unconditional close); the user can re-issue if they hit a race.
   if (args.length === 0) {
-    const currentCwd = sessionManager.getCwd(chatId);
+    const currentCwd = sessionManager.getCwd(route);
     await ctx.reply(formatCwdCurrent(currentCwd));
     return;
   }
@@ -265,7 +267,7 @@ export async function handleCwd(
     return;
   }
 
-  const base = sessionManager.getCwd(chatId) ?? process.cwd();
+  const base = sessionManager.getCwd(route) ?? process.cwd();
   const resolved = resolveCwdInput(pathArg, base);
 
   // Validate BEFORE persisting — a stat failure here means the next
@@ -291,7 +293,7 @@ export async function handleCwd(
   }
 
   try {
-    await sessionManager.setCwd(chatId, resolved);
+    await sessionManager.setCwd(route, resolved);
     await ctx.reply(formatCwdSwitch(resolved));
   } catch (error) {
     log('Cwd switch error:', error);
@@ -320,8 +322,8 @@ export async function handleName(
   sessionManager: SessionManager,
   log: LogFn,
 ): Promise<void> {
-  const chatId = ctx.chat?.id;
-  if (!chatId) {
+  const route = routeFromCtx(ctx);
+  if (!route) {
     await ctx.reply(formatError('Could not identify chat'));
     return;
   }
@@ -331,7 +333,7 @@ export async function handleName(
 
   // No arg → report the current name.
   if (!raw) {
-    await ctx.reply(formatNameCurrent(sessionManager.getSessionName(chatId)));
+    await ctx.reply(formatNameCurrent(sessionManager.getSessionName(route)));
     return;
   }
 
@@ -342,9 +344,9 @@ export async function handleName(
   }
 
   try {
-    const { persisted } = sessionManager.setSessionName(chatId, slug);
+    const { persisted } = sessionManager.setSessionName(route, slug);
     const resumeCommand = persisted
-      ? formatResumeCommand(slug, sessionManager.getModel(chatId))
+      ? formatResumeCommand(slug, sessionManager.getModel(route))
       : undefined;
     await ctx.reply(formatNameSet(slug, resumeCommand));
   } catch (error) {

--- a/src/telegram/handlers/message-attribution.test.ts
+++ b/src/telegram/handlers/message-attribution.test.ts
@@ -146,9 +146,9 @@ describe('sender attribution — text (handle)', () => {
       chatId: -100, text: 'hi', type: 'group', from: { id: 7, first_name: 'Alice' },
     }));
     const queues = (handler as unknown as {
-      messageQueues: Map<number, Array<{ type: string; text?: string }>>;
+      messageQueues: Map<string, Array<{ type: string; text?: string }>>;
     }).messageQueues;
-    expect(queues.get(-100)?.[0]?.text).toBe('[from Alice (id 7)]: hi');
+    expect(queues.get('-100')?.[0]?.text).toBe('[from Alice (id 7)]: hi');
     expect(mockStreamResponse).not.toHaveBeenCalled();
   });
 
@@ -156,8 +156,8 @@ describe('sender attribution — text (handle)', () => {
     const handler = makeHandler('streaming', 'streaming');
     const resolver = vi.fn();
     (handler as unknown as {
-      pendingElicitations: Map<number, (value: string) => void>;
-    }).pendingElicitations.set(-100, resolver);
+      pendingElicitations: Map<string, (value: string) => void>;
+    }).pendingElicitations.set('-100', resolver);
 
     await handler.handle(makeTextCtx({
       chatId: -100, text: 'blue', type: 'group', from: { id: 7, first_name: 'Alice' },
@@ -171,8 +171,8 @@ describe('sender attribution — text (handle)', () => {
     const handler = makeHandler('streaming', 'streaming');
     const resolver = vi.fn();
     (handler as unknown as {
-      pendingElicitations: Map<number, (value: string) => void>;
-    }).pendingElicitations.set(500, resolver);
+      pendingElicitations: Map<string, (value: string) => void>;
+    }).pendingElicitations.set('500', resolver);
 
     await handler.handle(makeTextCtx({
       chatId: 500, text: 'blue', type: 'private', from: { id: 7, first_name: 'Alice' },
@@ -193,8 +193,8 @@ describe('sender attribution — text (handle)', () => {
     const handler = makeHandler('streaming', 'streaming');
     const resolver = vi.fn();
     (handler as unknown as {
-      pendingElicitations: Map<number, (value: string) => void>;
-    }).pendingElicitations.set(500, resolver);
+      pendingElicitations: Map<string, (value: string) => void>;
+    }).pendingElicitations.set('500', resolver);
 
     await handler.handle(makeTextCtx({
       chatId: 500, text: '5', type: 'private', from: { id: 7, first_name: 'Alice' },
@@ -217,8 +217,8 @@ describe('sender attribution — text (handle)', () => {
     const handler = makeHandler('streaming', 'streaming');
     const resolver = vi.fn();
     (handler as unknown as {
-      pendingElicitations: Map<number, (value: string) => void>;
-    }).pendingElicitations.set(-100, resolver);
+      pendingElicitations: Map<string, (value: string) => void>;
+    }).pendingElicitations.set('-100', resolver);
 
     await handler.handle(makeTextCtx({
       chatId: -100, text: '5', type: 'group', from: { id: 7, first_name: 'Alice' },

--- a/src/telegram/handlers/message-compaction.test.ts
+++ b/src/telegram/handlers/message-compaction.test.ts
@@ -166,7 +166,7 @@ describe('MessageHandler — compaction queuing', () => {
       expect(mockStreamResponse).not.toHaveBeenCalled();
 
       // Now drain (simulates what happens after compact() finishes)
-      await handler.drainQueue(chatId);
+      await handler.drainQueue({ chatId });
 
       expect(mockStreamResponse).toHaveBeenCalledOnce();
       expect(mockStreamResponse).toHaveBeenCalledWith(
@@ -199,10 +199,10 @@ describe('MessageHandler — compaction queuing', () => {
       );
 
       const { ctx } = makeCompactCtx(chatId);
-      handler.enqueueCompact(chatId, ctx);
+      handler.enqueueCompact({ chatId }, ctx);
 
       // Drain the queue — processCompactDirect should call session.compact()
-      await handler.drainQueue(chatId);
+      await handler.drainQueue({ chatId });
 
       expect(idleSession.compact).toHaveBeenCalledOnce();
     });
@@ -239,16 +239,16 @@ describe('MessageHandler — compaction queuing', () => {
       );
 
       const { ctx, replies } = makeCompactCtx(chatId);
-      handler.enqueueCompact(chatId, ctx);
-      await handler.drainQueue(chatId);
+      handler.enqueueCompact({ chatId }, ctx);
+      await handler.drainQueue({ chatId });
 
       // compact() was attempted once and returned session-busy
       expect(busySession.compact).toHaveBeenCalledOnce();
       // No misleading no-op reply surfaced to the user
       expect(replies).toHaveLength(0);
       // The compact item is still queued, awaiting the next drain
-      expect((handler as any).messageQueues.get(chatId)).toHaveLength(1);
-      expect((handler as any).messageQueues.get(chatId)[0].type).toBe('compact');
+      expect((handler as any).messageQueues.get(String(chatId))).toHaveLength(1);
+      expect((handler as any).messageQueues.get(String(chatId))[0].type).toBe('compact');
     });
 
     it('completes the re-enqueued compact on a subsequent drain once the session is idle', async () => {
@@ -280,19 +280,19 @@ describe('MessageHandler — compaction queuing', () => {
       );
 
       const { ctx, replies } = makeCompactCtx(chatId);
-      handler.enqueueCompact(chatId, ctx);
+      handler.enqueueCompact({ chatId }, ctx);
 
       // First drain: busy → re-enqueue, no reply.
-      await handler.drainQueue(chatId);
+      await handler.drainQueue({ chatId });
       expect(replies).toHaveLength(0);
 
       // Second drain (session now idle): compact succeeds, success reply sent.
-      await handler.drainQueue(chatId);
+      await handler.drainQueue({ chatId });
       expect(session.compact).toHaveBeenCalledTimes(2);
       expect(replies).toHaveLength(1);
       expect(replies[0]).toContain('📦');
       // Queue is now empty.
-      expect((handler as any).messageQueues.get(chatId) ?? []).toHaveLength(0);
+      expect((handler as any).messageQueues.get(String(chatId)) ?? []).toHaveLength(0);
     });
   });
 });

--- a/src/telegram/handlers/message-tag-only.test.ts
+++ b/src/telegram/handlers/message-tag-only.test.ts
@@ -247,8 +247,9 @@ describe('MessageHandler tag-only gate — text', () => {
     // MessageHandler.ledgerOriginatedPendingChats.
     const { handler, getSession } = makeHandler(new Set([TAG_CHAT]));
     const resolved: string[] = [];
-    handler.pendingElicitations.set(TAG_CHAT, (text) => resolved.push(text));
-    handler.ledgerOriginatedPendingChats.add(TAG_CHAT);
+    const tagChatKey = String(TAG_CHAT);
+    handler.pendingElicitations.set(tagChatKey, (text) => resolved.push(text));
+    handler.ledgerOriginatedPendingChats.add(tagChatKey);
 
     const { ctx, react } = makeTextCtx({ chatId: TAG_CHAT, text: 'my answer, no mention' });
 
@@ -257,8 +258,8 @@ describe('MessageHandler tag-only gate — text', () => {
     // Resolver fired with the message text — the elicitation answer was consumed.
     expect(resolved).toEqual(['my answer, no mention']);
     // Entry cleaned up on both maps.
-    expect(handler.pendingElicitations.has(TAG_CHAT)).toBe(false);
-    expect(handler.ledgerOriginatedPendingChats.has(TAG_CHAT)).toBe(false);
+    expect(handler.pendingElicitations.has(tagChatKey)).toBe(false);
+    expect(handler.ledgerOriginatedPendingChats.has(tagChatKey)).toBe(false);
     // The message never reached the tag-only gate's drop path or processOne:
     // no ack react, no getSession, no queued turn.
     expect(react).not.toHaveBeenCalled();

--- a/src/telegram/handlers/message.test.ts
+++ b/src/telegram/handlers/message.test.ts
@@ -114,7 +114,7 @@ describe('MessageHandler.pendingElicitations intercept', () => {
     const resolvedValues: string[] = [];
 
     // Pre-seed the intercept
-    handler.pendingElicitations.set(chatId, (text) => {
+    handler.pendingElicitations.set(String(chatId), (text) => {
       resolvedValues.push(text);
     });
 
@@ -124,7 +124,7 @@ describe('MessageHandler.pendingElicitations intercept', () => {
     // Resolver must have been called with the message text
     expect(resolvedValues).toEqual(['my answer']);
     // Entry must be deleted after consumption
-    expect(handler.pendingElicitations.has(chatId)).toBe(false);
+    expect(handler.pendingElicitations.has(String(chatId))).toBe(false);
     // streamResponse (processOne) must NOT have been called
     expect(mockStreamResponse).not.toHaveBeenCalled();
     // ctx.reply must NOT have been called (no "Message queued" etc.)
@@ -138,7 +138,7 @@ describe('MessageHandler.pendingElicitations intercept', () => {
 
     // streamResponse may or may not be called depending on session state mocking,
     // but pendingElicitations must not have been modified
-    expect(handler.pendingElicitations.has(chatId)).toBe(false);
+    expect(handler.pendingElicitations.has(String(chatId))).toBe(false);
   });
 
   it('pendingElicitations is a public Map initialized to empty', () => {
@@ -150,13 +150,13 @@ describe('MessageHandler.pendingElicitations intercept', () => {
     const chatId = 7;
     let callCount = 0;
 
-    handler.pendingElicitations.set(chatId, () => { callCount += 1; });
+    handler.pendingElicitations.set(String(chatId), () => { callCount += 1; });
 
     // First message — consumed by resolver
     const { ctx: ctx1 } = makeMessageCtx(chatId, 'first');
     await handler.handle(ctx1);
     expect(callCount).toBe(1);
-    expect(handler.pendingElicitations.has(chatId)).toBe(false);
+    expect(handler.pendingElicitations.has(String(chatId))).toBe(false);
 
     // Second message — NOT intercepted (normal flow)
     const { ctx: ctx2 } = makeMessageCtx(chatId, 'second');
@@ -409,8 +409,8 @@ describe('MessageHandler.ledgerOriginatedPendingChats bypass (C3)', () => {
     const resolved: string[] = [];
 
     // Pre-seed as ledger-originated (as makeTelegramElicitationHandler would do).
-    handler.pendingElicitations.set(chatId, (text) => resolved.push(text));
-    handler.ledgerOriginatedPendingChats.add(chatId);
+    handler.pendingElicitations.set(String(chatId), (text) => resolved.push(text));
+    handler.ledgerOriginatedPendingChats.add(String(chatId));
 
     const { ctx } = makeMessageCtx(chatId, 'ledger answer');
     await handler.handle(ctx);
@@ -418,8 +418,8 @@ describe('MessageHandler.ledgerOriginatedPendingChats bypass (C3)', () => {
     // Resolver must fire even though there is no active session.
     expect(resolved).toEqual(['ledger answer']);
     // Both maps must be cleaned up after consumption.
-    expect(handler.pendingElicitations.has(chatId)).toBe(false);
-    expect(handler.ledgerOriginatedPendingChats.has(chatId)).toBe(false);
+    expect(handler.pendingElicitations.has(String(chatId))).toBe(false);
+    expect(handler.ledgerOriginatedPendingChats.has(String(chatId))).toBe(false);
   });
 
   it('fires a ledger-originated pending resolver even when session is idle', async () => {
@@ -444,15 +444,15 @@ describe('MessageHandler.ledgerOriginatedPendingChats bypass (C3)', () => {
     const chatId = 56;
     const resolved: string[] = [];
 
-    handler.pendingElicitations.set(chatId, (text) => resolved.push(text));
-    handler.ledgerOriginatedPendingChats.add(chatId);
+    handler.pendingElicitations.set(String(chatId), (text) => resolved.push(text));
+    handler.ledgerOriginatedPendingChats.add(String(chatId));
 
     const { ctx } = makeMessageCtx(chatId, 'idle session answer');
     await handler.handle(ctx);
 
     expect(resolved).toEqual(['idle session answer']);
-    expect(handler.pendingElicitations.has(chatId)).toBe(false);
-    expect(handler.ledgerOriginatedPendingChats.has(chatId)).toBe(false);
+    expect(handler.pendingElicitations.has(String(chatId))).toBe(false);
+    expect(handler.ledgerOriginatedPendingChats.has(String(chatId))).toBe(false);
   });
 
   it('still drops a genuinely stale session-local entry (no ledger-origin flag) when session is idle', async () => {
@@ -478,7 +478,7 @@ describe('MessageHandler.ledgerOriginatedPendingChats bypass (C3)', () => {
     let resolverCalled = false;
 
     // Pre-seed WITHOUT the ledger-origin flag (session-local, now stale).
-    handler.pendingElicitations.set(chatId, () => { resolverCalled = true; });
+    handler.pendingElicitations.set(String(chatId), () => { resolverCalled = true; });
     // ledgerOriginatedPendingChats NOT set — this is the stale-session path.
 
     const { ctx } = makeMessageCtx(chatId, 'stale reply');
@@ -487,7 +487,7 @@ describe('MessageHandler.ledgerOriginatedPendingChats bypass (C3)', () => {
     // Resolver must NOT fire — the stale-session guard must drop it.
     expect(resolverCalled).toBe(false);
     // The stale entry must be cleaned up.
-    expect(handler.pendingElicitations.has(chatId)).toBe(false);
+    expect(handler.pendingElicitations.has(String(chatId))).toBe(false);
   });
 
   it('ledgerOriginatedPendingChats is a public Set initialized to empty', () => {

--- a/src/telegram/handlers/message.ts
+++ b/src/telegram/handlers/message.ts
@@ -172,9 +172,9 @@ export class MessageHandler {
   private bot: Telegraf;
 
   /**
-   * Invariant: chat IDs with a turn claimed by an in-flight handle()/
+   * Invariant: routes with a turn claimed by an in-flight handle()/
    * handlePhoto()/drain call not yet reflected in `session.state`. bot.ts runs
-   * 'text'/'photo' detached, so a second same-chat update can be dispatched
+   * 'text'/'photo' detached, so a second same-route update can be dispatched
    * while the first is still between `getSession()` and the point where
    * `currentState` actually flips to 'streaming'.
    *
@@ -188,7 +188,7 @@ export class MessageHandler {
    * misses that window: two updates would both see 'idle' and race out of
    * arrival order (PR #602 review — Codex P1).
    *
-   * Reference-counted (chatId → live claim count) rather than a plain Set so
+   * Reference-counted (routeKey → live claim count) rather than a plain Set so
    * the reservation survives the hand-off across `processOne`'s un-awaited
    * `finally → drainQueue`: the drained turn takes its own +1 synchronously
    * before the outer turn's release drops back to 0, so the slot is never
@@ -197,17 +197,17 @@ export class MessageHandler {
    * claim* helpers below, so only the first arrival wins; `isClaimed` sees any
    * live count. See {@link reserveClaim}/{@link releaseClaim}.
    */
-  private claimedChats = new Map<number, number>();
+  private claimedChats = new Map<string, number>();
 
   /**
-   * Reserve this chat's turn slot (synchronous). Increments the live claim
+   * Reserve this route's turn slot (synchronous). Increments the live claim
    * count so overlapping reservations — handle()'s outer guard plus
    * processOne's own reservation plus a drain re-entry — compose instead of
    * clobbering a single boolean flag. Must be called with NO `await` between
    * the deciding `isClaimed` read and this call.
    */
-  private reserveClaim(chatId: number): void {
-    this.claimedChats.set(chatId, (this.claimedChats.get(chatId) ?? 0) + 1);
+  private reserveClaim(key: string): void {
+    this.claimedChats.set(key, (this.claimedChats.get(key) ?? 0) + 1);
   }
 
   /**
@@ -215,15 +215,15 @@ export class MessageHandler {
    * once the count reaches zero so `isClaimed` reports false again. Balanced:
    * each reserveClaim has exactly one releaseClaim on every code path.
    */
-  private releaseClaim(chatId: number): void {
-    const next = (this.claimedChats.get(chatId) ?? 0) - 1;
-    if (next <= 0) this.claimedChats.delete(chatId);
-    else this.claimedChats.set(chatId, next);
+  private releaseClaim(key: string): void {
+    const next = (this.claimedChats.get(key) ?? 0) - 1;
+    if (next <= 0) this.claimedChats.delete(key);
+    else this.claimedChats.set(key, next);
   }
 
-  /** True while any turn holds a slot for this chat (see {@link claimedChats}). */
-  private isClaimed(chatId: number): boolean {
-    return (this.claimedChats.get(chatId) ?? 0) > 0;
+  /** True while any turn holds a slot for this route (see {@link claimedChats}). */
+  private isClaimed(key: string): boolean {
+    return (this.claimedChats.get(key) ?? 0) > 0;
   }
 
   /**
@@ -354,8 +354,8 @@ export class MessageHandler {
       // not already claimed so a losing concurrent call doesn't inflate the
       // count it never releases; processOne takes its own reservation for the
       // turn it actually runs (drain-path coverage, #603 Item 1).
-      alreadyClaimed = this.isClaimed(chatId);
-      if (!alreadyClaimed) this.reserveClaim(chatId);
+      alreadyClaimed = this.isClaimed(routeKey(route));
+      if (!alreadyClaimed) this.reserveClaim(routeKey(route));
 
       // M3+M6: session lookup and queue-depth check happen before getFileLink /
       // download so that allowlist-burst rejections don't burn Telegram API quota
@@ -523,7 +523,7 @@ export class MessageHandler {
       // matching comment in handle(). processOne holds its own reservation for
       // the turn it runs, so releasing this outer guard here never drops the
       // slot out from under an in-flight (possibly drained) turn.
-      if (!alreadyClaimed) this.releaseClaim(chatId);
+      if (!alreadyClaimed) this.releaseClaim(routeKey(route));
     }
   }
 
@@ -651,8 +651,8 @@ export class MessageHandler {
       // inflate a count it never releases; processOne takes its own
       // reservation for the turn it actually runs (drain-path coverage,
       // #603 Item 1).
-      alreadyClaimed = this.isClaimed(chatId);
-      if (!alreadyClaimed) this.reserveClaim(chatId);
+      alreadyClaimed = this.isClaimed(routeKey(route));
+      if (!alreadyClaimed) this.reserveClaim(routeKey(route));
 
       const session = await this.sessionManager.getSession(route);
 
@@ -690,7 +690,7 @@ export class MessageHandler {
       // still-in-flight claim out from under it. processOne holds its own
       // reservation for the turn it runs, so this release never drops the slot
       // while a turn (first or drained) is still streaming.
-      if (!alreadyClaimed) this.releaseClaim(chatId);
+      if (!alreadyClaimed) this.releaseClaim(routeKey(route));
     }
   }
 
@@ -857,11 +857,10 @@ export class MessageHandler {
    * handle()/handlePhoto() guard and any drain re-entry.
    */
   private async processOne(route: TelegramRoute, ctx: Context, content: string | ContentBlockParam[]): Promise<void> {
-    const chatId = route.chatId;
     // Reserve this turn's slot synchronously, before the first `await` below, so
     // the slot is held continuously from dispatch through the finally's drain
     // hand-off. Paired 1:1 with the releaseClaim in the finally.
-    this.reserveClaim(chatId);
+    this.reserveClaim(routeKey(route));
     // Guard against a busy-spin cascade: if the catch block re-enqueues the item
     // because the session is busy, we must NOT also drain — the re-enqueued item will
     // be picked up by the active session's own drain cycle. Without this flag, the
@@ -931,7 +930,7 @@ export class MessageHandler {
       if (!reEnqueued) {
         this.drainQueue(route).catch(err => this.log('Drain error:', err));
       }
-      this.releaseClaim(chatId);
+      this.releaseClaim(routeKey(route));
     }
   }
 

--- a/src/telegram/handlers/message.ts
+++ b/src/telegram/handlers/message.ts
@@ -12,6 +12,7 @@ import { withTypingIndicator } from '../typing-indicator.js';
 import { StreamTimeoutError } from '../stream-timeout-error.js';
 import { registerChatCommands } from './registration.js';
 import { HookBlockedError } from '../../utils/errors.js';
+import { type TelegramRoute, routeFromCtx, routeKey } from '../route.js';
 import { senderPrefix } from '../sender-attribution.js';
 import { replyContextPrefix, type RepliedMessage } from '../reply-context.js';
 import type { ContentBlockParam } from '@anthropic-ai/sdk/resources';
@@ -158,7 +159,14 @@ export class MessageHandler {
   private static readonly MAX_QUEUE_DEPTH = 5;
 
   private sessionManager: SessionManager;
-  private messageQueues = new Map<number, Array<QueueItem>>();
+  /**
+   * Per-ROUTE message queues. Keyed by `routeKey(route)` — General / topics-off
+   * normalizes to `String(chatId)` (byte-identical to the pre-topics key), a
+   * real topic to `${chatId}:${threadId}`. This is a leak-critical map: a
+   * message queued in topic A must never drain into topic B's session.
+   */
+  private messageQueues = new Map<string, Array<QueueItem>>();
+  /** Chats (NOT routes) with dynamic commands registered — Telegram scopes setMyCommands per chat, not per topic. */
   private registeredCommandChats: Set<number>;
   private log: LogFn;
   private bot: Telegraf;
@@ -220,21 +228,26 @@ export class MessageHandler {
 
   /**
    * Active ask_question elicitations waiting for a text reply.
-   * Keys are chat IDs; values are resolver functions that consume
-   * the next plain-text message from that chat.
+   * Keys are ROUTE keys (`routeKey(route)`); values are resolver functions
+   * that consume the next plain-text message from that route.
+   *
+   * Invariant (leak fix): keying by route — not by chatId — is what isolates
+   * topics. An elicitation raised in topic A registers under A's routeKey and
+   * is resolved ONLY by a message whose route also resolves to A; a message in
+   * topic B (or General) resolves to a different key and cannot consume it.
    *
    * Answer consumed by active ask_question elicitation — never reaches
    * session message queue.
    */
-  public pendingElicitations = new Map<number, (text: string) => void>();
+  public pendingElicitations = new Map<string, (text: string) => void>();
 
   /**
-   * Chat IDs whose active pendingElicitations entry was registered by a
+   * Route keys whose active pendingElicitations entry was registered by a
    * ledger-originated (daemon-watch) elicitation rather than a session-local
    * ask_question call.
    *
    * Invariant: the idle-guard in handle() must fire the resolver for these
-   * chats even when no AgentSession is active for the chat (the REPL session
+   * routes even when no AgentSession is active for the route (the REPL session
    * lives in a different process). Without this bypass, every phone reply to a
    * ledger-originated elicitation is silently dropped because the guard sees
    * no in-flight session and treats the pending entry as stale.
@@ -244,7 +257,7 @@ export class MessageHandler {
    * the watch loop), and deleted when the resolver fires or is aborted — exactly
    * mirroring the pendingElicitations Map lifecycle.
    */
-  public ledgerOriginatedPendingChats = new Set<number>();
+  public ledgerOriginatedPendingChats = new Set<string>();
 
   /**
    * Chat IDs under the opt-in "tag-only" response policy. In these chats a
@@ -280,11 +293,12 @@ export class MessageHandler {
    * implemented here.
    */
   async handlePhoto(ctx: Context): Promise<void> {
-    const chatId = ctx.chat?.id;
+    const route = routeFromCtx(ctx);
+    const chatId = route?.chatId;
     const msg = ctx.message as Message.PhotoMessage | undefined;
     const photo = msg?.photo;
 
-    if (!chatId || !photo?.length) {
+    if (!route || !chatId || !photo?.length) {
       this.log(`Photo handling: missing chatId or photo array for chat ${chatId ?? '(unknown)'}`);
       return;
     }
@@ -346,9 +360,10 @@ export class MessageHandler {
       // M3+M6: session lookup and queue-depth check happen before getFileLink /
       // download so that allowlist-burst rejections don't burn Telegram API quota
       // or trigger a full CDN download for a message that will be dropped anyway.
-      const session = await this.sessionManager.getSession(chatId);
+      const session = await this.sessionManager.getSession(route);
 
-      // Register dynamic commands for this chat (non-blocking)
+      // Register dynamic commands for this chat (non-blocking). Chat-scoped, so
+      // keyed by chatId even when the message arrived in a topic.
       registerChatCommands(this.bot, chatId, session, this.registeredCommandChats, this.log).catch(err =>
         this.log('Failed to register chat commands:', err)
       );
@@ -356,7 +371,7 @@ export class MessageHandler {
       if (session.state !== 'idle' || alreadyClaimed) {
         // Check queue capacity before downloading: if the queue is already full we
         // can reject immediately without spending Telegram API quota on getFileLink.
-        const queue = this.messageQueues.get(chatId);
+        const queue = this.messageQueues.get(routeKey(route));
         if ((queue?.length ?? 0) >= MessageHandler.MAX_QUEUE_DEPTH) {
           await ctx.reply('⏳ Queue full. Please wait for your messages to be processed.');
           return;
@@ -477,12 +492,12 @@ export class MessageHandler {
       await registerInboundImageBlocks(contentBlocks, session.sessionId, [{ mediaType: media_type, bytes }]);
 
       if (session.state !== 'idle' || alreadyClaimed) {
-        const depth = this.enqueuePhoto(chatId, ctx, contentBlocks);
+        const depth = this.enqueuePhoto(route, ctx, contentBlocks);
         if (depth !== false) await ctx.reply(formatQueued(depth));
         return;
       }
 
-      await this.processOne(chatId, ctx, contentBlocks);
+      await this.processOne(route, ctx, contentBlocks);
     } catch (error) {
       // Redact any embedded bot token before logging: getFileLink() returns URLs of the form
       // https://api.telegram.org/file/bot<TOKEN>/<path>, and HTTP client errors frequently
@@ -516,12 +531,14 @@ export class MessageHandler {
    * Handle user text messages
    */
   async handle(ctx: Context): Promise<void> {
-    const chatId = ctx.chat?.id;
+    const route = routeFromCtx(ctx);
+    const chatId = route?.chatId;
     const messageText = (ctx.message as Message.TextMessage).text;
 
-    if (!chatId || !messageText) {
+    if (!route || !chatId || !messageText) {
       return;
     }
+    const key = routeKey(route);
 
     this.log(`📬 Message from chat ID: ${chatId}`);
 
@@ -570,25 +587,28 @@ export class MessageHandler {
     //      live session state here catches that case: a freshly-created session
     //      is always 'idle', so we delete the stale entry and fall through to
     //      processOne instead of routing to a dead resolver.
-    const elicitResolver = this.pendingElicitations.get(chatId);
+    // Resolve the elicitation by ROUTE key — this is the topic-isolation seam:
+    // a topic-A elicitation registered under A's key is never consumed by a
+    // topic-B message (which resolves to a different key).
+    const elicitResolver = this.pendingElicitations.get(key);
     if (elicitResolver) {
       // Case 1: ledger-originated bypass — fire resolver without session check.
-      if (this.ledgerOriginatedPendingChats.has(chatId)) {
-        this.pendingElicitations.delete(chatId);
-        this.ledgerOriginatedPendingChats.delete(chatId);
+      if (this.ledgerOriginatedPendingChats.has(key)) {
+        this.pendingElicitations.delete(key);
+        this.ledgerOriginatedPendingChats.delete(key);
         elicitResolver(elicitationAnswer);
         return;
       }
       // Case 2: session-local — fire only when the session is genuinely busy.
-      const existingSession = this.sessionManager.getSessionIfExists(chatId);
+      const existingSession = this.sessionManager.getSessionIfExists(route);
       if (existingSession && existingSession.state !== 'idle') {
-        this.pendingElicitations.delete(chatId);
+        this.pendingElicitations.delete(key);
         elicitResolver(elicitationAnswer);
         return;
       }
       // Stale entry — session was reset while elicitation was in flight.
-      this.log('[message] dropping stale pendingElicitation for chatId', chatId);
-      this.pendingElicitations.delete(chatId);
+      this.log('[message] dropping stale pendingElicitation for route', key);
+      this.pendingElicitations.delete(key);
     }
 
     // Tag-only response policy: in a configured chat, ignore any non-command
@@ -634,9 +654,9 @@ export class MessageHandler {
       alreadyClaimed = this.isClaimed(chatId);
       if (!alreadyClaimed) this.reserveClaim(chatId);
 
-      const session = await this.sessionManager.getSession(chatId);
+      const session = await this.sessionManager.getSession(route);
 
-      // Register dynamic commands for this chat (non-blocking)
+      // Register dynamic commands for this chat (non-blocking). Chat-scoped.
       registerChatCommands(this.bot, chatId, session, this.registeredCommandChats, this.log).catch(err =>
         this.log('Failed to register chat commands:', err)
       );
@@ -644,12 +664,12 @@ export class MessageHandler {
       const content = attributedMessageText;
 
       if (session.state !== 'idle' || alreadyClaimed) {
-        const depth = this.enqueueMessage(chatId, ctx, content);
+        const depth = this.enqueueMessage(route, ctx, content);
         if (depth !== false) await ctx.reply(formatQueued(depth));
         return;
       }
 
-      await this.processOne(chatId, ctx, content);
+      await this.processOne(route, ctx, content);
     } catch (error) {
       this.log('Message handling error:', error);
       // Note: 'session is busy' is no longer handled here — that race is covered
@@ -675,12 +695,15 @@ export class MessageHandler {
   }
 
   /**
-   * Process clear command when already idle (called from handlers)
+   * Process clear command when already idle (called from handlers).
+   * Resets the session for THIS route only; the chat's other topics are
+   * untouched. Command re-registration is chat-scoped (registeredCommandChats
+   * keyed by chatId).
    */
-  async processClearDirect(chatId: number, ctx: Context): Promise<void> {
+  async processClearDirect(route: TelegramRoute, ctx: Context): Promise<void> {
     try {
-      await this.sessionManager.resetSession(chatId);
-      this.registeredCommandChats.delete(chatId);
+      await this.sessionManager.resetSession(route);
+      this.registeredCommandChats.delete(route.chatId);
       await ctx.reply(formatClear());
     } catch (error) {
       this.log('Clear error:', error);
@@ -701,13 +724,13 @@ export class MessageHandler {
    * actually runs once the session is idle, instead of surfacing the misleading
    * "Nothing to compact (session-busy)" no-op and dropping the request.
    */
-  private async processCompactDirect(chatId: number, ctx: Context): Promise<void> {
+  private async processCompactDirect(route: TelegramRoute, ctx: Context): Promise<void> {
     // See processOne: when we re-enqueue because the session is busy, the active
     // turn's own finally will drain the item we pushed. Draining here too would
     // shift that item and re-enter immediately → busy-spin cascade.
     let reEnqueued = false;
     try {
-      const session = await this.sessionManager.getSession(chatId);
+      const session = await this.sessionManager.getSession(route);
       const hookRegistry = session.hookRegistry;
       // Keep the "typing…" indicator alive across the PreCompact hook and the
       // model-call compaction, which can outlast the ~5s one-shot expiry.
@@ -725,7 +748,7 @@ export class MessageHandler {
       if (result.reason === 'session-busy') {
         // Session became busy between drain-start and our compact() call (TOCTOU).
         // Re-enqueue so the compact isn't silently dropped with a confusing no-op.
-        this.enqueueCompact(chatId, ctx);
+        this.enqueueCompact(route, ctx);
         reEnqueued = true;
         return;
       }
@@ -755,21 +778,28 @@ export class MessageHandler {
       // Only drain when we did NOT re-enqueue — the active turn's finally will
       // drain the re-enqueued compact; draining here too causes a cascade.
       if (!reEnqueued) {
-        this.drainQueue(chatId).catch(err => this.log('Drain error:', err));
+        this.drainQueue(route).catch(err => this.log('Drain error:', err));
       }
     }
+  }
+
+  /** The queue for a route, creating it on first use. Keyed by routeKey. */
+  private queueFor(route: TelegramRoute): Array<QueueItem> {
+    const key = routeKey(route);
+    let queue = this.messageQueues.get(key);
+    if (!queue) {
+      queue = [];
+      this.messageQueues.set(key, queue);
+    }
+    return queue;
   }
 
   /**
    * Enqueue a text message for later processing.
    * Returns the 1-based queue depth on success, or false if the queue is full.
    */
-  private enqueueMessage(chatId: number, ctx: Context, text: string): number | false {
-    let queue = this.messageQueues.get(chatId);
-    if (!queue) {
-      queue = [];
-      this.messageQueues.set(chatId, queue);
-    }
+  private enqueueMessage(route: TelegramRoute, ctx: Context, text: string): number | false {
+    const queue = this.queueFor(route);
     if (queue.length >= MessageHandler.MAX_QUEUE_DEPTH) {
       ctx.reply('⏳ Queue full. Please wait for your messages to be processed.').catch(() => {});
       return false;
@@ -782,12 +812,8 @@ export class MessageHandler {
    * Enqueue a photo message for later processing.
    * Returns the 1-based queue depth on success, or false if the queue is full.
    */
-  private enqueuePhoto(chatId: number, ctx: Context, content: ContentBlockParam[]): number | false {
-    let queue = this.messageQueues.get(chatId);
-    if (!queue) {
-      queue = [];
-      this.messageQueues.set(chatId, queue);
-    }
+  private enqueuePhoto(route: TelegramRoute, ctx: Context, content: ContentBlockParam[]): number | false {
+    const queue = this.queueFor(route);
     if (queue.length >= MessageHandler.MAX_QUEUE_DEPTH) {
       ctx.reply('⏳ Queue full. Please wait for your messages to be processed.').catch(() => {});
       return false;
@@ -799,25 +825,15 @@ export class MessageHandler {
   /**
    * Enqueue a clear command for later processing
    */
-  enqueueClear(chatId: number, ctx: Context): void {
-    let queue = this.messageQueues.get(chatId);
-    if (!queue) {
-      queue = [];
-      this.messageQueues.set(chatId, queue);
-    }
-    queue.push({ type: 'clear', ctx });
+  enqueueClear(route: TelegramRoute, ctx: Context): void {
+    this.queueFor(route).push({ type: 'clear', ctx });
   }
 
   /**
    * Enqueue a compact command for later processing
    */
-  enqueueCompact(chatId: number, ctx: Context): void {
-    let queue = this.messageQueues.get(chatId);
-    if (!queue) {
-      queue = [];
-      this.messageQueues.set(chatId, queue);
-    }
-    queue.push({ type: 'compact', ctx });
+  enqueueCompact(route: TelegramRoute, ctx: Context): void {
+    this.queueFor(route).push({ type: 'compact', ctx });
   }
 
   /**
@@ -840,7 +856,8 @@ export class MessageHandler {
    * claimedChats field doc) composes this turn's reservation with the outer
    * handle()/handlePhoto() guard and any drain re-entry.
    */
-  private async processOne(chatId: number, ctx: Context, content: string | ContentBlockParam[]): Promise<void> {
+  private async processOne(route: TelegramRoute, ctx: Context, content: string | ContentBlockParam[]): Promise<void> {
+    const chatId = route.chatId;
     // Reserve this turn's slot synchronously, before the first `await` below, so
     // the slot is held continuously from dispatch through the finally's drain
     // hand-off. Paired 1:1 with the releaseClaim in the finally.
@@ -852,7 +869,7 @@ export class MessageHandler {
     // which shifts the item we just pushed and calls processOne again → cascade.
     let reEnqueued = false;
     try {
-      const session = await this.sessionManager.getSession(chatId);
+      const session = await this.sessionManager.getSession(route);
       // User text for the stored turn record: joined text blocks (caption) for
       // content-block (photo) messages, the raw string otherwise.
       const userText = typeof content === 'string'
@@ -866,7 +883,7 @@ export class MessageHandler {
           // Record the completed turn into the shared session store so the CLI
           // can `--resume <name>` this Telegram conversation. Best-effort inside.
           onComplete: (assistantText, metadata) => {
-            this.sessionManager.recordTelegramTurn(chatId, userText, assistantText, metadata);
+            this.sessionManager.recordTelegramTurn(route, userText, assistantText, metadata);
           },
         }),
       );
@@ -877,8 +894,8 @@ export class MessageHandler {
         // Session became busy between the caller's idle-check and our getSession call.
         // Re-enqueue the item so it isn't silently dropped.
         const depth = typeof content === 'string'
-          ? this.enqueueMessage(chatId, ctx, content)
-          : this.enqueuePhoto(chatId, ctx, content);
+          ? this.enqueueMessage(route, ctx, content)
+          : this.enqueuePhoto(route, ctx, content);
         if (depth !== false) await ctx.reply(formatQueued(depth));
         reEnqueued = true;
         return;
@@ -912,28 +929,28 @@ export class MessageHandler {
       // finally will drain the item we pushed; calling drain here too causes a
       // cascade.
       if (!reEnqueued) {
-        this.drainQueue(chatId).catch(err => this.log('Drain error:', err));
+        this.drainQueue(route).catch(err => this.log('Drain error:', err));
       }
       this.releaseClaim(chatId);
     }
   }
 
   /**
-   * Process the next queued item for this chat, if any.
+   * Process the next queued item for this route, if any.
    * Public so bot.ts can call it directly after /compact completes.
    */
-  async drainQueue(chatId: number): Promise<void> {
-    const queue = this.messageQueues.get(chatId);
+  async drainQueue(route: TelegramRoute): Promise<void> {
+    const queue = this.messageQueues.get(routeKey(route));
     if (!queue?.length) return;
     const item = queue.shift()!;
     if (item.type === 'message') {
-      await this.processOne(chatId, item.ctx, item.text);
+      await this.processOne(route, item.ctx, item.text);
     } else if (item.type === 'photo') {
-      await this.processOne(chatId, item.ctx, item.content);
+      await this.processOne(route, item.ctx, item.content);
     } else if (item.type === 'compact') {
-      await this.processCompactDirect(chatId, item.ctx);
+      await this.processCompactDirect(route, item.ctx);
     } else {
-      await this.processClearDirect(chatId, item.ctx);
+      await this.processClearDirect(route, item.ctx);
     }
   }
 }

--- a/src/telegram/handlers/sessions.test.ts
+++ b/src/telegram/handlers/sessions.test.ts
@@ -156,7 +156,8 @@ describe('session switcher handlers', () => {
       const { ctx, reply } = makeCtx(710);
       await handleNew(ctx, manager, registered, log);
 
-      expect(spy).toHaveBeenCalledWith(710);
+      // Handler derives a General route (routeFromCtx) — bare chat, no topic.
+      expect(spy).toHaveBeenCalledWith({ chatId: 710 });
       expect(registered.has(710)).toBe(false);
       expect(String(reply.mock.calls[0]![0])).toContain('fresh session');
       // Previous conversation is preserved as resumable.
@@ -184,7 +185,7 @@ describe('session switcher handlers', () => {
 
       await handleSwitchCallback(ctx, manager, log);
 
-      expect(spy).toHaveBeenCalledWith(720, 'sdk-A');
+      expect(spy).toHaveBeenCalledWith({ chatId: 720 }, 'sdk-A');
       const confirmed = String(editMessageText.mock.calls[0]?.[0] ?? reply.mock.calls[0]?.[0] ?? '');
       expect(confirmed).toContain('Switched');
       // sdk-A is now the active conversation.

--- a/src/telegram/handlers/sessions.ts
+++ b/src/telegram/handlers/sessions.ts
@@ -15,6 +15,7 @@
 
 import { Context, Markup } from 'telegraf';
 import { SessionManager } from '../session-manager.js';
+import { type TelegramRoute, routeFromCtx } from '../route.js';
 import {
   formatError,
   formatSessionsList,
@@ -40,9 +41,9 @@ function callbackData(ctx: Context): string {
   return typeof cq === 'object' && cq !== null && 'data' in cq ? (cq as { data: string }).data : '';
 }
 
-/** True when the chat has a live session that is NOT idle (mid-turn). */
-function isBusy(sessionManager: SessionManager, chatId: number): boolean {
-  const live = sessionManager.getSessionIfExists(chatId);
+/** True when the route has a live session that is NOT idle (mid-turn). */
+function isBusy(sessionManager: SessionManager, route: TelegramRoute): boolean {
+  const live = sessionManager.getSessionIfExists(route);
   return live !== undefined && live.state !== 'idle';
 }
 
@@ -56,13 +57,13 @@ export async function handleSessions(
   sessionManager: SessionManager,
   _log: LogFn,
 ): Promise<void> {
-  const chatId = ctx.chat?.id;
-  if (!chatId) {
+  const route = routeFromCtx(ctx);
+  if (!route) {
     await ctx.reply(formatError('Could not identify chat'));
     return;
   }
 
-  const sessions = sessionManager.listChatSessions(chatId);
+  const sessions = sessionManager.listChatSessions(route);
   if (sessions.length === 0) {
     await ctx.reply(formatNoSessions());
     return;
@@ -98,19 +99,19 @@ export async function handleNew(
   registeredCommandChats: Set<number>,
   log: LogFn,
 ): Promise<void> {
-  const chatId = ctx.chat?.id;
-  if (!chatId) {
+  const route = routeFromCtx(ctx);
+  if (!route) {
     await ctx.reply(formatError('Could not identify chat'));
     return;
   }
-  if (isBusy(sessionManager, chatId)) {
+  if (isBusy(sessionManager, route)) {
     await ctx.reply(formatSessionBusy());
     return;
   }
   try {
-    await sessionManager.newSession(chatId);
+    await sessionManager.newSession(route);
     // Force per-chat command re-registration for the fresh session (mirrors /clear).
-    registeredCommandChats.delete(chatId);
+    registeredCommandChats.delete(route.chatId);
     await ctx.reply(formatNewSession());
   } catch (error) {
     log('New session error:', error);
@@ -132,20 +133,22 @@ export async function handleSwitchCallback(
   sessionManager: SessionManager,
   log: LogFn,
 ): Promise<void> {
-  const chatId = ctx.chat?.id;
+  // routeFromCtx reads the thread id off callbackQuery.message (the §11 fix),
+  // so a switch tapped inside a topic operates on THAT topic's session.
+  const route = routeFromCtx(ctx);
   const data = callbackData(ctx);
   const targetSessionId = data.startsWith(SWITCH_CALLBACK_PREFIX)
     ? data.slice(SWITCH_CALLBACK_PREFIX.length)
     : '';
-  if (!chatId || !targetSessionId) return;
+  if (!route || !targetSessionId) return;
 
-  if (isBusy(sessionManager, chatId)) {
+  if (isBusy(sessionManager, route)) {
     await ctx.reply(formatSessionBusy());
     return;
   }
 
   try {
-    const res = await sessionManager.switchToSession(chatId, targetSessionId);
+    const res = await sessionManager.switchToSession(route, targetSessionId);
     if (!res.ok) {
       await ctx.reply(res.reason === 'already-active' ? formatAlreadyActive() : formatSwitchNotFound());
       return;

--- a/src/telegram/session-manager.test.ts
+++ b/src/telegram/session-manager.test.ts
@@ -162,9 +162,11 @@ describe('SessionManager', () => {
       expect(successCallCount).toBe(1);
 
       // lastActivity must have been refreshed (>= before timestamp).
+      // sessionData is now keyed by routeKey (string); a General route for
+      // chatId 22222 keys as "22222" (byte-identical to the legacy chatId key).
       const lastActivity = Date.parse(
-        (succeedingManager as unknown as { sessionData: Map<number, { lastActivity: string }> })
-          .sessionData.get(22222)!.lastActivity
+        (succeedingManager as unknown as { sessionData: Map<string, { lastActivity: string }> })
+          .sessionData.get('22222')!.lastActivity
       );
       expect(lastActivity).toBeGreaterThanOrEqual(before);
 

--- a/src/telegram/session-manager.test.ts
+++ b/src/telegram/session-manager.test.ts
@@ -1057,3 +1057,77 @@ describe('SessionManager — session switcher (/sessions, /switch, /new)', () =>
     await m.closeAll().catch(() => {});
   });
 });
+
+describe('SessionManager — per-route isolation (native topics)', () => {
+  // Step 6: two topics in one chat are concurrent, fully-isolated sessions.
+  // RouteTarget = TelegramRoute | number; a bare number === General topic, so
+  // General must stay byte-identical to the pre-topics behavior.
+  useUnsetAfkHome();
+
+  class MockSessionWithId implements IAgentSession {
+    state: SessionState = 'idle';
+    constructor(readonly sessionId?: string) {}
+    async sendMessage(content: string) {
+      return { role: 'assistant' as const, content: `Echo: ${content}`, timestamp: new Date() };
+    }
+    async *getOutputStream() { yield { type: 'done' as const }; }
+    abort(_reason: string): void { /* no-op */ }
+    async close() { /* no-op */ }
+    async reset() { /* no-op */ }
+  }
+
+  let testDataDir: string;
+  let tmpHome: string;
+  let originalHome: string | undefined;
+  let manager: SessionManager;
+
+  beforeEach(() => {
+    const entropy = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    testDataDir = join(tmpdir(), `afk-tg-iso-data-${entropy}`);
+    originalHome = process.env['HOME'];
+    tmpHome = join(tmpdir(), `afk-tg-iso-home-${entropy}`);
+    process.env['HOME'] = tmpHome;
+    let n = 0;
+    manager = new SessionManager({
+      dataDir: testDataDir,
+      apiKey: 'test-key',
+      defaultModel: 'sonnet',
+      createSession: async () => new MockSessionWithId(`sdk-live-${n++}`),
+    });
+  });
+
+  afterEach(async () => {
+    await manager.closeAll().catch(() => {});
+    if (existsSync(tmpHome)) rmSync(tmpHome, { recursive: true, force: true });
+    if (existsSync(testDataDir)) rmSync(testDataDir, { recursive: true, force: true });
+    if (originalHome !== undefined) process.env['HOME'] = originalHome;
+  });
+
+  test('two topics in one chat get distinct, concurrent sessions', async () => {
+    const general = { chatId: 900 };
+    const topic = { chatId: 900, threadId: 7 };
+
+    const sGeneral = await manager.getSession(general);
+    const sTopic = await manager.getSession(topic);
+
+    // Distinct live sessions coexist for the same chat — no cross-topic sharing.
+    expect(sGeneral).not.toBe(sTopic);
+    // Both stay live simultaneously (opening the topic did not tear down General).
+    expect(await manager.getSession(general)).toBe(sGeneral);
+    expect(manager.getSessionIfExists(topic)).toBe(sTopic);
+  });
+
+  test('per-route turns persist as separate resumable sidecars under the same chat', () => {
+    manager.recordTelegramTurn({ chatId: 900 }, 'general work', 'a', { sessionId: 'sdk-gen' });
+    manager.recordTelegramTurn({ chatId: 900, threadId: 7 }, 'topic work', 'b', { sessionId: 'sdk-top' });
+
+    // Both belong to chat 900 (listed together) but are distinct conversations.
+    expect(manager.listChatSessions(900).map((s) => s.sessionId).sort()).toEqual(['sdk-gen', 'sdk-top']);
+  });
+
+  test('General route is back-compat with the bare chatId (number === { chatId })', () => {
+    manager.recordTelegramTurn(901, 'hello', 'hi', { sessionId: 'sdk-901' });
+    // The explicit General route resolves the same chat's sessions as the bare number.
+    expect(manager.listChatSessions({ chatId: 901 }).map((s) => s.sessionId)).toEqual(['sdk-901']);
+  });
+});

--- a/src/telegram/session-manager.ts
+++ b/src/telegram/session-manager.ts
@@ -16,14 +16,44 @@ import { createSessionStats, recordTurn } from '../cli/slash/session-stats.js';
 import { saveSession, loadSession, listSessions } from '../cli/session-store.js';
 import { resumeConfigFor } from '../cli/resume-session.js';
 import type { SessionStats } from '../cli/slash/types.js';
+import { type TelegramRoute, routeKey } from './route.js';
 import { promises as fs } from 'fs';
 import { join } from 'path';
+
+/**
+ * Public methods that used to take a bare `chatId: number` now take a route
+ * target. A bare `number` is accepted as shorthand for that chat's General
+ * topic — `{ chatId: n }` — so every pre-topics caller (and the entire existing
+ * telegram test suite) is byte-identical: `routeKey({ chatId: n })` === the
+ * legacy `String(n)` key. A real topic passes a full `TelegramRoute` with a
+ * `threadId`, which keys as `${chatId}:${threadId}` and isolates that topic's
+ * session/queue/elicitation from every other topic in the same chat.
+ */
+export type RouteTarget = TelegramRoute | number;
+
+/** Normalize a RouteTarget to a full route. A bare number is the General topic. */
+function toRoute(target: RouteTarget): TelegramRoute {
+  return typeof target === 'number' ? { chatId: target } : target;
+}
 
 /**
  * Session data for persistence
  */
 interface SessionData {
+  /**
+   * Telegram chat id — retained for provenance and outbound sends
+   * (`stats.telegramChatId`, `bot.telegram.sendMessage(chatId, …)`). The
+   * in-memory maps and the on-disk sidecar are keyed by the ROUTE (see
+   * `routeKey`), not this field: General topics key as `String(chatId)`
+   * (unchanged on disk for existing users), a real topic as `${chatId}:${threadId}`.
+   */
   chatId: number;
+  /**
+   * Topic thread id when this session belongs to a non-General topic; absent
+   * for General / topics-off. Persisted so a per-topic sidecar round-trips its
+   * route on reload (the routeKey is otherwise recoverable only from the filename).
+   */
+  threadId?: number;
   model: AgentModelInput;
   createdAt: string;
   lastActivity: string;
@@ -100,39 +130,46 @@ export interface SessionManagerOptions {
 }
 
 /**
- * Manages Telegram chat sessions
- * One AgentSession per chat ID
+ * Manages Telegram chat sessions.
+ *
+ * Invariant: every live-session map is keyed by `routeKey(route)`, NOT a bare
+ * chatId. General / topics-off routes normalize to `String(chatId)` (so an
+ * existing single-session user is byte-identical to the pre-topics bot), while a
+ * real Telegram topic keys as `${chatId}:${threadId}` — giving one fully-isolated
+ * AgentSession per topic inside a single chat. Public methods accept a
+ * `RouteTarget` (a full `TelegramRoute`, or a bare `number` treated as that chat's
+ * General topic) and compute the routeKey internally.
  */
 export class SessionManager {
-  private sessions = new Map<number, IAgentSession>();
-  /** In-flight creation promises — prevent duplicate session spawns on concurrent messages. */
-  private pendingSessions = new Map<number, Promise<IAgentSession>>();
-  private sessionData = new Map<number, SessionData>();
+  private sessions = new Map<string, IAgentSession>();
+  /** In-flight creation promises — prevent duplicate session spawns on concurrent messages (per route). */
+  private pendingSessions = new Map<string, Promise<IAgentSession>>();
+  private sessionData = new Map<string, SessionData>();
   /**
-   * Per-chat accumulating session stats (turns, totals, name, sessionId).
+   * Per-route accumulating session stats (turns, totals, name, sessionId).
    * Recorded on each completed turn and written to the shared session store
    * so the CLI can `--resume <name>` a Telegram conversation. Reset whenever
    * the underlying AgentSession is torn down (/clear, model switch, /cd) so a
    * fresh sessionId and name are captured for the rebuilt session.
    */
-  private sessionStats = new Map<number, SessionStats>();
+  private sessionStats = new Map<string, SessionStats>();
   /**
-   * Chats that have already logged an autosave failure this conversation.
+   * Routes that have already logged an autosave failure this conversation.
    * Per-turn autosave is best-effort, but a persistent failure (EACCES,
    * ENOSPC) would otherwise be silently swallowed every turn while the user
-   * assumes the chat is resumable from the CLI. Log the FIRST failure per chat
+   * assumes the chat is resumable from the CLI. Log the FIRST failure per route
    * and stay quiet afterwards; the entry is cleared on _resetStats so a fresh
    * conversation gets a fresh warning.
    */
-  private autosaveFailureLogged = new Set<number>();
+  private autosaveFailureLogged = new Set<string>();
   /**
-   * Chats with a staged `/switch` resume target (SDK session id). Consumed once
+   * Routes with a staged `/switch` resume target (SDK session id). Consumed once
    * by the next getSession() to build the rebuilt session with `config.resume`
    * so it continues the chosen prior conversation. Cleared on any teardown
    * (/clear, model switch, /cd) via _resetStats so those start fresh, never
    * resuming a stale target.
    */
-  private pendingResume = new Map<number, string>();
+  private pendingResume = new Map<string, string>();
   private options: Required<Omit<SessionManagerOptions, 'createSession' | 'settingSources' | 'thinking' | 'effort' | 'botCwd'>> &
     Pick<SessionManagerOptions, 'createSession' | 'settingSources' | 'thinking' | 'effort' | 'botCwd'>;
 
@@ -152,51 +189,51 @@ export class SessionManager {
   }
 
   /**
-   * Get existing session for a chat without creating one.
+   * Get existing session for a route without creating one.
    * Used e.g. to read SDK-native slash commands for /help.
    */
-  getSessionIfExists(chatId: number): IAgentSession | undefined {
-    return this.sessions.get(chatId);
+  getSessionIfExists(target: RouteTarget): IAgentSession | undefined {
+    return this.sessions.get(routeKey(toRoute(target)));
   }
 
   /**
-   * Get or create a session for a chat.
+   * Get or create a session for a route (chat + optional topic thread).
    *
-   * Concurrent calls for the same `chatId` that arrive before the first
+   * Concurrent calls for the same route that arrive before the first
    * session is fully initialised (e.g. two Telegram messages arriving within
    * milliseconds of each other) all share a single in-flight creation promise
-   * rather than spawning duplicate sessions.
+   * rather than spawning duplicate sessions. Different topics in the same chat
+   * are distinct routes → distinct sessions, never shared.
    *
-   * @param chatId - Telegram chat ID
+   * @param target - Route (chat + optional topic) or a bare chatId (General topic)
    * @returns Agent session
    */
-  async getSession(chatId: number): Promise<IAgentSession> {
-    const existing = this.sessions.get(chatId);
+  async getSession(target: RouteTarget): Promise<IAgentSession> {
+    const route = toRoute(target);
+    const key = routeKey(route);
+
+    const existing = this.sessions.get(key);
     if (existing) {
-      this._touchActivity(chatId);
+      this._touchActivity(key);
       return existing;
     }
 
-    // If there is already an in-flight creation for this chatId, wait for it.
+    // If there is already an in-flight creation for this route, wait for it.
     // Use try/finally so _touchActivity runs on both success and rejection —
     // invariant: callers must not observe a stale lastActivity on retry after a failure.
-    const inflight = this.pendingSessions.get(chatId);
+    const inflight = this.pendingSessions.get(key);
     if (inflight) {
       try {
         const session = await inflight;
         return session;
       } finally {
-        this._touchActivity(chatId);
+        this._touchActivity(key);
       }
     }
 
-    // No session and no pending creation — start one.
-    const data = this.sessionData.get(chatId) ?? {
-      chatId,
-      model: this.options.defaultModel,
-      createdAt: new Date().toISOString(),
-      lastActivity: new Date().toISOString(),
-    };
+    // No session and no pending creation — start one. New SessionData carries
+    // the chatId (provenance/sends) and the topic threadId (route round-trip).
+    const data = this.sessionData.get(key) ?? this._newData(route);
 
     const creationPromise = (async (): Promise<IAgentSession> => {
       const config: AgentConfig = {
@@ -228,7 +265,7 @@ export class SessionManager {
       // (resume + sessionId + resumeHistory) so the providers actually replay the
       // saved transcript. Forwarding only config.resume (the SDK id) resumes an
       // empty conversation. Mirrors resumeConfigFor (src/cli/resume-session.ts).
-      const resumeTarget = this.pendingResume.get(chatId);
+      const resumeTarget = this.pendingResume.get(key);
       if (resumeTarget !== undefined) {
         const stored = loadSession(resumeTarget);
         Object.assign(
@@ -242,28 +279,40 @@ export class SessionManager {
       }
 
       const session = await this.options.createSession(injectCompanionPrimer(injectHotMemory(config)));
-      this.sessions.set(chatId, session);
-      this.sessionData.set(chatId, data);
+      this.sessions.set(key, session);
+      this.sessionData.set(key, data);
       // Consume the staged resume only after a successful build: a thrown
       // createSession must leave it staged so the next getSession retries the
       // resume instead of silently starting a fresh conversation.
-      if (resumeTarget !== undefined) this.pendingResume.delete(chatId);
+      if (resumeTarget !== undefined) this.pendingResume.delete(key);
       return session;
     })();
 
-    this.pendingSessions.set(chatId, creationPromise);
+    this.pendingSessions.set(key, creationPromise);
     try {
       const session = await creationPromise;
-      this._touchActivity(chatId);
+      this._touchActivity(key);
       return session;
     } finally {
       // Always clean up the in-flight entry regardless of success or failure.
-      this.pendingSessions.delete(chatId);
+      this.pendingSessions.delete(key);
     }
   }
 
-  private _touchActivity(chatId: number): void {
-    const data = this.sessionData.get(chatId);
+  /** Build a fresh SessionData for a route, carrying chatId + topic threadId. */
+  private _newData(route: TelegramRoute): SessionData {
+    const data: SessionData = {
+      chatId: route.chatId,
+      model: this.options.defaultModel,
+      createdAt: new Date().toISOString(),
+      lastActivity: new Date().toISOString(),
+    };
+    if (route.threadId !== undefined) data.threadId = route.threadId;
+    return data;
+  }
+
+  private _touchActivity(key: string): void {
+    const data = this.sessionData.get(key);
     if (data) data.lastActivity = new Date().toISOString();
   }
 
@@ -278,16 +327,18 @@ export class SessionManager {
    * persistence failures never disrupt the chat.
    */
   recordTelegramTurn(
-    chatId: number,
+    target: RouteTarget,
     userText: string,
     assistantText: string,
     metadata?: ResponseMetadata,
   ): void {
-    const stats = this._getOrCreateStats(chatId);
+    const route = toRoute(target);
+    const key = routeKey(route);
+    const stats = this._getOrCreateStats(route);
 
     // Capture the SDK sessionId from the live session if the turn metadata
     // didn't carry one (recordTurn also sets it from metadata when present).
-    const live = this.sessions.get(chatId);
+    const live = this.sessions.get(key);
     if (!stats.sessionId && live?.sessionId) stats.sessionId = live.sessionId;
 
     recordTurn(stats, userText, assistantText, metadata);
@@ -295,7 +346,7 @@ export class SessionManager {
     if (!stats.sessionId && live?.sessionId) stats.sessionId = live.sessionId;
 
     // Mirror the captured sessionId into SessionData so it survives bot restart.
-    const data = this.sessionData.get(chatId);
+    const data = this.sessionData.get(key);
     if (data && stats.sessionId) data.sessionId = stats.sessionId;
 
     // Persist to the shared store. Requires a sessionId to key the file;
@@ -306,13 +357,13 @@ export class SessionManager {
         saveSession(stats);
       } catch (err) {
         // Best-effort — never break the chat on a persistence failure. Surface
-        // the FIRST failure per chat (autosaveFailureLogged) so a persistent
+        // the FIRST failure per route (autosaveFailureLogged) so a persistent
         // EACCES/ENOSPC isn't silently swallowed every turn while the user
         // assumes the conversation is resumable from `afk i --resume`.
-        if (!this.autosaveFailureLogged.has(chatId)) {
-          this.autosaveFailureLogged.add(chatId);
+        if (!this.autosaveFailureLogged.has(key)) {
+          this.autosaveFailureLogged.add(key);
           console.error(
-            `[session-manager] autosave failed for chat ${chatId} — conversation may not be resumable:`,
+            `[session-manager] autosave failed for chat ${route.chatId} — conversation may not be resumable:`,
             err,
           );
         }
@@ -337,19 +388,22 @@ export class SessionManager {
    * prior-conversation stats (sessionId, turns, totals), so a rename persists
    * in-place without forking a duplicate sidecar and turn counts are preserved.
    */
-  private _hydrateStatsFromStore(chatId: number): void {
+  private _hydrateStatsFromStore(route: TelegramRoute): void {
+    const key = routeKey(route);
     // Never clobber live in-memory stats — this is a post-restart-only repair.
-    if (this.sessionStats.has(chatId)) return;
+    if (this.sessionStats.has(key)) return;
 
-    const sessionId = this.sessionData.get(chatId)?.sessionId;
+    const sessionId = this.sessionData.get(key)?.sessionId;
     if (!sessionId) return;
 
     const stored = loadSession(sessionId);
     if (!stored) return;
 
     // Only hydrate telegram sidecars that belong to THIS chat — prevent
-    // accidentally adopting a CLI sidecar or a different chat's sidecar.
-    if (stored.source !== 'telegram' || stored.telegramChatId !== chatId) return;
+    // accidentally adopting a CLI sidecar or a different chat's sidecar. The
+    // per-route sidecar is keyed by SDK sessionId, so a topic can only hydrate
+    // its own conversation (each topic's session has a distinct sessionId).
+    if (stored.source !== 'telegram' || stored.telegramChatId !== route.chatId) return;
 
     // Map StoredSession → SessionStats.
     // Critical rename: stored.startedAt === SessionStats.sessionStartTime.
@@ -375,10 +429,10 @@ export class SessionManager {
       turnTokens: [],
       permissionMode: 'default',
     };
-    // Carry forward the per-chat cwd override if one was set via /cd.
-    const chatCwd = this.sessionData.get(chatId)?.cwd;
+    // Carry forward the per-route cwd override if one was set via /cd.
+    const chatCwd = this.sessionData.get(key)?.cwd;
     if (chatCwd !== undefined) stats.cwd = chatCwd;
-    this.sessionStats.set(chatId, stats);
+    this.sessionStats.set(key, stats);
   }
 
   /**
@@ -395,9 +449,10 @@ export class SessionManager {
    * _getOrCreateStats — that would fabricate an empty stats entry for a
    * genuinely new chat that has never had a session.
    */
-  getSessionName(chatId: number): string | undefined {
-    this._hydrateStatsFromStore(chatId);
-    return this.sessionStats.get(chatId)?.name;
+  getSessionName(target: RouteTarget): string | undefined {
+    const route = toRoute(target);
+    this._hydrateStatsFromStore(route);
+    return this.sessionStats.get(routeKey(route))?.name;
   }
 
   /**
@@ -418,20 +473,22 @@ export class SessionManager {
    * @throws Propagates a `saveSession` failure so the caller can report that
    *   the name was set but the immediate persist failed (retries on next turn).
    */
-  setSessionName(chatId: number, slug: string): { persisted: boolean } {
-    const stats = this._getOrCreateStats(chatId);
+  setSessionName(target: RouteTarget, slug: string): { persisted: boolean } {
+    const route = toRoute(target);
+    const key = routeKey(route);
+    const stats = this._getOrCreateStats(route);
     stats.name = slug;
 
     // Capture the live session's id if the stats don't carry one yet, so the
     // persisted sidecar is keyed the same way the per-turn autosave keys it.
-    const live = this.sessions.get(chatId);
+    const live = this.sessions.get(key);
     if (!stats.sessionId && live?.sessionId) stats.sessionId = live.sessionId;
 
     if (stats.totalTurns > 0 && stats.sessionId) {
       // Mirror the captured sessionId into SessionData BEFORE saveSession so
       // the data.sessionId update is guaranteed even if saveSession throws.
       // The throw still propagates to the caller so it can report the failure.
-      const data = this.sessionData.get(chatId);
+      const data = this.sessionData.get(key);
       if (data) data.sessionId = stats.sessionId;
       saveSession(stats);
       return { persisted: true };
@@ -448,87 +505,89 @@ export class SessionManager {
    * (via _hydrateStatsFromStore) so setSessionName and recordTelegramTurn
    * see the full prior-conversation state instead of fresh empty stats.
    */
-  private _getOrCreateStats(chatId: number): SessionStats {
+  private _getOrCreateStats(route: TelegramRoute): SessionStats {
+    const key = routeKey(route);
     // Repair post-restart: if sessionData has a sessionId but sessionStats is
     // empty, hydrate from the persisted sidecar before the get-or-create.
-    this._hydrateStatsFromStore(chatId);
+    this._hydrateStatsFromStore(route);
 
-    let stats = this.sessionStats.get(chatId);
+    let stats = this.sessionStats.get(key);
     if (!stats) {
-      stats = createSessionStats(this.getModel(chatId));
+      stats = createSessionStats(this.getModel(route));
       stats.source = 'telegram';
-      stats.telegramChatId = chatId;
-      const cwd = this.getCwd(chatId);
+      // Provenance stays the chatId (topics in one chat share it); the route's
+      // isolation lives in the routeKey the maps + sidecar filename key on.
+      stats.telegramChatId = route.chatId;
+      const cwd = this.getCwd(route);
       if (cwd) stats.cwd = cwd;
-      this.sessionStats.set(chatId, stats);
+      this.sessionStats.set(key, stats);
     }
     return stats;
   }
 
   /**
-   * Drop the accumulating stats and stale sessionId for a chat. Called when
+   * Drop the accumulating stats and stale sessionId for a route. Called when
    * the underlying AgentSession is torn down (/clear, model switch, /cd) so
    * the rebuilt session captures a fresh sessionId and auto-name rather than
    * appending to the previous conversation's sidecar.
    */
-  private _resetStats(chatId: number): void {
-    this.sessionStats.delete(chatId);
+  private _resetStats(key: string): void {
+    this.sessionStats.delete(key);
     // Fresh conversation → allow the autosave-failure notice to fire again.
-    this.autosaveFailureLogged.delete(chatId);
+    this.autosaveFailureLogged.delete(key);
     // Drop any staged /switch resume so a teardown always starts fresh.
-    this.pendingResume.delete(chatId);
-    const data = this.sessionData.get(chatId);
+    this.pendingResume.delete(key);
+    const data = this.sessionData.get(key);
     if (data) delete data.sessionId;
   }
 
   /**
-   * Reset a chat session (clear history)
-   * 
-   * @param chatId - Telegram chat ID
+   * Reset a route's session (clear history).
+   *
+   * @param target - Route (chat + optional topic) or a bare chatId (General topic)
    */
-  async resetSession(chatId: number): Promise<void> {
-    const oldSession = this.sessions.get(chatId);
+  async resetSession(target: RouteTarget): Promise<void> {
+    const key = routeKey(toRoute(target));
+    const oldSession = this.sessions.get(key);
     if (oldSession) {
       await oldSession.close();
-      this.sessions.delete(chatId);
+      this.sessions.delete(key);
     }
     // New conversation → drop accumulated stats + stale sessionId so the
     // rebuilt session is recorded as a fresh sidecar, not appended to the old.
-    this._resetStats(chatId);
+    this._resetStats(key);
 
     // Keep session data but create new session on next request
-    const data = this.sessionData.get(chatId);
+    const data = this.sessionData.get(key);
     if (data) {
       data.lastActivity = new Date().toISOString();
     }
   }
 
   /**
-   * Switch model for a chat session
-   * 
-   * @param chatId - Telegram chat ID
+   * Switch model for a route's session.
+   *
+   * @param target - Route (chat + optional topic) or a bare chatId (General topic)
    * @param model - New model to use
    */
-  async switchModel(chatId: number, model: AgentModelInput): Promise<void> {
+  async switchModel(target: RouteTarget, model: AgentModelInput): Promise<void> {
+    const route = toRoute(target);
+    const key = routeKey(route);
     // Close old session
-    const oldSession = this.sessions.get(chatId);
+    const oldSession = this.sessions.get(key);
     if (oldSession) {
       await oldSession.close();
-      this.sessions.delete(chatId);
+      this.sessions.delete(key);
     }
     // Model switch rebuilds the session with a new sessionId → fresh sidecar.
-    this._resetStats(chatId);
+    this._resetStats(key);
 
     // Update session data
-    let data = this.sessionData.get(chatId);
+    let data = this.sessionData.get(key);
     if (!data) {
-      data = {
-        chatId,
-        model,
-        createdAt: new Date().toISOString(),
-        lastActivity: new Date().toISOString(),
-      };
-      this.sessionData.set(chatId, data);
+      data = this._newData(route);
+      data.model = model;
+      this.sessionData.set(key, data);
     } else {
       data.model = model;
       data.lastActivity = new Date().toISOString();
@@ -538,13 +597,13 @@ export class SessionManager {
   }
 
   /**
-   * Get current model for a chat
-   * 
-   * @param chatId - Telegram chat ID
+   * Get current model for a route.
+   *
+   * @param target - Route (chat + optional topic) or a bare chatId (General topic)
    * @returns Current model
    */
-  getModel(chatId: number): AgentModelInput {
-    const data = this.sessionData.get(chatId);
+  getModel(target: RouteTarget): AgentModelInput {
+    const data = this.sessionData.get(routeKey(toRoute(target)));
     return data?.model || this.options.defaultModel;
   }
 
@@ -558,30 +617,27 @@ export class SessionManager {
    * Callers are responsible for validating that `cwd` exists and is a
    * directory before calling — this method does not stat the filesystem.
    *
-   * @param chatId - Telegram chat ID
+   * @param target - Route (chat + optional topic) or a bare chatId (General topic)
    * @param cwd - Absolute path to the new working directory
    */
-  async setCwd(chatId: number, cwd: string): Promise<void> {
+  async setCwd(target: RouteTarget, cwd: string): Promise<void> {
+    const route = toRoute(target);
+    const key = routeKey(route);
     // Close old session — next getSession() call rebuilds it with the
     // new cwd threaded through to the AgentSession + SubagentManager.
-    const oldSession = this.sessions.get(chatId);
+    const oldSession = this.sessions.get(key);
     if (oldSession) {
       await oldSession.close();
-      this.sessions.delete(chatId);
+      this.sessions.delete(key);
     }
     // cwd change rebuilds the session with a new sessionId → fresh sidecar.
-    this._resetStats(chatId);
+    this._resetStats(key);
 
-    let data = this.sessionData.get(chatId);
+    let data = this.sessionData.get(key);
     if (!data) {
-      data = {
-        chatId,
-        model: this.options.defaultModel,
-        createdAt: new Date().toISOString(),
-        lastActivity: new Date().toISOString(),
-        cwd,
-      };
-      this.sessionData.set(chatId, data);
+      data = this._newData(route);
+      data.cwd = cwd;
+      this.sessionData.set(key, data);
     } else {
       data.cwd = cwd;
       data.lastActivity = new Date().toISOString();
@@ -589,17 +645,17 @@ export class SessionManager {
   }
 
   /**
-   * Get the effective working directory for a chat: per-session override
+   * Get the effective working directory for a route: per-session override
    * (set via `/cd`) if present, otherwise the bot-global fallback.
    *
    * Returns undefined when neither is set — callers that need a real
    * path should fall back to `process.cwd()`.
    *
-   * @param chatId - Telegram chat ID
+   * @param target - Route (chat + optional topic) or a bare chatId (General topic)
    * @returns Effective cwd, or undefined when no override is configured
    */
-  getCwd(chatId: number): string | undefined {
-    const data = this.sessionData.get(chatId);
+  getCwd(target: RouteTarget): string | undefined {
+    const data = this.sessionData.get(routeKey(toRoute(target)));
     return data?.cwd ?? this.options.botCwd;
   }
 
@@ -607,16 +663,22 @@ export class SessionManager {
    * List this chat's resumable conversations for the `/sessions` switcher,
    * newest-active first. Sourced from the shared sidecar store (telegram
    * sidecars for this chatId) — the durable record of every conversation the
-   * chat has held — with the currently-active one flagged.
+   * chat has held — with the route's currently-active one flagged.
+   *
+   * Provenance is the chatId, so this lists every conversation the chat has
+   * held (across General and any topics). The `active` flag reflects the
+   * requesting route's own live session id — the conversation the switcher
+   * would replace on that route.
    *
    * A brand-new conversation with no recorded turn yet has no sidecar and so
    * does not appear until its first turn is saved.
    */
-  listChatSessions(chatId: number): ChatSessionInfo[] {
-    const activeId = this.sessionData.get(chatId)?.sessionId;
+  listChatSessions(target: RouteTarget): ChatSessionInfo[] {
+    const route = toRoute(target);
+    const activeId = this.sessionData.get(routeKey(route))?.sessionId;
     return listSessions()
       .filter(
-        (s) => s.source === 'telegram' && s.telegramChatId === chatId && s.sessionId !== undefined,
+        (s) => s.source === 'telegram' && s.telegramChatId === route.chatId && s.sessionId !== undefined,
       )
       .map((s) => {
         const info: ChatSessionInfo = {
@@ -645,55 +707,54 @@ export class SessionManager {
    *   is missing / not a telegram sidecar for this chat, or already active.
    */
   async switchToSession(
-    chatId: number,
+    target: RouteTarget,
     targetSessionId: string,
   ): Promise<{ ok: true; name?: string } | { ok: false; reason: 'not-found' | 'already-active' }> {
-    // If a session creation is in flight for this chat, let it settle before we
+    const route = toRoute(target);
+    const key = routeKey(route);
+
+    // If a session creation is in flight for this route, let it settle before we
     // inspect and close the live session. Otherwise the in-flight promise sets
     // the pre-switch session as live AFTER we adopt the target below, silently
     // reverting the switch. Awaiting materializes it so the close path evicts it
     // normally; a failed creation leaves this.sessions empty, which the `old`
     // guard already handles.
-    const inflight = this.pendingSessions.get(chatId);
+    const inflight = this.pendingSessions.get(key);
     if (inflight !== undefined) {
       await inflight.catch(() => undefined);
     }
 
     // Already the live active conversation → no-op (avoid a needless rebuild).
-    if (this.sessions.has(chatId) && this.sessionData.get(chatId)?.sessionId === targetSessionId) {
+    if (this.sessions.has(key) && this.sessionData.get(key)?.sessionId === targetSessionId) {
       return { ok: false, reason: 'already-active' };
     }
 
     const stored = loadSession(targetSessionId);
-    if (!stored || stored.source !== 'telegram' || stored.telegramChatId !== chatId) {
+    if (!stored || stored.source !== 'telegram' || stored.telegramChatId !== route.chatId) {
       return { ok: false, reason: 'not-found' };
     }
 
     // Close the current live session (sidecar already persisted per-turn).
-    const old = this.sessions.get(chatId);
+    const old = this.sessions.get(key);
     if (old) {
       // Guard the close (mirrors closeAll): a throwing close() must never block
       // the delete + target-state adoption below, or the stale session stays keyed
       // in this.sessions and the next getSession returns it unrebuilt.
       await old.close().catch((err) => console.error('Error closing session on switch:', err));
-      this.sessions.delete(chatId);
+      this.sessions.delete(key);
     }
     // Drop in-memory stats so the resumed session hydrates the TARGET's stats
     // (name/turns/sessionId) from its sidecar on next access — never the
     // previous conversation's. autosave-failure notice re-arms for the switch.
-    this.sessionStats.delete(chatId);
-    this.autosaveFailureLogged.delete(chatId);
+    this.sessionStats.delete(key);
+    this.autosaveFailureLogged.delete(key);
 
     // Adopt the target's identity + model/cwd and stage the resume.
-    let data = this.sessionData.get(chatId);
+    let data = this.sessionData.get(key);
     if (!data) {
-      data = {
-        chatId,
-        model: stored.model,
-        createdAt: new Date().toISOString(),
-        lastActivity: new Date().toISOString(),
-      };
-      this.sessionData.set(chatId, data);
+      data = this._newData(route);
+      data.model = stored.model;
+      this.sessionData.set(key, data);
     } else {
       data.model = stored.model;
       data.lastActivity = new Date().toISOString();
@@ -704,7 +765,7 @@ export class SessionManager {
     // previously-active conversation's directory (getSession uses data.cwd ?? botCwd).
     if (stored.cwd !== undefined) data.cwd = stored.cwd;
     else delete data.cwd;
-    this.pendingResume.set(chatId, targetSessionId);
+    this.pendingResume.set(key, targetSessionId);
     return stored.name !== undefined ? { ok: true, name: stored.name } : { ok: true };
   }
 
@@ -715,15 +776,35 @@ export class SessionManager {
    * to it. Behaviorally this is resetSession (close + fresh sessionId), exposed
    * under a name that reflects the switcher intent.
    */
-  async newSession(chatId: number): Promise<void> {
+  async newSession(target: RouteTarget): Promise<void> {
     // resetSession → _resetStats already clears pendingResume; explicit here too
     // so intent is local and obvious.
-    this.pendingResume.delete(chatId);
-    await this.resetSession(chatId);
+    this.pendingResume.delete(routeKey(toRoute(target)));
+    await this.resetSession(target);
   }
 
   /**
-   * Load session data from disk
+   * The on-disk sidecar filename for a route's SessionData.
+   *
+   * Invariant: a General route's file is `<chatId>.json` — byte-identical to
+   * the pre-topics layout, so an existing user's session data loads unchanged.
+   * A topic route uses its routeKey (`<chatId>:<threadId>`). The `:` separator
+   * is legal on the macOS/Linux targets AFK supports; the loader recomputes the
+   * map key from the data's chatId+threadId, so it never relies on the filename.
+   */
+  private sidecarFileName(data: SessionData): string {
+    const route: TelegramRoute = { chatId: data.chatId };
+    if (data.threadId !== undefined) route.threadId = data.threadId;
+    return `${routeKey(route)}.json`;
+  }
+
+  /**
+   * Load session data from disk.
+   *
+   * Keys the in-memory map by the route recomputed from each file's payload
+   * (chatId + optional threadId), NOT the filename — so a legacy `<chatId>.json`
+   * (no threadId) loads to the General key `String(chatId)` exactly as before,
+   * and a topic sidecar loads to `<chatId>:<threadId>`.
    */
   async loadSessions(): Promise<void> {
     try {
@@ -735,7 +816,9 @@ export class SessionManager {
           const filePath = join(this.options.dataDir, file);
           const content = await fs.readFile(filePath, 'utf-8');
           const data: SessionData = JSON.parse(content);
-          this.sessionData.set(data.chatId, data);
+          const route: TelegramRoute = { chatId: data.chatId };
+          if (data.threadId !== undefined) route.threadId = data.threadId;
+          this.sessionData.set(routeKey(route), data);
         }
       }
     } catch (error) {
@@ -747,14 +830,14 @@ export class SessionManager {
   }
 
   /**
-   * Save session data to disk
+   * Save session data to disk, one file per route (General → `<chatId>.json`).
    */
   async saveSessions(): Promise<void> {
     try {
       await fs.mkdir(this.options.dataDir, { recursive: true });
       
-      for (const [chatId, data] of this.sessionData.entries()) {
-        const filePath = join(this.options.dataDir, `${chatId}.json`);
+      for (const data of this.sessionData.values()) {
+        const filePath = join(this.options.dataDir, this.sidecarFileName(data));
         await fs.writeFile(filePath, JSON.stringify(data, null, 2));
       }
     } catch (error) {

--- a/src/telegram/watch.test.ts
+++ b/src/telegram/watch.test.ts
@@ -234,8 +234,8 @@ describe('SessionWatchManager', () => {
  */
 function makeElicitStubs(chatId: number) {
   // Track the pending resolver installed by the elicitation handler.
-  const pendingElicitations = new Map<number, (text: string) => void>();
-  const ledgerOriginatedPendingChats = new Set<number>();
+  const pendingElicitations = new Map<string, (text: string) => void>();
+  const ledgerOriginatedPendingChats = new Set<string>();
 
   const sentMessages: string[] = [];
   const bot = {
@@ -295,7 +295,7 @@ describe('SessionWatchManager — elicitation intercept + signed write-back (cri
 
     // Simulate the operator typing an answer into Telegram (the message handler
     // fires the resolver, which is what handle() would do when it sees a text).
-    const resolver = pendingElicitations.get(chatId);
+    const resolver = pendingElicitations.get(String(chatId));
     expect(resolver).toBeDefined();
     resolver!('Alice');
 
@@ -355,7 +355,7 @@ describe('SessionWatchManager — elicitation intercept + signed write-back (cri
     await sleep(200);
 
     // Answer the pending resolver.
-    const resolver = pendingElicitations.get(chatId);
+    const resolver = pendingElicitations.get(String(chatId));
     expect(resolver).toBeDefined();
     resolver!('any answer');
 

--- a/src/telegram/watch.test.ts
+++ b/src/telegram/watch.test.ts
@@ -597,7 +597,7 @@ describe('SessionWatchManager — keep-alive heartbeat for a pending elicitation
     expect(nudges()).toBeGreaterThanOrEqual(1);
     expect(nudges()).toBeLessThanOrEqual(4);
     // ... and the wait is STILL open — answer whenever (resolver live, NOT cut off).
-    const resolver = pendingElicitations.get(chatId);
+    const resolver = pendingElicitations.get(String(chatId));
     expect(resolver).toBeDefined();
 
     // Answer → the wait resolves, the heartbeat is cleared, nudges stop.


### PR DESCRIPTION
Rebased steps 6–7 from the original stacked PR #570 (now closed) onto current main, after #562 (steps 1–5) was squash-merged.

## Summary

Builds on the #562 foundation to deliver the remaining two steps of the multi-session effort:

### Step 6 — Native Telegram topics routing

Re-key the entire `SessionManager` and `MessageHandler` from `chatId: number` to `routeKey: string`, enabling concurrent, fully-isolated sessions within one bot chat (one per topic `message_thread_id`).

- **SessionManager:** All 5 live-session maps (`sessions`, `sessionData`, `inflightCreation`, `pendingResume`, `stats`) re-keyed from `chatId` to `routeKey(route)`. Public methods accept a `RouteTarget` (`TelegramRoute | number`).
- **MessageHandler:** `pendingElicitations`, `ledgerOriginatedPendingChats`, and `messageQueues` re-keyed by routeKey. `handle()` and `processOne()` accept a `route` parameter.
- **Back-compat invariant:** `routeKey({chatId}) === String(chatId)` — users without topics see byte-identical behavior (same map keys, same `<chatId>.json` sidecar on disk).
- **Route primitive:** `src/telegram/route.ts` — `TelegramRoute`, `routeKey()`, `routeFromUpdate()`.
- **Commands:** `/sessions` and `/new` thread route through `bot.ts` command registration.
- **Tests:** Per-route isolation + General back-compat coverage.

### Step 7 — Cross-surface session registration

- `src/agent/session/register-surface-session.ts` — `registerSurfaceSession()` best-effort registers CLI REPL and daemon sessions in the session registry, late-attaching `sdkSessionId` after provider initialization.
- Wired into CLI REPL (`bootstrap.ts`, process-scoped, no dispose) and daemon (`scheduler.ts`, register on spawn + dispose/archive on close).

## Cherry-pick notes

The original PR #570 was stacked on `feat/telegram-session-registry` (PR #562). Since #562 was squash-merged, steps 1–5 are already in main. This PR cherry-picks only the steps 6–7 delta (5 commits), with conflict resolution against main's evolved `session-manager.ts` and `message.ts`. Test files updated for the number→string re-keying of map keys.

## Verification

- `tsc --noEmit` clean
- All 816 telegram tests pass
- All 19 changed files accounted for

## Related

- Closes the remaining work from #570
- Builds on #562 (merged)
- Design doc: `.afk/plans/session-registry-architecture.md`
