### PR TITLE
fix: gate plugin-shadowing notices behind AFK_DEBUG=1

### DIFF
--- a/src/cli/commands/interactive/loop-iteration.test.ts
+++ b/src/cli/commands/interactive/loop-iteration.test.ts
@@ -199,20 +199,15 @@ beforeEach(() => {
   delete process.env.AFK_SHELL_PASSTHROUGH;
 });
 
-describe('runReplLoop — plugin shadowing notices are not debug-gated', () => {
-  it('surfaces collision notices on a default (non-debug) run', async () => {
-    // Regression: the notice assignment used to sit behind `isDebugEnabled()`,
-    // which this file mocks to `false` — so on every default run a shadowed
-    // plugin command was suppressed and discoverable only via `/skills`. The
-    // gate belonged to the adjacent debug BANNER, not to these notices; the two
-    // were conflated. With `isDebugEnabled: () => false` still in force, the
-    // notice must reach the renderer anyway.
+describe('runReplLoop — plugin shadowing notices are debug-gated', () => {
+  it('suppresses collision notices on a default (non-debug) run', async () => {
+    // With 100+ plugin skills all shadowed by vendored equivalents, the
+    // per-skill listing is pure noise on a default run. Notices are gated
+    // behind isDebugEnabled() (AFK_DEBUG=1) and suppressed here because the
+    // module-scope mock returns false.
     vi.mocked(pluginSkillsMod.getPluginShadowingNoticeLines).mockReturnValue([
       '  /mint: vendored or user skill wins; plugin form /example-plugin:mint stays reachable.',
     ]);
-    // Two reads: iteration 1 lets the waitForInitialization().then() chain
-    // settle (it awaits autoRegisterPluginPassthroughs), iteration 2 flushes
-    // the pending notices at the top of the loop before exiting.
     surfaceState.readLineQueue = [
       { text: 'hello', attachments: [] },
       { text: '/exit', attachments: [] },
@@ -222,7 +217,7 @@ describe('runReplLoop — plugin shadowing notices are not debug-gated', () => {
     await runReplLoop(ctx, makeTranscript() as never, makeTurnState(), vi.fn());
 
     const lines = vi.mocked(ctx.replRenderer.writeLine).mock.calls.map((c) => String(c[0]));
-    expect(lines.some((l) => l.includes('/example-plugin:mint'))).toBe(true);
+    expect(lines.some((l) => l.includes('/example-plugin:mint'))).toBe(false);
   });
 
   it('stays silent when nothing collided', async () => {

--- a/src/cli/commands/interactive/loop-iteration.ts
+++ b/src/cli/commands/interactive/loop-iteration.ts
@@ -138,15 +138,13 @@ export async function runInputLoop(
     // surface a one-time dim notice telling the user where the shadowed
     // plugin form is still reachable (e.g. `/example-plugin:mint`).
     //
-    // Deliberately NOT gated on isDebugEnabled(), unlike the init banner
-    // above. A shadowed command is a behavioural surprise the user has to
-    // know about — their `/mint` may now resolve to a different skill than
-    // it did yesterday — not diagnostic noise. The two concerns were
-    // conflated behind one gate, which suppressed every collision notice on
-    // a default run and left shadowing discoverable only by pulling up
-    // `/skills`. Returns an empty array when nothing collided, so the
-    // common no-collision path stays silent.
-    pendingShadowingNotices = getPluginShadowingNoticeLines();
+    // Gated on isDebugEnabled() (AFK_DEBUG=1) — when the full plugin set
+    // shadows 100+ vendored skills the per-skill listing is pure noise on
+    // a default run. Users who need to audit collisions enable debug mode;
+    // everyone else discovers shadowed forms via `/skills`.
+    if (isDebugEnabled()) {
+      pendingShadowingNotices = getPluginShadowingNoticeLines();
+    }
   }).catch(() => { /* init / plugin discovery non-critical */ });
 
   // Slash-command submit queue: a slash handler may return


### PR DESCRIPTION
## Problem

After the first REPL turn, every plugin skill's shadowing notice prints — ~100+ dim lines of `/foo: vendored or user skill wins; plugin form /plugin:foo stays reachable.` This is because every plugin skill collides with a vendored equivalent, and the notice system was deliberately un-gated from `AFK_DEBUG=1`.

The per-skill listing is useful when a few skills collide (behavioral surprise). When all of them do, it's noise.

## Fix

Gate the `pendingShadowingNotices` assignment behind `isDebugEnabled()` so the notices only appear when `AFK_DEBUG=1` is set. Users who need to audit collisions enable debug mode; everyone else discovers shadowed forms via `/skills`.

## Changes

- `src/cli/commands/interactive/loop-iteration.ts`: Wrap the notice assignment in `if (isDebugEnabled())` and update the comment
- `src/cli/commands/interactive/loop-iteration.test.ts`: Flip the test to assert notices are suppressed on default runs (the mock returns `isDebugEnabled: () => false`)
