### PR TITLE
fix(trace): suppress sealed-writer error on SessionEnd hook_decision emit

### DIFF
--- a/.filesize-baseline.json
+++ b/.filesize-baseline.json
@@ -30,7 +30,7 @@
     "src/agent/providers/shared/compaction.ts": { "loc": 624, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/agent/risk-classifier.ts": { "loc": 385, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/agent/session-ledger.ts": { "loc": 451, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/agent/session/agent-session.ts": { "loc": 1440, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/agent/session/agent-session.ts": { "loc": 1442, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/agent/session/model-slots.ts": { "loc": 516, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/agent/session/stream-consumer.ts": { "loc": 522, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/agent/shell-jobs/streamer.ts": { "loc": 535, "reason": "legacy: predates the ceiling gate; pending concern extraction" },

--- a/src/agent/session/agent-session.ts
+++ b/src/agent/session/agent-session.ts
@@ -1361,7 +1361,9 @@ export class AgentSession implements IAgentSession {
           ? { tracePath: this.config.traceWriter.getTracePath() }
           : {}),
       },
-      this.config.traceWriter ? { traceWriter: this.config.traceWriter } : {},
+      // Invariant: skip traceWriter when this session owns the seal (step 2
+      // above) — the writer is sealed, so the hook_decision write would throw.
+      this.config.traceWriter && !this.ownsTraceSeal ? { traceWriter: this.config.traceWriter } : {},
     );
   }
 


### PR DESCRIPTION
## Problem

Every `/quit` prints a noisy stderr warning:

```
[afk] trace.emit artifact write failed (hook_decision): NdjsonTraceWriter: trace is sealed; write() rejected — further failures in this subsystem for this session are logged only under AFK_DEBUG=1.
```

## Root Cause

`dispatchSessionEndOnce()` intentionally seals the trace writer **before** dispatching SessionEnd hooks (step 2 before step 3) — a safety invariant so a hook crash cannot leave the trace without a seal record. But `dispatchSessionEnd()` then tries to emit a `hook_decision` trace event via the already-sealed writer, which throws.

The throw is caught by `reportArtifactFailure`, which surfaces the first failure per writer to stderr — producing the warning above.

## Fix

Skip passing `traceWriter` to `dispatchSessionEnd` when the session owns the seal (`this.ownsTraceSeal`). The hooks still **run** — only the low-value `hook_decision` recording is skipped. Subagent forks (which do not own the seal) still pass their shared, still-open writer through normally.

This is a one-conditional change that preserves the existing safety invariant while eliminating the cosmetic error.

## Verification

- `pnpm lint` — clean
- `pnpm test src/agent/session.test.ts` — 20/20 pass
- `pnpm test src/agent/trace/` — 261/261 pass
- Shadow-verified all 4 diagnostic claims independently (ordering, call chain, error surfacing, cosmetic-only)
