### PR TITLE
test(review): add negative assertion to no-git guard (#788)

### DIFF
--- a/src/bundled-plugins/awa-bundled/bundled.test.ts
+++ b/src/bundled-plugins/awa-bundled/bundled.test.ts
@@ -215,6 +215,11 @@ describe('bundled skills', () => {
       expect(content).toContain(
         '**Wave 1.5 — Citation + absence-claim verification (INLINE',
       );
+
+      // The Invariant paragraph is the ONLY place Wave 1 may name a git command —
+      // it exists to say what must not be mandated. Drop it, then no git may remain.
+      const withoutInvariant = waveOne.replace(/\*\*Invariant — why Wave 1[\s\S]*?\n\n/, '');
+      expect(withoutInvariant).not.toMatch(/`git (show|grep|diff|log)/);
     });
 
     // Invariant: severity and disposition are separate axes (#937). The two

--- a/src/bundled-plugins/awa-bundled/bundled.test.ts
+++ b/src/bundled-plugins/awa-bundled/bundled.test.ts
@@ -219,7 +219,7 @@ describe('bundled skills', () => {
       // The Invariant paragraph is the ONLY place Wave 1 may name a git command —
       // it exists to say what must not be mandated. Drop it, then no git may remain.
       const withoutInvariant = waveOne.replace(/\*\*Invariant — why Wave 1[\s\S]*?\n\n/, '');
-      expect(withoutInvariant).not.toMatch(/`git (show|grep|diff|log)/);
+      expect(withoutInvariant).not.toMatch(/`git(?:\s[^`]*)?`/);
     });
 
     // Invariant: severity and disposition are separate axes (#937). The two

--- a/src/bundled-plugins/awa-bundled/bundled.test.ts
+++ b/src/bundled-plugins/awa-bundled/bundled.test.ts
@@ -219,7 +219,11 @@ describe('bundled skills', () => {
       // The Invariant paragraph is the ONLY place Wave 1 may name a git command —
       // it exists to say what must not be mandated. Drop it, then no git may remain.
       const withoutInvariant = waveOne.replace(/\*\*Invariant — why Wave 1[\s\S]*?\n\n/, '');
-      expect(withoutInvariant).not.toMatch(/`git(?:\s[^`]*)?`/);
+      // Match commands in inline code or on their own shell line (including fenced
+      // snippets and optional shell prompts), regardless of subcommand or options.
+      const gitCommand = /(?:`+git(?=[\s`])|^[ \t]*(?:[$>][ \t]+)?git(?=\s))/m;
+      expect('```bash\ngit show HEAD:file\n```').toMatch(gitCommand);
+      expect(withoutInvariant).not.toMatch(gitCommand);
     });
 
     // Invariant: severity and disposition are separate axes (#937). The two


### PR DESCRIPTION
## Summary

Adds a negative assertion to the `review Wave 1 keeps the no-git citation contract (#726)` test so that the defect fixed in #726 cannot be silently reintroduced.

## Problem

The existing test made four presence assertions but no negative assertion. A bullet added to Wave 1 instructions containing `` `git show` `` would reintroduce the #726 defect with all four assertions intact and the suite green.

## Fix

After excising the Invariant paragraph (the one legitimate place `git show` may appear — it quotes the command to explain what must *not* be mandated), assert that no git command remains in Wave 1:

```typescript
// The Invariant paragraph is the ONLY place Wave 1 may name a git command —
// it exists to say what must not be mandated. Drop it, then no git may remain.
const withoutInvariant = waveOne.replace(/\*\*Invariant — why Wave 1[\s\S]*?\n\n/, '');
expect(withoutInvariant).not.toMatch(/`git (show|grep|diff|log)/);
```

## Verification

- All 20 tests in `bundled.test.ts` pass
- `pnpm lint` clean (tsc --noEmit)

Closes #788
