### PR TITLE
fix(telegram): use routeFromCtx in /afk and /help handlers

### DIFF
--- a/src/telegram/handlers/afk.ts
+++ b/src/telegram/handlers/afk.ts
@@ -21,6 +21,7 @@
 import type { Context } from 'telegraf';
 import type { Message } from 'telegraf/types';
 import { SessionManager } from '../session-manager.js';
+import { routeFromCtx } from '../route.js';
 import { formatError } from '../formatter.js';
 
 type LogFn = (...args: unknown[]) => void;
@@ -37,8 +38,8 @@ export async function handleAfk(
   sessionManager: SessionManager,
   log: LogFn,
 ): Promise<void> {
-  const chatId = ctx.chat?.id;
-  if (!chatId) {
+  const route = routeFromCtx(ctx);
+  if (!route) {
     await ctx.reply(formatError('Could not identify chat'));
     return;
   }
@@ -50,7 +51,7 @@ export async function handleAfk(
     // getSession lazily constructs the chat's session if needed — which also
     // binds the hook-registry mode getter to it (src/telegram.ts), so the gate
     // observes the flip below on the very next tool call.
-    const session = await sessionManager.getSession(chatId);
+    const session = await sessionManager.getSession(route);
     const current = session.getSessionMetadata().permissionMode === 'autonomous';
     const desired = arg === 'on' ? true : arg === 'off' ? false : !current;
 

--- a/src/telegram/handlers/help.ts
+++ b/src/telegram/handlers/help.ts
@@ -1,5 +1,6 @@
 import { Context } from 'telegraf';
 import { SessionManager } from '../session-manager.js';
+import { routeFromCtx } from '../route.js';
 import { formatHelp } from '../formatter.js';
 
 /**
@@ -9,9 +10,9 @@ export async function handleHelp(
   ctx: Context,
   sessionManager: SessionManager
 ): Promise<void> {
-  const chatId = ctx.chat?.id;
+  const route = routeFromCtx(ctx);
   let sdkCommands: string[] | undefined;
-  const session = chatId ? sessionManager.getSessionIfExists(chatId) : undefined;
+  const session = route ? sessionManager.getSessionIfExists(route) : undefined;
   if (session) {
     try {
       await Promise.race([


### PR DESCRIPTION
## Summary

`/afk` and `/help` handlers were using `ctx.chat?.id` (a bare `number`) to look up sessions, routing all commands from topics to the General session instead of the originating topic's session.

This PR applies the same `routeFromCtx(ctx)` pattern already used by `/clear`, `/compact`, `/model`, `/new`, `/sessions`, and `/switch` (introduced in PR #1020).

## Changes

- `src/telegram/handlers/afk.ts` — replace `ctx.chat?.id` / `getSession(chatId)` with `routeFromCtx(ctx)` / `getSession(route)`, add `!route` guard
- `src/telegram/handlers/help.ts` — replace `ctx.chat?.id` / `getSessionIfExists(chatId)` with `routeFromCtx(ctx)` / `getSessionIfExists(route)`, add `!route` guard

## Verification

- `pnpm lint` (tsc --noEmit): ✅ clean
- `pnpm test src/telegram/`: ✅ 816 tests passed (42 test files)

Closes #1022
