### PR TITLE
chore: fix stale comments and test cleanup at skill-dispatch sites

### DIFF
--- a/src/agent/tools/skill-dispatch-routing.test.ts
+++ b/src/agent/tools/skill-dispatch-routing.test.ts
@@ -41,7 +41,7 @@ import {
 import { buildMessages } from '../providers/openai-compatible/messages.js';
 import type { OpenAIChunk } from '../providers/openai-compatible/translate.js';
 import { SLASH_COMMAND_ROUTING_PROMPT, TOOL_SYSTEM_PROMPT_BASE } from './system-prompt.js';
-import { registerSkill } from '../../skills/index.js';
+import { registerSkill, _resetRegistry } from '../../skills/index.js';
 import { SkillExecutor } from './skill-executor.js';
 import { buildChildConfig } from './subagent/child-config.js';
 
@@ -165,6 +165,11 @@ describe('AnthropicDirectProvider — skill-dispatch self-entry suppression', ()
       description: 'Probe skill for self-suppression',
       handler: vi.fn(),
     });
+  });
+
+  afterEach(() => {
+    _resetRegistry();
+    __setAnthropicClientFactory(null);
   });
 
   async function systemTextFor(config: Record<string, unknown>): Promise<string> {
@@ -588,6 +593,7 @@ describe('OpenAICompatibleProvider — skill-dispatch self-entry suppression', (
   });
 
   afterEach(() => {
+    _resetRegistry();
     __setOpenAIClientFactory(null);
   });
 
@@ -698,6 +704,10 @@ describe('SkillExecutor — self-recursion execution guard (Fix A)', () => {
       description: 'Probe skill for self-recursion guard test',
       handler: vi.fn(),
     });
+  });
+
+  afterEach(() => {
+    _resetRegistry();
   });
 
   it('rejects a skill call matching skillDispatchName with a clear error', async () => {

--- a/src/agent/tools/skill-executor.ts
+++ b/src/agent/tools/skill-executor.ts
@@ -171,6 +171,9 @@ export class SkillExecutor {
 
     // Refresh the registry against this cwd: another session's scan may have
     // evicted this session's project entries between prompt assembly and now.
+    // Captured here (before registry and plugin lookups) so the "not found"
+    // fallback at the bottom of this method can list available skills without
+    // a second scan — both code paths share this single collection.
     const entries = collectSkillEntries(
       this.ctx.pluginConfigs,
       this.currentCwd !== undefined ? { cwd: this.currentCwd } : undefined,

--- a/src/agent/tools/skill-executor/fork-dispatch.ts
+++ b/src/agent/tools/skill-executor/fork-dispatch.ts
@@ -153,6 +153,11 @@ export async function executeForkedRegistrySkill(
       isSkillDispatch: true,
       // Suppresses this skill's own entry in the child's manifest — without it
       // the fork can read its own catalogue entry and re-dispatch itself.
+      // Uses the registry key (skill.name), which may be namespaced like
+      // `user:<name>` or `project:<name>`. Both the exact key and bare-name
+      // variants are safely excluded: skill-bridge's collectSkillEntries
+      // filter matches `e.name === exclude || e.name.endsWith(':<exclude>'),
+      // so a bare excludeName catches all namespaced aliases and vice-versa.
       skillDispatchName: skill.name,
       ...(ctx.traceWriter !== undefined ? { traceWriter: ctx.traceWriter } : {}),
     } as AgentConfig,
@@ -248,6 +253,9 @@ export async function executePluginSkill(
     isSkillDispatch: true,
     // Suppresses this skill's own entry in the child's manifest — without it
     // the fork can read its own catalogue entry and re-dispatch itself.
+    // Uses the bare skillName (the lookup key, not a namespaced registry key).
+    // Safe: skill-bridge's suffix match (`endsWith(':<name>')`) ensures the
+    // bare name also excludes any `user:<name>` / `project:<name>` aliases.
     skillDispatchName: skillName,
     ...(ctx.traceWriter !== undefined ? { traceWriter: ctx.traceWriter } : {}),
   } as AgentConfig;
@@ -351,7 +359,8 @@ export async function runForkedSkillToResult(
     // instruction was a task brief, which it could satisfy by re-dispatching the
     // very skill it already was (observed on `ground-state`). Args stay verbatim
     // under a labelled delimiter so a SKILL.md body that greps its arguments
-    // (e.g. mint's "approved") still matches.
+    // (e.g. a fork skill whose handler anchors on a keyword like "approved")
+    // still matches.
     const anchor = `Run the ${label} skill now, following the instructions in your system prompt.`;
     const userMessage =
       args && args.length > 0 ? `${anchor}\n\nSkill arguments:\n${args}` : anchor;

--- a/src/skills/user-skills.ts
+++ b/src/skills/user-skills.ts
@@ -212,6 +212,7 @@ function makeUserSkillHandler(parsed: ParsedSkillMd): SkillMetadata['handler'] {
         isSkillDispatch: true,
         // Suppresses this skill's own entry in the fork's manifest — without it
         // the fork can read its own catalogue entry and re-dispatch itself.
+        // Bare name is safe: skill-bridge's `endsWith(':<name>')` filter covers `user:<name>` / `project:<name>` aliases (#744).
         skillDispatchName: parsed.name,
       },
       idPrefix: `user-skill-${parsed.name}`,


### PR DESCRIPTION
Fixes four low-severity accuracy issues in skill dispatch code. No runtime behavior changes.

Closes #744

## Changes

### 1. Clarify `collectSkillEntries` pre-capture rationale (`skill-executor.ts`)
The comment near the `collectSkillEntries` call at line ~174 now explains that entries are captured **before** registry and plugin lookups so the "not found" fallback at the bottom of `execute()` can list available skills without a second scan — making the deferred-use pattern self-documenting for the next editor.

### 2. Fix misleading skill name in justification comment (`fork-dispatch.ts`)
`runForkedSkillToResult` had a comment claiming args stay verbatim "so a SKILL.md body that greps its arguments (e.g. mint's `approved`) still matches." Mint is an **inline** skill and never traverses this fork path. Replaced with a description of the actual hazard: a **fork skill** whose handler anchors on a keyword.

### 3. Document why mixed `skillDispatchName` flavors are safe at all three fork sites (`fork-dispatch.ts`, `user-skills.ts`)
Three fork sites pass different name flavors as `skillDispatchName`:
- `executeForkedRegistrySkill` passes `skill.name` (the registry key, possibly namespaced like `user:<name>`)
- `executePluginSkill` passes the bare `skillName` lookup key
- `user-skills.ts` passes the bare frontmatter `parsed.name`

Added a comment at each site explaining that all three are safe because `skill-bridge.ts`'s `collectSkillEntries` filter uses `endsWith(':<name>')` suffix matching — a bare name excludes all namespaced aliases, and a namespaced key excludes itself exactly.

### 4. Add `afterEach(_resetRegistry())` cleanup to three `describe` blocks (`skill-dispatch-routing.test.ts`)
Three `describe` blocks called `registerSkill` in `beforeEach` with no `afterEach` cleanup, causing registry state to leak across test suites. Added `_resetRegistry()` in `afterEach` for:
- `AnthropicDirectProvider — skill-dispatch self-entry suppression`
- `OpenAICompatibleProvider — skill-dispatch self-entry suppression` (existing `afterEach` extended)
- `SkillExecutor — self-recursion execution guard (Fix A)`

## Verification
- `pnpm lint` passes (TypeScript + no-emit check)
- `pnpm test src/agent/tools/skill-executor.test.ts src/agent/tools/skill-dispatch-routing.test.ts` — 115 tests pass
