### PR TITLE
refactor(tui): retire committedBandBottomRow erase-bound read in frame-preserve-archive (advances #540)

### DIFF
--- a/src/cli/terminal-compositor.committed-band-repin.ts
+++ b/src/cli/terminal-compositor.committed-band-repin.ts
@@ -70,8 +70,9 @@ export function flushResizeGhostErase(self: CommittedBandHost): void {
  * "void" class by construction (a stranded row above a drifted tracked top is
  * always erased) instead of relying on incremental band-adjacency bookkeeping.
  * The committedBand* fields are still MAINTAINED here for the commit / eviction
- * paths that read them; removing that coupling entirely, plus the Stage 3
- * single end-of-turn flush, remain follow-ups (see #540 / the PR body).
+ * paths that read them (see #540). Stage 3 (logical-line flush) and the
+ * frame-preserve-archive erase bound have been retired; the remaining
+ * coupling lives in the commit path's floor derivation and contiguity checks.
  *
  * @param desiredTopRow      the frame's true target top (pre-padding) this repaint
  * @param preRenderFrameTop  CupFrameRenderer.topRow captured BEFORE render() —

--- a/src/cli/terminal-compositor.frame-preserve-archive.ts
+++ b/src/cli/terminal-compositor.frame-preserve-archive.ts
@@ -76,9 +76,13 @@ export function archiveBandPrefixAndRepaintSurvivors(
   // terminal, not this process, owns the intervening scroll.
 
   // (1) Erase the band's previous painted footprint, from the geometric floor
-  // through its tracked bottom.
+  // through the band's bottom row — derived from `floor + bandLen` rather than
+  // reading `committedBandBottomRow`, retiring that adjacency-coupling read per
+  // #540. The algebra is equivalent (`committedBandBottomRow === floor +
+  // bandLen - 1` by the class invariant), but the derivation is geometry-only
+  // and cannot be stale.
   let erase = '';
-  for (let r = floor; r <= self.committedBandBottomRow; r++) erase += eraseAndPaintRow(r);
+  for (let r = floor; r < floor + bandLen; r++) erase += eraseAndPaintRow(r);
 
   // (2) Archive the prefix as logical lines. Autowrap stays ON for this write
   // (load-bearing, and the exact opposite of the on-screen band paint in step

--- a/src/cli/terminal-compositor.frame-preserve.ts
+++ b/src/cli/terminal-compositor.frame-preserve.ts
@@ -123,8 +123,8 @@ export function preserveRowsBeforeFrameRender(self: FrameHost, desiredTopRow: nu
       // helper erases from the geometric FLOOR (row 1) rather than reading the
       // tracked `committedBandTopRow`, retiring that adjacency-coupling read per
       // the Stage-2-core repin change (#552, committed-band-repin.ts); the
-      // tracked `bottom` stays, being the vacated-tail boundary and not
-      // derivable from geometry pre-Stage-3. The helper owns the
+      // tracked `bottom` read is also retired — the erase bound is now derived
+      // from `floor + bandLen` (geometry-only). The helper owns the
       // erase → archive → repaint ordering constraint and all band bookkeeping;
       // see terminal-compositor.frame-preserve-archive.ts.
       archiveBandPrefixAndRepaintSurvivors(self, overflow, 1);


### PR DESCRIPTION
Retire the last erase-bound `committedBandBottomRow` read in the compositor's archive path, continuing the adjacency-coupling removal tracked by #540.

## Change

`archiveBandPrefixAndRepaintSurvivors` (`frame-preserve-archive.ts:81`) erased the band from `floor` through `self.committedBandBottomRow`. That tracked field equals `floor + bandLen - 1` by the class invariant, so the loop now uses `floor + bandLen` as an exclusive upper bound — geometry-only, cannot be stale.

Same transformation #552 applied to the repin erase range and #573 applied to the frame-preserve erase-loop lower bounds, now extended to the archive path's upper bound.

### Stale comment updates
- `frame-preserve.ts`: note the tracked `bottom` read is retired
- `committed-band-repin.ts`: reflect that Stage 3 has shipped; the remaining coupling lives in the commit path's floor derivation and contiguity checks

## What remains on #540

| Category | Sites | Status |
|----------|-------|--------|
| Erase-bound reads | 0 | ✅ All retired (#552, #573, this PR) |
| Frame-top floor derivation | ~4 sites in `committed-band-commit.ts` | ❌ Load-bearing — needs new canonical frame-top source |
| Contiguity checks | 2 sites | ❌ Depends on floor derivation retirement |
| Resize row shift (writes) | 3 sites in `frame-preserve.ts` | ❌ Maintains fields for downstream consumers |

## Verification

- 433/433 compositor tests pass (all gap-class regressions: `collapse-void`, `scrollback-gap`, `shrink-gap`, `multi-commit-gap`, `commit-collapse-wrap-gap`, `two-table-overflow`, `wrap-gap`)
- 16,318/16,318 tests pass (1 pre-existing unrelated failure in `write-denylist.test.ts`)
- `pnpm lint` clean
- All touched files under 350-line ceiling (140, 171, 298)

⚠️ **Real-terminal validation**: this change affects the erase range in the eviction-to-scrollback path. The algebra is equivalent (same rows erased), but per #540's hard constraints, human-eyeball validation of the `long` and `grow-collapse` scenarios via `scripts/visual-void-repro.ts` is recommended before merge.
