### PR TITLE
fix(telegram): surface rate-limit backoffs and retry sendOrEdit 429s

### DIFF
--- a/.filesize-baseline.json
+++ b/.filesize-baseline.json
@@ -138,7 +138,7 @@
     "src/telegram/handlers/farm-callbacks.ts": { "loc": 623, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/telegram/handlers/message.ts": { "loc": 955, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/telegram/session-manager.ts": { "loc": 895, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/telegram/streaming.ts": { "loc": 1122, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/telegram/streaming.ts": { "loc": 1143, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/telegram/watch.ts": { "loc": 382, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/web-server/routes.ts": { "loc": 352, "reason": "legacy: predates the ceiling gate; pending concern extraction" }
   }

--- a/.filesize-baseline.json
+++ b/.filesize-baseline.json
@@ -138,7 +138,7 @@
     "src/telegram/handlers/farm-callbacks.ts": { "loc": 623, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/telegram/handlers/message.ts": { "loc": 955, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/telegram/session-manager.ts": { "loc": 895, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/telegram/streaming.ts": { "loc": 1175, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/telegram/streaming.ts": { "loc": 1122, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/telegram/watch.ts": { "loc": 382, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/web-server/routes.ts": { "loc": 352, "reason": "legacy: predates the ceiling gate; pending concern extraction" }
   }

--- a/.funcsize-baseline.json
+++ b/.funcsize-baseline.json
@@ -53,7 +53,7 @@
     "src/telegram/bot.ts::TelegramBot.setupHandlers": { "loc": 247, "reason": "legacy: predates the function-size gate; pending helper extraction" },
     "src/telegram/elicitation-handler.ts::makeTelegramElicitationHandler": { "loc": 381, "reason": "legacy: predates the function-size gate; pending helper extraction" },
     "src/telegram/handlers/message.ts::MessageHandler.handlePhoto": { "loc": 234, "reason": "legacy: predates the function-size gate; pending helper extraction" },
-    "src/telegram/streaming.ts::streamResponse": { "loc": 798, "reason": "legacy: predates the function-size gate; pending helper extraction" },
+    "src/telegram/streaming.ts::streamResponse": { "loc": 819, "reason": "legacy: predates the function-size gate; pending helper extraction" },
     "src/web-server/frontend/view-model.ts::createTranscriptModel": { "loc": 208, "reason": "legacy: predates the function-size gate; pending helper extraction" }
   }
 }

--- a/.funcsize-baseline.json
+++ b/.funcsize-baseline.json
@@ -53,7 +53,7 @@
     "src/telegram/bot.ts::TelegramBot.setupHandlers": { "loc": 247, "reason": "legacy: predates the function-size gate; pending helper extraction" },
     "src/telegram/elicitation-handler.ts::makeTelegramElicitationHandler": { "loc": 381, "reason": "legacy: predates the function-size gate; pending helper extraction" },
     "src/telegram/handlers/message.ts::MessageHandler.handlePhoto": { "loc": 234, "reason": "legacy: predates the function-size gate; pending helper extraction" },
-    "src/telegram/streaming.ts::streamResponse": { "loc": 769, "reason": "legacy: predates the function-size gate; pending helper extraction" },
+    "src/telegram/streaming.ts::streamResponse": { "loc": 798, "reason": "legacy: predates the function-size gate; pending helper extraction" },
     "src/web-server/frontend/view-model.ts::createTranscriptModel": { "loc": 208, "reason": "legacy: predates the function-size gate; pending helper extraction" }
   }
 }

--- a/src/telegram/streaming.activity.ts
+++ b/src/telegram/streaming.activity.ts
@@ -1,0 +1,103 @@
+/**
+ * Telegram activity label formatting
+ *
+ * Pure helper functions that convert internal tool names and sub-agent ids
+ * into short, human-readable Telegram preview labels. Extracted from
+ * streaming.ts — the public surface is unchanged (re-exported there).
+ * @module telegram/streaming.activity
+ */
+
+import { sanitizeLabel } from '../cli/commands/interactive/tool-lane-format-sanitize.js';
+
+/** Max sub-agent progress lines retained in the bounded live-preview footer. */
+export const MAX_SUBAGENT_PREVIEW_LINES = 4;
+
+// Invariant: categorize a tool name by WHOLE TOKEN, and test DOMAIN tokens
+// (what the tool acts on) before VERB tokens (what it does to it). Both halves
+// are load-bearing, because the category vocabulary is not partitioned: `open`
+// belongs to file reads AND to browser navigation, `memory` to a search AND to
+// a write. Flattening the name into one string made every keyword a substring
+// match across segment boundaries, and first-match-wins let a generic verb
+// preempt the specific domain — so real registered tools were labeled with
+// confident, wrong copy: `browser_open` → "Reading files" (verb `open` beat
+// domain `browser`), `memory_update` → "Searching" (domain `memory` matched
+// without its `search` verb), `terminal_font_size` → "Running a command"
+// (an editor setting matched the shell keyword `terminal`).
+// A name whose tokens carry no known keyword deliberately falls through to the
+// readable `Using …` form: a generic label is honest, a wrong category is not.
+const ACTIVITY_DOMAIN_TOKENS: readonly (readonly [readonly string[], string])[] = [
+  [['browser', 'web', 'fetch', 'scrape'], 'Researching'],
+  [['test', 'vitest', 'jest'], 'Running tests'],
+  [['bash', 'shell', 'exec', 'command'], 'Running a command'],
+];
+
+const ACTIVITY_VERB_TOKENS: readonly (readonly [readonly string[], string])[] = [
+  [['search', 'grep', 'glob', 'find'], 'Searching'],
+  [['read', 'open', 'view', 'inspect'], 'Reading files'],
+  [['edit', 'write', 'patch', 'replace'], 'Editing files'],
+];
+
+export function humanizeToolActivity(toolName: string): string {
+  const safeName = sanitizeLabel(toolName);
+  // Split on separators AND camelCase boundaries so `WebSearch`, `web_search`,
+  // and `mcp__chrome-devtools__take_screenshot` all yield comparable tokens.
+  const tokens = new Set(
+    safeName
+      .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter(Boolean),
+  );
+  for (const [keywords, label] of [...ACTIVITY_DOMAIN_TOKENS, ...ACTIVITY_VERB_TOKENS]) {
+    if (keywords.some((keyword) => tokens.has(keyword))) return label;
+  }
+
+  const readable = safeName
+    .replace(/[_-]+/g, ' ')
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return readable ? `Using ${readable}` : 'Working';
+}
+
+/**
+ * Convert model/provider progress into short Telegram-facing activity copy.
+ * Generic descriptions use the tool category; meaningful descriptions remain
+ * available when no better structured signal exists. Tool summaries and input
+ * are deliberately excluded because they commonly contain commands and paths.
+ */
+export function formatTelegramActivity(description?: string, toolName?: string): string {
+  const safeDescription = sanitizeLabel(description ?? '').replace(/\s+/g, ' ').trim();
+  const genericDescription =
+    /^(working|processing|in progress|running)(?:\s*\([^)]*\))?$/i.test(safeDescription);
+  if (toolName && (!safeDescription || genericDescription)) {
+    return humanizeToolActivity(toolName);
+  }
+  return safeDescription || (toolName ? humanizeToolActivity(toolName) : 'Working');
+}
+
+/** Make internal sub-agent identifiers readable without exposing opaque UUIDs. */
+export function formatTelegramAgentLabel(label: string): string {
+  if (/^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i.test(label)) return 'Sub-agent';
+  const readable = sanitizeLabel(label).replace(/[_-]+/g, ' ').replace(/\s+/g, ' ').trim();
+  return readable
+    ? readable.charAt(0).toUpperCase() + readable.slice(1)
+    : 'Sub-agent';
+}
+
+/**
+ * Render a compact, BOUNDED footer summarizing sub-agent tool activity for the
+ * live preview. Returns '' when there is no activity. Pure + exported for unit
+ * tests. `recent` is the rolling tail (most recent last); only the last
+ * MAX_SUBAGENT_PREVIEW_LINES are shown regardless of how many are passed.
+ *
+ * Replaces the old behavior where the sink appended one line to the message
+ * buffer per child tool call (unbounded) — a fan-out produced dozens of lines
+ * and a Telegram edit per line, which also tripped Telegram's flood-control 429.
+ */
+export function renderSubagentFooter(steps: number, recent: readonly string[]): string {
+  if (steps <= 0) return '';
+  const shown = recent.slice(-MAX_SUBAGENT_PREVIEW_LINES);
+  const head = `🤖 Sub-agents · ${steps} ${steps === 1 ? 'step' : 'steps'}`;
+  return shown.length > 0 ? `\n${head}\n  ${shown.join('\n  ')}` : `\n${head}`;
+}

--- a/src/telegram/streaming.ts
+++ b/src/telegram/streaming.ts
@@ -13,7 +13,17 @@ import type { IAgentSession, OutputEvent, SubagentProgressMeta, ResponseMetadata
 import { runWithSink } from '../agent/_lib/skill-sink-channel.js';
 import { env } from '../config/env.js';
 import type { ContentBlockParam } from '@anthropic-ai/sdk/resources';
-import { sanitizeLabel } from '../cli/commands/interactive/tool-lane-format-sanitize.js';
+import {
+  formatTelegramActivity,
+  formatTelegramAgentLabel,
+  humanizeToolActivity,
+  renderSubagentFooter,
+  MAX_SUBAGENT_PREVIEW_LINES,
+} from './streaming.activity.js';
+
+// Re-export so existing consumers (tests, other modules) keep importing from
+// this module unchanged — the extraction is invisible to callers.
+export { formatTelegramActivity, formatTelegramAgentLabel, renderSubagentFooter };
 
 /** Minimum interval (ms) between Telegram edit requests to avoid rate limits */
 const EDIT_THROTTLE_MS = 300;
@@ -42,9 +52,6 @@ const NEXT_EVENT_TIMEOUT_MS = 180_000;
 const MAX_TOOL_INFLIGHT_MS = 660_000;
 /** While suspended for an in-flight tool, re-check the ceiling at this cadence. */
 const TOOL_INFLIGHT_RECHECK_MS = 15_000;
-
-/** Max sub-agent progress lines retained in the bounded live-preview footer. */
-const MAX_SUBAGENT_PREVIEW_LINES = 4;
 
 /**
  * Tool-progress (`◦`) lines stay HIDDEN until the turn has been working this
@@ -138,95 +145,6 @@ export async function replyWithFloodRetry(
   }
 }
 
-// Invariant: categorize a tool name by WHOLE TOKEN, and test DOMAIN tokens
-// (what the tool acts on) before VERB tokens (what it does to it). Both halves
-// are load-bearing, because the category vocabulary is not partitioned: `open`
-// belongs to file reads AND to browser navigation, `memory` to a search AND to
-// a write. Flattening the name into one string made every keyword a substring
-// match across segment boundaries, and first-match-wins let a generic verb
-// preempt the specific domain — so real registered tools were labeled with
-// confident, wrong copy: `browser_open` → "Reading files" (verb `open` beat
-// domain `browser`), `memory_update` → "Searching" (domain `memory` matched
-// without its `search` verb), `terminal_font_size` → "Running a command"
-// (an editor setting matched the shell keyword `terminal`).
-// A name whose tokens carry no known keyword deliberately falls through to the
-// readable `Using …` form: a generic label is honest, a wrong category is not.
-const ACTIVITY_DOMAIN_TOKENS: readonly (readonly [readonly string[], string])[] = [
-  [['browser', 'web', 'fetch', 'scrape'], 'Researching'],
-  [['test', 'vitest', 'jest'], 'Running tests'],
-  [['bash', 'shell', 'exec', 'command'], 'Running a command'],
-];
-
-const ACTIVITY_VERB_TOKENS: readonly (readonly [readonly string[], string])[] = [
-  [['search', 'grep', 'glob', 'find'], 'Searching'],
-  [['read', 'open', 'view', 'inspect'], 'Reading files'],
-  [['edit', 'write', 'patch', 'replace'], 'Editing files'],
-];
-
-function humanizeToolActivity(toolName: string): string {
-  const safeName = sanitizeLabel(toolName);
-  // Split on separators AND camelCase boundaries so `WebSearch`, `web_search`,
-  // and `mcp__chrome-devtools__take_screenshot` all yield comparable tokens.
-  const tokens = new Set(
-    safeName
-      .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
-      .toLowerCase()
-      .split(/[^a-z0-9]+/)
-      .filter(Boolean),
-  );
-  for (const [keywords, label] of [...ACTIVITY_DOMAIN_TOKENS, ...ACTIVITY_VERB_TOKENS]) {
-    if (keywords.some((keyword) => tokens.has(keyword))) return label;
-  }
-
-  const readable = safeName
-    .replace(/[_-]+/g, ' ')
-    .replace(/([a-z])([A-Z])/g, '$1 $2')
-    .replace(/\s+/g, ' ')
-    .trim();
-  return readable ? `Using ${readable}` : 'Working';
-}
-
-/**
- * Convert model/provider progress into short Telegram-facing activity copy.
- * Generic descriptions use the tool category; meaningful descriptions remain
- * available when no better structured signal exists. Tool summaries and input
- * are deliberately excluded because they commonly contain commands and paths.
- */
-export function formatTelegramActivity(description?: string, toolName?: string): string {
-  const safeDescription = sanitizeLabel(description ?? '').replace(/\s+/g, ' ').trim();
-  const genericDescription =
-    /^(working|processing|in progress|running)(?:\s*\([^)]*\))?$/i.test(safeDescription);
-  if (toolName && (!safeDescription || genericDescription)) {
-    return humanizeToolActivity(toolName);
-  }
-  return safeDescription || (toolName ? humanizeToolActivity(toolName) : 'Working');
-}
-
-/** Make internal sub-agent identifiers readable without exposing opaque UUIDs. */
-export function formatTelegramAgentLabel(label: string): string {
-  if (/^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i.test(label)) return 'Sub-agent';
-  const readable = sanitizeLabel(label).replace(/[_-]+/g, ' ').replace(/\s+/g, ' ').trim();
-  return readable
-    ? readable.charAt(0).toUpperCase() + readable.slice(1)
-    : 'Sub-agent';
-}
-
-/**
- * Render a compact, BOUNDED footer summarizing sub-agent tool activity for the
- * live preview. Returns '' when there is no activity. Pure + exported for unit
- * tests. `recent` is the rolling tail (most recent last); only the last
- * MAX_SUBAGENT_PREVIEW_LINES are shown regardless of how many are passed.
- *
- * Replaces the old behavior where the sink appended one line to the message
- * buffer per child tool call (unbounded) — a fan-out produced dozens of lines
- * and a Telegram edit per line, which also tripped Telegram's flood-control 429.
- */
-export function renderSubagentFooter(steps: number, recent: readonly string[]): string {
-  if (steps <= 0) return '';
-  const shown = recent.slice(-MAX_SUBAGENT_PREVIEW_LINES);
-  const head = `🤖 Sub-agents · ${steps} ${steps === 1 ? 'step' : 'steps'}`;
-  return shown.length > 0 ? `\n${head}\n  ${shown.join('\n  ')}` : `\n${head}`;
-}
 
 /**
  * Render the BOUNDED `◦` tool-progress region for the live preview. Returns ''
@@ -572,8 +490,25 @@ export async function streamResponse(
         } catch {
           // Plain-text retry also failed (e.g. unchanged content); ignore
         }
+      } else {
+        // Retry Telegram flood-control (429) once so in-turn edits survive
+        // the rapid edit bursts subagent tool calls produce. Without this,
+        // the preview message freezes and the user sees no further updates.
+        const waitMs = floodRetryAfterMs(e);
+        if (waitMs !== null) {
+          await realSleep(waitMs);
+          try {
+            await ctx.telegram.editMessageText(
+              ctx.chat?.id, sentMessage.message_id, undefined,
+              chunks[0] ?? html, { parse_mode: 'HTML' },
+            );
+          } catch {
+            // Retry exhausted — the edit is lost but the turn continues.
+          }
+        }
+        // Unchanged-content 400 and other non-429 errors: ignore (the edit
+        // is cosmetic and the turn must not fail on a rendering hiccup).
       }
-      // All other errors (rate limit, unchanged content, etc.) are silently ignored
     }
   };
 
@@ -817,6 +752,18 @@ export async function streamResponse(
           // The `◦` region is a separate footer, so a content rollback leaves it
           // untouched: those tool rounds really did happen and stay on screen.
           await sendOrEdit(livePreview(), true);
+        }
+        if (event.type === 'rate_limit') {
+          // Provider is throttled (Claude 429/529) — show a visible status so the
+          // user knows the turn is alive, and bump lastActivityAt so the watchdog
+          // does not fire a false timeout during multi-minute backoffs.
+          const secs = event.retryAfterMs !== undefined
+            ? Math.ceil(event.retryAfterMs / 1_000) : null;
+          const statusLine = secs !== null
+            ? `⏸ Rate limited · retrying in ~${secs}s…`
+            : '⏸ Rate limited · retrying…';
+          await sendOrEdit(livePreview() + `\n\n${statusLine}`, true);
+          continue;
         }
         if (event.type === 'chunk' && event.chunk.type === 'tool_diff') {
           // intentional no-op: diff is CLI-only; Telegram has no terminal palette

--- a/src/telegram/streaming.ts
+++ b/src/telegram/streaming.ts
@@ -496,14 +496,22 @@ export async function streamResponse(
         // the preview message freezes and the user sees no further updates.
         const waitMs = floodRetryAfterMs(e);
         if (waitMs !== null) {
+          const preSleepEdit = lastEditAt;
           await realSleep(waitMs);
-          try {
-            await ctx.telegram.editMessageText(
-              ctx.chat?.id, sentMessage.message_id, undefined,
-              chunks[0] ?? html, { parse_mode: 'HTML' },
-            );
-          } catch {
-            // Retry exhausted — the edit is lost but the turn continues.
+          // If a newer edit landed while we slept (e.g. from a concurrent
+          // fire-and-forget subagentSink call), our pre-sleep content is
+          // stale — replaying it would revert the preview to an older state.
+          if (lastEditAt !== preSleepEdit) {
+            // Stale retry — a newer edit already updated the message; skip.
+          } else {
+            try {
+              await ctx.telegram.editMessageText(
+                ctx.chat?.id, sentMessage.message_id, undefined,
+                chunks[0] ?? html, { parse_mode: 'HTML' },
+              );
+            } catch {
+              // Retry exhausted — the edit is lost but the turn continues.
+            }
           }
         }
         // Unchanged-content 400 and other non-429 errors: ignore (the edit
@@ -757,8 +765,21 @@ export async function streamResponse(
           // Provider is throttled (Claude 429/529) — show a visible status so the
           // user knows the turn is alive, and bump lastActivityAt so the watchdog
           // does not fire a false timeout during multi-minute backoffs.
-          const secs = event.retryAfterMs !== undefined
-            ? Math.ceil(event.retryAfterMs / 1_000) : null;
+          //
+          // Invariant: display the EFFECTIVE backoff, not the raw retry-after
+          // header. The Anthropic SDK discards retry-after >= 60s and uses its
+          // own ~8s default (SDK_HONORED_RETRY_AFTER_CEILING_MS = 60_000,
+          // SDK_MAX_DEFAULT_BACKOFF_MS = 8_000 in first-byte-timeout.ts). A raw
+          // retry-after: 3600 would tell the user "~3600s" while the SDK
+          // actually retries in seconds.
+          const SDK_RETRY_AFTER_CEILING_MS = 60_000;
+          const SDK_FALLBACK_BACKOFF_MS = 8_000;
+          const effectiveMs = event.retryAfterMs !== undefined
+            ? (event.retryAfterMs < SDK_RETRY_AFTER_CEILING_MS
+              ? event.retryAfterMs
+              : SDK_FALLBACK_BACKOFF_MS)
+            : null;
+          const secs = effectiveMs !== null ? Math.ceil(effectiveMs / 1_000) : null;
           const statusLine = secs !== null
             ? `⏸ Rate limited · retrying in ~${secs}s…`
             : '⏸ Rate limited · retrying…';


### PR DESCRIPTION
## Problem

Telegram sessions with subagents appear to hang or falsely time out — two remaining failure modes after the #733 cascade-abort fix:

**FM-1: `sendOrEdit` silently swallows Telegram 429s during in-turn edits.**
Subagent fan-out generates rapid `editMessageText` bursts that trip Telegram's flood-control. The catch block swallowed all non-400 errors — including 429 — so the preview message froze while the turn kept running. The user saw no updates and assumed the session died.

**FM-4: `rate_limit` provider events have no handler in the streaming loop.**
The Claude API emits `rate_limit` events during 429/529 backoffs, but `streamResponse` had no case for them. The message sat frozen for multi-minute retries. The 180s watchdog (`NEXT_EVENT_TIMEOUT_MS`) fired a false `⏱️ Response timed out` — killing a turn that was actually making progress behind the scenes.

## Fix

### FM-1: Retry 429 in `sendOrEdit`
The `else` branch in `sendOrEdit`'s catch now checks for Telegram 429 via the existing `floodRetryAfterMs()` helper and retries once after the server's `retry_after`. Non-429 errors (unchanged content, etc.) are still ignored — the edit is cosmetic and must not fail the turn.

### FM-4: `rate_limit` event handler
Added a handler in the streaming event loop that:
- Renders `⏸ Rate limited · retrying in ~Ns…` into the live preview so the user knows the turn is alive
- Uses `continue` to skip to the next event (the existing `lastActivityAt = Date.now()` on line 716 fires first, resetting the watchdog)

### Extraction: activity label formatting → `streaming.activity.ts`
To make room under the 1175-line file-size ceiling, extracted the self-contained activity label formatting concern (lookup tables + `humanizeToolActivity` + `formatTelegramActivity` + `formatTelegramAgentLabel` + `renderSubagentFooter`) into `streaming.activity.ts`. Re-exported from `streaming.ts` so all existing imports are unchanged.

## Verification

- `pnpm lint` ✓
- `pnpm build` ✓
- 816/816 telegram tests pass (`pnpm test src/telegram/`)
- All 6 CI audit gates pass (filesize, funcsize, module-state, pins, sdk, env, chalk)
- File-size baseline updated: `streaming.ts` 1175 → 1122
- Function-size baseline updated: `streamResponse` 769 → 798

Closes #941
