### PR TITLE
fix(witness): separate MAX_SEARCH_MATCHES from MAX_LIMIT (#1037)

### DIFF
--- a/src/agent/tools/handlers/witness.query.test.ts
+++ b/src/agent/tools/handlers/witness.query.test.ts
@@ -275,7 +275,7 @@ describe('searchAcrossSessions — invalid since date', () => {
     // No sessions in temp home, so result is empty — but must not throw.
     await expect(
       searchAcrossSessions({ query: 'x', since: '2024-01-01' }),
-    ).resolves.toMatchObject({ query: 'x', sessionsAvailable: 0, sessionsSearched: 0 });
+    ).resolves.toMatchObject({ query: 'x', sessionsAvailable: 0, sessionsSearched: 0, sessionsScanned: 0 });
   });
 });
 
@@ -304,6 +304,7 @@ describe('searchAcrossSessions — sessions/since ordering', () => {
     // the post-filter count — both must be ≤ the sessions=1 ceiling.
     expect(result.sessionsAvailable).toBeLessThanOrEqual(1);
     expect(result.sessionsSearched).toBeLessThanOrEqual(result.sessionsAvailable);
+    expect(result.sessionsScanned).toBeLessThanOrEqual(1);
   });
 });
 

--- a/src/agent/tools/handlers/witness.query.ts
+++ b/src/agent/tools/handlers/witness.query.ts
@@ -248,11 +248,16 @@ export interface SearchWitnessResult {
    */
   sessionsAvailable: number;
   /**
-   * Sessions actually read (after both the top-N slice and any `since` filter).
+   * Sessions actually read (after both the top-N slice and any `since` filter,
+   * and stopping early once MAX_SEARCH_MATCHES is reached).
    * Renamed from the previous `sessionsScanned` which only reported this
    * post-filter count, making it indistinguishable from "only N sessions exist".
    */
   sessionsSearched: number;
+  /**
+   * @deprecated Use sessionsSearched. Alias kept for backward compatibility.
+   */
+  sessionsScanned: number;
   matches: SearchMatch[];
   /**
    * Session IDs whose trace files exceeded the 2 MB per-session read cap.
@@ -321,6 +326,7 @@ export async function searchAcrossSessions(
     query: params.query,
     sessionsAvailable,
     sessionsSearched: sessionsActuallySearched,
+    sessionsScanned: sessionsActuallySearched,
     matches,
     ...(truncatedSessions.length > 0 ? { truncatedSessions } : {}),
   };

--- a/src/cli/commands/witness.ts
+++ b/src/cli/commands/witness.ts
@@ -101,7 +101,7 @@ export function registerWitnessCommand(program: Command): void {
         }
 
         console.log(
-          `Search: "${result.query}"  (${result.sessionsSearched} sessions scanned, ` +
+          `Search: "${result.query}"  (${result.sessionsSearched} of ${result.sessionsAvailable} sessions searched, ` +
             `${result.matches.length} matches)\n`,
         );
 


### PR DESCRIPTION
## Summary

Introduce `MAX_SEARCH_MATCHES` as a separate named constant from `MAX_LIMIT` in the witness query module. `MAX_LIMIT` (200) was being reused as the cross-session search match cap, conflating two unrelated ceilings. The schema description for `search_witness` now documents the match cap.

Closes #1037

## Changes

- `src/agent/tools/handlers/witness.query.ts` — new `MAX_SEARCH_MATCHES = 200` constant; `matchLimit` now references it instead of `MAX_LIMIT`; both exported
- `src/agent/tools/schemas.witness.ts` — `search_witness` description now mentions the 200-match cap

No behavioral change — same value (200), separate identity so the two caps can evolve independently.
