### PR TITLE
feat(witness): surface truncatedSessions in search_witness results (#1036)

### DIFF
--- a/src/agent/tools/handlers/witness.query.io.ts
+++ b/src/agent/tools/handlers/witness.query.io.ts
@@ -1,0 +1,41 @@
+/**
+ * Low-level trace I/O for witness query.
+ *
+ * Extracted from witness.query.ts to satisfy the 350-line ceiling.
+ * Owns the byte-capped `readTraceSafe` helper and its result type.
+ *
+ * @module agent/tools/handlers/witness.query.io
+ */
+
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+
+/** Max bytes to read from a single trace file. Prevents OOM on huge traces. */
+export const MAX_READ_BYTES = 2_097_152; // 2 MB
+
+/** Result from readTraceSafe: content and whether the file was byte-capped. */
+export interface ReadTraceSafeResult {
+  content: string;
+  truncated: boolean;
+}
+
+/** Read a trace.jsonl file with a byte-size cap (async). */
+export async function readTraceSafe(tracePath: string): Promise<ReadTraceSafeResult> {
+  if (!existsSync(tracePath)) return { content: '', truncated: false };
+  try {
+    const buf = await readFile(tracePath);
+    if (buf.length <= MAX_READ_BYTES) {
+      return { content: buf.toString('utf-8'), truncated: false };
+    }
+    // Slice from the tail then align to the next newline boundary to avoid
+    // splitting a multi-byte UTF-8 sequence or a partial JSON object.
+    let capped = buf.subarray(buf.length - MAX_READ_BYTES);
+    const firstNewline = capped.indexOf(0x0a);
+    if (firstNewline !== -1) {
+      capped = capped.subarray(firstNewline + 1);
+    }
+    return { content: capped.toString('utf-8'), truncated: true };
+  } catch {
+    return { content: '', truncated: false };
+  }
+}

--- a/src/agent/tools/handlers/witness.query.test.ts
+++ b/src/agent/tools/handlers/witness.query.test.ts
@@ -275,7 +275,7 @@ describe('searchAcrossSessions — invalid since date', () => {
     // No sessions in temp home, so result is empty — but must not throw.
     await expect(
       searchAcrossSessions({ query: 'x', since: '2024-01-01' }),
-    ).resolves.toMatchObject({ query: 'x', sessionsScanned: 0 });
+    ).resolves.toMatchObject({ query: 'x', sessionsAvailable: 0, sessionsSearched: 0 });
   });
 });
 
@@ -299,7 +299,90 @@ describe('searchAcrossSessions — sessions/since ordering', () => {
       sessions: 1,
       since: '2000-01-01',
     });
-    // At most 1 session can be scanned (sessions slice applied first)
-    expect(result.sessionsScanned).toBeLessThanOrEqual(1);
+    // At most 1 session can be scanned (sessions slice applied first).
+    // sessionsAvailable reflects the pre-filter count; sessionsSearched reflects
+    // the post-filter count — both must be ≤ the sessions=1 ceiling.
+    expect(result.sessionsAvailable).toBeLessThanOrEqual(1);
+    expect(result.sessionsSearched).toBeLessThanOrEqual(result.sessionsAvailable);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// searchAcrossSessions — truncatedSessions signal
+// ---------------------------------------------------------------------------
+
+describe('searchAcrossSessions — truncatedSessions', () => {
+  /**
+   * Write a trace that is guaranteed to exceed the 2 MB read cap.
+   * We write enough padding lines so the file exceeds 2_097_152 bytes, then
+   * add a "needle" line that will only appear in the tail (visible portion)
+   * and a "earlyNeedle" line near the top (invisible after truncation).
+   */
+  async function writeOversizedTrace(sessionId: string): Promise<void> {
+    const dir = join(tmpHome, 'state', 'witness', sessionId);
+    await mkdir(dir, { recursive: true });
+    const tracePath = join(dir, 'trace.jsonl');
+
+    // 2 MB + 1 byte requires >2_097_152 bytes total.
+    // Each padding line is ~1 KB. Write 2200 of them to safely exceed the cap.
+    const paddingLine = makeEventLine('session_phase', 0, {
+      phase: 'padding',
+      data: 'x'.repeat(950), // ~1 KB per line with JSON overhead
+    });
+    const earlyNeedleLine = makeEventLine('tool_call', 1, {
+      phase: 'completed', isError: false, name: 'bash',
+      // unique marker only in the dropped head
+      earlyNeedle: 'EARLY_UNIQUE_MARKER_THAT_IS_TRUNCATED',
+    });
+    const tailNeedleLine = makeEventLine('closure', 9999, {
+      reason: 'end_turn', finalCostUsd: 0, finalTurnCount: 1,
+      tailNeedle: 'TAIL_UNIQUE_MARKER_VISIBLE',
+    });
+
+    // Build: earlyNeedle first, then 2200 padding lines, then tailNeedle.
+    const lines: string[] = [earlyNeedleLine];
+    for (let i = 0; i < 2200; i++) lines.push(paddingLine);
+    lines.push(tailNeedleLine);
+
+    const { createWriteStream } = await import('node:fs');
+    const ws = createWriteStream(tracePath, { flags: 'w', encoding: 'utf-8' });
+    await new Promise<void>((resolve, reject) => {
+      ws.on('error', reject);
+      ws.on('finish', resolve);
+      for (const line of lines) ws.write(line + '\n');
+      ws.end();
+    });
+  }
+
+  it('sets truncatedSessions when a trace file exceeds 2 MB', async () => {
+    await writeOversizedTrace('big-session-1');
+
+    const result = await searchAcrossSessions({ query: 'TAIL_UNIQUE_MARKER_VISIBLE' });
+
+    expect(result.truncatedSessions).toBeDefined();
+    expect(result.truncatedSessions).toContain('big-session-1');
+  });
+
+  it('does NOT set truncatedSessions when no trace exceeds 2 MB', async () => {
+    await writeTrace('small-session-1', [
+      makeEventLine('closure', 1, { reason: 'end_turn', finalCostUsd: 0, finalTurnCount: 1 }),
+    ]);
+
+    const result = await searchAcrossSessions({ query: 'end_turn' });
+
+    // Either absent or an empty array — both are acceptable for a non-truncated result.
+    const truncated = result.truncatedSessions;
+    expect(truncated === undefined || truncated.length === 0).toBe(true);
+  });
+
+  it('finds tail matches in oversized traces while still flagging truncation', async () => {
+    await writeOversizedTrace('big-session-2');
+
+    const result = await searchAcrossSessions({ query: 'TAIL_UNIQUE_MARKER_VISIBLE' });
+
+    // The tail needle is within the 2 MB window and must be found.
+    expect(result.matches.some((m) => m.sessionId === 'big-session-2')).toBe(true);
+    // And truncation must be reported.
+    expect(result.truncatedSessions).toContain('big-session-2');
   });
 });

--- a/src/agent/tools/handlers/witness.query.ts
+++ b/src/agent/tools/handlers/witness.query.ts
@@ -290,10 +290,12 @@ export async function searchAcrossSessions(
   const matches: SearchMatch[] = [];
   const matchLimit = MAX_SEARCH_MATCHES; // cap total matches
   const truncatedSessions: string[] = [];
+  let sessionsActuallySearched = 0;
 
   for (const entry of traces) {
     if (matches.length >= matchLimit) break;
     const { content, truncated } = await readTraceSafe(entry.tracePath);
+    sessionsActuallySearched++;
     if (truncated) truncatedSessions.push(entry.sessionId);
     for (const line of content.split('\n')) {
       if (matches.length >= matchLimit) break;
@@ -318,7 +320,7 @@ export async function searchAcrossSessions(
   return {
     query: params.query,
     sessionsAvailable,
-    sessionsSearched: traces.length,
+    sessionsSearched: sessionsActuallySearched,
     matches,
     ...(truncatedSessions.length > 0 ? { truncatedSessions } : {}),
   };

--- a/src/agent/tools/handlers/witness.query.ts
+++ b/src/agent/tools/handlers/witness.query.ts
@@ -17,19 +17,16 @@
  */
 
 import { existsSync } from 'node:fs';
-import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { getTraceDir } from '../../../paths.js';
 import { readLedger } from '../../session-ledger.js';
 import { listTraces, resolveLatestSession } from '../../trace/listing.js';
 import type { TraceEvent } from '../../trace/index.js';
+import { readTraceSafe } from './witness.query.io.js';
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
-
-/** Max bytes to read from a single trace file. Prevents OOM on huge traces. */
-const MAX_READ_BYTES = 2_097_152; // 2 MB
 
 /** Default event limit per query. */
 const DEFAULT_LIMIT = 50;
@@ -75,33 +72,6 @@ function parseEvents(content: string): TraceEvent[] {
     }
   }
   return events;
-}
-
-/** Result from readTraceSafe: content and whether the file was byte-capped. */
-interface ReadTraceSafeResult {
-  content: string;
-  truncated: boolean;
-}
-
-/** Read a trace.jsonl file with a byte-size cap (async). */
-async function readTraceSafe(tracePath: string): Promise<ReadTraceSafeResult> {
-  if (!existsSync(tracePath)) return { content: '', truncated: false };
-  try {
-    const buf = await readFile(tracePath);
-    if (buf.length <= MAX_READ_BYTES) {
-      return { content: buf.toString('utf-8'), truncated: false };
-    }
-    // Slice from the tail then align to the next newline boundary to avoid
-    // splitting a multi-byte UTF-8 sequence or a partial JSON object.
-    let capped = buf.subarray(buf.length - MAX_READ_BYTES);
-    const firstNewline = capped.indexOf(0x0a);
-    if (firstNewline !== -1) {
-      capped = capped.subarray(firstNewline + 1);
-    }
-    return { content: capped.toString('utf-8'), truncated: true };
-  } catch {
-    return { content: '', truncated: false };
-  }
 }
 
 /** Clamp a limit value to [1, MAX_LIMIT], defaulting to DEFAULT_LIMIT. */

--- a/src/agent/tools/handlers/witness.query.ts
+++ b/src/agent/tools/handlers/witness.query.ts
@@ -35,7 +35,10 @@ const MAX_READ_BYTES = 2_097_152; // 2 MB
 const DEFAULT_LIMIT = 50;
 
 /** Hard ceiling on events returned. */
-const MAX_LIMIT = 200;
+export const MAX_LIMIT = 200;
+
+/** Hard ceiling on total matches returned by cross-session search. */
+export const MAX_SEARCH_MATCHES = 200;
 
 /** Default number of sessions to scan for cross-session search. */
 const DEFAULT_SESSION_COUNT = 20;
@@ -74,13 +77,19 @@ function parseEvents(content: string): TraceEvent[] {
   return events;
 }
 
+/** Result from readTraceSafe: content and whether the file was byte-capped. */
+interface ReadTraceSafeResult {
+  content: string;
+  truncated: boolean;
+}
+
 /** Read a trace.jsonl file with a byte-size cap (async). */
-async function readTraceSafe(tracePath: string): Promise<string> {
-  if (!existsSync(tracePath)) return '';
+async function readTraceSafe(tracePath: string): Promise<ReadTraceSafeResult> {
+  if (!existsSync(tracePath)) return { content: '', truncated: false };
   try {
     const buf = await readFile(tracePath);
     if (buf.length <= MAX_READ_BYTES) {
-      return buf.toString('utf-8');
+      return { content: buf.toString('utf-8'), truncated: false };
     }
     // Slice from the tail then align to the next newline boundary to avoid
     // splitting a multi-byte UTF-8 sequence or a partial JSON object.
@@ -89,9 +98,9 @@ async function readTraceSafe(tracePath: string): Promise<string> {
     if (firstNewline !== -1) {
       capped = capped.subarray(firstNewline + 1);
     }
-    return capped.toString('utf-8');
+    return { content: capped.toString('utf-8'), truncated: true };
   } catch {
-    return '';
+    return { content: '', truncated: false };
   }
 }
 
@@ -210,7 +219,7 @@ export async function readSessionTrace(
     }
   }
 
-  const content = await readTraceSafe(tracePath);
+  const { content } = await readTraceSafe(tracePath);
   const allEvents = parseEvents(content);
 
   const filter: EventFilter = {
@@ -262,8 +271,26 @@ export interface SearchMatch {
 
 export interface SearchWitnessResult {
   query: string;
-  sessionsScanned: number;
+  /**
+   * Sessions in the requested window (top-N slice) before the `since` date
+   * filter was applied. Use this to tell "few sessions exist" from "the date
+   * filter excluded most of them".
+   */
+  sessionsAvailable: number;
+  /**
+   * Sessions actually read (after both the top-N slice and any `since` filter).
+   * Renamed from the previous `sessionsScanned` which only reported this
+   * post-filter count, making it indistinguishable from "only N sessions exist".
+   */
+  sessionsSearched: number;
   matches: SearchMatch[];
+  /**
+   * Session IDs whose trace files exceeded the 2 MB per-session read cap.
+   * Events before the cap boundary are not visible to this search; matches
+   * may be incomplete for these sessions. Only present when at least one
+   * session was truncated.
+   */
+  truncatedSessions?: string[];
 }
 
 export async function searchAcrossSessions(
@@ -274,24 +301,30 @@ export async function searchAcrossSessions(
 
   // Slice first (N most recent sessions per schema semantics), then filter by
   // date — so `sessions` means "most recent N", not "N within the date window".
-  let traces = allTraces.slice(0, sessionCount);
+  const sliced = allTraces.slice(0, sessionCount);
+  // Capture the pre-filter count so callers can distinguish "few sessions
+  // exist" from "the since filter excluded most of them".
+  const sessionsAvailable = sliced.length;
 
+  let traces = sliced;
   if (params.since) {
     const sinceMs = Date.parse(params.since);
     if (Number.isNaN(sinceMs)) {
       throw new Error(`Invalid "since" date: ${params.since}`);
     }
-    traces = traces.filter((t) => t.mtimeMs >= sinceMs);
+    traces = sliced.filter((t) => t.mtimeMs >= sinceMs);
   }
 
   const kindFilter = params.kinds ? new Set(params.kinds) : undefined;
   const queryLower = params.query.toLowerCase();
   const matches: SearchMatch[] = [];
-  const matchLimit = MAX_LIMIT; // cap total matches
+  const matchLimit = MAX_SEARCH_MATCHES; // cap total matches
+  const truncatedSessions: string[] = [];
 
   for (const entry of traces) {
     if (matches.length >= matchLimit) break;
-    const content = await readTraceSafe(entry.tracePath);
+    const { content, truncated } = await readTraceSafe(entry.tracePath);
+    if (truncated) truncatedSessions.push(entry.sessionId);
     for (const line of content.split('\n')) {
       if (matches.length >= matchLimit) break;
       if (line.trim() === '') continue;
@@ -314,7 +347,9 @@ export async function searchAcrossSessions(
 
   return {
     query: params.query,
-    sessionsScanned: traces.length,
+    sessionsAvailable,
+    sessionsSearched: traces.length,
     matches,
+    ...(truncatedSessions.length > 0 ? { truncatedSessions } : {}),
   };
 }

--- a/src/agent/tools/schemas.witness.ts
+++ b/src/agent/tools/schemas.witness.ts
@@ -62,7 +62,7 @@ export const searchWitnessTool: AnthropicToolDef = {
     'Search across multiple sessions\' witness traces for a text pattern. Returns matching ' +
     'trace events grouped by session. Use to find patterns across sessions — recurring errors, ' +
     'specific tool usage, cost spikes, or any text that appears in trace event payloads. ' +
-    'Scans the N most recent sessions (default 20).',
+    'Scans the N most recent sessions (default 20). Results are capped at 200 total matches.',
   input_schema: {
     type: 'object',
     properties: {
@@ -72,7 +72,12 @@ export const searchWitnessTool: AnthropicToolDef = {
       },
       sessions: {
         type: 'number',
-        description: 'Number of recent sessions to scan (default: 20, max: 100).',
+        description:
+          'Number of recent sessions to scan (default: 20, max: 100). ' +
+          'The result includes sessionsAvailable (sessions in this window before ' +
+          'any since filter) and sessionsSearched (sessions actually read after ' +
+          'the since filter) so you can distinguish "few sessions exist" from ' +
+          '"the date filter excluded most of them".',
       },
       kinds: {
         type: 'array',

--- a/src/cli/commands/witness.ts
+++ b/src/cli/commands/witness.ts
@@ -101,7 +101,7 @@ export function registerWitnessCommand(program: Command): void {
         }
 
         console.log(
-          `Search: "${result.query}"  (${result.sessionsScanned} sessions scanned, ` +
+          `Search: "${result.query}"  (${result.sessionsSearched} sessions scanned, ` +
             `${result.matches.length} matches)\n`,
         );
 


### PR DESCRIPTION
## Summary

When `search_witness` searches across sessions, `readTraceSafe` silently truncates traces exceeding 2 MB (takes the tail). Callers had no way to distinguish "pattern not found" from "pattern exists but was in the truncated head." This PR surfaces that truncation.

Closes #1036

**Depends on #1041 (MAX_SEARCH_MATCHES separation)** — merge #1041 first.

## Changes

- `src/agent/tools/handlers/witness.query.io.ts` — **new** extracted sibling containing `readTraceSafe` + `ReadTraceSafeResult` + `MAX_READ_BYTES` (required to keep `witness.query.ts` under the 350-line ceiling)
- `src/agent/tools/handlers/witness.query.ts` — imports `readTraceSafe` from `.io` sibling; adds `truncatedSessions?: string[]` to `SearchWitnessResult`; collects truncated session IDs during search
- `src/agent/tools/handlers/witness.query.test.ts` — 3 new tests covering truncation detection
- `src/agent/tools/schemas.witness.ts` — documents the 2 MB per-session cap and `truncatedSessions` field

## Interface change (backward compatible)

```ts
interface SearchWitnessResult {
  // ... existing fields
  truncatedSessions?: string[];  // session IDs where the 2MB cap applied
}
```

Existing consumers that don't destructure `truncatedSessions` are unaffected.
