### PR TITLE
fix(witness): disambiguate sessionsScanned vs filtered count (#1035)

### DIFF
--- a/src/agent/tools/handlers/witness.query.test.ts
+++ b/src/agent/tools/handlers/witness.query.test.ts
@@ -275,7 +275,7 @@ describe('searchAcrossSessions — invalid since date', () => {
     // No sessions in temp home, so result is empty — but must not throw.
     await expect(
       searchAcrossSessions({ query: 'x', since: '2024-01-01' }),
-    ).resolves.toMatchObject({ query: 'x', sessionsScanned: 0 });
+    ).resolves.toMatchObject({ query: 'x', sessionsSearched: 0 });
   });
 });
 
@@ -300,6 +300,6 @@ describe('searchAcrossSessions — sessions/since ordering', () => {
       since: '2000-01-01',
     });
     // At most 1 session can be scanned (sessions slice applied first)
-    expect(result.sessionsScanned).toBeLessThanOrEqual(1);
+    expect(result.sessionsSearched).toBeLessThanOrEqual(1);
   });
 });

--- a/src/agent/tools/handlers/witness.query.test.ts
+++ b/src/agent/tools/handlers/witness.query.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { mkdtemp, mkdir, writeFile, rm, utimes } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { clampLimit, clampSessions, readSessionTrace, searchAcrossSessions } from './witness.query.js';
@@ -301,5 +301,28 @@ describe('searchAcrossSessions — sessions/since ordering', () => {
     });
     // At most 1 session can be scanned (sessions slice applied first)
     expect(result.sessionsSearched).toBeLessThanOrEqual(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// searchAcrossSessions — sessions searched stops at match cap
+// ---------------------------------------------------------------------------
+
+describe('searchAcrossSessions — match cap', () => {
+  it('counts only sessions reached before the match cap', async () => {
+    const olderTrace = await writeTrace('session-older', [makeEventLine('closure', 1, { text: 'needle' })]);
+    const cappedTrace = await writeTrace(
+      'session-capped',
+      Array.from({ length: 200 }, (_, index) => makeEventLine('closure', index + 1, { text: 'needle' })),
+    );
+    await utimes(olderTrace, new Date('2024-01-01'), new Date('2024-01-01'));
+    await utimes(cappedTrace, new Date('2024-01-02'), new Date('2024-01-02'));
+
+    const result = await searchAcrossSessions({ query: 'needle', sessions: 2 });
+
+    expect(result.sessionsAvailable).toBe(2);
+    expect(result.sessionsSearched).toBe(1);
+    expect(result.matches).toHaveLength(200);
+    expect(new Set(result.matches.map((match) => match.sessionId))).toEqual(new Set(['session-capped']));
   });
 });

--- a/src/agent/tools/handlers/witness.query.ts
+++ b/src/agent/tools/handlers/witness.query.ts
@@ -295,9 +295,11 @@ export async function searchAcrossSessions(
   const queryLower = params.query.toLowerCase();
   const matches: SearchMatch[] = [];
   const matchLimit = MAX_LIMIT; // cap total matches
+  let sessionsSearched = 0;
 
   for (const entry of traces) {
     if (matches.length >= matchLimit) break;
+    sessionsSearched += 1;
     const content = await readTraceSafe(entry.tracePath);
     for (const line of content.split('\n')) {
       if (matches.length >= matchLimit) break;
@@ -322,7 +324,7 @@ export async function searchAcrossSessions(
   return {
     query: params.query,
     sessionsAvailable,
-    sessionsSearched: traces.length,
+    sessionsSearched,
     matches,
   };
 }

--- a/src/agent/tools/handlers/witness.query.ts
+++ b/src/agent/tools/handlers/witness.query.ts
@@ -262,7 +262,10 @@ export interface SearchMatch {
 
 export interface SearchWitnessResult {
   query: string;
-  sessionsScanned: number;
+  /** Total sessions in the requested window (before any `since` date filter). */
+  sessionsAvailable: number;
+  /** Sessions actually read/searched (after the `since` date filter was applied). */
+  sessionsSearched: number;
   matches: SearchMatch[];
 }
 
@@ -275,6 +278,10 @@ export async function searchAcrossSessions(
   // Slice first (N most recent sessions per schema semantics), then filter by
   // date — so `sessions` means "most recent N", not "N within the date window".
   let traces = allTraces.slice(0, sessionCount);
+
+  // Capture pre-filter count so callers can distinguish "no sessions exist" from
+  // "sessions exist but none fall within the requested date window".
+  const sessionsAvailable = traces.length;
 
   if (params.since) {
     const sinceMs = Date.parse(params.since);
@@ -314,7 +321,8 @@ export async function searchAcrossSessions(
 
   return {
     query: params.query,
-    sessionsScanned: traces.length,
+    sessionsAvailable,
+    sessionsSearched: traces.length,
     matches,
   };
 }

--- a/src/agent/tools/schemas.witness.ts
+++ b/src/agent/tools/schemas.witness.ts
@@ -62,7 +62,9 @@ export const searchWitnessTool: AnthropicToolDef = {
     'Search across multiple sessions\' witness traces for a text pattern. Returns matching ' +
     'trace events grouped by session. Use to find patterns across sessions — recurring errors, ' +
     'specific tool usage, cost spikes, or any text that appears in trace event payloads. ' +
-    'Scans the N most recent sessions (default 20).',
+    'Scans the N most recent sessions (default 20). Result includes sessionsAvailable (sessions ' +
+    'in the requested window before any since filter) and sessionsSearched (sessions actually ' +
+    'read after the since filter); when these differ, some sessions were excluded by the date filter.',
   input_schema: {
     type: 'object',
     properties: {

--- a/src/cli/commands/witness.ts
+++ b/src/cli/commands/witness.ts
@@ -100,8 +100,11 @@ export function registerWitnessCommand(program: Command): void {
           return;
         }
 
+        const sessionsSummary = result.sessionsSearched === result.sessionsAvailable
+          ? `${result.sessionsSearched} sessions searched`
+          : `${result.sessionsSearched}/${result.sessionsAvailable} sessions searched`;
         console.log(
-          `Search: "${result.query}"  (${result.sessionsScanned} sessions scanned, ` +
+          `Search: "${result.query}"  (${sessionsSummary}, ` +
             `${result.matches.length} matches)\n`,
         );
 


### PR DESCRIPTION
## Summary

`searchAcrossSessions` returned `sessionsScanned: traces.length` after the `since` date filter had already been applied. A caller requesting 50 sessions with a `since` filter that narrowed to 3 got `sessionsScanned: 3` — indistinguishable from "only 3 sessions exist."

Now returns both counts so callers can see the full picture.

Closes #1035

## Changes

- `src/agent/tools/handlers/witness.query.ts` — `SearchWitnessResult` gains `sessionsAvailable` (pre-filter count) and renames `sessionsScanned` → `sessionsSearched` (post-filter count, sessions actually read)
- `src/agent/tools/handlers/witness.query.test.ts` — updated assertions for new field names
- `src/agent/tools/schemas.witness.ts` — documents both counts in the schema description
- `src/cli/commands/witness.ts` — display now shows "3/20 sessions searched" when counts differ

## Interface change

```ts
// Before
sessionsScanned: number;

// After
sessionsAvailable: number;   // pre-filter (sessions in the requested window)
sessionsSearched: number;    // post-filter (sessions actually read after since filter)
```
