### PR TITLE
fix(witness): track pre/post-filter session counts in search_witness (#1035)

### DIFF
--- a/src/agent/tools/handlers/witness.query.test.ts
+++ b/src/agent/tools/handlers/witness.query.test.ts
@@ -275,7 +275,7 @@ describe('searchAcrossSessions — invalid since date', () => {
     // No sessions in temp home, so result is empty — but must not throw.
     await expect(
       searchAcrossSessions({ query: 'x', since: '2024-01-01' }),
-    ).resolves.toMatchObject({ query: 'x', sessionsScanned: 0 });
+    ).resolves.toMatchObject({ query: 'x', sessionsScanned: 0, sessionsMatchedDateFilter: 0 });
   });
 });
 
@@ -299,7 +299,67 @@ describe('searchAcrossSessions — sessions/since ordering', () => {
       sessions: 1,
       since: '2000-01-01',
     });
-    // At most 1 session can be scanned (sessions slice applied first)
-    expect(result.sessionsScanned).toBeLessThanOrEqual(1);
+    // sessions slice is applied BEFORE the date filter, so sessionsScanned is the
+    // pre-filter count (1 — from the sessions:1 cap), not the post-filter count.
+    expect(result.sessionsScanned).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// searchAcrossSessions — pre/post-filter session count tracking (#1035)
+// ---------------------------------------------------------------------------
+
+describe('searchAcrossSessions — sessionsScanned vs sessionsMatchedDateFilter', () => {
+  it('sessionsScanned reflects pre-filter count; sessionsMatchedDateFilter reflects post-filter count', async () => {
+    // Write 3 sessions. We will filter by a future date so none survive the since gate.
+    await writeTrace('scan-session-a', [
+      makeEventLine('closure', 1, { reason: 'end_turn', finalCostUsd: 0, finalTurnCount: 1 }),
+    ]);
+    await writeTrace('scan-session-b', [
+      makeEventLine('closure', 1, { reason: 'end_turn', finalCostUsd: 0, finalTurnCount: 1 }),
+    ]);
+    await writeTrace('scan-session-c', [
+      makeEventLine('closure', 1, { reason: 'end_turn', finalCostUsd: 0, finalTurnCount: 1 }),
+    ]);
+
+    // Use a far-future date so all sessions fail the since filter.
+    const result = await searchAcrossSessions({
+      query: 'end_turn',
+      sessions: 50,
+      since: '2099-01-01',
+    });
+
+    // sessionsScanned must equal the number of trace dirs found (3), NOT 0.
+    expect(result.sessionsScanned).toBe(3);
+    // sessionsMatchedDateFilter must be 0 — none survived the future date gate.
+    expect(result.sessionsMatchedDateFilter).toBe(0);
+  });
+
+  it('sessionsMatchedDateFilter is undefined when no since filter is used', async () => {
+    await writeTrace('no-filter-session', [
+      makeEventLine('closure', 1, { reason: 'end_turn', finalCostUsd: 0, finalTurnCount: 1 }),
+    ]);
+
+    const result = await searchAcrossSessions({ query: 'end_turn' });
+
+    expect(result.sessionsScanned).toBeGreaterThanOrEqual(1);
+    // Key assertion: field must be absent when since is not supplied.
+    expect(result.sessionsMatchedDateFilter).toBeUndefined();
+  });
+
+  it('sessionsMatchedDateFilter equals sessionsScanned when all sessions pass the since filter', async () => {
+    await writeTrace('old-enough-session', [
+      makeEventLine('closure', 1, { reason: 'end_turn', finalCostUsd: 0, finalTurnCount: 1 }),
+    ]);
+
+    // Use a very old since date so every session passes the gate.
+    const result = await searchAcrossSessions({
+      query: 'end_turn',
+      since: '2000-01-01',
+    });
+
+    expect(result.sessionsScanned).toBeGreaterThanOrEqual(1);
+    // All sessions survived, so post-filter == pre-filter.
+    expect(result.sessionsMatchedDateFilter).toBe(result.sessionsScanned);
   });
 });

--- a/src/agent/tools/handlers/witness.query.ts
+++ b/src/agent/tools/handlers/witness.query.ts
@@ -262,7 +262,14 @@ export interface SearchMatch {
 
 export interface SearchWitnessResult {
   query: string;
+  /** How many session traces were read from disk (before the `since` date filter). */
   sessionsScanned: number;
+  /**
+   * How many of those sessions survived the `since` date gate.
+   * Only present when a `since` filter was supplied; omitted otherwise so
+   * callers can distinguish "no filter used" from "all passed the filter".
+   */
+  sessionsMatchedDateFilter?: number;
   matches: SearchMatch[];
 }
 
@@ -274,7 +281,11 @@ export async function searchAcrossSessions(
 
   // Slice first (N most recent sessions per schema semantics), then filter by
   // date — so `sessions` means "most recent N", not "N within the date window".
-  let traces = allTraces.slice(0, sessionCount);
+  const tracesBeforeFilter = allTraces.slice(0, sessionCount);
+  const preFilterCount = tracesBeforeFilter.length;
+
+  let traces = tracesBeforeFilter;
+  let postFilterCount: number | undefined;
 
   if (params.since) {
     const sinceMs = Date.parse(params.since);
@@ -282,6 +293,7 @@ export async function searchAcrossSessions(
       throw new Error(`Invalid "since" date: ${params.since}`);
     }
     traces = traces.filter((t) => t.mtimeMs >= sinceMs);
+    postFilterCount = traces.length;
   }
 
   const kindFilter = params.kinds ? new Set(params.kinds) : undefined;
@@ -312,9 +324,13 @@ export async function searchAcrossSessions(
     }
   }
 
-  return {
+  const result: SearchWitnessResult = {
     query: params.query,
-    sessionsScanned: traces.length,
+    sessionsScanned: preFilterCount,
     matches,
   };
+  if (postFilterCount !== undefined) {
+    result.sessionsMatchedDateFilter = postFilterCount;
+  }
+  return result;
 }

--- a/src/agent/tools/schemas.witness.ts
+++ b/src/agent/tools/schemas.witness.ts
@@ -62,7 +62,10 @@ export const searchWitnessTool: AnthropicToolDef = {
     'Search across multiple sessions\' witness traces for a text pattern. Returns matching ' +
     'trace events grouped by session. Use to find patterns across sessions — recurring errors, ' +
     'specific tool usage, cost spikes, or any text that appears in trace event payloads. ' +
-    'Scans the N most recent sessions (default 20).',
+    'Scans the N most recent sessions (default 20). ' +
+    'Result fields: sessionsScanned = sessions read from disk before the since date filter; ' +
+    'sessionsMatchedDateFilter = sessions that survived the since gate (only present when ' +
+    'since is supplied).',
   input_schema: {
     type: 'object',
     properties: {


### PR DESCRIPTION
## Problem

`searchAcrossSessions` returns `sessionsScanned: traces.length` **after** the `since` date filter has already been applied. A caller requesting `sessions: 50, since: "2026-01-01"` that finds 3 sessions in the date range gets `sessionsScanned: 3` — indistinguishable from "only 3 sessions exist."

## Fix

Track both counts in `SearchWitnessResult`:
- `sessionsScanned` — pre-filter count (how many session traces were read from disk)
- `sessionsMatchedDateFilter` — post-`since`-filter count (only present when `since` was used)

Updated schema description in `schemas.witness.ts` to document both fields.

## Changes

- `src/agent/tools/handlers/witness.query.ts` — capture pre-filter count before the `since` filter runs; add `sessionsMatchedDateFilter` to result type and return value
- `src/agent/tools/schemas.witness.ts` — document both result fields
- `src/agent/tools/handlers/witness.query.test.ts` — 3 new tests + fixed existing assertion

## Test Results

25/25 tests pass. `pnpm lint` clean.

Closes #1035
