### PR TITLE
feat(witness): surface truncated sessions in search_witness results (#1036)

### DIFF
--- a/src/agent/tools/handlers/witness.query.test.ts
+++ b/src/agent/tools/handlers/witness.query.test.ts
@@ -303,3 +303,68 @@ describe('searchAcrossSessions — sessions/since ordering', () => {
     expect(result.sessionsScanned).toBeLessThanOrEqual(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// searchAcrossSessions — truncation signal (#1036)
+// ---------------------------------------------------------------------------
+
+describe('searchAcrossSessions — truncation signal', () => {
+  /**
+   * Build a trace file that exceeds the 2 MB cap by writing many event lines.
+   * We do this by creating a large payload string on each event.
+   */
+  async function writeLargeTrace(sessionId: string, searchToken: string): Promise<void> {
+    const dir = join(tmpHome, 'state', 'witness', sessionId);
+    await mkdir(dir, { recursive: true });
+    const tracePath = join(dir, 'trace.jsonl');
+
+    // Write enough bytes to exceed MAX_READ_BYTES (2_097_152).
+    // Each line is ~2100 bytes; 1100 lines ≈ 2.31 MB.
+    const lines: string[] = [];
+    const filler = 'x'.repeat(2000);
+    for (let i = 0; i < 1100; i++) {
+      lines.push(
+        JSON.stringify({
+          kind: 'tool_call',
+          seq: i,
+          ts: new Date().toISOString(),
+          payload: { name: 'bash', filler, searchToken: i === 0 ? searchToken : 'nope' },
+        }),
+      );
+    }
+    // The searchable event is at the very beginning — it will be sliced off.
+    const { writeFile: wf } = await import('node:fs/promises');
+    await wf(tracePath, lines.join('\n') + '\n', 'utf-8');
+  }
+
+  it('populates truncatedSessions when a trace exceeds the 2 MB cap', async () => {
+    const sessionId = 'large-trace-session';
+    // Write a trace that is guaranteed to exceed 2 MB.
+    await writeLargeTrace(sessionId, 'unique-needle-xyz');
+
+    // Query for a token that appears in a line near the tail (not the head)
+    // so we can confirm the file was read at all, then separately check truncation.
+    const result = await searchAcrossSessions({ query: 'bash', sessions: 5 });
+
+    expect(result.truncatedSessions).toBeDefined();
+    expect(result.truncatedSessions).toContain(sessionId);
+  });
+
+  it('does NOT include truncatedSessions when all traces fit within 2 MB', async () => {
+    const sessionId = 'small-trace-session';
+    await writeTrace(sessionId, [
+      makeEventLine('closure', 1, { reason: 'end_turn', finalCostUsd: 0, finalTurnCount: 1 }),
+    ]);
+
+    const result = await searchAcrossSessions({ query: 'end_turn', sessions: 5 });
+
+    // truncatedSessions should be absent (undefined), not an empty array.
+    expect(result.truncatedSessions).toBeUndefined();
+  });
+
+  it('truncatedSessions is absent (undefined) when no sessions are truncated', async () => {
+    // Empty witness dir — no sessions at all.
+    const result = await searchAcrossSessions({ query: 'anything', sessions: 5 });
+    expect(result.truncatedSessions).toBeUndefined();
+  });
+});

--- a/src/agent/tools/handlers/witness.query.ts
+++ b/src/agent/tools/handlers/witness.query.ts
@@ -74,13 +74,20 @@ function parseEvents(content: string): TraceEvent[] {
   return events;
 }
 
+/** Result type for `readTraceSafe`, including truncation signal. */
+interface ReadTraceSafeResult {
+  content: string;
+  /** True when the file exceeded MAX_READ_BYTES and only the tail was read. */
+  truncated: boolean;
+}
+
 /** Read a trace.jsonl file with a byte-size cap (async). */
-async function readTraceSafe(tracePath: string): Promise<string> {
-  if (!existsSync(tracePath)) return '';
+async function readTraceSafe(tracePath: string): Promise<ReadTraceSafeResult> {
+  if (!existsSync(tracePath)) return { content: '', truncated: false };
   try {
     const buf = await readFile(tracePath);
     if (buf.length <= MAX_READ_BYTES) {
-      return buf.toString('utf-8');
+      return { content: buf.toString('utf-8'), truncated: false };
     }
     // Slice from the tail then align to the next newline boundary to avoid
     // splitting a multi-byte UTF-8 sequence or a partial JSON object.
@@ -89,9 +96,9 @@ async function readTraceSafe(tracePath: string): Promise<string> {
     if (firstNewline !== -1) {
       capped = capped.subarray(firstNewline + 1);
     }
-    return capped.toString('utf-8');
+    return { content: capped.toString('utf-8'), truncated: true };
   } catch {
-    return '';
+    return { content: '', truncated: false };
   }
 }
 
@@ -210,7 +217,7 @@ export async function readSessionTrace(
     }
   }
 
-  const content = await readTraceSafe(tracePath);
+  const { content } = await readTraceSafe(tracePath);
   const allEvents = parseEvents(content);
 
   const filter: EventFilter = {
@@ -264,6 +271,12 @@ export interface SearchWitnessResult {
   query: string;
   sessionsScanned: number;
   matches: SearchMatch[];
+  /**
+   * Session IDs where the trace file exceeded the 2 MB read cap.
+   * Events from the earlier portion of those traces were not searched.
+   * Present only when at least one session was truncated.
+   */
+  truncatedSessions?: string[];
 }
 
 export async function searchAcrossSessions(
@@ -287,11 +300,13 @@ export async function searchAcrossSessions(
   const kindFilter = params.kinds ? new Set(params.kinds) : undefined;
   const queryLower = params.query.toLowerCase();
   const matches: SearchMatch[] = [];
+  const truncatedSessions: string[] = [];
   const matchLimit = MAX_LIMIT; // cap total matches
 
   for (const entry of traces) {
     if (matches.length >= matchLimit) break;
-    const content = await readTraceSafe(entry.tracePath);
+    const { content, truncated } = await readTraceSafe(entry.tracePath);
+    if (truncated) truncatedSessions.push(entry.sessionId);
     for (const line of content.split('\n')) {
       if (matches.length >= matchLimit) break;
       if (line.trim() === '') continue;
@@ -316,5 +331,6 @@ export async function searchAcrossSessions(
     query: params.query,
     sessionsScanned: traces.length,
     matches,
+    ...(truncatedSessions.length > 0 && { truncatedSessions }),
   };
 }

--- a/src/agent/tools/schemas.witness.ts
+++ b/src/agent/tools/schemas.witness.ts
@@ -62,7 +62,10 @@ export const searchWitnessTool: AnthropicToolDef = {
     'Search across multiple sessions\' witness traces for a text pattern. Returns matching ' +
     'trace events grouped by session. Use to find patterns across sessions — recurring errors, ' +
     'specific tool usage, cost spikes, or any text that appears in trace event payloads. ' +
-    'Scans the N most recent sessions (default 20).',
+    'Scans the N most recent sessions (default 20). Each session trace is capped at 2 MB ' +
+    '(tail-slice); when a trace exceeds this limit only its most recent events are searched. ' +
+    'The result includes a `truncatedSessions` array listing any session IDs where the ' +
+    '2 MB cap was hit, so callers can detect incomplete coverage.',
   input_schema: {
     type: 'object',
     properties: {


### PR DESCRIPTION
## Problem

`searchAcrossSessions` uses `readTraceSafe` which caps reads at 2 MB (tail slice). When a trace exceeds 2 MB, events in the first portion are silently dropped from search results. There is no signal to callers that coverage was incomplete, so they cannot distinguish "pattern not found" from "pattern exists but was in the truncated portion."

## Fix

- Changed `readTraceSafe` to return `{ content: string; truncated: boolean }` instead of just a string
- Added `truncatedSessions?: string[]` to `SearchWitnessResult`, populated with session IDs where the trace was truncated
- Updated both callers (`readSessionTrace`, `searchAcrossSessions`) for the new return type
- The field is absent (not empty array) when no truncation occurs

## Changes

- `src/agent/tools/handlers/witness.query.ts` — new `ReadTraceSafeResult` type, updated callers, `truncatedSessions` in result
- `src/agent/tools/schemas.witness.ts` — documented 2 MB cap and `truncatedSessions` field
- `src/agent/tools/handlers/witness.query.test.ts` — 3 new tests (large trace truncation, small trace no truncation, empty dir)

## Test Results

25/25 tests pass. `pnpm lint` clean.

Closes #1036
