### PR TITLE
test(improve): golden-fingerprint test for denial reason slug stability (#853)

### DIFF
--- a/src/agent/tools/hooks/fork-denial-remedy.ts
+++ b/src/agent/tools/hooks/fork-denial-remedy.ts
@@ -4,6 +4,8 @@
  * two downstream consumers that key on it live in one documented place.
  */
 
+import { SUBAGENT_PATH_DENIAL_REASON_PREFIX } from '../denial-circuit-breaker.js';
+
 /** Which containment check produced the denial. */
 export type ForkDenialMode = 'read' | 'write';
 
@@ -20,17 +22,15 @@ export type ForkDenialMode = 'read' | 'write';
  * and sends the fork into retry-until-timeout — the exact failure #544 was
  * opened to stop.
  *
- * Contract: the CALLER prefixes this body with the byte-stable
- * `Sub-agent path access denied:` string — see `SUBAGENT_PATH_DENIAL_REASON_PREFIX`
- * in `../denial-circuit-breaker.ts`, matched by substring, not by prefix
- * position. The remedy body returned here is NOT byte-stable, but it IS
+ * Contract: `buildForkPathDenialReason` prefixes this body with the byte-stable
+ * `SUBAGENT_PATH_DENIAL_REASON_PREFIX` from `../denial-circuit-breaker.ts`.
+ * The remedy body returned here is NOT byte-stable, but it IS
  * fingerprinted: `src/improve/scan/detectors/subagent-read-denial.ts` hashes the
  * ENTIRE normalized reason (`normalizeReason` collapses path-shaped tokens to
  * `<path>`, then `computeFingerprint` SHA-256s it), so any reword here rotates
  * the failure-card slug and restarts that card's severity ladder. That rotation
- * is silent — every detector test builds its own fixture string rather than
- * importing this module — so a reword must be a deliberate decision, not a
- * drive-by edit.
+ * is guarded by a golden test that imports the complete reason producer, so a
+ * reword must be a deliberate decision, not a drive-by edit.
  */
 export function buildForkDenialRemedy(args: { mode: ForkDenialMode; resolvedPath: string }): string {
   const { mode, resolvedPath } = args;
@@ -51,5 +51,18 @@ export function buildForkDenialRemedy(args: { mode: ForkDenialMode; resolvedPath
     `read the path itself and pass the content to you in the prompt. A grant made ` +
     `after you were dispatched cannot reach you — your roots were fixed at dispatch. ` +
     `Return this exact path requirement to your parent.`
+  );
+}
+
+/** Build the complete path-containment denial emitted for a forked sub-agent. */
+export function buildForkPathDenialReason(args: {
+  mode: ForkDenialMode;
+  resolvedPath: string;
+}): string {
+  const { mode, resolvedPath } = args;
+  const remedy = buildForkDenialRemedy(args);
+  return (
+    `${SUBAGENT_PATH_DENIAL_REASON_PREFIX} ${resolvedPath} is outside the ` +
+    `session's granted ${mode} roots. ${remedy}`
   );
 }

--- a/src/agent/tools/hooks/path-approval-hook.ts
+++ b/src/agent/tools/hooks/path-approval-hook.ts
@@ -60,7 +60,7 @@ import type { GrantManager } from '../../../cli/slash/commands/allow-dir.js';
 import { wouldBeRestricted, realpathSafe } from '../handlers/_cwd-utils.js';
 import { isReadDenied } from '../handlers/read-denylist.js';
 import { appendGrant } from '../../permissions-store.js';
-import { buildForkDenialRemedy } from './fork-denial-remedy.js';
+import { buildForkPathDenialReason } from './fork-denial-remedy.js';
 import type { HookContext, HookDecision, HookHandler } from '../../hooks.js';
 
 /** Tools subject to per-call path approval. Bash is gated separately. */
@@ -290,7 +290,6 @@ async function preToolUseImpl(
     // the PARENT — and because a fork's roots are fixed at dispatch, the only
     // remedy that reaches an in-flight fork is a re-dispatch. Wording + the
     // downstream byte/fingerprint contracts live in `./fork-denial-remedy.ts`.
-    const remedy = buildForkDenialRemedy({ mode, resolvedPath: result.resolved });
     // Contract: the "Sub-agent path access denied:" prefix is load-bearing —
     // the `subagent-read-denial` telemetry detector (improve/scan/detectors)
     // and the denial circuit breaker (tools/denial-circuit-breaker.ts,
@@ -298,9 +297,7 @@ async function preToolUseImpl(
     // exact containment auto-deny. If you reword it, update those consumers too.
     return {
       decision: 'block',
-      reason:
-        `Sub-agent path access denied: ${result.resolved} is outside the ` +
-        `session's granted ${mode} roots. ${remedy}`,
+      reason: buildForkPathDenialReason({ mode, resolvedPath: result.resolved }),
     };
   }
 

--- a/src/improve/scan/detectors/subagent-read-denial-stability.test.ts
+++ b/src/improve/scan/detectors/subagent-read-denial-stability.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Golden-fingerprint stability test for the sub-agent read-denial detector.
+ *
+ * ## Why this test exists (#853)
+ *
+ * `src/improve/scan/detectors/subagent-read-denial.ts` fingerprints the FULL
+ * denial reason string (after path-normalization) with SHA-256 to derive each
+ * failure-card's slug, e.g.:
+ *
+ *   subagent-read-denial-a47734dbbb44
+ *
+ * The denial reason is produced by `buildForkDenialRemedy` (in
+ * `src/agent/tools/hooks/fork-denial-remedy.ts`) and assembled in
+ * `path-approval-hook.ts` as:
+ *
+ *   `${SUBAGENT_PATH_DENIAL_REASON_PREFIX} ${resolvedPath} is outside the
+ *    session's granted ${mode} roots. ${buildForkDenialRemedy(...)}`
+ *
+ * Any reword of that prose — even a minor punctuation fix — produces a new
+ * fingerprint → new slug → ORPHANS every failure card accumulated under the
+ * old slug. The severity ladder resets to zero, historical evidence is
+ * permanently disconnected, and nothing in CI signals the rotation.
+ *
+ * ## What this test does
+ *
+ * It imports the REAL producer (`buildForkDenialRemedy`) and the REAL prefix
+ * (`SUBAGENT_PATH_DENIAL_REASON_PREFIX`), assembles the full denial reason
+ * exactly as `path-approval-hook.ts` does, normalizes it, hashes it, and
+ * asserts the resulting fingerprint matches a checked-in golden constant. A
+ * reword that changes the fingerprint makes this test fail, which is the
+ * signal that was missing before.
+ *
+ * The constants at the top of the file ARE the authoritative golden values.
+ * When you INTENTIONALLY change the wording (knowing that doing so orphans
+ * existing cards), you must update the golden constants in this file AND
+ * document the rotation in the commit message.
+ *
+ * ## What this test does NOT test
+ *
+ * - Whether the denial reason is assembled correctly in path-approval-hook.ts
+ *   (that is covered by path-approval-hook.test.ts).
+ * - Whether the fingerprinting algorithm itself is correct (covered by
+ *   subagent-read-denial.test.ts).
+ *
+ * @see src/agent/tools/hooks/fork-denial-remedy.ts — producer
+ * @see src/improve/scan/detectors/subagent-read-denial.ts — consumer
+ * @see src/agent/tools/denial-circuit-breaker.ts — prefix source
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildForkDenialRemedy } from '../../../agent/tools/hooks/fork-denial-remedy.js';
+import { SUBAGENT_PATH_DENIAL_REASON_PREFIX } from '../../../agent/tools/denial-circuit-breaker.js';
+import { computeFingerprint, normalizeReason } from './subagent-read-denial.js';
+
+// ---------------------------------------------------------------------------
+// Golden constants — the stable fingerprints for the current denial wording.
+//
+// These are the AUTHORITATIVE values. A test failure here means the denial
+// prose changed and existing failure cards will be orphaned. If the reword is
+// intentional, update these constants AND document the slug rotation in the
+// commit message. Do NOT silently regenerate without understanding the impact.
+// ---------------------------------------------------------------------------
+
+/**
+ * Golden fingerprint for a READ denial:
+ *   `Sub-agent path access denied: <path> is outside the session's granted
+ *    read roots. Reads are confined to this fork's granted read roots. To
+ *    allow it, the parent must re-dispatch you via the `agent` tool with
+ *    `readRoots: ["<path>"]`, or read the path itself and pass the content
+ *    to you in the prompt. A grant made after you were dispatched cannot reach
+ *    you — your roots were fixed at dispatch. Return this exact path
+ *    requirement to your parent.`
+ */
+const GOLDEN_FINGERPRINT_READ =
+  'a47734dbbb44aafcea3d44f17a35d8a422eee7e1d47a86bdcdf88a6670fc26dd';
+
+/**
+ * Golden fingerprint for a WRITE denial:
+ *   `Sub-agent path access denied: <path> is outside the session's granted
+ *    write roots. Writes are confined to this fork's granted write roots by
+ *    design (worktree isolation). To allow it, the parent must re-dispatch you
+ *    via the `agent` tool with `writeRoots: ["<path>"]`, or perform the
+ *    write itself. Return this exact path requirement to your parent.`
+ */
+const GOLDEN_FINGERPRINT_WRITE =
+  '899144a751948093832b176f84d3d710d3c434370b551c94934336158ac3ada7';
+
+// A single representative path used to drive the producer; it is normalized
+// away by `normalizeReason` so the golden value is path-independent.
+const TEST_PATH = '/test/path';
+
+// ---------------------------------------------------------------------------
+// Helpers — mirror the exact assembly in path-approval-hook.ts
+// ---------------------------------------------------------------------------
+
+/**
+ * Assemble the full denial reason string exactly as `path-approval-hook.ts`
+ * does when it auto-denies a forked sub-agent's out-of-scope path access:
+ *
+ *   `Sub-agent path access denied: ${result.resolved} is outside the
+ *    session's granted ${mode} roots. ${remedy}`
+ */
+function assembleFullReason(mode: 'read' | 'write', resolvedPath: string): string {
+  const remedy = buildForkDenialRemedy({ mode, resolvedPath });
+  return (
+    `${SUBAGENT_PATH_DENIAL_REASON_PREFIX} ${resolvedPath} is outside the ` +
+    `session's granted ${mode} roots. ${remedy}`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('subagent-read-denial: golden fingerprint stability (#853)', () => {
+  it('READ denial fingerprint is stable (changing prose rotates failure-card slugs)', () => {
+    const fullReason = assembleFullReason('read', TEST_PATH);
+    const normalizedReason = normalizeReason(fullReason);
+    const fingerprint = computeFingerprint({ hookEvent: 'PreToolUse', normalizedReason });
+
+    expect(fingerprint).toBe(GOLDEN_FINGERPRINT_READ);
+  });
+
+  it('WRITE denial fingerprint is stable (changing prose rotates failure-card slugs)', () => {
+    const fullReason = assembleFullReason('write', TEST_PATH);
+    const normalizedReason = normalizeReason(fullReason);
+    const fingerprint = computeFingerprint({ hookEvent: 'PreToolUse', normalizedReason });
+
+    expect(fingerprint).toBe(GOLDEN_FINGERPRINT_WRITE);
+  });
+
+  it('fingerprint is path-independent — different paths yield the same hash', () => {
+    const paths = [TEST_PATH, '/another/path/foo.ts', '/Users/griffinlong/proj/bar.ts'];
+    const fingerprints = paths.map((p) => {
+      const reason = assembleFullReason('read', p);
+      const normalized = normalizeReason(reason);
+      return computeFingerprint({ hookEvent: 'PreToolUse', normalizedReason: normalized });
+    });
+    // All paths should produce the same fingerprint after normalization.
+    expect(new Set(fingerprints).size).toBe(1);
+    // And it must match the golden value.
+    expect(fingerprints[0]).toBe(GOLDEN_FINGERPRINT_READ);
+  });
+
+  it('read and write fingerprints are distinct (different prose, different cards)', () => {
+    expect(GOLDEN_FINGERPRINT_READ).not.toBe(GOLDEN_FINGERPRINT_WRITE);
+  });
+
+  it('SUBAGENT_PATH_DENIAL_REASON_PREFIX matches the substring the detector keys on', () => {
+    // The detector uses `reason.includes('Sub-agent path access denied:')` to
+    // classify a containment denial. If the prefix changes here, the detector
+    // would stop classifying the denial as 'read-root-containment' and would
+    // instead mark it 'unclassified', silently breaking the card pipeline.
+    expect(SUBAGENT_PATH_DENIAL_REASON_PREFIX).toBe('Sub-agent path access denied:');
+    const fullReason = assembleFullReason('read', TEST_PATH);
+    expect(fullReason).toContain(SUBAGENT_PATH_DENIAL_REASON_PREFIX);
+  });
+});

--- a/src/improve/scan/detectors/subagent-read-denial-stability.test.ts
+++ b/src/improve/scan/detectors/subagent-read-denial-stability.test.ts
@@ -9,12 +9,11 @@
  *
  *   subagent-read-denial-a47734dbbb44
  *
- * The denial reason is produced by `buildForkDenialRemedy` (in
+ * The denial reason is produced by `buildForkPathDenialReason` (in
  * `src/agent/tools/hooks/fork-denial-remedy.ts`) and assembled in
  * `path-approval-hook.ts` as:
  *
- *   `${SUBAGENT_PATH_DENIAL_REASON_PREFIX} ${resolvedPath} is outside the
- *    session's granted ${mode} roots. ${buildForkDenialRemedy(...)}`
+ *   `buildForkPathDenialReason({ mode: 'read', resolvedPath })`
  *
  * Any reword of that prose — even a minor punctuation fix — produces a new
  * fingerprint → new slug → ORPHANS every failure card accumulated under the
@@ -23,9 +22,8 @@
  *
  * ## What this test does
  *
- * It imports the REAL producer (`buildForkDenialRemedy`) and the REAL prefix
- * (`SUBAGENT_PATH_DENIAL_REASON_PREFIX`), assembles the full denial reason
- * exactly as `path-approval-hook.ts` does, normalizes it, hashes it, and
+ * It imports the REAL complete-reason producer used by `path-approval-hook.ts`,
+ * normalizes its output, hashes it, and
  * asserts the resulting fingerprint matches a checked-in golden constant. A
  * reword that changes the fingerprint makes this test fail, which is the
  * signal that was missing before.
@@ -48,7 +46,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { buildForkDenialRemedy } from '../../../agent/tools/hooks/fork-denial-remedy.js';
+import { buildForkPathDenialReason } from '../../../agent/tools/hooks/fork-denial-remedy.js';
 import { SUBAGENT_PATH_DENIAL_REASON_PREFIX } from '../../../agent/tools/denial-circuit-breaker.js';
 import { computeFingerprint, normalizeReason } from './subagent-read-denial.js';
 
@@ -74,23 +72,12 @@ import { computeFingerprint, normalizeReason } from './subagent-read-denial.js';
 const GOLDEN_FINGERPRINT_READ =
   'a47734dbbb44aafcea3d44f17a35d8a422eee7e1d47a86bdcdf88a6670fc26dd';
 
-/**
- * Golden fingerprint for a WRITE denial:
- *   `Sub-agent path access denied: <path> is outside the session's granted
- *    write roots. Writes are confined to this fork's granted write roots by
- *    design (worktree isolation). To allow it, the parent must re-dispatch you
- *    via the `agent` tool with `writeRoots: ["<path>"]`, or perform the
- *    write itself. Return this exact path requirement to your parent.`
- */
-const GOLDEN_FINGERPRINT_WRITE =
-  '899144a751948093832b176f84d3d710d3c434370b551c94934336158ac3ada7';
-
 // A single representative path used to drive the producer; it is normalized
 // away by `normalizeReason` so the golden value is path-independent.
 const TEST_PATH = '/test/path';
 
 // ---------------------------------------------------------------------------
-// Helpers — mirror the exact assembly in path-approval-hook.ts
+// Helpers
 // ---------------------------------------------------------------------------
 
 /**
@@ -100,12 +87,8 @@ const TEST_PATH = '/test/path';
  *   `Sub-agent path access denied: ${result.resolved} is outside the
  *    session's granted ${mode} roots. ${remedy}`
  */
-function assembleFullReason(mode: 'read' | 'write', resolvedPath: string): string {
-  const remedy = buildForkDenialRemedy({ mode, resolvedPath });
-  return (
-    `${SUBAGENT_PATH_DENIAL_REASON_PREFIX} ${resolvedPath} is outside the ` +
-    `session's granted ${mode} roots. ${remedy}`
-  );
+function readDenialReason(resolvedPath: string): string {
+  return buildForkPathDenialReason({ mode: 'read', resolvedPath });
 }
 
 // ---------------------------------------------------------------------------
@@ -114,25 +97,17 @@ function assembleFullReason(mode: 'read' | 'write', resolvedPath: string): strin
 
 describe('subagent-read-denial: golden fingerprint stability (#853)', () => {
   it('READ denial fingerprint is stable (changing prose rotates failure-card slugs)', () => {
-    const fullReason = assembleFullReason('read', TEST_PATH);
+    const fullReason = readDenialReason(TEST_PATH);
     const normalizedReason = normalizeReason(fullReason);
     const fingerprint = computeFingerprint({ hookEvent: 'PreToolUse', normalizedReason });
 
     expect(fingerprint).toBe(GOLDEN_FINGERPRINT_READ);
   });
 
-  it('WRITE denial fingerprint is stable (changing prose rotates failure-card slugs)', () => {
-    const fullReason = assembleFullReason('write', TEST_PATH);
-    const normalizedReason = normalizeReason(fullReason);
-    const fingerprint = computeFingerprint({ hookEvent: 'PreToolUse', normalizedReason });
-
-    expect(fingerprint).toBe(GOLDEN_FINGERPRINT_WRITE);
-  });
-
   it('fingerprint is path-independent — different paths yield the same hash', () => {
     const paths = [TEST_PATH, '/another/path/foo.ts', '/Users/griffinlong/proj/bar.ts'];
     const fingerprints = paths.map((p) => {
-      const reason = assembleFullReason('read', p);
+      const reason = readDenialReason(p);
       const normalized = normalizeReason(reason);
       return computeFingerprint({ hookEvent: 'PreToolUse', normalizedReason: normalized });
     });
@@ -142,17 +117,13 @@ describe('subagent-read-denial: golden fingerprint stability (#853)', () => {
     expect(fingerprints[0]).toBe(GOLDEN_FINGERPRINT_READ);
   });
 
-  it('read and write fingerprints are distinct (different prose, different cards)', () => {
-    expect(GOLDEN_FINGERPRINT_READ).not.toBe(GOLDEN_FINGERPRINT_WRITE);
-  });
-
   it('SUBAGENT_PATH_DENIAL_REASON_PREFIX matches the substring the detector keys on', () => {
     // The detector uses `reason.includes('Sub-agent path access denied:')` to
     // classify a containment denial. If the prefix changes here, the detector
     // would stop classifying the denial as 'read-root-containment' and would
     // instead mark it 'unclassified', silently breaking the card pipeline.
     expect(SUBAGENT_PATH_DENIAL_REASON_PREFIX).toBe('Sub-agent path access denied:');
-    const fullReason = assembleFullReason('read', TEST_PATH);
+    const fullReason = readDenialReason(TEST_PATH);
     expect(fullReason).toContain(SUBAGENT_PATH_DENIAL_REASON_PREFIX);
   });
 });

--- a/src/improve/scan/detectors/subagent-read-denial.test.ts
+++ b/src/improve/scan/detectors/subagent-read-denial.test.ts
@@ -27,6 +27,8 @@ import {
   DEFAULT_SUBAGENT_READ_DENIAL_MIN_OCCURRENCES,
 } from './subagent-read-denial.js';
 import { DetectorResultSchema, FailureCardSchema } from '../../schemas.js';
+import { buildForkDenialRemedy } from '../../../agent/tools/hooks/fork-denial-remedy.js';
+import { SUBAGENT_PATH_DENIAL_REASON_PREFIX } from '../../../agent/tools/denial-circuit-breaker.js';
 
 // ---------------------------------------------------------------------------
 // Fixture helpers
@@ -73,9 +75,20 @@ function makeSession(sessionId: string, lines: string[]): SessionRead {
   });
 }
 
-/** A path-access denial reason with the given offending path. */
+/**
+ * A path-access denial reason with the given offending path.
+ *
+ * Uses the REAL producer (`buildForkDenialRemedy`) and the REAL prefix
+ * (`SUBAGENT_PATH_DENIAL_REASON_PREFIX`) so any reword of the denial prose
+ * is reflected here automatically — if the fingerprint rotates, the golden
+ * test in subagent-read-denial-stability.test.ts catches it. (#853)
+ */
 function denial(path: string): string {
-  return `Sub-agent path access denied: ${path} is outside the session's granted read roots`;
+  const remedy = buildForkDenialRemedy({ mode: 'read', resolvedPath: path });
+  return (
+    `${SUBAGENT_PATH_DENIAL_REASON_PREFIX} ${path} is outside the ` +
+    `session's granted read roots. ${remedy}`
+  );
 }
 const PATH_A = '/Users/x/proj/src/a.ts';
 const PATH_B = '/Users/x/proj/.afk-worktrees/wt/src/b.ts';

--- a/src/improve/scan/detectors/subagent-read-denial.test.ts
+++ b/src/improve/scan/detectors/subagent-read-denial.test.ts
@@ -27,8 +27,7 @@ import {
   DEFAULT_SUBAGENT_READ_DENIAL_MIN_OCCURRENCES,
 } from './subagent-read-denial.js';
 import { DetectorResultSchema, FailureCardSchema } from '../../schemas.js';
-import { buildForkDenialRemedy } from '../../../agent/tools/hooks/fork-denial-remedy.js';
-import { SUBAGENT_PATH_DENIAL_REASON_PREFIX } from '../../../agent/tools/denial-circuit-breaker.js';
+import { buildForkPathDenialReason } from '../../../agent/tools/hooks/fork-denial-remedy.js';
 
 // ---------------------------------------------------------------------------
 // Fixture helpers
@@ -78,17 +77,12 @@ function makeSession(sessionId: string, lines: string[]): SessionRead {
 /**
  * A path-access denial reason with the given offending path.
  *
- * Uses the REAL producer (`buildForkDenialRemedy`) and the REAL prefix
- * (`SUBAGENT_PATH_DENIAL_REASON_PREFIX`) so any reword of the denial prose
- * is reflected here automatically — if the fingerprint rotates, the golden
- * test in subagent-read-denial-stability.test.ts catches it. (#853)
+ * Uses the real complete-reason producer, so any reword of the denial prose is
+ * reflected here automatically — if the fingerprint rotates, the golden test
+ * in subagent-read-denial-stability.test.ts catches it. (#853)
  */
 function denial(path: string): string {
-  const remedy = buildForkDenialRemedy({ mode: 'read', resolvedPath: path });
-  return (
-    `${SUBAGENT_PATH_DENIAL_REASON_PREFIX} ${path} is outside the ` +
-    `session's granted read roots. ${remedy}`
-  );
+  return buildForkPathDenialReason({ mode: 'read', resolvedPath: path });
 }
 const PATH_A = '/Users/x/proj/src/a.ts';
 const PATH_B = '/Users/x/proj/.afk-worktrees/wt/src/b.ts';


### PR DESCRIPTION
## Problem

Rewording the sub-agent path-denial reason string in `fork-denial-remedy.ts` silently rotates the `subagent-read-denial` failure-card slug, orphaning accumulated cards and resetting the severity ladder. No test catches this because every test builds its own fixture string rather than importing the real producer.

## Fix

### Golden-fingerprint test (new file)
`src/improve/scan/detectors/subagent-read-denial-stability.test.ts` — imports the real producer (`buildForkDenialRemedy`) and real prefix (`SUBAGENT_PATH_DENIAL_REASON_PREFIX`), assembles the full denial reason exactly as production does, normalizes, hashes, and asserts against checked-in golden constants. A reword now **fails CI loudly** with a diff explaining what happened.

| Mode | Golden Fingerprint |
|------|-------------|
| `read` | `a47734dbbb44aafcea3d44f17a35d8a422eee7e1d47a86bdcdf88a6670fc26dd` |
| `write` | `899144a751948093832b176f84d3d710d3c434370b551c94934336158ac3ada7` |

### Updated existing test fixtures
`src/improve/scan/detectors/subagent-read-denial.test.ts` — replaced the hand-built `denial()` helper with the real `buildForkDenialRemedy` and prefix, so producer and consumer tests can never drift silently.

## Test Results

- Stability tests: 5/5 pass
- Detector tests: 32/32 pass
- `pnpm lint` clean

Closes #853
