### PR TITLE
feat(closure-guidance): add recovery hints for iteration_cap and timeout closures

### DIFF
--- a/src/agent/session/closure-guidance.test.ts
+++ b/src/agent/session/closure-guidance.test.ts
@@ -2,17 +2,23 @@
  * Tests for the `closure-anomaly` guardrail — {@link buildClosureGuidance}.
  *
  * Pure function: maps a {@link ClosureReason} to an actionable recovery hint
- * (abort subtype) or `null` (benign closes + anomalous reasons not yet
- * covered). The wiring onto the closure trace event is covered in
- * `trace/closure.test.ts`; the eval-run contract is covered in
+ * (abort, iteration_cap, timeout subtypes) or `null` (benign closes +
+ * anomalous reasons not yet covered). The wiring onto the closure trace event
+ * is covered in `trace/closure.test.ts`; the eval-run contract is covered in
  * `improve/eval-run/contracts.test.ts`.
  */
 
 import { describe, it, expect } from 'vitest';
 import type { ClosureReason } from '../trace/index.js';
-import { buildClosureGuidance, CLOSURE_ABORT_RECOVERY_HINT } from './closure-guidance.js';
+import {
+  buildClosureGuidance,
+  CLOSURE_ABORT_RECOVERY_HINT,
+  CLOSURE_ITERATION_CAP_RECOVERY_HINT,
+  CLOSURE_TIMEOUT_RECOVERY_HINT,
+} from './closure-guidance.js';
 
 describe('buildClosureGuidance', () => {
+  // -- abort --
   it('returns the canonical recovery hint for an abort closure', () => {
     expect(buildClosureGuidance('abort')).toBe(CLOSURE_ABORT_RECOVERY_HINT);
     expect(CLOSURE_ABORT_RECOVERY_HINT.trim().length).toBeGreaterThan(0);
@@ -26,17 +32,45 @@ describe('buildClosureGuidance', () => {
     expect(CLOSURE_ABORT_RECOVERY_HINT).toMatch(/afk --resume/);
   });
 
+  // -- iteration_cap --
+  it('returns the canonical recovery hint for an iteration_cap closure', () => {
+    expect(buildClosureGuidance('iteration_cap')).toBe(CLOSURE_ITERATION_CAP_RECOVERY_HINT);
+    expect(CLOSURE_ITERATION_CAP_RECOVERY_HINT.trim().length).toBeGreaterThan(0);
+  });
+
+  it('the iteration_cap hint names a concrete recovery action', () => {
+    expect(buildClosureGuidance('iteration_cap')).toMatch(/\b(resume|re-run|rerun|retry)\b/i);
+  });
+
+  it('the iteration_cap hint mentions the budget lever', () => {
+    expect(CLOSURE_ITERATION_CAP_RECOVERY_HINT).toMatch(/max.turns|max_tool_use_iterations/i);
+  });
+
+  // -- timeout --
+  it('returns the canonical recovery hint for a timeout closure', () => {
+    expect(buildClosureGuidance('timeout')).toBe(CLOSURE_TIMEOUT_RECOVERY_HINT);
+    expect(CLOSURE_TIMEOUT_RECOVERY_HINT.trim().length).toBeGreaterThan(0);
+  });
+
+  it('the timeout hint names a concrete recovery action', () => {
+    expect(buildClosureGuidance('timeout')).toMatch(/\b(resume|re-run|rerun|retry)\b/i);
+  });
+
+  it('the timeout hint mentions checking what was slow', () => {
+    expect(CLOSURE_TIMEOUT_RECOVERY_HINT).toMatch(/trace|slow tool/i);
+  });
+
+  // -- benign --
   it('returns null for benign closes — no false-positive guidance', () => {
     expect(buildClosureGuidance('model_end_turn')).toBeNull();
     expect(buildClosureGuidance('truncated')).toBeNull();
   });
 
+  // -- deferred anomalous subtypes --
   it('returns null for anomalous reasons not yet covered (deferred subtypes)', () => {
     const deferred: ClosureReason[] = [
-      'timeout',
       'budget_exceeded',
       'hook_blocked',
-      'iteration_cap',
       'max_turns_exceeded',
     ];
     for (const reason of deferred) {
@@ -44,7 +78,10 @@ describe('buildClosureGuidance', () => {
     }
   });
 
+  // -- purity --
   it('is pure — repeated calls return the identical value', () => {
     expect(buildClosureGuidance('abort')).toBe(buildClosureGuidance('abort'));
+    expect(buildClosureGuidance('iteration_cap')).toBe(buildClosureGuidance('iteration_cap'));
+    expect(buildClosureGuidance('timeout')).toBe(buildClosureGuidance('timeout'));
   });
 });

--- a/src/agent/session/closure-guidance.ts
+++ b/src/agent/session/closure-guidance.ts
@@ -13,12 +13,11 @@
  * deterministic builder, wired at one production site and exercised directly
  * by an `afk improve eval-run` contract (no LLM, no network).
  *
- * Scope — first concrete subtype only: only `abort` carries guidance today.
- * The detector flags six anomalous reasons; covering all six in one change
- * would couple the fix to six distinct recovery stories. The rest (timeout,
- * budget_exceeded, hook_blocked, iteration_cap, max_turns_exceeded) each get
- * their own hint in a follow-up. Benign reasons (model_end_turn, truncated)
- * never carry guidance — a clean close needs no recovery action.
+ * Coverage: `abort`, `iteration_cap`, and `timeout` carry guidance today.
+ * The detector flags six anomalous reasons; the remaining three
+ * (budget_exceeded, hook_blocked, max_turns_exceeded) each get their own
+ * hint in a follow-up. Benign reasons (model_end_turn, truncated) never
+ * carry guidance — a clean close needs no recovery action.
  *
  * @module agent/session/closure-guidance
  */
@@ -36,6 +35,29 @@ export const CLOSURE_ABORT_RECOVERY_HINT =
   'from saved state, or re-run the task if the interruption was intentional.';
 
 /**
+ * Recovery hint for an `iteration_cap` closure. The tool-use round budget was
+ * exhausted — the session did real work but ran out of runway. The wind-down
+ * round already fired, so the transcript holds partial progress.
+ */
+export const CLOSURE_ITERATION_CAP_RECOVERY_HINT =
+  'Session hit the tool-use iteration cap before reaching a terminal state. ' +
+  'Partial work is preserved in the transcript and witness trace. Resume with ' +
+  '`afk --resume <sessionId>` to continue from where it stopped, or re-run ' +
+  'with a higher budget (`--max-turns` or `max_tool_use_iterations`).';
+
+/**
+ * Recovery hint for a `timeout` closure. The wall-clock cap fired — unlike
+ * iteration_cap the session may have been idle (waiting on a slow tool) or
+ * actively working when the deadline hit.
+ */
+export const CLOSURE_TIMEOUT_RECOVERY_HINT =
+  'Session was terminated by the wall-clock timeout before reaching a terminal ' +
+  'state. The transcript and witness trace are preserved — resume with ' +
+  '`afk --resume <sessionId>` to continue, or re-run with a longer timeout. ' +
+  'Check the trace for whether the timeout hit during active work or while ' +
+  'waiting on a slow tool call.';
+
+/**
  * Map a closure reason to an actionable recovery hint, or `null` when no
  * guidance applies (benign closes, and anomalous reasons not yet covered).
  *
@@ -47,6 +69,10 @@ export function buildClosureGuidance(reason: ClosureReason): string | null {
   switch (reason) {
     case 'abort':
       return CLOSURE_ABORT_RECOVERY_HINT;
+    case 'iteration_cap':
+      return CLOSURE_ITERATION_CAP_RECOVERY_HINT;
+    case 'timeout':
+      return CLOSURE_TIMEOUT_RECOVERY_HINT;
     default:
       return null;
   }

--- a/src/improve/eval-run/replay.test.ts
+++ b/src/improve/eval-run/replay.test.ts
@@ -381,9 +381,10 @@ describe('replayClosureAnomaly', () => {
   });
 
   it('FAILS closed for an anomalous reason the guardrail does not cover yet', async () => {
-    // `timeout` is anomalous (reproduces) but buildClosureGuidance returns null
-    // for it today → not neutralised → fail-closed (real guardrail, no inject).
-    const bytes = Buffer.from(closureContent('timeout'), 'utf8');
+    // `budget_exceeded` is anomalous (reproduces) but buildClosureGuidance
+    // returns null for it today → not neutralised → fail-closed (real
+    // guardrail, no inject).
+    const bytes = Buffer.from(closureContent('budget_exceeded'), 'utf8');
     const probe = await closureHandler!.run(makeClosureEvalCase(), bytes, {});
 
     expect(check(probe.checks, REPLAY_CHECK_CLOSURE_REPRODUCES)?.status).toBe('pass');

--- a/src/improve/eval-run/runner.test.ts
+++ b/src/improve/eval-run/runner.test.ts
@@ -534,9 +534,9 @@ describe('runEvalCase fixture-replay', () => {
   });
 
   it('FAILS end to end for an anomalous closure the guardrail does not cover (fail-closed)', async () => {
-    // `timeout` reproduces but buildClosureGuidance returns null for it today.
+    // `budget_exceeded` reproduces but buildClosureGuidance returns null for it today.
     const run = await runEvalCase(
-      makeEvalCase({ pattern: 'closure-anomaly', fixtureBytes: closureFixtureBytes('timeout') }),
+      makeEvalCase({ pattern: 'closure-anomaly', fixtureBytes: closureFixtureBytes('budget_exceeded') }),
       baseCtx,
     );
 


### PR DESCRIPTION
## What

Add actionable recovery guidance for `iteration_cap` and `timeout` closure reasons in `buildClosureGuidance()`, closing the two highest-severity open cards in the `afk improve` pipeline.

## Why

The `afk improve` pipeline detected 53 combined evidence hits across these two closure patterns with no guardrail:
- `closure-anomaly-iteration-cap` — 24 hits, high severity, eval-run FAIL
- `closure-anomaly-timeout` — 29 hits, high severity, eval-run FAIL

Both eval-runs failed on `replay:guardrail-guides-recorded-closure` because `buildClosureGuidance()` returned `null` for these reasons. Only `abort` had guidance.

## Changes

**`src/agent/session/closure-guidance.ts`** — Add `CLOSURE_ITERATION_CAP_RECOVERY_HINT` and `CLOSURE_TIMEOUT_RECOVERY_HINT` constants, wire them into the `buildClosureGuidance()` switch. Each hint names a concrete recovery action (resume, re-run with higher budget/timeout) and diagnostic step.

**`src/agent/session/closure-guidance.test.ts`** — Add dedicated tests for both new hints (canonical value, recovery action mention, budget/timeout lever mention). Update deferred-reasons list to remove `iteration_cap` and `timeout`. Extend purity test.

**`src/improve/eval-run/replay.test.ts`** + **`runner.test.ts`** — Switch the "uncovered anomalous reason" test case from `timeout` to `budget_exceeded` (since `timeout` is now covered).

## Verification

- 125 tests pass across all 6 affected test files
- `pnpm lint` clean
- `pnpm audit:filesize:check` passes (source file well under 350-line ceiling)
- `pnpm fix:pins:check` passes
- Live `afk improve eval-run` for both cards expected to flip from FAIL → PASS after merge
