### PR TITLE
feat(telegram): add thread_id to send_telegram for topic targeting

### DIFF
--- a/src/agent/tools/handlers/send-telegram.test.ts
+++ b/src/agent/tools/handlers/send-telegram.test.ts
@@ -312,4 +312,38 @@ describe('send_telegram handler', () => {
       expect(r.content).toMatch(/chat 222: network down/);
     });
   });
+
+  describe('thread_id (topic targeting)', () => {
+    it('forwards messageThreadId when thread_id + chat are both set', async () => {
+      const { handler, pushFn } = makeHarness({ token: 't', allowed: '-100500' });
+      const r = await handler({ message: 'hi', chat: -100500, thread_id: 42 }, signal);
+      expect(r.isError).toBeUndefined();
+      expect(pushFn).toHaveBeenCalledWith({ token: 't', chatId: -100500, text: 'hi', messageThreadId: 42 });
+      expect(r.content).toMatch(/topic 42/);
+    });
+
+    it('errors when thread_id is set but chat is omitted', async () => {
+      const { handler, pushFn } = makeHarness({ token: 't', allowed: '111' });
+      const r = await handler({ message: 'hi', thread_id: 5 }, signal);
+      expect(r.isError).toBe(true);
+      expect(r.content).toMatch(/thread_id requires chat/);
+      expect(pushFn).not.toHaveBeenCalled();
+    });
+
+    it.each([['non-number', 'main'], ['zero', 0], ['negative', -1]])(
+      'errors when thread_id is %s', async (_label, bad) => {
+        const { handler, pushFn } = makeHarness({ token: 't', allowed: '111' });
+        const r = await handler({ message: 'hi', chat: 111, thread_id: bad }, signal);
+        expect(r.isError).toBe(true);
+        expect(r.content).toMatch(/positive integer/);
+        expect(pushFn).not.toHaveBeenCalled();
+      });
+
+    it('omitting thread_id keeps existing behavior (no messageThreadId in call)', async () => {
+      const { handler, pushFn } = makeHarness({ token: 't', allowed: '111' });
+      const r = await handler({ message: 'hi' }, signal);
+      expect(r.isError).toBeUndefined();
+      expect(pushFn).toHaveBeenCalledWith({ token: 't', chatId: 111, text: 'hi' });
+    });
+  });
 });

--- a/src/agent/tools/handlers/send-telegram.ts
+++ b/src/agent/tools/handlers/send-telegram.ts
@@ -33,6 +33,7 @@ export function createSendTelegramHandler(
     const obj = input as Record<string, unknown>;
     const message = obj['message'];
     const chat = obj['chat'];
+    const threadId = obj['thread_id'];
 
     if (typeof message !== 'string') {
       return { content: 'Invalid input: message must be a string', isError: true };
@@ -43,6 +44,24 @@ export function createSendTelegramHandler(
         content: 'Invalid input: chat must be a number (chat id) or string (chat id or alias name)',
         isError: true,
       };
+    }
+
+    if (threadId !== undefined) {
+      if (typeof threadId !== 'number' || !Number.isInteger(threadId) || threadId <= 0) {
+        return {
+          content: 'Invalid input: thread_id must be a positive integer',
+          isError: true,
+        };
+      }
+      if (chat === undefined) {
+        return {
+          content:
+            'Invalid input: thread_id requires chat to be set explicitly. ' +
+            'Thread targeting without an explicit chat target is ambiguous — ' +
+            'default routing goes to a DM, which has no topics.',
+          isError: true,
+        };
+      }
     }
 
     if (message.length === 0) {
@@ -112,7 +131,12 @@ export function createSendTelegramHandler(
     const failures: string[] = [];
 
     for (const chatId of targets) {
-      const result = await pushFn({ token: botToken, chatId, text: message });
+      const result = await pushFn({
+        token: botToken,
+        chatId,
+        text: message,
+        ...(threadId !== undefined ? { messageThreadId: threadId as number } : {}),
+      });
       if (!result.ok) {
         failures.push(`chat ${chatId}: ${result.errorMessage ?? `HTTP ${result.status}`}`);
       }
@@ -137,7 +161,9 @@ export function createSendTelegramHandler(
     return {
       content:
         targets.length === 1
-          ? `Sent Telegram message to chat ${targets[0]}.`
+          ? threadId !== undefined
+            ? `Sent Telegram message to chat ${targets[0]} (topic ${threadId}).`
+            : `Sent Telegram message to chat ${targets[0]}.`
           : `Sent Telegram message to ${targets.length} chats.`,
     };
   };

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -235,7 +235,9 @@ export const sendTelegramTool: AnthropicToolDef = {
     'pass a numeric chat id (e.g. -1001234567890 for a group) or a chat alias name defined in ' +
     'afk.config.json `telegram.chatAliases` (e.g. "ops"). An explicitly-targeted chat must be ' +
     'in the inbound allowlist (AFK_TELEGRAM_ALLOWED_CHAT_IDS) — a non-allowlisted target is ' +
-    'rejected (fail-closed). Omit `chat` for the default behavior (unchanged).',
+    'rejected (fail-closed). Omit `chat` for the default behavior (unchanged).\n\n' +
+    'For supergroups with topics enabled, set `thread_id` alongside `chat` to send to a ' +
+    'specific topic thread.',
   input_schema: {
     type: 'object',
     properties: {
@@ -253,6 +255,14 @@ export const sendTelegramTool: AnthropicToolDef = {
           'looked up as a name in afk.config.json `telegram.chatAliases`. The resolved chat ' +
           'must be allowlisted (AFK_TELEGRAM_ALLOWED_CHAT_IDS) or the send is rejected. ' +
           'Omit to send to the configured default (primary DM chat / notify targets).',
+      },
+      thread_id: {
+        type: 'number',
+        description:
+          'Optional. Telegram message_thread_id for sending to a specific topic ' +
+          'in a supergroup with topics enabled. Pass the numeric thread/topic ID. ' +
+          'Ignored when the target chat is not a supergroup with topics. ' +
+          'Requires `chat` to be set explicitly (thread targeting without a chat target is ambiguous).',
       },
     },
     required: ['message'],

--- a/src/telegram/push.ts
+++ b/src/telegram/push.ts
@@ -35,6 +35,12 @@ export interface PushOptions {
    * can be added by widening the union when needed.
    */
   replyMarkup?: InlineKeyboardMarkup;
+  /**
+   * Optional Telegram `message_thread_id` for sending to a specific topic in
+   * a supergroup with topics enabled. Ignored when the target chat is not a
+   * supergroup with topics. Thread id 1 is the General topic and is a no-op.
+   */
+  messageThreadId?: number;
   /** Override fetch (tests). Defaults to global fetch. */
   fetchImpl?: typeof fetch;
   /** Override API base (tests). */
@@ -71,6 +77,7 @@ export async function push(options: PushOptions): Promise<PushResult> {
   };
   if (options.parseMode) body['parse_mode'] = options.parseMode;
   if (options.replyMarkup) body['reply_markup'] = options.replyMarkup;
+  if (options.messageThreadId) body['message_thread_id'] = options.messageThreadId;
 
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), 10_000);


### PR DESCRIPTION
## Summary

Adds topic/thread support to the `send_telegram` tool so agents can send messages to specific topics within Telegram supergroups — not just the chat-level General topic.

## Motivation

Telegram supergroups with topics enabled use `message_thread_id` to route messages to specific topic threads. The inbound bot path already has full topic support (`src/telegram/route.ts` — `TelegramRoute`, `sendOptions()`, `routeKey()`), but the outbound `send_telegram` tool only passed `chat_id` with no way to specify a thread.

## Approach

Adds an optional `thread_id` integer parameter alongside the existing `chat` parameter — matching Telegram's own API model where `chat_id` and `message_thread_id` are flat siblings.

**Design decision:** A separate parameter was chosen over overloading `chat` with a `chatId:threadId` colon syntax. The colon approach would have required modifying `resolveChatTarget`/`parseChatId` (shared by env vars and daemon config), widening the `chatAliases` type, and introducing parsing ambiguity with negative group IDs. The separate parameter is strictly additive with zero changes to existing parse paths.

### Changes

| File | What |
|------|------|
| `src/telegram/push.ts` | `messageThreadId?: number` on `PushOptions`, forwarded to Telegram's `message_thread_id` body field |
| `src/agent/tools/schemas.ts` | `thread_id` property added to tool schema, description updated |
| `src/agent/tools/handlers/send-telegram.ts` | Extract + validate `thread_id`, require explicit `chat`, forward to `push()`, include topic in success message |
| `src/agent/tools/handlers/send-telegram.test.ts` | 5 new test cases: happy path, no-chat error, non-number/zero/negative errors, omitted = unchanged |

### What was NOT changed (intentionally)

- `resolveChatTarget` / `parseChatId` — no colon-syntax parsing needed
- `allowlist.ts` — allowlist checks the chat ID; thread ID is not an access-control surface
- `chatAliases` type — stays `Record<string, number>`; compose alias + `thread_id` for topic targeting
- `notify-routing.ts` — default routing is unaffected
- `pushIfConfigured` / `pushMarkdown` — `messageThreadId` passes through via spread when present

## Usage

```
send_telegram({ message: "Hello topic!", chat: -1004394541150, thread_id: 2 })
```

`thread_id` requires `chat` to be set explicitly — thread targeting without a chat target is ambiguous (default routing goes to a DM, which has no topics).
