### PR TITLE
docs(skill-executor): add Invariant comment guarding sync block (#743)

### DIFF
--- a/src/agent/tools/skill-executor.ts
+++ b/src/agent/tools/skill-executor.ts
@@ -174,6 +174,14 @@ export class SkillExecutor {
     // Captured here (before registry and plugin lookups) so the "not found"
     // fallback at the bottom of this method can list available skills without
     // a second scan — both code paths share this single collection.
+    //
+    // Invariant: the collectSkillEntries() call and the getSkill() lookup below
+    // MUST remain in the same synchronous block — no `await` may be inserted
+    // between them. Concurrent sessions call evictSkillsByOrigin('project')
+    // when they rescan, which can remove this session's project-skill entries
+    // from the global registry at any point. An `await` here would open a race
+    // window where another session evicts those entries before getSkill() runs,
+    // causing a spurious "Skill not found" for a skill that exists on disk.
     const entries = collectSkillEntries(
       this.ctx.pluginConfigs,
       this.currentCwd !== undefined ? { cwd: this.currentCwd } : undefined,
@@ -246,9 +254,9 @@ export class SkillExecutor {
       );
     }
 
-    // 3. Not found — return available skills list. Resolve project skills
-    // against the session cwd (worktree / daemon-task / Telegram-chat dir),
-    // not the host process cwd — mirrors the manifest build in the provider.
+    // 3. Not found — return available skills list. `entries` was collected
+    // above (synchronously, before the registry lookup) so no second scan is
+    // needed here; it already reflects the session cwd.
     const available = entries.map((e) => e.name).join(', ');
     return {
       content: `Skill "${parsed.name}" not found. Available skills: ${available || '(none)'}`,


### PR DESCRIPTION
## Summary

Adds an explicit `Invariant:` comment guarding the synchronous gap between `collectSkillEntries()` and `getSkill()` in `SkillExecutor.execute()`, and fixes a stale comment that still described the collection as local to the not-found branch.

## Problem

PR #737 moved the `collectSkillEntries()` call ~77 lines up so it runs before the `getSkill()` lookup. The fix works only because both calls are synchronous — no other session can interleave an `evictSkillsByOrigin('project')` eviction into the gap. But nothing in the code stated this constraint, so the next editor could insert an `await` and reopen the race.

## Changes

1. **Invariant comment** — 8-line block above `collectSkillEntries()` naming the no-await constraint and explaining the concurrent-eviction race it prevents.
2. **Stale comment fix** — the "not found" step-3 block still described `collectSkillEntries` as if it ran locally; updated to reflect the pre-collected `entries` variable.

Closes #743.
