### PR TITLE
test(cli): pin terminal width in quota-footer tests (#795)

### DIFF
--- a/src/cli/commands/interactive/turn-handler.test.ts
+++ b/src/cli/commands/interactive/turn-handler.test.ts
@@ -2480,13 +2480,33 @@ describe('printTurnFooter — subscription-quota line', () => {
   // an exactly-12-minute deadline can degrade to 719_999ms elapsed and floor
   // to `11m` — a flake that races the runner's speed. Freezing the clock
   // makes the deadline arithmetic exact instead of racing the runner.
+  //
+  // Width invariant: any code path that calls getTerminalWidth() (via
+  // boundLineToTerminal, clampToTerminal, or similar) reads
+  // process.stdout.columns, which is undefined in non-TTY CI environments
+  // and defaults to 80. A quota line exceeds 80 columns, so the assertion on
+  // the deadline suffix would fail on a narrow runner even when the text is
+  // correct. Pin to 200 so the full line is always present in captured output
+  // regardless of runner environment. See issue #795.
+  let _prevColumns: number | undefined;
   beforeEach(() => {
+    _prevColumns = process.stdout.columns;
+    Object.defineProperty(process.stdout, 'columns', {
+      configurable: true,
+      writable: true,
+      value: 200,
+    });
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
     resetQuotaCacheForTests();
     configStub.autoResume = true;
   });
   afterEach(() => {
+    Object.defineProperty(process.stdout, 'columns', {
+      configurable: true,
+      writable: true,
+      value: _prevColumns,
+    });
     vi.useRealTimers();
     resetQuotaCacheForTests();
     configStub.autoResume = true;


### PR DESCRIPTION
## Summary

Pins terminal width to 200 columns in the subscription-quota footer tests, so assertions on the full quota line (including the deadline suffix) pass regardless of CI runner terminal geometry.

## Problem

The quota footer line is ~82 columns wide. `getTerminalWidth()` reads `process.stdout.columns`, which is undefined in non-TTY CI environments and falls back to 80. The Auto Release job reported a narrower effective width than the CI Test job, so `clampToTerminal` / `boundLineToTerminal` truncated the "resets in 12m" suffix — making the `toContain('resets in 12m')` assertion fail on one workflow but pass on another.

Result: a merge could land green on CI and produce no release (the Auto Release workflow failed on this single test).

## Changes

- **`turn-handler.test.ts`** — Added `process.stdout.columns = 200` in the `beforeEach` / `afterEach` of the `printTurnFooter — subscription-quota line` describe block, following the pattern from `bounded-line.test.ts`, `measure.test.ts`, and `markdown-stream.test.ts`.
- The existing `vi.useFakeTimers()` setup (covering `11m`/`12m` arithmetic flicker) is preserved unchanged.

All 75 tests pass.

Closes #795.
