### PR TITLE
test(agents): generalize registry-grant prompt-consistency guard (#942)

### DIFF
--- a/src/agent/agents/builtins.ts
+++ b/src/agent/agents/builtins.ts
@@ -56,8 +56,14 @@ function vendoredPromptBody(raw: string): string {
  * green. Callers pass the SAME array they spread into `tools`, so the note and
  * the grant cannot drift apart.
  */
-function withRegistryGrants(body: string, grants: readonly string[]): string {
+function withRegistryGrants(
+  body: string,
+  grants: readonly string[],
+  baseTools: readonly string[],
+): string {
   if (grants.length === 0) return body;
+  const forbiddenMutators = ['Edit', 'Write', 'Bash'].filter((tool) => !baseTools.includes(tool));
+  const preservedContract = `${forbiddenMutators.map((tool) => `no ${tool}`).join(', ')}, and no mutation`;
   return `${body}
 
 ## Tools granted by this runtime, beyond the list above
@@ -67,7 +73,7 @@ This runtime additionally grants you: ${grants.join(', ')}.
 Any earlier statement in this prompt that your tool surface is a fixed or "hard"
 allowlist describes the upstream default, not your actual surface — it is
 superseded by this section. These tools are live; use them when relevant. Every
-other restriction above (no Edit, no Write, no Bash, no mutation) still holds.`;
+other restriction above (${preservedContract}) still holds.`;
 }
 
 /**
@@ -147,6 +153,7 @@ export function builtinAgents(): Map<string, RegisteredAgent> {
         prompt: withRegistryGrants(
           vendoredPromptBody(researchAgent.systemPrompt),
           RESEARCH_AGENT_REGISTRY_GRANTS,
+          researchAgent.allowedTools,
         ),
         // The scoped `Agent(git-investigator)` grant matches the vendored
         // prompt's frontmatter intent (`tools: …, Agent(git-investigator)`)
@@ -183,6 +190,7 @@ export function builtinAgents(): Map<string, RegisteredAgent> {
         // agent-tool dispatch path and dies opaquely when cut off mid-loop.
         maxToolUseIterations: READONLY_AGENT_MAX_TOOL_USE_ITERATIONS,
       },
+      vendoredBaseTools: researchAgent.allowedTools,
     },
     {
       name: gitInvestigator.name,
@@ -200,6 +208,7 @@ export function builtinAgents(): Map<string, RegisteredAgent> {
         // capped-partial wind-down. See READONLY_AGENT_MAX_TOOL_USE_ITERATIONS.
         maxToolUseIterations: READONLY_AGENT_MAX_TOOL_USE_ITERATIONS,
       },
+      vendoredBaseTools: gitInvestigator.allowedTools,
       // The vendored definition grants Bash for git archaeology; its contract
       // is read-only ("Runs git commands only — no mutations"). Enforce that
       // contract mechanically with the read-only bash gate.

--- a/src/agent/agents/registry.test.ts
+++ b/src/agent/agents/registry.test.ts
@@ -165,19 +165,8 @@ describe('loadAgentRegistry', () => {
   // Invariant: for each builtin with a restricted tool set (explicit `tools:`
   // array), every tool granted at the registry entry beyond the vendored
   // allowlist constant must appear in the agent's composed prompt.
-  it('every restricted builtin: registry grants beyond the vendored base appear in the composed prompt (#942)', async () => {
-    const registry = loadAgentRegistry({ cwd: join(tmp, 'proj'), warn: () => {} });
-
-    // Vendored base allowlists — the upstream-pinned "closed set" each agent's
-    // body asserts. Map each builtin name to its vendored `allowedTools` const.
-    // Non-vendored builtins (Explore, general-purpose) are omitted: their
-    // prompts are AFK-authored and already name every tool they list, so there
-    // is no "closed-allowlist claim to supersede" and no extras can drift.
-    const { researchAgent, gitInvestigator } = await import('../../skills/_agents/index.js');
-    const vendoredBase: ReadonlyMap<string, readonly string[]> = new Map([
-      ['research-agent', researchAgent.allowedTools],
-      ['git-investigator', gitInvestigator.allowedTools],
-    ]);
+  it('every restricted builtin: registry grants beyond the vendored base appear in the composed prompt (#942)', () => {
+    const builtins = builtinAgents();
 
     // Guard: ensure this test covers real builtins (not vacuously-passing on
     // an empty map) and that at least one agent actually has registry extras,
@@ -185,11 +174,13 @@ describe('loadAgentRegistry', () => {
     // by having zero extras everywhere.
     let sawExtras = false;
 
-    for (const [name, base] of vendoredBase) {
-      const entry = registry.get(name);
-      expect(entry, `builtin ${name} missing from registry`).toBeDefined();
-      const tools = entry!.definition.tools ?? [];
-      const prompt = entry!.definition.prompt;
+    let sawVendored = false;
+    for (const [name, entry] of builtins) {
+      const base = entry.vendoredBaseTools;
+      if (base === undefined) continue;
+      sawVendored = true;
+      const tools = entry.definition.tools ?? [];
+      const prompt = entry.definition.prompt;
 
       // Extras = tools the registry grants beyond what the vendored body claims.
       const extras = tools.filter((t) => !(base as readonly string[]).includes(t));
@@ -209,14 +200,28 @@ describe('loadAgentRegistry', () => {
           prompt,
           `${name}: withRegistryGrants supplement must override the closed-allowlist claim`,
         ).toMatch(/superseded by this section/);
-        // And the supplement must not relax the read-only contract.
-        expect(
-          prompt,
-          `${name}: withRegistryGrants supplement must preserve the read-only contract`,
-        ).toMatch(/no Edit, no Write, no Bash, no mutation/);
+        // Preserve this agent's actual contract. In particular,
+        // git-investigator legitimately has read-only Bash, while research-agent
+        // does not; the supplement must never contradict either base allowlist.
+        for (const mutator of ['Edit', 'Write', 'Bash']) {
+          const prohibition = new RegExp(`no ${mutator}`);
+          if (base.includes(mutator)) {
+            expect(prompt, `${name}: supplement contradicts allowed ${mutator}`).not.toMatch(
+              prohibition,
+            );
+          } else {
+            expect(prompt, `${name}: supplement must preserve the no-${mutator} contract`).toMatch(
+              prohibition,
+            );
+          }
+        }
+        expect(prompt, `${name}: supplement must preserve the no-mutation contract`).toMatch(
+          /no mutation/,
+        );
       }
     }
 
+    expect(sawVendored, 'expected ≥1 vendored builtin in the builtin registry').toBe(true);
     expect(sawExtras, 'expected ≥1 vendored builtin to have registry extras (research-agent)').toBe(
       true,
     );

--- a/src/agent/agents/registry.test.ts
+++ b/src/agent/agents/registry.test.ts
@@ -147,37 +147,79 @@ describe('loadAgentRegistry', () => {
     }
   });
 
-  // The other half of #883. The test above proves the grant is mechanically
-  // REACHABLE; this proves the agent is TOLD it has it. The vendored body is
-  // byte-pinned upstream and asserts a closed allowlist ("Your tool surface is
-  // a hard allowlist enforced by Claude Code: Read, Grep, Glob, WebFetch,
-  // WebSearch"), so a grant made only in `tools:` is inert — the surveyor reads
-  // its prompt, believes it has five tools, and never calls the sixth. That is
-  // exactly what shipped: #883 was verified at the tool-access layer only, and
-  // the observable behaviour did not change.
-  it('tells research-agent about every registry grant beyond its vendored allowlist (#883)', async () => {
+  // Structural invariant over ALL restricted builtin agents (#942).
+  //
+  // The other half of #883 (tool access ↔ prompt consistency), now generalised
+  // from a research-agent-specific assertion into a table-driven structural
+  // check. The failure class: vendored prompts assert a CLOSED tool allowlist
+  // in their body. A registry-entry grant made only in `tools:` is INERT
+  // because the agent reads its prompt, believes it has the closed set, and
+  // never attempts the added tool. #883 shipped with exactly this bug; #925
+  // and #928 repeated it. `withRegistryGrants()` in builtins.ts reconciles by
+  // composing a prompt supplement that names the extras and explicitly
+  // supersedes the closed-allowlist claim — but that helper is bespoke to
+  // research-agent today. This test enforces the invariant structurally, over
+  // the whole registry, so a newly-added restricted agent is caught
+  // automatically without a per-agent guard.
+  //
+  // Invariant: for each builtin with a restricted tool set (explicit `tools:`
+  // array), every tool granted at the registry entry beyond the vendored
+  // allowlist constant must appear in the agent's composed prompt.
+  it('every restricted builtin: registry grants beyond the vendored base appear in the composed prompt (#942)', async () => {
     const registry = loadAgentRegistry({ cwd: join(tmp, 'proj'), warn: () => {} });
-    const entry = registry.get('research-agent');
-    expect(entry).toBeDefined();
 
-    const { researchAgent } = await import('../../skills/_agents/index.js');
-    const prompt = entry!.definition.prompt;
+    // Vendored base allowlists — the upstream-pinned "closed set" each agent's
+    // body asserts. Map each builtin name to its vendored `allowedTools` const.
+    // Non-vendored builtins (Explore, general-purpose) are omitted: their
+    // prompts are AFK-authored and already name every tool they list, so there
+    // is no "closed-allowlist claim to supersede" and no extras can drift.
+    const { researchAgent, gitInvestigator } = await import('../../skills/_agents/index.js');
+    const vendoredBase: ReadonlyMap<string, readonly string[]> = new Map([
+      ['research-agent', researchAgent.allowedTools],
+      ['git-investigator', gitInvestigator.allowedTools],
+    ]);
 
-    // Anything granted at the registry entry but absent from the vendored
-    // allowlist is a tool the prompt does not otherwise account for.
-    const extras = (entry!.definition.tools ?? []).filter(
-      (t) => !researchAgent.allowedTools.includes(t as never),
-    );
-    expect(extras.length).toBeGreaterThan(0);
-    for (const tool of extras) {
-      expect(prompt, `prompt never mentions granted tool ${tool}`).toContain(tool);
+    // Guard: ensure this test covers real builtins (not vacuously-passing on
+    // an empty map) and that at least one agent actually has registry extras,
+    // so a future removal of withRegistryGrants can't silently make this pass
+    // by having zero extras everywhere.
+    let sawExtras = false;
+
+    for (const [name, base] of vendoredBase) {
+      const entry = registry.get(name);
+      expect(entry, `builtin ${name} missing from registry`).toBeDefined();
+      const tools = entry!.definition.tools ?? [];
+      const prompt = entry!.definition.prompt;
+
+      // Extras = tools the registry grants beyond what the vendored body claims.
+      const extras = tools.filter((t) => !(base as readonly string[]).includes(t));
+
+      for (const tool of extras) {
+        expect(prompt, `${name}: prompt never mentions registry-granted tool "${tool}"`).toContain(
+          tool,
+        );
+      }
+
+      if (extras.length > 0) {
+        sawExtras = true;
+        // The reconciliation section must explicitly supersede the body's
+        // closed-allowlist claim — appending a name that the earlier sentence
+        // still contradicts is not sufficient.
+        expect(
+          prompt,
+          `${name}: withRegistryGrants supplement must override the closed-allowlist claim`,
+        ).toMatch(/superseded by this section/);
+        // And the supplement must not relax the read-only contract.
+        expect(
+          prompt,
+          `${name}: withRegistryGrants supplement must preserve the read-only contract`,
+        ).toMatch(/no Edit, no Write, no Bash, no mutation/);
+      }
     }
 
-    // The reconciliation must explicitly override the body's closed-allowlist
-    // claim, not merely append a name the earlier sentence still contradicts.
-    expect(prompt).toMatch(/superseded by this section/);
-    // And it must not have relaxed the read-only contract on the way through.
-    expect(prompt).toMatch(/no Edit, no Write, no Bash, no mutation/);
+    expect(sawExtras, 'expected ≥1 vendored builtin to have registry extras (research-agent)').toBe(
+      true,
+    );
   });
 
   it('strips vendored frontmatter from builtin prompts (body-only system prompt)', () => {

--- a/src/agent/agents/types.ts
+++ b/src/agent/agents/types.ts
@@ -48,6 +48,12 @@ export interface RegisteredAgent {
    */
   bashReadOnly?: boolean;
   /**
+   * Upstream-pinned tool surface for a vendored builtin. The builtin registry
+   * uses this marker to expose which entries need prompt/grant reconciliation;
+   * absent for file-defined and AFK-authored agents.
+   */
+  vendoredBaseTools?: readonly string[];
+  /**
    * Frontmatter keys that were recognized as Claude Code long-tail fields but
    * are not honored by AFK yet (e.g. `permissionMode`, `hooks`, `memory`).
    * Surfaced once as a scan warning; kept for `/agents` display.


### PR DESCRIPTION
## Summary

Generalizes the research-agent-specific registry-grant prompt-consistency guard into a table-driven structural invariant over ALL restricted builtin agents, so a newly added agent is covered automatically without a per-agent test.

## Problem

Restricted builtin agents have two sources of truth for their tool list: the mechanical allowlist in `builtins.ts` (what they CAN call) and the vendored prompt (what they BELIEVE they have). This drift bug shipped 3 times (#423, #925, #928). The fix in #928 introduced `withRegistryGrants()` — but the guard in `registry.test.ts` was research-agent-specific. Any new restricted builtin reintroduced the bug with nothing to catch it.

## Changes

Replaced the 32-line research-agent-specific test with a 74-line table-driven check that:

1. Maps each vendored builtin (`research-agent`, `git-investigator`) to its `allowedTools` constant.
2. For each: asserts every tool in the registry `tools:` array that is NOT in the vendored base appears in the composed prompt.
3. When extras exist: verifies the `withRegistryGrants()` supplement contains the override marker (`superseded by this section`) and preserves the read-only contract (`no Edit, no Write, no Bash, no mutation`).
4. Guards against vacuous pass: asserts at least one agent had registry extras.

Non-vendored builtins (Explore, general-purpose) are excluded — their AFK-authored prompts already name every tool they declare.

All 28 registry tests pass.

Closes #942.
