### PR TITLE
refactor: clean up dead re-exports and double re-export chain

### DIFF
--- a/src/agent/shell-jobs/index.ts
+++ b/src/agent/shell-jobs/index.ts
@@ -11,10 +11,6 @@
  */
 
 export {
-  startShell,
-  DEFAULT_TIMEOUT_MS,
-  DEFAULT_MAX_BYTES,
-  type StartShellOptions,
   type ShellHandle,
   type ShellResult,
   type ShellErrorReason,
@@ -24,6 +20,5 @@ export {
   ShellJobRegistry,
   type ShellJob,
   type ShellJobStatus,
-  type ShellJobRegistryEvents,
   type StartJobOptions,
 } from './registry.js';

--- a/src/cli/commands/login-command.ts
+++ b/src/cli/commands/login-command.ts
@@ -6,7 +6,7 @@ import { promptToken, runAuthWizard } from '../auth-wizard.js';
 
 // Re-export upsertEnvVar so existing tests that import it from this module
 // continue to work without modification.
-export { upsertEnvVar } from '../auth-wizard.js';
+export { upsertEnvVar } from '../../utils/envFile.js';
 
 export { promptToken };
 


### PR DESCRIPTION
Closes #1071

## Changes

### 1. Remove dead re-exports from `src/agent/shell-jobs/index.ts`

Grep-verified zero external consumers for each removed symbol:

| Symbol | Verdict |
|--------|---------|
| `DEFAULT_TIMEOUT_MS` | Dead — each file that uses this name defines its own local constant (`web-scrape.ts`, `mcp/client.ts`, `hooks/config-loader.ts`, etc.) |
| `DEFAULT_MAX_BYTES` | Dead — `web-scrape.ts` defines its own, no barrel import found |
| `StartShellOptions` | Dead — only used internally within `shell-jobs/` (by `registry.ts` and `streamer.test.ts` importing directly from `./streamer.js`) |
| `ShellJobRegistryEvents` | Dead — only in `registry.ts` and the barrel, no external import found |
| `startShell` | Dead — only used internally by `registry.ts` and `streamer.test.ts`, no external barrel import |

Retained all symbols that `src/cli/commands/interactive/shell-passthrough.ts` imports from the barrel: `ShellHandle`, `ShellResult`, `ShellErrorReason`, `ShellJobRegistry`, `ShellJob`, `ShellJobStatus`, `StartJobOptions`.

### 2. Fix double re-export chain for `upsertEnvVar`

**Before:** `src/utils/envFile.ts` → `src/cli/auth-wizard.ts` → `src/cli/commands/login-command.ts`

**After:** `src/utils/envFile.ts` → `src/cli/commands/login-command.ts` (direct)

- `login-command.ts` now re-exports `upsertEnvVar` directly from `../../utils/envFile.js` instead of routing through `auth-wizard.ts`
- The re-export in `login-command.ts` is preserved — `src/cli/login-command.test.ts` imports from this module and must continue to work
- The re-export in `auth-wizard.ts` is preserved — `src/cli/commands/telegram.ts` still imports `upsertEnvVar` from `auth-wizard.ts`

## Verification

- `pnpm lint` — passes clean
- `pnpm test` — 16570 passed; 2 pre-existing failures unrelated to this change (`write-denylist` symlink test, intermittent `subagent-prompt-capture-wiring` test) both reproduced on unmodified `main`
