### PR TITLE
refactor: extract duplicated escapeRegExp into src/utils/regexp.ts

### DIFF
--- a/src/agent/tools/hooks/bash-restriction-hook.ts
+++ b/src/agent/tools/hooks/bash-restriction-hook.ts
@@ -91,6 +91,7 @@ import {
   afkAllowlistFileForms,
   relocatedAfkSensitiveRoots,
 } from './afk-home-refs.js';
+import { escapeRegExp } from '../../../utils/regexp.js';
 
 /**
  * Interpreter denylist regex. Matches `<interpreter> -<flag>` where flag is
@@ -340,9 +341,6 @@ const PATH_LIKE_SPAN = /\/[^\s'"`;|&()<>]*/g;
  * any path characters so it can never itself satisfy a root or signal match. */
 const ALLOWLISTED_PLACEHOLDER = '<allowlisted-file>';
 
-function escapeRegExp(literal: string): string {
-  return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
 
 /**
  * The exact-file carve-outs (`READ_ALLOWLIST_REL`) in every spelling a bash

--- a/src/cli/slash/_lib/command-tags.ts
+++ b/src/cli/slash/_lib/command-tags.ts
@@ -2,6 +2,8 @@
  * XML tag constants and breadcrumb formatter for command input metadata.
  */
 
+import { escapeRegExp } from '../../../utils/regexp.js';
+
 export const COMMAND_NAME_TAG = 'command-name';
 export const COMMAND_MESSAGE_TAG = 'command-message';
 export const COMMAND_ARGS_TAG = 'command-args';
@@ -78,9 +80,6 @@ export function stripCommandTags(text: string): string {
   return result;
 }
 
-function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
 
 /**
  * Detect and strip `<skillName>` / `</skillName>` tags from content.

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -30,6 +30,7 @@ import { readSessionKey, signAbortRequest, freshChannelId } from '../agent/afk-c
 import { SessionLedgerWriter } from '../agent/session-ledger.js';
 import { splitLongMessage } from './formatter.js';
 import { routeFromCtx, sendOptions } from './route.js';
+import { escapeRegExp } from '../utils/regexp.js';
 
 /**
  * Bot configuration options
@@ -633,9 +634,4 @@ export class TelegramBot {
       console.log('[TelegramBot]', ...args);
     }
   }
-}
-
-/** Inline regex escape (avoids pulling in lodash for one call site). */
-function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/src/telegram/elicitation-handler.ts
+++ b/src/telegram/elicitation-handler.ts
@@ -34,15 +34,12 @@ import {
 } from './elicitation-callback-data.js';
 import { randomBytes } from 'node:crypto';
 import { escapeHtml } from './formatter.js';
+import { escapeRegExp } from '../utils/regexp.js';
 
 function nextElicitationId(): string {
   return `elic-${randomBytes(8).toString('hex')}`;
 }
 
-/** Inline regex escape helper (same pattern as bot.ts). */
-function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
 
 /** Sentinel returned by the custom-entry wildcard handler to the dispatch table. */
 const CUSTOM_ENTRY_SENTINEL_INDEX = -1;

--- a/src/telegram/elicitation-telegram.ts
+++ b/src/telegram/elicitation-telegram.ts
@@ -59,6 +59,7 @@ import type {
   ElicitationRequest,
   ElicitationResult,
 } from '../agent/types/sdk-types.js';
+import { escapeRegExp } from '../utils/regexp.js';
 
 /**
  * Prefix for path-approval / MCP elicitation callbacks. DISTINCT from the
@@ -290,9 +291,6 @@ function labelFor(choice: string): string {
   }
 }
 
-function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
 
 /**
  * Compose the two Telegram elicitation handlers into ONE dispatcher for

--- a/src/utils/envFile.ts
+++ b/src/utils/envFile.ts
@@ -14,15 +14,7 @@
 
 import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync, unlinkSync } from 'fs';
 import { dirname } from 'path';
-
-/**
- * Escape a string for safe literal use inside a `RegExp`. Env-var names are
- * normally `[A-Z0-9_]`, but callers may pass arbitrary keys (e.g. the
- * config-mutation engine), so we never interpolate a raw key into a pattern.
- */
-function escapeRegExp(literal: string): string {
-  return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
+import { escapeRegExp } from './regexp.js';
 
 /**
  * Write `contents` to `filePath` atomically: write a sibling temp file, then

--- a/src/utils/regexp.ts
+++ b/src/utils/regexp.ts
@@ -1,0 +1,19 @@
+/**
+ * Regular-expression utilities shared across the codebase.
+ *
+ * @module utils/regexp
+ */
+
+/**
+ * Escape a string so it can be used as a literal match inside a `RegExp`.
+ *
+ * Replaces every character that has special meaning in a regex pattern
+ * (`.*+?^${}()|[\]`) with its backslash-escaped equivalent, using the
+ * industry-standard character class from MDN's "Escaping user input" guide.
+ *
+ * @example
+ * const re = new RegExp(`^${escapeRegExp(key)}=.*$`, 'm');
+ */
+export function escapeRegExp(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}


### PR DESCRIPTION
## Summary

`escapeRegExp` was implemented independently in 6 files with byte-identical bodies — a classic copy/paste duplication that creates drift risk when the regex ever needs updating.

This refactor extracts the single canonical implementation into `src/utils/regexp.ts` and replaces all 6 private copies with imports from the new shared utility.

## Changes

**New file:**
- `src/utils/regexp.ts` — exports `escapeRegExp(literal: string): string` with JSDoc

**Updated (local function removed, import added):**
- `src/utils/envFile.ts`
- `src/agent/tools/hooks/bash-restriction-hook.ts`
- `src/cli/slash/_lib/command-tags.ts`
- `src/telegram/elicitation-handler.ts`
- `src/telegram/bot.ts`
- `src/telegram/elicitation-telegram.ts`

The regex pattern `str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')` is preserved byte-for-byte. No behavior change.

## Verification

- `pnpm lint` ✅ — TypeScript compiles cleanly (zero errors)
- `pnpm test` ✅ — 16,569 tests pass; 3 pre-existing failures on `origin/main` are unrelated to this change (confirmed by running the same 3 tests against baseline before applying the patch)

Closes #1066
