### PR TITLE
feat(schedule): add enable flag to cancel_schedule for re-enabling tasks

### DIFF
--- a/.filesize-baseline.json
+++ b/.filesize-baseline.json
@@ -48,7 +48,7 @@
     "src/agent/tools/hooks/path-approval-hook.ts": { "loc": 652, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/agent/tools/nesting.ts": { "loc": 520, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/agent/tools/readonly-bash.ts": { "loc": 763, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/agent/tools/schemas.ts": { "loc": 1345, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/agent/tools/schemas.ts": { "loc": 1339, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/agent/tools/skill-bridge.ts": { "loc": 498, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/agent/tools/skill-executor.ts": { "loc": 456, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/agent/tools/skill-executor/fork-dispatch.ts": { "loc": 393, "reason": "legacy: predates the ceiling gate; pending concern extraction" },

--- a/src/agent/tools/handlers/schedules.test.ts
+++ b/src/agent/tools/handlers/schedules.test.ts
@@ -200,6 +200,62 @@ describe('cancel_schedule handler', () => {
     }>;
     expect(list[0]?.enabled).toBe(false);
   });
+
+  it('enable: true → re-enables a disabled task', async () => {
+    await createScheduleHandler(
+      { name: 'Toggle Me', command: '/toggle', cron: '0 6 * * *' },
+      fakeSignal,
+    );
+    // Disable first
+    await cancelScheduleHandler({ taskId: 'toggle-me' }, fakeSignal);
+    const afterDisable = await listSchedulesHandler(null, fakeSignal);
+    const disabled = JSON.parse(afterDisable.content as string) as Array<{
+      id: string;
+      enabled: boolean;
+    }>;
+    expect(disabled[0]?.enabled).toBe(false);
+
+    // Re-enable
+    const result = await cancelScheduleHandler(
+      { taskId: 'toggle-me', enable: true },
+      fakeSignal,
+    );
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content as string) as {
+      ok: boolean;
+      enabled: boolean;
+    };
+    expect(parsed.ok).toBe(true);
+    expect(parsed.enabled).toBe(true);
+
+    // Verify via list
+    const afterEnable = await listSchedulesHandler(null, fakeSignal);
+    const enabled = JSON.parse(afterEnable.content as string) as Array<{
+      id: string;
+      enabled: boolean;
+    }>;
+    expect(enabled[0]?.enabled).toBe(true);
+  });
+
+  it('permanent: true takes precedence over enable: true', async () => {
+    await createScheduleHandler(
+      { name: 'Conflict', command: '/x', cron: '* * * * *' },
+      fakeSignal,
+    );
+    const result = await cancelScheduleHandler(
+      { taskId: 'conflict', permanent: true, enable: true },
+      fakeSignal,
+    );
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content as string) as { ok: boolean; permanent: boolean };
+    expect(parsed.ok).toBe(true);
+    expect(parsed.permanent).toBe(true);
+
+    // Should be removed from store
+    const listResult = await listSchedulesHandler(null, fakeSignal);
+    const list = JSON.parse(listResult.content as string) as unknown[];
+    expect(list).toHaveLength(0);
+  });
 });
 
 describe('get_schedule_history handler', () => {

--- a/src/agent/tools/handlers/schedules.test.ts
+++ b/src/agent/tools/handlers/schedules.test.ts
@@ -448,4 +448,33 @@ describe('live-sync surface (daemonSynced)', () => {
     expect(parsed.daemonSynced).toBe(false);
     expect(parsed.syncNote).toMatch(/next daemon/i);
   });
+
+  it('enable:true against a live daemon re-registers and reports synced', async () => {
+    const handle = await startDaemon({ port: 0 });
+    try {
+      // Create a disabled task (won't be registered with daemon)
+      await createScheduleHandler(
+        { name: 'Revive Me', command: '/x', cron: '59 23 31 12 *', enabled: false },
+        fakeSignal,
+      );
+      // Disable it via cancel (soft disable, not permanent)
+      await cancelScheduleHandler({ taskId: 'revive-me' }, fakeSignal);
+      // Re-enable via enable:true
+      const enable = await cancelScheduleHandler(
+        { taskId: 'revive-me', enable: true },
+        fakeSignal,
+      );
+      const parsed = JSON.parse(enable.content as string) as SyncShape;
+      expect(parsed.ok).toBe(true);
+      expect(parsed.daemonSynced).toBe(true);
+      expect(parsed.syncDetail).toBe('synced');
+      // Verify the daemon actually has the task registered
+      const tasks = (await (await fetch(`http://localhost:${handle.port}/tasks`)).json()) as Array<{
+        taskId: string;
+      }>;
+      expect(tasks.some((t) => t.taskId === 'revive-me')).toBe(true);
+    } finally {
+      await handle.stop();
+    }
+  });
 });

--- a/src/agent/tools/handlers/schedules.ts
+++ b/src/agent/tools/handlers/schedules.ts
@@ -23,6 +23,7 @@ import {
   addSchedule,
   removeSchedule,
   getSchedule,
+  toScheduledTask,
 } from '../../daemon/schedule-store.js';
 import { getTelemetryPath } from '../../../paths.js';
 import {
@@ -179,6 +180,7 @@ export const cancelScheduleHandler: ToolHandler = async (input, _signal) => {
   }
   const taskId = obj['taskId'] as string;
   const permanent = obj['permanent'] === true;
+  const enable = obj['enable'] === true;
 
   const existing = getSchedule(taskId);
   if (!existing) {
@@ -189,6 +191,17 @@ export const cancelScheduleHandler: ToolHandler = async (input, _signal) => {
   if (permanent) {
     removeSchedule(taskId);
     sync = await trySyncToDaemon('DELETE', `/tasks/${taskId}`);
+  } else if (enable) {
+    // Re-enable a previously disabled task and register with daemon
+    const schedules = loadSchedules();
+    const updated = schedules.map((s) =>
+      s.id === taskId ? { ...s, enabled: true, updatedAt: new Date().toISOString() } : s,
+    );
+    saveSchedules(updated);
+    const refreshed = getSchedule(taskId);
+    sync = refreshed
+      ? await trySyncToDaemon('POST', '/tasks', toScheduledTask(refreshed))
+      : await trySyncToDaemon('DELETE', `/tasks/${taskId}`);
   } else {
     const schedules = loadSchedules();
     const updated = schedules.map((s) =>
@@ -204,6 +217,7 @@ export const cancelScheduleHandler: ToolHandler = async (input, _signal) => {
       ok: true,
       taskId,
       permanent,
+      enabled: enable ? true : permanent ? undefined : false,
       daemonSynced: sync.synced,
       syncDetail: sync.detail,
       ...(sync.synced ? {} : { syncNote: SYNC_FAILED_NOTE }),

--- a/src/agent/tools/handlers/schedules.ts
+++ b/src/agent/tools/handlers/schedules.ts
@@ -198,10 +198,7 @@ export const cancelScheduleHandler: ToolHandler = async (input, _signal) => {
       s.id === taskId ? { ...s, enabled: true, updatedAt: new Date().toISOString() } : s,
     );
     saveSchedules(updated);
-    const refreshed = getSchedule(taskId);
-    sync = refreshed
-      ? await trySyncToDaemon('POST', '/tasks', toScheduledTask(refreshed))
-      : await trySyncToDaemon('DELETE', `/tasks/${taskId}`);
+    sync = await trySyncToDaemon('POST', '/tasks', toScheduledTask({ ...existing, enabled: true }));
   } else {
     const schedules = loadSchedules();
     const updated = schedules.map((s) =>
@@ -217,7 +214,7 @@ export const cancelScheduleHandler: ToolHandler = async (input, _signal) => {
       ok: true,
       taskId,
       permanent,
-      enabled: enable ? true : permanent ? undefined : false,
+      enabled: permanent ? undefined : enable ? true : false,
       daemonSynced: sync.synced,
       syncDetail: sync.detail,
       ...(sync.synced ? {} : { syncNote: SYNC_FAILED_NOTE }),

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -700,23 +700,17 @@ export const cancelScheduleTool: AnthropicToolDef = {
   category: 'schedule',
   concurrencySafe: false,
   description:
-    'Disable or permanently remove a scheduled task. ' +
-    'If permanent is false (default), sets enabled: false so the task can be re-enabled later. ' +
-    'If permanent is true, removes the task from the store entirely. ' +
+    'Disable, re-enable, or permanently remove a scheduled task. ' +
+    'Default (no flags): sets enabled: false. enable: true re-enables and re-registers with the daemon. ' +
+    'permanent: true removes from the store entirely (takes precedence over enable). ' +
     'The result includes daemonSynced/syncDetail — when daemonSynced is false, a running daemon ' +
     'still has the task registered until it restarts.',
   input_schema: {
     type: 'object',
     properties: {
-      taskId: {
-        type: 'string',
-        description: 'The task ID (slug) to cancel.',
-      },
-      permanent: {
-        type: 'boolean',
-        description:
-          'If true, remove from store entirely. If false (default), only sets enabled: false.',
-      },
+      taskId: { type: 'string', description: 'The task ID (slug) to operate on.' },
+      permanent: { type: 'boolean', description: 'If true, remove from store entirely.' },
+      enable: { type: 'boolean', description: 'If true, re-enable a disabled task and register it with the daemon.' },
     },
     required: ['taskId'],
   },

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -703,8 +703,8 @@ export const cancelScheduleTool: AnthropicToolDef = {
     'Disable, re-enable, or permanently remove a scheduled task. ' +
     'Default (no flags): sets enabled: false. enable: true re-enables and re-registers with the daemon. ' +
     'permanent: true removes from the store entirely (takes precedence over enable). ' +
-    'The result includes daemonSynced/syncDetail — when daemonSynced is false, a running daemon ' +
-    'still has the task registered until it restarts.',
+    'The result includes daemonSynced/syncDetail — when daemonSynced is false, the running daemon ' +
+    'did not pick up the change and will apply it on next restart.',
   input_schema: {
     type: 'object',
     properties: {


### PR DESCRIPTION
## Problem

Re-enabling a disabled scheduled task required a painful workaround: pull the full command text from `get_schedule_history`, then `create_schedule` a new task — which minted a duplicate `-2` suffixed ID, left the old disabled task in the store, and lost the original task's identity.

The `cancel_schedule` description even says *"sets enabled: false so the task can be re-enabled later"* but there was no tool to do the re-enabling.

## Solution

Add `enable?: boolean` as an optional field on `cancel_schedule`. Three-way branch ordering:

| Input | Behavior |
|---|---|
| `{ taskId, permanent: true }` | Remove from store entirely (unchanged) |
| `{ taskId, enable: true }` | **NEW** — flip `enabled: true`, POST to daemon using stored config via `toScheduledTask()` |
| `{ taskId }` (default) | Set `enabled: false` (unchanged) |

`permanent` takes precedence over `enable` when both are supplied.

## Changes

- **`src/agent/tools/handlers/schedules.ts`** — import `toScheduledTask`, add `enable` branch that reads stored config and POSTs to daemon
- **`src/agent/tools/schemas.ts`** — add `enable` property to `cancel_schedule` schema, update description (net -6 lines — under baseline)
- **`src/agent/tools/handlers/schedules.test.ts`** — two new tests: re-enable round-trip, permanent-takes-precedence guard
- **`.filesize-baseline.json`** — regenerated (schemas.ts ratcheted down)

## Testing

- `pnpm test src/agent/tools/handlers/schedules.test.ts` — 22/22 pass
- `pnpm lint` — clean
- `pnpm audit:filesize:check` — clean (schemas.ts 1345→1339, under baseline)
