### PR TITLE
feat(facets): auto-derive session facets at SessionEnd + backfill script

### DIFF
--- a/scripts/backfill-facets.ts
+++ b/scripts/backfill-facets.ts
@@ -1,0 +1,73 @@
+/**
+ * Batch-derive facets for all persisted sessions that don't have one yet.
+ *
+ * Usage:
+ *   npx tsx scripts/backfill-facets.ts [--dry-run] [--force]
+ *
+ * --dry-run  Count sessions needing derivation without writing anything.
+ * --force    Re-derive even when a fresh cache entry exists.
+ *
+ * Exit codes:
+ *   0  All sessions processed (or dry-run complete).
+ *   1  Unexpected error.
+ */
+
+import { existsSync, readdirSync } from 'fs';
+import { basename, join } from 'path';
+import { getOrDeriveFacet, listSessionIds } from '../src/agent/facets/store.js';
+import { getFacetCacheDir } from '../src/paths.js';
+
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const force = args.includes('--force');
+
+const sessionIds = listSessionIds();
+const cacheDir = getFacetCacheDir();
+
+// Determine which sessions already have cached facets.
+const cachedIds = new Set<string>();
+if (existsSync(cacheDir)) {
+  for (const f of readdirSync(cacheDir)) {
+    if (f.endsWith('.json')) cachedIds.add(basename(f, '.json'));
+  }
+}
+
+const needDerivation = force ? sessionIds : sessionIds.filter((id) => !cachedIds.has(id));
+
+console.log(`Total sessions:       ${sessionIds.length}`);
+console.log(`Already cached:       ${cachedIds.size}`);
+console.log(`Needing derivation:   ${needDerivation.length}`);
+
+if (dryRun) {
+  console.log('(dry-run — no facets written)');
+  process.exit(0);
+}
+
+let derived = 0;
+let skipped = 0;
+let failed = 0;
+
+for (const id of needDerivation) {
+  try {
+    const facet = getOrDeriveFacet(id, { force });
+    if (facet) {
+      derived++;
+    } else {
+      // Session file missing or unparseable — loadStoredSession returned undefined.
+      skipped++;
+    }
+  } catch {
+    failed++;
+  }
+
+  // Progress every 500 sessions.
+  const total = derived + skipped + failed;
+  if (total % 500 === 0 && total > 0) {
+    console.log(`  … ${total}/${needDerivation.length} processed`);
+  }
+}
+
+console.log(`\nDone.`);
+console.log(`  Derived: ${derived}`);
+console.log(`  Skipped: ${skipped} (missing or unparseable session file)`);
+console.log(`  Failed:  ${failed} (derivation error)`);

--- a/src/agent/default-hook-registry.ts
+++ b/src/agent/default-hook-registry.ts
@@ -16,6 +16,7 @@ import { createPlanModeGate } from './plan-mode-gate.js';
 import { createAfkModeGate } from './afk-mode-gate.js';
 import { cleanupComposeSpills } from './tools/compose-executor.js';
 import { runReceiptSessionEndHook } from './trace/receipt.js';
+import { createFacetSessionEndHook } from './facets/session-end-hook.js';
 import { inboundAttachmentRegistry } from './content/attachment-registry.js';
 import { env } from '../config/env.js';
 import {
@@ -280,6 +281,10 @@ export function createDefaultHookRegistry(
   // JSON+Markdown summary of the run under ~/.afk/state/receipts/. Best-effort
   // and never injects/blocks; skips subagents and honors AFK_RUN_RECEIPT_DISABLED.
   registry.register('SessionEnd', runReceiptSessionEndHook);
+  // Derive and cache a session facet at teardown so every top-level session
+  // is visible to harvest --rank and other facet consumers. Best-effort;
+  // skips subagents; never blocks teardown.
+  registry.register('SessionEnd', createFacetSessionEndHook());
   if (onSubagentComplete) {
     registry.register('SubagentStop', (context) => {
       if (context.event !== 'SubagentStop') return {};

--- a/src/agent/facets/index.ts
+++ b/src/agent/facets/index.ts
@@ -38,3 +38,5 @@ export {
   listSessionIds,
   type FacetStoreOptions,
 } from './store.js';
+
+export { createFacetSessionEndHook } from './session-end-hook.js';

--- a/src/agent/facets/session-end-hook.test.ts
+++ b/src/agent/facets/session-end-hook.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Unit tests for the facet SessionEnd hook.
+ *
+ * Verifies the subagent guard (skips children), the no-sessionId guard,
+ * and that derivation failures never propagate (best-effort contract).
+ */
+import { describe, expect, it, vi } from 'vitest';
+import type { SessionEndContext } from '../hooks.js';
+import { createFacetSessionEndHook } from './session-end-hook.js';
+
+// Mock the store module so we can intercept getOrDeriveFacet calls
+// without touching the real filesystem.
+vi.mock('./store.js', () => ({
+  getOrDeriveFacet: vi.fn(),
+}));
+
+import { getOrDeriveFacet } from './store.js';
+const mockDerive = vi.mocked(getOrDeriveFacet);
+
+function endCtx(over: Partial<SessionEndContext> = {}): SessionEndContext {
+  return { event: 'SessionEnd', sessionId: 'sess-1', ...over };
+}
+
+describe('createFacetSessionEndHook', () => {
+  it('derives a facet for a top-level session', () => {
+    const hook = createFacetSessionEndHook();
+
+    hook(endCtx({ sessionId: 'top-level' }));
+
+    expect(mockDerive).toHaveBeenCalledTimes(1);
+    expect(mockDerive).toHaveBeenCalledWith('top-level');
+  });
+
+  it('skips subagent sessions (parentSessionId set)', () => {
+    mockDerive.mockClear();
+    const hook = createFacetSessionEndHook();
+
+    hook(endCtx({ sessionId: 'child-1', parentSessionId: 'parent-1' }));
+
+    expect(mockDerive).not.toHaveBeenCalled();
+  });
+
+  it('skips when sessionId is absent', () => {
+    mockDerive.mockClear();
+    const hook = createFacetSessionEndHook();
+
+    hook(endCtx({ sessionId: undefined }));
+
+    expect(mockDerive).not.toHaveBeenCalled();
+  });
+
+  it('returns {} for non-SessionEnd events', () => {
+    mockDerive.mockClear();
+    const hook = createFacetSessionEndHook();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = hook({ event: 'SessionStart', sessionId: 'x' } as any);
+
+    expect(result).toEqual({});
+    expect(mockDerive).not.toHaveBeenCalled();
+  });
+
+  it('swallows derivation errors without propagating', () => {
+    mockDerive.mockClear();
+    mockDerive.mockImplementation(() => {
+      throw new Error('corrupt session JSON');
+    });
+    const hook = createFacetSessionEndHook();
+
+    // Must not throw
+    expect(() => hook(endCtx({ sessionId: 'corrupt' }))).not.toThrow();
+    expect(mockDerive).toHaveBeenCalledWith('corrupt');
+  });
+});

--- a/src/agent/facets/session-end-hook.ts
+++ b/src/agent/facets/session-end-hook.ts
@@ -1,0 +1,45 @@
+/**
+ * SessionEnd hook that derives and caches a facet for the completed session.
+ *
+ * Facets are structured summaries of a session's tool usage, outcomes, and
+ * metadata. Before this hook, facets were only derived on-demand when a
+ * plugin (e.g. harvest) explicitly requested one — so only ~5% of sessions
+ * had facets. This hook ensures every top-level session gets a facet
+ * automatically at teardown.
+ *
+ * Contract:
+ * - Skips subagent sessions (parentSessionId present) — only top-level
+ *   sessions produce harvestable facets.
+ * - Best-effort: a derivation failure never blocks session teardown.
+ * - The facet is written to the cache dir (getFacetCacheDir()) via the
+ *   existing atomic write-through in getOrDeriveFacet.
+ *
+ * @module agent/facets/session-end-hook
+ */
+
+import type { HookHandler } from '../hooks.js';
+import { getOrDeriveFacet } from './store.js';
+
+export function createFacetSessionEndHook(): HookHandler {
+  return (context) => {
+    if (context.event !== 'SessionEnd') return {};
+    // Subagent guard: forked children inherit the parent's hook registry,
+    // so their teardown fires this too. Skip — subagent sessions are worker
+    // details, not standalone harvestable units.
+    if (context.parentSessionId) return {};
+
+    const sessionId = context.sessionId;
+    if (!sessionId) return {};
+
+    try {
+      getOrDeriveFacet(sessionId);
+    } catch {
+      // Best-effort: derivation failures (corrupt session JSON, schema
+      // mismatch) must never block teardown. The session sidecar is still
+      // on disk — a future getOrDeriveFacet call (or a FACET_VERSION bump
+      // that fixes the schema) will succeed.
+    }
+
+    return {};
+  };
+}


### PR DESCRIPTION
## Problem

Facet derivation was entirely lazy and demand-driven — `getOrDeriveFacet()` only ran when a plugin (e.g. harvest) explicitly requested a specific session. This meant only ~5% of sessions (144 out of 3,015) had facets, making `/harvest --rank` blind to the vast majority of session history.

## Changes

### SessionEnd hook (going forward)

- `src/agent/facets/session-end-hook.ts` — `createFacetSessionEndHook()` derives and caches a facet automatically at session teardown
- Registered in `default-hook-registry.ts` after the run-receipt hook
- Skips subagent sessions (`parentSessionId` guard), best-effort (derivation failures never block teardown)
- 5 unit tests covering: top-level derive, subagent skip, no-sessionId skip, wrong-event skip, error swallowing

### Backfill script (one-time catch-up)

- `scripts/backfill-facets.ts` — batch-derives facets for all sessions missing one
- Supports `--dry-run` (count only) and `--force` (re-derive even when cached)
- Already ran on this machine: 2,877 new facets derived (144 → 3,021), 0 failures

## Verification

- `pnpm lint` — clean
- `pnpm test src/agent/facets/` — 36 tests pass (4 files including the new one)
- `pnpm audit:filesize:check` — `default-hook-registry.ts` at 336 lines (under 350 ceiling)
