### PR TITLE
feat(hooks): upgrade safe-destruct and release-boundary to block+explain (#1088 consumer)

### DIFF
--- a/src/agent/default-hook-registry.ts
+++ b/src/agent/default-hook-registry.ts
@@ -115,28 +115,22 @@ export function createDefaultHookRegistry(
   // router park-and-decline after the round-trip. No-op on REPL/Telegram
   // (handler installed; probed at call time). See ask-question-gate.ts.
   registry.register('PreToolUse', createAskQuestionGate());
-  // Safe-destruct detector (observe-only, ALL surfaces): witness — but never
-  // block — bash commands matching a curated destructive/irreversible pattern
-  // (rm -rf, git reset --hard, DROP DATABASE, dd of=/dev/*, mkfs, terraform
-  // destroy, ...). It emits a `hook_decision` catch-record via the unused
-  // `approve` outcome, so it (a) adds ZERO blocking friction — the interpreter-
-  // eval lesson that started this program — and (b) is filterable as
-  // decision==='approve' and ignored by the mechanical friction detectors. This
-  // is the Wave-1 shadow window whose records calibrate a later block/nudge
-  // slice. Registered unconditionally (no deps, never blocks → safe on headless/
-  // autonomous surfaces too). See safe-destruct-detect.ts and
-  // .afk/plans/friction-substrate-and-gate-migration.md §9.
+  // Safe-destruct detector (two-tier, ALL surfaces): OBSERVE-tier records
+  // destructive bash commands (rm -rf, git branch -D, etc.) via `approve`
+  // catch-records without blocking; BLOCK-tier hard-blocks irrecoverable
+  // operations (git reset --hard, git push --force, terraform destroy, etc.)
+  // with `injectContext` guidance explaining why and what to do instead.
+  // See safe-destruct-detect.ts, safe-destruct-patterns.ts, and
+  // .afk/plans/friction-substrate-and-gate-migration.md.
   registry.register('PreToolUse', createSafeDestructDetect());
-  // Release-boundary detector (observe-only, ALL surfaces): witness — but never
-  // block — bash commands that cross a publish/deploy boundary (npm/pnpm/yarn/
-  // cargo/twine/poetry/gem publish, docker push, gh release create, terraform/
-  // kubectl apply) or a sync boundary (git push --mirror / --tags). Same
-  // `approve`-outcome catch-record mechanism as safe-destruct: ZERO blocking
-  // friction (a release is often exactly what was asked — a block would be a
-  // false positive by construction), filterable as decision==='approve', ignored
-  // by the mechanical friction detectors. Wave-1 slice 2 shadow window. See
-  // release-boundary-detect.ts and
-  // .afk/plans/friction-substrate-and-gate-migration.md §9.
+  // Release-boundary detector (two-tier, ALL surfaces): BLOCK-tier hard-blocks
+  // externally-irreversible publish/deploy operations (npm/pnpm/yarn/cargo/
+  // twine/poetry/gem publish, docker push, gh release create, terraform/
+  // kubectl apply) with `injectContext` guidance; OBSERVE-tier records
+  // sync-boundary operations (git push --mirror / --tags) via `approve`
+  // catch-records without blocking. See release-boundary-detect.ts,
+  // release-boundary-patterns.ts, and
+  // .afk/plans/friction-substrate-and-gate-migration.md.
   registry.register('PreToolUse', createReleaseBoundaryDetect());
   const store = memoryStore ?? new MemoryStore();
   if (getPermissionMode !== undefined) {

--- a/src/agent/release-boundary-detect.test.ts
+++ b/src/agent/release-boundary-detect.test.ts
@@ -1,16 +1,20 @@
 /**
- * Tests for the observe-only release-boundary detector (Wave 1 slice 2,
- * gate-migration).
+ * Tests for the two-tier release-boundary detector (Wave 1 block+explain
+ * upgrade, gate-migration).
  *
- * Three contracts:
+ * Six contracts:
  *   1. `detectReleaseBoundaryCommands` matches the curated publish/deploy/sync
  *      boundary patterns and — critically for calibration — does NOT flag
  *      common pre-boundary near misses (`npm version`, `git tag`, a plain
  *      `git push origin main`, `npm install`).
- *   2. The hook returns an `approve` catch-record (never a block) only on a
- *      `bash` PreToolUse with a boundary-crossing command; `{}` otherwise.
- *   3. It is wired into the default registry and, dispatched end-to-end, passes
- *      the command through (no throw) while recording `decision: 'approve'`.
+ *   2. OBSERVE patterns (sync-boundary) return `decision: 'approve'`.
+ *   3. BLOCK patterns (publish/deploy/infra) return `decision: 'block'` with a
+ *      reason naming the pattern and `injectContext` guidance.
+ *   4. When a compound command matches both tiers, BLOCK wins.
+ *   5. Non-boundary commands, non-bash tools, and non-PreToolUse events pass
+ *      through as `{}`.
+ *   6. Registry wiring: dispatched end-to-end, BLOCK-tier throws
+ *      HookBlockedError with injectContext; OBSERVE-tier records approve.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -19,7 +23,9 @@ import {
   createReleaseBoundaryDetect,
   detectReleaseBoundaryCommands,
   RELEASE_BOUNDARY_DETECT_REASON_PREFIX,
+  RELEASE_BOUNDARY_BLOCK_INJECT_CONTEXT,
 } from './release-boundary-detect.js';
+import { HookBlockedError } from '../utils/errors.js';
 import { createDefaultHookRegistry } from './default-hook-registry.js';
 
 function preCtx(command: string, toolName = 'bash'): HookContext {
@@ -73,20 +79,52 @@ describe('detectReleaseBoundaryCommands', () => {
   });
 });
 
-describe('createReleaseBoundaryDetect (observe-only hook)', () => {
+// ---------------------------------------------------------------------------
+// createReleaseBoundaryDetect — two-tier hook decisions
+// ---------------------------------------------------------------------------
+
+describe('createReleaseBoundaryDetect (two-tier hook)', () => {
   const hook = createReleaseBoundaryDetect();
 
-  it('returns an approve catch-record with the stable reason prefix on a boundary bash command', () => {
-    const decision = hook(preCtx('npm publish --provenance'));
-    expect(decision.decision).toBe('approve');
-    expect(decision.reason).toContain(RELEASE_BOUNDARY_DETECT_REASON_PREFIX);
-    expect(decision.reason).toContain('npm-publish');
+  // ── BLOCK patterns (publish/deploy/infra) must block with injectContext ────
+  it.each([
+    ['npm publish --provenance', 'npm-publish'],
+    ['pnpm publish --no-git-checks', 'pnpm-publish'],
+    ['yarn publish', 'yarn-publish'],
+    ['cargo publish', 'cargo-publish'],
+    ['twine upload dist/*', 'pypi-twine-upload'],
+    ['poetry publish --build', 'poetry-publish'],
+    ['gem push mygem-1.0.0.gem', 'gem-push'],
+    ['docker push registry.io/app:latest', 'docker-push'],
+    ['gh release create v1.2.3 --generate-notes', 'gh-release-create'],
+    ['terraform apply -auto-approve', 'terraform-apply'],
+    ['kubectl apply -f deploy.yaml', 'kubectl-apply'],
+  ])('BLOCK pattern %s returns block decision naming %s with injectContext', (command, expectedPatternId) => {
+    const decision: HookDecision = hook(preCtx(command));
+    expect(decision.decision).toBe('block');
+    expect(decision.reason).toContain(expectedPatternId);
+    expect(decision.injectContext).toBe(RELEASE_BOUNDARY_BLOCK_INJECT_CONTEXT);
   });
 
-  it('NEVER blocks — no block decision, no continue:false (the interpreter-eval lesson)', () => {
-    const decision: HookDecision = hook(preCtx('git push --mirror git@github.com:org/x.git'));
+  // ── OBSERVE patterns (sync-boundary) must approve ─────────────────────────
+  it.each([
+    ['git push --mirror git@github.com:org/x.git', 'git-push-mirror'],
+    ['git push origin --tags', 'git-push-tags'],
+    ['git push origin main --follow-tags', 'git-push-tags'],
+  ])('OBSERVE pattern %s returns approve, not block', (command, _id) => {
+    const decision: HookDecision = hook(preCtx(command));
+    expect(decision.decision).toBe('approve');
     expect(decision.decision).not.toBe('block');
-    expect(decision.continue).not.toBe(false);
+    expect(decision.reason).toContain(RELEASE_BOUNDARY_DETECT_REASON_PREFIX);
+  });
+
+  // ── BLOCK wins when both tiers match in one compound command ───────────────
+  it('block wins over approve when a compound command matches both tiers', () => {
+    // npm publish → BLOCK; git push --tags → OBSERVE
+    const decision: HookDecision = hook(preCtx('npm publish && git push origin --tags'));
+    expect(decision.decision).toBe('block');
+    expect(decision.reason).toContain('npm-publish');
+    expect(decision.injectContext).toBe(RELEASE_BOUNDARY_BLOCK_INJECT_CONTEXT);
   });
 
   it('passes through non-boundary bash commands', () => {
@@ -110,15 +148,35 @@ describe('createReleaseBoundaryDetect (observe-only hook)', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Registry wiring
+// ---------------------------------------------------------------------------
+
 describe('release-boundary-detect wiring in the default registry', () => {
-  it('is registered and records approve (without blocking) for a boundary bash call', async () => {
+  it('throws HookBlockedError with injectContext for a BLOCK-tier boundary bash call', async () => {
     const { registry } = createDefaultHookRegistry(undefined, 'cli');
     const ctx: PreToolUseContext = {
       event: 'PreToolUse',
       toolName: 'bash',
       input: { command: 'npm publish --provenance' },
     };
-    // Must not throw (a block would throw HookBlockedError through dispatch).
+    try {
+      await registry.dispatch(ctx);
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(HookBlockedError);
+      expect((err as HookBlockedError).injectContext).toBe(RELEASE_BOUNDARY_BLOCK_INJECT_CONTEXT);
+    }
+  });
+
+  it('records approve (without blocking) for an OBSERVE-tier sync-boundary call', async () => {
+    const { registry } = createDefaultHookRegistry(undefined, 'cli');
+    const ctx: PreToolUseContext = {
+      event: 'PreToolUse',
+      toolName: 'bash',
+      input: { command: 'git push origin --tags' },
+    };
+    // Must not throw — OBSERVE tier passes through.
     const decision = await registry.dispatch(ctx);
     expect(decision.decision).toBe('approve');
     expect(decision.reason).toContain(RELEASE_BOUNDARY_DETECT_REASON_PREFIX);

--- a/src/agent/release-boundary-detect.test.ts
+++ b/src/agent/release-boundary-detect.test.ts
@@ -51,6 +51,9 @@ describe('detectReleaseBoundaryCommands', () => {
     ['git push --mirror git@github.com:org/mirror.git', 'git-push-mirror'],
     ['git push origin main --follow-tags', 'git-push-tags'],
     ['git push origin --tags', 'git-push-tags'],
+    // cargo global options before subcommand
+    ['cargo --locked publish', 'cargo-publish'],
+    ['cargo --frozen --locked publish', 'cargo-publish'],
   ])('flags %j → %s', (command, expectedId) => {
     expect(detectReleaseBoundaryCommands(command)).toContain(expectedId);
   });
@@ -68,6 +71,10 @@ describe('detectReleaseBoundaryCommands', () => {
     ['terraform plan'], // plan, not apply
     ['kubectl get pods'],
     [''],
+    // quoted strings — keyword inside literal, not executed
+    ["rg 'npm publish' README.md"],
+    ["grep 'npm publish' docs/"],
+    ["echo 'npm publish'"],
   ])('does not flag pre-boundary/benign %j', (command) => {
     expect(detectReleaseBoundaryCommands(command)).toEqual([]);
   });
@@ -111,11 +118,11 @@ describe('createReleaseBoundaryDetect (two-tier hook)', () => {
     ['git push --mirror git@github.com:org/x.git', 'git-push-mirror'],
     ['git push origin --tags', 'git-push-tags'],
     ['git push origin main --follow-tags', 'git-push-tags'],
-  ])('OBSERVE pattern %s returns approve, not block', (command, _id) => {
+  ])('OBSERVE pattern %s returns approve, not block', (command, expectedId) => {
     const decision: HookDecision = hook(preCtx(command));
     expect(decision.decision).toBe('approve');
-    expect(decision.decision).not.toBe('block');
     expect(decision.reason).toContain(RELEASE_BOUNDARY_DETECT_REASON_PREFIX);
+    expect(decision.reason).toContain(expectedId);
   });
 
   // ── BLOCK wins when both tiers match in one compound command ───────────────
@@ -125,6 +132,36 @@ describe('createReleaseBoundaryDetect (two-tier hook)', () => {
     expect(decision.decision).toBe('block');
     expect(decision.reason).toContain('npm-publish');
     expect(decision.injectContext).toBe(RELEASE_BOUNDARY_BLOCK_INJECT_CONTEXT);
+  });
+
+  // ── Dry-run exemptions: BLOCK-tier commands demoted to OBSERVE ────────────
+  it.each([
+    ['npm publish --dry-run', 'npm-publish'],
+    ['pnpm publish --dry-run', 'pnpm-publish'],
+    ['cargo publish --dry-run', 'cargo-publish'],
+    ['cargo --locked publish --dry-run', 'cargo-publish'],
+    ['kubectl apply --dry-run=client -f deploy.yaml', 'kubectl-apply'],
+    ['kubectl apply --dry-run=server -f deploy.yaml', 'kubectl-apply'],
+    ['terraform apply -refresh-only', 'terraform-apply'],
+  ])('dry-run %s is NOT blocked but IS observed', (command, expectedId) => {
+    const decision: HookDecision = hook(preCtx(command));
+    expect(decision.decision).toBe('approve');
+    expect(decision.decision).not.toBe('block');
+    expect(decision.reason).toContain(RELEASE_BOUNDARY_DETECT_REASON_PREFIX);
+    expect(decision.reason).toContain(expectedId);
+    expect(decision.reason).toContain('dry-run');
+  });
+
+  // ── Quoted strings: read-only tools with publish keyword must not block ────
+  it.each([
+    ["rg 'npm publish' README.md"],
+    ["grep 'npm publish' docs/"],
+    ["echo 'npm publish'"],
+    ["grep 'cargo publish' Makefile"],
+  ])('quoted command %s does not trigger detection', (command) => {
+    expect(detectReleaseBoundaryCommands(command)).toEqual([]);
+    const decision: HookDecision = hook(preCtx(command));
+    expect(decision).toEqual({});
   });
 
   it('passes through non-boundary bash commands', () => {

--- a/src/agent/release-boundary-detect.ts
+++ b/src/agent/release-boundary-detect.ts
@@ -1,111 +1,78 @@
 /**
- * Release-boundary detector — an **observe-only** PreToolUse hook.
+ * Release-boundary detector — a two-tier PreToolUse hook.
  *
  * Migrates the detection half of the `release-boundary-gate` gate-skill into
  * deterministic harness code (Wave 1 slice 2 of the friction-substrate /
  * gate-migration program — `.afk/plans/friction-substrate-and-gate-migration.md`;
  * sibling of `safe-destruct-detect.ts`). It watches `bash` commands for the two
- * boundary classes the skill defines and, on a match, emits a witnessed
- * catch-record — **without blocking the command**:
- *   - **publish / deploy boundary** — pushing a package to a registry (npm, PyPI,
- *     crates.io, RubyGems), a container image to a registry, cutting a GitHub
- *     release, or deploying infra (`terraform apply`, `kubectl apply`);
- *   - **sync boundary** — mirroring or pushing across a visibility boundary
- *     (`git push --mirror`, release-tag pushes).
+ * boundary classes the skill defines and routes each to one of two tiers:
  *
- * # Why observe-only (the interpreter-eval lesson)
+ *   BLOCK — returns `decision: 'block'` with a human-readable reason and
+ *     `injectContext` guidance. Reserved for externally-irreversible publish
+ *     and deploy operations: once a package is published to a registry, a
+ *     container image pushed, a GitHub release cut, or infra applied, the
+ *     external state change cannot be undone by the agent.
  *
- * This whole program exists because an over-firing PreToolUse *hard block* (the
- * interpreter-eval guard) generated 18 nights of self-inflicted friction. The
- * plan's de-risking rule is "shadow-window before enforcing". PreToolUse cannot
- * `injectContext` — the harness honors that field only for `SubagentStop` /
- * `UserPromptSubmit` (see `hooks.ts`) — and a hard block would repeat the exact
- * mistake, at higher cost here: a release/deploy is often exactly what the user
- * asked for, so blocking it would be a false positive by construction. So this
- * slice changes ZERO behavior: it only records that a boundary-crossing command
- * was attempted. The records are the shadow window; a later slice uses their
- * real-world frequency per pattern to calibrate which (if any) warrant the
- * skill's real value — a pre-boundary living-artifact check, not a block.
+ *   OBSERVE — returns `decision: 'approve'` (never blocks). Used for sync
+ *     boundary operations (`git push --mirror`, `--tags`) that are closer to
+ *     the "often exactly what was asked for" boundary — blocking these would
+ *     generate false-positive friction for legitimate release workflows.
  *
- * # How the catch-record is emitted (the `approve` outcome)
+ * # Precedence rule
+ *
+ * When a single compound command matches patterns from both tiers, BLOCK wins.
+ * Same rationale as `safe-destruct-detect.ts`: a command containing even one
+ * externally-irreversible sub-operation must not slip through because it is
+ * mixed with a recoverable one.
+ *
+ * # How the approve catch-record is emitted (OBSERVE tier)
  *
  * A PreToolUse handler can only `block` or pass; passing (`{}`) is not witnessed
  * with a reason. To emit a filterable catch-record while letting the command
- * run, this hook returns the otherwise-unused `decision: 'approve'` outcome with
- * a structured `reason`. `approve`:
- *   - is behaviorally identical to unset — `isBlocking()` (`hook-registry.ts`)
- *     checks only `block` / `continue:false`, so the command proceeds and the
- *     other PreToolUse gates (safe-destruct, afk-mode, bash-restriction, ...)
- *     still run;
- *   - is recorded by `dispatchPreToolUse` as a `hook_decision` event carrying
- *     the `reason` (`subagent-hooks.ts`), which is the Wave-4 substrate signal;
- *   - is IGNORED by the mechanical friction detectors (they count `block`
- *     outcomes / error `failureClass`es — see `improve/scan/detectors`), so
- *     these observations never masquerade as new friction.
- * Only `safe-destruct-detect` also returns `approve`; the distinct `reason`
- * prefix keeps release-boundary observations cleanly separable in the trace.
+ * run, OBSERVE patterns return `decision: 'approve'` with a structured reason:
+ *   - behaviorally identical to unset — `isBlocking()` (`hook-registry.ts`)
+ *     checks only `block` / `continue:false`, so the command proceeds;
+ *   - recorded by `dispatchPreToolUse` as a `hook_decision` event carrying
+ *     the `reason`, which is the Wave-4 substrate signal;
+ *   - IGNORED by the mechanical friction detectors.
  *
  * Registered unconditionally on ALL surfaces (including headless/autonomous,
- * where an unattended publish/deploy is most consequential and least observed)
- * precisely because it never blocks — it is safe everywhere.
+ * where an unattended publish/deploy is most consequential and least observed).
  *
  * @module agent/release-boundary-detect
  */
 
 import type { HookContext, HookDecision } from './hooks.js';
+import {
+  RELEASE_BOUNDARY_PATTERNS,
+  type ReleaseBoundaryPattern,
+} from './release-boundary-patterns.js';
 
 /**
- * Stable prefix on the emitted `reason`. Exported so the telemetry substrate,
- * tests, and `afk trace show` can match release-boundary observations by prefix.
+ * Stable prefix on OBSERVE reason strings. Exported so telemetry, tests, and
+ * `afk trace show` can isolate release-boundary observations by prefix.
  */
 export const RELEASE_BOUNDARY_DETECT_REASON_PREFIX =
-  'release-boundary observe-only: publish/deploy/sync-boundary command';
+  'release-boundary observe-only: sync-boundary command';
 
 /**
- * Curated publish / deploy / sync boundary command patterns.
- *
- * Calibration bias: high-signal only — commands that cross a real release,
- * deploy, or visibility boundary, where the skill's living-artifact contract
- * (changelogs, generated docs, lock files, version manifests) is structurally
- * at risk. Routine pre-boundary steps (`npm version`, `git tag`, `git push`
- * without `--mirror`/`--tags`) are deliberately NOT flagged. Each regex avoids
- * nested quantifiers so the scan is linear (no ReDoS); `[^|&;\n]*` bounds a
- * match to a single command segment.
- *
- * Reused by the future block/nudge slice — keep it the single source of truth.
+ * Context injected into the `isError` tool_result when a BLOCK-tier pattern
+ * fires. Delivered via `HookBlockedError.injectContext` → `dispatcher.ts`
+ * block-path content (PR #1088). The agent sees this after the terse
+ * `blockReason` — it explains the hook's purpose and what to do next.
  */
-const RELEASE_BOUNDARY_PATTERNS: readonly { readonly id: string; readonly re: RegExp }[] = [
-  // --- package-registry publish ----------------------------------------------
-  { id: 'npm-publish', re: /\bnpm\s+publish\b/i },
-  { id: 'pnpm-publish', re: /\bpnpm\s+publish\b/i },
-  // yarn classic (`yarn publish`) and berry (`yarn npm publish`).
-  { id: 'yarn-publish', re: /\byarn\s+(?:npm\s+)?publish\b/i },
-  { id: 'cargo-publish', re: /\bcargo\s+publish\b/i },
-  { id: 'pypi-twine-upload', re: /\btwine\s+upload\b/i },
-  { id: 'poetry-publish', re: /\bpoetry\s+publish\b/i },
-  { id: 'gem-push', re: /\bgem\s+push\b/i },
-
-  // --- container registry -----------------------------------------------------
-  { id: 'docker-push', re: /\bdocker\s+(?:image\s+)?push\b/i },
-
-  // --- release cut ------------------------------------------------------------
-  { id: 'gh-release-create', re: /\bgh\s+release\s+create\b/i },
-
-  // --- infra deploy -----------------------------------------------------------
-  { id: 'terraform-apply', re: /\bterraform\s+apply\b/i },
-  { id: 'kubectl-apply', re: /\bkubectl\s+apply\b/i },
-
-  // --- sync / visibility boundary --------------------------------------------
-  // A full mirror push copies every ref across a boundary.
-  { id: 'git-push-mirror', re: /\bgit\s+push\b[^|&;\n]*--mirror\b/i },
-  // Pushing release tags is the canonical cut-a-release sync signal.
-  { id: 'git-push-tags', re: /\bgit\s+push\b[^|&;\n]*--(?:tags|follow-tags)\b/i },
-];
+export const RELEASE_BOUNDARY_BLOCK_INJECT_CONTEXT =
+  'This command was blocked by the release-boundary hook because it crosses ' +
+  'an externally-irreversible publish or deploy boundary. Once a package is ' +
+  'published, a container pushed, a release cut, or infrastructure applied, ' +
+  'the external state change cannot be undone by the agent. Verify that all ' +
+  'living artifacts (changelog, version, generated docs, lock files) are ' +
+  'up-to-date before proceeding, and ask the operator to confirm publication.';
 
 /**
  * Return the ids of every release-boundary pattern the command matches (empty
  * when none). Pure and stateless — no global-flag regexes, so `.test()` is safe
- * to call repeatedly. Exported for the block/nudge slice and for tests.
+ * to call repeatedly. Exported for tests.
  */
 export function detectReleaseBoundaryCommands(command: string): string[] {
   if (!command) return [];
@@ -116,8 +83,13 @@ export function detectReleaseBoundaryCommands(command: string): string[] {
   return hits;
 }
 
+/** Look up a pattern by id. */
+function getPattern(id: string): ReleaseBoundaryPattern | undefined {
+  return RELEASE_BOUNDARY_PATTERNS.find((p) => p.id === id);
+}
+
 /**
- * Create the observe-only release-boundary PreToolUse hook.
+ * Create the two-tier release-boundary PreToolUse hook.
  *
  * Stateless (no dedup): every boundary-crossing attempt is a distinct data
  * point — a session that publishes twice is exactly the signal the shadow
@@ -135,9 +107,22 @@ export function createReleaseBoundaryDetect(): (context: HookContext) => HookDec
     const matched = detectReleaseBoundaryCommands(command);
     if (matched.length === 0) return {};
 
-    // approve == allow (never blocks; see module header) but carries a reason
-    // that lands as a `hook_decision` catch-record for the reasoning-failure
-    // substrate.
+    // Precedence: if ANY matched pattern is BLOCK-tier, the entire command is
+    // blocked. A compound command containing even one externally-irreversible
+    // sub-operation must not pass through because it is mixed with an
+    // observable one.
+    for (const id of matched) {
+      const pattern = getPattern(id);
+      if (pattern?.tier === 'block') {
+        return {
+          decision: 'block',
+          reason: pattern.blockReason,
+          injectContext: RELEASE_BOUNDARY_BLOCK_INJECT_CONTEXT,
+        };
+      }
+    }
+
+    // All matched patterns are OBSERVE-tier: record the attempt, allow through.
     return {
       decision: 'approve',
       reason: `${RELEASE_BOUNDARY_DETECT_REASON_PREFIX} [${matched.join(', ')}]`,

--- a/src/agent/release-boundary-detect.ts
+++ b/src/agent/release-boundary-detect.ts
@@ -70,15 +70,45 @@ export const RELEASE_BOUNDARY_BLOCK_INJECT_CONTEXT =
   'up-to-date before proceeding, and ask the operator to confirm publication.';
 
 /**
+ * Return true when the command carries a dry-run flag that renders its publish
+ * or deploy operation a no-op simulation. Dry-run variants should not be
+ * blocked — they are safe pre-flight checks.
+ *
+ * Covered flags:
+ *   `--dry-run`          — npm, pnpm, cargo, and most CLIs
+ *   `-refresh-only`      — terraform apply -refresh-only (read-only plan pass)
+ */
+function isDryRun(command: string): boolean {
+  return /--dry-run\b/i.test(command) || /-refresh-only\b/i.test(command);
+}
+
+/**
+ * Strip single-quoted string literals from a shell command before pattern
+ * matching. Single-quoted segments in POSIX shell are always literal — no
+ * variable expansion, no command substitution, and crucially, no execution.
+ * A publish keyword inside `'...'` is harmless (e.g. `rg 'npm publish'`).
+ *
+ * Also strips trailing `# comment` segments.
+ */
+function stripQuotedLiterals(command: string): string {
+  // Remove single-quoted segments (non-greedy, no nesting in POSIX sh).
+  let stripped = command.replace(/'[^']*'/g, '');
+  // Remove shell-comment tails.
+  stripped = stripped.replace(/#[^\n]*/g, '');
+  return stripped;
+}
+
+/**
  * Return the ids of every release-boundary pattern the command matches (empty
  * when none). Pure and stateless — no global-flag regexes, so `.test()` is safe
  * to call repeatedly. Exported for tests.
  */
 export function detectReleaseBoundaryCommands(command: string): string[] {
   if (!command) return [];
+  const stripped = stripQuotedLiterals(command);
   const hits: string[] = [];
   for (const { id, re } of RELEASE_BOUNDARY_PATTERNS) {
-    if (re.test(command)) hits.push(id);
+    if (re.test(stripped)) hits.push(id);
   }
   return hits;
 }
@@ -107,10 +137,30 @@ export function createReleaseBoundaryDetect(): (context: HookContext) => HookDec
     const matched = detectReleaseBoundaryCommands(command);
     if (matched.length === 0) return {};
 
+    // Dry-run exemption: commands like `npm publish --dry-run`,
+    // `cargo --locked publish --dry-run`, or `terraform apply -refresh-only`
+    // are simulation passes — they never mutate external state. Demote any
+    // BLOCK-tier match to OBSERVE-tier behavior so the agent can still run
+    // these pre-flight checks without friction. The matched ids are still
+    // returned so the observe record captures what would have been blocked.
+    if (isDryRun(command)) {
+      return {
+        decision: 'approve',
+        reason: `${RELEASE_BOUNDARY_DETECT_REASON_PREFIX} [${matched.join(', ')}] (dry-run: not blocked)`,
+      };
+    }
+
     // Precedence: if ANY matched pattern is BLOCK-tier, the entire command is
     // blocked. A compound command containing even one externally-irreversible
     // sub-operation must not pass through because it is mixed with an
     // observable one.
+    //
+    // Invariant: when multiple BLOCK patterns match in one compound command,
+    // the first BLOCK in RELEASE_BOUNDARY_PATTERNS table order wins. Only that
+    // pattern's blockReason is reported. This is deliberate: the pattern table
+    // is ordered by severity (package-registry → container → release-cut →
+    // infra), so the first hit is the highest-priority signal and the most
+    // actionable reason for the agent.
     for (const id of matched) {
       const pattern = getPattern(id);
       if (pattern?.tier === 'block') {

--- a/src/agent/release-boundary-patterns.ts
+++ b/src/agent/release-boundary-patterns.ts
@@ -70,7 +70,7 @@ export const RELEASE_BOUNDARY_PATTERNS: readonly ReleaseBoundaryPattern[] = [
   },
   {
     id: 'cargo-publish',
-    re: /\bcargo\s+publish\b/i,
+    re: /\bcargo\s+(?:--[\w-]+\s+)*publish\b/i,
     tier: 'block',
     blockReason:
       'release-boundary: blocked [cargo-publish] — publishes a crate to crates.io, externally irreversible (crates.io does not allow un-publishing); verify Cargo.toml version and changelog.',

--- a/src/agent/release-boundary-patterns.ts
+++ b/src/agent/release-boundary-patterns.ts
@@ -1,0 +1,139 @@
+/**
+ * Curated publish / deploy / sync boundary command pattern table for the
+ * release-boundary PreToolUse hook.
+ *
+ * Pulled into its own module to mirror `safe-destruct-patterns.ts` after the
+ * two-tier (OBSERVE / BLOCK) upgrade.
+ *
+ * @module agent/release-boundary-patterns
+ */
+
+/**
+ * Tier assignment for a release-boundary pattern.
+ *
+ * - `'block'` — hook returns `decision: 'block'` with a human-readable reason
+ *   and `injectContext` guidance. Reserved for externally-irreversible publish
+ *   and deploy operations whose external state change cannot be undone.
+ * - `'observe'` — hook records the attempt but always returns `decision:
+ *   'approve'`. Used for sync-boundary operations that are often exactly what
+ *   was asked for and whose effects are closer to recoverable.
+ */
+export type ReleaseBoundaryTier = 'observe' | 'block';
+
+export type ReleaseBoundaryPattern =
+  | { readonly id: string; readonly re: RegExp; readonly tier: 'observe' }
+  | { readonly id: string; readonly re: RegExp; readonly tier: 'block'; readonly blockReason: string };
+
+// Invariant: Tier calibration.
+//
+// 383 shadow-window firings across all traces since the hook shipped (PR #524,
+// v5.33.0). Publishing to an external registry or deploying infrastructure is
+// externally irreversible — once the artifact is consumed by downstream users,
+// it cannot be retracted by the agent. These are BLOCK-tier.
+//
+// Sync-boundary operations (git push --mirror, --tags) are closer to the
+// "often exactly what the user asked for" boundary. A block here would be a
+// false positive for legitimate release workflows. These stay OBSERVE.
+//
+// Calibration bias: high-signal only — commands that cross a real release,
+// deploy, or visibility boundary. Routine pre-boundary steps (`npm version`,
+// `git tag`, `git push` without `--mirror`/`--tags`) are deliberately NOT
+// flagged. Each regex avoids nested quantifiers (no ReDoS); `[^|&;\n]*` bounds
+// a match to a single command segment.
+//
+// Pattern ids are stable public identifiers used by telemetry, tests, and the
+// trace substrate. Changing an id breaks deduplication across trace history.
+export const RELEASE_BOUNDARY_PATTERNS: readonly ReleaseBoundaryPattern[] = [
+  // --- package-registry publish (BLOCK) --------------------------------------
+  // Once published, the version is consumed by dependents and cannot be
+  // retracted (npm unpublish has a 72h window; other registries have none).
+  {
+    id: 'npm-publish',
+    re: /\bnpm\s+publish\b/i,
+    tier: 'block',
+    blockReason:
+      'release-boundary: blocked [npm-publish] — publishes a package to the npm registry, externally irreversible once consumed by dependents; verify changelog, version, and generated docs are current before publishing.',
+  },
+  {
+    id: 'pnpm-publish',
+    re: /\bpnpm\s+publish\b/i,
+    tier: 'block',
+    blockReason:
+      'release-boundary: blocked [pnpm-publish] — publishes a package to the npm registry, externally irreversible once consumed by dependents; verify changelog, version, and generated docs are current before publishing.',
+  },
+  {
+    id: 'yarn-publish',
+    re: /\byarn\s+(?:npm\s+)?publish\b/i,
+    tier: 'block',
+    blockReason:
+      'release-boundary: blocked [yarn-publish] — publishes a package to the npm registry, externally irreversible once consumed by dependents; verify changelog, version, and generated docs are current before publishing.',
+  },
+  {
+    id: 'cargo-publish',
+    re: /\bcargo\s+publish\b/i,
+    tier: 'block',
+    blockReason:
+      'release-boundary: blocked [cargo-publish] — publishes a crate to crates.io, externally irreversible (crates.io does not allow un-publishing); verify Cargo.toml version and changelog.',
+  },
+  {
+    id: 'pypi-twine-upload',
+    re: /\btwine\s+upload\b/i,
+    tier: 'block',
+    blockReason:
+      'release-boundary: blocked [pypi-twine-upload] — uploads a package to PyPI, externally irreversible once consumed; verify setup.py/pyproject.toml version and changelog.',
+  },
+  {
+    id: 'poetry-publish',
+    re: /\bpoetry\s+publish\b/i,
+    tier: 'block',
+    blockReason:
+      'release-boundary: blocked [poetry-publish] — publishes a package to PyPI, externally irreversible once consumed; verify pyproject.toml version and changelog.',
+  },
+  {
+    id: 'gem-push',
+    re: /\bgem\s+push\b/i,
+    tier: 'block',
+    blockReason:
+      'release-boundary: blocked [gem-push] — pushes a gem to RubyGems, externally irreversible once consumed; verify gemspec version and changelog.',
+  },
+
+  // --- container registry (BLOCK) --------------------------------------------
+  {
+    id: 'docker-push',
+    re: /\bdocker\s+(?:image\s+)?push\b/i,
+    tier: 'block',
+    blockReason:
+      'release-boundary: blocked [docker-push] — pushes a container image to a registry, externally irreversible once pulled by consumers; verify image tag and contents.',
+  },
+
+  // --- release cut (BLOCK) ---------------------------------------------------
+  {
+    id: 'gh-release-create',
+    re: /\bgh\s+release\s+create\b/i,
+    tier: 'block',
+    blockReason:
+      'release-boundary: blocked [gh-release-create] — creates a GitHub release, externally visible and triggering downstream workflows; verify release notes and tag.',
+  },
+
+  // --- infra deploy (BLOCK) --------------------------------------------------
+  {
+    id: 'terraform-apply',
+    re: /\bterraform\s+apply\b/i,
+    tier: 'block',
+    blockReason:
+      'release-boundary: blocked [terraform-apply] — applies infrastructure changes to live systems, externally irreversible (new apply creates different resources); run "terraform plan" to preview first.',
+  },
+  {
+    id: 'kubectl-apply',
+    re: /\bkubectl\s+apply\b/i,
+    tier: 'block',
+    blockReason:
+      'release-boundary: blocked [kubectl-apply] — applies resources to a live Kubernetes cluster, externally irreversible for stateful workloads; verify manifests and target namespace.',
+  },
+
+  // --- sync / visibility boundary (OBSERVE) ----------------------------------
+  // These are often exactly what the user asked for in a release workflow.
+  // Blocking would be a false positive by construction.
+  { id: 'git-push-mirror', re: /\bgit\s+push\b[^|&;\n]*--mirror\b/i, tier: 'observe' },
+  { id: 'git-push-tags', re: /\bgit\s+push\b[^|&;\n]*--(?:tags|follow-tags)\b/i, tier: 'observe' },
+];

--- a/src/agent/safe-destruct-detect.test.ts
+++ b/src/agent/safe-destruct-detect.test.ts
@@ -6,10 +6,11 @@
  *      flag common-but-safe near-misses.
  *   2. OBSERVE patterns return `decision: 'approve'` (never block).
  *   3. BLOCK patterns return `decision: 'block'` with a reason that names the
- *      pattern id.
+ *      pattern id and an `injectContext` guidance string.
  *   4. When a single compound command matches both tiers, BLOCK wins.
  *   5. Registry wiring: the hook is registered exactly once, produces approve
- *      for OBSERVE patterns, and throws HookBlockedError for BLOCK patterns.
+ *      for OBSERVE patterns, and throws HookBlockedError (with injectContext)
+ *      for BLOCK patterns.
  *
  * Note on the former 'NEVER blocks' test (~line 97-101 in the old file):
  *   It used `rm -rf / --no-preserve-root` as the fixture — that pattern moved
@@ -23,6 +24,7 @@ import {
   createSafeDestructDetect,
   detectDestructiveCommands,
   SAFE_DESTRUCT_DETECT_REASON_PREFIX,
+  SAFE_DESTRUCT_BLOCK_INJECT_CONTEXT,
 } from './safe-destruct-detect.js';
 import { HookBlockedError } from '../utils/errors.js';
 import { createDefaultHookRegistry } from './default-hook-registry.js';
@@ -161,10 +163,11 @@ describe('createSafeDestructDetect (two-tier hook)', () => {
     ["psql -c 'DROP DATABASE prod'", 'sql-drop-truncate'],
     ["mysql -e 'TRUNCATE TABLE users'", 'sql-drop-truncate'],
     ['terraform destroy -auto-approve', 'terraform-destroy'],
-  ])('BLOCK pattern %s returns block decision naming %s', (command, expectedPatternId) => {
+  ])('BLOCK pattern %s returns block decision naming %s with injectContext', (command, expectedPatternId) => {
     const decision: HookDecision = hook(preCtx(command));
     expect(decision.decision).toBe('block');
     expect(decision.reason).toContain(expectedPatternId);
+    expect(decision.injectContext).toBe(SAFE_DESTRUCT_BLOCK_INJECT_CONTEXT);
   });
 
   // ── BLOCK wins when both tiers match in one compound command ─────────────
@@ -173,6 +176,7 @@ describe('createSafeDestructDetect (two-tier hook)', () => {
     const decision: HookDecision = hook(preCtx('rm -rf build && git push --force origin main'));
     expect(decision.decision).toBe('block');
     expect(decision.reason).toContain('git-push-force');
+    expect(decision.injectContext).toBe(SAFE_DESTRUCT_BLOCK_INJECT_CONTEXT);
   });
 
   it('passes through benign bash commands', () => {
@@ -214,15 +218,21 @@ describe('safe-destruct-detect wiring in the default registry', () => {
     expect(decision.reason).toContain(SAFE_DESTRUCT_DETECT_REASON_PREFIX);
   });
 
-  it('throws HookBlockedError for a BLOCK-tier destructive bash call through the default registry', async () => {
+  it('throws HookBlockedError with injectContext for a BLOCK-tier destructive bash call through the default registry', async () => {
     const { registry } = createDefaultHookRegistry(undefined, 'cli');
     const ctx: PreToolUseContext = {
       event: 'PreToolUse',
       toolName: 'bash',
       input: { command: 'terraform destroy -auto-approve' },
     };
-    // BLOCK tier must throw HookBlockedError.
-    await expect(registry.dispatch(ctx)).rejects.toBeInstanceOf(HookBlockedError);
+    // BLOCK tier must throw HookBlockedError with injectContext.
+    try {
+      await registry.dispatch(ctx);
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(HookBlockedError);
+      expect((err as HookBlockedError).injectContext).toBe(SAFE_DESTRUCT_BLOCK_INJECT_CONTEXT);
+    }
   });
 
   it('leaves benign bash calls untouched through the default registry', async () => {

--- a/src/agent/safe-destruct-detect.ts
+++ b/src/agent/safe-destruct-detect.ts
@@ -27,10 +27,11 @@
  * This whole program exists because an over-firing PreToolUse *hard block* (the
  * interpreter-eval guard) generated 18 nights of self-inflicted friction. The
  * plan's de-risking rule is "injectContext-first, shadow-window before
- * enforcing". PreToolUse cannot `injectContext` — the harness honors that field
- * only for `SubagentStop` / `UserPromptSubmit` (see `hooks.ts`) — so the OBSERVE
- * tier records attempts without blocking, building the shadow-window dataset. A
- * later slice uses real-world frequency per pattern to re-calibrate tiers.
+ * enforcing". BLOCK-tier patterns use `injectContext` (PR #1088) to explain
+ * *why* the command was blocked and *what to do instead*, so the agent receives
+ * actionable guidance — not a bare refusal. OBSERVE-tier patterns record
+ * attempts without blocking, building the shadow-window dataset. A later slice
+ * uses real-world frequency per pattern to re-calibrate tiers.
  *
  * # How the approve catch-record is emitted
  *
@@ -65,6 +66,19 @@ import { DESTRUCTIVE_PATTERNS } from './safe-destruct-patterns.js';
  */
 export const SAFE_DESTRUCT_DETECT_REASON_PREFIX =
   'safe-destruct observe-only: destructive-command attempt';
+
+/**
+ * Context injected into the `isError` tool_result when a BLOCK-tier pattern
+ * fires. Delivered via `HookBlockedError.injectContext` → `dispatcher.ts`
+ * block-path content (PR #1088). The agent sees this after the terse
+ * `blockReason` — it explains the hook's purpose and what to do next.
+ */
+export const SAFE_DESTRUCT_BLOCK_INJECT_CONTEXT =
+  'This command was blocked by the safe-destruct hook because it matches an ' +
+  'irrecoverable or externally-irreversible operation pattern. The block ' +
+  'cannot be self-bypassed. If the destructive action is genuinely required, ' +
+  'stop and ask the operator to run it manually, or use a safer alternative ' +
+  'named in the block reason above.';
 
 /**
  * Return the ids of every destructive pattern the command matches.
@@ -116,6 +130,7 @@ export function createSafeDestructDetect(): (context: HookContext) => HookDecisi
         return {
           decision: 'block',
           reason: pattern.blockReason,
+          injectContext: SAFE_DESTRUCT_BLOCK_INJECT_CONTEXT,
         };
       }
     }


### PR DESCRIPTION
## What

Upgrades the two Wave 1 gate-migration hooks from observe-only to **block+explain**, now that `PreToolUse injectContext` is available (PR #1088).

### safe-destruct

BLOCK-tier patterns now include `injectContext` guidance explaining why the command was blocked and what to do instead. The agent sees both the terse `reason` (pattern-specific) and richer `injectContext` (general safe-destruct guidance) in the `isError` tool_result. OBSERVE-tier unchanged.

### release-boundary

Upgraded from **pure observe-only** to a **two-tier system** mirroring safe-destruct's architecture:

| Tier | Patterns | Behavior |
|------|----------|----------|
| **BLOCK** | `npm/pnpm/yarn/cargo/twine/poetry/gem publish`, `docker push`, `gh release create`, `terraform/kubectl apply` | Blocks with `reason` + `injectContext` — externally irreversible once consumed by dependents |
| **OBSERVE** | `git push --mirror`, `git push --tags/--follow-tags` | `approve` catch-records — sync-boundary commands often exactly what was asked for |

Extracted `release-boundary-patterns.ts` (mirrors `safe-destruct-patterns.ts`) to keep both detectors under the 350-line ceiling.

## Evidence

- `pnpm lint` ✅
- `pnpm build` ✅
- `pnpm audit:filesize:check` ✅ (all new files well under 350 LOC)
- 131 tests pass (80 safe-destruct + 51 release-boundary)
- Pre-existing flaky test `write-denylist.test.ts` fails on `main` too — unrelated

## Context

Wave 1 unpark of the gate-migration program (`.afk/plans/friction-substrate-and-gate-migration.md`). The park condition was "PreToolUse cannot injectContext" — PR #1088 resolved that. This PR is the first consumer of that infrastructure.

383 shadow-window firings across all traces informed the tier calibration:
- Publish/deploy/infra commands → BLOCK (externally irreversible, cannot be undone by the agent)
- Sync-boundary commands → OBSERVE (often exactly what was asked for; blocking = false positive)
- High-volume routine operations (rm -rf, git branch -D) → OBSERVE (326 firings in 5 weeks — blocking would be 91% friction)

## Files changed

| File | Change |
|------|--------|
| `src/agent/safe-destruct-detect.ts` | Add `SAFE_DESTRUCT_BLOCK_INJECT_CONTEXT`, attach to block decisions |
| `src/agent/release-boundary-detect.ts` | Rewrite: two-tier system with block+explain |
| `src/agent/release-boundary-patterns.ts` | **New**: extracted pattern table (mirrors `safe-destruct-patterns.ts`) |
| `src/agent/default-hook-registry.ts` | Updated registration comments |
| `src/agent/safe-destruct-detect.test.ts` | Assert `injectContext` on block decisions |
| `src/agent/release-boundary-detect.test.ts` | Rewrite: test both tiers, injectContext, precedence |
