### PR TITLE
fix: remove unused join import from backfill-facets script

### DIFF
--- a/scripts/backfill-facets.ts
+++ b/scripts/backfill-facets.ts
@@ -13,7 +13,7 @@
  */
 
 import { existsSync, readdirSync } from 'fs';
-import { basename, join } from 'path';
+import { basename } from 'path';
 import { getOrDeriveFacet, listSessionIds } from '../src/agent/facets/store.js';
 import { getFacetCacheDir } from '../src/paths.js';
 


### PR DESCRIPTION
Remove unused `join` import from `scripts/backfill-facets.ts` (shipped in #1089). Only `basename` is used.
