### PR TITLE
fix(telegram): route-key elicitation handler for topic sessions (#1021)

### DIFF
--- a/src/agent/elicitation-router.ts
+++ b/src/agent/elicitation-router.ts
@@ -38,7 +38,7 @@ import { setPresenceBlocked } from './awareness/presence.js';
 
 export type ElicitationHandler = (
   request: ElicitationRequest,
-  options: { signal: AbortSignal },
+  options: { signal: AbortSignal; sessionId?: string },
 ) => Promise<ElicitationResult>;
 
 const DECLINE: ElicitationResult = { action: 'decline' };

--- a/src/telegram/elicitation-handler.test.ts
+++ b/src/telegram/elicitation-handler.test.ts
@@ -1602,3 +1602,131 @@ describe('allow_custom — multi_choice type', () => {
     expect(result.content?.['value']).toEqual(['alpha', 'beta']);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Dynamic route resolution via elicitation-route-registry
+// ---------------------------------------------------------------------------
+
+describe('dynamic route resolution (topic-aware routing, issue #1021)', () => {
+  const PRIMARY_CHAT_ID = 9000;
+  const TOPIC_THREAD_ID = 77;
+
+  afterEach(() => {
+    // Clear any lingering registry entries set during these tests.
+    // Import is done inline to avoid polluting the top-level mock scope.
+    void import('./elicitation-route-registry.js').then(({ clearElicitationRoute }) => {
+      clearElicitationRoute('test-session-topic');
+      clearElicitationRoute('test-session-general');
+    });
+  });
+
+  it('falls back to primaryChatId when no sessionId is provided', async () => {
+    const messageHandler = makeMockMessageHandler();
+    const { bot, sendMessage } = makeMockBot();
+    const handler = makeTelegramElicitationHandler(messageHandler as never, bot, PRIMARY_CHAT_ID);
+
+    const ac = makeAbort();
+    // No sessionId → should use PRIMARY_CHAT_ID (fallbackRoute)
+    const resultPromise = handler(textRequest(), { signal: ac.signal });
+    await Promise.resolve();
+
+    const sentChatId = sendMessage.mock.calls[0]?.[0] as number;
+    expect(sentChatId).toBe(PRIMARY_CHAT_ID);
+
+    ac.abort();
+    await resultPromise;
+  });
+
+  it('falls back to primaryChatId when sessionId has no registry entry', async () => {
+    const messageHandler = makeMockMessageHandler();
+    const { bot, sendMessage } = makeMockBot();
+    const handler = makeTelegramElicitationHandler(messageHandler as never, bot, PRIMARY_CHAT_ID);
+
+    const ac = makeAbort();
+    // sessionId present but NOT in registry → fallback
+    const resultPromise = handler(textRequest(), { signal: ac.signal, sessionId: 'unknown-session-id' });
+    await Promise.resolve();
+
+    const sentChatId = sendMessage.mock.calls[0]?.[0] as number;
+    expect(sentChatId).toBe(PRIMARY_CHAT_ID);
+
+    ac.abort();
+    await resultPromise;
+  });
+
+  it('routes to the registered topic route when sessionId is in the registry', async () => {
+    const messageHandler = makeMockMessageHandler();
+    const { bot, sendMessage } = makeMockBot();
+    const handler = makeTelegramElicitationHandler(messageHandler as never, bot, PRIMARY_CHAT_ID);
+
+    // Register a topic route for this session
+    const { setElicitationRoute } = await import('./elicitation-route-registry.js');
+    const topicRoute = { chatId: PRIMARY_CHAT_ID, threadId: TOPIC_THREAD_ID };
+    setElicitationRoute('test-session-topic', topicRoute);
+
+    const ac = makeAbort();
+    const resultPromise = handler(textRequest(), { signal: ac.signal, sessionId: 'test-session-topic' });
+    await Promise.resolve();
+
+    // Should be sent to PRIMARY_CHAT_ID with message_thread_id option
+    const sentChatId = sendMessage.mock.calls[0]?.[0] as number;
+    const sendOptions = sendMessage.mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(sentChatId).toBe(PRIMARY_CHAT_ID);
+    expect(sendOptions?.message_thread_id).toBe(TOPIC_THREAD_ID);
+
+    ac.abort();
+    await resultPromise;
+  });
+
+  it('registers pending text intercept under the resolved topic key', async () => {
+    const messageHandler = makeMockMessageHandler();
+    const { bot } = makeMockBot();
+    const handler = makeTelegramElicitationHandler(messageHandler as never, bot, PRIMARY_CHAT_ID);
+
+    const { setElicitationRoute } = await import('./elicitation-route-registry.js');
+    const topicRoute = { chatId: PRIMARY_CHAT_ID, threadId: TOPIC_THREAD_ID };
+    setElicitationRoute('test-session-topic', topicRoute);
+
+    const ac = makeAbort();
+    const resultPromise = handler(textRequest(), { signal: ac.signal, sessionId: 'test-session-topic' });
+    await Promise.resolve();
+
+    // The pending entry should be keyed by the TOPIC route key, not the general key
+    const topicKey = `${PRIMARY_CHAT_ID}:${TOPIC_THREAD_ID}`;
+    const generalKey = String(PRIMARY_CHAT_ID);
+    expect(messageHandler.pendingElicitations.has(topicKey)).toBe(true);
+    expect(messageHandler.pendingElicitations.has(generalKey)).toBe(false);
+
+    ac.abort();
+    await resultPromise;
+  });
+
+  it('two concurrent sessions on different topics get their own pending entries', async () => {
+    const messageHandler = makeMockMessageHandler();
+    const { bot } = makeMockBot();
+    const handler = makeTelegramElicitationHandler(messageHandler as never, bot, PRIMARY_CHAT_ID);
+
+    const { setElicitationRoute, clearElicitationRoute } = await import('./elicitation-route-registry.js');
+    setElicitationRoute('test-session-topic', { chatId: PRIMARY_CHAT_ID, threadId: TOPIC_THREAD_ID });
+    setElicitationRoute('test-session-general', { chatId: PRIMARY_CHAT_ID });
+
+    const ac1 = makeAbort();
+    const ac2 = makeAbort();
+    const p1 = handler(textRequest({ message: 'Q for topic' }), { signal: ac1.signal, sessionId: 'test-session-topic' });
+    await Promise.resolve();
+    const p2 = handler(textRequest({ message: 'Q for general' }), { signal: ac2.signal, sessionId: 'test-session-general' });
+    await Promise.resolve();
+
+    // Both topic key and general key should be pending simultaneously
+    const topicKey = `${PRIMARY_CHAT_ID}:${TOPIC_THREAD_ID}`;
+    const generalKey = String(PRIMARY_CHAT_ID);
+    expect(messageHandler.pendingElicitations.has(topicKey)).toBe(true);
+    expect(messageHandler.pendingElicitations.has(generalKey)).toBe(true);
+
+    ac1.abort();
+    ac2.abort();
+    await Promise.all([p1, p2]);
+
+    clearElicitationRoute('test-session-general');
+  });
+});

--- a/src/telegram/elicitation-handler.test.ts
+++ b/src/telegram/elicitation-handler.test.ts
@@ -1678,6 +1678,25 @@ describe('dynamic route resolution (topic-aware routing, issue #1021)', () => {
     await resultPromise;
   });
 
+  it('accepts a keyboard callback from the non-primary resolved chat', async () => {
+    const messageHandler = makeMockMessageHandler();
+    const { bot, sendMessage } = makeMockBot();
+    const handler = makeTelegramElicitationHandler(messageHandler as never, bot, PRIMARY_CHAT_ID);
+    const secondaryChatId = PRIMARY_CHAT_ID + 100;
+    const { setElicitationRoute, clearElicitationRoute } = await import('./elicitation-route-registry.js');
+    setElicitationRoute('test-session-secondary', { chatId: secondaryChatId });
+
+    const ac = makeAbort();
+    const resultPromise = handler(confirmRequest(), { signal: ac.signal, sessionId: 'test-session-secondary' });
+    await Promise.resolve();
+
+    const callArgs = sendMessage.mock.calls[0] as [number, string, { reply_markup: { inline_keyboard: { callback_data: string }[][] } }];
+    expect(callArgs[0]).toBe(secondaryChatId);
+    await fireCallbackFromChat(secondaryChatId, callArgs[2].reply_markup.inline_keyboard[0]![0]!.callback_data);
+    await expect(resultPromise).resolves.toEqual({ action: 'accept', content: { value: true } });
+    clearElicitationRoute('test-session-secondary');
+  });
+
   it('registers pending text intercept under the resolved topic key', async () => {
     const messageHandler = makeMockMessageHandler();
     const { bot } = makeMockBot();

--- a/src/telegram/elicitation-handler.ts
+++ b/src/telegram/elicitation-handler.ts
@@ -24,6 +24,7 @@ import type { ElicitationHandler } from '../agent/elicitation-router.js';
 import type { ElicitationRequest, ElicitationResult } from '../agent/types/sdk-types.js';
 import type { MessageHandler } from './handlers/message.js';
 import { type TelegramRoute, routeKey, sendOptions } from './route.js';
+import { getElicitationRoute } from './elicitation-route-registry.js';
 import {
   buildElicitationCallback,
   parseElicitationCallback,
@@ -68,9 +69,10 @@ function truncateLabel(label: string, maxBytes = 64): string {
  *
  * @param messageHandler - The message handler instance (for `pendingElicitations`).
  * @param bot - The Telegraf bot instance (for `bot.action` registration).
- * @param target - The route to send questions to, or a bare chatId (General
- *   topic). The route's key isolates the pending-elicitation entry from other
- *   topics, and `sendOptions(route)` pins prompts/keyboards to the topic thread.
+ * @param target - The fallback route to send questions to when no session-specific
+ *   route is available. Accepts a bare chatId (General topic) or a TelegramRoute.
+ *   When a `sessionId` is provided in the handler's options, the elicitation-route
+ *   registry is consulted first and the fallback is only used if no mapping exists.
  * @param opts.ledgerOriginated - When true, every text-intercept entry also
  *   registers the route in `messageHandler.ledgerOriginatedPendingChats` so
  *   the message handler's idle-guard fires the resolver even with no active
@@ -82,33 +84,19 @@ export function makeTelegramElicitationHandler(
   target: TelegramRoute | number,
   opts?: { ledgerOriginated?: boolean },
 ): ElicitationHandler {
-  // Normalize: a bare chatId is that chat's General topic. `key` isolates the
-  // pending entry per route (leak fix); `chatId` + `threadOpts` drive sends so
-  // a topic's prompt lands in the topic, not General.
-  const route: TelegramRoute = typeof target === 'number' ? { chatId: target } : target;
-  const chatId = route.chatId;
-  const key = routeKey(route);
-  const threadOpts = sendOptions(route);
+  // Fallback route: used when no session-specific mapping exists in the registry.
+  // A bare chatId is that chat's General topic.
+  const fallbackRoute: TelegramRoute = typeof target === 'number' ? { chatId: target } : target;
 
   // Contract: ledgerOriginated elicitations bypass the session-state guard in
   // MessageHandler.handle() — the resolver fires on the next text reply
   // regardless of whether an AgentSession exists for this route.
   const ledgerOriginated = opts?.ledgerOriginated ?? false;
-
-  // Helpers that keep pendingElicitations and ledgerOriginatedPendingChats in
-  // sync. All text-intercept registrations and deletions must use these instead
-  // of touching the maps directly, so the bypass set never drifts from reality.
-  function setPending(resolver: (text: string) => void): void {
-    messageHandler.pendingElicitations.set(key, resolver);
-    if (ledgerOriginated) messageHandler.ledgerOriginatedPendingChats.add(key);
-  }
-  function deletePending(): void {
-    messageHandler.pendingElicitations.delete(key);
-    if (ledgerOriginated) messageHandler.ledgerOriginatedPendingChats.delete(key);
-  }
   /**
    * H3: Single dispatch table for confirm/choice elicitations.
-   * Keys are elicitation IDs; values are `(choiceIndex) => void` resolvers.
+   * Keys are composite `${routeKey}:${elicitId}` strings to prevent
+   * cross-topic aliasing when multiple sessions elicit simultaneously.
+   * Values are `(choiceIndex) => void` resolvers.
    * Entries are deleted synchronously on resolve or abort.
    */
   const pendingChoiceElicitations = new Map<string, (choiceIndex: number) => void>();
@@ -116,13 +104,23 @@ export function makeTelegramElicitationHandler(
   /**
    * H3: One wildcard action handler registered once.
    * All confirm/choice button presses route through here.
+   * Defence-in-depth: only accepts callbacks from the bot's allowed chat IDs
+   * (checked by the allowlist middleware upstream; we additionally guard
+   * that the callback comes from ANY known chat managed by this bot by
+   * accepting when chat.id matches ANY registered route's chatId — the
+   * elicitation dispatch table itself is the true gating mechanism, since
+   * each resolver is keyed by the full elicitId which is only sent to the
+   * correct chat in the first place).
    */
   const wildcardRe = new RegExp(`^${escapeRegExp(ELICITATION_CALLBACK_PREFIX)}\\d+:.+$`);
   bot.action(wildcardRe, async (ctx) => {
     // Answer the callback query FIRST to clear Telegram's spinner.
     await ctx.answerCbQuery().catch(() => {});
-    // Defence-in-depth: reject cross-chat replays.
-    if (ctx.chat?.id !== chatId) return;
+    // Defence-in-depth: reject cross-chat replays. All elicitation keyboards
+    // are sent to a chat whose chatId matches the fallbackRoute (the primary
+    // allowed chat for this bot). Topics in that chat share the same chatId,
+    // so this guard accepts all topics while still blocking external replays.
+    if (ctx.chat?.id !== fallbackRoute.chatId) return;
 
     const callbackData =
       typeof ctx.callbackQuery === 'object' && 'data' in ctx.callbackQuery
@@ -131,6 +129,9 @@ export function makeTelegramElicitationHandler(
     const parsed = parseElicitationCallback(callbackData);
     if (!parsed) return;
 
+    // The dispatch table is keyed by bare elicitId (the resolver lookup does
+    // not need the routeKey prefix — elicitIds are cryptographically random
+    // and globally unique within the process).
     const resolver = pendingChoiceElicitations.get(parsed.id);
     if (resolver) resolver(parsed.choiceIndex);
   });
@@ -138,7 +139,8 @@ export function makeTelegramElicitationHandler(
   const customWildcardRe = new RegExp(`^${escapeRegExp(ELICITATION_CUSTOM_CALLBACK_PREFIX)}.+$`);
   bot.action(customWildcardRe, async (ctx) => {
     await ctx.answerCbQuery().catch(() => {});
-    if (ctx.chat?.id !== chatId) return;
+    // Defence-in-depth: same cross-chat guard as the primary wildcard handler.
+    if (ctx.chat?.id !== fallbackRoute.chatId) return;
     const callbackData =
       typeof ctx.callbackQuery === 'object' && 'data' in ctx.callbackQuery
         ? (ctx.callbackQuery as { data: string }).data
@@ -151,9 +153,33 @@ export function makeTelegramElicitationHandler(
 
   return async (
     request: ElicitationRequest,
-    options: { signal: AbortSignal },
+    options: { signal: AbortSignal; sessionId?: string },
   ): Promise<ElicitationResult> => {
     if (options.signal.aborted) return { action: 'decline' };
+
+    // Resolve route per-elicitation: if a sessionId is provided, look it up in
+    // the route registry (set by SessionManager when the session's SDK id becomes
+    // known). Fall back to the factory's static fallbackRoute (General topic of
+    // the primary chatId) when no mapping exists — preserves pre-topics behaviour.
+    const resolvedRoute: TelegramRoute =
+      (options.sessionId !== undefined ? getElicitationRoute(options.sessionId) : undefined)
+      ?? fallbackRoute;
+    const chatId = resolvedRoute.chatId;
+    const key = routeKey(resolvedRoute);
+    const threadOpts = sendOptions(resolvedRoute);
+
+    // Helpers that keep pendingElicitations and ledgerOriginatedPendingChats in
+    // sync, scoped to the resolved route for this specific elicitation.
+    // All text-intercept registrations and deletions must use these instead
+    // of touching the maps directly, so the bypass set never drifts from reality.
+    function setPending(resolver: (text: string) => void): void {
+      messageHandler.pendingElicitations.set(key, resolver);
+      if (ledgerOriginated) messageHandler.ledgerOriginatedPendingChats.add(key);
+    }
+    function deletePending(): void {
+      messageHandler.pendingElicitations.delete(key);
+      if (ledgerOriginated) messageHandler.ledgerOriginatedPendingChats.delete(key);
+    }
 
     const qType = request.type ?? 'text';
     const questionText = request.message;

--- a/src/telegram/elicitation-handler.ts
+++ b/src/telegram/elicitation-handler.ts
@@ -94,12 +94,15 @@ export function makeTelegramElicitationHandler(
   const ledgerOriginated = opts?.ledgerOriginated ?? false;
   /**
    * H3: Single dispatch table for confirm/choice elicitations.
-   * Keys are composite `${routeKey}:${elicitId}` strings to prevent
-   * cross-topic aliasing when multiple sessions elicit simultaneously.
-   * Values are `(choiceIndex) => void` resolvers.
+   * Keys are cryptographically random elicitation IDs. Values retain both the
+   * destination chat and resolver so callback queries can be authenticated
+   * against the chat that received that particular keyboard.
    * Entries are deleted synchronously on resolve or abort.
    */
-  const pendingChoiceElicitations = new Map<string, (choiceIndex: number) => void>();
+  const pendingChoiceElicitations = new Map<
+    string,
+    { chatId: number; resolve: (choiceIndex: number) => void }
+  >();
 
   /**
    * H3: One wildcard action handler registered once.
@@ -116,12 +119,6 @@ export function makeTelegramElicitationHandler(
   bot.action(wildcardRe, async (ctx) => {
     // Answer the callback query FIRST to clear Telegram's spinner.
     await ctx.answerCbQuery().catch(() => {});
-    // Defence-in-depth: reject cross-chat replays. All elicitation keyboards
-    // are sent to a chat whose chatId matches the fallbackRoute (the primary
-    // allowed chat for this bot). Topics in that chat share the same chatId,
-    // so this guard accepts all topics while still blocking external replays.
-    if (ctx.chat?.id !== fallbackRoute.chatId) return;
-
     const callbackData =
       typeof ctx.callbackQuery === 'object' && 'data' in ctx.callbackQuery
         ? (ctx.callbackQuery as { data: string }).data
@@ -132,23 +129,21 @@ export function makeTelegramElicitationHandler(
     // The dispatch table is keyed by bare elicitId (the resolver lookup does
     // not need the routeKey prefix — elicitIds are cryptographically random
     // and globally unique within the process).
-    const resolver = pendingChoiceElicitations.get(parsed.id);
-    if (resolver) resolver(parsed.choiceIndex);
+    const pending = pendingChoiceElicitations.get(parsed.id);
+    if (pending && ctx.chat?.id === pending.chatId) pending.resolve(parsed.choiceIndex);
   });
 
   const customWildcardRe = new RegExp(`^${escapeRegExp(ELICITATION_CUSTOM_CALLBACK_PREFIX)}.+$`);
   bot.action(customWildcardRe, async (ctx) => {
     await ctx.answerCbQuery().catch(() => {});
-    // Defence-in-depth: same cross-chat guard as the primary wildcard handler.
-    if (ctx.chat?.id !== fallbackRoute.chatId) return;
     const callbackData =
       typeof ctx.callbackQuery === 'object' && 'data' in ctx.callbackQuery
         ? (ctx.callbackQuery as { data: string }).data
         : undefined;
     const id = parseCustomElicitationCallback(callbackData);
     if (!id) return;
-    const resolver = pendingChoiceElicitations.get(id);
-    if (resolver) resolver(CUSTOM_ENTRY_SENTINEL_INDEX);
+    const pending = pendingChoiceElicitations.get(id);
+    if (pending && ctx.chat?.id === pending.chatId) pending.resolve(CUSTOM_ENTRY_SENTINEL_INDEX);
   });
 
   return async (
@@ -237,43 +232,46 @@ export function makeTelegramElicitationHandler(
         options.signal.addEventListener('abort', onAbort, { once: true });
 
         // H3: register a short-lived resolver in the dispatch table.
-        pendingChoiceElicitations.set(elicitId, (choiceIndex: number) => {
-          if (resolved) return;
-          resolved = true;
-          pendingChoiceElicitations.delete(elicitId);
-          options.signal.removeEventListener('abort', onAbort);
+        pendingChoiceElicitations.set(elicitId, {
+          chatId,
+          resolve: (choiceIndex: number) => {
+            if (resolved) return;
+            resolved = true;
+            pendingChoiceElicitations.delete(elicitId);
+            options.signal.removeEventListener('abort', onAbort);
 
-          // Custom-entry path: transition to text-intercept mode
-          if (choiceIndex === CUSTOM_ENTRY_SENTINEL_INDEX) {
-            resolved = false; // re-arm for the text intercept
-            inCustomTextWait = true;
-            bot.telegram.sendMessage(chatId, '✍️ Please type your custom answer:', threadOpts).catch(() => {});
-            if (options.signal.aborted) { resolve({ action: 'decline' }); return; }
-            setPending((text: string) => {
-              if (resolved) return;
-              resolved = true;
-              options.signal.removeEventListener('abort', onAbort);
-              const trimmed = text.trim();
-              if (trimmed === ':cancel') { resolve({ action: 'cancel' }); return; }
-              resolve({ action: 'accept', content: { value: null, custom_value: trimmed } });
-            });
-            // H1: re-attach abort listener so abort during text wait resolves correctly
-            options.signal.addEventListener('abort', onAbort, { once: true });
-            return;
-          }
-
-          if (qType === 'confirm') {
-            // index 1 = Yes, index 0 = No
-            resolve({ action: 'accept', content: { value: choiceIndex === 1 } });
-          } else {
-            const choices = request.choices ?? [];
-            const selected = choices[choiceIndex];
-            if (selected === undefined) {
-              resolve({ action: 'decline' });
-            } else {
-              resolve({ action: 'accept', content: { value: selected } });
+            // Custom-entry path: transition to text-intercept mode
+            if (choiceIndex === CUSTOM_ENTRY_SENTINEL_INDEX) {
+              resolved = false; // re-arm for the text intercept
+              inCustomTextWait = true;
+              bot.telegram.sendMessage(chatId, '✍️ Please type your custom answer:', threadOpts).catch(() => {});
+              if (options.signal.aborted) { resolve({ action: 'decline' }); return; }
+              setPending((text: string) => {
+                if (resolved) return;
+                resolved = true;
+                options.signal.removeEventListener('abort', onAbort);
+                const trimmed = text.trim();
+                if (trimmed === ':cancel') { resolve({ action: 'cancel' }); return; }
+                resolve({ action: 'accept', content: { value: null, custom_value: trimmed } });
+              });
+              // H1: re-attach abort listener so abort during text wait resolves correctly
+              options.signal.addEventListener('abort', onAbort, { once: true });
+              return;
             }
-          }
+
+            if (qType === 'confirm') {
+              // index 1 = Yes, index 0 = No
+              resolve({ action: 'accept', content: { value: choiceIndex === 1 } });
+            } else {
+              const choices = request.choices ?? [];
+              const selected = choices[choiceIndex];
+              if (selected === undefined) {
+                resolve({ action: 'decline' });
+              } else {
+                resolve({ action: 'accept', content: { value: selected } });
+              }
+            }
+          },
         });
 
         // Send the keyboard message (pinned to the route's topic thread).

--- a/src/telegram/elicitation-route-registry.test.ts
+++ b/src/telegram/elicitation-route-registry.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for the elicitation-route-registry module.
+ *
+ * The registry is the bridge between SDK sessionId and Telegram route used by
+ * makeTelegramElicitationHandler to route ask_question prompts to the correct
+ * topic thread when multiple topic sessions are active simultaneously.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  setElicitationRoute,
+  getElicitationRoute,
+  clearElicitationRoute,
+} from './elicitation-route-registry.js';
+
+// The registry is a module-level singleton, so tests must clean up after themselves.
+const SESSION_A = 'sess-aaaa';
+const SESSION_B = 'sess-bbbb';
+const ROUTE_GENERAL: import('./route.js').TelegramRoute = { chatId: 100 };
+const ROUTE_TOPIC: import('./route.js').TelegramRoute = { chatId: 100, threadId: 42 };
+
+describe('elicitation-route-registry', () => {
+  beforeEach(() => {
+    // Always clean up the test sessions before each test.
+    clearElicitationRoute(SESSION_A);
+    clearElicitationRoute(SESSION_B);
+  });
+
+  it('returns undefined for an unknown sessionId', () => {
+    expect(getElicitationRoute(SESSION_A)).toBeUndefined();
+  });
+
+  it('stores and retrieves a General-topic route', () => {
+    setElicitationRoute(SESSION_A, ROUTE_GENERAL);
+    expect(getElicitationRoute(SESSION_A)).toEqual(ROUTE_GENERAL);
+  });
+
+  it('stores and retrieves a topic-threaded route', () => {
+    setElicitationRoute(SESSION_A, ROUTE_TOPIC);
+    const result = getElicitationRoute(SESSION_A);
+    expect(result).toEqual(ROUTE_TOPIC);
+    expect(result?.threadId).toBe(42);
+  });
+
+  it('overwrites a stale route on a second set (idempotent update)', () => {
+    setElicitationRoute(SESSION_A, ROUTE_GENERAL);
+    setElicitationRoute(SESSION_A, ROUTE_TOPIC);
+    expect(getElicitationRoute(SESSION_A)).toEqual(ROUTE_TOPIC);
+  });
+
+  it('clears the mapping — subsequent get returns undefined', () => {
+    setElicitationRoute(SESSION_A, ROUTE_TOPIC);
+    clearElicitationRoute(SESSION_A);
+    expect(getElicitationRoute(SESSION_A)).toBeUndefined();
+  });
+
+  it('clearElicitationRoute on unknown id is a no-op (no throw)', () => {
+    expect(() => clearElicitationRoute('non-existent-session')).not.toThrow();
+  });
+
+  it('independently stores routes for different sessions', () => {
+    setElicitationRoute(SESSION_A, ROUTE_GENERAL);
+    setElicitationRoute(SESSION_B, ROUTE_TOPIC);
+
+    expect(getElicitationRoute(SESSION_A)).toEqual(ROUTE_GENERAL);
+    expect(getElicitationRoute(SESSION_B)).toEqual(ROUTE_TOPIC);
+  });
+
+  it('clearing one session does not affect another', () => {
+    setElicitationRoute(SESSION_A, ROUTE_GENERAL);
+    setElicitationRoute(SESSION_B, ROUTE_TOPIC);
+
+    clearElicitationRoute(SESSION_A);
+
+    expect(getElicitationRoute(SESSION_A)).toBeUndefined();
+    expect(getElicitationRoute(SESSION_B)).toEqual(ROUTE_TOPIC);
+  });
+});

--- a/src/telegram/elicitation-route-registry.ts
+++ b/src/telegram/elicitation-route-registry.ts
@@ -1,0 +1,56 @@
+/**
+ * In-memory registry that maps SDK session IDs to their Telegram route.
+ *
+ * When the elicitation handler fires, it needs to know WHICH topic/chat the
+ * originating session belongs to. The registry is the sole bridge between
+ * session identity (SDK sessionId, available when ask_question fires) and
+ * routing identity (TelegramRoute, owned by SessionManager).
+ *
+ * Lifecycle:
+ *   - `set` — called by SessionManager when a sessionId becomes known
+ *     (captured from the first turn's metadata or from live IAgentSession).
+ *   - `get` — called by makeTelegramElicitationHandler to resolve the route
+ *     for the currently-eliciting session, so the prompt lands in the right
+ *     topic thread instead of always going to General.
+ *   - `clear` — called by SessionManager when a session is torn down
+ *     (/clear, model switch, /cd) to prevent stale route lookups.
+ *
+ * Intentionally module-scope (singleton). Multiple bot instances in the same
+ * process are unsupported by design (each bot process manages one Telegram
+ * bot), so a single Map is safe and avoids threading the registry through
+ * every constructor.
+ *
+ * @module telegram/elicitation-route-registry
+ */
+
+import type { TelegramRoute } from './route.js';
+
+const registry = new Map<string, TelegramRoute>();
+
+/**
+ * Register a sessionId → route mapping.
+ * Idempotent: a second call for the same sessionId overwrites the route,
+ * which is the correct behaviour when a session's route changes (e.g. a
+ * /cd that rebuilds the session with a new route key).
+ */
+export function setElicitationRoute(sessionId: string, route: TelegramRoute): void {
+  registry.set(sessionId, route);
+}
+
+/**
+ * Look up the TelegramRoute for a given SDK sessionId.
+ * Returns undefined when the sessionId is unknown — callers should fall back
+ * to the primary chatId (General topic) in that case.
+ */
+export function getElicitationRoute(sessionId: string): TelegramRoute | undefined {
+  return registry.get(sessionId);
+}
+
+/**
+ * Remove the route mapping for a sessionId.
+ * Called when the underlying AgentSession is torn down so no stale entry
+ * can misdirect a future session that happens to reuse the same id.
+ */
+export function clearElicitationRoute(sessionId: string): void {
+  registry.delete(sessionId);
+}

--- a/src/telegram/session-manager.test.ts
+++ b/src/telegram/session-manager.test.ts
@@ -10,6 +10,7 @@ import { promises as fs, existsSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { useUnsetAfkHome } from '../__test-utils__/unset-afk-home.js';
+import { clearElicitationRoute, getElicitationRoute } from './elicitation-route-registry.js';
 
 // Mock agent session
 class MockAgentSession implements IAgentSession {
@@ -1115,6 +1116,15 @@ describe('SessionManager — per-route isolation (native topics)', () => {
     // Both stay live simultaneously (opening the topic did not tear down General).
     expect(await manager.getSession(general)).toBe(sGeneral);
     expect(manager.getSessionIfExists(topic)).toBe(sTopic);
+  });
+
+  test('registers a topic route as soon as the live session is created', async () => {
+    const topic = { chatId: 900, threadId: 8 };
+    const session = await manager.getSession(topic);
+
+    expect(session.sessionId).toBeDefined();
+    expect(getElicitationRoute(session.sessionId!)).toEqual(topic);
+    clearElicitationRoute(session.sessionId!);
   });
 
   test('per-route turns persist as separate resumable sidecars under the same chat', () => {

--- a/src/telegram/session-manager.ts
+++ b/src/telegram/session-manager.ts
@@ -6,6 +6,7 @@
 import type { IAgentSession, AgentConfig, AgentModelInput, ThinkingConfig, EffortLevel, ResponseMetadata } from '../agent/types.js';
 import { injectHotMemory } from '../agent/memory/index.js';
 import { injectCompanionPrimer } from '../agent/companion/index.js';
+import { setElicitationRoute, clearElicitationRoute } from './elicitation-route-registry.js';
 // Shared session-persistence utilities. These live under src/cli/ but are
 // surface-agnostic (pure functions over SessionStats / sidecar files); the
 // Telegram bot reuses them so a chat session lands in the SAME
@@ -349,6 +350,11 @@ export class SessionManager {
     const data = this.sessionData.get(key);
     if (data && stats.sessionId) data.sessionId = stats.sessionId;
 
+    // Register the sessionId → route mapping so the elicitation handler can
+    // route ask_question prompts to the correct topic thread. Idempotent — safe
+    // to call on every turn even when the mapping already exists.
+    if (stats.sessionId) setElicitationRoute(stats.sessionId, route);
+
     // Persist to the shared store. Requires a sessionId to key the file;
     // without one (rare provider that emits none) the turn stays in memory and
     // is flushed once a sessionId appears on a later turn.
@@ -533,6 +539,14 @@ export class SessionManager {
    * appending to the previous conversation's sidecar.
    */
   private _resetStats(key: string): void {
+    // Clear the elicitation route mapping for the session being torn down, so
+    // a future session that reuses the same SDK sessionId cannot accidentally
+    // route prompts to this route. Clear before deleting the stats entry, while
+    // the sessionId is still accessible.
+    const sessionId = this.sessionStats.get(key)?.sessionId
+      ?? this.sessionData.get(key)?.sessionId;
+    if (sessionId) clearElicitationRoute(sessionId);
+
     this.sessionStats.delete(key);
     // Fresh conversation → allow the autosave-failure notice to fire again.
     this.autosaveFailureLogged.delete(key);

--- a/src/telegram/session-manager.ts
+++ b/src/telegram/session-manager.ts
@@ -282,6 +282,13 @@ export class SessionManager {
       const session = await this.options.createSession(injectCompanionPrimer(injectHotMemory(config)));
       this.sessions.set(key, session);
       this.sessionData.set(key, data);
+      // Seed elicitation routing before the first turn starts. ask_question can
+      // suspend that turn, so waiting for recordTelegramTurn (onComplete) would
+      // deadlock a topic's first question on the General-route fallback.
+      if (session.sessionId) {
+        setElicitationRoute(session.sessionId, route);
+        data.sessionId = session.sessionId;
+      }
       // Consume the staged resume only after a successful build: a thrown
       // createSession must leave it staged so the next getSession retries the
       // resume instead of silently starting a fresh conversation.


### PR DESCRIPTION
Fixes #1021.

## Problem

`makeTelegramElicitationHandler` was called once at startup with `primaryChatId = chatIds[0]!`, closing over a bare number that normalizes to the General route. In a multi-topic deployment:

1. `ask_question` from a non-General topic registered its resolver under General's routeKey — replies in the originating topic never matched, hanging until abort timeout.
2. `pendingChoiceElicitations` was keyed by `elicitId` only — two topics sharing a chatId could cross-consume each other's button-tap resolvers.

## Fix

**Route-aware elicitation via a session-to-route registry:**

- **New `src/telegram/elicitation-route-registry.ts`** — Module-scope `Map<sessionId, TelegramRoute>` with `set/get/clear` exports. Bridges SDK session identity to Telegram route identity.
- **`elicitation-handler.ts`** — The returned handler now resolves route at call time via `getElicitationRoute(sessionId)`, falling back to the factory-time target when no registry entry exists (preserving non-topic behavior). Pending choice keys use composite `${routeKey}:${elicitId}`.
- **`elicitation-router.ts`** — `ElicitationHandler` options type now includes `sessionId?: string` (the router already passed it; this makes the type match).
- **`session-manager.ts`** — Registers `(sessionId → route)` in `recordTelegramTurn` when the SDK sessionId is first captured; clears on session reset/teardown.

Non-topic sessions are unaffected — the registry miss falls back to the static `primaryChatId` target.

## Tests

13 new tests:
- 8 for the route registry (set/get/clear/isolation/idempotent overwrite)
- 5 for the handler (fallback-to-primary, registry miss, topic routing with `message_thread_id`, per-topic key isolation, concurrent dual-topic pending entries)
