### PR TITLE
fix(cli): fix pre-existing reader bugs flagged in PR #1097 review

### DIFF
--- a/src/cli/input/reader.keypress.paste.ts
+++ b/src/cli/input/reader.keypress.paste.ts
@@ -48,6 +48,7 @@ export function handlePasteEnd(
     if (!st.clipboardInFlight) {
       st.clipboardInFlight = true;
       readClipboardImage().then((img) => {
+        if (st.settled) return;
         if (img) {
           st.clipboardFailureMsg = null;
           st.attachments.push(img);
@@ -65,6 +66,7 @@ export function handlePasteEnd(
     if (!st.clipboardInFlight) {
       st.clipboardInFlight = true;
       readClipboardImage().then((img) => {
+        if (st.settled) return;
         if (img) {
           st.clipboardFailureMsg = null;
           st.attachments.push(img);
@@ -92,6 +94,7 @@ export function handleCtrlV(
   if (!st.clipboardInFlight) {
     st.clipboardInFlight = true;
     readClipboardImage().then((img) => {
+      if (st.settled) return;
       if (img) {
         st.clipboardFailureMsg = null;
         st.attachments.push(img);

--- a/src/cli/input/reader.repaint.ts
+++ b/src/cli/input/reader.repaint.ts
@@ -104,6 +104,7 @@ export function repaint(st: ReaderState, ctx: RepaintCtx): void {
     st.ac.dropdownOpen = false;
     st.ac.candidates = [];
   }
+  // Order matters: bounds-check → up-follow → down-follow
   if (st.ac.selectedIndex >= st.ac.candidates.length) st.ac.selectedIndex = Math.max(0, st.ac.candidates.length - 1);
   if (st.ac.viewportStart > st.ac.selectedIndex) st.ac.viewportStart = st.ac.selectedIndex;
   if (st.ac.selectedIndex >= st.ac.viewportStart + st.maxDropdownRows) {

--- a/src/cli/input/reader.ts
+++ b/src/cli/input/reader.ts
@@ -184,8 +184,9 @@ export async function readWithAutocompleteTty(
       };
 
       const onAbort = (err: Error) => {
-        if (st.prevBufferRows > 0) {
-          stdout.write(ansiEscapes.cursorUp(st.prevBufferRows));
+        const abortUpRows = st.prevStatusRows + st.prevBufferRows;
+        if (abortUpRows > 0) {
+          stdout.write(ansiEscapes.cursorUp(abortUpRows));
         }
         if (st.rowsBelow > 0) {
           stdout.write(ansiEscapes.eraseDown);


### PR DESCRIPTION
## What

Fixes three pre-existing bugs in the REPL input reader that were identified during the [PR #1097](https://github.com/griffinwork40/agent-afk/pull/1097) review. All three were waived on #1097 as faithful mechanical copies of pre-existing `main` code; this PR addresses the underlying issues.

## Fixes

### M-1: `onAbort` cursor-up omits `prevStatusRows` (correctness)
**File:** `src/cli/input/reader.ts`

`onAbort` moved the cursor up only by `st.prevBufferRows`, omitting `st.prevStatusRows`. When a status line is visible (attachment summary), Ctrl+C abort orphans one terminal row, shifting all subsequent shell output down by one line. The Ctrl+D (EOF) path already correctly used `st.prevStatusRows + st.prevBufferRows`; the abort path now matches.

### M-2: Clipboard `.then()` callbacks mutate abandoned `ReaderState` (correctness)
**File:** `src/cli/input/reader.keypress.paste.ts`

`readClipboardImage()` is async. If submit races ahead of the clipboard probe, the `.then()` callback pushes to `st.attachments` and writes `st.clipboardFailureMsg` on an already-settled `ReaderState`. Added `if (st.settled) return;` guards at the top of each `.then()` callback in `handlePasteEnd()` and `handleCtrlV()`, matching the existing settled guard in `schedulePaint()`.

### N-3: Viewport-clamp ordering undocumented (observability)
**File:** `src/cli/input/reader.repaint.ts`

The three-clause `selectedIndex`/`viewportStart` sequence in `repaint()` is order-dependent (bounds-check → up-follow → down-follow). Reversing clauses 2 and 3 produces a viewport-leads-selection bug. Added a one-line invariant comment.

## Gate results

| Gate | Result |
|---|---|
| `pnpm lint` | ✅ pass |
| `pnpm test src/cli/input/` | ✅ 424 passed |
| `pnpm audit:filesize:check` | ✅ pass (all files within ceiling) |
