### PR TITLE
refactor(plugin-skills): dead-field + error-handling cleanup (#503)

### DIFF
--- a/src/cli/slash/plugin-skills/dispatch.ts
+++ b/src/cli/slash/plugin-skills/dispatch.ts
@@ -90,6 +90,9 @@ export function makeForwardHandler(skill: DiscoveredSkill, flags?: readonly stri
         try {
           prRefFromArgs = parsePrRef(dispatchArgs);
         } catch {
+          // Contract: fail-soft — an invalid PR ref (e.g. `/review 0`) must not
+          // abort the review dispatch. The reviewer still runs; the post step
+          // resolves the current branch's PR at publish time instead.
           prRefFromArgs = null;
         }
       }
@@ -253,7 +256,6 @@ export async function registerPluginSkills(
       collisions.push({
         bare,
         altSlash: `/${fallbackName}`,
-        altDescription: skill.description,
         ...(skill.source ? { source: skill.source } : {}),
       });
       shadowedBareNames.add(bare);

--- a/src/cli/slash/plugin-skills/flags.ts
+++ b/src/cli/slash/plugin-skills/flags.ts
@@ -37,6 +37,8 @@ export function harvestPluginSkillFlags(cacheRoot?: string): Map<string, string[
     try {
       entries = readdirSync(dir);
     } catch {
+      // Contract: fail-soft — an unreadable plugin directory (missing, permissions)
+      // must not abort the walk; flags from other dirs still apply.
       return;
     }
 
@@ -47,6 +49,8 @@ export function harvestPluginSkillFlags(cacheRoot?: string): Map<string, string[
       try {
         stat = statSync(fullPath);
       } catch {
+        // Contract: fail-soft — a stat error on a single entry (race, symlink
+        // dangling) skips that entry; the rest of the directory still walks.
         continue;
       }
 
@@ -60,6 +64,8 @@ export function harvestPluginSkillFlags(cacheRoot?: string): Map<string, string[
       try {
         content = readFileSync(fullPath, 'utf-8');
       } catch {
+        // Contract: fail-soft — an unreadable SKILL.md (permissions, race) skips
+        // that skill's flags; the walk continues for all other SKILL.md files.
         continue;
       }
 

--- a/src/cli/slash/plugin-skills/reload.ts
+++ b/src/cli/slash/plugin-skills/reload.ts
@@ -134,6 +134,9 @@ export const reloadPluginsCmd: SlashCommand = {
         await q.reloadPlugins();
       }
     } catch (err) {
+      // Contract: fail-soft — reloadPlugins() is a best-effort SDK flush;
+      // the user sees the warning and the re-registration below still runs
+      // against the current (possibly stale) SDK state rather than aborting.
       ctx.out.warn(`Plugin reload failed: ${err instanceof Error ? err.message : String(err)}`);
     }
     // Refresh skills + agents in parallel — neither depends on the other.

--- a/src/cli/slash/plugin-skills/state.ts
+++ b/src/cli/slash/plugin-skills/state.ts
@@ -24,8 +24,6 @@ export interface PluginCollision {
   bare: string;
   /** Slash form of the surviving plugin alt (e.g. `/example-plugin:mint`). */
   altSlash: string;
-  /** Description from the plugin side, for the alt continuation row. */
-  altDescription: string;
   /** Origin of the shadowed entry, so an alt row labels a command as such. */
   source?: SkillManifestEntry['source'];
 }


### PR DESCRIPTION
## Summary

Closes #503

Three cleanup items surfaced (report-only) during the #366 plugin-skills split. Each assessed against current code; two fixed, one confirmed already-ok.

---

## Per-item verdicts

### 1. Dead field `altDescription` — **FIXED**

`grep altDescription src/` confirmed exactly two sites: the type declaration (`state.ts:28`) and the population (`dispatch.ts:256`). No reader or consumer exists anywhere in `src/` (verified: `listing.ts` reads `collision.altSlash` and `collision.source` but never `collision.altDescription`).

**Removed:**
- `altDescription: string` from `PluginCollision` interface in `state.ts`
- `altDescription: skill.description` from the `collisions.push(...)` call in `dispatch.ts`

Change is inert by definition — the field was written but never read.

### 2. Error-swallowing annotation — **FIXED** (behavior unchanged, intent documented)

Three fail-soft sites identified and annotated with `// Contract:` comments:

- **`harvestPluginSkillFlags` in `flags.ts`** — three bare `catch {}` blocks (unreadable dir, stat error on entry, unreadable SKILL.md). Each is correctly fail-soft: a missing or unreadable plugin dir/file must not abort the walk. Added `// Contract:` comments to each.

- **`parsePrRef` catch in `dispatch.ts`** — `try { prRefFromArgs = parsePrRef(...) } catch { prRefFromArgs = null }`. Correctly fail-soft: an invalid PR ref (e.g. `/review 0`) must not abort the review dispatch. Added `// Contract:` comment.

- **`reloadPlugins()` catch in `reload.ts`** — warns then proceeds against current (possibly stale) SDK state. Correctly fail-soft: the REPL stays usable even when the SDK flush fails, and the user sees the warning. Added `// Contract:` comment.

No behavior was changed. Only intent documentation was added.

### 3. Stale header comment — **ALREADY OK — SKIPPED**

The `dispatch.ts` module header reads: *"Plugin-skill dispatch: forward-handler construction + registration."* This describes the module's role (constructing passthrough/forward handlers), not a `SlashResult` return value. No claim that handlers return `'forward'` appears in the header.

The existing inline comment at line 102 explicitly states *"rather than returning `'forward'`"* — documenting the deliberate departure from that pattern. The header is accurate.

---

## Gates

| Gate | Result |
|------|--------|
| `pnpm lint` (`tsc --noEmit`) | ✅ Pass — no errors |
| `pnpm test src/cli/slash` | ✅ Pass — 739 tests, 50 files |
| `pnpm audit:filesize:check` | ℹ️ Pre-existing failures in unrelated files (`nesting.ts`, `child-config.ts`, `stream-renderer.ts`, `elicitation-handler.ts`, `session-manager.ts`) — all outside `src/cli/slash/plugin-skills/`. My four touched files are all under the 350-line ceiling and not in the baseline exceptions. |

---

## Files changed

- `src/cli/slash/plugin-skills/state.ts` — drop dead `altDescription` field
- `src/cli/slash/plugin-skills/dispatch.ts` — stop populating `altDescription`; add `// Contract:` on `parsePrRef` catch
- `src/cli/slash/plugin-skills/flags.ts` — add `// Contract:` on three fs-error swallows
- `src/cli/slash/plugin-skills/reload.ts` — add `// Contract:` on `reloadPlugins` catch

---

## DCO

- [x] I certify that this contribution is made under the terms of the project's DCO, and I sign off with `git commit -s` (Signed-off-by trailer present in commit).
