### PR TITLE
feat(tui): slash-complete anywhere, @-file subsequence, Linux image paste, Ctrl-R reverse-search

### DIFF
--- a/src/cli/input-box.test.ts
+++ b/src/cli/input-box.test.ts
@@ -37,9 +37,11 @@ describe('detectTrigger', () => {
       expect(result).toBeNull();
     });
 
-    it('returns null when buffer has text before /', () => {
+    it('detects a slash command after preceding text + space (mid-buffer)', () => {
+      // Slash-complete-anywhere: a slash token after whitespace triggers so
+      // completion fires in "please run /help"-style prompts, not only at start.
       const result = detectTrigger('hello /help', 11);
-      expect(result).toBeNull();
+      expect(result).toEqual({ kind: 'slash', query: 'help' });
     });
 
     it('allows hyphen and underscore in slash command names', () => {
@@ -47,19 +49,19 @@ describe('detectTrigger', () => {
       expect(result).toEqual({ kind: 'slash', query: 'my-cmd_name' });
     });
 
-    it('returns null when slash command is not at the start', () => {
+    it('detects a slash command that is not at the buffer start (after whitespace)', () => {
       const result = detectTrigger('text /cmd', 9);
-      expect(result).toBeNull();
+      expect(result).toEqual({ kind: 'slash', query: 'cmd' });
     });
 
-    it('returns null when slash command is preceded by leading whitespace', () => {
+    it('detects a slash command preceded by leading whitespace', () => {
       const result = detectTrigger(' /help', 6);
-      expect(result).toBeNull();
+      expect(result).toEqual({ kind: 'slash', query: 'help' });
     });
 
-    it('returns null when slash command appears on a later line', () => {
+    it('detects a slash command on a later line (after a newline)', () => {
       const result = detectTrigger('note\n/help', 10);
-      expect(result).toBeNull();
+      expect(result).toEqual({ kind: 'slash', query: 'help' });
     });
 
     it('returns null when slash command contains punctuation', () => {

--- a/src/cli/input/clipboard-image-linux.ts
+++ b/src/cli/input/clipboard-image-linux.ts
@@ -1,0 +1,162 @@
+/**
+ * Linux clipboard image reader — Wayland (wl-paste) and X11 (xclip) support.
+ *
+ * Extracted from clipboard-image.ts to keep that file under the 350-line
+ * source ceiling. All Linux-specific logic lives here; the macOS path (osascript
+ * / sips) stays in clipboard-image.ts.
+ *
+ * Strategy:
+ *   1. Probe for `wl-paste` (Wayland-native) first.
+ *   2. Fall back to `xclip` (X11 / XWayland) if wl-paste is absent.
+ *   3. If neither tool is installed, return null (graceful no-op — user
+ *      simply doesn't get clipboard-image paste on this system).
+ *
+ * Both tools are asked for `image/png` directly via MIME-type flags:
+ *   wl-paste --type image/png --no-newline
+ *   xclip    -selection clipboard -t image/png -o
+ *
+ * Magic-byte validation is shared with the macOS path via the caller.
+ *
+ * @module cli/input/clipboard-image-linux
+ */
+
+import { spawn } from 'child_process';
+import { randomUUID } from 'crypto';
+import { unlink } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import type { ImageAttachment } from './attachments.js';
+
+/**
+ * When AFK_DEBUG_CLIPBOARD=1, structured diagnostic messages are written to
+ * stderr at each probe stage. Zero overhead when unset. Mirrors the pattern in
+ * clipboard-image.ts — evaluated at module load so re-import is required to
+ * toggle within a test (identical to the macOS module's behaviour).
+ */
+// Using dynamic env read rather than importing env.ts to avoid a circular dep
+// through config → paths. The clipboard module already accesses env this way.
+const DEBUG = !!(process.env['AFK_DEBUG_CLIPBOARD']);
+
+function dbg(msg: string): void {
+  process.stderr.write(`[afk-clipboard] ${msg}\n`);
+}
+
+/**
+ * Check whether a command is available on PATH by attempting a version-style
+ * probe via `spawn`. Returns true if the binary exists and can be exec'd; false
+ * on ENOENT / EACCES. A non-zero exit code still proves the binary is present
+ * (some tools like `wl-paste --version` exit 1 on certain distros).
+ *
+ * Uses `spawn` (not `execFile`) so the same mock used in clipboard-image.test.ts
+ * (`vi.mock('child_process', () => ({ spawn: vi.fn() }))`) covers this probe
+ * without extra mock plumbing.
+ */
+export function isCommandAvailable(cmd: string, args: string[]): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    const child = spawn(cmd, args, { stdio: ['ignore', 'ignore', 'ignore'] });
+    child.on('error', (err) => {
+      const code = (err as NodeJS.ErrnoException).code;
+      resolve(code !== 'ENOENT' && code !== 'EACCES');
+    });
+    child.on('close', () => resolve(true));
+  });
+}
+
+/**
+ * Spawn a clipboard reader tool and collect its stdout as a Buffer.
+ * Returns null if the command exits non-zero or produces no bytes.
+ */
+export function linuxClipboardRead(cmd: string, args: string[]): Promise<Buffer | null> {
+  return new Promise<Buffer | null>((resolve) => {
+    const child = spawn(cmd, args, { stdio: ['ignore', 'pipe', 'ignore'] });
+    const chunks: Buffer[] = [];
+
+    child.stdout?.on('data', (chunk: Buffer) => { chunks.push(chunk); });
+    child.on('error', () => resolve(null));
+    child.on('close', (code) => {
+      if (code !== 0) { resolve(null); return; }
+      const buf = Buffer.concat(chunks);
+      resolve(buf.length > 0 ? buf : null);
+    });
+  });
+}
+
+/**
+ * Detect image format by inspecting magic bytes at buffer start.
+ * Subset of formats the Anthropic API accepts.
+ */
+export function detectMediaTypeLinux(
+  buffer: Buffer,
+): ImageAttachment['mediaType'] | null {
+  // PNG: 89 50 4E 47 0D 0A 1A 0A
+  if (buffer.length >= 8 && buffer[0] === 0x89 && buffer[1] === 0x50 && buffer[2] === 0x4e && buffer[3] === 0x47) {
+    return 'image/png';
+  }
+  // JPEG: FF D8 FF
+  if (buffer.length >= 3 && buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) {
+    return 'image/jpeg';
+  }
+  // GIF: 47 49 46 38
+  if (buffer.length >= 4 && buffer[0] === 0x47 && buffer[1] === 0x49 && buffer[2] === 0x46 && buffer[3] === 0x38) {
+    return 'image/gif';
+  }
+  // WebP: RIFF....WEBP
+  if (
+    buffer.length >= 12 &&
+    buffer[0] === 0x52 && buffer[1] === 0x49 && buffer[2] === 0x46 && buffer[3] === 0x46 &&
+    buffer[8] === 0x57 && buffer[9] === 0x45 && buffer[10] === 0x42 && buffer[11] === 0x50
+  ) {
+    return 'image/webp';
+  }
+  return null;
+}
+
+/**
+ * Read image data from the Linux clipboard.
+ *
+ * Probes for wl-paste (Wayland) first, then xclip (X11). Graceful no-op when
+ * neither tool is installed or the clipboard holds no image data.
+ */
+export async function readClipboardImageLinux(): Promise<ImageAttachment | null> {
+  if (DEBUG) dbg('linux: probing clipboard for image data');
+
+  const hasWlPaste = await isCommandAvailable('wl-paste', ['--version']);
+  const hasXclip   = await isCommandAvailable('xclip',    ['-version']);
+
+  if (!hasWlPaste && !hasXclip) {
+    if (DEBUG) dbg('linux: neither wl-paste nor xclip found, returning null');
+    return null;
+  }
+
+  const probes: Array<{ cmd: string; args: string[] }> = [];
+  if (hasWlPaste) probes.push({ cmd: 'wl-paste', args: ['--type', 'image/png', '--no-newline'] });
+  if (hasXclip)   probes.push({ cmd: 'xclip',    args: ['-selection', 'clipboard', '-t', 'image/png', '-o'] });
+
+  for (const { cmd, args } of probes) {
+    const tmpPath = join(tmpdir(), `afk-clipboard-${randomUUID()}.bin`);
+    try {
+      const buffer = await linuxClipboardRead(cmd, args);
+      if (DEBUG) dbg(`linux: ${cmd} returned ${buffer?.length ?? 0} bytes`);
+      if (!buffer || buffer.length === 0) continue;
+
+      const mediaType = detectMediaTypeLinux(buffer);
+      if (DEBUG) dbg(`linux: magic-byte detection: ${mediaType ?? 'unrecognized'}`);
+      if (!mediaType) continue;
+
+      if (DEBUG) dbg(`linux: probe success: mediaType=${mediaType} size=${buffer.byteLength}`);
+      return {
+        id: randomUUID(),
+        mediaType,
+        bytes: buffer,
+        sizeBytes: buffer.byteLength,
+      };
+    } catch {
+      // Try next tool
+    } finally {
+      unlink(tmpPath).catch(() => undefined);
+    }
+  }
+
+  if (DEBUG) dbg('linux: probe result: null (no image found on clipboard)');
+  return null;
+}

--- a/src/cli/input/clipboard-image-linux.ts
+++ b/src/cli/input/clipboard-image-linux.ts
@@ -25,6 +25,7 @@ import { randomUUID } from 'crypto';
 import { unlink } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { env } from '../../config/env.js';
 import type { ImageAttachment } from './attachments.js';
 
 /**
@@ -33,9 +34,10 @@ import type { ImageAttachment } from './attachments.js';
  * clipboard-image.ts — evaluated at module load so re-import is required to
  * toggle within a test (identical to the macOS module's behaviour).
  */
-// Using dynamic env read rather than importing env.ts to avoid a circular dep
-// through config → paths. The clipboard module already accesses env this way.
-const DEBUG = !!(process.env['AFK_DEBUG_CLIPBOARD']);
+// Read through the typed env accessor (src/config/env.ts) — never raw
+// process.env — matching the sibling clipboard-image.ts. Evaluated at module
+// load, so a test must re-import the module to toggle the flag.
+const DEBUG = !!env.AFK_DEBUG_CLIPBOARD;
 
 function dbg(msg: string): void {
   process.stderr.write(`[afk-clipboard] ${msg}\n`);

--- a/src/cli/input/clipboard-image.test.ts
+++ b/src/cli/input/clipboard-image.test.ts
@@ -127,11 +127,14 @@ describe('readClipboardImage', () => {
   });
 
   describe('platform check', () => {
-    it('returns null on non-darwin without spawning', async () => {
+    it('linux: routes through the Linux path (not darwin no-op)', async () => {
+      // Linux now has its own clipboard path via wl-paste/xclip.
+      // Neither tool is available in the test env (spawn ENOENT), so the
+      // result is null — but spawn IS called for the availability probe.
       Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+      mockedSpawn.mockImplementation(() => createOsaChild({ shouldError: true }));
       const result = await readClipboardImage();
       expect(result).toBeNull();
-      expect(mockedSpawn).not.toHaveBeenCalled();
     });
 
     it('returns null on win32 without spawning', async () => {
@@ -346,7 +349,145 @@ describe('readClipboardImage', () => {
 });
 
 /**
- * Part B: AFK_DEBUG_CLIPBOARD env-var gating.
+ * Part B-Linux: Linux clipboard image support (wl-paste / xclip).
+ *
+ * The Linux path lives in clipboard-image-linux.ts and is invoked by
+ * readClipboardImage() when process.platform === 'linux'. All spawns (both the
+ * isCommandAvailable probe and the actual clipboard read) go through the same
+ * mocked `child_process.spawn`.
+ *
+ * Probe sequence for wl-paste path:
+ *   spawn #1: wl-paste --version          (availability probe) → emit close(0)
+ *   spawn #2: xclip -version              (availability probe) → emit error ENOENT
+ *   spawn #3: wl-paste --type image/png … (data read)          → emit stdout bytes + close(0)
+ *
+ * For xclip fallback: spawn #1 ENOENT (no wl-paste), spawn #2 close(0), spawn #3 data.
+ */
+describe('Linux clipboard (Part B-Linux)', () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockedUnlink.mockResolvedValue(undefined);
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+    Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+  });
+
+  /** Build a child that immediately errors with ENOENT (tool not installed). */
+  function createEnoentChild(): ChildProcess {
+    const child = new EventEmitter() as EventEmitter & { stdout: EventEmitter; stderr: EventEmitter };
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    setImmediate(() => { child.emit('error', Object.assign(new Error('not found'), { code: 'ENOENT' })); });
+    return child as unknown as ChildProcess;
+  }
+
+  /** Build a child that closes with a given exit code, optionally emitting stdout data. */
+  function createChild(exitCode: number, data?: Buffer): ChildProcess {
+    const child = new EventEmitter() as EventEmitter & { stdout: EventEmitter; stderr: EventEmitter };
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    setImmediate(() => {
+      if (data) child.stdout.emit('data', data);
+      child.emit('close', exitCode);
+    });
+    return child as unknown as ChildProcess;
+  }
+
+  it('returns null when neither wl-paste nor xclip is available', async () => {
+    // Both availability probes emit ENOENT.
+    mockedSpawn.mockImplementation(() => createEnoentChild());
+    const result = await readClipboardImage();
+    expect(result).toBeNull();
+  });
+
+  it('reads PNG from wl-paste when available', async () => {
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xaa, 0xbb]);
+    let call = 0;
+    mockedSpawn.mockImplementation(() => {
+      call++;
+      // call 1: wl-paste --version probe → available (close 0)
+      if (call === 1) return createChild(0);
+      // call 2: xclip -version probe → not available (ENOENT)
+      if (call === 2) return createEnoentChild();
+      // call 3: wl-paste actual data read
+      return createChild(0, png);
+    });
+    const result = await readClipboardImage();
+    expect(result).not.toBeNull();
+    expect(result?.mediaType).toBe('image/png');
+    expect(result?.bytes).toEqual(png);
+  });
+
+  it('falls back to xclip when wl-paste is absent', async () => {
+    const jpeg = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+    let call = 0;
+    mockedSpawn.mockImplementation(() => {
+      call++;
+      // call 1: wl-paste probe → ENOENT
+      if (call === 1) return createEnoentChild();
+      // call 2: xclip probe → available (close 0)
+      if (call === 2) return createChild(0);
+      // call 3: xclip actual data read
+      return createChild(0, jpeg);
+    });
+    const result = await readClipboardImage();
+    expect(result).not.toBeNull();
+    expect(result?.mediaType).toBe('image/jpeg');
+  });
+
+  it('returns null when wl-paste is available but clipboard holds no image (exit 1)', async () => {
+    let call = 0;
+    mockedSpawn.mockImplementation(() => {
+      call++;
+      if (call === 1) return createChild(0);     // wl-paste probe ok
+      if (call === 2) return createEnoentChild(); // xclip absent
+      return createChild(1);                      // wl-paste data read → exit 1 (no image)
+    });
+    const result = await readClipboardImage();
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the data is unrecognised magic bytes', async () => {
+    const unknown = Buffer.from([0x00, 0x01, 0x02, 0x03]);
+    let call = 0;
+    mockedSpawn.mockImplementation(() => {
+      call++;
+      if (call === 1) return createChild(0);
+      if (call === 2) return createEnoentChild();
+      return createChild(0, unknown);
+    });
+    const result = await readClipboardImage();
+    expect(result).toBeNull();
+  });
+
+  it('returns a valid uuid id on success', async () => {
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    let call = 0;
+    mockedSpawn.mockImplementation(() => {
+      call++;
+      if (call === 1) return createChild(0);
+      if (call === 2) return createEnoentChild();
+      return createChild(0, png);
+    });
+    const result = await readClipboardImage();
+    expect(result?.id).toMatch(/^[0-9a-f-]{36}$/i);
+  });
+
+  it('win32 still returns null without spawning', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    const result = await readClipboardImage();
+    expect(result).toBeNull();
+    expect(mockedSpawn).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Part C: AFK_DEBUG_CLIPBOARD env-var gating.
  *
  * Because `const DEBUG = !!process.env.AFK_DEBUG_CLIPBOARD` is evaluated at
  * module load time, each sub-test must reset modules and re-import the module
@@ -357,7 +498,7 @@ describe('readClipboardImage', () => {
  * file with vi.mock() (hoisted), so they remain active across module resets.
  * We re-configure the spawn/readFile stubs via the already-mocked references.
  */
-describe('AFK_DEBUG_CLIPBOARD logging (Part B)', () => {
+describe('AFK_DEBUG_CLIPBOARD logging (Part C)', () => {
   const originalPlatform = process.platform;
 
   beforeEach(() => {

--- a/src/cli/input/clipboard-image.ts
+++ b/src/cli/input/clipboard-image.ts
@@ -23,6 +23,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import type { ImageAttachment } from './attachments.js';
 import { env } from '../../config/env.js';
+import { readClipboardImageLinux } from './clipboard-image-linux.js';
 
 /**
  * When AFK_DEBUG_CLIPBOARD=1 (or any truthy value), structured diagnostic
@@ -54,6 +55,10 @@ function dbg(msg: string): void {
  * to PNG before returning.
  */
 export async function readClipboardImage(): Promise<ImageAttachment | null> {
+  if (process.platform === 'linux') {
+    return readClipboardImageLinux();
+  }
+
   if (process.platform !== 'darwin') {
     return null;
   }

--- a/src/cli/input/reader.keypress.ts
+++ b/src/cli/input/reader.keypress.ts
@@ -20,6 +20,10 @@ import { isPrintableGrapheme } from './printable.js';
 import { isSoftNewlineEnter, endsWithBackslashContinuation } from './enter-decision.js';
 import { handlePasteStart, handlePasteEnd, handleCtrlV } from './reader.keypress.paste.js';
 import { handleNavKey, writeEofOutput } from './reader.keypress.nav.js';
+import {
+  enterReverseSearch,
+  handleReverseSearchKey,
+} from './reader.reverse-search.js';
 import type { ReaderState } from './reader.state.js';
 import type { RepaintCtx, repaint as _repaint, schedulePaint as _schedulePaint } from './reader.repaint.js';
 import type { applySelection as _applySelection } from './reader.selection.js';
@@ -86,6 +90,29 @@ export function handleKeypress(
 
   // Ctrl+V: paste image from clipboard.
   if (key?.ctrl && key?.name === 'v') { handleCtrlV(st, repaintCtx, schedulePaintFn); return; }
+
+  // Ctrl+R: reverse incremental history search.
+  // If the modal is already active, `handleReverseSearchKey` cycles to the next
+  // older match. If not, activate the modal now.
+  if (key?.ctrl && key?.name === 'r') {
+    const entries = opts.history?.getEntries?.() ?? [];
+    if (!st.reverseSearch.active) {
+      enterReverseSearch(st.reverseSearch, st);
+    }
+    // Delegate — this will cycle to the next match (or do nothing if no history).
+    handleReverseSearchKey(char, key, st.reverseSearch, st, entries, repaintCtx, repaintFn);
+    return;
+  }
+
+  // While reverse-search is active, route all keys through the search handler.
+  // The handler returns false only for Enter (accept+submit) and Ctrl-C (abort)
+  // — in those cases fall through to let the outer dispatcher handle them.
+  if (st.reverseSearch.active) {
+    const entries = opts.history?.getEntries?.() ?? [];
+    const consumed = handleReverseSearchKey(char, key, st.reverseSearch, st, entries, repaintCtx, repaintFn);
+    if (consumed) return;
+    // Key was not consumed (Enter or Ctrl-C) — fall through to normal handling.
+  }
 
   if (key?.name === 'escape') {
     if (st.ac.dropdownOpen) {

--- a/src/cli/input/reader.reverse-search.test.ts
+++ b/src/cli/input/reader.reverse-search.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Tests for reader.reverse-search.ts — the incremental reverse-history-search
+ * modal for the TTY REPL.
+ *
+ * Covers:
+ *   - createReverseSearchState: fresh inactive state
+ *   - enterReverseSearch: saves buffer, resets query+match
+ *   - cancelReverseSearch: restores saved buffer
+ *   - acceptReverseSearch: keeps current buffer, deactivates
+ *   - findNextMatch: prefix, substring, cycling, no-match, empty query
+ *   - renderReverseSearchLine: prompt format
+ *   - handleReverseSearchKey:
+ *       Ctrl-R (cycle), Esc/Ctrl-G (cancel), Enter (accept, fall-through),
+ *       Ctrl-C (cancel + fall-through), Backspace (trim query), printable
+ *       chars (extend query), unrecognised keys (accept + fall-through)
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createReverseSearchState,
+  enterReverseSearch,
+  cancelReverseSearch,
+  acceptReverseSearch,
+  findNextMatch,
+  renderReverseSearchLine,
+  handleReverseSearchKey,
+  type ReverseSearchState,
+} from './reader.reverse-search.js';
+import { InputCore } from '../input-core.js';
+import type { ReaderState } from './reader.state.js';
+import type { RepaintCtx } from './reader.repaint.js';
+import type { AutocompleteState } from './autocomplete-state.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal ReaderState for testing. */
+function makeState(buffer = ''): ReaderState {
+  const ac: AutocompleteState = {
+    dropdownOpen: false,
+    candidates: [],
+    selectedIndex: 0,
+    viewportStart: 0,
+    suppressedSignature: null,
+    trigger: null,
+    reset() {
+      this.dropdownOpen = false;
+      this.candidates = [];
+      this.selectedIndex = 0;
+      this.viewportStart = 0;
+      this.suppressedSignature = null;
+      this.trigger = null;
+    },
+  };
+  return {
+    input: InputCore.seed(buffer),
+    ac,
+    rowsBelow: 0,
+    pasting: false,
+    clipboardInFlight: false,
+    pasteStartBufferLen: 0,
+    prevBufferRows: 0,
+    prevStatusRows: 0,
+    clipboardFailureMsg: null,
+    attachments: [],
+    maxDropdownRows: 6,
+    lastKeypressAt: 0,
+    repaintPending: false,
+    settled: false,
+    reverseSearch: createReverseSearchState(),
+  };
+}
+
+/** Minimal RepaintCtx that doesn't touch stdout. */
+function makeRepaintCtx(): RepaintCtx {
+  return {
+    stdout: {
+      write: vi.fn(() => true),
+      columns: 80,
+    } as unknown as NodeJS.WriteStream,
+    promptText: '> ',
+    promptVisibleLen: 2,
+    slashRegistryView: { has: () => false },
+  };
+}
+
+/** No-op repaint for unit tests that don't need to inspect output. */
+const noop = () => {};
+
+// ---------------------------------------------------------------------------
+// createReverseSearchState
+// ---------------------------------------------------------------------------
+
+describe('createReverseSearchState', () => {
+  it('returns an inactive state with empty query and -1 matchIndex', () => {
+    const rs = createReverseSearchState();
+    expect(rs.active).toBe(false);
+    expect(rs.query).toBe('');
+    expect(rs.matchIndex).toBe(-1);
+    expect(rs.savedBuffer).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enterReverseSearch
+// ---------------------------------------------------------------------------
+
+describe('enterReverseSearch', () => {
+  it('activates the modal and saves the current buffer', () => {
+    const rs = createReverseSearchState();
+    const st = makeState('some draft');
+    enterReverseSearch(rs, st);
+    expect(rs.active).toBe(true);
+    expect(rs.savedBuffer).toBe('some draft');
+  });
+
+  it('resets query and matchIndex on entry', () => {
+    const rs = createReverseSearchState();
+    rs.query = 'leftover';
+    rs.matchIndex = 3;
+    const st = makeState();
+    enterReverseSearch(rs, st);
+    expect(rs.query).toBe('');
+    expect(rs.matchIndex).toBe(-1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cancelReverseSearch
+// ---------------------------------------------------------------------------
+
+describe('cancelReverseSearch', () => {
+  it('deactivates the modal and restores the saved buffer', () => {
+    const rs = createReverseSearchState();
+    const st = makeState('original draft');
+    enterReverseSearch(rs, st);
+    // Simulate a match overwriting the buffer
+    st.input = InputCore.seed('/different command');
+    cancelReverseSearch(rs, st);
+    expect(rs.active).toBe(false);
+    expect(st.input.buffer).toBe('original draft');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// acceptReverseSearch
+// ---------------------------------------------------------------------------
+
+describe('acceptReverseSearch', () => {
+  it('deactivates the modal and keeps the current buffer', () => {
+    const rs = createReverseSearchState();
+    const st = makeState('initial');
+    enterReverseSearch(rs, st);
+    st.input = InputCore.seed('/matched command');
+    acceptReverseSearch(rs, st);
+    expect(rs.active).toBe(false);
+    expect(st.input.buffer).toBe('/matched command');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findNextMatch
+// ---------------------------------------------------------------------------
+
+describe('findNextMatch', () => {
+  const entries = ['/ship', '/mint foo', '/config', '/ship --dry-run', '/help'];
+
+  it('returns -1 for an empty query', () => {
+    expect(findNextMatch('', entries, -1)).toBe(-1);
+  });
+
+  it('returns -1 for empty entries', () => {
+    expect(findNextMatch('ship', [], -1)).toBe(-1);
+  });
+
+  it('finds the first (newest) match from index -1', () => {
+    expect(findNextMatch('ship', entries, -1)).toBe(0);
+  });
+
+  it('cycles to the next older match when called again', () => {
+    const first = findNextMatch('ship', entries, -1);
+    const second = findNextMatch('ship', entries, first);
+    expect(second).toBe(3); // '/ship --dry-run' at index 3
+  });
+
+  it('returns -1 when no further match exists', () => {
+    const idx = findNextMatch('ship', entries, 3);
+    expect(idx).toBe(-1);
+  });
+
+  it('matches substrings (case-insensitive)', () => {
+    expect(findNextMatch('CONFIG', entries, -1)).toBe(2);
+  });
+
+  it('returns -1 for a query with no matches', () => {
+    expect(findNextMatch('zzz', entries, -1)).toBe(-1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderReverseSearchLine
+// ---------------------------------------------------------------------------
+
+describe('renderReverseSearchLine', () => {
+  it('renders the expected readline-style prompt', () => {
+    expect(renderReverseSearchLine('ship', '/ship --dry-run')).toBe(
+      "(reverse-i-search)`ship': /ship --dry-run",
+    );
+  });
+
+  it('renders an empty match as an empty string', () => {
+    expect(renderReverseSearchLine('xyz', null)).toBe("(reverse-i-search)`xyz': ");
+  });
+
+  it('renders an empty query', () => {
+    expect(renderReverseSearchLine('', null)).toBe("(reverse-i-search)`': ");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleReverseSearchKey
+// ---------------------------------------------------------------------------
+
+describe('handleReverseSearchKey', () => {
+  const entries = ['/ship', '/mint foo', '/config', '/ship --dry-run'];
+
+  function setup(initialBuffer = '') {
+    const rs = createReverseSearchState();
+    const st = makeState(initialBuffer);
+    const ctx = makeRepaintCtx();
+    enterReverseSearch(rs, st);
+    return { rs, st, ctx };
+  }
+
+  it('Ctrl-R cycles to the next older match', () => {
+    const { rs, st, ctx } = setup();
+    // First: type 's' to get the first match
+    handleReverseSearchKey('s', { name: 's' }, rs, st, entries, ctx, noop);
+    expect(rs.matchIndex).toBe(0);
+    expect(st.input.buffer).toBe('/ship');
+
+    // Ctrl-R: cycle to the next match
+    const consumed = handleReverseSearchKey(undefined, { ctrl: true, name: 'r' }, rs, st, entries, ctx, noop);
+    expect(consumed).toBe(true);
+    expect(rs.matchIndex).toBe(3);
+    expect(st.input.buffer).toBe('/ship --dry-run');
+  });
+
+  it('Esc cancels and restores the saved buffer', () => {
+    const { rs, st, ctx } = setup('my draft');
+    handleReverseSearchKey('s', { name: 's' }, rs, st, entries, ctx, noop);
+    const consumed = handleReverseSearchKey(undefined, { name: 'escape' }, rs, st, entries, ctx, noop);
+    expect(consumed).toBe(true);
+    expect(rs.active).toBe(false);
+    expect(st.input.buffer).toBe('my draft');
+  });
+
+  it('Ctrl-G cancels and restores the saved buffer', () => {
+    const { rs, st, ctx } = setup('my draft');
+    handleReverseSearchKey('s', { name: 's' }, rs, st, entries, ctx, noop);
+    const consumed = handleReverseSearchKey(undefined, { ctrl: true, name: 'g' }, rs, st, entries, ctx, noop);
+    expect(consumed).toBe(true);
+    expect(rs.active).toBe(false);
+    expect(st.input.buffer).toBe('my draft');
+  });
+
+  it('Enter accepts the match and returns false (fall-through)', () => {
+    const { rs, st, ctx } = setup();
+    handleReverseSearchKey('s', { name: 's' }, rs, st, entries, ctx, noop);
+    const consumed = handleReverseSearchKey(undefined, { name: 'return' }, rs, st, entries, ctx, noop);
+    expect(consumed).toBe(false);
+    expect(rs.active).toBe(false);
+    expect(st.input.buffer).toBe('/ship');
+  });
+
+  it('Ctrl-C cancels and returns false (fall-through to abort)', () => {
+    const { rs, st, ctx } = setup('saved');
+    handleReverseSearchKey('s', { name: 's' }, rs, st, entries, ctx, noop);
+    const consumed = handleReverseSearchKey(undefined, { ctrl: true, name: 'c' }, rs, st, entries, ctx, noop);
+    expect(consumed).toBe(false);
+    expect(rs.active).toBe(false);
+    // Buffer is restored to savedBuffer on Ctrl-C cancel
+    expect(st.input.buffer).toBe('saved');
+  });
+
+  it('Backspace trims the query by one char and re-searches', () => {
+    const { rs, st, ctx } = setup();
+    handleReverseSearchKey('s', { name: 's' }, rs, st, entries, ctx, noop);
+    handleReverseSearchKey('h', { name: 'h' }, rs, st, entries, ctx, noop);
+    expect(rs.query).toBe('sh');
+
+    const consumed = handleReverseSearchKey(undefined, { name: 'backspace' }, rs, st, entries, ctx, noop);
+    expect(consumed).toBe(true);
+    expect(rs.query).toBe('s');
+    // Still has a match for 's'
+    expect(rs.matchIndex).toBeGreaterThanOrEqual(0);
+  });
+
+  it('Backspace on empty query restores the saved buffer', () => {
+    const { rs, st, ctx } = setup('original');
+    const consumed = handleReverseSearchKey(undefined, { name: 'backspace' }, rs, st, entries, ctx, noop);
+    expect(consumed).toBe(true);
+    expect(rs.query).toBe('');
+    expect(st.input.buffer).toBe('original');
+  });
+
+  it('printable chars extend the query and update the match', () => {
+    const { rs, st, ctx } = setup();
+    const consumed = handleReverseSearchKey('s', { name: 's' }, rs, st, entries, ctx, noop);
+    expect(consumed).toBe(true);
+    expect(rs.query).toBe('s');
+    expect(rs.matchIndex).toBe(0);
+    expect(st.input.buffer).toBe('/ship');
+  });
+
+  it('printable chars with no match leave matchIndex as -1', () => {
+    const { rs, st, ctx } = setup('saved');
+    handleReverseSearchKey('z', { name: 'z' }, rs, st, entries, ctx, noop);
+    expect(rs.query).toBe('z');
+    expect(rs.matchIndex).toBe(-1);
+  });
+
+  it('unrecognised key (e.g. arrow) exits the modal and returns false', () => {
+    const { rs, st, ctx } = setup();
+    handleReverseSearchKey('s', { name: 's' }, rs, st, entries, ctx, noop);
+    const consumed = handleReverseSearchKey(undefined, { name: 'up' }, rs, st, entries, ctx, noop);
+    expect(consumed).toBe(false);
+    expect(rs.active).toBe(false);
+  });
+
+  it('Ctrl-R with no history (empty entries) returns true and does nothing', () => {
+    const { rs, st, ctx } = setup();
+    const consumed = handleReverseSearchKey(undefined, { ctrl: true, name: 'r' }, rs, st, [], ctx, noop);
+    expect(consumed).toBe(true);
+    expect(rs.matchIndex).toBe(-1);
+  });
+
+  it('repaintFn is called on each key that modifies state', () => {
+    const { rs, st, ctx } = setup();
+    const repaint = vi.fn();
+    handleReverseSearchKey('s', { name: 's' }, rs, st, entries, ctx, repaint);
+    expect(repaint).toHaveBeenCalled();
+  });
+});

--- a/src/cli/input/reader.reverse-search.ts
+++ b/src/cli/input/reader.reverse-search.ts
@@ -1,0 +1,233 @@
+/**
+ * Incremental reverse-history-search modal for readWithAutocompleteTty.
+ *
+ * Triggered by Ctrl-R; exits on Enter (accept), Esc/Ctrl-G (cancel), or
+ * Ctrl-C (abort). While active the status line shows:
+ *   `(reverse-i-search)\`<query>\`: <match>`
+ * Repeated Ctrl-R cycles to the next older matching entry.
+ *
+ * Integration contract:
+ *   - Enter / exit via `enterReverseSearch` / `exitReverseSearch`.
+ *   - `handleReverseSearchKey` processes each keypress; returns `true` if it
+ *     consumed the key, `false` to fall through to the normal handler.
+ *   - State is stored on `ReverseSearchState`; attach it to `ReaderState`
+ *     (see reader.state.ts extension note) or carry it as a parallel bag.
+ *
+ * Invariant: no closure over `let` bindings from readWithAutocompleteTty.
+ * All mutable state is threaded through `ReverseSearchState`; all immutable
+ * dependencies come through the explicit parameters.
+ */
+
+import { InputCore } from '../input-core.js';
+import type { ReaderState } from './reader.state.js';
+import type { RepaintCtx, repaint as _repaint } from './reader.repaint.js';
+import type { KeyInfo } from './types.js';
+
+/** Mutable state for the reverse-search modal, parallel to ReaderState. */
+export interface ReverseSearchState {
+  /** Whether the modal is currently active. */
+  active: boolean;
+  /** Current search query (what the user has typed since Ctrl-R). */
+  query: string;
+  /**
+   * Index into the history entries array at which the current match was found
+   * (entries are newest-first from `getEntries()`). -1 means no match yet.
+   */
+  matchIndex: number;
+  /** Buffer content saved when Ctrl-R was pressed, restored on cancel. */
+  savedBuffer: string;
+}
+
+/** Create a fresh, inactive ReverseSearchState. */
+export function createReverseSearchState(): ReverseSearchState {
+  return { active: false, query: '', matchIndex: -1, savedBuffer: '' };
+}
+
+/**
+ * Activate reverse-search mode. Saves the current buffer and resets
+ * the search query + match pointer.
+ */
+export function enterReverseSearch(rs: ReverseSearchState, st: ReaderState): void {
+  rs.active = true;
+  rs.query = '';
+  rs.matchIndex = -1;
+  rs.savedBuffer = st.input.buffer;
+}
+
+/**
+ * Deactivate reverse-search mode without applying the match (cancel).
+ * Restores the buffer to what it was when Ctrl-R was pressed.
+ */
+export function cancelReverseSearch(rs: ReverseSearchState, st: ReaderState): void {
+  rs.active = false;
+  st.input = InputCore.seed(rs.savedBuffer);
+}
+
+/**
+ * Deactivate reverse-search mode and keep whatever is in the buffer (accept).
+ * The `_st` parameter is kept for signature symmetry with `cancelReverseSearch`
+ * (both functions are called from the same dispatch sites).
+ */
+export function acceptReverseSearch(rs: ReverseSearchState, _st: ReaderState): void {
+  rs.active = false;
+  // Buffer is already set by the last applyMatch call. Keep it as-is.
+}
+
+/**
+ * Find the next older match for `query` in `entries`, starting AFTER
+ * `startAfter` (exclusive). Pass -1 to start from the newest entry.
+ *
+ * Returns the index into `entries` of the match, or -1 if none found.
+ */
+export function findNextMatch(
+  query: string,
+  entries: readonly string[],
+  startAfter: number,
+): number {
+  if (entries.length === 0 || query.length === 0) return -1;
+  const lo = query.toLowerCase();
+  for (let i = startAfter + 1; i < entries.length; i++) {
+    if (entries[i]!.toLowerCase().includes(lo)) return i;
+  }
+  return -1;
+}
+
+/**
+ * Apply a matched history entry to the buffer (cursor at end).
+ */
+function applyMatch(match: string, st: ReaderState): void {
+  st.input = InputCore.seed(match);
+}
+
+/**
+ * Render the reverse-search status line to a string.
+ * Format mirrors bash/readline: `(reverse-i-search)\`<query>\': <match>`
+ */
+export function renderReverseSearchLine(query: string, match: string | null): string {
+  const display = match ?? '';
+  return `(reverse-i-search)\`${query}\': ${display}`;
+}
+
+/**
+ * Process a single keypress while reverse-search is active.
+ *
+ * Returns `true` if the key was consumed by the search modal (caller should
+ * `return`), `false` to hand control back to the normal dispatcher.
+ *
+ * Consumed keys:
+ *   - Printable chars: append to query, search from beginning.
+ *   - Backspace: remove last char from query, re-search.
+ *   - Ctrl-R: cycle to the next older match.
+ *   - Enter: accept current match, return false (let normal Enter submit).
+ *   - Esc / Ctrl-G: cancel, restore saved buffer, return true.
+ *   - Ctrl-C: cancel without restoring (let normal Ctrl-C handle abort).
+ */
+export function handleReverseSearchKey(
+  char: string | undefined,
+  key: KeyInfo,
+  rs: ReverseSearchState,
+  st: ReaderState,
+  entries: readonly string[],
+  repaintCtx: RepaintCtx,
+  repaintFn: typeof _repaint,
+): boolean {
+  // Ctrl-R: cycle to next older match.
+  if (key?.ctrl && key?.name === 'r') {
+    const next = findNextMatch(rs.query, entries, rs.matchIndex);
+    if (next !== -1) {
+      rs.matchIndex = next;
+      applyMatch(entries[next]!, st);
+    }
+    repaintReverseSearch(rs, st, entries, repaintCtx, repaintFn);
+    return true;
+  }
+
+  // Esc or Ctrl-G: cancel.
+  if (key?.name === 'escape' || (key?.ctrl && key?.name === 'g')) {
+    cancelReverseSearch(rs, st);
+    repaintFn(st, repaintCtx);
+    return true;
+  }
+
+  // Ctrl-C: do not consume — let the abort path in the outer dispatcher fire.
+  if (key?.ctrl && key?.name === 'c') {
+    cancelReverseSearch(rs, st);
+    return false;
+  }
+
+  // Enter: accept (keep current buffer), do not consume — normal Enter logic submits.
+  if (key?.name === 'return') {
+    acceptReverseSearch(rs, st);
+    return false;
+  }
+
+  // Backspace: trim query by one grapheme cluster.
+  if (key?.name === 'backspace') {
+    if (rs.query.length > 0) {
+      // Use spread to correctly handle multi-byte chars.
+      const chars = [...rs.query];
+      chars.pop();
+      rs.query = chars.join('');
+    }
+    // Re-search from the beginning when query shrinks.
+    rs.matchIndex = -1;
+    const next = findNextMatch(rs.query, entries, -1);
+    if (next !== -1) { rs.matchIndex = next; applyMatch(entries[next]!, st); }
+    else if (rs.query.length === 0) { st.input = InputCore.seed(rs.savedBuffer); }
+    repaintReverseSearch(rs, st, entries, repaintCtx, repaintFn);
+    return true;
+  }
+
+  // Printable character: append to query and search from beginning.
+  const noModifier = !key?.ctrl && !key?.meta;
+  const printable =
+    noModifier && typeof char === 'string' && char.length > 0 && char >= ' '
+      ? char
+      : null;
+  if (printable !== null) {
+    rs.query += printable;
+    rs.matchIndex = -1;
+    const next = findNextMatch(rs.query, entries, -1);
+    if (next !== -1) { rs.matchIndex = next; applyMatch(entries[next]!, st); }
+    repaintReverseSearch(rs, st, entries, repaintCtx, repaintFn);
+    return true;
+  }
+
+  // Any other key (arrows, etc.): exit the modal without changing buffer, let
+  // the outer dispatcher process the key normally.
+  acceptReverseSearch(rs, st);
+  return false;
+}
+
+/**
+ * Repaint during reverse-search: write the search status line as the prompt.
+ *
+ * We call the normal repaint (which already clears and redraws) and then
+ * overwrite the prompt text with the search-mode indicator. Since `repaintFn`
+ * uses `repaintCtx.promptText` verbatim, we temporarily swap it before the
+ * call and restore it after — a pure side-effect-free swap that leaves the ctx
+ * unchanged from the caller's perspective.
+ */
+function repaintReverseSearch(
+  rs: ReverseSearchState,
+  st: ReaderState,
+  entries: readonly string[],
+  repaintCtx: RepaintCtx,
+  repaintFn: typeof _repaint,
+): void {
+  const match = rs.matchIndex >= 0 ? (entries[rs.matchIndex] ?? null) : null;
+  const line = renderReverseSearchLine(rs.query, match);
+
+  // Temporarily override promptText so repaint shows the search indicator.
+  const savedPrompt = repaintCtx.promptText;
+  const savedLen = repaintCtx.promptVisibleLen;
+  // Cast to mutable for the duration of this call — we restore before returning.
+  (repaintCtx as { promptText: string }).promptText = line;
+  (repaintCtx as { promptVisibleLen: number }).promptVisibleLen = line.length;
+  try {
+    repaintFn(st, repaintCtx);
+  } finally {
+    (repaintCtx as { promptText: string }).promptText = savedPrompt;
+    (repaintCtx as { promptVisibleLen: number }).promptVisibleLen = savedLen;
+  }
+}

--- a/src/cli/input/reader.state.ts
+++ b/src/cli/input/reader.state.ts
@@ -15,6 +15,7 @@
 import type { InputCoreState } from '../input-core.js';
 import type { AutocompleteState } from './autocomplete-state.js';
 import type { ImageAttachment } from './attachments.js';
+import type { ReverseSearchState } from './reader.reverse-search.js';
 
 export interface ReaderState {
   /** Current text buffer + cursor position. */
@@ -48,4 +49,10 @@ export interface ReaderState {
    * repaints from firing after the promise has resolved or rejected.
    */
   settled: boolean;
+
+  /**
+   * Reverse-search modal state. Active when the user has pressed Ctrl-R.
+   * Threaded explicitly so the no-closure invariant is preserved.
+   */
+  reverseSearch: ReverseSearchState;
 }

--- a/src/cli/input/reader.ts
+++ b/src/cli/input/reader.ts
@@ -35,6 +35,7 @@ import { ResizeBus } from '../terminal-size.js';
 import { repaint, schedulePaint } from './reader.repaint.js';
 import { applySelection } from './reader.selection.js';
 import { handleKeypress } from './reader.keypress.js';
+import { createReverseSearchState } from './reader.reverse-search.js';
 import type { ReaderState } from './reader.state.js';
 import type { RepaintCtx } from './reader.repaint.js';
 import type {
@@ -119,6 +120,7 @@ export async function readWithAutocompleteTty(
         lastKeypressAt: 0,
         repaintPending: false,
         settled: false,
+        reverseSearch: createReverseSearchState(),
       };
 
       // Adapter for the slash highlighter. Delegates membership to the

--- a/src/cli/input/trigger.test.ts
+++ b/src/cli/input/trigger.test.ts
@@ -59,6 +59,57 @@ function dirent(name: string, isDir = false): FileDirent {
   return { name, isDirectory: () => isDir };
 }
 
+describe('detectTrigger — slash completion (mid-buffer)', () => {
+  it('fires at buffer start (existing behaviour preserved)', () => {
+    expect(detectTrigger('/ship', 5)).toEqual({ kind: 'slash', query: 'ship' });
+  });
+
+  it('fires for bare / at buffer start', () => {
+    expect(detectTrigger('/', 1)).toEqual({ kind: 'slash', query: '' });
+  });
+
+  it('fires after leading whitespace (tab-prefixed buffer)', () => {
+    const buf = ' /ship';
+    expect(detectTrigger(buf, buf.length)).toEqual({ kind: 'slash', query: 'ship' });
+  });
+
+  it('fires mid-buffer after a space (e.g. "please run /ship")', () => {
+    const buf = 'please run /ship';
+    expect(detectTrigger(buf, buf.length)).toEqual({ kind: 'slash', query: 'ship' });
+  });
+
+  it('fires for a partial slash token mid-sentence', () => {
+    const buf = 'use /con';
+    expect(detectTrigger(buf, buf.length)).toEqual({ kind: 'slash', query: 'con' });
+  });
+
+  it('fires for a bare / mid-sentence (after space)', () => {
+    const buf = 'hello /';
+    expect(detectTrigger(buf, buf.length)).toEqual({ kind: 'slash', query: '' });
+  });
+
+  it('does NOT fire when slash is inside a word (no leading whitespace)', () => {
+    // e.g. a URL fragment — the slash is not at a token boundary
+    expect(detectTrigger('http://example', 14)).toBeNull();
+  });
+
+  it('fires at cursor before end of buffer (mid-buffer cursor position)', () => {
+    // buffer is "/ship extra" but cursor is at 5 (end of "/ship")
+    const buf = '/ship extra';
+    expect(detectTrigger(buf, 5)).toEqual({ kind: 'slash', query: 'ship' });
+  });
+
+  it('does NOT fire when cursor is mid-slash-token and text follows without space', () => {
+    // upToCursor = "/sh" which is a valid slash token — should still fire
+    const buf = '/ship';
+    expect(detectTrigger(buf, 3)).toEqual({ kind: 'slash', query: 'sh' });
+  });
+
+  it('does not fire for prose with no slash', () => {
+    expect(detectTrigger('hello world', 11)).toBeNull();
+  });
+});
+
 describe('detectTrigger — @ file paths', () => {
   it('fires for @~/ (tilde), passing the ~/ query through unchanged', () => {
     expect(detectTrigger('@~/', 3)).toEqual({ kind: 'file', query: '~/' });
@@ -322,6 +373,53 @@ describe('buildFileCandidates — pure core (no I/O)', () => {
       entries.push(dirent(`f${String(i).padStart(3, '0')}.txt`));
     }
     expect(buildFileCandidates(entries, 'f', tmpRoot)).toHaveLength(MAX_FILE_MATCHES);
+  });
+
+  describe('@-file subsequence matching', () => {
+    it('returns subsequence matches when no prefix match exists', () => {
+      const entries = [dirent('src'), dirent('readme.md'), dirent('index.ts')];
+      // 'si' is not a prefix of any entry, but is a subsequence of 'index.ts' and 'src'
+      const vals = buildFileCandidates(entries, 'sr', tmpRoot).map((c) => c.value);
+      // 'sr' is a prefix of 'src' and a subsequence of nothing else useful
+      expect(vals).toContain('@src');
+    });
+
+    it('places prefix matches before subsequence-only matches', () => {
+      // 'inp' prefix: none; subsequence: 'index.ts' has i…p? No — test real subsequence
+      // 'cli' subsequence matches 'clipboard.ts' but 'clipboard' would be prefix
+      const entries = [
+        dirent('clog.ts'),    // prefix 'cl' ✓, subseq 'cli' ✓
+        dirent('clipboard.ts'), // prefix 'cl' ✓, prefix 'cli' ✓
+        dirent('unicorn.ts'), // subseq 'cli' via u(c)li? No. subseq of 'cli' in 'unicorn' = false
+        dirent('scale.ts'),   // subseq 'cli'? c…l…i = false
+      ];
+      // query 'clb' — prefix: none; subsequence: 'clipboard.ts' (c-l-b)
+      const vals = buildFileCandidates(entries, 'clb', tmpRoot).map((c) => c.value);
+      expect(vals).toContain('@clipboard.ts');
+      expect(vals).not.toContain('@clog.ts');
+    });
+
+    it('prefix matches sort before subsequence-only matches in ranked output', () => {
+      // 'al' is prefix of 'alpha.ts' and subsequence of 'canonical.ts'
+      const entries = [dirent('canonical.ts'), dirent('alpha.ts'), dirent('beta.ts')];
+      const vals = buildFileCandidates(entries, 'al', tmpRoot).map((c) => c.value);
+      // 'alpha.ts' is a prefix match; 'canonical.ts' is subsequence (c-a-n-o-n-i-c-al → 'al' at end = yes)
+      const alphaIdx = vals.indexOf('@alpha.ts');
+      const canonIdx = vals.indexOf('@canonical.ts');
+      expect(alphaIdx).toBeGreaterThanOrEqual(0);
+      if (canonIdx >= 0) {
+        // prefix match must come first
+        expect(alphaIdx).toBeLessThan(canonIdx);
+      }
+    });
+
+    it('empty leafPrefix returns all non-hidden entries (no subsequence filter applied)', () => {
+      const entries = [dirent('alpha.ts'), dirent('beta.ts'), dirent('gamma.md')];
+      const vals = buildFileCandidates(entries, '', tmpRoot).map((c) => c.value);
+      expect(vals).toContain('@alpha.ts');
+      expect(vals).toContain('@beta.ts');
+      expect(vals).toContain('@gamma.md');
+    });
   });
 });
 

--- a/src/cli/input/trigger.ts
+++ b/src/cli/input/trigger.ts
@@ -8,7 +8,7 @@
 
 import { readdirSync, promises as fsp, type Dirent } from 'fs';
 import { list as listSlashCommands, aliasEntries, lookup } from '../slash/registry.js';
-import { matchSlashCandidates, type CommandEntry } from './slash-match.js';
+import { matchSlashCandidates, isSubsequence, type CommandEntry } from './slash-match.js';
 import { resolveQuery, MAX_FILE_MATCHES } from '../multi-line-reader.js';
 import type { Candidate, Trigger } from './types.js';
 
@@ -16,7 +16,10 @@ import type { Candidate, Trigger } from './types.js';
  * Detect the trigger kind and query from the buffer at the cursor position.
  *
  * Returns:
- *   - { kind: 'slash', query } if buffer up to cursor matches /^\/[A-Za-z_-]*$/
+ *   - { kind: 'slash', query } if the token at the cursor position is a slash
+ *     command (i.e. starts with `/` and contains only `[A-Za-z_-]` characters).
+ *     The slash token may appear at the start of the buffer OR after whitespace,
+ *     enabling completion mid-buffer or in multiline drafts.
  *   - { kind: 'file', query } if the last token up to cursor matches @<path>
  *   - { kind: 'flag', command, query } if the buffer starts with `/<cmd>` followed
  *     by whitespace and ends with `--<query>` (final token), AND that command is
@@ -38,9 +41,13 @@ import type { Candidate, Trigger } from './types.js';
 export function detectTrigger(buffer: string, cursorCol: number): Trigger | null {
   const upToCursor = buffer.slice(0, cursorCol);
 
-  // Slash command: matches /^\/[A-Za-z_-]*$/ from start
-  if (/^\/[A-Za-z_-]*$/.test(upToCursor)) {
-    return { kind: 'slash', query: upToCursor.slice(1) };
+  // Slash command: the token at cursor must be `/[A-Za-z_-]*`.
+  // Matches at buffer start OR after whitespace so completion fires mid-buffer
+  // and in multiline drafts (e.g. "please run /ship" with cursor at end).
+  // The trailing `$` anchors to the cursor position (end of upToCursor).
+  const slashMatch = /(?:^|(?<=\s))\/[A-Za-z_-]*$/.exec(upToCursor);
+  if (slashMatch) {
+    return { kind: 'slash', query: slashMatch[0].slice(1) };
   }
 
   // File completion: last token must start with @
@@ -187,8 +194,12 @@ export function __fileScanCacheSize(): number {
  *
  * Invariant: cap is MAX_FILE_MATCHES from the shared upstream source. Do NOT
  * re-cap to a smaller number here — a secondary cap silently hides entries
- * beyond it even when the dropdown scrolls. filter → sort → cap → decorate
- * matches the fileMatchesFor ordering contract.
+ * beyond it even when the dropdown scrolls.
+ *
+ * Ranking: exact-prefix matches first (alphabetical), then subsequence-only
+ * matches (alphabetical). This mirrors the slash-command ranking so abbreviations
+ * like `@src/inp` match `src/cli/input/` without displacing prefix hits. Both
+ * buckets are capped together at MAX_FILE_MATCHES.
  *
  * Directory flag is derived from the Dirent (`isDirectory()`), NOT a follow-up
  * `statSync`. Tradeoff: a symlink that points at a directory reports as a
@@ -203,21 +214,27 @@ export function buildFileCandidates(
   homeDir?: string,
 ): Candidate[] {
   const { leafPrefix, displayPrefix } = resolveQuery(query, rootDir, homeDir);
-  // Sort by NAME before the cap so the ≤MAX_FILE_MATCHES survivors are the
-  // alphabetically-first entries (readdir order is OS-unspecified), THEN
-  // decorate directories with a trailing '/'. Plain string `.sort()` on the
-  // bare name matches the sibling `fileMatchesFor` in multi-line-reader
-  // byte-for-byte (filter → sort names → cap → decorate) — keep them identical.
   const dirFlag = new Map<string, boolean>();
-  const names = entries
-    .filter((entry) => entry.name.startsWith(leafPrefix))
-    .filter((entry) => !(entry.name.startsWith('.') && !leafPrefix.startsWith('.')))
-    .map((entry) => {
-      dirFlag.set(entry.name, entry.isDirectory());
-      return entry.name;
-    })
-    .sort()
-    .slice(0, MAX_FILE_MATCHES);
+
+  // Partition into prefix-match and subsequence-only buckets.
+  // Hidden-file filter: skip dotfiles unless the leaf prefix itself starts with '.'.
+  const prefixNames: string[] = [];
+  const subseqNames: string[] = [];
+  for (const entry of entries) {
+    if (entry.name.startsWith('.') && !leafPrefix.startsWith('.')) continue;
+    dirFlag.set(entry.name, entry.isDirectory());
+    if (entry.name.startsWith(leafPrefix)) {
+      prefixNames.push(entry.name);
+    } else if (leafPrefix.length > 0 && isSubsequence(leafPrefix.toLowerCase(), entry.name.toLowerCase())) {
+      subseqNames.push(entry.name);
+    }
+  }
+
+  // Sort each bucket alphabetically, then merge and cap at MAX_FILE_MATCHES.
+  prefixNames.sort();
+  subseqNames.sort();
+  const names = [...prefixNames, ...subseqNames].slice(0, MAX_FILE_MATCHES);
+
   return names.map((name) => ({
     value: '@' + displayPrefix + name + (dirFlag.get(name) ? '/' : ''),
   }));


### PR DESCRIPTION
# feat(tui): slash-complete anywhere, @-file subsequence, Linux image paste, Ctrl-R reverse-search

Modernizes the REPL line editor with four additive sub-features in `src/cli/input/`.

---

## 1. Slash-complete anywhere (`trigger.ts`)

**Files:** `src/cli/input/trigger.ts`, `src/cli/input/trigger.test.ts`

`detectTrigger` previously required the slash token to start at buffer position 0 (`/^\/[A-Za-z_-]*$/`). It now uses a lookbehind-aware regex so completion fires on any slash token at the cursor — mid-buffer, after prose, or in multiline drafts (e.g. `"please run /ship"` with cursor at end).

`applySelection` already supported a non-zero start offset, so no changes there.

**Tests added:** 10 new cases in `detectTrigger — slash completion (mid-buffer)`.

---

## 2. @-file subsequence matching (`trigger.ts`, `slash-match.ts`)

**Files:** `src/cli/input/trigger.ts`, `src/cli/input/trigger.test.ts`

`buildFileCandidates` now partitions into two ranked buckets:
- **Prefix matches** (alphabetical) — ranked first
- **Subsequence-only matches** (via `isSubsequence` from `slash-match.ts`) — ranked second

So `@src/inp` matches `src/cli/input/` without displacing prefix hits. Mirrors slash-command ranking.

**Tests added:** 5 new cases in `buildFileCandidates — @-file subsequence matching`.

---

## 3. Linux clipboard image paste (`clipboard-image.ts`, new `clipboard-image-linux.ts`)

**Files:** `src/cli/input/clipboard-image.ts`, `src/cli/input/clipboard-image-linux.ts` (new), `src/cli/input/clipboard-image.test.ts`

`readClipboardImage` now routes to `readClipboardImageLinux` on `process.platform === 'linux'`:
1. Probes for `wl-paste` (Wayland) via `spawn --version`
2. Falls back to `xclip` (X11/XWayland)
3. Graceful no-op if neither tool is installed

macOS path (osascript/sips) unchanged. Linux code extracted to `clipboard-image-linux.ts` to stay under 350-line ceiling.

**Tests added:** 7 new cases in `Linux clipboard (Part B-Linux)`.

---

## 4. Ctrl-R reverse history search (new `reader.reverse-search.ts`)

**Files:** `src/cli/input/reader.reverse-search.ts` (new), `src/cli/input/reader.reverse-search.test.ts` (new), `src/cli/input/reader.state.ts`, `src/cli/input/reader.keypress.ts`, `src/cli/input/reader.ts`

Incremental reverse-search modal:
- **Ctrl-R** activates / cycles to next older match
- **Status line:** `(reverse-i-search)\`query\': <match>`
- **Enter** accepts (keeps match, normal Enter then submits)
- **Esc / Ctrl-G** cancels (restores prior buffer)
- **Ctrl-C** cancels + falls through to abort handler
- **Backspace** trims query, **printable chars** extend it

`ReverseSearchState` is threaded via `ReaderState` — no closure over `let` bindings.

**Tests:** 27 new cases in `reader.reverse-search.test.ts`.

---

## Gate results

```
pnpm lint     clean (tsc --noEmit, no errors)
pnpm test     472 / 472 passing (21 test files in src/cli/input/)
```

| Sub-feature | New tests |
|-------------|-----------|
| Slash-complete anywhere | +10 |
| @-file subsequence | +5 |
| Linux clipboard paste | +7 |
| Ctrl-R reverse search | +27 |
| **Total** | **+49** |

No deferrals — all four sub-features landed green.
