### PR TITLE
perf(xai): cache OIDC discovery response with 24h TTL (#1064)

### DIFF
--- a/src/agent/providers/xai/index.ts
+++ b/src/agent/providers/xai/index.ts
@@ -228,6 +228,8 @@ export {
   refreshXaiTokens,
   ensureFreshAccessToken,
   discoverXaiOidc,
+  discoverXaiOidcCached,
+  clearOidcCache,
 } from './oauth.js';
 export {
   deriveXaiCallCostUsd,

--- a/src/agent/providers/xai/oauth-http.test.ts
+++ b/src/agent/providers/xai/oauth-http.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it } from 'vitest';
-import { tokenResponseToBundle } from './oauth-http.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearOidcCache, discoverXaiOidcCached, tokenResponseToBundle } from './oauth-http.js';
 
+// ---------------------------------------------------------------------------
+// tokenResponseToBundle
+// ---------------------------------------------------------------------------
 describe('tokenResponseToBundle', () => {
   const base = { access_token: 'at', refresh_token: 'rt' };
   const fixedNow = () => 1000;
@@ -38,5 +41,92 @@ describe('tokenResponseToBundle', () => {
   it('defaults to 3600 when expires_in is not a number', () => {
     const b = tokenResponseToBundle({ ...base }, fixedNow);
     expect(b?.expires_at).toBe(1000 + 3600);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// discoverXaiOidcCached
+// ---------------------------------------------------------------------------
+const DISCOVERY_BODY = {
+  issuer: 'https://auth.x.ai',
+  authorization_endpoint: 'https://auth.x.ai/oauth2/auth',
+  token_endpoint: 'https://auth.x.ai/oauth2/token',
+};
+
+function makeFetchFn(body = DISCOVERY_BODY, status = 200) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  });
+}
+
+describe('discoverXaiOidcCached', () => {
+  beforeEach(() => {
+    clearOidcCache();
+  });
+
+  it('fetches on first call and returns the discovery document', async () => {
+    const fetchFn = makeFetchFn();
+    const result = await discoverXaiOidcCached({
+      fetchFn: fetchFn as unknown as typeof fetch,
+      issuer: 'https://auth.x.ai',
+    });
+    expect(result.token_endpoint).toBe(DISCOVERY_BODY.token_endpoint);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns cached result on second call without fetching again', async () => {
+    const fetchFn = makeFetchFn();
+    const deps = { fetchFn: fetchFn as unknown as typeof fetch, issuer: 'https://auth.x.ai' };
+    const first = await discoverXaiOidcCached(deps);
+    const second = await discoverXaiOidcCached(deps);
+    expect(second).toBe(first); // same object reference
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-fetches after TTL expires', async () => {
+    const fetchFn = makeFetchFn();
+    let now = 0;
+    const nowMs = () => now;
+    const deps = {
+      fetchFn: fetchFn as unknown as typeof fetch,
+      issuer: 'https://auth.x.ai',
+      nowMs,
+    };
+
+    // First call at t=0
+    await discoverXaiOidcCached(deps);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    // Advance just past the 24h TTL (24 * 3600 * 1000 ms)
+    now = 24 * 60 * 60 * 1000 + 1;
+    await discoverXaiOidcCached(deps);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT re-fetch while still within the TTL', async () => {
+    const fetchFn = makeFetchFn();
+    let now = 0;
+    const nowMs = () => now;
+    const deps = {
+      fetchFn: fetchFn as unknown as typeof fetch,
+      issuer: 'https://auth.x.ai',
+      nowMs,
+    };
+
+    await discoverXaiOidcCached(deps);
+    now = 23 * 60 * 60 * 1000; // 23 hours in — still valid
+    await discoverXaiOidcCached(deps);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('clearOidcCache forces a fresh fetch', async () => {
+    const fetchFn = makeFetchFn();
+    const deps = { fetchFn: fetchFn as unknown as typeof fetch, issuer: 'https://auth.x.ai' };
+    await discoverXaiOidcCached(deps);
+    clearOidcCache();
+    await discoverXaiOidcCached(deps);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/agent/providers/xai/oauth-http.ts
+++ b/src/agent/providers/xai/oauth-http.ts
@@ -9,6 +9,12 @@ import type { XaiTokenBundle } from './auth-store.js';
 
 export type FetchFn = typeof fetch;
 
+/** TTL for the in-memory OIDC discovery cache (24 hours in milliseconds). */
+const OIDC_DISCOVERY_TTL_MS = 24 * 60 * 60 * 1000;
+
+/** Cached OIDC discovery result; keyed implicitly to the single issuer per process. */
+let cachedDiscovery: { result: XaiOidcDiscovery; expiresAt: number } | null = null;
+
 export interface XaiOidcDiscovery {
   issuer: string;
   authorization_endpoint: string;
@@ -24,6 +30,8 @@ export interface OAuthHttpDeps {
   clientId?: string;
   scopes?: string;
   nowSeconds?: () => number;
+  /** Override wall-clock ms for cache TTL in tests. */
+  nowMs?: () => number;
 }
 
 export function asNonEmptyString(v: unknown): string | undefined {
@@ -37,6 +45,13 @@ export async function safeText(res: Response): Promise<string> {
   } catch {
     return '';
   }
+}
+
+/**
+ * Reset the module-scope OIDC discovery cache. Intended for tests only.
+ */
+export function clearOidcCache(): void {
+  cachedDiscovery = null;
 }
 
 /**
@@ -66,6 +81,27 @@ export async function discoverXaiOidc(deps: OAuthHttpDeps = {}): Promise<XaiOidc
   const userinfo = asNonEmptyString(body['userinfo_endpoint']);
   if (userinfo) out.userinfo_endpoint = userinfo;
   return out;
+}
+
+/**
+ * Cached wrapper around {@link discoverXaiOidc}.
+ *
+ * Returns the cached discovery document if it was fetched within the last 24 hours
+ * (or `OIDC_DISCOVERY_TTL_MS` when `deps.nowMs` is injected for testing).
+ * On cache miss or expiry, fetches fresh and stores the result.
+ *
+ * The cache is process-scoped: different issuer overrides in tests should call
+ * {@link clearOidcCache} before each case to avoid cross-test contamination.
+ */
+export async function discoverXaiOidcCached(deps: OAuthHttpDeps = {}): Promise<XaiOidcDiscovery> {
+  const nowMs = deps.nowMs ?? (() => Date.now());
+  const now = nowMs();
+  if (cachedDiscovery && cachedDiscovery.expiresAt > now) {
+    return cachedDiscovery.result;
+  }
+  const result = await discoverXaiOidc(deps);
+  cachedDiscovery = { result, expiresAt: now + OIDC_DISCOVERY_TTL_MS };
+  return result;
 }
 
 /**

--- a/src/agent/providers/xai/oauth.ts
+++ b/src/agent/providers/xai/oauth.ts
@@ -22,13 +22,13 @@ import {
 } from './auth-store.js';
 import {
   asNonEmptyString,
-  discoverXaiOidc,
+  discoverXaiOidcCached,
   tokenResponseToBundle,
   type OAuthHttpDeps,
 } from './oauth-http.js';
 
 export type { FetchFn, OAuthHttpDeps, XaiOidcDiscovery } from './oauth-http.js';
-export { discoverXaiOidc, tokenResponseToBundle } from './oauth-http.js';
+export { clearOidcCache, discoverXaiOidc, discoverXaiOidcCached, tokenResponseToBundle } from './oauth-http.js';
 export {
   startDeviceCodeFlow,
   pollDeviceCodeToken,
@@ -64,7 +64,7 @@ export async function refreshXaiTokens(
   refreshToken: string,
   deps: OAuthHttpDeps & { store?: XaiAuthStoreDeps; persist?: boolean } = {},
 ): Promise<XaiTokenBundle> {
-  const discovery = await discoverXaiOidc(deps);
+  const discovery = await discoverXaiOidcCached(deps);
   const fetchFn = deps.fetchFn ?? fetch;
   const clientId = deps.clientId ?? XAI_OAUTH_CLIENT_ID;
   const body = new URLSearchParams({


### PR DESCRIPTION
## Summary

Closes #1064.

`refreshXaiTokens` was calling `discoverXaiOidc` on every token refresh, adding ~100ms RTT each time. The OIDC discovery document at `auth.x.ai/.well-known/openid-configuration` rarely changes — `issuer`, `token_endpoint`, and `authorization_endpoint` are stable for the lifetime of a session.

## Changes

- **`oauth-http.ts`**: Added a module-scope `cachedDiscovery` variable (TTL 24 hours) and two new exports:
  - `discoverXaiOidcCached` — returns cached result if fresh, otherwise fetches and caches
  - `clearOidcCache` — resets the cache (for tests)
  - `OAuthHttpDeps` gains optional `nowMs` for deterministic TTL testing
- **`oauth.ts`**: `refreshXaiTokens` now calls `discoverXaiOidcCached` instead of `discoverXaiOidc`; re-exports `clearOidcCache` and `discoverXaiOidcCached`
- **`index.ts`**: Re-exports `clearOidcCache` and `discoverXaiOidcCached`
- **`oauth-http.test.ts`**: Five new cache tests — cache hit returns same reference, no re-fetch within TTL, re-fetch after TTL, `clearOidcCache` forces refresh

## Test Results

```
✓ src/agent/providers/xai/oauth-http.test.ts  (12 tests)
✓ src/agent/providers/xai/oauth.test.ts       (13 tests)
```

All CI audits pass: `audit:env:check`, `audit:sdk:check`, `audit:module-state:check`.
The `audit:filesize:check` failures are pre-existing (none of the modified files exceed the 350-line ceiling: `oauth-http.ts` is 135 lines).
