### PR TITLE
fix(subagent): surface partial tool results on empty-buffer stream cut-off (#724)

### DIFF
--- a/src/agent/subagent/empty-buffer-partial.test.ts
+++ b/src/agent/subagent/empty-buffer-partial.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for empty-buffer-partial helpers (GitHub issue #724).
+ *
+ * Verifies that when a subagent stream is cut off with an empty text buffer
+ * but prior tool results exist, the helpers produce the correct error and
+ * partial output — so the parent can distinguish "died with N gathered
+ * results" from "died with nothing gathered".
+ */
+
+import { describe, it, expect } from 'vitest';
+import { StreamIncompleteError } from '../../utils/errors.js';
+import { buildEmptyBufferError, synthesizeEmptyBufferPartial } from './empty-buffer-partial.js';
+import type { SubagentToolResult } from './result.js';
+
+// ---------------------------------------------------------------------------
+// buildEmptyBufferError
+// ---------------------------------------------------------------------------
+
+describe('buildEmptyBufferError', () => {
+  it('returns a StreamIncompleteError', () => {
+    const err = buildEmptyBufferError('sub-1', []);
+    expect(err).toBeInstanceOf(StreamIncompleteError);
+  });
+
+  it('no-results path: toolResultsGathered is absent, message mentions "no output"', () => {
+    const err = buildEmptyBufferError('sub-1', []);
+    expect(err.toolResultsGathered).toBeUndefined();
+    expect(err.message).toContain('no output');
+  });
+
+  it('with-results path: toolResultsGathered equals the count', () => {
+    const results: SubagentToolResult[] = [
+      { toolUseId: 'a', sizeBytes: 1000 },
+      { toolUseId: 'b', sizeBytes: 2000 },
+    ];
+    const err = buildEmptyBufferError('sub-2', results);
+    expect(err.toolResultsGathered).toBe(2);
+    expect(err.message).toContain('2 tool result(s)');
+    expect(err.message).toContain('sub-2');
+  });
+
+  it('single result: toolResultsGathered is 1', () => {
+    const err = buildEmptyBufferError('sub-3', [{ toolUseId: 'x', sizeBytes: 500 }]);
+    expect(err.toolResultsGathered).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// synthesizeEmptyBufferPartial
+// ---------------------------------------------------------------------------
+
+describe('synthesizeEmptyBufferPartial', () => {
+  it('returns undefined when there are no tool results', () => {
+    expect(synthesizeEmptyBufferPartial('sub-1', [])).toBeUndefined();
+  });
+
+  it('returns a string mentioning the count and subagent id', () => {
+    const results: SubagentToolResult[] = [
+      { toolUseId: 'a', sizeBytes: 1000 },
+      { toolUseId: 'b', sizeBytes: 2000 },
+      { toolUseId: 'c', sizeBytes: 500 },
+    ];
+    const out = synthesizeEmptyBufferPartial('sub-2', results);
+    expect(out).toBeTypeOf('string');
+    expect(out).toContain('sub-2');
+    expect(out).toContain('3 tool result(s)');
+    expect(out).toContain('3500'); // total bytes
+  });
+
+  it('includes error count when some results errored', () => {
+    const results: SubagentToolResult[] = [
+      { toolUseId: 'a', isError: true, sizeBytes: 100 },
+      { toolUseId: 'b', sizeBytes: 200 },
+    ];
+    const out = synthesizeEmptyBufferPartial('sub-3', results);
+    expect(out).toContain('1 errored');
+  });
+
+  it('omits error suffix when no results errored', () => {
+    const results: SubagentToolResult[] = [
+      { toolUseId: 'a', sizeBytes: 100 },
+    ];
+    const out = synthesizeEmptyBufferPartial('sub-4', results);
+    expect(out).not.toContain('errored');
+  });
+
+  it('treats missing sizeBytes as 0 when summing total bytes', () => {
+    const results: SubagentToolResult[] = [
+      { toolUseId: 'a' },          // no sizeBytes
+      { toolUseId: 'b', sizeBytes: 500 },
+    ];
+    const out = synthesizeEmptyBufferPartial('sub-5', results);
+    expect(out).toContain('500');  // 0 + 500
+  });
+});

--- a/src/agent/subagent/empty-buffer-partial.ts
+++ b/src/agent/subagent/empty-buffer-partial.ts
@@ -1,0 +1,59 @@
+/**
+ * Helpers for the empty-buffer stream-cut path in {@link SubagentHandleImpl}.
+ *
+ * When a subagent's model stream ends with NO terminal message AND an EMPTY
+ * streamed text buffer, the run classifies as `failed` (via a thrown
+ * {@link StreamIncompleteError}). If tool-call cycles completed before the
+ * cut (read_file, bash, grep, …), that gathered evidence is not lost — it
+ * lives in the handle's `currentTrace.toolResults`. This module synthesizes
+ * a human-readable `partialOutput` summary and the typed error so the parent
+ * can distinguish "died with N gathered results" from "died with nothing".
+ *
+ * @module agent/subagent/empty-buffer-partial
+ */
+
+import { StreamIncompleteError } from '../../utils/errors.js';
+import type { SubagentToolResult } from './result.js';
+
+/**
+ * Build the {@link StreamIncompleteError} for the empty-buffer stream-cut
+ * path, with `toolResultsGathered` populated when prior tool results exist.
+ */
+export function buildEmptyBufferError(
+  subagentId: string,
+  toolResults: SubagentToolResult[],
+): StreamIncompleteError {
+  const n = toolResults.length;
+  const msg =
+    n > 0
+      ? `subagent ${subagentId} stream cut off after ${n} tool result(s); see partialOutput.`
+      : `subagent ${subagentId} produced no output — stream ended without a terminal ` +
+        `message (stream_incomplete). No findings were produced; retry or fall back.`;
+  const err = new StreamIncompleteError(msg);
+  if (n > 0) err.toolResultsGathered = n;
+  return err;
+}
+
+/**
+ * Synthesize a `partialOutput` string from accumulated tool results when a
+ * stream cut off before any assistant text was produced.
+ *
+ * Returns `undefined` when there are no tool results (caller should omit
+ * `partialOutput` from the result in that case).
+ */
+export function synthesizeEmptyBufferPartial(
+  subagentId: string,
+  toolResults: SubagentToolResult[],
+): string | undefined {
+  if (toolResults.length === 0) return undefined;
+  const totalBytes = toolResults.reduce((s, r) => s + (r.sizeBytes ?? 0), 0);
+  const errorCount = toolResults.filter((r) => r.isError).length;
+  const errorSuffix = errorCount > 0 ? ` (${errorCount} errored)` : '';
+  return (
+    `[Stream cut off before any assistant text was produced. ` +
+    `Subagent ${subagentId} completed ${toolResults.length} tool result(s)${errorSuffix} ` +
+    `(~${totalBytes} bytes total) before the cut. ` +
+    `The run is failed — no final answer was produced — but tool evidence is ` +
+    `available via result.trace for recovery or retry decisions.]`
+  );
+}

--- a/src/agent/subagent/handle.test.ts
+++ b/src/agent/subagent/handle.test.ts
@@ -358,3 +358,96 @@ describe('pause-aware wall-clock ceiling (handle wiring)', () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// Issue #724 — empty-buffer stream cut with prior tool results (#724)
+//
+// When a stream ends with no terminal message AND an empty text buffer, the
+// run classifies `failed` (StreamIncompleteError). If tool-call cycles
+// completed before the cut, partialOutput must carry a summary and
+// toolResultsGathered must be set on the error — so the parent can
+// distinguish "died with N gathered results" from "died with nothing".
+// ---------------------------------------------------------------------------
+
+describe('#724 — empty-buffer stream cut with prior tool results', () => {
+  let abortGraph: AbortGraph;
+  let controller: AbortController;
+
+  beforeEach(() => {
+    abortGraph = new AbortGraph();
+    controller = new AbortController();
+    abortGraph.register('root', controller);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function makeHandle(session: IAgentSession): SubagentHandleImpl<unknown> {
+    return new SubagentHandleImpl(
+      'sub-724',
+      session,
+      controller,
+      abortGraph,
+      undefined,  // outputSchema
+      5000,       // timeoutMs
+      undefined,  // hookRegistry
+      vi.fn(),    // onTerminal
+    );
+  }
+
+  /** Session that emits N tool_result chunks then ends abruptly (no message/done). */
+  function makeStreamCutSession(toolResultCount: number): IAgentSession {
+    return makeMinimalSession({
+      async *sendMessageStream(): AsyncIterable<OutputEvent> {
+        for (let i = 0; i < toolResultCount; i++) {
+          yield {
+            type: 'chunk',
+            chunk: {
+              type: 'tool_result',
+              toolUseId: `tu-${i}`,
+              content: 'some file content',
+              isError: false,
+              sizeBytes: 1000 + i * 500,
+            },
+          };
+        }
+        // No 'message' or 'done' event — stream ends abruptly.
+      },
+    });
+  }
+
+  it('classifies as failed when stream cuts with empty buffer and no tool results', async () => {
+    const handle = makeHandle(makeStreamCutSession(0));
+    const result = await handle.runToResult('go');
+    expect(result.status).toBe('failed');
+    expect(result.partialOutput).toBeUndefined();
+  });
+
+  it('classifies as failed AND populates partialOutput when stream cuts after 5 tool results', async () => {
+    const handle = makeHandle(makeStreamCutSession(5));
+    const result = await handle.runToResult('go');
+    expect(result.status).toBe('failed');
+    expect(result.partialOutput).toBeTypeOf('string');
+    expect(result.partialOutput as string).toContain('5 tool result(s)');
+    expect(result.partialOutput as string).toContain('sub-724');
+  });
+
+  it('sets toolResultsGathered on the error when tool results exist', async () => {
+    const handle = makeHandle(makeStreamCutSession(3));
+    const result = await handle.runToResult('go');
+    expect(result.status).toBe('failed');
+    // The error must carry toolResultsGathered for the retry-dispatch layer.
+    const { StreamIncompleteError: SIE } = await import('../../utils/errors.js');
+    expect(result.error).toBeInstanceOf(SIE);
+    expect((result.error as InstanceType<typeof SIE>).toolResultsGathered).toBe(3);
+  });
+
+  it('does NOT set toolResultsGathered when no tool results were gathered', async () => {
+    const handle = makeHandle(makeStreamCutSession(0));
+    const result = await handle.runToResult('go');
+    const { StreamIncompleteError: SIE } = await import('../../utils/errors.js');
+    expect(result.error).toBeInstanceOf(SIE);
+    expect((result.error as InstanceType<typeof SIE>).toolResultsGathered).toBeUndefined();
+  });
+});

--- a/src/agent/subagent/handle.ts
+++ b/src/agent/subagent/handle.ts
@@ -33,6 +33,7 @@ import {
   type SubagentStatus,
   type SubagentTrace,
 } from './result.js';
+import { buildEmptyBufferError, synthesizeEmptyBufferPartial } from './empty-buffer-partial.js';
 
 export interface SubagentHandle<T = unknown> {
   /** Stable ID for tracking. */
@@ -617,13 +618,7 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
     // met by StreamIncompleteError's informative, actionable message, not by
     // masking the failure as a success.
     this.lastStopReason = STREAM_INCOMPLETE;
-    throw new StreamIncompleteError(
-      `subagent ${this.id} produced no output — its model stream ended without a ` +
-        `terminal message (stream_incomplete), and no partial text was streamed. ` +
-        `This is typically a first-token timeout while the provider was overloaded ` +
-        `(the connection was aborted mid retry-backoff). No findings were produced; ` +
-        `the parent should retry or fall back.`,
-    );
+    throw buildEmptyBufferError(this.id, this.currentTrace.toolResults);
   }
 
   async runToResult(
@@ -655,6 +650,10 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
       // on `SubagentResult` so this assignment is honest — no cast needed.
       if (this.lastStreamedContent.length > 0) {
         result.partialOutput = this.lastStreamedContent;
+      } else if (err instanceof StreamIncompleteError) {
+        // Empty text buffer: synthesize partial from accumulated tool results.
+        const p = synthesizeEmptyBufferPartial(this.id, this.currentTrace.toolResults);
+        if (p !== undefined) result.partialOutput = p;
       }
       return result;
     }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -84,6 +84,15 @@ export class HookBlockedError extends Error {
  * and annotated at the consumption boundary.
  */
 export class StreamIncompleteError extends Error {
+  /**
+   * Number of tool results accumulated before the stream cut off.
+   * Set to a positive integer when the subagent completed real tool-call
+   * cycles (read_file, bash, grep, …) before the cut — so the parent can
+   * distinguish "died with N gathered results" from "died with nothing".
+   * Absent (undefined) when there were no prior tool results.
+   */
+  toolResultsGathered?: number;
+
   constructor(message: string) {
     super(message);
     this.name = "StreamIncompleteError";


### PR DESCRIPTION
## Problem

When a subagent stream is cut off with an empty text buffer (`StreamIncompleteError`), ALL accumulated tool results from that run are discarded. A 12-minute run with 5 `read_file` calls returns nothing to the parent — the run classifies `failed` with no recoverable evidence.

Closes #724.

## Root Cause

`src/agent/subagent/handle.ts` line ~619: the empty-buffer path throws `StreamIncompleteError` unconditionally. `runToResult`'s catch block only sets `partialOutput` from `lastStreamedContent`, which is empty in this case — so tool evidence in `currentTrace.toolResults` is never surfaced.

## Fix

### `src/utils/errors.ts`
Added `toolResultsGathered?: number` to `StreamIncompleteError` so callers can distinguish "died with N gathered results" from "died with nothing".

### `src/agent/subagent/empty-buffer-partial.ts` _(new)_
Two helpers extracted into a sibling file to keep `handle.ts` under the GREW gate:
- `buildEmptyBufferError(id, toolResults)` — factory that populates `toolResultsGathered` and tailors the error message to the zero/non-zero tool-results case.
- `synthesizeEmptyBufferPartial(id, toolResults)` — returns a human-readable `partialOutput` summary (count, total bytes, error count) when tool results exist; `undefined` otherwise.

### `src/agent/subagent/handle.ts`
- Replaced the inline 6-line throw block with `throw buildEmptyBufferError(...)` (net −1 LOC; clears the GREW filesize gate).
- Extended `runToResult` catch: when `lastStreamedContent` is empty and the error is a `StreamIncompleteError`, calls `synthesizeEmptyBufferPartial` and sets `result.partialOutput`.

The run **remains `failed`** — no final answer was produced — but `SubagentResult.partialOutput` and `.trace` now carry recoverable evidence.

## Tests

**`src/agent/subagent/empty-buffer-partial.test.ts`** (9 new unit tests)
- `buildEmptyBufferError`: zero/non-zero tool-result counts, `toolResultsGathered` presence/absence, message content.
- `synthesizeEmptyBufferPartial`: `undefined` on empty, string content on non-empty, error suffix, missing `sizeBytes` treated as 0.

**`src/agent/subagent/handle.test.ts`** (4 new integration tests via mock session)
- `status: 'failed'` and no `partialOutput` when stream cuts with zero tool results.
- `status: 'failed'` AND `partialOutput` populated when stream cuts after 5 tool results.
- `toolResultsGathered` set to 3 on the error when 3 results were gathered.
- `toolResultsGathered` absent when no results were gathered.

## CI Gates

| Gate | Status |
|---|---|
| `pnpm lint` | ✅ |
| `pnpm build` | ✅ |
| `pnpm test` (all files) | ✅ (1 pre-existing flaky failure in `write-denylist.test.ts` unrelated to this change — confirmed present on `main` before this branch) |
| `pnpm audit:filesize:check` | ✅ (handle.ts net −1 LOC; new file is 59 LOC) |
