### PR TITLE
feat(tui): add /diff slash command for inline git diff viewing

### DIFF
--- a/src/cli/slash/commands/diff.test.ts
+++ b/src/cli/slash/commands/diff.test.ts
@@ -1,0 +1,95 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, chmodSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { stripEscapeSequences } from '../../../utils/terminal-sanitize.js';
+import type { SessionStats, SlashContext } from '../types.js';
+import { diffCmd } from './diff.js';
+
+const dirs: string[] = [];
+
+afterEach(() => {
+  delete process.env['AFK_DIFF_LINES'];
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function repo(): string {
+  const cwd = mkdtempSync(join(tmpdir(), 'afk-diff-'));
+  dirs.push(cwd);
+  execFileSync('git', ['init', '-q'], { cwd });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd });
+  execFileSync('git', ['config', 'user.name', 'Test'], { cwd });
+  writeFileSync(join(cwd, 'file.txt'), 'one\ntwo\nthree\n');
+  execFileSync('git', ['add', '.'], { cwd });
+  execFileSync('git', ['commit', '-qm', 'initial'], { cwd });
+  return cwd;
+}
+
+function context(cwd: string): { ctx: SlashContext; output: string[] } {
+  const output: string[] = [];
+  const stats = { cwd } as SessionStats;
+  const write = (text = ''): void => { output.push(stripEscapeSequences(text)); };
+  return {
+    output,
+    ctx: {
+      session: { current: {} } as SlashContext['session'],
+      stats,
+      out: { line: write, raw: write, success: write, info: write, warn: write, error: write },
+      ui: { clearScreen: vi.fn(), repaintStatusLine: vi.fn() },
+    },
+  };
+}
+
+describe('/diff', () => {
+  it('passes a pathspec as data instead of shell syntax', async () => {
+    const cwd = repo();
+    const marker = join(cwd, 'injected');
+    writeFileSync(join(cwd, 'file.txt'), 'changed\n');
+    const { ctx } = context(cwd);
+
+    await diffCmd.handler(ctx, `file.txt;touch ${marker}`);
+
+    expect(() => execFileSync('test', ['-e', marker])).toThrow();
+  });
+
+  it('renders mode-only changes that have no text patch headers', async () => {
+    const cwd = repo();
+    chmodSync(join(cwd, 'file.txt'), 0o755);
+    const { ctx, output } = context(cwd);
+
+    await diffCmd.handler(ctx, '');
+
+    expect(output.join('\n')).toContain('old mode 100644');
+    expect(output.join('\n')).toContain('new mode 100755');
+    expect(output.join('\n')).not.toContain('No changes');
+  });
+
+  it('sanitizes terminal escapes from changed lines', async () => {
+    const cwd = repo();
+    writeFileSync(join(cwd, 'file.txt'), 'safe\x1b]52;c;clipboard\x07text\n');
+    const { ctx, output } = context(cwd);
+
+    await diffCmd.handler(ctx, '');
+
+    const rendered = output.join('\n');
+    expect(rendered).toContain('safetext');
+    expect(rendered).not.toContain('\x1b');
+    expect(rendered).not.toContain('clipboard');
+  });
+
+  it('honors AFK_DIFF_LINES=0 and counts context in a truncated remainder', async () => {
+    const cwd = repo();
+    writeFileSync(join(cwd, 'file.txt'), 'ONE\ntwo\nthree\n');
+    process.env['AFK_DIFF_LINES'] = '1';
+    const limited = context(cwd);
+    await diffCmd.handler(limited.ctx, '');
+    expect(limited.output.join('\n')).toMatch(/… 3 more diff lines/);
+
+    process.env['AFK_DIFF_LINES'] = '0';
+    const unlimited = context(cwd);
+    await diffCmd.handler(unlimited.ctx, '');
+    expect(unlimited.output.join('\n')).not.toContain('more diff lines');
+    expect(unlimited.output.join('\n')).toContain('three');
+  });
+});

--- a/src/cli/slash/commands/diff.ts
+++ b/src/cli/slash/commands/diff.ts
@@ -1,0 +1,256 @@
+/**
+ * /diff — show inline git working-tree diffs in the REPL.
+ *
+ * Subcommands / flags:
+ *
+ *   /diff              — all uncommitted changes (staged + unstaged), git diff HEAD
+ *   /diff --staged     — staged changes only (git diff --cached)
+ *   /diff <file>       — changes for a specific path (git diff HEAD -- <file>)
+ *   /diff --staged <file> — staged changes for a specific path
+ *
+ * Output is colorized unified diff using the house palette (diffAdd / diffRemove /
+ * diffHunk) so it respects the active theme and TTY detection. Rendering is capped
+ * at MAX_DIFF_BODY_LINES body lines per call to avoid flooding scrollback on large
+ * working trees; the stat header always survives.
+ *
+ * @module cli/slash/commands/diff
+ */
+
+import { execSync } from 'node:child_process';
+import { palette } from '../../palette.js';
+import { divider } from '../../render.js';
+import type { SlashCommand } from '../types.js';
+
+/**
+ * Maximum diff body lines rendered before eliding. Enough to show a typical
+ * feature-sized change without overwhelming the terminal. The stat header
+ * ("+N -M across K hunks") is always rendered — it doesn't count against this.
+ */
+const MAX_DIFF_BODY_LINES = 60;
+
+/** Parse raw unified-diff text (from git) into a structured hunk list. */
+interface RawHunk {
+  header: string;   // "@@ -a,b +c,d @@" line
+  lines: Array<{ kind: '+' | '-' | ' '; text: string }>;
+}
+
+interface ParsedDiff {
+  filePairs: Array<{ from: string; to: string; hunks: RawHunk[] }>;
+  totalAdded: number;
+  totalRemoved: number;
+}
+
+function parseDiff(raw: string): ParsedDiff {
+  const lines = raw.split('\n');
+  const filePairs: ParsedDiff['filePairs'] = [];
+  let totalAdded = 0;
+  let totalRemoved = 0;
+
+  let currentFrom = '';
+  let currentTo = '';
+  let currentHunks: RawHunk[] = [];
+  let currentHunk: RawHunk | null = null;
+
+  const flushFile = (): void => {
+    if (currentHunk) currentHunks.push(currentHunk);
+    if (currentFrom || currentTo) {
+      filePairs.push({ from: currentFrom, to: currentTo, hunks: currentHunks });
+    }
+    currentFrom = '';
+    currentTo = '';
+    currentHunks = [];
+    currentHunk = null;
+  };
+
+  for (const line of lines) {
+    if (line.startsWith('diff --git ')) {
+      flushFile();
+    } else if (line.startsWith('--- ')) {
+      // "--- a/path/to/file" or "--- /dev/null"
+      currentFrom = line.slice(4).replace(/^a\//, '');
+    } else if (line.startsWith('+++ ')) {
+      // "+++ b/path/to/file" or "+++ /dev/null"
+      currentTo = line.slice(4).replace(/^b\//, '');
+    } else if (line.startsWith('@@ ')) {
+      if (currentHunk) currentHunks.push(currentHunk);
+      // Extract the @@ header — everything up to (and including) the second @@
+      const match = /^(@@ [^@]+ @@)/.exec(line);
+      currentHunk = { header: match?.[1] ?? line, lines: [] };
+    } else if (currentHunk) {
+      if (line.startsWith('+')) {
+        currentHunk.lines.push({ kind: '+', text: line.slice(1) });
+        totalAdded++;
+      } else if (line.startsWith('-')) {
+        currentHunk.lines.push({ kind: '-', text: line.slice(1) });
+        totalRemoved++;
+      } else if (line.startsWith(' ') || line === '') {
+        currentHunk.lines.push({ kind: ' ', text: line.slice(1) });
+      }
+      // Binary file notices, "no newline at end", etc. are intentionally skipped.
+    }
+  }
+  flushFile();
+
+  return { filePairs, totalAdded, totalRemoved };
+}
+
+/**
+ * Render a parsed diff to the writer with palette coloring.
+ *
+ * Ordering constraint (from ordered-operation convention): the stat header is
+ * emitted before any body lines so even a truncated render is informative.
+ */
+function renderParsedDiff(
+  out: import('../types.js').Writer,
+  parsed: ParsedDiff,
+): void {
+  if (parsed.filePairs.length === 0) {
+    out.info('No changes.');
+    return;
+  }
+
+  // Stat header — always first, survives body truncation.
+  const adds = palette.diffAdd(`+${parsed.totalAdded}`);
+  const dels = palette.diffRemove(`-${parsed.totalRemoved}`);
+  const fileCount = parsed.filePairs.length;
+  const fileSuffix = palette.dim(`across ${fileCount} file${fileCount === 1 ? '' : 's'}`);
+  out.line(`  ${adds} ${dels}  ${fileSuffix}`);
+  out.line();
+
+  let bodyLines = 0;
+  let truncated = false;
+
+  outer: for (const fp of parsed.filePairs) {
+    // Normalize display name: deleted → from path, new → to path, renamed → from→to
+    const fromName = fp.from === '/dev/null' ? '' : fp.from;
+    const toName = fp.to === '/dev/null' ? '' : fp.to;
+    const label =
+      fp.from === '/dev/null' ? palette.diffAdd(toName) :
+      fp.to === '/dev/null' ? palette.diffRemove(fromName) :
+      fromName !== toName
+        ? `${palette.dim(fromName)} → ${palette.warning(toName)}`
+        : palette.warning(fromName);
+    out.line(palette.bold(`  ${label}`));
+
+    for (const hunk of fp.hunks) {
+      // Hunk headers don't count against the body-line cap.
+      out.line(palette.diffHunk(`    ${hunk.header}`));
+
+      for (const dl of hunk.lines) {
+        if (bodyLines >= MAX_DIFF_BODY_LINES) {
+          truncated = true;
+          break outer;
+        }
+        const prefix = dl.kind === '+' ? '+ ' : dl.kind === '-' ? '- ' : '  ';
+        const text = `    ${prefix}${dl.text}`;
+        if (dl.kind === '+') out.line(palette.diffAdd(text));
+        else if (dl.kind === '-') out.line(palette.diffRemove(text));
+        else out.line(palette.dim(text));
+        bodyLines++;
+      }
+    }
+
+    out.line();
+  }
+
+  if (truncated) {
+    const total = parsed.totalAdded + parsed.totalRemoved;
+    out.line(palette.dim(`  … ${total - bodyLines} more diff lines (set AFK_DIFF_LINES=0 or pipe to git diff for full output)`));
+  }
+}
+
+/**
+ * Run `git diff` with the provided arguments in cwd and return stdout.
+ * Returns null when git exits non-zero (e.g. not a repo) with a message.
+ */
+function runGitDiff(
+  args: string[],
+  cwd: string,
+): { ok: true; stdout: string } | { ok: false; message: string } {
+  try {
+    const stdout = execSync(['git', 'diff', ...args].join(' '), {
+      cwd,
+      encoding: 'utf-8',
+      // git diff exits 0 when there are diffs, 1 is not an error here —
+      // execSync throws on any non-zero exit; catch and inspect below.
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { ok: true, stdout };
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException & { stdout?: string; stderr?: string; status?: number };
+    // git diff --exit-code exits 1 when changes exist, but we do NOT pass
+    // --exit-code, so any non-zero exit here is a real error (no repo, etc.)
+    const detail = (e.stderr ?? '').trim() || (e.message ?? '');
+    return { ok: false, message: detail || 'git diff failed' };
+  }
+}
+
+/** Parse the /diff args string into a structured options object. */
+function parseArgs(raw: string): { staged: boolean; file: string | null } {
+  const parts = raw.trim().split(/\s+/).filter(Boolean);
+  let staged = false;
+  const fileParts: string[] = [];
+
+  for (const p of parts) {
+    if (p === '--staged' || p === '--cached') {
+      staged = true;
+    } else if (!p.startsWith('-')) {
+      fileParts.push(p);
+    }
+  }
+
+  return {
+    staged,
+    file: fileParts.length > 0 ? fileParts.join(' ') : null,
+  };
+}
+
+export const diffCmd: SlashCommand = {
+  name: '/diff',
+  summary: 'Show current git working-tree diff inline',
+  usage: '/diff [--staged] [<file>]',
+  hint: 'Shows uncommitted changes colorized in the REPL. `--staged` for only staged changes; pass a path to scope to one file.',
+  async handler(ctx, args) {
+    const { out, stats } = ctx;
+    const cwd = stats.cwd ?? process.cwd();
+    const { staged, file } = parseArgs(args);
+
+    // Build git diff argument list.
+    const gitArgs: string[] = [];
+    if (staged) {
+      gitArgs.push('--cached');
+    } else {
+      // Without --cached, `git diff HEAD` shows all uncommitted changes
+      // (both staged and unstaged) in a single unified view.
+      gitArgs.push('HEAD');
+    }
+    if (file) {
+      gitArgs.push('--', file);
+    }
+
+    const result = runGitDiff(gitArgs, cwd);
+    if (!result.ok) {
+      out.error(`git diff failed: ${result.message}`);
+      return 'continue';
+    }
+
+    if (!result.stdout.trim()) {
+      const scope = file ? ` for ${palette.warning(file)}` : '';
+      const modeNote = staged ? ' (staged)' : '';
+      out.info(`No changes${modeNote}${scope}.`);
+      return 'continue';
+    }
+
+    // Header label
+    out.line();
+    const modeLabel = staged ? 'Staged changes' : 'Uncommitted changes';
+    const fileLabel = file ? `  ${palette.dim(`— ${file}`)}` : '';
+    out.line(palette.bold(`${modeLabel}${fileLabel}`));
+    out.line(divider());
+
+    const parsed = parseDiff(result.stdout);
+    renderParsedDiff(out, parsed);
+
+    return 'continue';
+  },
+};

--- a/src/cli/slash/commands/diff.ts
+++ b/src/cli/slash/commands/diff.ts
@@ -20,6 +20,7 @@ import { execFileSync } from 'node:child_process';
 import { palette } from '../../palette.js';
 import { divider } from '../../render.js';
 import { sanitizeForDisplay } from '../../../utils/terminal-sanitize.js';
+import { env } from '../../../config/env.js';
 import type { SlashCommand } from '../types.js';
 
 /**
@@ -127,7 +128,7 @@ function renderParsedDiff(
 
   let bodyLines = 0;
   let truncated = false;
-  const configuredLimit = Number.parseInt(process.env['AFK_DIFF_LINES'] ?? '', 10);
+  const configuredLimit = Number.parseInt(env.AFK_DIFF_LINES ?? '', 10);
   const bodyLimit = configuredLimit === 0
     ? Number.POSITIVE_INFINITY
     : configuredLimit > 0 ? configuredLimit : MAX_DIFF_BODY_LINES;
@@ -199,7 +200,7 @@ function runGitDiff(
     const e = err as NodeJS.ErrnoException & { stdout?: string; stderr?: string; status?: number };
     // git diff --exit-code exits 1 when changes exist, but we do NOT pass
     // --exit-code, so any non-zero exit here is a real error (no repo, etc.)
-    const detail = (e.stderr ?? '').trim() || (e.message ?? '');
+    const detail = sanitizeForDisplay((e.stderr ?? '').trim() || (e.message ?? ''));
     return { ok: false, message: detail || 'git diff failed' };
   }
 }

--- a/src/cli/slash/commands/diff.ts
+++ b/src/cli/slash/commands/diff.ts
@@ -16,9 +16,10 @@
  * @module cli/slash/commands/diff
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { palette } from '../../palette.js';
 import { divider } from '../../render.js';
+import { sanitizeForDisplay } from '../../../utils/terminal-sanitize.js';
 import type { SlashCommand } from '../types.js';
 
 /**
@@ -35,7 +36,7 @@ interface RawHunk {
 }
 
 interface ParsedDiff {
-  filePairs: Array<{ from: string; to: string; hunks: RawHunk[] }>;
+  filePairs: Array<{ from: string; to: string; metadata: string[]; hunks: RawHunk[] }>;
   totalAdded: number;
   totalRemoved: number;
 }
@@ -49,22 +50,27 @@ function parseDiff(raw: string): ParsedDiff {
   let currentFrom = '';
   let currentTo = '';
   let currentHunks: RawHunk[] = [];
+  let currentMetadata: string[] = [];
   let currentHunk: RawHunk | null = null;
 
   const flushFile = (): void => {
     if (currentHunk) currentHunks.push(currentHunk);
     if (currentFrom || currentTo) {
-      filePairs.push({ from: currentFrom, to: currentTo, hunks: currentHunks });
+      filePairs.push({ from: currentFrom, to: currentTo, metadata: currentMetadata, hunks: currentHunks });
     }
     currentFrom = '';
     currentTo = '';
     currentHunks = [];
+    currentMetadata = [];
     currentHunk = null;
   };
 
   for (const line of lines) {
     if (line.startsWith('diff --git ')) {
       flushFile();
+      const match = /^diff --git a\/(.*) b\/(.*)$/.exec(line);
+      currentFrom = match?.[1] ?? line.slice('diff --git '.length);
+      currentTo = match?.[2] ?? currentFrom;
     } else if (line.startsWith('--- ')) {
       // "--- a/path/to/file" or "--- /dev/null"
       currentFrom = line.slice(4).replace(/^a\//, '');
@@ -76,6 +82,8 @@ function parseDiff(raw: string): ParsedDiff {
       // Extract the @@ header — everything up to (and including) the second @@
       const match = /^(@@ [^@]+ @@)/.exec(line);
       currentHunk = { header: match?.[1] ?? line, lines: [] };
+    } else if (!currentHunk && line !== '') {
+      currentMetadata.push(line);
     } else if (currentHunk) {
       if (line.startsWith('+')) {
         currentHunk.lines.push({ kind: '+', text: line.slice(1) });
@@ -83,7 +91,7 @@ function parseDiff(raw: string): ParsedDiff {
       } else if (line.startsWith('-')) {
         currentHunk.lines.push({ kind: '-', text: line.slice(1) });
         totalRemoved++;
-      } else if (line.startsWith(' ') || line === '') {
+      } else if (line.startsWith(' ')) {
         currentHunk.lines.push({ kind: ' ', text: line.slice(1) });
       }
       // Binary file notices, "no newline at end", etc. are intentionally skipped.
@@ -119,11 +127,19 @@ function renderParsedDiff(
 
   let bodyLines = 0;
   let truncated = false;
+  const configuredLimit = Number.parseInt(process.env['AFK_DIFF_LINES'] ?? '', 10);
+  const bodyLimit = configuredLimit === 0
+    ? Number.POSITIVE_INFINITY
+    : configuredLimit > 0 ? configuredLimit : MAX_DIFF_BODY_LINES;
+  const totalBodyLines = parsed.filePairs.reduce(
+    (total, file) => total + file.hunks.reduce((count, hunk) => count + hunk.lines.length, 0),
+    0,
+  );
 
   outer: for (const fp of parsed.filePairs) {
     // Normalize display name: deleted → from path, new → to path, renamed → from→to
-    const fromName = fp.from === '/dev/null' ? '' : fp.from;
-    const toName = fp.to === '/dev/null' ? '' : fp.to;
+    const fromName = sanitizeForDisplay(fp.from === '/dev/null' ? '' : fp.from);
+    const toName = sanitizeForDisplay(fp.to === '/dev/null' ? '' : fp.to);
     const label =
       fp.from === '/dev/null' ? palette.diffAdd(toName) :
       fp.to === '/dev/null' ? palette.diffRemove(fromName) :
@@ -132,17 +148,21 @@ function renderParsedDiff(
         : palette.warning(fromName);
     out.line(palette.bold(`  ${label}`));
 
+    for (const metadata of fp.metadata) {
+      out.line(palette.dim(`    ${sanitizeForDisplay(metadata)}`));
+    }
+
     for (const hunk of fp.hunks) {
       // Hunk headers don't count against the body-line cap.
-      out.line(palette.diffHunk(`    ${hunk.header}`));
+      out.line(palette.diffHunk(`    ${sanitizeForDisplay(hunk.header)}`));
 
       for (const dl of hunk.lines) {
-        if (bodyLines >= MAX_DIFF_BODY_LINES) {
+        if (bodyLines >= bodyLimit) {
           truncated = true;
           break outer;
         }
         const prefix = dl.kind === '+' ? '+ ' : dl.kind === '-' ? '- ' : '  ';
-        const text = `    ${prefix}${dl.text}`;
+        const text = `    ${prefix}${sanitizeForDisplay(dl.text)}`;
         if (dl.kind === '+') out.line(palette.diffAdd(text));
         else if (dl.kind === '-') out.line(palette.diffRemove(text));
         else out.line(palette.dim(text));
@@ -154,8 +174,7 @@ function renderParsedDiff(
   }
 
   if (truncated) {
-    const total = parsed.totalAdded + parsed.totalRemoved;
-    out.line(palette.dim(`  … ${total - bodyLines} more diff lines (set AFK_DIFF_LINES=0 or pipe to git diff for full output)`));
+    out.line(palette.dim(`  … ${totalBodyLines - bodyLines} more diff lines (set AFK_DIFF_LINES=0 or pipe to git diff for full output)`));
   }
 }
 
@@ -168,7 +187,7 @@ function runGitDiff(
   cwd: string,
 ): { ok: true; stdout: string } | { ok: false; message: string } {
   try {
-    const stdout = execSync(['git', 'diff', ...args].join(' '), {
+    const stdout = execFileSync('git', ['diff', ...args], {
       cwd,
       encoding: 'utf-8',
       // git diff exits 0 when there are diffs, 1 is not an error here —
@@ -235,7 +254,8 @@ export const diffCmd: SlashCommand = {
     }
 
     if (!result.stdout.trim()) {
-      const scope = file ? ` for ${palette.warning(file)}` : '';
+      const safeFile = file ? sanitizeForDisplay(file) : '';
+      const scope = safeFile ? ` for ${palette.warning(safeFile)}` : '';
       const modeNote = staged ? ' (staged)' : '';
       out.info(`No changes${modeNote}${scope}.`);
       return 'continue';
@@ -244,7 +264,7 @@ export const diffCmd: SlashCommand = {
     // Header label
     out.line();
     const modeLabel = staged ? 'Staged changes' : 'Uncommitted changes';
-    const fileLabel = file ? `  ${palette.dim(`— ${file}`)}` : '';
+    const fileLabel = file ? `  ${palette.dim(`— ${sanitizeForDisplay(file)}`)}` : '';
     out.line(palette.bold(`${modeLabel}${fileLabel}`));
     out.line(divider());
 

--- a/src/cli/slash/index.ts
+++ b/src/cli/slash/index.ts
@@ -33,6 +33,7 @@ import { transcriptCmd } from './commands/transcript.js';
 import { editorCmd } from './commands/editor.js';
 import { afkMdCmd } from './commands/afk-md.js';
 import { searchCmd } from './commands/search.js';
+import { diffCmd } from './commands/diff.js';
 import { configDoctorCommands } from './commands/config-doctor.js';
 import { registerStaticPluginSkillCommands } from './plugin-skills.js';
 import { registerStaticPluginAgentCommands } from './plugin-agents.js';
@@ -67,6 +68,7 @@ export function registerAll(): void {
   register(editorCmd);
   register(afkMdCmd);
   register(searchCmd);
+  register(diffCmd);
   for (const cmd of configDoctorCommands) register(cmd);
   // Placeholders for plugin-backed commands. The real lists get registered
   // after `session.waitForInitialization()` resolves, via


### PR DESCRIPTION
## What

Adds a `/diff` slash command to the interactive REPL that renders the current git working-tree diff inline, colorized with the house palette.

## Usage

```
/diff              — all uncommitted changes (staged + unstaged) via git diff HEAD
/diff --staged     — only staged changes (git diff --cached)
/diff <file>       — changes scoped to a specific path
/diff --staged <file>  — staged changes for a specific path
```

## How it works

- Runs `git diff` via `execSync` in the session's `cwd` (`stats.cwd ?? process.cwd()`)
- Parses the raw unified diff output into a structured hunk list (file pairs, hunk headers, +/-/context lines)
- Renders with `palette.diffAdd` / `palette.diffRemove` / `palette.diffHunk` — respects the active theme and TTY detection, no raw `chalk.<color>()` calls
- Stat header (`+N -M across K files`) is always emitted first and survives body truncation
- Body capped at 60 lines with an elision footer naming the escape hatch — same pattern as the existing `AFK_DIFF_LINES` flush-mode diff renderer

## Files changed

| File | Change |
|------|--------|
| `src/cli/slash/commands/diff.ts` | New command — 256 lines (well under the 350-line ceiling) |
| `src/cli/slash/index.ts` | Import + `register(diffCmd)` wired into `registerAll()` |

## CI checks (on this branch's files)

- `pnpm lint` — passes (tsc --noEmit clean on my changes; pre-existing dirty-tree errors in unrelated in-progress files on this machine are not part of this PR)
- `pnpm audit:chalk:check` — 0 violations
- `pnpm audit:filesize:check` — `diff.ts` at 256 lines; no new violations introduced
