### PR TITLE
fix(doctor): refresh expired keychain OAuth before checking

### DIFF
--- a/src/cli/commands/doctor-checks.test.ts
+++ b/src/cli/commands/doctor-checks.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { checkImportAvailable } from './doctor-checks.js';
+import { describe, it, expect, vi } from 'vitest';
+import { checkImportAvailable, checkAnthropicKey } from './doctor-checks.js';
 import type { DetectedSource } from '../../config/import-sources.js';
 
 /** Minimal fixture for a present source with zero assets. */
@@ -18,6 +18,21 @@ function makeSource(
     ...overrides,
   };
 }
+
+vi.mock('../../agent/auth/credential-resolver.js', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('../../agent/auth/credential-resolver.js')>();
+  return { ...orig, preloadClaudeKeychainOAuth: vi.fn().mockResolvedValue(undefined) };
+});
+
+describe('checkAnthropicKey', () => {
+  it('calls preloadClaudeKeychainOAuth before checking the key', async () => {
+    const { preloadClaudeKeychainOAuth } = await import(
+      '../../agent/auth/credential-resolver.js'
+    );
+    await checkAnthropicKey();
+    expect(preloadClaudeKeychainOAuth).toHaveBeenCalledWith('anthropic-direct');
+  });
+});
 
 describe('checkImportAvailable', () => {
   it('returns null when detected list is empty', async () => {

--- a/src/cli/commands/doctor-checks.ts
+++ b/src/cli/commands/doctor-checks.ts
@@ -13,6 +13,7 @@ import { getConcurrencyStatuses } from '../../config/concurrency.js';
 import { access, constants, mkdir, readFile } from 'fs/promises';
 import { execSync } from 'child_process';
 import { getApiKey, getCodexApiKey } from '../shared-helpers.js';
+import { preloadClaudeKeychainOAuth } from '../../agent/auth/credential-resolver.js';
 import {
   getAfkConfigDir,
   getAfkStateDir,
@@ -34,6 +35,12 @@ export interface Check {
 }
 
 export async function checkAnthropicKey(): Promise<Check> {
+  // Attempt a keychain OAuth refresh before checking — without this, an expired
+  // Claude Code OAuth token (which expires hourly) causes a false negative.
+  // The guard inside `preloadClaudeKeychainOAuth` skips the refresh when an env
+  // credential already exists or the provider isn't anthropic-direct.
+  await preloadClaudeKeychainOAuth('anthropic-direct');
+
   const key = getApiKey();
   if (key) {
     return { name: 'Anthropic API Key', state: 'pass', detail: 'ANTHROPIC_API_KEY set' };


### PR DESCRIPTION
## Summary

`afk doctor` reported `✗ Anthropic API Key` when the only credential was a Claude Code OAuth token stored in the macOS keychain, because expired tokens were never refreshed.

## Root cause

The async refresh path (`preloadClaudeKeychainOAuth`) was wired to auth-gated commands (chat, interactive, daemon) via `AUTH_GATED_COMMANDS`, but `doctor` was excluded. When the OAuth access token expired (~1 hour), `loadClaudeCodeOauthToken()` returned `undefined` and the check failed with a misleading "Set ANTHROPIC_API_KEY" message.

## Fix

Call `preloadClaudeKeychainOAuth('anthropic-direct')` at the top of `checkAnthropicKey()`. This:
- Refreshes expired keychain OAuth tokens before the sync read
- Is a no-op when an env credential already exists (`ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN`)
- Is a no-op for non-Anthropic providers
- Adds no overhead for env-var users

## Test

Added a test verifying `checkAnthropicKey` calls `preloadClaudeKeychainOAuth` with `'anthropic-direct'` before checking.

## Changes

| File | Change |
|------|--------|
| `src/cli/commands/doctor-checks.ts` | Import + call `preloadClaudeKeychainOAuth` in `checkAnthropicKey()` |
| `src/cli/commands/doctor-checks.test.ts` | New test: verifies refresh is called before key check |

Closes #1131
