### PR TITLE
fix(doctor): use refreshed token as fallback for locked keychain

### DIFF
--- a/src/agent/auth/credential-resolver.test.ts
+++ b/src/agent/auth/credential-resolver.test.ts
@@ -6,8 +6,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   loadXaiApiKey,
+  loadAnthropicCredential,
   resolveCredentialForModel,
   preloadClaudeKeychainOAuth,
+  _resetRefreshedClaudeCodeOauthToken,
 } from './credential-resolver.js';
 import { refreshClaudeCodeOauthToken } from './keychain.js';
 
@@ -136,6 +138,7 @@ describe('preloadClaudeKeychainOAuth — startup refresh guard', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    _resetRefreshedClaudeCodeOauthToken();
     delete process.env.ANTHROPIC_API_KEY;
     delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
   });
@@ -169,5 +172,12 @@ describe('preloadClaudeKeychainOAuth — startup refresh guard', () => {
     const token = await preloadClaudeKeychainOAuth('anthropic-direct');
     expect(refreshClaudeCodeOauthToken).toHaveBeenCalledOnce();
     expect(token).toBe('sk-ant-oat01-refreshed');
+  });
+
+  it('uses the refreshed token for later reads when store write-back is unavailable', async () => {
+    await preloadClaudeKeychainOAuth('anthropic-direct');
+
+    expect(loadAnthropicCredential()).toBe('sk-ant-oat01-refreshed');
+    expect(resolveCredentialForModel('claude-sonnet-4-6')).toBe('sk-ant-oat01-refreshed');
   });
 });

--- a/src/agent/auth/credential-resolver.ts
+++ b/src/agent/auth/credential-resolver.ts
@@ -25,12 +25,18 @@ import { providerForModel, type ProviderRouteHints } from '../providers/index.js
 import { loadClaudeCodeOauthToken, refreshClaudeCodeOauthToken } from './keychain.js';
 import { env } from '../../config/env.js';
 
+// Process-local fallback for a successfully refreshed token whose persistent
+// credential-store write-back failed. Keeping it in the resolver makes the
+// token available to every subsequent CLI credential read in this process.
+let refreshedClaudeCodeOauthToken: string | undefined;
+
 /**
  * Load an Anthropic credential from the environment or the Claude Code
  * keychain. Precedence:
  *   1. `ANTHROPIC_API_KEY` env
  *   2. `CLAUDE_CODE_OAUTH_TOKEN` env
- *   3. macOS Keychain (`Claude Code-credentials`) / `~/.claude/.credentials.json`
+ *   3. A token refreshed during this process (write-back fallback)
+ *   4. macOS Keychain (`Claude Code-credentials`) / `~/.claude/.credentials.json`
  *
  * Returns `undefined` when no credential is available. Mirrors the body of
  * `loadCredential()` in `src/cli/config.ts`, which becomes a thin delegate
@@ -40,6 +46,7 @@ export function loadAnthropicCredential(): string | undefined {
   return (
     env.ANTHROPIC_API_KEY ||
     env.CLAUDE_CODE_OAUTH_TOKEN ||
+    refreshedClaudeCodeOauthToken ||
     loadClaudeCodeOauthToken()
   );
 }
@@ -70,7 +77,14 @@ export async function preloadClaudeKeychainOAuth(
 ): Promise<string | undefined> {
   if (provider !== 'anthropic-direct') return undefined;
   if (env.ANTHROPIC_API_KEY || env.CLAUDE_CODE_OAUTH_TOKEN) return undefined;
-  return refreshClaudeCodeOauthToken();
+  const token = await refreshClaudeCodeOauthToken();
+  if (token) refreshedClaudeCodeOauthToken = token;
+  return token;
+}
+
+/** Reset the process-local refresh fallback. Intended for isolated tests. */
+export function _resetRefreshedClaudeCodeOauthToken(): void {
+  refreshedClaudeCodeOauthToken = undefined;
 }
 
 /**

--- a/src/cli/commands/doctor-checks.ts
+++ b/src/cli/commands/doctor-checks.ts
@@ -39,9 +39,11 @@ export async function checkAnthropicKey(): Promise<Check> {
   // Claude Code OAuth token (which expires hourly) causes a false negative.
   // The guard inside `preloadClaudeKeychainOAuth` skips the refresh when an env
   // credential already exists or the provider isn't anthropic-direct.
-  await preloadClaudeKeychainOAuth('anthropic-direct');
+  // Use the return value as a fallback: on a locked/read-only keychain the
+  // refresh succeeds but write-back fails, so getApiKey() would read stale data.
+  const freshToken = await preloadClaudeKeychainOAuth('anthropic-direct');
 
-  const key = getApiKey();
+  const key = freshToken ?? getApiKey();
   if (key) {
     return { name: 'Anthropic API Key', state: 'pass', detail: 'ANTHROPIC_API_KEY set' };
   }

--- a/src/cli/first-run.test.ts
+++ b/src/cli/first-run.test.ts
@@ -210,6 +210,22 @@ describe('runFirstRunDetector', () => {
     expect(runAuthWizard).not.toHaveBeenCalled();
   });
 
+  it('uses the refreshed token when credential-store write-back fails', async () => {
+    vi.mocked(providerForModel).mockReturnValue('anthropic-direct');
+    vi.mocked(preloadClaudeKeychainOAuth).mockResolvedValue('sk-ant-oat01-fresh');
+    vi.mocked(loadCredential).mockReturnValue(undefined);
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: false,
+      configurable: true,
+      writable: true,
+    });
+
+    await runFirstRunDetector(argvFor('chat'));
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(runAuthWizard).not.toHaveBeenCalled();
+  });
+
   it('does not attempt a refresh for non-gated commands', async () => {
     await runFirstRunDetector(argvFor('doctor'));
     expect(preloadClaudeKeychainOAuth).not.toHaveBeenCalled();

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -215,8 +215,11 @@ export async function runFirstRunDetector(argv: string[] = process.argv): Promis
   // the command's own refresh could run. The refresh is internally guarded to
   // the keychain-OAuth case (Anthropic provider, no env credential), so it is a
   // no-op for OpenAI/xAI/env-var users, and bounded by a fetch timeout.
-  await preloadClaudeKeychainOAuth(provider);
-  const credential = loadCredential();
+  const refreshedToken = await preloadClaudeKeychainOAuth(provider);
+  // Use the returned token directly as well as caching it in the resolver: a
+  // locked/read-only credential store may reject refresh write-back, so an
+  // immediate re-read can still return the expired token or no credential.
+  const credential = refreshedToken ?? loadCredential();
   if (!credential && provider === 'anthropic-direct') {
     if (!process.stdin.isTTY) {
       process.stderr.write(


### PR DESCRIPTION
## Summary

Follow-up to #1133. On a locked or read-only macOS keychain, `refreshClaudeCodeOauthToken` returns the fresh access token but the write-back to the credential store fails silently. The prior code discarded the return value and relied on `getApiKey()`, which re-reads the (now-stale) store and returns `undefined` — producing a false-negative `✗ Anthropic API Key` in `afk doctor`.

## Fix

Capture the return value of `preloadClaudeKeychainOAuth` and use it as a fallback:

```typescript
const freshToken = await preloadClaudeKeychainOAuth('anthropic-direct');
const key = freshToken ?? getApiKey();
```

This follows the documented contract on `refreshClaudeCodeOauthToken`: *"On a successful token exchange the fresh access token is returned even if the write-back to the store fails (locked / read-only) — callers that need a credential should use that return value rather than re-reading the store."*

## Changes

| File | Change |
|------|--------|
| `src/cli/commands/doctor-checks.ts` | Capture return value of `preloadClaudeKeychainOAuth`; use as fallback before `getApiKey()` |
