### PR TITLE
fix(witness): correct sessionsScanned to report post-filter count accurately (#1035)

### DIFF
--- a/src/agent/tools/handlers/witness.query.test.ts
+++ b/src/agent/tools/handlers/witness.query.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { mkdtemp, mkdir, writeFile, rm, utimes } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { clampLimit, clampSessions, readSessionTrace, searchAcrossSessions, MAX_SEARCH_MATCHES } from './witness.query.js';
@@ -305,6 +305,49 @@ describe('searchAcrossSessions — sessions/since ordering', () => {
     expect(result.sessionsAvailable).toBeLessThanOrEqual(1);
     expect(result.sessionsSearched).toBeLessThanOrEqual(result.sessionsAvailable);
     expect(result.sessionsScanned).toBeLessThanOrEqual(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// searchAcrossSessions — sessionsAvailable vs sessionsSearched pre/post-filter (#1035)
+// ---------------------------------------------------------------------------
+
+describe('searchAcrossSessions — sessionsAvailable vs sessionsSearched pre/post-filter', () => {
+  it('sessionsAvailable is the pre-filter count; sessionsSearched is the post-filter count', async () => {
+    // Write three sessions: stamp two with a 2020 mtime (old) and one with a
+    // 2030 mtime (future-ish) so the since filter can cleanly split them.
+    const pathA = await writeTrace('prefilter-session-a', [
+      makeEventLine('closure', 1, { reason: 'end_turn', finalCostUsd: 0, finalTurnCount: 1 }),
+    ]);
+    const pathB = await writeTrace('prefilter-session-b', [
+      makeEventLine('closure', 1, { reason: 'end_turn', finalCostUsd: 0, finalTurnCount: 1 }),
+    ]);
+    const pathC = await writeTrace('prefilter-session-c', [
+      makeEventLine('closure', 1, { reason: 'end_turn', finalCostUsd: 0, finalTurnCount: 1 }),
+    ]);
+
+    const old = new Date('2020-06-01T00:00:00Z');
+    const fresh = new Date('2030-06-01T00:00:00Z');
+    await utimes(pathA, old, old);   // fails the since filter below
+    await utimes(pathB, old, old);   // fails the since filter below
+    await utimes(pathC, fresh, fresh); // survives the since filter below
+
+    // since='2025-01-01' keeps only pathC; pathA and pathB are excluded.
+    const result = await searchAcrossSessions({
+      query: 'end_turn',
+      sessions: 50,
+      since: '2025-01-01',
+    });
+
+    // Pre-filter: all 3 sessions were in the window.
+    expect(result.sessionsAvailable).toBe(3);
+    // Post-filter: only 1 session survived the since gate.
+    expect(result.sessionsSearched).toBe(1);
+    // Deprecated alias always mirrors sessionsSearched.
+    expect(result.sessionsScanned).toBe(result.sessionsSearched);
+    // At least one match from the surviving session.
+    expect(result.matches.length).toBeGreaterThanOrEqual(1);
+    expect(result.matches.every((m) => m.sessionId === 'prefilter-session-c')).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Problem

`searchAcrossSessions` originally returned `sessionsScanned: traces.length` **after** the `since` date filter was applied, making `sessionsScanned: 3` indistinguishable from "only 3 sessions exist" vs "47 sessions were excluded by the date filter."

## What was wrong with the counting

The original return was:
```ts
sessionsScanned: traces.length,  // traces = already-filtered list
```

So a caller requesting `sessions: 50, since: "2026-01-01"` that found 3 sessions in the date range got `sessionsScanned: 3` — even if 47 sessions existed but were older than the cutoff.

## What was changed

Prior commits (b3ddf37c → 0023b07b → d91ef1cf) fixed the implementation by tracking two separate counts:

- **`sessionsAvailable`** — pre-filter count (sessions in the top-N slice before `since` is applied)  
- **`sessionsSearched`** — post-filter count (sessions actually read after `since` and match-cap)
- **`sessionsScanned`** — deprecated alias for `sessionsSearched`, kept for backward compatibility

This PR adds a deterministic test that was missing: the existing `sessions/since ordering` test only used `sessions: 1`, which can't distinguish pre- from post-filter because both are ≤ 1. The new test writes 3 sessions with controlled mtimes (2 old, 1 future), queries with `since: '2025-01-01'`, and asserts:

```
sessionsAvailable == 3   // pre-filter: all sessions in the 50-session window
sessionsSearched  == 1   // post-filter: only the 2030-stamped session survives
sessionsScanned   == 1   // deprecated alias mirrors sessionsSearched
```

This closes the regression-detection gap for the core invariant of #1035.

## Testing

```
pnpm exec vitest run src/agent/tools/handlers/witness.query.test.ts
# 28 tests, all pass
pnpm exec tsc --noEmit
# no errors
```

Fixes #1035
