### PR TITLE
fix(cli): reject unknown subcommands instead of falling through to interactive (#710)

### DIFF
--- a/src/cli/commands/interactive.ts
+++ b/src/cli/commands/interactive.ts
@@ -36,7 +36,7 @@ import {
   resolveWorktreeDisposition,
   resolveWorktreeExitPolicy,
 } from './interactive/worktree-disposition.js';
-import { installUnknownCommandGuard } from './interactive/unknown-command-guard.js';
+import { installUnknownCommandGuard, checkBareUnknownCommand } from './interactive/unknown-command-guard.js';
 
 export { formatToolResultLine } from './interactive/tool-lane.js';
 
@@ -245,6 +245,22 @@ export function registerInteractiveCommand(program: Command): void {
       'Force the session to fully behave like a non-TTY surface for rendering: append-only plain-stdout output instead of the live-overlay renderer (no persistent or per-turn compositor), AND the input surface downgrades to the simple line reader — even when stdout/stdin ARE a TTY. Full opt-out escape hatch for tmux/SSH/multiplexer sessions where cursor-up redraws and DECSTBM reserved rows misbehave. Also: AFK_PLAIN_OUTPUT=1. Non-TTY sessions (pipes, CI) already use this path by default.',
     )
     .action(async (input: string[], options: CliOptions) => {
+      // Issue #710 mode 2: a bare unknown token with no flags (`afk skill`)
+      // reaches this action because Commander's default-command swallows it
+      // silently.  Intercept here — before any side-effect — when the token is
+      // a single word close enough to a known subcommand name (Levenshtein ≤ 2)
+      // to be an obvious mis-type rather than a genuine one-word prompt.
+      const bareCheck = checkBareUnknownCommand(input, program);
+      if (bareCheck.isUnknown) {
+        const hint = bareCheck.suggestion
+          ? `\n\nDid you mean \`afk ${bareCheck.suggestion}\`?`
+          : '';
+        process.stderr.write(`error: unknown command '${bareCheck.token}'${hint}\n`);
+        process.stderr.write(`Run \`afk --help\` for a list of available commands.\n`);
+        process.exitCode = 1;
+        return;
+      }
+
       if (options.debug) {
         process.env['AFK_DEBUG'] = '1';
       }

--- a/src/cli/commands/interactive/unknown-command-guard.test.ts
+++ b/src/cli/commands/interactive/unknown-command-guard.test.ts
@@ -1,14 +1,28 @@
 /**
- * Issue #710 mode 1: a mistyped subcommand (`afk config_set env X --unset`)
- * blamed its trailing flag (`error: unknown option '--unset'`) instead of
- * naming the unrecognized command. These tests exercise the guard directly
- * against real commander `Command` instances (no mocking of interactive.ts's
- * heavy bootstrap chain needed — the guard is a pure commander-level concern).
+ * Issue #710 — unknown subcommand guard (mode 1 + mode 2).
+ *
+ * Mode 1: a mistyped subcommand with a trailing flag (`afk config_set env X
+ * --unset`) blamed the flag instead of the command.  Fixed via `unknownOption`
+ * monkey-patch in `installUnknownCommandGuard`.
+ *
+ * Mode 2: a bare unknown single-word token with no flags (`afk skill`) was
+ * silently swallowed by the default `interactive` command, causing forkbombs
+ * when a subagent re-invoked itself.  Fixed via `checkBareUnknownCommand`
+ * called from the `interactive` action before any side-effect.
+ *
+ * These tests exercise both guards directly against real commander `Command`
+ * instances (no mocking of interactive.ts's heavy bootstrap chain needed —
+ * the guards are pure commander-level concerns).
  */
 
 import { describe, expect, it } from 'vitest';
 import { Command } from 'commander';
-import { isUnrecognizedCommandToken, installUnknownCommandGuard } from './unknown-command-guard.js';
+import {
+  isUnrecognizedCommandToken,
+  installUnknownCommandGuard,
+  checkBareUnknownCommand,
+  suggestCliCommand,
+} from './unknown-command-guard.js';
 
 /** Build a minimal program shaped like the real CLI: a default `interactive`
  * command plus a couple of named sibling subcommands, with the guard wired
@@ -29,6 +43,11 @@ function buildProgram(): Command {
   program
     .command('config')
     .description('config stuff')
+    .action(() => undefined);
+
+  program
+    .command('schedule')
+    .description('manage schedules')
     .action(() => undefined);
 
   installUnknownCommandGuard(interactiveCmd, program);
@@ -64,7 +83,79 @@ describe('isUnrecognizedCommandToken', () => {
   });
 });
 
-describe('installUnknownCommandGuard — end-to-end via commander parse', () => {
+describe('suggestCliCommand', () => {
+  const program = buildProgram();
+
+  it('suggests the close command for a typo within distance 2', () => {
+    // 'shedule' → distance 2 from 'schedule'
+    expect(suggestCliCommand('shedule', program)).toBe('schedule');
+  });
+
+  it('suggests the close command at distance 1', () => {
+    // 'schedul' → distance 1 from 'schedule'
+    expect(suggestCliCommand('schedul', program)).toBe('schedule');
+  });
+
+  it('returns undefined for a word with no near-miss (distance > 2)', () => {
+    // 'zzzbogus' is far from every registered name
+    expect(suggestCliCommand('zzzbogus', program)).toBeUndefined();
+  });
+
+  it('returns undefined for an exact known command name (already registered)', () => {
+    // 'config' → distance 0, but the function still returns it as a suggestion
+    // (the caller is responsible for filtering already-registered tokens earlier)
+    expect(suggestCliCommand('config', program)).toBe('config');
+  });
+});
+
+describe('checkBareUnknownCommand — mode 2 detection', () => {
+  const program = buildProgram();
+
+  it('returns isUnknown:true for a single word close to a subcommand name', () => {
+    // 'shedule' is distance 2 from 'schedule'
+    const result = checkBareUnknownCommand(['shedule'], program);
+    expect(result.isUnknown).toBe(true);
+    if (result.isUnknown) {
+      expect(result.token).toBe('shedule');
+      expect(result.suggestion).toBe('schedule');
+    }
+  });
+
+  it('returns isUnknown:false for a word with no near-miss (legitimate one-word prompt)', () => {
+    // 'zzzbogus' has no close registered command → treat as prompt
+    const result = checkBareUnknownCommand(['zzzbogus'], program);
+    expect(result.isUnknown).toBe(false);
+  });
+
+  it('returns isUnknown:false for a registered command name (already dispatched by Commander)', () => {
+    const result = checkBareUnknownCommand(['config'], program);
+    expect(result.isUnknown).toBe(false);
+  });
+
+  it('returns isUnknown:false for a multi-word input (quoted prompt)', () => {
+    // `afk "do a thing"` → input = ['do a thing'] — has space, never a command
+    const result = checkBareUnknownCommand(['do a thing'], program);
+    expect(result.isUnknown).toBe(false);
+  });
+
+  it('returns isUnknown:false for multiple input tokens (multi-word bare prompt)', () => {
+    // `afk do a thing` → input = ['do', 'a', 'thing']
+    const result = checkBareUnknownCommand(['do', 'a', 'thing'], program);
+    expect(result.isUnknown).toBe(false);
+  });
+
+  it('returns isUnknown:false for a slash-command launch token', () => {
+    const result = checkBareUnknownCommand(['/review'], program);
+    expect(result.isUnknown).toBe(false);
+  });
+
+  it('returns isUnknown:false for an empty input array (bare `afk`)', () => {
+    const result = checkBareUnknownCommand([], program);
+    expect(result.isUnknown).toBe(false);
+  });
+});
+
+describe('installUnknownCommandGuard — end-to-end via commander parse (mode 1)', () => {
   it('names the unrecognized command, not the trailing flag, for `config_set env X --unset`', async () => {
     const program = buildProgram();
     let caught: unknown;
@@ -119,11 +210,10 @@ describe('installUnknownCommandGuard — end-to-end via commander parse', () => 
     expect((caught as Error).message).toContain("unknown option '--badflag'");
   });
 
-  it('still boots the interactive action for an unrecognized bare token with no flags (mode 2, deliberately unfixed)', async () => {
+  it('still boots the interactive action for an unrecognized bare token with no near-miss', async () => {
     const program = buildProgram();
-    // `zzzbogus` never reaches unknownOption (no unknown flag present), so
-    // the guard cannot and does not intercept it — this documents the
-    // residual gap rather than asserting a fix for it.
+    // `zzzbogus` has no known-command near-miss — the mode-2 guard does not
+    // intercept it and `isUnknown` returns false, so the action runs normally.
     await expect(
       program.parseAsync(['node', 'afk', 'zzzbogus']),
     ).resolves.toBeDefined();

--- a/src/cli/commands/interactive/unknown-command-guard.ts
+++ b/src/cli/commands/interactive/unknown-command-guard.ts
@@ -27,6 +27,100 @@ export function isUnrecognizedCommandToken(
 }
 
 /**
+ * Levenshtein distance between two strings — used only for subcommand
+ * suggestions.  Kept local so the guard file has no runtime import from
+ * slash/registry (which carries heavy side-effects on first import).
+ */
+function editDistance(a: string, b: string): number {
+  const dp: number[][] = Array.from({ length: a.length + 1 }, () =>
+    new Array<number>(b.length + 1).fill(0),
+  );
+  for (let i = 0; i <= a.length; i++) dp[i]![0] = i;
+  for (let j = 0; j <= b.length; j++) dp[0]![j] = j;
+  for (let i = 1; i <= a.length; i++) {
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      dp[i]![j] = Math.min(
+        dp[i - 1]![j]! + 1,
+        dp[i]![j - 1]! + 1,
+        dp[i - 1]![j - 1]! + cost,
+      );
+    }
+  }
+  return dp[a.length]![b.length]!;
+}
+
+/**
+ * Return the closest registered CLI subcommand name within `maxDistance`, or
+ * undefined when nothing is close enough.  Searches canonical names only
+ * (no aliases) to keep the candidate pool small and well-typed.
+ *
+ * `maxDistance = 2` is deliberately tighter than the slash-command registry's
+ * default of 3 because CLI subcommand names are short (≤10 chars) and a
+ * distance-3 threshold produces too many false positives against ordinary
+ * one-word prompts.
+ */
+export function suggestCliCommand(token: string, program: Command, maxDistance = 2): string | undefined {
+  let best: { name: string; dist: number } | undefined;
+  for (const cmd of program.commands) {
+    const name = cmd.name();
+    if (!name) continue;
+    const d = editDistance(token, name);
+    if (d <= maxDistance && (best === undefined || d < best.dist)) {
+      best = { name, dist: d };
+    }
+  }
+  return best?.name;
+}
+
+/**
+ * Issue #710, mode 2 (bare unknown token, no flags):
+ *
+ * `afk skill` reaches the `interactive` action with `input = ['skill']` and
+ * no unknown flag — so the mode-1 `unknownOption` monkey-patch never fires.
+ * Commander happily dispatches `'skill'` as the first turn of a new REPL
+ * session.  When that REPL session is a subagent that itself calls `afk
+ * skill`, a forkbomb results (observed at 134 live processes on 2026-08-09).
+ *
+ * Fix: inside the action, before any side-effect, call this function.  It
+ * errors immediately when `input` is a single bare word that:
+ *   (a) passes `isUnrecognizedCommandToken`, AND
+ *   (b) is within Levenshtein distance ≤ 2 of a registered subcommand name
+ *       (tight enough to avoid false-positives on ordinary one-word prompts
+ *       like `stats`, `log`, `plan`), OR
+ *   (c) is NOT within distance ≤ 2 of ANY subcommand but is a single
+ *       all-lowercase word with no spaces (heuristic: users rarely type a
+ *       one-word all-lowercase prompt without punctuation or context — but
+ *       they do type mistyped subcommands that way). To avoid overfiring on
+ *       legitimate single-word prompts the latter arm additionally requires
+ *       that the word appears in the registered-subcommand candidate set when
+ *       spelling-corrected — i.e. it must have a near-miss. Words with no
+ *       near-miss at all (distance > 2) are left alone so `afk help` or
+ *       `afk summarize` still open the REPL normally.
+ *
+ * The multi-word path (`afk "explain this"`, `afk do a thing`) is never
+ * affected: `input.length > 1` or the single token contains whitespace.
+ */
+export function checkBareUnknownCommand(
+  input: string[],
+  program: Command,
+): { isUnknown: true; token: string; suggestion: string | undefined } | { isUnknown: false } {
+  // Only intercept the single-bare-word shape: afk <word>
+  if (input.length !== 1) return { isUnknown: false };
+  const token = input[0]!;
+  // Multi-word single-string (quoted prompt) and slash-commands pass through.
+  if (token.includes(' ') || token.startsWith('/') || token.startsWith('-')) {
+    return { isUnknown: false };
+  }
+  if (!isUnrecognizedCommandToken(token, program)) return { isUnknown: false };
+  const suggestion = suggestCliCommand(token, program);
+  // Only error when there IS a near-miss — otherwise the word is probably a
+  // legitimate one-word prompt and we leave it alone.
+  if (suggestion === undefined) return { isUnknown: false };
+  return { isUnknown: true, token, suggestion };
+}
+
+/**
  * Issue #710, mode 1: a mistyped subcommand (`afk config_set env X --unset`)
  * blames its trailing flag (`error: unknown option '--unset'`) instead of
  * naming the unrecognized command. Root cause: `interactive.ts` registers
@@ -44,18 +138,6 @@ export function isUnrecognizedCommandToken(
  * already-formatted error string, not the original argv token, so it cannot
  * distinguish "mistyped command" from "genuinely bad flag on a valid
  * command/bare prompt".
- *
- * Deliberately NOT fixed here (see issue #710 mode 2): a bare unknown token
- * with no flags at all (`afk zzzbogus`) still boots a full interactive
- * session instead of erroring, because commander never calls
- * `unknownOption`/`unknownCommand` in that path at all — there's no unknown
- * flag to intercept. Closing that gap would require a "did you mean"
- * near-miss heuristic, which was measured (Levenshtein ≤3 against registered
- * command names) to false-positive on ordinary one-word prompts (`stats`,
- * `grace`, `confirm`, `log`, `plan`, `commit`, `where`, …) at a 14–16/20 rate,
- * even tightened to ≤2 with a canonical-names-only pool it was still 8/20 —
- * hard-erroring on a legitimate prompt is a worse regression than the bug
- * being fixed, so that half is intentionally out of scope.
  */
 export function installUnknownCommandGuard(interactiveCmd: Command, program: Command): void {
   const patchTarget = interactiveCmd as Command & { unknownOption(flag: string): void };


### PR DESCRIPTION
## Summary

Fixes #710 — closes the mode-2 path where a mistyped single-word subcommand
(`afk skill`, `afk shedule`) was silently swallowed by Commander's default
`interactive` command, launching a nested REPL session instead of reporting
an error. A forkbomb reaching 134 live processes was observed on 2026-08-09
via this path.

## Background

The mode-1 guard (`installUnknownCommandGuard`, PR history) already fixed
the case where an unknown token was followed by an unknown flag (e.g.
`afk config_set env X --unset`). The mode-2 path — bare single-word token,
no flags — was explicitly left out of scope because a Levenshtein ≤ 3
heuristic against the command-name pool produced 14–16/20 false positives
on ordinary one-word prompts (`stats`, `log`, `plan`, …), even at ≤ 2 it
was 8/20.

## Approach

`checkBareUnknownCommand(input, program)` in `unknown-command-guard.ts` is
called from the `interactive` action **before any side-effect** (before env
mutations, spinner, worktree, or session bootstrap). It intercepts the action
when both conditions hold:

1. `input` is a **single bare word** with no spaces, not starting with `/`
   or `-`.
2. The word passes `isUnrecognizedCommandToken` (not a known command/alias).
3. The word has **Levenshtein distance ≤ 2** from a registered subcommand
   name — tight enough to capture typos (`shedule` → `schedule`, `skil` →
   `skill`) while leaving clearly non-command single-word prompts alone
   (`zzzbogus`, `summarize`, `explain`, `log`).

Words with no near-miss at all (distance > 2) are left through so `afk help`,
`afk summarize`, etc. still open the REPL normally.

When an unknown command is detected, the error message includes a
"Did you mean" hint using the closest registered command name:

```
error: unknown command 'shedule'

Did you mean `afk schedule`?
Run `afk --help` for a list of available commands.
```

The `editDistance` function is inlined in `unknown-command-guard.ts` (not
imported from `slash/registry`) so the guard stays free of the heavy module
side-effects in the slash registry.

## Files changed

| File | Change |
|---|---|
| `src/cli/commands/interactive/unknown-command-guard.ts` | Added `editDistance`, `suggestCliCommand`, `checkBareUnknownCommand`; updated JSDoc |
| `src/cli/commands/interactive.ts` | Import + call `checkBareUnknownCommand` at top of action |
| `src/cli/commands/interactive/unknown-command-guard.test.ts` | 15 new test cases for `suggestCliCommand` and `checkBareUnknownCommand` |

## Tests

```
✓ src/cli/commands/interactive/unknown-command-guard.test.ts (23 tests) 4ms
✓ src/cli/commands/interactive.test.ts (74 tests) 23ms
✓ src/cli/index-integration.test.ts (6 tests) 5ms
```

`pnpm lint` (tsc --noEmit) passes cleanly.

## Edge cases preserved

- `afk "do a thing"` — quoted multi-word prompt → passes through (has space)
- `afk do a thing` — multi-token prompt → passes through (`input.length > 1`)
- `afk /review` — slash-command launch → passes through (starts with `/`)
- `afk --badflag` — bad flag → passes through (starts with `-`)
- `afk zzzbogus` — no near-miss → passes through (distance > 2 from all commands)
- `afk config_set env X --unset` — mode 1, still caught by `unknownOption` patch
