### PR TITLE
test+fix: fork helpers, deliverOverflow contract, xAI OAuth tests, OIDC origin validation (#1119, #1122, #1063, #1058)

### DIFF
--- a/src/agent/providers/xai/oauth-http.test.ts
+++ b/src/agent/providers/xai/oauth-http.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { clearOidcCache, discoverXaiOidcCached, tokenResponseToBundle } from './oauth-http.js';
+import { clearOidcCache, discoverXaiOidc, discoverXaiOidcCached, tokenResponseToBundle } from './oauth-http.js';
 
 // ---------------------------------------------------------------------------
 // tokenResponseToBundle
@@ -128,5 +128,77 @@ describe('discoverXaiOidcCached', () => {
     clearOidcCache();
     await discoverXaiOidcCached(deps);
     expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RFC 8414 §3 — origin validation in discoverXaiOidc
+// ---------------------------------------------------------------------------
+describe('discoverXaiOidc — RFC 8414 §3 origin validation', () => {
+  beforeEach(() => {
+    clearOidcCache();
+  });
+
+  it('happy path: all endpoints share the issuer origin', async () => {
+    const fetchFn = makeFetchFn({
+      issuer: 'https://auth.x.ai',
+      authorization_endpoint: 'https://auth.x.ai/oauth2/auth',
+      token_endpoint: 'https://auth.x.ai/oauth2/token',
+    });
+    await expect(
+      discoverXaiOidc({ fetchFn: fetchFn as unknown as typeof fetch, issuer: 'https://auth.x.ai' }),
+    ).resolves.toMatchObject({
+      issuer: 'https://auth.x.ai',
+      authorization_endpoint: 'https://auth.x.ai/oauth2/auth',
+      token_endpoint: 'https://auth.x.ai/oauth2/token',
+    });
+  });
+
+  it('happy path: device_authorization_endpoint on same origin is accepted', async () => {
+    const fetchFn = makeFetchFn({
+      issuer: 'https://auth.x.ai',
+      authorization_endpoint: 'https://auth.x.ai/oauth2/auth',
+      token_endpoint: 'https://auth.x.ai/oauth2/token',
+      device_authorization_endpoint: 'https://auth.x.ai/oauth2/device',
+    } as Record<string, string>);
+    const result = await discoverXaiOidc({
+      fetchFn: fetchFn as unknown as typeof fetch,
+      issuer: 'https://auth.x.ai',
+    });
+    expect(result.device_authorization_endpoint).toBe('https://auth.x.ai/oauth2/device');
+  });
+
+  it('throws when authorization_endpoint origin mismatches issuer', async () => {
+    const fetchFn = makeFetchFn({
+      issuer: 'https://auth.x.ai',
+      authorization_endpoint: 'https://evil.example.com/oauth2/auth',
+      token_endpoint: 'https://auth.x.ai/oauth2/token',
+    });
+    await expect(
+      discoverXaiOidc({ fetchFn: fetchFn as unknown as typeof fetch, issuer: 'https://auth.x.ai' }),
+    ).rejects.toThrow('authorization_endpoint origin does not match issuer');
+  });
+
+  it('throws when token_endpoint origin mismatches issuer', async () => {
+    const fetchFn = makeFetchFn({
+      issuer: 'https://auth.x.ai',
+      authorization_endpoint: 'https://auth.x.ai/oauth2/auth',
+      token_endpoint: 'https://evil.example.com/oauth2/token',
+    });
+    await expect(
+      discoverXaiOidc({ fetchFn: fetchFn as unknown as typeof fetch, issuer: 'https://auth.x.ai' }),
+    ).rejects.toThrow('token_endpoint origin does not match issuer');
+  });
+
+  it('throws when device_authorization_endpoint origin mismatches issuer', async () => {
+    const fetchFn = makeFetchFn({
+      issuer: 'https://auth.x.ai',
+      authorization_endpoint: 'https://auth.x.ai/oauth2/auth',
+      token_endpoint: 'https://auth.x.ai/oauth2/token',
+      device_authorization_endpoint: 'https://evil.example.com/oauth2/device',
+    } as Record<string, string>);
+    await expect(
+      discoverXaiOidc({ fetchFn: fetchFn as unknown as typeof fetch, issuer: 'https://auth.x.ai' }),
+    ).rejects.toThrow('device_authorization_endpoint origin does not match issuer');
   });
 });

--- a/src/agent/providers/xai/oauth-http.test.ts
+++ b/src/agent/providers/xai/oauth-http.test.ts
@@ -201,4 +201,41 @@ describe('discoverXaiOidc — RFC 8414 §3 origin validation', () => {
       discoverXaiOidc({ fetchFn: fetchFn as unknown as typeof fetch, issuer: 'https://auth.x.ai' }),
     ).rejects.toThrow('device_authorization_endpoint origin does not match issuer');
   });
+
+  it('throws when userinfo_endpoint origin mismatches issuer', async () => {
+    const fetchFn = makeFetchFn({
+      issuer: 'https://auth.x.ai',
+      authorization_endpoint: 'https://auth.x.ai/oauth2/auth',
+      token_endpoint: 'https://auth.x.ai/oauth2/token',
+      userinfo_endpoint: 'https://evil.example.com/userinfo',
+    } as Record<string, string>);
+    await expect(
+      discoverXaiOidc({ fetchFn: fetchFn as unknown as typeof fetch, issuer: 'https://auth.x.ai' }),
+    ).rejects.toThrow('userinfo_endpoint origin does not match issuer');
+  });
+
+  it('throws a typed error when body issuer is a malformed URL (not-a-url)', async () => {
+    const fetchFn = makeFetchFn({
+      issuer: 'not-a-url',
+      authorization_endpoint: 'https://auth.x.ai/oauth2/auth',
+      token_endpoint: 'https://auth.x.ai/oauth2/token',
+    });
+    // After Item 2 fix: body issuer is validated against the configured issuer origin.
+    // A malformed body issuer whose origin doesn't match should throw a clean typed error,
+    // not a raw TypeError from `new URL('not-a-url')`.
+    await expect(
+      discoverXaiOidc({ fetchFn: fetchFn as unknown as typeof fetch, issuer: 'https://auth.x.ai' }),
+    ).rejects.toThrow('xAI OIDC discovery: body issuer origin does not match configured issuer');
+  });
+
+  it('throws when body issuer origin differs from configured issuer', async () => {
+    const fetchFn = makeFetchFn({
+      issuer: 'https://evil.example.com',
+      authorization_endpoint: 'https://auth.x.ai/oauth2/auth',
+      token_endpoint: 'https://auth.x.ai/oauth2/token',
+    });
+    await expect(
+      discoverXaiOidc({ fetchFn: fetchFn as unknown as typeof fetch, issuer: 'https://auth.x.ai' }),
+    ).rejects.toThrow('body issuer origin does not match configured issuer');
+  });
 });

--- a/src/agent/providers/xai/oauth-http.ts
+++ b/src/agent/providers/xai/oauth-http.ts
@@ -71,13 +71,29 @@ export async function discoverXaiOidc(deps: OAuthHttpDeps = {}): Promise<XaiOidc
   if (!authorization_endpoint || !token_endpoint) {
     throw new Error('xAI OIDC discovery missing authorization_endpoint or token_endpoint');
   }
+  // RFC 8414 §3: authorization_endpoint and token_endpoint MUST share the issuer's origin.
+  // Validate against the resolved issuer (prefer body['issuer'] when present, else the
+  // configured issuer string) so spoofed discovery documents can't redirect token traffic.
+  const resolvedIssuer = asNonEmptyString(body['issuer']) ?? issuer;
+  const issuerOrigin = new URL(resolvedIssuer).origin;
+  if (new URL(authorization_endpoint).origin !== issuerOrigin) {
+    throw new Error('xAI OIDC discovery: authorization_endpoint origin does not match issuer');
+  }
+  if (new URL(token_endpoint).origin !== issuerOrigin) {
+    throw new Error('xAI OIDC discovery: token_endpoint origin does not match issuer');
+  }
   const out: XaiOidcDiscovery = {
-    issuer: asNonEmptyString(body['issuer']) ?? issuer,
+    issuer: resolvedIssuer,
     authorization_endpoint,
     token_endpoint,
   };
   const device = asNonEmptyString(body['device_authorization_endpoint']);
-  if (device) out.device_authorization_endpoint = device;
+  if (device) {
+    if (new URL(device).origin !== issuerOrigin) {
+      throw new Error('xAI OIDC discovery: device_authorization_endpoint origin does not match issuer');
+    }
+    out.device_authorization_endpoint = device;
+  }
   const userinfo = asNonEmptyString(body['userinfo_endpoint']);
   if (userinfo) out.userinfo_endpoint = userinfo;
   return out;

--- a/src/agent/providers/xai/oauth-http.ts
+++ b/src/agent/providers/xai/oauth-http.ts
@@ -71,11 +71,23 @@ export async function discoverXaiOidc(deps: OAuthHttpDeps = {}): Promise<XaiOidc
   if (!authorization_endpoint || !token_endpoint) {
     throw new Error('xAI OIDC discovery missing authorization_endpoint or token_endpoint');
   }
-  // RFC 8414 §3: authorization_endpoint and token_endpoint MUST share the issuer's origin.
-  // Validate against the resolved issuer (prefer body['issuer'] when present, else the
-  // configured issuer string) so spoofed discovery documents can't redirect token traffic.
-  const resolvedIssuer = asNonEmptyString(body['issuer']) ?? issuer;
-  const issuerOrigin = new URL(resolvedIssuer).origin;
+  // RFC 8414 §3: all endpoints MUST share the issuer's origin. Anchor the origin check to
+  // the *configured* issuer (not the body-supplied one) so a spoofed discovery document
+  // cannot redirect token traffic by advertising its own origin as `issuer`.
+  const issuerOrigin = new URL(issuer).origin;
+  const bodyIssuer = asNonEmptyString(body['issuer']);
+  if (bodyIssuer) {
+    let bodyIssuerOrigin: string;
+    try {
+      bodyIssuerOrigin = new URL(bodyIssuer).origin;
+    } catch {
+      throw new Error('xAI OIDC discovery: body issuer origin does not match configured issuer');
+    }
+    if (bodyIssuerOrigin !== issuerOrigin) {
+      throw new Error('xAI OIDC discovery: body issuer origin does not match configured issuer');
+    }
+  }
+  const resolvedIssuer = bodyIssuer ?? issuer;
   if (new URL(authorization_endpoint).origin !== issuerOrigin) {
     throw new Error('xAI OIDC discovery: authorization_endpoint origin does not match issuer');
   }
@@ -95,7 +107,12 @@ export async function discoverXaiOidc(deps: OAuthHttpDeps = {}): Promise<XaiOidc
     out.device_authorization_endpoint = device;
   }
   const userinfo = asNonEmptyString(body['userinfo_endpoint']);
-  if (userinfo) out.userinfo_endpoint = userinfo;
+  if (userinfo) {
+    if (new URL(userinfo).origin !== issuerOrigin) {
+      throw new Error('xAI OIDC discovery: userinfo_endpoint origin does not match issuer');
+    }
+    out.userinfo_endpoint = userinfo;
+  }
   return out;
 }
 

--- a/src/agent/providers/xai/oauth.test.ts
+++ b/src/agent/providers/xai/oauth.test.ts
@@ -319,6 +319,48 @@ describe('ensureFreshAccessToken', () => {
     expect(readXaiTokens(store)).toBeNull();
   });
 
+  it('concurrent callers both fall back gracefully when refresh fails but token is still valid', async () => {
+    const store = memStore();
+    store.authPath = () => '/tmp/xai-oauth-concurrent-graceful.json';
+    const now = 1_000_000;
+    const { writeXaiTokens } = await import('./auth-store.js');
+    const originalBundle: XaiTokenBundle = {
+      access_token: 'concurrent-valid',
+      refresh_token: 'rt-concurrent',
+      expires_at: now + 30, // within skew → triggers refresh; above now → still valid
+    };
+    writeXaiTokens(originalBundle, store);
+
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    const fetchFn = vi.fn(async (url: RequestInfo) => {
+      if (String(url).includes('openid-configuration')) return jsonResponse(discoveryDoc);
+      // Block until both callers have joined the in-flight promise, then fail.
+      await gate;
+      return jsonResponse({ error: 'server_error', error_description: 'upstream unavailable' }, 503);
+    });
+
+    const deps = {
+      store,
+      fetchFn: fetchFn as unknown as typeof fetch,
+      nowSeconds: () => now,
+    };
+    const p1 = ensureFreshAccessToken(deps);
+    const p2 = ensureFreshAccessToken(deps);
+    // Yield so both callers enter the in-flight path before the response resolves.
+    await Promise.resolve();
+    release();
+    const [a, b] = await Promise.all([p1, p2]);
+
+    // Both should degrade gracefully — returning the still-valid token, not null/throw.
+    expect(a?.access_token).toBe('concurrent-valid');
+    expect(b?.access_token).toBe('concurrent-valid');
+    // Store must be intact (token not cleared).
+    expect(readXaiTokens(store)?.access_token).toBe('concurrent-valid');
+  });
+
   it('single-flights concurrent refresh for the same store path', async () => {
     const store = memStore();
     store.authPath = () => '/tmp/xai-oauth-singleflight.json';

--- a/src/bundled-plugins/awa-bundled/bundled.test.ts
+++ b/src/bundled-plugins/awa-bundled/bundled.test.ts
@@ -279,6 +279,8 @@ describe('bundled skills', () => {
 
       // Remove the required prohibition before looking for a contradictory,
       // affirmative dispatch directive in the same section.
+      // No `g` flag: only one canonical prohibition sentence exists, so a single
+      // replace is intentional and avoids accidentally stripping repeated text.
       const directives = inlineRecon!.replace(
         /Do NOT dispatch any sub-agents[^.]*\./,
         '',

--- a/src/bundled-plugins/awa-bundled/bundled.test.ts
+++ b/src/bundled-plugins/awa-bundled/bundled.test.ts
@@ -260,5 +260,35 @@ describe('bundled skills', () => {
       // Wave 2 emits the verdict, so its receives list carries the rule.
       expect(content).toContain('**the merge-decision rule and its counts format below**');
     });
+
+    // Invariant: #1134 — ground-state runs inline reconnaissance only. The skill
+    // body explicitly forbids dispatching sub-agents so that every survey is a
+    // deterministic read in the same fork, not a spawned child that could stall,
+    // hit depth limits, or produce non-deterministic results. A later edit that
+    // removes the prohibition or re-introduces `agent`/`skill` dispatch would
+    // silently break the no-dispatch guarantee the orchestrator depends on.
+    it('ground-state keeps the no-dispatch invariant (#1134)', () => {
+      const content = readBundled('ground-state');
+      const inlineRecon = content.match(
+        /## Inline reconnaissance\n([\s\S]*?)(?=\n## )/,
+      )?.[1];
+      expect(inlineRecon).toBeDefined();
+      expect(inlineRecon).toContain('Do NOT dispatch any sub-agents');
+      // The inline-recon section must name the tools the fork uses directly.
+      expect(inlineRecon).toContain('directly using your own tools');
+
+      // Remove the required prohibition before looking for a contradictory,
+      // affirmative dispatch directive in the same section.
+      const directives = inlineRecon!.replace(
+        /Do NOT dispatch any sub-agents[^.]*\./,
+        '',
+      );
+      const dispatchDirective =
+        /\b(?:(?:dispatch|invoke|call)\b[^.\n]*\b(?:sub-?agents?|agents?|skills?)|use\b[^.\n]*\b(?:agent|skill)\b[^.\n]*\btools?)\b/i;
+      expect('Dispatch a sub-agent for the state survey').toMatch(
+        dispatchDirective,
+      );
+      expect(directives).not.toMatch(dispatchDirective);
+    });
   });
 });


### PR DESCRIPTION
## Summary

This PR addresses four open issues in a single branch:

### #1119 — Unit tests for extracted fork helpers
Adds `src/agent/subagent/fork-helpers.test.ts` with **39 tests** covering:
- `validatePhaseRole` — mutual-exclusion conditions + happy paths
- `assembleChildConfig` — key field spot-checks (permissions, tool-budget preamble, elicitation gate)
- `emitForkStarted` — witness emit structure, promptHead slicing, model serialization
- `appendForkTelemetry` — telemetry append shape and field presence

### #1122 — Document deliverOverflow guard contract
Adds a `// Contract:` comment on the `else` branch in `streaming.ts` explaining that `deliverOverflow` internalizes the full guard (preview non-null, finalBody truthy, and the negated `cleanFinal && answerText.trim()` condition). Two redundant blank lines collapsed to stay within the filesize baseline.

### #1063 — Test for xAI OAuth refresh-failure graceful degradation
Adds a test in `oauth.test.ts` exercising the fallback path: when token refresh fails (HTTP 503) but the current access token is still valid (`expires_at > now`), `ensureFreshAccessToken` returns the existing bundle without throwing.

### #1058 — Validate OIDC discovery endpoint origins per RFC 8414 §3
Adds origin validation in `discoverXaiOidc()`: after parsing the discovery document, verifies that `authorization_endpoint`, `token_endpoint`, and `device_authorization_endpoint` origins match the issuer's origin. Throws on mismatch. Adds 5 tests in `oauth-http.test.ts`.

## Verification

All tests pass:
```
✓ src/agent/subagent/fork-helpers.test.ts (39 tests)
✓ src/agent/providers/xai/oauth.test.ts (14 tests)
✓ src/agent/providers/xai/oauth-http.test.ts (17 tests)
pnpm lint — clean
```

Closes #1119, closes #1122, closes #1063, closes #1058
