### PR TITLE
test(bundled): add content-level contract test for ground-state no-dispatch invariant (#1138)

### DIFF
--- a/src/bundled-plugins/awa-bundled/bundled.test.ts
+++ b/src/bundled-plugins/awa-bundled/bundled.test.ts
@@ -260,5 +260,18 @@ describe('bundled skills', () => {
       // Wave 2 emits the verdict, so its receives list carries the rule.
       expect(content).toContain('**the merge-decision rule and its counts format below**');
     });
+
+    // Invariant: #1134 — ground-state runs inline reconnaissance only. The skill
+    // body explicitly forbids dispatching sub-agents so that every survey is a
+    // deterministic read in the same fork, not a spawned child that could stall,
+    // hit depth limits, or produce non-deterministic results. A later edit that
+    // removes the prohibition or re-introduces `agent`/`skill` dispatch would
+    // silently break the no-dispatch guarantee the orchestrator depends on.
+    it('ground-state keeps the no-dispatch invariant (#1134)', () => {
+      const content = readBundled('ground-state');
+      expect(content).toContain('Do NOT dispatch any sub-agents');
+      // The inline-recon section must name the tools the fork uses directly.
+      expect(content).toContain('directly using your own tools');
+    });
   });
 });


### PR DESCRIPTION
Closes #1138

## What

Adds a content-level contract test for the ground-state no-dispatch invariant introduced in #1134. The existing SHA-256 pinned hash in `bundled.test.ts` catches any byte-level change to the skill but cannot identify *which* clause was removed. This test makes the invariant explicit and self-documenting.

## Why

The `/ground-state` skill body mandates that all reconnaissance runs **inline in the same fork** — no `agent` or `skill` dispatch. This constraint exists so every survey is deterministic, avoids depth-limit risks, and doesn't spawn extra sessions that could stall or hit 429s. A future edit that accidentally drops the prohibition (e.g. while refactoring the inline-recon section) would pass the hash check only if the hash is bumped correctly — the content test gives an independent, readable signal.

## Test added

```ts
it('ground-state keeps the no-dispatch invariant (#1134)', () => {
  const content = readBundled('ground-state');
  expect(content).toContain('Do NOT dispatch any sub-agents');
  // The inline-recon section must name the tools the fork uses directly.
  expect(content).toContain('directly using your own tools');
});
```

Both strings are verbatim from the `## Inline reconnaissance` section of `SKILL.md` (line 21). `SKILL.md` is not modified.

## Checklist

- [x] `pnpm test src/bundled-plugins/awa-bundled/bundled.test.ts` — 22/22 pass
- [x] `pnpm lint` — clean
- [x] File stays under 350-line ceiling (265 → 278 lines)
- [x] No SKILL.md modifications
