### PR TITLE
fix(witness): report pre-filter sessionsAvailable alongside sessionsSearched

### DIFF
--- a/src/agent/tools/handlers/witness.test.ts
+++ b/src/agent/tools/handlers/witness.test.ts
@@ -45,6 +45,8 @@ function makeReadResult(partial?: Partial<ReadWitnessResult>): ReadWitnessResult
 function makeSearchResult(partial?: Partial<SearchWitnessResult>): SearchWitnessResult {
   return {
     query: 'test',
+    sessionsAvailable: 0,
+    sessionsSearched: 0,
     sessionsScanned: 0,
     matches: [],
     ...partial,
@@ -289,7 +291,7 @@ describe('searchWitnessHandler — valid input', () => {
       kinds: ['subagent_lifecycle'],
       since: '2024-01-01T00:00:00Z',
     };
-    const expectedResult = makeSearchResult({ query: 'forkbomb', sessionsScanned: 10 });
+    const expectedResult = makeSearchResult({ query: 'forkbomb', sessionsAvailable: 10, sessionsSearched: 10, sessionsScanned: 10 });
     mockSearchAcrossSessions.mockResolvedValue(expectedResult);
 
     const result = await searchWitnessHandler(input, signal);


### PR DESCRIPTION
## Summary

Fixes the test compilation gap for #1035. The implementation (`witness.query.ts`) and schema (`schemas.witness.ts`) already ship both `sessionsAvailable` (pre-filter count) and `sessionsSearched` (post-filter count), but the test helper `makeSearchResult` was missing the new required fields, causing type errors.

## Changes

- **`src/agent/tools/handlers/witness.test.ts`** — added `sessionsAvailable` and `sessionsSearched` defaults to `makeSearchResult` helper; fixed one test call missing the new fields.

## Verification

- 52/52 witness tests pass
- `pnpm lint` clean

Closes #1035
