### PR TITLE
chore(telegram): document deliverOverflow guard contract (#1122)

### DIFF
--- a/src/telegram/streaming.ts
+++ b/src/telegram/streaming.ts
@@ -323,6 +323,14 @@ export async function streamResponse(
           }
         }
       } else {
+        // Contract: deliverOverflow internalizes the full guard —
+        // `!(cleanFinal && answerText.trim()) && finalBodyText && preview` — so
+        // this bare `else` is safe without a redundant outer check. The function
+        // returns early (no-op) when: (a) the `done` handler already took the
+        // `deliverClean` path (preview null-checked out), (b) `finalBodyText` is
+        // empty/falsy, or (c) the cleanFinal+answerText guard matches the `done`
+        // handler's own delivery branch. Callers must never replicate that guard
+        // here; it belongs exclusively inside deliverOverflow (streaming.handlers.ts).
         await deliverOverflow(ctx, cleanFinal, state.answerText, finalBody(), preview);
       }
     } finally {


### PR DESCRIPTION
## Summary

Documents the structural contract change from PR #1110 where `deliverOverflow` internalized the full guard that was previously at the call site.

## Changes

- Added a `// Contract:` comment on the `else` branch in `streaming.ts` explaining that `deliverOverflow` internalizes the full guard
- No runtime behavior changes

Closes #1122
