### PR TITLE
feat(xai): validate OIDC discovery endpoint origins per RFC 8414 §3 (#1058)

### DIFF
--- a/src/agent/providers/xai/oauth-http.test.ts
+++ b/src/agent/providers/xai/oauth-http.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { clearOidcCache, discoverXaiOidcCached, tokenResponseToBundle } from './oauth-http.js';
+import {
+  clearOidcCache,
+  discoverXaiOidc,
+  discoverXaiOidcCached,
+  tokenResponseToBundle,
+} from './oauth-http.js';
 
 // ---------------------------------------------------------------------------
 // tokenResponseToBundle
@@ -128,5 +133,59 @@ describe('discoverXaiOidcCached', () => {
     clearOidcCache();
     await discoverXaiOidcCached(deps);
     expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RFC 8414 §3 origin validation
+// ---------------------------------------------------------------------------
+describe('discoverXaiOidc — origin validation', () => {
+  beforeEach(() => {
+    clearOidcCache();
+  });
+
+  it('accepts endpoints whose origin matches the issuer', async () => {
+    const fetchFn = makeFetchFn(DISCOVERY_BODY);
+    await expect(
+      discoverXaiOidc({ fetchFn: fetchFn as unknown as typeof fetch, issuer: 'https://auth.x.ai' }),
+    ).resolves.toMatchObject({
+      token_endpoint: DISCOVERY_BODY.token_endpoint,
+      authorization_endpoint: DISCOVERY_BODY.authorization_endpoint,
+    });
+  });
+
+  it('rejects a token_endpoint whose origin differs from the issuer', async () => {
+    const body = {
+      ...DISCOVERY_BODY,
+      token_endpoint: 'https://evil.example.com/token',
+    };
+    const fetchFn = makeFetchFn(body);
+    await expect(
+      discoverXaiOidc({ fetchFn: fetchFn as unknown as typeof fetch, issuer: 'https://auth.x.ai' }),
+    ).rejects.toThrow('token_endpoint origin does not match issuer');
+  });
+
+  it('rejects an authorization_endpoint whose origin differs from the issuer', async () => {
+    const body = {
+      ...DISCOVERY_BODY,
+      authorization_endpoint: 'https://evil.example.com/auth',
+    };
+    const fetchFn = makeFetchFn(body);
+    await expect(
+      discoverXaiOidc({ fetchFn: fetchFn as unknown as typeof fetch, issuer: 'https://auth.x.ai' }),
+    ).rejects.toThrow('authorization_endpoint origin does not match issuer');
+  });
+
+  it('validates against the issuer field in the document when present', async () => {
+    // Document advertises a different issuer subdomain; endpoints must match that, not the URL origin.
+    const body = {
+      issuer: 'https://auth2.x.ai',
+      authorization_endpoint: 'https://auth2.x.ai/oauth2/auth',
+      token_endpoint: 'https://auth.x.ai/oauth2/token', // mismatch vs doc issuer
+    };
+    const fetchFn = makeFetchFn(body);
+    await expect(
+      discoverXaiOidc({ fetchFn: fetchFn as unknown as typeof fetch, issuer: 'https://auth2.x.ai' }),
+    ).rejects.toThrow('token_endpoint origin does not match issuer');
   });
 });

--- a/src/agent/providers/xai/oauth-http.ts
+++ b/src/agent/providers/xai/oauth-http.ts
@@ -71,8 +71,17 @@ export async function discoverXaiOidc(deps: OAuthHttpDeps = {}): Promise<XaiOidc
   if (!authorization_endpoint || !token_endpoint) {
     throw new Error('xAI OIDC discovery missing authorization_endpoint or token_endpoint');
   }
+  // RFC 8414 §3: token_endpoint and authorization_endpoint must share the issuer's origin.
+  const resolvedIssuer = asNonEmptyString(body['issuer']) ?? issuer;
+  const issuerOrigin = new URL(resolvedIssuer).origin;
+  if (new URL(token_endpoint).origin !== issuerOrigin) {
+    throw new Error('OIDC discovery: token_endpoint origin does not match issuer');
+  }
+  if (new URL(authorization_endpoint).origin !== issuerOrigin) {
+    throw new Error('OIDC discovery: authorization_endpoint origin does not match issuer');
+  }
   const out: XaiOidcDiscovery = {
-    issuer: asNonEmptyString(body['issuer']) ?? issuer,
+    issuer: resolvedIssuer,
     authorization_endpoint,
     token_endpoint,
   };


### PR DESCRIPTION
## Summary

Validates OIDC discovery endpoint origins per RFC 8414 §3 — rejects `token_endpoint` or `authorization_endpoint` whose origin doesn't match the issuer's origin.

## Changes

- Added origin validation in `discoverXaiOidc` after parsing the discovery document
- Added 4 test cases covering valid and cross-origin-invalid endpoint combinations

Closes #1058
