### PR TITLE
fix(postinstall): stop killing telegram bot mid-session on upgrade

### DIFF
--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -197,11 +197,21 @@ if (isMain) {
   // running process keeps the old module graph in memory after npm overwrites
   // the files on disk — only a restart swaps it.
   //
-  // 1. launchd-supervised services (telegram + daemon): restart in place so
-  //    they re-exec the new entrypoint. macOS only; fail-open.
+  // Invariant: the telegram service is EXCLUDED from postinstall restart.
+  // `launchctl kickstart -k` sends SIGTERM which kills all active sessions
+  // mid-turn — the relaunched binary starts cold and cannot resume them. The
+  // telegram bot has its own version-drift watchdog (stats-ticker.ts) that
+  // detects the on-disk version mismatch within 5 minutes and exits ONLY when
+  // no session is mid-turn (or after a bounded deferral window). Restarting it
+  // here bypasses that session-safety logic and is the root cause of "sessions
+  // that work but never respond" — see telegram-stuck-diagnosis.md.
+  //
+  // The daemon is stateless (no active user sessions) and safe to force-restart.
   if (process.platform === 'darwin') {
     try {
-      const restarted = restartLaunchdServices();
+      const restarted = restartLaunchdServices({
+        labels: ['com.afk.daemon'],
+      });
       if (restarted.length > 0) {
         const names = restarted.map((l) => l.replace(/^com\.afk\./, '')).join(', ');
         process.stdout.write(


### PR DESCRIPTION
## Problem

The Telegram bot's `postinstall` hook called `launchctl kickstart -k` on `com.afk.telegram`, which sends `SIGTERM` and kills all active sessions immediately. Every `npm install -g agent-afk` (triggered on each CI publish) severed in-flight turns — users saw "Thinking…" freeze permanently with no response delivered.

**Evidence from today's service log:**
- Multiple sessions sealed at identical timestamps (`12:38:27.990Z` and `11:24:46.750Z`) with `status: "failed"`, `incomplete: true`, `finalTurnCount: 0`
- launchd system log confirms `service inactive: com.afk.telegram` at those exact moments  
- No version-drift watchdog messages in the bot log — the kill came from postinstall, not the drift check
- 5 releases today (5.128.0–5.128.4) each triggered the cycle: CI publish → npm install → postinstall → bot killed

## Fix

Exclude `com.afk.telegram` from the postinstall `restartLaunchdServices()` call. The telegram bot already has its own session-aware version-drift watchdog (`stats-ticker.ts` + `version-check.ts`) that:
1. Detects on-disk version mismatch within 5 minutes (the stats tick interval)  
2. **Defers** the exit while any session is mid-turn (`getBusySessionCount()`)
3. Force-exits after 12 deferrals (~1 hour) as a livelock escape

The daemon (`com.afk.daemon`) remains in the restart list — it's stateless (no active user sessions).

## Additional findings (not fixed in this PR)

Session `740cbcd6` was NOT killed by a restart — it genuinely got stuck after completing all tool work. The model generated its final response but nothing was delivered to the user. This is a separate bug in the streaming/delivery path (possibly related to empty `answerText` when the model's final turn was thinking-only, or a silent `deliverClean` failure). Diagnosis written to `telegram-stuck-diagnosis.md` in the worktree.
