### PR TITLE
chore(test): remove dead resolveSecond variable in watchdog test

### DIFF
--- a/src/telegram/streaming.watchdog.test.ts
+++ b/src/telegram/streaming.watchdog.test.ts
@@ -124,9 +124,8 @@ describe('makeNextWithTimeout — apiRoundInFlight behavioral tests', () => {
     vi.useFakeTimers();
     try {
       let releaseFirst: () => void = () => {};
-      let resolveSecond: (v: IteratorResult<never>) => void = () => {};
       // First call resolves immediately (simulates the subsequent event that
-      // clears apiRoundInFlight); second call hangs.
+      // clears apiRoundInFlight); second call hangs forever (never resolved).
       let callCount = 0;
       const iter: AsyncIterator<never> = {
         next: () => {
@@ -134,7 +133,7 @@ describe('makeNextWithTimeout — apiRoundInFlight behavioral tests', () => {
           if (callCount === 1) {
             return new Promise<IteratorResult<never>>((res) => { releaseFirst = () => res({ value: undefined as never, done: false }); });
           }
-          return new Promise<IteratorResult<never>>((res) => { resolveSecond = res; });
+          return new Promise<IteratorResult<never>>(() => {});
         },
       };
 


### PR DESCRIPTION
## Summary

Cleanup from PR #1148 review: removes a dead `resolveSecond` variable in the watchdog behavioral test.

## What

In the "resumes normal watchdog cadence" test, `resolveSecond` was declared, captured inside `iter.next()`, but never called — the second Promise intentionally hangs forever until the watchdog fires `StreamTimeoutError`. The captured resolve function was scaffolding left from an earlier draft.

## Changes

- Removed `resolveSecond` declaration (line 127)
- Replaced `(res) => { resolveSecond = res; }` with `() => {}` — an empty callback that never resolves
- Clarified comment: "second call hangs forever (never resolved)"

## Verification

- `pnpm test src/telegram/streaming.watchdog.test.ts` — 7/7 pass
