### PR TITLE
feat(tools): add extract_document tool for cross-platform document text extraction (#660)

### DIFF
--- a/src/agent/tool-category.ts
+++ b/src/agent/tool-category.ts
@@ -15,8 +15,9 @@
  *   - PascalCase Anthropic-SDK names: `Read`, `Write`, `Bash`, `Agent`, ...
  *   - snake_case agent-afk built-in tool names from src/agent/tools/schemas.ts
  *     and src/agent/memory/memory-tools.ts:
- *     `read_file`, `write_file`, `edit_file`, `bash`, `agent`, `skill`,
- *     `compose`, `send_telegram`, `web_scrape`, `glob`, `grep`, `list_directory`,
+ *     `read_file`, `extract_document`, `write_file`, `edit_file`, `bash`,
+ *     `agent`, `skill`, `compose`, `send_telegram`, `web_scrape`, `glob`,
+ *     `grep`, `list_directory`,
  *     `memory_search`, `memory_update`, `procedure_write`,
  *     `create_schedule`, `list_schedules`, `get_schedule_history`, `cancel_schedule`,
  *     `terminal_font_size`, `config_get`, `config_set`.
@@ -45,7 +46,7 @@ const READ_TOOLS = new Set([
   // Anthropic SDK PascalCase
   'Read', 'Glob', 'Grep', 'NotebookRead', 'LS',
   // agent-afk built-in snake_case (src/agent/tools/schemas.ts)
-  'read_file', 'glob', 'grep', 'list_directory',
+  'read_file', 'extract_document', 'glob', 'grep', 'list_directory',
   // config_get reads ~/.afk/config (afk.env / afk.config.json); secrets are
   // masked by the handler. Read-only by construction — no mutation surface.
   'config_get',
@@ -221,6 +222,7 @@ export const READ_ONLY_PHASE_TOOLS: readonly string[] = [
   'LS',
   // agent-afk snake_case (src/agent/tools/schemas.ts)
   'read_file',
+  'extract_document',
   'glob',
   'grep',
   'list_directory',

--- a/src/agent/tools/handlers/extract-document.test.ts
+++ b/src/agent/tools/handlers/extract-document.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Tests for the `extract_document` tool handler.
+ *
+ * Builds minimal fixture files in-memory (no checked-in binaries) using Node's
+ * zlib to construct valid ZIP archives containing OOXML payloads.
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { deflateRawSync } from 'zlib';
+import { extractDocumentHandler, createExtractDocumentHandler } from './extract-document.js';
+import type { ToolHandlerContext } from '../types.js';
+
+const signal = new AbortController().signal;
+
+// ── ZIP builder helpers ──────────────────────────────────────────────
+
+/** Build a minimal ZIP file from an array of {name, data} entries. */
+function buildZip(entries: { name: string; data: Buffer }[]): Buffer {
+  const localHeaders: Buffer[] = [];
+  const centralHeaders: Buffer[] = [];
+  let offset = 0;
+
+  for (const entry of entries) {
+    const nameBytes = Buffer.from(entry.name, 'utf-8');
+    const compressed = deflateRawSync(entry.data);
+
+    // Local file header
+    const local = Buffer.alloc(30 + nameBytes.length + compressed.length);
+    local.writeUInt32LE(0x04034b50, 0);  // signature
+    local.writeUInt16LE(20, 4);          // version needed
+    local.writeUInt16LE(0, 6);           // flags
+    local.writeUInt16LE(8, 8);           // compression: deflate
+    local.writeUInt16LE(0, 10);          // mod time
+    local.writeUInt16LE(0, 12);          // mod date
+    local.writeUInt32LE(0, 14);          // crc32 (not validated by our parser)
+    local.writeUInt32LE(compressed.length, 18);
+    local.writeUInt32LE(entry.data.length, 22);
+    local.writeUInt16LE(nameBytes.length, 26);
+    local.writeUInt16LE(0, 28);          // extra length
+    nameBytes.copy(local, 30);
+    compressed.copy(local, 30 + nameBytes.length);
+    localHeaders.push(local);
+
+    // Central directory header
+    const central = Buffer.alloc(46 + nameBytes.length);
+    central.writeUInt32LE(0x02014b50, 0);
+    central.writeUInt16LE(20, 4);        // version made by
+    central.writeUInt16LE(20, 6);        // version needed
+    central.writeUInt16LE(0, 8);         // flags
+    central.writeUInt16LE(8, 10);        // compression: deflate
+    central.writeUInt16LE(0, 12);        // mod time
+    central.writeUInt16LE(0, 14);        // mod date
+    central.writeUInt32LE(0, 16);        // crc32
+    central.writeUInt32LE(compressed.length, 20);
+    central.writeUInt32LE(entry.data.length, 24);
+    central.writeUInt16LE(nameBytes.length, 28);
+    central.writeUInt16LE(0, 30);        // extra length
+    central.writeUInt16LE(0, 32);        // comment length
+    central.writeUInt16LE(0, 34);        // disk number
+    central.writeUInt16LE(0, 36);        // internal attrs
+    central.writeUInt32LE(0, 38);        // external attrs
+    central.writeUInt32LE(offset, 42);   // local header offset
+    nameBytes.copy(central, 46);
+    centralHeaders.push(central);
+
+    offset += local.length;
+  }
+
+  const cdOffset = offset;
+  const cdSize = centralHeaders.reduce((a, b) => a + b.length, 0);
+
+  // End of central directory
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(0, 4);             // disk number
+  eocd.writeUInt16LE(0, 6);             // cd start disk
+  eocd.writeUInt16LE(entries.length, 8);
+  eocd.writeUInt16LE(entries.length, 10);
+  eocd.writeUInt32LE(cdSize, 12);
+  eocd.writeUInt32LE(cdOffset, 16);
+  eocd.writeUInt16LE(0, 20);            // comment length
+
+  return Buffer.concat([...localHeaders, ...centralHeaders, eocd]);
+}
+
+/** Build a minimal .docx (ZIP with word/document.xml). */
+function buildDocx(bodyXml: string): Buffer {
+  const xml =
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+    '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">' +
+    '<w:body>' + bodyXml + '</w:body></w:document>';
+  return buildZip([{ name: 'word/document.xml', data: Buffer.from(xml, 'utf-8') }]);
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(join(tmpdir(), 'extract-doc-test-'));
+});
+
+afterEach(async () => {
+  try { await fs.rm(tmpDir, { recursive: true }); } catch { /* best-effort */ }
+});
+
+describe('extractDocumentHandler', () => {
+  describe('input validation', () => {
+    it('rejects missing input', async () => {
+      const result = await extractDocumentHandler(null, signal);
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('Invalid input');
+    });
+
+    it('rejects missing file_path', async () => {
+      const result = await extractDocumentHandler({}, signal);
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('file_path must be a string');
+    });
+
+    it('rejects unsupported extension', async () => {
+      const filePath = join(tmpDir, 'test.rtf');
+      await fs.writeFile(filePath, 'test');
+      const result = await extractDocumentHandler({ file_path: filePath }, signal);
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('Unsupported format');
+      expect(result.content).toContain('.rtf');
+    });
+  });
+
+  describe('.docx extraction', () => {
+    it('extracts text from a minimal docx', async () => {
+      const docx = buildDocx(
+        '<w:p><w:r><w:t>Hello World</w:t></w:r></w:p>' +
+        '<w:p><w:r><w:t>Second paragraph</w:t></w:r></w:p>',
+      );
+      const filePath = join(tmpDir, 'test.docx');
+      await fs.writeFile(filePath, docx);
+      const result = await extractDocumentHandler({ file_path: filePath }, signal);
+      expect(result.isError).not.toBe(true);
+      expect(result.content).toContain('Hello World');
+      expect(result.content).toContain('Second paragraph');
+    });
+
+    it('strips tracked deletions from docx', async () => {
+      const docx = buildDocx(
+        '<w:p><w:r><w:t>Keep this</w:t></w:r>' +
+        '<w:del><w:r><w:t>Remove this</w:t></w:r></w:del></w:p>',
+      );
+      const filePath = join(tmpDir, 'tracked.docx');
+      await fs.writeFile(filePath, docx);
+      const result = await extractDocumentHandler({ file_path: filePath }, signal);
+      expect(result.content).toContain('Keep this');
+      expect(result.content).not.toContain('Remove this');
+    });
+
+    it('handles XML entities', async () => {
+      const docx = buildDocx(
+        '<w:p><w:r><w:t>A &amp; B &lt; C</w:t></w:r></w:p>',
+      );
+      const filePath = join(tmpDir, 'entities.docx');
+      await fs.writeFile(filePath, docx);
+      const result = await extractDocumentHandler({ file_path: filePath }, signal);
+      expect(result.content).toContain('A & B < C');
+    });
+
+    it('returns error for docx missing word/document.xml', async () => {
+      const badDocx = buildZip([{ name: 'other.xml', data: Buffer.from('<x/>') }]);
+      const filePath = join(tmpDir, 'bad.docx');
+      await fs.writeFile(filePath, badDocx);
+      const result = await extractDocumentHandler({ file_path: filePath }, signal);
+      expect(result.content).toContain('word/document.xml not found');
+    });
+  });
+
+  describe('.zip extraction', () => {
+    it('lists members and extracts text files', async () => {
+      const zip = buildZip([
+        { name: 'readme.txt', data: Buffer.from('Hello from zip') },
+        { name: 'data.csv', data: Buffer.from('a,b,c\n1,2,3') },
+        { name: 'image.png', data: Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00]) },
+      ]);
+      const filePath = join(tmpDir, 'test.zip');
+      await fs.writeFile(filePath, zip);
+      const result = await extractDocumentHandler({ file_path: filePath }, signal);
+      expect(result.isError).not.toBe(true);
+      expect(result.content).toContain('3 entries');
+      expect(result.content).toContain('readme.txt');
+      expect(result.content).toContain('Hello from zip');
+      expect(result.content).toContain('a,b,c');
+      // Binary file (image.png) should be listed but not extracted as text
+      expect(result.content).toContain('image.png');
+    });
+
+    it('skips zip entries with path traversal', async () => {
+      const zip = buildZip([
+        { name: '../escape.txt', data: Buffer.from('escaped') },
+        { name: 'safe.txt', data: Buffer.from('safe content') },
+      ]);
+      const filePath = join(tmpDir, 'traversal.zip');
+      await fs.writeFile(filePath, zip);
+      const result = await extractDocumentHandler({ file_path: filePath }, signal);
+      expect(result.content).toContain('safe content');
+      // The traversal entry should be listed but its content should NOT be extracted
+      expect(result.content).not.toContain('escaped');
+    });
+  });
+
+  describe('.xlsx extraction', () => {
+    it('extracts cell values from a minimal xlsx', async () => {
+      const sharedStrings =
+        '<?xml version="1.0"?><sst><si><t>Name</t></si><si><t>Alice</t></si></sst>';
+      const sheet =
+        '<?xml version="1.0"?><worksheet><sheetData>' +
+        '<row r="1"><c r="A1" t="s"><v>0</v></c><c r="B1"><v>42</v></c></row>' +
+        '<row r="2"><c r="A2" t="s"><v>1</v></c><c r="B2"><v>99</v></c></row>' +
+        '</sheetData></worksheet>';
+      const xlsx = buildZip([
+        { name: 'xl/sharedStrings.xml', data: Buffer.from(sharedStrings) },
+        { name: 'xl/worksheets/sheet1.xml', data: Buffer.from(sheet) },
+      ]);
+      const filePath = join(tmpDir, 'test.xlsx');
+      await fs.writeFile(filePath, xlsx);
+      const result = await extractDocumentHandler({ file_path: filePath }, signal);
+      expect(result.isError).not.toBe(true);
+      expect(result.content).toContain('Name');
+      expect(result.content).toContain('Alice');
+      expect(result.content).toContain('42');
+      expect(result.content).toContain('99');
+    });
+  });
+
+  describe('.pptx extraction', () => {
+    it('extracts slide text from a minimal pptx', async () => {
+      const slide =
+        '<?xml version="1.0"?><p:sld xmlns:a="urn:a" xmlns:p="urn:p">' +
+        '<p:cSld><p:spTree><p:sp><p:txBody>' +
+        '<a:p><a:r><a:t>Slide Title</a:t></a:r></a:p>' +
+        '</p:txBody></p:sp></p:spTree></p:cSld></p:sld>';
+      const pptx = buildZip([
+        { name: 'ppt/slides/slide1.xml', data: Buffer.from(slide) },
+      ]);
+      const filePath = join(tmpDir, 'test.pptx');
+      await fs.writeFile(filePath, pptx);
+      const result = await extractDocumentHandler({ file_path: filePath }, signal);
+      expect(result.isError).not.toBe(true);
+      expect(result.content).toContain('Slide Title');
+    });
+  });
+
+  describe('.pdf extraction', () => {
+    it('returns install instructions when pdftotext is not available', async () => {
+      // Write a minimal PDF-like binary (just needs the extension to trigger the path)
+      const filePath = join(tmpDir, 'test.pdf');
+      await fs.writeFile(filePath, Buffer.from('%PDF-1.4 fake'));
+      const result = await extractDocumentHandler({ file_path: filePath }, signal);
+      // On CI/test machines without poppler, this should give install instructions
+      // On machines with pdftotext, it may succeed or fail on the fake PDF — both ok
+      expect(result.isError).not.toBe(true);
+      expect(typeof result.content).toBe('string');
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns error for non-existent file', async () => {
+      const result = await extractDocumentHandler(
+        { file_path: join(tmpDir, 'nonexistent.docx') }, signal,
+      );
+      expect(result.isError).toBe(true);
+    });
+
+    it('returns error for invalid zip data with docx extension', async () => {
+      const filePath = join(tmpDir, 'corrupt.docx');
+      await fs.writeFile(filePath, 'not a zip file at all');
+      const result = await extractDocumentHandler({ file_path: filePath }, signal);
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('Not a valid ZIP');
+    });
+  });
+
+  describe('cwd containment', () => {
+    it('rejects paths outside context.cwd', async () => {
+      const context: ToolHandlerContext = { cwd: tmpDir };
+      const result = await extractDocumentHandler(
+        { file_path: '/etc/passwd.docx' }, signal, context,
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatch(/outside.*allowed|not allowed|Access denied/i);
+    });
+
+    it('factory handler uses cwd for containment', async () => {
+      const handler = createExtractDocumentHandler(tmpDir);
+      const result = await handler(
+        { file_path: '/tmp/outside.docx' }, signal,
+      );
+      expect(result.isError).toBe(true);
+    });
+  });
+});

--- a/src/agent/tools/handlers/extract-document.ts
+++ b/src/agent/tools/handlers/extract-document.ts
@@ -1,0 +1,329 @@
+/**
+ * Handler for the `extract_document` tool.
+ *
+ * Extracts text from binary document formats (.docx, .pdf, .xlsx, .pptx, .zip)
+ * that `read_file` rejects at its null-byte check. Zero npm dependencies for
+ * Office formats (OOXML is just zipped XML); PDF delegates to `pdftotext`
+ * (poppler-utils) via subprocess with an explicit argv array — no shell string.
+ *
+ * Security: 4 MB decompression cap, zip-slip path containment, explicit argv
+ * (no shell injection surface), read-only (`category: 'read'`).
+ *
+ * @module agent/tools/handlers/extract-document
+ */
+
+import { promises as fs } from 'fs';
+import { spawn } from 'child_process';
+import { extname, basename, normalize, isAbsolute } from 'path';
+import { createInflateRaw } from 'zlib';
+import type { ToolHandler, ToolHandlerContext } from '../types.js';
+import { resolveAndContain } from './_cwd-utils.js';
+import { fsErrorToToolResult } from './_fs-error.js';
+
+/** Max decompressed bytes before we stop reading (4 MB). */
+const MAX_DECOMPRESSED_BYTES = 4 * 1024 * 1024;
+
+/** Max output text length returned to the model (512 KB of text). */
+const MAX_OUTPUT_CHARS = 512 * 1024;
+
+// ── ZIP Central-Directory parser (minimal, no npm deps) ──────────────
+
+interface ZipEntry {
+  name: string;
+  compressedSize: number;
+  uncompressedSize: number;
+  compressionMethod: number;
+  localHeaderOffset: number;
+}
+
+/**
+ * Parse the ZIP central directory from a buffer. Returns entries in order.
+ * Throws on malformed archives or if the end-of-central-directory record
+ * is not found (not a ZIP file).
+ */
+function parseZipEntries(buf: Buffer): ZipEntry[] {
+  // Find End of Central Directory (EOCD) — scan backwards from end.
+  let eocdOffset = -1;
+  for (let i = buf.length - 22; i >= 0 && i >= buf.length - 65557; i--) {
+    if (buf.readUInt32LE(i) === 0x06054b50) { eocdOffset = i; break; }
+  }
+  if (eocdOffset === -1) throw new Error('Not a valid ZIP file (no EOCD record)');
+
+  const cdOffset = buf.readUInt32LE(eocdOffset + 16);
+  const cdEntries = buf.readUInt16LE(eocdOffset + 10);
+  const entries: ZipEntry[] = [];
+  let pos = cdOffset;
+
+  for (let i = 0; i < cdEntries && pos + 46 <= buf.length; i++) {
+    if (buf.readUInt32LE(pos) !== 0x02014b50) break;
+    const compressionMethod = buf.readUInt16LE(pos + 10);
+    const compressedSize = buf.readUInt32LE(pos + 20);
+    const uncompressedSize = buf.readUInt32LE(pos + 24);
+    const nameLen = buf.readUInt16LE(pos + 28);
+    const extraLen = buf.readUInt16LE(pos + 30);
+    const commentLen = buf.readUInt16LE(pos + 32);
+    const localHeaderOffset = buf.readUInt32LE(pos + 42);
+    const name = buf.subarray(pos + 46, pos + 46 + nameLen).toString('utf-8');
+    entries.push({ name, compressedSize, uncompressedSize, compressionMethod, localHeaderOffset });
+    pos += 46 + nameLen + extraLen + commentLen;
+  }
+  return entries;
+}
+
+/**
+ * Zip-slip guard: reject entry names that escape the archive root.
+ * Rejects absolute paths and `..` traversal.
+ */
+function isSafeZipEntryName(name: string): boolean {
+  if (isAbsolute(name)) return false;
+  const normalized = normalize(name);
+  if (normalized.startsWith('..')) return false;
+  return true;
+}
+
+/**
+ * Extract raw bytes of a single entry from the ZIP buffer.
+ * Handles stored (method 0) and deflated (method 8) entries.
+ */
+async function extractEntryBytes(buf: Buffer, entry: ZipEntry): Promise<Buffer> {
+  if (entry.uncompressedSize > MAX_DECOMPRESSED_BYTES) {
+    throw new Error(`Entry ${entry.name} too large (${entry.uncompressedSize} bytes, cap ${MAX_DECOMPRESSED_BYTES})`);
+  }
+  const lhOff = entry.localHeaderOffset;
+  if (lhOff + 30 > buf.length || buf.readUInt32LE(lhOff) !== 0x04034b50) {
+    throw new Error(`Invalid local header for ${entry.name}`);
+  }
+  const localNameLen = buf.readUInt16LE(lhOff + 26);
+  const localExtraLen = buf.readUInt16LE(lhOff + 28);
+  const dataStart = lhOff + 30 + localNameLen + localExtraLen;
+  const raw = buf.subarray(dataStart, dataStart + entry.compressedSize);
+
+  if (entry.compressionMethod === 0) return Buffer.from(raw);
+  if (entry.compressionMethod === 8) {
+    return new Promise<Buffer>((res, rej) => {
+      const inflate = createInflateRaw();
+      const chunks: Buffer[] = [];
+      let total = 0;
+      inflate.on('data', (chunk: Buffer) => {
+        total += chunk.length;
+        if (total > MAX_DECOMPRESSED_BYTES) { inflate.destroy(); rej(new Error('Decompression cap exceeded')); return; }
+        chunks.push(chunk);
+      });
+      inflate.on('end', () => res(Buffer.concat(chunks)));
+      inflate.on('error', rej);
+      inflate.end(raw);
+    });
+  }
+  throw new Error(`Unsupported compression method ${entry.compressionMethod} for ${entry.name}`);
+}
+
+// ── Format extractors ────────────────────────────────────────────────
+
+/** Strip XML tags and collapse whitespace. Handles <w:t>, <w:p>, etc. */
+function stripXmlToText(xml: string): string {
+  return xml
+    .replace(/<w:p\b[^>]*\/>/g, '\n')          // self-closing paragraphs → newline
+    .replace(/<\/w:p>/g, '\n')                  // paragraph close → newline
+    .replace(/<w:tab\/>/g, '\t')                // tabs
+    .replace(/<w:br[^>]*\/>/g, '\n')            // breaks
+    .replace(/<w:del\b[^>]*>[\s\S]*?<\/w:del>/g, '') // remove tracked deletions
+    .replace(/<[^>]+>/g, '')                    // strip remaining tags
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/\n{3,}/g, '\n\n')                 // collapse triple+ newlines
+    .trim();
+}
+
+async function extractDocx(buf: Buffer): Promise<string> {
+  const entries = parseZipEntries(buf);
+  const docEntry = entries.find(e => e.name === 'word/document.xml');
+  if (!docEntry) return '[Error: word/document.xml not found in .docx archive]';
+  const xml = (await extractEntryBytes(buf, docEntry)).toString('utf-8');
+  return stripXmlToText(xml);
+}
+
+async function extractXlsx(buf: Buffer): Promise<string> {
+  const entries = parseZipEntries(buf);
+  // Read shared strings first
+  const ssEntry = entries.find(e => e.name === 'xl/sharedStrings.xml');
+  const strings: string[] = [];
+  if (ssEntry) {
+    const ssXml = (await extractEntryBytes(buf, ssEntry)).toString('utf-8');
+    const re = /<t[^>]*>([\s\S]*?)<\/t>/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(ssXml)) !== null) strings.push(m[1]!);
+  }
+  // Read each sheet
+  const sheetEntries = entries.filter(e => /^xl\/worksheets\/sheet\d+\.xml$/.test(e.name)).sort();
+  const sheets: string[] = [];
+  for (const se of sheetEntries) {
+    const xml = (await extractEntryBytes(buf, se)).toString('utf-8');
+    const rows: string[] = [];
+    const rowRe = /<row\b[^>]*>([\s\S]*?)<\/row>/g;
+    let rowMatch: RegExpExecArray | null;
+    while ((rowMatch = rowRe.exec(xml)) !== null) {
+      const cells: string[] = [];
+      const cellRe = /<c\b([^>]*)>([\s\S]*?)<\/c>/g;
+      let cellMatch: RegExpExecArray | null;
+      while ((cellMatch = cellRe.exec(rowMatch[1]!)) !== null) {
+        const attrs = cellMatch[1]!;
+        const inner = cellMatch[2]!;
+        const valMatch = inner.match(/<v>([\s\S]*?)<\/v>/);
+        if (!valMatch) { cells.push(''); continue; }
+        const val = valMatch[1]!;
+        // t="s" → shared string index; otherwise literal value
+        cells.push(attrs.includes('t="s"') ? (strings[parseInt(val, 10)] ?? val) : val);
+      }
+      rows.push(cells.join('\t'));
+    }
+    sheets.push(`--- ${basename(se.name)} ---\n${rows.join('\n')}`);
+  }
+  return sheets.join('\n\n') || '[No sheet data found]';
+}
+
+async function extractPptx(buf: Buffer): Promise<string> {
+  const entries = parseZipEntries(buf);
+  const slideEntries = entries.filter(e => /^ppt\/slides\/slide\d+\.xml$/.test(e.name)).sort();
+  const slides: string[] = [];
+  for (const se of slideEntries) {
+    const xml = (await extractEntryBytes(buf, se)).toString('utf-8');
+    const text = stripXmlToText(xml);
+    if (text) slides.push(`--- Slide ${slides.length + 1} ---\n${text}`);
+  }
+  return slides.join('\n\n') || '[No slide text found]';
+}
+
+async function extractZip(buf: Buffer): Promise<string> {
+  const entries = parseZipEntries(buf);
+  const lines = [`Archive contains ${entries.length} entries:\n`];
+  const textEntries: { name: string; text: string }[] = [];
+  for (const e of entries) {
+    const sizeInfo = e.uncompressedSize > 0 ? ` (${e.uncompressedSize} bytes)` : '';
+    lines.push(`  ${e.name}${sizeInfo}`);
+    if (e.name.endsWith('/') || !isSafeZipEntryName(e.name)) continue;
+    // Extract text-like members (by extension)
+    const ext = extname(e.name).toLowerCase();
+    if (['.txt', '.md', '.csv', '.json', '.xml', '.html', '.yml', '.yaml', '.log', '.ini', '.cfg', '.toml'].includes(ext)) {
+      if (e.uncompressedSize <= MAX_DECOMPRESSED_BYTES) {
+        try {
+          const data = await extractEntryBytes(buf, e);
+          // Quick binary check (null bytes in first 1KB)
+          const check = Math.min(1024, data.length);
+          let isBinary = false;
+          for (let i = 0; i < check; i++) { if (data[i] === 0) { isBinary = true; break; } }
+          if (!isBinary) textEntries.push({ name: e.name, text: data.toString('utf-8') });
+        } catch { /* skip unextractable entries */ }
+      }
+    }
+  }
+  if (textEntries.length > 0) {
+    lines.push('\n--- Text file contents ---');
+    for (const te of textEntries) {
+      lines.push(`\n=== ${te.name} ===\n${te.text}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+async function extractPdf(filePath: string, signal: AbortSignal): Promise<string> {
+  return new Promise<string>((res, rej) => {
+    // Explicit argv array — no shell string, no injection surface.
+    const child = spawn('pdftotext', [filePath, '-'], { stdio: ['ignore', 'pipe', 'pipe'], signal });
+    const chunks: Buffer[] = [];
+    let total = 0;
+    child.stdout.on('data', (chunk: Buffer) => {
+      total += chunk.length;
+      if (total <= MAX_DECOMPRESSED_BYTES) chunks.push(chunk);
+    });
+    let stderr = '';
+    child.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString(); });
+    child.on('error', (err: NodeJS.ErrnoException) => {
+      if (err.code === 'ENOENT') {
+        res('[pdftotext not found. Install poppler-utils to extract PDF text:\n' +
+          '  macOS:  brew install poppler\n' +
+          '  Linux:  apt install poppler-utils (or yum install poppler-utils)\n]');
+      } else {
+        rej(err);
+      }
+    });
+    child.on('close', (code) => {
+      if (code !== 0) { res(`[pdftotext failed (exit ${code}): ${stderr.trim()}]`); return; }
+      const text = Buffer.concat(chunks).toString('utf-8').trim();
+      res(text || '[PDF contains no extractable text (may be image-only)]');
+    });
+  });
+}
+
+// ── Main handler ─────────────────────────────────────────────────────
+
+const SUPPORTED_EXTS = new Set(['.docx', '.pdf', '.xlsx', '.pptx', '.zip']);
+
+const extractDocumentImpl = async (
+  input: unknown,
+  signal: AbortSignal,
+  context: ToolHandlerContext | undefined,
+  cwd: string | undefined,
+) => {
+  if (!input || typeof input !== 'object') {
+    return { content: 'Invalid input: expected an object', isError: true };
+  }
+  const obj = input as Record<string, unknown>;
+  const rawPath = obj['file_path'];
+  if (typeof rawPath !== 'string') {
+    return { content: 'Invalid input: file_path must be a string', isError: true };
+  }
+
+  let filePath: string;
+  try {
+    filePath = resolveAndContain(rawPath, context, 'read', cwd);
+  } catch (err) {
+    return { content: err instanceof Error ? err.message : String(err), isError: true };
+  }
+
+  const ext = extname(filePath).toLowerCase();
+  if (!SUPPORTED_EXTS.has(ext)) {
+    return {
+      content: `Unsupported format "${ext}". extract_document supports: ${[...SUPPORTED_EXTS].join(', ')}`,
+      isError: true,
+    };
+  }
+
+  try {
+    // PDF uses subprocess — no buffer read needed
+    if (ext === '.pdf') {
+      const text = await extractPdf(filePath, signal);
+      return { content: text.length > MAX_OUTPUT_CHARS ? text.slice(0, MAX_OUTPUT_CHARS) + '\n\n[… truncated]' : text };
+    }
+
+    // All other formats are ZIP-based — read into buffer
+    const stat = await fs.stat(filePath);
+    if (stat.size > MAX_DECOMPRESSED_BYTES * 2) {
+      return { content: `File too large (${stat.size} bytes). Max supported: ${MAX_DECOMPRESSED_BYTES * 2} bytes.`, isError: true };
+    }
+    const buf = await fs.readFile(filePath);
+
+    let text: string;
+    switch (ext) {
+      case '.docx': text = await extractDocx(buf); break;
+      case '.xlsx': text = await extractXlsx(buf); break;
+      case '.pptx': text = await extractPptx(buf); break;
+      case '.zip':  text = await extractZip(buf);  break;
+      default:      text = '[Unsupported format]';  break;
+    }
+    return { content: text.length > MAX_OUTPUT_CHARS ? text.slice(0, MAX_OUTPUT_CHARS) + '\n\n[… truncated]' : text };
+  } catch (err) {
+    const known = fsErrorToToolResult(err, filePath, 'File');
+    if (known) return known;
+    if (err instanceof Error) return { content: `Error extracting document: ${err.message}`, isError: true };
+    return { content: 'Unknown error extracting document', isError: true };
+  }
+};
+
+export function createExtractDocumentHandler(cwd?: string): ToolHandler {
+  return (input, signal, context) => extractDocumentImpl(input, signal, context, cwd);
+}
+
+export const extractDocumentHandler: ToolHandler = createExtractDocumentHandler();

--- a/src/agent/tools/handlers/index.test.ts
+++ b/src/agent/tools/handlers/index.test.ts
@@ -5,7 +5,7 @@ import { BUILTIN_TOOL_NAMES } from '../schemas.js';
 describe('createBuiltinHandlers', () => {
   it('returns a Map with all 22 built-in tools', () => {
     const handlers = createBuiltinHandlers();
-    expect(handlers.size).toBe(25);
+    expect(handlers.size).toBe(26);
   });
 
   it('has an entry for every tool in BUILTIN_TOOL_NAMES', () => {
@@ -27,7 +27,7 @@ describe('createBuiltinHandlers', () => {
     // when permissionMode is undefined but cwd is set. Ensure we get a
     // valid map back and bash is still callable.
     const handlers = createBuiltinHandlers(undefined, '/tmp');
-    expect(handlers.size).toBe(25);
+    expect(handlers.size).toBe(26);
     expect(typeof handlers.get('bash')).toBe('function');
     expect(typeof handlers.get('grep')).toBe('function');
     expect(typeof handlers.get('glob')).toBe('function');
@@ -35,7 +35,7 @@ describe('createBuiltinHandlers', () => {
 
   it('cwd parameter: builds handler set with both permissionMode and cwd', () => {
     const handlers = createBuiltinHandlers('default', '/tmp');
-    expect(handlers.size).toBe(25);
+    expect(handlers.size).toBe(26);
     expect(typeof handlers.get('bash')).toBe('function');
   });
 

--- a/src/agent/tools/handlers/index.ts
+++ b/src/agent/tools/handlers/index.ts
@@ -10,6 +10,7 @@
 import type { ToolHandler } from '../types.js';
 import { bashHandler, createBashHandler } from './bash.js';
 import { readFileHandler, createReadFileHandler } from './read-file.js';
+import { extractDocumentHandler, createExtractDocumentHandler } from './extract-document.js';
 import { writeFileHandler, createWriteFileHandler } from './write-file.js';
 import { editFileHandler, createEditFileHandler } from './edit-file.js';
 import { globHandler, createGlobHandler } from './glob.js';
@@ -69,6 +70,7 @@ export function createBuiltinHandlers(
   // (issue #434) — parity with glob/grep. No-op on the dispatcher path, where
   // context.resolveBase already carries this same value.
   const readFile = cwd !== undefined ? createReadFileHandler(cwd) : readFileHandler;
+  const extractDocument = cwd !== undefined ? createExtractDocumentHandler(cwd) : extractDocumentHandler;
   const writeFile = cwd !== undefined ? createWriteFileHandler(cwd) : writeFileHandler;
   const editFile = cwd !== undefined ? createEditFileHandler(cwd) : editFileHandler;
   const listDirectory = cwd !== undefined ? createListDirectoryHandler(cwd) : listDirectoryHandler;
@@ -77,6 +79,7 @@ export function createBuiltinHandlers(
   return new Map<string, ToolHandler>([
     ['bash', bash],
     ['read_file', readFile],
+    ['extract_document', extractDocument],
     ['write_file', writeFile],
     ['edit_file', editFile],
     ['glob', glob],
@@ -106,6 +109,7 @@ export function createBuiltinHandlers(
 export {
   bashHandler,
   readFileHandler,
+  extractDocumentHandler,
   writeFileHandler,
   editFileHandler,
   globHandler,

--- a/src/agent/tools/handlers/read-file.ts
+++ b/src/agent/tools/handlers/read-file.ts
@@ -76,7 +76,7 @@ const readFileImpl = async (
     const checkSize = Math.min(8192, buffer.length);
     for (let i = 0; i < checkSize; i++) {
       if (buffer[i] === 0) {
-        return { content: `File appears to be binary: ${filePath}`, isError: true };
+        return { content: `File appears to be binary: ${filePath}. Use extract_document for .docx, .pdf, .xlsx, .pptx, and .zip files.`, isError: true };
       }
     }
 

--- a/src/agent/tools/schemas.test.ts
+++ b/src/agent/tools/schemas.test.ts
@@ -15,6 +15,7 @@ describe('builtinToolSchemas', () => {
     expect(BUILTIN_TOOL_NAMES).toEqual([
       'bash',
       'read_file',
+      'extract_document',
       'write_file',
       'edit_file',
       'glob',

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -54,7 +54,7 @@ export const readFileTool: AnthropicToolDef = {
     'Read a file from the filesystem. Returns the file content with line numbers. ' +
     'Use offset and limit to read specific sections of large files. ' +
     'When the read returns a partial view, the response ends with a `... (showing lines X-Y of Z [— pass offset=N to continue])` annotation indicating the full file size and how to continue. ' +
-    'Binary files are detected and rejected. Missing files return an error.',
+    'Binary files are detected and rejected — use extract_document for .docx, .pdf, .xlsx, .pptx, and .zip files. Missing files return an error.',
   input_schema: {
     type: 'object',
     properties: {
@@ -69,6 +69,31 @@ export const readFileTool: AnthropicToolDef = {
       limit: {
         type: 'number',
         description: 'Maximum number of lines to read. Defaults to 2000.',
+      },
+    },
+    required: ['file_path'],
+  },
+};
+
+export const extractDocumentTool: AnthropicToolDef = {
+  name: 'extract_document',
+  category: 'read',
+  concurrencySafe: true,
+  description:
+    'Extract text from binary document formats that read_file rejects. ' +
+    'Supports .docx, .xlsx, .pptx (Office/OOXML — zero external dependencies), ' +
+    '.pdf (requires pdftotext from poppler-utils; emits install instructions if missing), ' +
+    'and .zip (lists members and extracts text-file contents). ' +
+    'Use this when read_file reports "File appears to be binary" on a document you need to read. ' +
+    'Returns plain text extracted from the document. ' +
+    'Security: 4 MB decompression cap, zip-slip path containment, no shell execution. ' +
+    'Output is capped at 512 KB of text; larger documents are truncated with a marker.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      file_path: {
+        type: 'string',
+        description: 'Absolute path to the document file to extract text from.',
       },
     },
     required: ['file_path'],
@@ -1293,6 +1318,7 @@ export const browserCloseTool: AnthropicToolDef = {
 export const builtinToolSchemas: readonly AnthropicToolDef[] = [
   bashTool,
   readFileTool,
+  extractDocumentTool,
   writeFileTool,
   editFileTool,
   globTool,


### PR DESCRIPTION
## Summary

Adds a first-class `extract_document` tool for cross-platform text extraction from binary document formats — closing the gap where `read_file` rejects `.docx`/`.pdf`/`.xlsx`/`.pptx`/`.zip` files and the only workaround was macOS-only `textutil`.

Closes #660

## What changed

### New tool: `extract_document`
- **Handler**: `src/agent/tools/handlers/extract-document.ts` (328 lines)
- **Schema**: registered in `schemas.ts` as `category: 'read'`, `concurrencySafe: true`
- **Tool category**: added to `READ_TOOLS` and `READ_ONLY_PHASE_TOOLS` in `tool-category.ts`
- **Handler registry**: registered in `handlers/index.ts` with factory + singleton pattern

### Format support

| Format | Method | External deps |
|--------|--------|---------------|
| `.docx` | Node zlib → unzip `word/document.xml` → XML text extraction | None |
| `.xlsx` | Node zlib → shared strings + sheet XML parsing | None |
| `.pptx` | Node zlib → slide XML text extraction | None |
| `.pdf` | `pdftotext` subprocess via explicit `spawn` argv | `poppler-utils` (optional; clear install message) |
| `.zip` | Member listing + selective text-file extraction | None |

### Security
- 4 MB decompression cap (prevents zip bombs)
- Zip-slip path containment (rejects `../` traversal and absolute paths)
- No shell strings — PDF uses `child_process.spawn` with explicit argv array
- `resolveAndContain` for cwd-based path containment (same as `read_file`)

### UX improvement
- `read_file`'s binary rejection message now says: _"File appears to be binary: {path}. Use extract_document for .docx, .pdf, .xlsx, .pptx, and .zip files."_
- `read_file` schema description updated to mention `extract_document`
- The model sees `extract_document` in the tool list every session — no procedure/skill recall needed

### Design decisions (from devil's-advocate critique)
The original proposal was a bash script + procedure. Three adversarial critics (pragmatist, paranoid, architect) all returned **strong** alternatives pointing to a first-class tool:
1. **Pragmatist**: a bash script adds a deployment artifact; a procedure is cheaper but loses consistency
2. **Paranoid**: `unzip` is in the readonly-bash denylist (`readonly-bash.ts`); shell injection risk on file paths; sed XML stripping is unreliable on real Word docs
3. **Architect**: a first-class tool appears in the schema every session (zero recall tax), follows the established handler pattern, and handles OOXML extension scalability (.xlsx/.pptx) for free

## Tests
- 16 new tests in `extract-document.test.ts` covering:
  - Input validation (missing input, missing path, unsupported format)
  - `.docx` extraction (basic, tracked deletions, XML entities, missing document.xml)
  - `.xlsx` extraction (shared strings, cell values)
  - `.pptx` extraction (slide text)
  - `.pdf` extraction (pdftotext availability)
  - `.zip` extraction (member listing, text extraction, zip-slip rejection)
  - Error handling (non-existent file, corrupt archive)
  - cwd containment (context-based and factory-based)
- Updated `schemas.test.ts` (tool count 25 → 26, name list)
- Updated `index.test.ts` (handler map size 25 → 26)

## CI gates
All passing locally: `pnpm lint`, `pnpm audit:filesize:check`, `pnpm audit:sdk:check`, `pnpm scan:env:check`, `pnpm audit:env:check`, `pnpm audit:chalk:check`, `pnpm fix:pins:check`

Note: `write-denylist.test.ts` has 1 pre-existing failure (symlink repoint test) confirmed on clean HEAD — not related to this change.
