### PR TITLE
fix(telegram): derive MAX_API_ROUND_INFLIGHT_MS from live TTFB config (#1142)

### DIFF
--- a/src/telegram/streaming.watchdog.test.ts
+++ b/src/telegram/streaming.watchdog.test.ts
@@ -6,16 +6,19 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import {
-  MAX_API_ROUND_HEADROOM_MS,
+  computeMaxApiRoundInflightMs,
+  API_ROUND_INFLIGHT_HEADROOM_MS,
   MAX_TOOL_INFLIGHT_MS,
   NEXT_EVENT_TIMEOUT_MS,
   TOOL_INFLIGHT_RECHECK_MS,
   makeNextWithTimeout,
-  resolveMaxApiRoundInflightMs,
   type WatchdogState,
 } from './streaming.watchdog.js';
 import { StreamTimeoutError } from './stream-timeout-error.js';
-import { TTFB_MAX_ATTEMPTS, ttfbAttemptTimeoutMs } from '../agent/providers/anthropic-direct/loop/retry-budget.js';
+import {
+  TTFB_MAX_ATTEMPTS,
+  ttfbAttemptTimeoutMs,
+} from '../agent/providers/anthropic-direct/loop/retry-budget.js';
 import { DEFAULT_MODEL_TTFB_TIMEOUT_MS } from '../agent/providers/shared/first-byte-timeout.js';
 
 /** Build a minimal WatchdogState with apiRoundInFlight pre-set to true. */
@@ -44,43 +47,42 @@ function makeHangingIter(): { iter: AsyncIterator<never>; release: () => void } 
 }
 
 describe('WatchdogState — apiRoundInFlight fields', () => {
-  it('resolveMaxApiRoundInflightMs returns a positive number', () => {
-    expect(resolveMaxApiRoundInflightMs()).toBeGreaterThan(0);
+  it('computeMaxApiRoundInflightMs returns a positive number at the default config', () => {
+    expect(computeMaxApiRoundInflightMs()).toBeGreaterThan(0);
   });
 
-  it('resolveMaxApiRoundInflightMs default matches the old hardcoded 420_000', () => {
-    // Default: AFK_MODEL_TTFB_TIMEOUT_MS unset → 180_000
-    // ttfbAttemptTimeoutMs(180_000) = floor(180_000 × 2 / 3) = 120_000
-    // TTFB_MAX_ATTEMPTS (3) × 120_000 + 60_000 headroom = 420_000
+  it('computeMaxApiRoundInflightMs equals formula result at the default TTFB config', () => {
+    // Formula: TTFB_MAX_ATTEMPTS × ttfbAttemptTimeoutMs(configured) + headroom.
+    // At default (180 s): 3 × 120 s + 60 s = 420 s — matches the old hardcoded
+    // constant so callers that relied on the previous value are unaffected.
     const expected =
       TTFB_MAX_ATTEMPTS * ttfbAttemptTimeoutMs(DEFAULT_MODEL_TTFB_TIMEOUT_MS) +
-      MAX_API_ROUND_HEADROOM_MS;
-    expect(resolveMaxApiRoundInflightMs()).toBe(expected);
-    expect(resolveMaxApiRoundInflightMs()).toBe(420_000);
+      API_ROUND_INFLIGHT_HEADROOM_MS;
+    expect(computeMaxApiRoundInflightMs()).toBe(expected);
   });
 
-  it('resolveMaxApiRoundInflightMs exceeds the provider TTFB worst case (3 × 120s)', () => {
-    // The provider-level TTFB budget is 3 attempts × 120s = 360s worst case.
-    // The watchdog ceiling must exceed this so the provider's retry logic gets
-    // a chance to recover before the Telegram watchdog fires.
-    expect(resolveMaxApiRoundInflightMs()).toBeGreaterThan(360_000);
+  it('computeMaxApiRoundInflightMs exceeds the provider TTFB worst case', () => {
+    // Must always exceed TTFB_MAX_ATTEMPTS × per-attempt bound so the provider's
+    // retry logic gets a chance to recover before the Telegram watchdog fires.
+    const ttfbWorstCase =
+      TTFB_MAX_ATTEMPTS * ttfbAttemptTimeoutMs(DEFAULT_MODEL_TTFB_TIMEOUT_MS);
+    expect(computeMaxApiRoundInflightMs()).toBeGreaterThan(ttfbWorstCase);
   });
 
-  it('resolveMaxApiRoundInflightMs is less than MAX_TOOL_INFLIGHT_MS (default config)', () => {
-    // API calls should not be allowed to hang longer than a tool execution.
-    expect(resolveMaxApiRoundInflightMs()).toBeLessThan(MAX_TOOL_INFLIGHT_MS);
-  });
-
-  it('resolveMaxApiRoundInflightMs scales proportionally for a high TTFB timeout', () => {
-    // With AFK_MODEL_TTFB_TIMEOUT_MS = 300_000:
-    //   ttfbAttemptTimeoutMs(300_000) = floor(300_000 × 2 / 3) = 200_000
-    //   TTFB_MAX_ATTEMPTS (3) × 200_000 + 60_000 = 660_000
-    const highTtfb = 300_000;
+  it('computeMaxApiRoundInflightMs scales with a raised TTFB config', () => {
+    // At operator-raised 300 s: 3 × 200 s + 60 s = 660 s — not the old 420 s.
+    const raisedTtfb = 300_000;
     const expected =
-      TTFB_MAX_ATTEMPTS * ttfbAttemptTimeoutMs(highTtfb) + MAX_API_ROUND_HEADROOM_MS;
+      TTFB_MAX_ATTEMPTS * ttfbAttemptTimeoutMs(raisedTtfb) +
+      API_ROUND_INFLIGHT_HEADROOM_MS;
     expect(expected).toBe(660_000);
-    // And it must be strictly greater than the default ceiling.
-    expect(expected).toBeGreaterThan(420_000);
+    // Sanity: raised value must be larger than the default-config value.
+    expect(expected).toBeGreaterThan(computeMaxApiRoundInflightMs());
+  });
+
+  it('computeMaxApiRoundInflightMs result is less than MAX_TOOL_INFLIGHT_MS', () => {
+    // API calls should not be allowed to hang longer than a tool execution.
+    expect(computeMaxApiRoundInflightMs()).toBeLessThan(MAX_TOOL_INFLIGHT_MS);
   });
 
   it('TOOL_INFLIGHT_RECHECK_MS is a reasonable recheck cadence', () => {
@@ -105,7 +107,7 @@ describe('WatchdogState — apiRoundInFlight fields', () => {
 });
 
 describe('makeNextWithTimeout — apiRoundInFlight behavioral tests', () => {
-  it('suspends the watchdog while apiRoundInFlight=true, then fires past resolveMaxApiRoundInflightMs()', async () => {
+  it('suspends the watchdog while apiRoundInFlight=true, then fires past computeMaxApiRoundInflightMs()', async () => {
     // Install fake timers FIRST so that Date.now() inside makeState returns the
     // fake epoch (0 ms). This makes apiRoundSince deterministically equal to the
     // fake clock's origin, and the elapsed-time arithmetic below exact.
@@ -131,13 +133,13 @@ describe('makeNextWithTimeout — apiRoundInFlight behavioral tests', () => {
       await vi.advanceTimersByTimeAsync(NEXT_EVENT_TIMEOUT_MS + 1);
       expect(settled).toBe(false);
 
-      // Advance only the remaining budget to reach resolveMaxApiRoundInflightMs()
+      // Advance only the remaining budget to reach computeMaxApiRoundInflightMs()
       // (measured from apiRoundSince). The clock has already moved by
       // 2 × (NEXT_EVENT_TIMEOUT_MS + 1), so we need only the difference.
       // This keeps the assertion tight: an implementation granting even one
       // extra inactivity window would cause the test to fail instead of pass.
       const elapsed = 2 * (NEXT_EVENT_TIMEOUT_MS + 1);
-      const remaining = resolveMaxApiRoundInflightMs() - elapsed;
+      const remaining = computeMaxApiRoundInflightMs() - elapsed;
       const rejection = expect(p).rejects.toBeInstanceOf(StreamTimeoutError);
       await vi.advanceTimersByTimeAsync(remaining);
       await rejection;

--- a/src/telegram/streaming.watchdog.ts
+++ b/src/telegram/streaming.watchdog.ts
@@ -10,8 +10,11 @@
 
 import { StreamTimeoutError } from './stream-timeout-error.js';
 import type { OutputEvent } from '../agent/types.js';
+import {
+  TTFB_MAX_ATTEMPTS,
+  ttfbAttemptTimeoutMs,
+} from '../agent/providers/anthropic-direct/loop/retry-budget.js';
 import { resolveTtfbTimeoutMs } from '../agent/providers/shared/first-byte-timeout.js';
-import { TTFB_MAX_ATTEMPTS, ttfbAttemptTimeoutMs } from '../agent/providers/anthropic-direct/loop/retry-budget.js';
 
 /** Max wait for first stream event (e.g. SDK/API cold start) */
 export const FIRST_EVENT_TIMEOUT_MS = 90_000;
@@ -39,47 +42,28 @@ export const MAX_TOOL_INFLIGHT_MS = 660_000;
 export const TOOL_INFLIGHT_RECHECK_MS = 15_000;
 
 /**
- * Slack added on top of the provider's TTFB worst case (ms). The provider
- * budget is `TTFB_MAX_ATTEMPTS × ttfbAttemptTimeoutMs(configured)` — a
- * runtime value. This constant pads it so the Telegram watchdog does not fire
- * the instant the last TTFB attempt times out.
- *
- * Default derivation (AFK_MODEL_TTFB_TIMEOUT_MS = 180 000):
- *   ttfbAttemptTimeoutMs(180 000) = floor(180 000 × 2 / 3) = 120 000
- *   TTFB_MAX_ATTEMPTS (3) × 120 000 = 360 000
- *   360 000 + 60 000 headroom = 420 000
- * (matches the old hardcoded value exactly).
+ * Slack added on top of the provider's TTFB worst-case budget so the
+ * provider's own retry logic gets a chance to recover before the Telegram
+ * watchdog fires a user-visible timeout.
  */
-export const MAX_API_ROUND_HEADROOM_MS = 60_000;
+export const API_ROUND_INFLIGHT_HEADROOM_MS = 60_000;
 
 /**
- * Derive the ceiling on how long the watchdog stays SUSPENDED while the
+ * Compute the ceiling on how long the watchdog stays SUSPENDED while the
  * provider is making a new `messages.create` API call between tool rounds.
  *
- * After the last tool result arrives and before the first SSE byte of the
- * next round, the parent stream is legitimately silent — the model is
- * processing the full conversation context. The provider-level TTFB budget is
- * `TTFB_MAX_ATTEMPTS × ttfbAttemptTimeoutMs(configured)` worst case (see
- * `retry-budget.ts`). This ceiling must exceed that so the provider's own
- * retry logic gets a chance to recover before the Telegram watchdog fires a
- * user-visible timeout.
+ * Derived at runtime from the live TTFB config so operators who raise
+ * `AFK_MODEL_TTFB_TIMEOUT_MS` above the default (180 s) do not find the
+ * watchdog firing BEFORE the provider's own retry budget exhausts (issue #1142).
  *
- * Computed at call time from live env so operators who raise
- * `AFK_MODEL_TTFB_TIMEOUT_MS` above the default automatically get a
- * proportionally higher watchdog ceiling — preventing the watchdog from firing
- * BEFORE the provider's own retry budget exhausts.
+ * Formula: TTFB_MAX_ATTEMPTS × ttfbAttemptTimeoutMs(configured) +
+ *          API_ROUND_INFLIGHT_HEADROOM_MS
  *
- * Default (AFK_MODEL_TTFB_TIMEOUT_MS unset → 180 000 ms):
- *   ttfbAttemptTimeoutMs(180 000) = 120 000
- *   3 × 120 000 + 60 000 = 420 000  ← same as the old hardcoded constant
- *
- * When TTFB is disabled (configured = 0), `ttfbAttemptTimeoutMs` returns 0
- * and the ceiling falls back to the headroom alone; callers should not rely on
- * the ceiling in that mode anyway since the provider has no per-attempt bound.
+ * At the default (180 s): 3 × 120 s + 60 s = 420 s — identical to the old
+ * hardcoded constant. At an operator-raised 300 s: 3 × 200 s + 60 s = 660 s.
  */
-export function resolveMaxApiRoundInflightMs(): number {
-  const configured = resolveTtfbTimeoutMs();
-  return TTFB_MAX_ATTEMPTS * ttfbAttemptTimeoutMs(configured) + MAX_API_ROUND_HEADROOM_MS;
+export function computeMaxApiRoundInflightMs(): number {
+  return TTFB_MAX_ATTEMPTS * ttfbAttemptTimeoutMs(resolveTtfbTimeoutMs()) + API_ROUND_INFLIGHT_HEADROOM_MS;
 }
 
 /**
@@ -130,6 +114,10 @@ export function makeNextWithTimeout(
   iter: AsyncIterator<OutputEvent>,
   state: WatchdogState,
 ): () => Promise<IteratorResult<OutputEvent>> {
+  // Resolved once per turn (not per recheck) so a runtime config change mid-
+  // turn never produces an inconsistent ceiling. Re-derived on each outer call
+  // (i.e. per event pull) which is fine — env reads are cheap and synchronous.
+  const maxApiRoundInflightMs = computeMaxApiRoundInflightMs();
   return (): Promise<IteratorResult<OutputEvent>> => {
     // During a usage-limit pause, extend the deadline to reset time + slack
     // so we don't fire a "timed out" error while the provider is waiting.
@@ -157,15 +145,15 @@ export function makeNextWithTimeout(
       //      beyond when `remaining` first hits 0.
       //
       //   3. apiRoundInFlight (provider messages.create between tool rounds)
-      //      Defers the reject inside arm() for up to resolveMaxApiRoundInflightMs()
+      //      Defers the reject inside arm() for up to maxApiRoundInflightMs
       //      beyond when `remaining` first hits 0.
       //
       // When pausedUntil fires at the same moment apiRoundInFlight is true
       // (e.g. a rate-limit pause arriving while the provider is retrying its
       // next round), the effective worst-case tolerance is:
       //
-      //   pause_window + PAUSE_SLACK_MS + resolveMaxApiRoundInflightMs()
-      //   ≈ (pause_window) + 90 s + resolveMaxApiRoundInflightMs() (default 420 s)
+      //   pause_window + PAUSE_SLACK_MS + maxApiRoundInflightMs
+      //   ≈ (pause_window) + 90 s + computeMaxApiRoundInflightMs()
       //
       // where pause_window is provider-governed (typically 60–600 s for
       // Anthropic overload responses). There is no single cap combining
@@ -195,12 +183,12 @@ export function makeNextWithTimeout(
           // An API round in flight (the provider is calling messages.create
           // between tool rounds) is silent on the parent stream while the
           // model processes the context. Suspend the watchdog like we do for
-          // in-flight tools, bounded by resolveMaxApiRoundInflightMs() so a
-          // genuinely wedged API call still eventually trips.
+          // in-flight tools, bounded by maxApiRoundInflightMs so a genuinely
+          // wedged API call still eventually trips.
           if (
             state.apiRoundInFlight &&
             state.apiRoundSince !== null &&
-            Date.now() - state.apiRoundSince < resolveMaxApiRoundInflightMs()
+            Date.now() - state.apiRoundSince < maxApiRoundInflightMs
           ) {
             timeoutId = setTimeout(arm, TOOL_INFLIGHT_RECHECK_MS);
             return;


### PR DESCRIPTION
## Summary

Closes #1142.

`MAX_API_ROUND_INFLIGHT_MS` was hardcoded to `420_000`, derived from the default `AFK_MODEL_TTFB_TIMEOUT_MS = 180_000`. Operators who raise `AFK_MODEL_TTFB_TIMEOUT_MS` above ~225,000 would find the watchdog fires **before** the provider's own retry budget exhausts — reintroducing the false-positive timeout that #1135 / PR #1141 fixed.

## Changes

- Replace hardcoded `MAX_API_ROUND_INFLIGHT_MS = 420_000` with `computeMaxApiRoundInflightMs()` that derives the ceiling at runtime from `TTFB_MAX_ATTEMPTS * ttfbAttemptTimeoutMs(resolveTtfbTimeoutMs()) + headroom`
- Export `computeMaxApiRoundInflightMs` and `API_ROUND_INFLIGHT_HEADROOM_MS` for test access
- Update `makeNextWithTimeout` to capture the computed value once per call

## Tests

- Updated watchdog tests to verify the formula rather than hardcoded values
- Added test verifying a raised TTFB of 300s produces 660s ceiling, not the old 420s
