### PR TITLE
fix(daemon): parsePortFile rejects bracketed IPv6 and out-of-range ports (#1165)

### DIFF
--- a/src/agent/daemon/http-client.test.ts
+++ b/src/agent/daemon/http-client.test.ts
@@ -31,4 +31,20 @@ describe('parsePortFile', () => {
   it('"" → null', () => {
     expect(parsePortFile('')).toBeNull();
   });
+
+  it('"[::1]:7777" → { host: "::1", port: 7777 } (brackets stripped)', () => {
+    expect(parsePortFile('[::1]:7777')).toEqual({ host: '::1', port: 7777 });
+  });
+
+  it('"0" → null (port below valid range)', () => {
+    expect(parsePortFile('0')).toBeNull();
+  });
+
+  it('"65536" → null (port above valid range)', () => {
+    expect(parsePortFile('65536')).toBeNull();
+  });
+
+  it('"0.0.0.0:7777" → { host: "0.0.0.0", port: 7777 } (accepted)', () => {
+    expect(parsePortFile('0.0.0.0:7777')).toEqual({ host: '0.0.0.0', port: 7777 });
+  });
 });

--- a/src/agent/daemon/http-client.ts
+++ b/src/agent/daemon/http-client.ts
@@ -111,5 +111,9 @@ export function parsePortFile(raw: string): { host: string; port: number } | nul
   // Reject degenerate hosts that are only colons (e.g. "::" from splitting "::1").
   // A valid host must contain at least one non-colon character.
   if (/^:+$/.test(host)) return null;
-  return { host, port };
+  // Strip surrounding brackets from bracketed IPv6 literals (e.g. "[::1]" → "::1").
+  // trySyncToDaemon re-adds brackets when building the URL, so double-bracketing
+  // ([[::1]]) would cause a TypeError — strip here to keep the stored host clean.
+  const cleanHost = host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host;
+  return { host: cleanHost, port };
 }


### PR DESCRIPTION
## Summary

Closes #1165.

`parsePortFile('[::1]:7777')` returned `{ host: '[::1]', port: 7777 }` instead of stripping the brackets. The subsequent URL construction in `trySyncToDaemon` double-brackets it (`[[::1]]`), producing a `TypeError` on `fetch`. Schedule live-sync operations appear to succeed locally but the daemon never receives them.

## Changes

- Strip brackets from parsed IPv6 host in `parsePortFile` (Option B from the issue — more tolerant)
- Port-range validation was already in place

## Tests

Added the four missing test cases:
- `'[::1]:7777'` → stripped to `{ host: '::1', port: 7777 }`
- `'0'` → `null` (port below range)
- `'65536'` → `null` (port above range)
- `'0.0.0.0:7777'` → `{ host: '0.0.0.0', port: 7777 }` (accepted)
