### PR TITLE
chore(daemon): harden portHasOwner — execFileSync, permission-denied, IPv6 guard (#1167)

### DIFF
--- a/src/agent/daemon.listen.test.ts
+++ b/src/agent/daemon.listen.test.ts
@@ -3,39 +3,49 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { networkInterfaces } from 'node:os';
 
 // vi.mock is hoisted above imports — must appear before any other import.
 vi.mock('node:child_process', async (importActual) => {
   const actual = await importActual<typeof import('node:child_process')>();
   return {
     ...actual,
-    execSync: vi.fn(actual.execSync),
+    execFileSync: vi.fn(actual.execFileSync),
   };
 });
 
-import { execSync } from 'node:child_process';
-import { createServer, type Server } from 'node:http';
+import { execFileSync } from 'node:child_process';
+import { createServer as createHttpServer, type Server as HttpServer } from 'node:http';
 import { listenWithRecovery, closeServer } from './daemon.listen.js';
 
-const mockExecSync = vi.mocked(execSync);
+const mockExecFileSync = vi.mocked(execFileSync);
+
+/** Return true when this host has an IPv6 loopback interface (::1). */
+function hasIPv6Loopback(): boolean {
+  return Object.values(networkInterfaces())
+    .flat()
+    .some((iface) => iface?.family === 'IPv6' && iface.address === '::1');
+}
+
+const IPV6_AVAILABLE = hasIPv6Loopback();
 
 // Track servers to close in afterEach to prevent port leaks
-let servers: Server[] = [];
+let servers: HttpServer[] = [];
 
-function tracked(s: Server): Server {
+function tracked(s: HttpServer): HttpServer {
   servers.push(s);
   return s;
 }
 
 beforeEach(() => {
   servers = [];
-  // Default: delegate to the real execSync so lsof runs normally.
-  mockExecSync.mockImplementation((...args) => {
-    const { execSync: realExecSync } = vi.importActual<typeof import('node:child_process')>(
+  // Default: delegate to the real execFileSync so lsof runs normally.
+  mockExecFileSync.mockImplementation((...args) => {
+    const { execFileSync: realExecFileSync } = vi.importActual<typeof import('node:child_process')>(
       'node:child_process',
     ) as typeof import('node:child_process');
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (realExecSync as any)(...args);
+    return (realExecFileSync as any)(...args);
   });
 });
 
@@ -52,14 +62,14 @@ afterEach(async () => {
 
 describe('listenWithRecovery', () => {
   it('binds to the requested address when port is free', async () => {
-    const server = tracked(createServer());
+    const server = tracked(createHttpServer());
     const result = await listenWithRecovery(server, 0, '127.0.0.1');
     expect(result.port).toBeGreaterThan(0);
     expect(result.address).toBe('127.0.0.1');
   });
 
-  it('binds to IPv6 loopback when requested', async () => {
-    const server = tracked(createServer());
+  it.skipIf(!IPV6_AVAILABLE)('binds to IPv6 loopback when requested', async () => {
+    const server = tracked(createHttpServer());
     const result = await listenWithRecovery(server, 0, '::1');
     expect(result.port).toBeGreaterThan(0);
     expect(result.address).toBe('::1');
@@ -67,70 +77,127 @@ describe('listenWithRecovery', () => {
 
   it('throws EADDRINUSE when a real process holds the port', async () => {
     // Occupy a port with a real server
-    const blocker = tracked(createServer());
+    const blocker = tracked(createHttpServer());
     const { port } = await listenWithRecovery(blocker, 0, '127.0.0.1');
 
     // Attempt to bind the same address:port — should fail since a real process owns it
-    const server = tracked(createServer());
+    const server = tracked(createHttpServer());
     await expect(listenWithRecovery(server, port, '127.0.0.1')).rejects.toThrow(/EADDRINUSE/);
   });
 
   it('surfaces enriched error message with diagnostic guidance', async () => {
-    const blocker = tracked(createServer());
+    const blocker = tracked(createHttpServer());
     const { port } = await listenWithRecovery(blocker, 0, '127.0.0.1');
 
-    const server = tracked(createServer());
+    const server = tracked(createHttpServer());
     await expect(listenWithRecovery(server, port, '127.0.0.1')).rejects.toThrow(/ghost socket/);
   });
 
   it('throws on non-loopback EADDRINUSE without fallback attempt', async () => {
     // Occupy 0.0.0.0:port
-    const blocker = tracked(createServer());
+    const blocker = tracked(createHttpServer());
     const { port } = await listenWithRecovery(blocker, 0, '0.0.0.0');
 
-    const server = tracked(createServer());
+    const server = tracked(createHttpServer());
     await expect(listenWithRecovery(server, port, '0.0.0.0')).rejects.toThrow(/EADDRINUSE/);
   });
 
   describe('ghost-socket fallback: lsof finds no owner (exit status 1)', () => {
-    // Stub execSync to simulate "lsof ran, found no listener" — ghost socket.
+    // Stub execFileSync to simulate "lsof ran, found no listener" — ghost socket.
     // exit status 1 is the signal that portHasOwner returns `false`, allowing
     // the fallback to the alternate loopback address to proceed.
     beforeEach(() => {
-      mockExecSync.mockImplementation(() => {
+      mockExecFileSync.mockImplementation(() => {
         const err = Object.assign(new Error('Command failed'), { status: 1 });
         throw err;
       });
     });
 
-    it('falls back to ::1 when 127.0.0.1 has a ghost socket', async () => {
-      // Occupy 127.0.0.1:PORT with a real server so EADDRINUSE fires on that
-      // address, then verify listenWithRecovery binds successfully on ::1.
-      const blocker = tracked(createServer());
-      const { port } = await listenWithRecovery(blocker, 0, '127.0.0.1');
+    it.skipIf(!IPV6_AVAILABLE)(
+      'falls back to ::1 when 127.0.0.1 has a ghost socket',
+      async () => {
+        // Occupy 127.0.0.1:PORT with a real server so EADDRINUSE fires on that
+        // address, then verify listenWithRecovery binds successfully on ::1.
+        const blocker = tracked(createHttpServer());
+        const { port } = await listenWithRecovery(blocker, 0, '127.0.0.1');
 
-      const server = tracked(createServer());
-      const result = await listenWithRecovery(server, port, '127.0.0.1');
-      expect(result.address).toBe('::1');
-      expect(result.port).toBe(port);
+        const server = tracked(createHttpServer());
+        const result = await listenWithRecovery(server, port, '127.0.0.1');
+        expect(result.address).toBe('::1');
+        expect(result.port).toBe(port);
+      },
+    );
+  });
+
+  describe('fallback-failure: both loopback addresses occupied (ghost socket confirmed)', () => {
+    // Stub execFileSync to simulate "lsof ran, found no listener" (exit 1), so the
+    // ghost-socket path is taken. Then hold BOTH 127.0.0.1:P and ::1:P with real
+    // servers so the fallback bind also fails. Verifies the error is enriched with
+    // both addresses and that stderr captures the recovery attempt.
+    beforeEach(() => {
+      mockExecFileSync.mockImplementation(() => {
+        const err = Object.assign(new Error('Command failed'), { status: 1 });
+        throw err;
+      });
     });
+
+    it.skipIf(!IPV6_AVAILABLE)(
+      'throws EADDRINUSE naming both addresses when fallback also fails',
+      async () => {
+        // Block 127.0.0.1:P
+        const blocker4 = tracked(createHttpServer());
+        const { port } = await listenWithRecovery(blocker4, 0, '127.0.0.1');
+
+        // Block ::1:P with the same port number
+        const blocker6 = tracked(createHttpServer());
+        await listenWithRecovery(blocker6, port, '::1');
+
+        const stderrWrites: string[] = [];
+        const orig = process.stderr.write.bind(process.stderr);
+        const spy = vi
+          .spyOn(process.stderr, 'write')
+          .mockImplementation((chunk: unknown, ...rest: unknown[]) => {
+            if (typeof chunk === 'string') stderrWrites.push(chunk);
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            return (orig as any)(chunk, ...rest);
+          });
+
+        const server = tracked(createHttpServer());
+        let caught: Error | undefined;
+        try {
+          await listenWithRecovery(server, port, '127.0.0.1');
+        } catch (e) {
+          caught = e as Error;
+        } finally {
+          spy.mockRestore();
+        }
+
+        expect(caught).toBeDefined();
+        expect((caught as NodeJS.ErrnoException).code).toBe('EADDRINUSE');
+        expect(caught!.message).toContain('127.0.0.1');
+        expect(caught!.message).toContain('::1');
+        expect(
+          stderrWrites.some((line) => line.includes('fallback') && line.includes('::1')),
+        ).toBe(true);
+      },
+    );
   });
 
   describe('lsof unavailable: ownership unknown (exit status 127)', () => {
-    // Stub execSync to simulate lsof not installed — returns null from
+    // Stub execFileSync to simulate lsof not installed — returns null from
     // portHasOwner, which must NOT fall back (emit stderr + throw).
     beforeEach(() => {
-      mockExecSync.mockImplementation(() => {
+      mockExecFileSync.mockImplementation(() => {
         const err = Object.assign(new Error('lsof: command not found'), { status: 127 });
         throw err;
       });
     });
 
     it('throws with lsof-unavailable message when ownership is unknown', async () => {
-      const blocker = tracked(createServer());
+      const blocker = tracked(createHttpServer());
       const { port } = await listenWithRecovery(blocker, 0, '127.0.0.1');
 
-      const server = tracked(createServer());
+      const server = tracked(createHttpServer());
       await expect(listenWithRecovery(server, port, '127.0.0.1')).rejects.toThrow(
         /lsof unavailable/,
       );
@@ -140,13 +207,13 @@ describe('listenWithRecovery', () => {
 
 describe('closeServer', () => {
   it('resolves on a listening server', async () => {
-    const server = createServer();
+    const server = createHttpServer();
     await listenWithRecovery(server, 0, '127.0.0.1');
     await expect(closeServer(server)).resolves.toBeUndefined();
   });
 
   it('rejects on an already-closed server', async () => {
-    const server = createServer();
+    const server = createHttpServer();
     await listenWithRecovery(server, 0, '127.0.0.1');
     await closeServer(server);
     await expect(closeServer(server)).rejects.toThrow();

--- a/src/agent/daemon.listen.test.ts
+++ b/src/agent/daemon.listen.test.ts
@@ -176,11 +176,34 @@ describe('listenWithRecovery', () => {
         expect((caught as NodeJS.ErrnoException).code).toBe('EADDRINUSE');
         expect(caught!.message).toContain('127.0.0.1');
         expect(caught!.message).toContain('::1');
+        expect(caught!.message).toContain('fallback');
         expect(
           stderrWrites.some((line) => line.includes('fallback') && line.includes('::1')),
         ).toBe(true);
       },
     );
+  });
+
+  describe('lsof permission denied: ownership unknown (exit status 1 + Permission denied)', () => {
+    beforeEach(() => {
+      mockExecFileSync.mockImplementation(() => {
+        const err = Object.assign(new Error('Command failed'), {
+          status: 1,
+          stderr: 'Permission denied',
+        });
+        throw err;
+      });
+    });
+
+    it('throws with lsof-unavailable message when lsof is permission-denied', async () => {
+      const blocker = tracked(createHttpServer());
+      const { port } = await listenWithRecovery(blocker, 0, '127.0.0.1');
+
+      const server = tracked(createHttpServer());
+      await expect(listenWithRecovery(server, port, '127.0.0.1')).rejects.toThrow(
+        /lsof unavailable/,
+      );
+    });
   });
 
   describe('lsof unavailable: ownership unknown (exit status 127)', () => {

--- a/src/agent/daemon.listen.ts
+++ b/src/agent/daemon.listen.ts
@@ -62,9 +62,12 @@ export function listenWithRecovery(
       logFallback(requestedPort, host, fallback);
       return result;
     } catch (retryErr: unknown) {
-      // Fallback also failed — both addresses are in use. Log to stderr so
-      // the operator and launchd capture the recovery attempt, then re-throw
-      // an enriched error naming both the original and fallback addresses.
+      // Only diagnose "both occupied" when the fallback also hit EADDRINUSE.
+      // Other codes (EACCES, EADDRNOTAVAIL, etc.) are rethrown as-is so the
+      // operator sees the real failure, not misleading ghost-socket guidance.
+      const retryCode = (retryErr as NodeJS.ErrnoException)?.code;
+      if (retryCode !== 'EADDRINUSE') throw retryErr;
+
       process.stderr.write(
         `[daemon] EADDRINUSE on ${host}:${requestedPort} (ghost socket attempt) — ` +
           `fallback to ${fallback}:${requestedPort} also failed. ` +
@@ -147,7 +150,7 @@ function portHasOwner(port: number): boolean | null {
           'stderr' in err && typeof (err as { stderr: unknown }).stderr === 'string'
             ? (err as { stderr: string }).stderr
             : '';
-        if (stderr.includes('Permission denied') || stderr.includes('WARNING:')) return null;
+        if (stderr.includes('Permission denied')) return null;
         return false; // lsof ran cleanly, no listener → ghost
       }
     }

--- a/src/agent/daemon.listen.ts
+++ b/src/agent/daemon.listen.ts
@@ -15,7 +15,7 @@
  */
 
 import type { Server } from 'node:http';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 
 // Invariant: these are the only two loopback literals the fallback considers.
 // 'localhost' is intentionally excluded — its resolution is OS-dependent and
@@ -62,8 +62,15 @@ export function listenWithRecovery(
       logFallback(requestedPort, host, fallback);
       return result;
     } catch (retryErr: unknown) {
-      // Fallback also failed — surface the original error with diagnostics.
-      throw enrichEaddrinuse(requestedPort, host);
+      // Fallback also failed — both addresses are in use. Log to stderr so
+      // the operator and launchd capture the recovery attempt, then re-throw
+      // an enriched error naming both the original and fallback addresses.
+      process.stderr.write(
+        `[daemon] EADDRINUSE on ${host}:${requestedPort} (ghost socket attempt) — ` +
+          `fallback to ${fallback}:${requestedPort} also failed. ` +
+          `Both loopback addresses are occupied. Try --port <other> or reboot to clear ghost sockets.\n`,
+      );
+      throw enrichEaddrinuse(requestedPort, host, undefined, fallback);
     }
   });
 }
@@ -122,8 +129,8 @@ function loopbackFallback(host: string): string | undefined {
 function portHasOwner(port: number): boolean | null {
   try {
     // lsof exits 0 with output when a listener exists, and exits 1 with no
-    // output when nothing matches. execSync throws on non-zero exit.
-    const out = execSync(`lsof -i :${port} -sTCP:LISTEN -t`, {
+    // output when nothing matches. execFileSync throws on non-zero exit.
+    const out = execFileSync('lsof', ['-i', `:${port}`, '-sTCP:LISTEN', '-t'], {
       encoding: 'utf-8',
       timeout: 3_000,
       stdio: ['pipe', 'pipe', 'pipe'], // capture stderr to distinguish lsof-not-found
@@ -133,7 +140,16 @@ function portHasOwner(port: number): boolean | null {
     // Distinguish "lsof ran, found nothing" (exit 1) from "lsof not found" (exit 127/ENOENT).
     if (err && typeof err === 'object' && 'status' in err) {
       const status = (err as { status: number | null }).status;
-      if (status === 1) return false; // lsof ran, no listener → ghost
+      if (status === 1) {
+        // Even on exit 1, check stderr for permission/warning keywords — if
+        // lsof was denied access it may report nothing but still be unreliable.
+        const stderr =
+          'stderr' in err && typeof (err as { stderr: unknown }).stderr === 'string'
+            ? (err as { stderr: string }).stderr
+            : '';
+        if (stderr.includes('Permission denied') || stderr.includes('WARNING:')) return null;
+        return false; // lsof ran cleanly, no listener → ghost
+      }
     }
     return null; // lsof unavailable or unexpected error → unknown
   }
@@ -144,16 +160,25 @@ function portHasOwner(port: number): boolean | null {
  *
  * @param ownershipStatus - `true` or `undefined` = real/unknown owner (default message);
  *                          `null` = lsof unavailable (ownership-unknown message).
+ * @param fallbackHost    - When provided, the error occurred after a fallback attempt
+ *                          on this address also failed; both hosts are named in the message.
  */
 function enrichEaddrinuse(
   port: number,
   host: string,
   ownershipStatus?: boolean | null,
+  fallbackHost?: string,
 ): NodeJS.ErrnoException {
-  const msg =
-    ownershipStatus === null
-      ? `listen EADDRINUSE: address already in use ${host}:${port}. lsof unavailable — ownership unknown; cannot determine if a ghost socket or a real listener holds the port. Try --port <other>.`
-      : `listen EADDRINUSE: address already in use ${host}:${port}. If no process owns this port (check: lsof -i :${port}), the kernel may hold a ghost socket from a killed daemon. A reboot clears it; or try --port <other>.`;
+  let msg: string;
+  if (ownershipStatus === null) {
+    msg = `listen EADDRINUSE: address already in use ${host}:${port}. lsof unavailable — ownership unknown; cannot determine if a ghost socket or a real listener holds the port. Try --port <other>.`;
+  } else if (fallbackHost !== undefined) {
+    msg =
+      `listen EADDRINUSE: address already in use ${host}:${port} and fallback ${fallbackHost}:${port}. ` +
+      `Both loopback addresses are occupied. A reboot clears ghost sockets; or try --port <other>.`;
+  } else {
+    msg = `listen EADDRINUSE: address already in use ${host}:${port}. If no process owns this port (check: lsof -i :${port}), the kernel may hold a ghost socket from a killed daemon. A reboot clears it; or try --port <other>.`;
+  }
   const enriched = new Error(msg) as NodeJS.ErrnoException;
   enriched.code = 'EADDRINUSE';
   return enriched;


### PR DESCRIPTION
## Summary

Closes #1167. Also covers the observability gap from #1166.

Three hardening items in `daemon.listen.ts`:

### 1. `execSync` → `execFileSync`
Eliminates the shell entirely. `port` is typed `number` so no injection exists today, but this hardens against future type-widening.

### 2. Permission-denied detection in `portHasOwner`
After catching exit status 1, inspects stderr for `Permission denied` or `WARNING:` keywords. Returns `null` (unknown) instead of `false` when found, preventing silent fallback when lsof lacks privilege.

### 3. IPv6 skip guard in tests
Added `hasIPv6Loopback()` helper and `it.skipIf(!IPV6_AVAILABLE)` guards around IPv6-dependent test blocks, so environments with IPv6 disabled get a clean skip instead of a confusing failure.

### Bonus: Fallback-failure observability (#1166)
- Added `process.stderr.write` before re-throw naming both addresses
- Enriched error message includes fallback address
- Added test for the fallback-failure path

## Tests

- All mocks updated from `execSync` to `execFileSync`
- IPv6 skip guards on 3 test blocks
- Fallback-failure path test with both-address assertion
