### PR TITLE
fix(telegram): await bot.start() and deduplicate signal handlers

### DIFF
--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -430,15 +430,10 @@ export class TelegramBot {
     // only read presence files and call watchManager; no second Telegraf poller).
     this.startAutoSubscribe();
 
-    // Graceful shutdown handlers
-    const shutdown = async (signal: string) => {
-      this.log(`Received ${signal}, shutting down...`);
-      await this.stop();
-      process.exit(0);
-    };
-
-    process.once('SIGINT', () => shutdown('SIGINT'));
-    process.once('SIGTERM', () => shutdown('SIGTERM'));
+    // Invariant: SIGINT/SIGTERM handlers are NOT registered here. Signal
+    // ownership lives in the process entrypoint (entry.ts) so that resources
+    // it created (sharedMemoryStore, statsInterval) are correctly torn down.
+    // Adding handlers here would cause a double-shutdown sequence.
   }
 
   /**

--- a/src/telegram/entry.ts
+++ b/src/telegram/entry.ts
@@ -173,8 +173,27 @@ export async function main(): Promise<void> {
   // `bot.start()` via composeTelegramElicitation — a SINGLE composed handler,
   // so the two systems no longer clobber each other on `elicitationRouter
   // .install` (PR #477 review B1/B2). See `TelegramBot.start()`.
+  const statsInterval = startStatsTicker({ bot, spawnedVersion: daemonVersion });
+
+  const shutdown = async () => {
+    console.log('\n\n🛑 Shutting down bot...');
+    clearInterval(statsInterval);
+    await bot.stop();
+    sharedMemoryStore.close();
+    console.log('✅ Bot stopped.');
+    process.exit(0);
+  };
+
+  // Invariant: signal handlers are registered BEFORE bot.start() so a
+  // SIGTERM arriving during async startup still runs a clean shutdown.
+  // Use `once` — shutdown calls process.exit, so a second invocation
+  // is impossible and `on` would only risk stacking handlers.
+  process.once('SIGINT', shutdown);
+  process.once('SIGTERM', shutdown);
+
   try {
-    bot.start();
+    await bot.start();
+
     console.log('✅ Bot started successfully!');
     console.log('\n📝 Slash commands (Agent SDK):');
     console.log('  /start   - Welcome and command list');
@@ -185,21 +204,10 @@ export async function main(): Promise<void> {
     console.log('\n💬 Send any message to chat with the agent.');
     console.log('\n⏹️  Press Ctrl+C to stop the bot.');
 
-    const statsInterval = startStatsTicker({ bot, spawnedVersion: daemonVersion });
-
-    const shutdown = async () => {
-      console.log('\n\n🛑 Shutting down bot...');
-      clearInterval(statsInterval);
-      await bot.stop();
-      sharedMemoryStore.close();
-      console.log('✅ Bot stopped.');
-      process.exit(0);
-    };
-
-    process.on('SIGINT', shutdown);
-    process.on('SIGTERM', shutdown);
-
   } catch (error) {
+    clearInterval(statsInterval);
+    process.removeListener('SIGINT', shutdown);
+    process.removeListener('SIGTERM', shutdown);
     console.error('❌ Failed to start bot:', error);
     process.exit(1);
   }


### PR DESCRIPTION
## Summary

Fixes two startup/shutdown issues in the Telegram bot:

### 1. `bot.start()` not awaited (`entry.ts`)

`bot.start()` is async (does `loadSessions()`, `bot.launch()`, `setMyCommands()`) but was called without `await`. Startup errors became unhandled promise rejections, and the "✅ Bot started successfully!" log printed before initialization completed.

**Fix:** `await bot.start()` with try/catch for clean error reporting. Signal handlers and the stats ticker are set up *before* the await so a SIGTERM during startup still runs clean shutdown.

### 2. Duplicate signal handlers (`entry.ts` + `bot.ts`)

`entry.ts` registered `process.on('SIGINT/SIGTERM')` (persistent) and `bot.ts` registered `process.once('SIGINT/SIGTERM')` — both fired on SIGINT causing double-shutdown.

**Fix:** Removed signal handlers from `bot.ts` (with an Invariant comment explaining why). Changed `entry.ts` from `process.on` to `process.once` since shutdown calls `process.exit()`.

## Test Results

- `pnpm lint` ✅
- `entry.test.ts` + `bot.test.ts`: 26/26 pass ✅
- File sizes: `entry.ts` 214 LOC, `bot.ts` 637 LOC ✅
