### PR TITLE
fix(telegram): clear apiRoundInFlight in streamResponse finally block

### DIFF
--- a/src/telegram/streaming.ts
+++ b/src/telegram/streaming.ts
@@ -348,6 +348,8 @@ export async function streamResponse(
       state.turnEnded = true;
       clearProgressTimer();
       state.editInFlight = false;
+      watchdog.apiRoundInFlight = false;
+      watchdog.apiRoundSince = null;
       // Always close the generator so session.currentState resets to 'idle' only after
       // all Telegram messages are sent. Without this, a throw at event.type === 'error'
       // skips iter.return() and leaves the session permanently "busy".


### PR DESCRIPTION
Closes #1143

## Problem

`apiRoundInFlight` is set on every `progress` event (line 277–278 of `streaming.ts`) to suspend the watchdog during an active provider API round. However, the `finally` block of `streamResponse()` cleared all other mutable streaming state (`countdownInterval`, `editInFlight`, `turnEnded`) but missed the two watchdog API-round fields.

On a wedged or timed-out stream, `apiRoundInFlight` could remain `true` after the turn exits. The watchdog checks this flag to decide whether to apply the shorter `IDLE_TIMEOUT_MS` (180 s) or the longer `MAX_API_ROUND_INFLIGHT_MS` (420 s) threshold. A stale `true` means the next session's watchdog suspends for up to 420 s instead of 180 s.

## Fix

Added two lines to the `finally` block immediately alongside the existing state resets and before the `iter.return()` call that flips session state to idle:

```ts
watchdog.apiRoundInFlight = false;
watchdog.apiRoundSince = null;
```

This makes the `finally` block consistent: every piece of mutable state mutated during the event loop is now unconditionally reset on exit, regardless of whether the stream completed normally, threw, or timed out.

## Verification

- `pnpm lint` — clean
- `pnpm test src/telegram/ tests/telegram/` — 911 tests, all passing
