### PR TITLE
fix(telegram): derive MAX_API_ROUND_INFLIGHT_MS from live TTFB config

### DIFF
--- a/src/telegram/streaming.watchdog.test.ts
+++ b/src/telegram/streaming.watchdog.test.ts
@@ -6,14 +6,17 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import {
-  MAX_API_ROUND_INFLIGHT_MS,
+  MAX_API_ROUND_HEADROOM_MS,
   MAX_TOOL_INFLIGHT_MS,
   NEXT_EVENT_TIMEOUT_MS,
   TOOL_INFLIGHT_RECHECK_MS,
   makeNextWithTimeout,
+  resolveMaxApiRoundInflightMs,
   type WatchdogState,
 } from './streaming.watchdog.js';
 import { StreamTimeoutError } from './stream-timeout-error.js';
+import { TTFB_MAX_ATTEMPTS, ttfbAttemptTimeoutMs } from '../agent/providers/anthropic-direct/loop/retry-budget.js';
+import { DEFAULT_MODEL_TTFB_TIMEOUT_MS } from '../agent/providers/shared/first-byte-timeout.js';
 
 /** Build a minimal WatchdogState with apiRoundInFlight pre-set to true. */
 function makeState(overrides: Partial<WatchdogState> = {}): WatchdogState {
@@ -41,20 +44,43 @@ function makeHangingIter(): { iter: AsyncIterator<never>; release: () => void } 
 }
 
 describe('WatchdogState — apiRoundInFlight fields', () => {
-  it('exports MAX_API_ROUND_INFLIGHT_MS as a positive number', () => {
-    expect(MAX_API_ROUND_INFLIGHT_MS).toBeGreaterThan(0);
+  it('resolveMaxApiRoundInflightMs returns a positive number', () => {
+    expect(resolveMaxApiRoundInflightMs()).toBeGreaterThan(0);
   });
 
-  it('MAX_API_ROUND_INFLIGHT_MS exceeds the provider TTFB worst case (3 × 120s)', () => {
+  it('resolveMaxApiRoundInflightMs default matches the old hardcoded 420_000', () => {
+    // Default: AFK_MODEL_TTFB_TIMEOUT_MS unset → 180_000
+    // ttfbAttemptTimeoutMs(180_000) = floor(180_000 × 2 / 3) = 120_000
+    // TTFB_MAX_ATTEMPTS (3) × 120_000 + 60_000 headroom = 420_000
+    const expected =
+      TTFB_MAX_ATTEMPTS * ttfbAttemptTimeoutMs(DEFAULT_MODEL_TTFB_TIMEOUT_MS) +
+      MAX_API_ROUND_HEADROOM_MS;
+    expect(resolveMaxApiRoundInflightMs()).toBe(expected);
+    expect(resolveMaxApiRoundInflightMs()).toBe(420_000);
+  });
+
+  it('resolveMaxApiRoundInflightMs exceeds the provider TTFB worst case (3 × 120s)', () => {
     // The provider-level TTFB budget is 3 attempts × 120s = 360s worst case.
     // The watchdog ceiling must exceed this so the provider's retry logic gets
     // a chance to recover before the Telegram watchdog fires.
-    expect(MAX_API_ROUND_INFLIGHT_MS).toBeGreaterThan(360_000);
+    expect(resolveMaxApiRoundInflightMs()).toBeGreaterThan(360_000);
   });
 
-  it('MAX_API_ROUND_INFLIGHT_MS is less than MAX_TOOL_INFLIGHT_MS', () => {
+  it('resolveMaxApiRoundInflightMs is less than MAX_TOOL_INFLIGHT_MS (default config)', () => {
     // API calls should not be allowed to hang longer than a tool execution.
-    expect(MAX_API_ROUND_INFLIGHT_MS).toBeLessThan(MAX_TOOL_INFLIGHT_MS);
+    expect(resolveMaxApiRoundInflightMs()).toBeLessThan(MAX_TOOL_INFLIGHT_MS);
+  });
+
+  it('resolveMaxApiRoundInflightMs scales proportionally for a high TTFB timeout', () => {
+    // With AFK_MODEL_TTFB_TIMEOUT_MS = 300_000:
+    //   ttfbAttemptTimeoutMs(300_000) = floor(300_000 × 2 / 3) = 200_000
+    //   TTFB_MAX_ATTEMPTS (3) × 200_000 + 60_000 = 660_000
+    const highTtfb = 300_000;
+    const expected =
+      TTFB_MAX_ATTEMPTS * ttfbAttemptTimeoutMs(highTtfb) + MAX_API_ROUND_HEADROOM_MS;
+    expect(expected).toBe(660_000);
+    // And it must be strictly greater than the default ceiling.
+    expect(expected).toBeGreaterThan(420_000);
   });
 
   it('TOOL_INFLIGHT_RECHECK_MS is a reasonable recheck cadence', () => {
@@ -79,7 +105,7 @@ describe('WatchdogState — apiRoundInFlight fields', () => {
 });
 
 describe('makeNextWithTimeout — apiRoundInFlight behavioral tests', () => {
-  it('suspends the watchdog while apiRoundInFlight=true, then fires past MAX_API_ROUND_INFLIGHT_MS', async () => {
+  it('suspends the watchdog while apiRoundInFlight=true, then fires past resolveMaxApiRoundInflightMs()', async () => {
     // Install fake timers FIRST so that Date.now() inside makeState returns the
     // fake epoch (0 ms). This makes apiRoundSince deterministically equal to the
     // fake clock's origin, and the elapsed-time arithmetic below exact.
@@ -105,13 +131,13 @@ describe('makeNextWithTimeout — apiRoundInFlight behavioral tests', () => {
       await vi.advanceTimersByTimeAsync(NEXT_EVENT_TIMEOUT_MS + 1);
       expect(settled).toBe(false);
 
-      // Advance only the remaining budget to reach MAX_API_ROUND_INFLIGHT_MS
+      // Advance only the remaining budget to reach resolveMaxApiRoundInflightMs()
       // (measured from apiRoundSince). The clock has already moved by
       // 2 × (NEXT_EVENT_TIMEOUT_MS + 1), so we need only the difference.
       // This keeps the assertion tight: an implementation granting even one
       // extra inactivity window would cause the test to fail instead of pass.
       const elapsed = 2 * (NEXT_EVENT_TIMEOUT_MS + 1);
-      const remaining = MAX_API_ROUND_INFLIGHT_MS - elapsed;
+      const remaining = resolveMaxApiRoundInflightMs() - elapsed;
       const rejection = expect(p).rejects.toBeInstanceOf(StreamTimeoutError);
       await vi.advanceTimersByTimeAsync(remaining);
       await rejection;
@@ -167,6 +193,8 @@ describe('makeNextWithTimeout — apiRoundInFlight behavioral tests', () => {
       const rejection = expect(secondCall).rejects.toBeInstanceOf(StreamTimeoutError);
       await vi.advanceTimersByTimeAsync(2);
       await rejection;
+
+      void resolveSecond; // silence unused var warning
     } finally {
       vi.useRealTimers();
     }

--- a/src/telegram/streaming.watchdog.ts
+++ b/src/telegram/streaming.watchdog.ts
@@ -10,6 +10,8 @@
 
 import { StreamTimeoutError } from './stream-timeout-error.js';
 import type { OutputEvent } from '../agent/types.js';
+import { resolveTtfbTimeoutMs } from '../agent/providers/shared/first-byte-timeout.js';
+import { TTFB_MAX_ATTEMPTS, ttfbAttemptTimeoutMs } from '../agent/providers/anthropic-direct/loop/retry-budget.js';
 
 /** Max wait for first stream event (e.g. SDK/API cold start) */
 export const FIRST_EVENT_TIMEOUT_MS = 90_000;
@@ -37,16 +39,48 @@ export const MAX_TOOL_INFLIGHT_MS = 660_000;
 export const TOOL_INFLIGHT_RECHECK_MS = 15_000;
 
 /**
- * Ceiling on how long the watchdog stays SUSPENDED while the provider is
- * making a new `messages.create` API call between tool rounds. After the last
- * tool result arrives and before the first SSE byte of the next round, the
- * parent stream is legitimately silent — the model is processing the full
- * conversation context. The provider-level TTFB budget is 3 attempts × 120s
- * = 360s worst case (see `retry-budget.ts`). This ceiling must exceed that so
- * the provider's own retry logic gets a chance to recover before the Telegram
- * watchdog fires a user-visible timeout.
+ * Slack added on top of the provider's TTFB worst case (ms). The provider
+ * budget is `TTFB_MAX_ATTEMPTS × ttfbAttemptTimeoutMs(configured)` — a
+ * runtime value. This constant pads it so the Telegram watchdog does not fire
+ * the instant the last TTFB attempt times out.
+ *
+ * Default derivation (AFK_MODEL_TTFB_TIMEOUT_MS = 180 000):
+ *   ttfbAttemptTimeoutMs(180 000) = floor(180 000 × 2 / 3) = 120 000
+ *   TTFB_MAX_ATTEMPTS (3) × 120 000 = 360 000
+ *   360 000 + 60 000 headroom = 420 000
+ * (matches the old hardcoded value exactly).
  */
-export const MAX_API_ROUND_INFLIGHT_MS = 420_000;
+export const MAX_API_ROUND_HEADROOM_MS = 60_000;
+
+/**
+ * Derive the ceiling on how long the watchdog stays SUSPENDED while the
+ * provider is making a new `messages.create` API call between tool rounds.
+ *
+ * After the last tool result arrives and before the first SSE byte of the
+ * next round, the parent stream is legitimately silent — the model is
+ * processing the full conversation context. The provider-level TTFB budget is
+ * `TTFB_MAX_ATTEMPTS × ttfbAttemptTimeoutMs(configured)` worst case (see
+ * `retry-budget.ts`). This ceiling must exceed that so the provider's own
+ * retry logic gets a chance to recover before the Telegram watchdog fires a
+ * user-visible timeout.
+ *
+ * Computed at call time from live env so operators who raise
+ * `AFK_MODEL_TTFB_TIMEOUT_MS` above the default automatically get a
+ * proportionally higher watchdog ceiling — preventing the watchdog from firing
+ * BEFORE the provider's own retry budget exhausts.
+ *
+ * Default (AFK_MODEL_TTFB_TIMEOUT_MS unset → 180 000 ms):
+ *   ttfbAttemptTimeoutMs(180 000) = 120 000
+ *   3 × 120 000 + 60 000 = 420 000  ← same as the old hardcoded constant
+ *
+ * When TTFB is disabled (configured = 0), `ttfbAttemptTimeoutMs` returns 0
+ * and the ceiling falls back to the headroom alone; callers should not rely on
+ * the ceiling in that mode anyway since the provider has no per-attempt bound.
+ */
+export function resolveMaxApiRoundInflightMs(): number {
+  const configured = resolveTtfbTimeoutMs();
+  return TTFB_MAX_ATTEMPTS * ttfbAttemptTimeoutMs(configured) + MAX_API_ROUND_HEADROOM_MS;
+}
 
 /**
  * Tool-progress (`◦`) lines stay HIDDEN until the turn has been working this
@@ -123,15 +157,15 @@ export function makeNextWithTimeout(
       //      beyond when `remaining` first hits 0.
       //
       //   3. apiRoundInFlight (provider messages.create between tool rounds)
-      //      Defers the reject inside arm() for up to MAX_API_ROUND_INFLIGHT_MS
+      //      Defers the reject inside arm() for up to resolveMaxApiRoundInflightMs()
       //      beyond when `remaining` first hits 0.
       //
       // When pausedUntil fires at the same moment apiRoundInFlight is true
       // (e.g. a rate-limit pause arriving while the provider is retrying its
       // next round), the effective worst-case tolerance is:
       //
-      //   pause_window + PAUSE_SLACK_MS + MAX_API_ROUND_INFLIGHT_MS
-      //   ≈ (pause_window) + 90 s + 420 s
+      //   pause_window + PAUSE_SLACK_MS + resolveMaxApiRoundInflightMs()
+      //   ≈ (pause_window) + 90 s + resolveMaxApiRoundInflightMs() (default 420 s)
       //
       // where pause_window is provider-governed (typically 60–600 s for
       // Anthropic overload responses). There is no single cap combining
@@ -161,12 +195,12 @@ export function makeNextWithTimeout(
           // An API round in flight (the provider is calling messages.create
           // between tool rounds) is silent on the parent stream while the
           // model processes the context. Suspend the watchdog like we do for
-          // in-flight tools, bounded by MAX_API_ROUND_INFLIGHT_MS so a
+          // in-flight tools, bounded by resolveMaxApiRoundInflightMs() so a
           // genuinely wedged API call still eventually trips.
           if (
             state.apiRoundInFlight &&
             state.apiRoundSince !== null &&
-            Date.now() - state.apiRoundSince < MAX_API_ROUND_INFLIGHT_MS
+            Date.now() - state.apiRoundSince < resolveMaxApiRoundInflightMs()
           ) {
             timeoutId = setTimeout(arm, TOOL_INFLIGHT_RECHECK_MS);
             return;


### PR DESCRIPTION
## What

Replaces the hardcoded `MAX_API_ROUND_INFLIGHT_MS = 420_000` constant in `streaming.watchdog.ts` with a `resolveMaxApiRoundInflightMs()` function that derives the watchdog ceiling at call time from the live TTFB configuration.

## Why

Operators who raise `AFK_MODEL_TTFB_TIMEOUT_MS` above ~225 s hit false watchdog timeouts. The provider-level TTFB budget is `TTFB_MAX_ATTEMPTS × ttfbAttemptTimeoutMs(configured)` — a runtime value that scales with that env var. The old hardcoded `420_000` ceiling assumed the default (180 s), so any higher TTFB configuration caused the Telegram watchdog to fire *before* the provider's own retry logic had a chance to recover, producing spurious `StreamTimeoutError`s mid-conversation.

## How

```
resolveMaxApiRoundInflightMs()
  = TTFB_MAX_ATTEMPTS × ttfbAttemptTimeoutMs(resolveTtfbTimeoutMs())
    + MAX_API_ROUND_HEADROOM_MS (60 s)
```

- `MAX_API_ROUND_HEADROOM_MS = 60_000` is the fixed slack added on top of the provider's worst-case TTFB budget.
- `resolveMaxApiRoundInflightMs()` reads the live env at call time, so raising `AFK_MODEL_TTFB_TIMEOUT_MS` automatically raises the watchdog ceiling proportionally.
- Both call sites of the old constant are replaced with the function.

## Backward compatibility

With `AFK_MODEL_TTFB_TIMEOUT_MS` unset (default → 180 000 ms):

```
ttfbAttemptTimeoutMs(180_000) = floor(180_000 × 2/3) = 120_000
3 × 120_000 + 60_000 = 420_000
```

The default config produces exactly the previous hardcoded value — no behavior change for existing deployments.

## Tests

New test cases in `streaming.watchdog.test.ts`:

| Test | Assertion |
|------|-----------|
| Default matches old 420 000 | `resolveMaxApiRoundInflightMs() === 420_000` |
| Exceeds provider TTFB worst case | `> 3 × 120_000 = 360_000` |
| Less than `MAX_TOOL_INFLIGHT_MS` | API calls can't hang longer than tools |
| Scales for high TTFB (300 s → 660 s) | Proportional derivation verified |
| Behavioral: suspends past `NEXT_EVENT_TIMEOUT_MS` | `apiRoundInFlight=true` delays reject until `resolveMaxApiRoundInflightMs()` elapses |
| Behavioral: resumes after event clears flag | Normal `NEXT_EVENT_TIMEOUT_MS` cadence restored |

Full regression run: **913 tests, 48 files — all pass**.

Closes #1142
