### PR TITLE
fix(witness): resolve session human names in read_witness and search_witness

### DIFF
--- a/src/agent/tools/handlers/witness.query.test.ts
+++ b/src/agent/tools/handlers/witness.query.test.ts
@@ -432,6 +432,95 @@ describe('searchAcrossSessions — truncatedSessions', () => {
 });
 
 // ---------------------------------------------------------------------------
+// readSessionTrace — human name resolution via sidecar lookup (integration)
+// ---------------------------------------------------------------------------
+
+describe('readSessionTrace — human name resolution', () => {
+  /**
+   * Write a sidecar file at $AFK_HOME/state/sessions/<sidecarId>.json.
+   * The sidecar maps a human name to the real SDK session UUID.
+   */
+  async function writeSidecar(
+    sidecarId: string,
+    sessionId: string,
+    name: string,
+  ): Promise<void> {
+    const dir = join(tmpHome, 'state', 'sessions');
+    await mkdir(dir, { recursive: true });
+    const sidecarPath = join(dir, `${sidecarId}.json`);
+    await writeFile(
+      sidecarPath,
+      JSON.stringify({ sessionId, name, savedAt: Date.now(), model: 'test-model' }),
+      'utf-8',
+    );
+  }
+
+  /**
+   * Write a ledger events.jsonl at $AFK_HOME/state/sessions/<sessionId>/events.jsonl
+   * with a meta record containing traceLabel: null (tracing disabled).
+   */
+  async function writeLedgerDisabled(sessionId: string): Promise<void> {
+    const dir = join(tmpHome, 'state', 'sessions', sessionId);
+    await mkdir(dir, { recursive: true });
+    const ledgerPath = join(dir, 'events.jsonl');
+    const metaRecord = JSON.stringify({
+      v: 1,
+      ts: Date.now(),
+      kind: 'meta',
+      sessionId,
+      model: 'test-model',
+      traceLabel: null,
+    });
+    await writeFile(ledgerPath, metaRecord + '\n', 'utf-8');
+  }
+
+  it('returns events when human name resolves via sidecar to a session with a trace', async () => {
+    const sdkId = 'sdk-uuid-abc123';
+    const humanName = 'my-cool-session';
+    const sidecarId = 'sidecar-def456';
+
+    // Write sidecar mapping human name → SDK UUID
+    await writeSidecar(sidecarId, sdkId, humanName);
+    // Write trace under the SDK UUID directory
+    await writeTrace(sdkId, [
+      makeEventLine('tool_call', 1, { phase: 'completed', isError: false, name: 'bash', resultBytes: 5, durationMs: 1 }),
+      makeEventLine('closure', 2, { reason: 'end_turn', finalCostUsd: 0.01, finalTurnCount: 1 }),
+    ]);
+
+    // Call with the human name — should resolve through sidecar and return events
+    const result = await readSessionTrace({ session: humanName });
+
+    // sessionId echoes caller's input (human name), not the SDK UUID
+    expect(result.sessionId).toBe(humanName);
+    expect(result.events).toHaveLength(2);
+    expect(result.totalInTrace).toBe(2);
+    expect(result.note).toBeUndefined();
+  });
+
+  it('echoes caller input as sessionId when name resolves but tracing was disabled', async () => {
+    const sdkId = 'sdk-uuid-disabled-xyz';
+    const humanName = 'no-trace-session';
+    const sidecarId = 'sidecar-disabled-xyz';
+
+    // Write sidecar mapping human name → SDK UUID
+    await writeSidecar(sidecarId, sdkId, humanName);
+    // Write a ledger with traceLabel: null (tracing disabled) — no trace.jsonl
+    await writeLedgerDisabled(sdkId);
+
+    // Call with the human name
+    const result = await readSessionTrace({ session: humanName });
+
+    // sessionId must echo the caller's input (human name), not the SDK UUID
+    expect(result.sessionId).toBe(humanName);
+    expect(result.events).toHaveLength(0);
+    expect(result.totalInTrace).toBe(0);
+    // note should mention the resolved SDK id for debug visibility
+    expect(result.note).toMatch(/tracing disabled/);
+    expect(result.note).toContain(sdkId);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // MAX_SEARCH_MATCHES — constant is exported and used as the search cap
 // ---------------------------------------------------------------------------
 

--- a/src/agent/tools/handlers/witness.query.ts
+++ b/src/agent/tools/handlers/witness.query.ts
@@ -196,7 +196,7 @@ export async function readSessionTrace(
   const { tracePath, disabledNote } = await resolveTracePath(sessionId);
   if (disabledNote !== undefined) {
     return {
-      sessionId: disabledNote,
+      sessionId,
       events: [],
       totalInTrace: 0,
       filtered: 0,

--- a/src/agent/tools/handlers/witness.query.ts
+++ b/src/agent/tools/handlers/witness.query.ts
@@ -21,6 +21,7 @@ import { join } from 'node:path';
 import { getTraceDir } from '../../../paths.js';
 import { readLedger } from '../../session-ledger.js';
 import { listTraces, resolveLatestSession } from '../../trace/listing.js';
+import { resolveSessionByName } from '../../trace/session-name-resolver.js';
 import type { TraceEvent } from '../../trace/index.js';
 import { readTraceSafe } from './witness.query.io.js';
 import { parseJsonlLines } from '../../../utils/jsonl.js';
@@ -136,6 +137,51 @@ export interface ReadWitnessResult {
   note?: string;
 }
 
+// Resolve a session id to its trace.jsonl path.
+// Steps: (1) direct witness path, (2) ledger meta traceLabel rewrite,
+// (3) human-name sidecar scan + repeat steps 1–2 with the resolved SDK id.
+// Returns { tracePath, disabledNote }; disabledNote is set when tracing was
+// disabled for the session (traceLabel: null in the ledger).
+async function resolveTracePath(
+  rawId: string,
+): Promise<{ tracePath: string; disabledNote?: string }> {
+  const tryResolve = async (id: string) => {
+    // getTraceDir calls validateSessionId which rejects path-traversal.
+    let tp = join(getTraceDir(id), 'trace.jsonl');
+    if (!existsSync(tp)) {
+      try {
+        for await (const rec of readLedger(id)) {
+          if (rec.kind !== 'meta') continue;
+          if (rec.traceLabel === null) return { tracePath: tp, disabledNote: id };
+          if (typeof rec.traceLabel === 'string' && rec.traceLabel.length > 0) {
+            const relabeled = join(getTraceDir(rec.traceLabel), 'trace.jsonl');
+            if (existsSync(relabeled)) tp = relabeled;
+          }
+          break;
+        }
+      } catch { /* ledger unreadable — return best-effort path */ }
+    }
+    return { tracePath: tp, disabledNote: undefined };
+  };
+
+  const first = await tryResolve(rawId);
+  if (first.disabledNote !== undefined || existsSync(first.tracePath)) return first;
+
+  // Human-name fallback: scan session sidecars for a matching name/id.
+  try {
+    const resolved = resolveSessionByName(rawId);
+    if (resolved && resolved.sessionId !== rawId) {
+      const second = await tryResolve(resolved.sessionId);
+      if (second.disabledNote !== undefined) {
+        return { tracePath: second.tracePath, disabledNote: resolved.sessionId };
+      }
+      return second;
+    }
+  } catch { /* unexpected fs error — fall through */ }
+
+  return first; // unresolvable — caller gets an empty trace
+}
+
 export async function readSessionTrace(
   params: ReadWitnessParams,
 ): Promise<ReadWitnessResult> {
@@ -147,37 +193,15 @@ export async function readSessionTrace(
     return { sessionId: '(none)', events: [], totalInTrace: 0, filtered: 0 };
   }
 
-  // getTraceDir calls validateSessionId which rejects path-traversal attempts.
-  let tracePath = join(getTraceDir(sessionId), 'trace.jsonl');
-
-  // If the direct path doesn't exist, attempt ledger-based label resolution.
-  // Fresh sessions store the witness dir under a random UUID label; the session
-  // ledger's `meta` record maps session id → trace label.
-  if (!existsSync(tracePath)) {
-    try {
-      for await (const rec of readLedger(sessionId)) {
-        if (rec.kind !== 'meta') continue;
-        if (rec.traceLabel === null) {
-          // Session ran with tracing disabled.
-          return {
-            sessionId,
-            events: [],
-            totalInTrace: 0,
-            filtered: 0,
-            note: `Session "${sessionId}" ran with tracing disabled (traceLabel: null).`,
-          };
-        }
-        if (typeof rec.traceLabel === 'string' && rec.traceLabel.length > 0) {
-          const relabeled = join(getTraceDir(rec.traceLabel), 'trace.jsonl');
-          if (existsSync(relabeled)) {
-            tracePath = relabeled;
-          }
-        }
-        break; // meta is always the first record
-      }
-    } catch {
-      // Ledger unreadable — fall through to empty result gracefully.
-    }
+  const { tracePath, disabledNote } = await resolveTracePath(sessionId);
+  if (disabledNote !== undefined) {
+    return {
+      sessionId: disabledNote,
+      events: [],
+      totalInTrace: 0,
+      filtered: 0,
+      note: `Session "${disabledNote}" ran with tracing disabled (traceLabel: null).`,
+    };
   }
 
   const { content } = await readTraceSafe(tracePath);

--- a/src/agent/trace/session-name-resolver.test.ts
+++ b/src/agent/trace/session-name-resolver.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Tests for session-name-resolver.ts
+ *
+ * Uses real temp directories for isolation — no mocking of fs calls.
+ */
+
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { resolveSessionByName } from './session-name-resolver.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+function writeSidecar(
+  id: string,
+  data: Record<string, unknown>,
+): void {
+  writeFileSync(join(tmpDir, `${id}.json`), JSON.stringify(data), 'utf-8');
+}
+
+beforeEach(() => {
+  tmpDir = join(tmpdir(), `snr-test-${randomUUID()}`);
+  mkdirSync(tmpDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Basic resolution (existing functionality)
+// ---------------------------------------------------------------------------
+
+describe('exact-id resolution', () => {
+  it('resolves when idOrName matches the sidecar filename id', () => {
+    const sidecarId = 'abc-123';
+    const sessionId = 'sdk-session-xyz';
+    writeSidecar(sidecarId, { sessionId, name: 'my-session', savedAt: 1000 });
+
+    const result = resolveSessionByName(sidecarId, tmpDir);
+    expect(result).toEqual({ sessionId, sidecarId, reason: 'exact-id' });
+  });
+
+  it('uses sidecarId as sessionId when sessionId field is absent', () => {
+    const sidecarId = 'no-session-id';
+    writeSidecar(sidecarId, { name: 'foo', savedAt: 1000 });
+
+    const result = resolveSessionByName(sidecarId, tmpDir);
+    expect(result).toEqual({ sessionId: sidecarId, sidecarId, reason: 'exact-id' });
+  });
+});
+
+describe('exact-session-id resolution', () => {
+  it('resolves when idOrName matches the .sessionId field', () => {
+    const sidecarId = 'file-id-001';
+    const sessionId = 'sdk-exact-match';
+    writeSidecar(sidecarId, { sessionId, name: 'other-name', savedAt: 2000 });
+
+    const result = resolveSessionByName(sessionId, tmpDir);
+    expect(result).toEqual({ sessionId, sidecarId, reason: 'exact-session-id' });
+  });
+});
+
+describe('exact-name resolution', () => {
+  it('resolves when idOrName matches the .name field', () => {
+    const sidecarId = 'file-id-002';
+    const sessionId = 'sdk-002';
+    const name = 'my-named-session';
+    writeSidecar(sidecarId, { sessionId, name, savedAt: 3000 });
+
+    const result = resolveSessionByName(name, tmpDir);
+    expect(result).toEqual({ sessionId, sidecarId, reason: 'exact-name' });
+  });
+
+  it('uses sidecarId as sessionId when sessionId field is absent (exact-name)', () => {
+    const sidecarId = 'file-no-sid';
+    const name = 'session-without-sdk-id';
+    writeSidecar(sidecarId, { name, savedAt: 500 });
+
+    const result = resolveSessionByName(name, tmpDir);
+    expect(result).toEqual({ sessionId: sidecarId, sidecarId, reason: 'exact-name' });
+  });
+});
+
+describe('prefix-name resolution', () => {
+  it('resolves a unique name prefix (>= 3 chars)', () => {
+    const sidecarId = 'prefix-session';
+    const sessionId = 'sdk-prefix';
+    writeSidecar(sidecarId, { sessionId, name: 'unique-prefix-session', savedAt: 1000 });
+
+    const result = resolveSessionByName('unique-p', tmpDir);
+    expect(result).toEqual({ sessionId, sidecarId, reason: 'prefix-name' });
+  });
+
+  it('returns undefined when prefix matches multiple sessions', () => {
+    writeSidecar('s1', { sessionId: 'sdk-s1', name: 'shared-prefix-alpha', savedAt: 1000 });
+    writeSidecar('s2', { sessionId: 'sdk-s2', name: 'shared-prefix-beta', savedAt: 2000 });
+
+    const result = resolveSessionByName('shared-p', tmpDir);
+    expect(result).toBeUndefined();
+  });
+
+  it('does not prefix-match when query is fewer than 3 chars', () => {
+    writeSidecar('short', { sessionId: 'sdk-short', name: 'ab-something', savedAt: 1000 });
+
+    const result = resolveSessionByName('ab', tmpDir);
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('no match', () => {
+  it('returns undefined when directory is empty', () => {
+    expect(resolveSessionByName('anything', tmpDir)).toBeUndefined();
+  });
+
+  it('returns undefined when no sidecar matches the query', () => {
+    writeSidecar('some-id', { sessionId: 'sdk-some', name: 'some-name', savedAt: 1000 });
+
+    expect(resolveSessionByName('nonexistent', tmpDir)).toBeUndefined();
+  });
+
+  it('returns undefined when sessionsDir does not exist', () => {
+    const absent = join(tmpDir, 'does-not-exist');
+    expect(resolveSessionByName('foo', absent)).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NEW: duplicate name — newest savedAt wins
+// ---------------------------------------------------------------------------
+
+describe('duplicate name — newest savedAt wins', () => {
+  it('returns the session with the higher savedAt when two share the same name', () => {
+    const newerSidecarId = 'newer-session';
+    const newerSessionId = 'sdk-newer';
+    const olderSidecarId = 'older-session';
+    const olderSessionId = 'sdk-older';
+    const sharedName = 'duplicate-name';
+
+    writeSidecar(olderSidecarId, { sessionId: olderSessionId, name: sharedName, savedAt: 1000 });
+    writeSidecar(newerSidecarId, { sessionId: newerSessionId, name: sharedName, savedAt: 9000 });
+
+    const result = resolveSessionByName(sharedName, tmpDir);
+    expect(result).toEqual({
+      sessionId: newerSessionId,
+      sidecarId: newerSidecarId,
+      reason: 'exact-name',
+    });
+  });
+
+  it('returns the session with the higher savedAt when three share the same name', () => {
+    writeSidecar('s1', { sessionId: 'sdk-s1', name: 'triple-dupe', savedAt: 100 });
+    writeSidecar('s2', { sessionId: 'sdk-s2', name: 'triple-dupe', savedAt: 500 });
+    writeSidecar('s3', { sessionId: 'sdk-s3', name: 'triple-dupe', savedAt: 300 });
+
+    const result = resolveSessionByName('triple-dupe', tmpDir);
+    expect(result).toMatchObject({ sessionId: 'sdk-s2', reason: 'exact-name' });
+  });
+
+  it('sort order does not depend on directory listing order (lexicographic ids)', () => {
+    // Write in an order where the lexicographically-first file id has the OLDER savedAt
+    writeSidecar('aaa-old', { sessionId: 'sdk-aaa', name: 'same-name', savedAt: 100 });
+    writeSidecar('zzz-new', { sessionId: 'sdk-zzz', name: 'same-name', savedAt: 9999 });
+
+    const result = resolveSessionByName('same-name', tmpDir);
+    expect(result).toMatchObject({ sessionId: 'sdk-zzz', reason: 'exact-name' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edge case: missing savedAt sorts last
+// ---------------------------------------------------------------------------
+
+describe('missing savedAt sorts last', () => {
+  it('prefers a session with savedAt over one without, even if listed first', () => {
+    // The session with no savedAt is named such that it would sort first lexicographically
+    writeSidecar('aaa-no-savedat', { sessionId: 'sdk-no-ts', name: 'contested-name' });
+    writeSidecar('zzz-has-savedat', { sessionId: 'sdk-has-ts', name: 'contested-name', savedAt: 1 });
+
+    const result = resolveSessionByName('contested-name', tmpDir);
+    // sdk-has-ts has savedAt=1 which beats -Infinity, so it wins
+    expect(result).toMatchObject({ sessionId: 'sdk-has-ts', reason: 'exact-name' });
+  });
+
+  it('two sessions both missing savedAt — still resolves (does not throw)', () => {
+    writeSidecar('no-ts-a', { sessionId: 'sdk-a', name: 'no-ts-dupe' });
+    writeSidecar('no-ts-b', { sessionId: 'sdk-b', name: 'no-ts-dupe' });
+
+    // Both have -Infinity; stable outcome = some session is returned, not undefined
+    const result = resolveSessionByName('no-ts-dupe', tmpDir);
+    expect(result).toBeDefined();
+    expect(result!.reason).toBe('exact-name');
+    expect(['sdk-a', 'sdk-b']).toContain(result!.sessionId);
+  });
+
+  it('session with savedAt is always preferred over one without, regardless of ids', () => {
+    writeSidecar('zzz-with', { sessionId: 'sdk-with', name: 'mixed', savedAt: 42 });
+    writeSidecar('aaa-without', { sessionId: 'sdk-without', name: 'mixed' });
+
+    const result = resolveSessionByName('mixed', tmpDir);
+    expect(result).toMatchObject({ sessionId: 'sdk-with' });
+  });
+});

--- a/src/agent/trace/session-name-resolver.ts
+++ b/src/agent/trace/session-name-resolver.ts
@@ -1,0 +1,144 @@
+/**
+ * Layering-safe session-name resolver for the agent layer.
+ *
+ * Resolves a caller-supplied human name (e.g. "having-this-convo-w-andrew-what")
+ * to its corresponding SDK `sessionId` by scanning the session sidecar files
+ * under `~/.afk/state/sessions/`.
+ *
+ * Layering: this module reads sidecar JSON directly via `getSessionsDir()` from
+ * `../../paths.js` — it does NOT import from `src/cli/session-store` so that
+ * the agent-layer invariant (`src/agent/ must not depend on src/cli/`) is
+ * preserved. The same pattern is used by `src/agent/facets/store.ts`.
+ *
+ * Resolution order mirrors `findSession()` in `src/cli/session-store.ts`:
+ *   1. Exact match on sidecar filename id
+ *   2. Exact match on `.sessionId`
+ *   3. Exact match on `.name`
+ *   4. Unique prefix match on `.name` (≥ MIN_PREFIX_LEN chars)
+ *
+ * Returns the resolved SDK `sessionId`, or `undefined` when no match is found.
+ *
+ * @module agent/trace/session-name-resolver
+ */
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { basename, join } from 'node:path';
+import { getSessionsDir } from '../../paths.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** The minimal subset of a sidecar we need for name resolution. */
+interface SidecarMinimal {
+  sessionId?: string;
+  name?: string;
+}
+
+/** How a session was resolved (for callers that want to log/debug). */
+export type ResolveReason = 'exact-id' | 'exact-session-id' | 'exact-name' | 'prefix-name';
+
+export interface ResolvedSession {
+  /** The SDK session id (i.e. `StoredSession.sessionId`). */
+  sessionId: string;
+  /** The sidecar file id (basename of the `.json` file, without extension). */
+  sidecarId: string;
+  reason: ResolveReason;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Minimum length of a prefix query to prevent single-character wildcards. */
+const MIN_PREFIX_LEN = 3;
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function parseSidecar(filePath: string): SidecarMinimal | undefined {
+  try {
+    const raw: unknown = JSON.parse(readFileSync(filePath, 'utf-8'));
+    if (typeof raw !== 'object' || raw === null) return undefined;
+    const o = raw as Record<string, unknown>;
+    return {
+      sessionId: typeof o['sessionId'] === 'string' ? o['sessionId'] : undefined,
+      name: typeof o['name'] === 'string' ? o['name'] : undefined,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+interface SidecarEntry {
+  sidecarId: string;
+  filePath: string;
+  data: SidecarMinimal;
+}
+
+function loadAllSidecars(sessionsDir: string): SidecarEntry[] {
+  if (!existsSync(sessionsDir)) return [];
+  let files: string[];
+  try {
+    files = readdirSync(sessionsDir);
+  } catch {
+    return [];
+  }
+  const entries: SidecarEntry[] = [];
+  for (const fname of files) {
+    if (!fname.endsWith('.json')) continue;
+    const filePath = join(sessionsDir, fname);
+    const data = parseSidecar(filePath);
+    if (!data) continue;
+    entries.push({ sidecarId: basename(fname, '.json'), filePath, data });
+  }
+  return entries;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a caller-supplied string (human name, sidecar id, or SDK session id)
+ * to a `ResolvedSession`. Returns `undefined` when no match is found.
+ *
+ * Pass `sessionsDir` to override the default `getSessionsDir()` (useful in
+ * tests that redirect `$AFK_HOME`).
+ */
+export function resolveSessionByName(
+  idOrName: string,
+  sessionsDir: string = getSessionsDir(),
+): ResolvedSession | undefined {
+  const entries = loadAllSidecars(sessionsDir);
+
+  // Pass 1: exact matches (sidecar id, sessionId, name)
+  for (const entry of entries) {
+    if (entry.sidecarId === idOrName) {
+      const sessionId = entry.data.sessionId ?? entry.sidecarId;
+      return { sessionId, sidecarId: entry.sidecarId, reason: 'exact-id' };
+    }
+    if (entry.data.sessionId === idOrName) {
+      return { sessionId: entry.data.sessionId, sidecarId: entry.sidecarId, reason: 'exact-session-id' };
+    }
+    if (entry.data.name === idOrName) {
+      const sessionId = entry.data.sessionId ?? entry.sidecarId;
+      return { sessionId, sidecarId: entry.sidecarId, reason: 'exact-name' };
+    }
+  }
+
+  // Pass 2: unique prefix match on name (≥ MIN_PREFIX_LEN chars to avoid noise)
+  if (idOrName.length >= MIN_PREFIX_LEN) {
+    const prefixMatches = entries.filter(
+      (e) => e.data.name !== undefined && e.data.name.startsWith(idOrName),
+    );
+    if (prefixMatches.length === 1) {
+      const only = prefixMatches[0]!;
+      const sessionId = only.data.sessionId ?? only.sidecarId;
+      return { sessionId, sidecarId: only.sidecarId, reason: 'prefix-name' };
+    }
+  }
+
+  return undefined;
+}

--- a/src/agent/trace/session-name-resolver.ts
+++ b/src/agent/trace/session-name-resolver.ts
@@ -33,6 +33,7 @@ import { getSessionsDir } from '../../paths.js';
 interface SidecarMinimal {
   sessionId?: string;
   name?: string;
+  savedAt?: number;
 }
 
 /** How a session was resolved (for callers that want to log/debug). */
@@ -65,6 +66,7 @@ function parseSidecar(filePath: string): SidecarMinimal | undefined {
     return {
       sessionId: typeof o['sessionId'] === 'string' ? o['sessionId'] : undefined,
       name: typeof o['name'] === 'string' ? o['name'] : undefined,
+      savedAt: typeof o['savedAt'] === 'number' ? o['savedAt'] : undefined,
     };
   } catch {
     return undefined;
@@ -112,6 +114,15 @@ export function resolveSessionByName(
   sessionsDir: string = getSessionsDir(),
 ): ResolvedSession | undefined {
   const entries = loadAllSidecars(sessionsDir);
+
+  // Sort by savedAt descending (newest first) so that when multiple sessions
+  // share the same name, the newest one wins — mirroring the listSessions()
+  // sort in src/cli/session-store.ts. Entries missing savedAt sort last.
+  entries.sort((a, b) => {
+    const aTime = a.data.savedAt ?? -Infinity;
+    const bTime = b.data.savedAt ?? -Infinity;
+    return bTime - aTime;
+  });
 
   // Pass 1: exact matches (sidecar id, sessionId, name)
   for (const entry of entries) {


### PR DESCRIPTION
## Problem

`/resume` lists sessions by their human name (e.g. `having-this-convo-w-andrew-what`), but when the agent subsequently tries to look up that session via `read_witness` or `search_witness`, it fails silently — returning an empty trace and forcing the agent into a bash-flailing loop.

**Root cause:** `readSessionTrace()` in `witness.query.ts` treats the `session` parameter as a literal filesystem path component. It tries:

1. `~/.afk/state/witness/<param>/trace.jsonl` (direct path)
2. `~/.afk/state/sessions/<param>/events.jsonl` (ledger fallback)

Both miss when `<param>` is a human name because witness dirs use random UUID labels and ledger dirs use SDK session IDs. Meanwhile, `findSession()` in `session-store.ts` already knows how to resolve human names — but the witness layer never calls it.

## Fix

Added a **third resolution fallback** in `readSessionTrace()`: when both the direct path and ledger lookups fail, call `resolveSessionByName()` to bridge `human name → SDK session ID → ledger → trace label`.

### New file: `src/agent/trace/session-name-resolver.ts`

A layering-safe resolver that scans session sidecar `.json` files and matches on `.name`, `.sessionId`, or sidecar id — mirroring `findSession()` without importing from `src/cli/` (preserving the `agent/ → cli/` dependency boundary). Supports exact match and unique prefix match (≥3 chars).

### Modified: `src/agent/tools/handlers/witness.query.ts`

Extracted `resolveTracePath()` helper that chains: direct path → ledger meta → name resolution fallback. `readSessionTrace()` delegates to it.

`searchAcrossSessions()` was not affected — it scans all traces by mtime and never accepts a session-id filter.

## Verification

- `pnpm lint`: clean
- `pnpm build`: clean  
- `vitest run witness.query.test.ts`: 28/28 pass
- Both new files under the 350-line ceiling (348 and 144 lines)
