### PR TITLE
fix(tui): use basename for PAGER path comparison in resolvePager (#1171)

### DIFF
--- a/src/cli/slash/commands/transcript.test.ts
+++ b/src/cli/slash/commands/transcript.test.ts
@@ -80,6 +80,84 @@ async function flushUntilSpawn(): Promise<void> {
   }
 }
 
+describe('resolvePager — PAGER env resolution', () => {
+  let origPager: string | undefined;
+  let origIsTTY: boolean | undefined;
+  let pauseSpy: ReturnType<typeof vi.spyOn>;
+  let resumeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    origPager = process.env['PAGER'];
+    origIsTTY = process.stdout.isTTY;
+    (process.stdout as { isTTY?: boolean }).isTTY = true;
+    pauseSpy = vi.spyOn(process.stdin, 'pause').mockReturnValue(process.stdin);
+    resumeSpy = vi.spyOn(process.stdin, 'resume').mockReturnValue(process.stdin);
+  });
+
+  afterEach(() => {
+    if (origPager === undefined) {
+      delete process.env['PAGER'];
+    } else {
+      process.env['PAGER'] = origPager;
+    }
+    (process.stdout as { isTTY?: boolean }).isTTY = origIsTTY;
+    vi.restoreAllMocks();
+  });
+
+  it('appends -R when PAGER is a full path to less', async () => {
+    process.env['PAGER'] = '/usr/bin/less';
+    const child = new EventEmitter();
+    mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+    const { ctx } = makeCtx();
+    const p = transcriptCmd.handler(ctx);
+    await flushUntilSpawn();
+
+    const call = mockSpawn.mock.calls[0]!;
+    const spawnArgs = call[1] as string[];
+    // -R must appear even though PAGER was set to an absolute path
+    expect(spawnArgs).toContain('-R');
+
+    child.emit('exit', 0);
+    await p;
+  });
+
+  it('does not duplicate -R when PAGER is less with -R already set', async () => {
+    process.env['PAGER'] = 'less -R';
+    const child = new EventEmitter();
+    mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+    const { ctx } = makeCtx();
+    const p = transcriptCmd.handler(ctx);
+    await flushUntilSpawn();
+
+    const call = mockSpawn.mock.calls[0]!;
+    const spawnArgs = call[1] as string[];
+    expect(spawnArgs.filter((a) => a === '-R')).toHaveLength(1);
+
+    child.emit('exit', 0);
+    await p;
+  });
+
+  it('does not append -R when PAGER is less with -r (deprecated variant) already set', async () => {
+    process.env['PAGER'] = '/usr/bin/less -r';
+    const child = new EventEmitter();
+    mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+    const { ctx } = makeCtx();
+    const p = transcriptCmd.handler(ctx);
+    await flushUntilSpawn();
+
+    const call = mockSpawn.mock.calls[0]!;
+    const spawnArgs = call[1] as string[];
+    expect(spawnArgs).not.toContain('-R');
+
+    child.emit('exit', 0);
+    await p;
+  });
+});
+
 describe('/transcript slash command — pager TTY handoff', () => {
   let origIsTTY: boolean | undefined;
   let pauseSpy: ReturnType<typeof vi.spyOn>;

--- a/src/cli/slash/commands/transcript.ts
+++ b/src/cli/slash/commands/transcript.ts
@@ -114,8 +114,10 @@ function resolvePager(): { cmd: string; args: string[] } | null {
     // Invariant: the formatted transcript contains ANSI color codes from
     // palette.*() calls. `less` without `-R` renders them as raw escape
     // bytes, corrupting the display and breaking navigation. Append `-R`
-    // when the resolved command is `less` and the flag is not already present.
-    if (cmd === 'less' && !args.includes('-R')) args.push('-R');
+    // when the resolved command is `less` and neither `-R` nor the deprecated
+    // `-r` variant is already present. Use basename() so that a full-path
+    // PAGER value (e.g. `/usr/bin/less`) matches as well as a bare name.
+    if (path.basename(cmd) === 'less' && !args.includes('-R') && !args.includes('-r')) args.push('-R');
     return { cmd, args };
   }
   return { cmd: 'less', args: ['-R'] };


### PR DESCRIPTION
Closes #1171

## Problem

`resolvePager()` in `src/cli/slash/commands/transcript.ts` appends `-R` to `less` so ANSI color codes render correctly, but the check uses a bare-name comparison:

```ts
if (cmd === 'less' && !args.includes('-R')) args.push('-R');
```

Users who set `PAGER=/usr/bin/less` (full path) get `cmd = '/usr/bin/less'`, which does not match `'less'`, so `-R` is not appended and the transcript renders raw escape bytes.

## Fix

- Use `path.basename(cmd) === 'less'` instead of `cmd === 'less'`
- Also guard against `-r` (the deprecated but functional lowercase variant) to avoid appending a redundant `-R`

## Changes

| File | Change |
|------|--------|
| `src/cli/slash/commands/transcript.ts` | `path.basename(cmd)` comparison + `-r` guard |
| `src/cli/slash/commands/transcript.test.ts` | 3 new regression tests (full-path PAGER, already-set `-R`, already-set `-r`) |

## Test results

All 7 tests pass (4 existing + 3 new).
