### PR TITLE
fix(tui): stop bgStatusBar and mascotBar during pager/editor handoffs (#1170)

### DIFF
--- a/src/cli/commands/interactive/repl-loop.ts
+++ b/src/cli/commands/interactive/repl-loop.ts
@@ -113,8 +113,14 @@ export async function runReplLoop(
     // stop/start on the health rail (the primary offender) as suspendFooter/
     // resumeFooter so /transcript and /editor can bracket the handoff.
     const f = footer;
-    ctx.slashCtx.suspendFooter = () => { f.healthRail.stop(); ctx.statusLine.stop(); };
-    ctx.slashCtx.resumeFooter = () => { ctx.statusLine.start(); f.healthRail.start(); };
+    ctx.slashCtx.suspendFooter = () => {
+      f.bgStatusBar.stop(); f.mascotBar.stop();
+      f.healthRail.stop(); ctx.statusLine.stop();
+    };
+    ctx.slashCtx.resumeFooter = () => {
+      ctx.statusLine.start(); f.healthRail.start();
+      f.mascotBar.start(); f.bgStatusBar.start();
+    };
 
     await runInputLoop(
       ctx,

--- a/src/cli/commands/interactive/repl-loop.ts
+++ b/src/cli/commands/interactive/repl-loop.ts
@@ -119,7 +119,7 @@ export async function runReplLoop(
     };
     ctx.slashCtx.resumeFooter = () => {
       ctx.statusLine.start(); f.healthRail.start();
-      f.mascotBar.start(); f.bgStatusBar.start();
+      f.mascotBar.start(); f.bgStatusBar.start(); f.bgStatusBar.redraw();
     };
 
     await runInputLoop(


### PR DESCRIPTION
Closes #1170

## Problem

PR #1168 wired `suspendFooter`/`resumeFooter` to stop periodic terminal writers during pager/editor handoffs, but only stops 2 of the 4 timer-based writers:

| Writer | Interval | Stopped? |
|---|---|---|
| `healthRail` | 1s tick | ✅ |
| `statusLine` | configurable tick | ✅ |
| `bgStatusBar` | ~50ms spinner | ❌ |
| `mascotBar` | animation timer | ❌ |

The bgStatusBar spinner fires at ~50ms when background agents are active and can still corrupt the pager display.

## Fix

Extend both callbacks in `src/cli/commands/interactive/repl-loop.ts` to include `bgStatusBar` and `mascotBar`. Both `.stop()` and `.start()` are guarded and idempotent. Order mirrors the teardown sequence in the `finally` block.

## Changes

| File | Change |
|------|--------|
| `src/cli/commands/interactive/repl-loop.ts` | Add `f.bgStatusBar.stop()/start()` and `f.mascotBar.stop()/start()` to suspend/resume callbacks |
