### PR TITLE
fix(health-rail): use authoritative contextLimitFor instead of stale heuristic

### DIFF
--- a/src/cli/health-rail.ts
+++ b/src/cli/health-rail.ts
@@ -32,6 +32,7 @@ import type { SessionStats } from './slash/types.js';
 import { formatHealthRail, type HealthRailFields } from './health-rail.format.js';
 import { ResizeBus } from './terminal-size.js';
 import { isPlainOutputRequested } from '../config/env.js';
+import { contextLimitFor } from './model-limits.js';
 
 export interface HealthRailOptions {
   stream?: NodeJS.WriteStream;
@@ -150,7 +151,7 @@ export class HealthRail {
     } else {
       const last = stats.turnTokens[stats.turnTokens.length - 1];
       contextRatio = last !== undefined
-        ? (last.footprint ?? last.input + last.output + last.cache) / contextLimitFor(stats)
+        ? (last.footprint ?? last.input + last.output + last.cache) / contextLimitFor(stats.model)
         : 0;
     }
 
@@ -221,22 +222,4 @@ export class HealthRail {
   }
 }
 
-/**
- * Approximate context-window limit for the session's model.
- *
- * Contract: this is a best-effort approximation used ONLY for the glance
- * indicator — it does not feed any operational decision. The authoritative
- * value lives in `model-limits.ts`; importing it here would drag the full
- * model table into the CLI render path, so we use a simple common-case
- * heuristic (200k for Claude) that keeps the health rail self-contained.
- * A better future option: accept `contextLimit` as a field in `update()`.
- */
-function contextLimitFor(stats: SessionStats): number {
-  const model = String(stats.model);
-  // Claude extended context tiers
-  if (model.includes('opus-5') || model.includes('claude-opus-5')) return 500_000;
-  if (model.includes('3-5') || model.includes('claude-3-5')) return 200_000;
-  if (model.includes('3-7') || model.includes('claude-3-7')) return 200_000;
-  // Default for other Claude / OpenAI models
-  return 200_000;
-}
+


### PR DESCRIPTION
## Problem

The health rail (`ctx 75%`) and the status-line context bar (`[ ████ ] 15%`) both display context-window usage but were computing it against **different denominators**, showing two conflicting percentages on screen simultaneously.

The status line imported the authoritative `contextLimitFor()` from `model-limits.ts`, which correctly reports **1,000,000 tokens** for `claude-opus-4-6`. The health rail had its own inlined heuristic that only recognized `opus-5`, `3-5`, and `3-7` model-id patterns — everything else (including all opus-4 variants) fell through to a **200,000** default.

Same token usage ÷ 200k = 75%; same usage ÷ 1M = 15%.

## Fix

Replace the stale local heuristic with an import of the authoritative `contextLimitFor` from `model-limits.ts` (already loaded in the same CLI render path via `shared.ts`). Delete the 19-line local function.

Both percentages now agree. The original comment on the deleted function even noted: *"A better future option: accept `contextLimit` as a field in `update()`."* — importing the real table is that better option.

## Verification

- `pnpm lint` — clean
- `pnpm test src/cli/health-rail.format.test.ts src/cli/context-bar.test.ts src/cli/status-line.test.ts` — 103 tests pass
- `pnpm audit:filesize:check` — clean
- Confirmed via `grep` that no other stale `contextLimitFor` heuristics exist in the codebase
