### PR TITLE
feat(workspace): shared agent workspace v1 — publish tool + harness-injected retrieval

### DIFF
--- a/src/agent/providers/anthropic-direct/build-dispatcher.ts
+++ b/src/agent/providers/anthropic-direct/build-dispatcher.ts
@@ -160,7 +160,7 @@ export function buildDispatcher(
   // Workspace tool: workspace_publish. Registered for ALL sessions —
   // children publish findings; the parent can too. No readOnly gate
   // (workspace is per-session and ephemeral, unlike memory).
-  const wsHandlers = createWorkspaceHandlers(deps.workspaceStore, opts?.sessionId ?? '');
+  const wsHandlers = createWorkspaceHandlers(deps.workspaceStore, opts?.sessionId ?? '', opts?.subagentId);
   for (const [name, handler] of wsHandlers) {
     handlers.set(name, handler);
   }

--- a/src/agent/providers/anthropic-direct/build-dispatcher.ts
+++ b/src/agent/providers/anthropic-direct/build-dispatcher.ts
@@ -23,6 +23,8 @@ import type { CanUseTool } from '../../types/sdk-types.js';
 import type { PlanExitControls } from '../../types/config-types.js';
 import type { HookRegistry } from '../../hooks.js';
 import type { MemoryStore } from '../../memory/index.js';
+import type { WorkspaceStore } from '../../workspace/workspace-store.js';
+import { createWorkspaceHandlers } from '../../workspace/index.js';
 import type { SubagentExecutor } from '../../tools/subagent-executor.js';
 import type { SkillExecutor } from '../../tools/skill-executor.js';
 import type { ComposeExecutor } from '../../tools/compose-executor.js';
@@ -104,6 +106,7 @@ export interface BuildDispatcherOptions {
  */
 export interface BuildDispatcherDeps {
   memoryStore: MemoryStore;
+  workspaceStore: WorkspaceStore;
   surface: string;
   readOnlyMemory: boolean;
   readOnlyBash: boolean;
@@ -152,6 +155,13 @@ export function buildDispatcher(
   // `memory_update` / `procedure_write` despite the schema being absent.
   for (const [name, handler] of memoryHandlers) {
     if (deps.readOnlyMemory && name !== 'memory_search') continue;
+    handlers.set(name, handler);
+  }
+  // Workspace tool: workspace_publish. Registered for ALL sessions —
+  // children publish findings; the parent can too. No readOnly gate
+  // (workspace is per-session and ephemeral, unlike memory).
+  const wsHandlers = createWorkspaceHandlers(deps.workspaceStore, opts?.sessionId ?? '');
+  for (const [name, handler] of wsHandlers) {
     handlers.set(name, handler);
   }
   if (opts?.runtimeStateSource) {

--- a/src/agent/providers/anthropic-direct/provider-options.ts
+++ b/src/agent/providers/anthropic-direct/provider-options.ts
@@ -26,6 +26,7 @@ import type Anthropic from '@anthropic-ai/sdk';
 import type { CanUseTool } from '../../types/sdk-types.js';
 import type { HookRegistry } from '../../hooks.js';
 import type { MemoryStore } from '../../memory/index.js';
+import type { WorkspaceStore } from '../../workspace/workspace-store.js';
 import type { SubagentExecutor } from '../../tools/subagent-executor.js';
 import type { SkillExecutor } from '../../tools/skill-executor.js';
 import type { ComposeExecutor } from '../../tools/compose-executor.js';
@@ -94,6 +95,8 @@ export interface AnthropicDirectProviderOptions {
   composeExecutor?: ComposeExecutor;
   /** Shared MemoryStore instance. When set, avoids creating a second store. */
   memoryStore?: MemoryStore;
+  /** Shared WorkspaceStore instance. When set, children share the parent's ephemeral workspace. */
+  workspaceStore?: WorkspaceStore;
   /** Surface identifier for fact metadata (e.g. 'cli', 'daemon', 'telegram'). */
   surface?: string;
   /**

--- a/src/agent/providers/anthropic-direct/provider-runtime.ts
+++ b/src/agent/providers/anthropic-direct/provider-runtime.ts
@@ -58,6 +58,7 @@ export {
 import type { ToolPermissionConfig } from '../../tools/permissions.js';
 import type { SkillExecutor } from '../../tools/skill-executor.js';
 import { MemoryStore } from '../../memory/index.js';
+import { WorkspaceStore } from '../../workspace/workspace-store.js';
 import { env } from '../../../config/env.js';
 import { buildProviderSchemas } from './provider-schemas.js';
 import type { ProviderQueryContext } from './provider-context.js';
@@ -84,6 +85,7 @@ export class AnthropicDirectProvider implements ModelProvider {
   /** Non-null only when the caller provides an explicit `opts.tools` override. */
   private readonly externalTools: ToolDispatcher | undefined;
   private readonly memoryStore: MemoryStore;
+  private readonly workspaceStore: WorkspaceStore;
   private readonly providerFactory?: AnthropicClientFactory;
   private readonly skillExecutor?: SkillExecutor;
   // Fields retained for per-query dispatcher construction (fixes C2 env race).
@@ -152,6 +154,7 @@ export class AnthropicDirectProvider implements ModelProvider {
 
   constructor(opts: AnthropicDirectProviderOptions = {}) {
     this.memoryStore = opts.memoryStore ?? new MemoryStore();
+    this.workspaceStore = opts.workspaceStore ?? new WorkspaceStore();
     this.externalTools = opts.tools;
     this.skillExecutor = opts.skillExecutor;
     this.schemas = buildProviderSchemas(opts);
@@ -206,6 +209,7 @@ export class AnthropicDirectProvider implements ModelProvider {
     return buildDispatcherImpl(
       {
         memoryStore: this.memoryStore,
+        workspaceStore: this.workspaceStore,
         surface: this.surface,
         readOnlyMemory: this.readOnlyMemory,
         readOnlyBash: this.readOnlyBash,
@@ -231,6 +235,7 @@ export class AnthropicDirectProvider implements ModelProvider {
 
   close(): void {
     this.memoryStore.close();
+    this.workspaceStore.close();
   }
 
   /**

--- a/src/agent/providers/anthropic-direct/provider-schemas.ts
+++ b/src/agent/providers/anthropic-direct/provider-schemas.ts
@@ -11,6 +11,7 @@
 
 import { builtinToolSchemas, agentTool, skillTool, composeTool } from '../../tools/schemas.js';
 import { memoryToolSchemas, memorySearchTool } from '../../memory/index.js';
+import { workspaceToolSchemas } from '../../workspace/index.js';
 import { getRuntimeStateTool } from '../../awareness/index.js';
 import type { AnthropicDirectProviderOptions } from './provider-options.js';
 import type { AnthropicToolDef } from '../../tools/types.js';
@@ -51,6 +52,10 @@ export function buildProviderSchemas(opts: AnthropicDirectProviderOptions): Anth
   // available — it reads in-memory state only, so there is no executor
   // gating like `agent`/`skill`/`compose`. The source is constructed
   // per-query in `query()` and merged into the dispatcher handler map.
+  // Workspace tool: workspace_publish. Always available — children publish
+  // findings to the shared per-session workspace; no readOnly gate (workspace
+  // is ephemeral, unlike cross-session memory).
+  schemas.push(...workspaceToolSchemas);
   schemas.push(getRuntimeStateTool);
   // Custom (consumer-registered) tool schemas are appended last so their
   // names never silently shadow a builtin. A custom schema whose name

--- a/src/agent/providers/openai-compatible/index.ts
+++ b/src/agent/providers/openai-compatible/index.ts
@@ -43,6 +43,7 @@ import {
   composeTool,
 } from '../../tools/schemas.js';
 import { MemoryStore, createMemoryHandlers, memoryToolSchemas, memorySearchTool } from '../../memory/index.js';
+import { WorkspaceStore, createWorkspaceHandlers, workspaceToolSchemas } from '../../workspace/index.js';
 import { resolveToolSystemPrompt, resolveMemorySystemPrompt } from '../../tools/system-prompt.js';
 import { buildSkillManifest } from '../../tools/skill-bridge.js';
 import type { AnthropicToolDef } from '../anthropic-direct/types.js';
@@ -88,6 +89,7 @@ export interface OpenAICompatibleProviderOptions {
   composeExecutor?: ComposeExecutor;
   /** Shared memory store (avoids dual SQLite handles when CLI builds it once). */
   memoryStore?: MemoryStore;
+  workspaceStore?: WorkspaceStore;
   /** UI surface tag forwarded to memory handlers ('cli' | 'telegram' | etc.). */
   surface?: string;
   /**
@@ -134,6 +136,7 @@ export class OpenAICompatibleProvider implements ModelProvider {
   readonly name = PROVIDER_NAME;
   private readonly providerOpts: OpenAICompatibleProviderOptions;
   private readonly memoryStore: MemoryStore;
+  private readonly workspaceStore: WorkspaceStore;
   private readonly schemas: AnthropicToolDef[];
   /**
    * Mutable per-session endpoint headers (xAI CLI proxy). Construction-time
@@ -173,6 +176,7 @@ export class OpenAICompatibleProvider implements ModelProvider {
     this.providerOpts = opts;
     this._defaultHeaders = opts.defaultHeaders;
     this.memoryStore = opts.memoryStore ?? new MemoryStore();
+    this.workspaceStore = opts.workspaceStore ?? new WorkspaceStore();
 
     const schemas: AnthropicToolDef[] = [...builtinToolSchemas];
     // Executor-supplied `agent` def advertises named agent types when a
@@ -185,15 +189,9 @@ export class OpenAICompatibleProvider implements ModelProvider {
     } else {
       schemas.push(...memoryToolSchemas);
     }
-    // Awareness layer (Phase 1) — parity with anthropic-direct. The
-    // system-prompt identity fragment is NOT built here: it's assembled
-    // per-query below (`envFragment`, Phase 2, ~line 325) once `config.cwd`
-    // and `runtimeStateSource` are available, then re-rendered per turn by
-    // `refreshEnvironmentDate()` in messages.ts so a resident session's
-    // `# Environment` block never goes stale across a local midnight. The
-    // `get_runtime_state` tool remains available so the model can also pull
-    // identity on demand.
-    schemas.push(getRuntimeStateTool);
+    // Workspace (per-session publish) + awareness (runtime-state) — parity
+    // with anthropic-direct/provider-schemas.ts.
+    schemas.push(...workspaceToolSchemas, getRuntimeStateTool);
     // Custom (consumer-registered) tool schemas are appended last so their
     // names never silently shadow a builtin. A custom schema whose name
     // collides with an already-present builtin (or an earlier custom tool) is
@@ -530,15 +528,13 @@ export class OpenAICompatibleProvider implements ModelProvider {
     },
   ): SessionToolDispatcher {
     const handlers = createBuiltinHandlers(permissionMode, opts.cwd);
-    const memoryHandlers = createMemoryHandlers(
-      this.memoryStore,
-      undefined,
-      this.providerOpts.surface ?? 'cli',
-    );
+    const memoryHandlers = createMemoryHandlers(this.memoryStore, undefined, this.providerOpts.surface ?? 'cli');
     for (const [name, handler] of memoryHandlers) {
       if (this.providerOpts.readOnlyMemory === true && name !== 'memory_search') continue;
       handlers.set(name, handler);
     }
+    // Workspace tool: workspace_publish (per-session, ephemeral — no readOnly gate).
+    for (const [n, h] of createWorkspaceHandlers(this.workspaceStore, opts.sessionId ?? '')) handlers.set(n, h);
     if (opts.runtimeStateSource) {
       handlers.set('get_runtime_state', createGetRuntimeStateHandler(opts.runtimeStateSource));
     }
@@ -548,11 +544,7 @@ export class OpenAICompatibleProvider implements ModelProvider {
     // the builtin wins (we skip the custom registration). This prevents a
     // user-supplied tool from silently overriding a built-in capability.
     // Location: src/agent/providers/openai-compatible/index.ts buildDispatcher.
-    for (const t of this.providerOpts.customTools ?? []) {
-      if (!handlers.has(t.schema.name)) {
-        handlers.set(t.schema.name, t.handler);
-      }
-    }
+    for (const t of this.providerOpts.customTools ?? []) if (!handlers.has(t.schema.name)) handlers.set(t.schema.name, t.handler);
     // Plan-exit tool: registered RESIDENT whenever the session supplied control
     // callbacks (top-level sessions only). NOT gated on the construction-time
     // `permissionMode` — the dispatcher is built once per query() and is not
@@ -717,6 +709,7 @@ export class OpenAICompatibleProvider implements ModelProvider {
 
   close(): void {
     this.memoryStore.close();
+    this.workspaceStore.close();
   }
 
   /**

--- a/src/agent/providers/openai-compatible/index.ts
+++ b/src/agent/providers/openai-compatible/index.ts
@@ -534,7 +534,7 @@ export class OpenAICompatibleProvider implements ModelProvider {
       handlers.set(name, handler);
     }
     // Workspace tool: workspace_publish (per-session, ephemeral — no readOnly gate).
-    for (const [n, h] of createWorkspaceHandlers(this.workspaceStore, opts.sessionId ?? '')) handlers.set(n, h);
+    for (const [n, h] of createWorkspaceHandlers(this.workspaceStore, opts.sessionId ?? '', opts.subagentId)) handlers.set(n, h);
     if (opts.runtimeStateSource) {
       handlers.set('get_runtime_state', createGetRuntimeStateHandler(opts.runtimeStateSource));
     }

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -20,6 +20,7 @@
  */
 
 import type { CanUseTool } from './types/sdk-types.js';
+import type { WorkspaceStore } from './workspace/workspace-store.js';
 import { AbortGraph, type ChildAbortedListener } from './abort-graph.js';
 import type { HookRegistry } from './hooks.js';
 import { AgentSession } from './session.js';
@@ -118,6 +119,7 @@ export class SubagentManager {
   private parentTraceWriter: TraceSink | undefined;
   private readonly parentSurface: Surface | undefined;
   private readonly parentAbortSignal: AbortSignal | undefined;
+  private readonly workspaceStore: WorkspaceStore | undefined;
   private readonly abortGraph: AbortGraph;
   private readonly rootId: string;
   private rootController: AbortController;
@@ -141,6 +143,7 @@ export class SubagentManager {
     this.parentSurface = options.surface;
     this.parentAbortSignal = options.parentAbortSignal;
     this.onSubagentSucceededCb = options.onSubagentSucceeded;
+    this.workspaceStore = options.workspaceStore;
     // Witness layer: AbortGraph receives the writer at construction so
     // cascades fire `abort` events without per-call plumbing.
     this.abortGraph = new AbortGraph(options.traceWriter);
@@ -404,6 +407,7 @@ export class SubagentManager {
       parentTraceWriter: this.parentTraceWriter,
       parentSurface: this.parentSurface,
       parentCanUseTool: this.parentCanUseTool,
+      workspaceStore: this.workspaceStore,
     });
 
     // Occupancy touch: subagents never write presence files (top-level-only

--- a/src/agent/subagent/fork-child-config.ts
+++ b/src/agent/subagent/fork-child-config.ts
@@ -28,6 +28,8 @@ import { buildPhaseRestrictedProvider } from '../tools/nesting.js';
 import { MODEL_CAP_BYTES } from '../tools/handlers/_output-cap.js';
 import { applyManagerApiKeyFallback } from '../tools/child-credential.js';
 import { injectToolBudgetPreamble } from './budget-preamble.js';
+import { injectWorkspacePreamble } from '../workspace/index.js';
+import type { WorkspaceStore } from '../workspace/workspace-store.js';
 import { DENY_ELICITATION, SUBAGENT_DEFAULT_MAX_TOOL_USE_ITERATIONS } from './constants.js';
 import { resolveSoftDeadlineMs } from '../providers/shared/soft-deadline.js';
 
@@ -42,6 +44,7 @@ export interface AssembleChildConfigArgs<T> {
   inheritedReadRoots: string[] | undefined;
   composedWriteRoots: string[] | undefined;
   childController: AbortController;
+  workspaceStore?: WorkspaceStore;
   // Manager-level inherited values
   parentCwd: string | undefined;
   parentApiKey: string | undefined;
@@ -91,7 +94,17 @@ export function assembleChildConfig<T>(args: AssembleChildConfigArgs<T>): AgentC
     parentCanUseTool,
   } = args;
 
-  return injectToolBudgetPreamble({
+  // Query the shared workspace for entries relevant to this child's task
+  // and inject them as a system-prompt preamble so the child sees sibling
+  // agents' findings without needing a workspace_query tool.
+  const taskPrompt = typeof options.config.systemPrompt === 'string'
+    ? options.config.systemPrompt
+    : '';
+  const workspaceEntries = args.workspaceStore
+    ? args.workspaceStore.queryRelevant(resume ?? '', taskPrompt)
+    : [];
+
+  return injectWorkspacePreamble(injectToolBudgetPreamble({
     ...options.config,
     // Invariant (trace seal ownership): mark this session as a fork so it
     // never seals the SHARED witness trace. The whole tree shares ONE
@@ -283,5 +296,5 @@ export function assembleChildConfig<T>(args: AssembleChildConfigArgs<T>): AgentC
     ...(options.phaseRole === 'read-only'
       ? { provider: buildPhaseRestrictedProvider('read-only', effectiveChildModel) }
       : {}),
-  });
+  }), workspaceEntries);
 }

--- a/src/agent/subagent/fork-child-config.ts
+++ b/src/agent/subagent/fork-child-config.ts
@@ -97,9 +97,9 @@ export function assembleChildConfig<T>(args: AssembleChildConfigArgs<T>): AgentC
   // Query the shared workspace for entries relevant to this child's task
   // and inject them as a system-prompt preamble so the child sees sibling
   // agents' findings without needing a workspace_query tool.
-  const taskPrompt = typeof options.config.systemPrompt === 'string'
+  const taskPrompt = resume ?? (typeof options.config.systemPrompt === 'string'
     ? options.config.systemPrompt
-    : '';
+    : '');
   const workspaceEntries = args.workspaceStore
     ? args.workspaceStore.queryRelevant(resume ?? '', taskPrompt)
     : [];

--- a/src/agent/subagent/fork-child-config.ts
+++ b/src/agent/subagent/fork-child-config.ts
@@ -97,11 +97,15 @@ export function assembleChildConfig<T>(args: AssembleChildConfigArgs<T>): AgentC
   // Query the shared workspace for entries relevant to this child's task
   // and inject them as a system-prompt preamble so the child sees sibling
   // agents' findings without needing a workspace_query tool.
+  //
+  // Invariant: pass `null` as sessionId — the store is already scoped to one
+  // root session, and children publish under their own IDs, so a session-
+  // filtered query would miss sibling findings (the partition mismatch bug).
   const taskPrompt = resume ?? (typeof options.config.systemPrompt === 'string'
     ? options.config.systemPrompt
     : '');
   const workspaceEntries = args.workspaceStore
-    ? args.workspaceStore.queryRelevant(resume ?? '', taskPrompt)
+    ? args.workspaceStore.queryRelevant(null, taskPrompt)
     : [];
 
   return injectWorkspacePreamble(injectToolBudgetPreamble({

--- a/src/agent/subagent/fork-types.ts
+++ b/src/agent/subagent/fork-types.ts
@@ -10,6 +10,7 @@
 
 import type { ZodType } from 'zod';
 import type { CanUseTool } from '../types/sdk-types.js';
+import type { WorkspaceStore } from '../workspace/workspace-store.js';
 import type { HookRegistry } from '../hooks.js';
 import type { AgentConfig, IAgentSession } from '../types.js';
 import type { SubagentProgressSink } from '../types/session-types.js';
@@ -237,4 +238,10 @@ export interface SubagentManagerOptions {
     usage: import('./result.js').SubagentTrace['usage'],
     costUsd: number | undefined,
   ) => void;
+  /**
+   * Shared workspace store inherited by all forked children. When provided,
+   * child configs are augmented with a workspace context preamble containing
+   * relevant entries published by sibling agents.
+   */
+  workspaceStore?: WorkspaceStore;
 }

--- a/src/agent/tool-category.ts
+++ b/src/agent/tool-category.ts
@@ -69,6 +69,9 @@ const WRITE_TOOLS = new Set([
   // load-bearing: it makes config_set plan-mode-blocked (excluded from
   // READ_ONLY_PHASE_TOOLS) and sequential (not concurrency-safe).
   'config_set',
+  // workspace-tools.ts — workspace_publish mutates ephemeral per-session
+  // state that influences sibling-agent system prompts.
+  'workspace_publish',
 ]);
 // These categorization sets intentionally list BOTH the Claude Code / SDK
 // PascalCase tool names (Bash, Agent, Task, Skill, Compose) and AFK's lowercase

--- a/src/agent/tools/nesting.ts
+++ b/src/agent/tools/nesting.ts
@@ -16,6 +16,7 @@ import type { Surface } from '../awareness/types.js';
 import type { ReadScopeInputs } from '../subagent-read-scope.js';
 import { AnthropicDirectProvider } from '../providers/anthropic-direct/index.js';
 import { OpenAICompatibleProvider } from '../providers/openai-compatible/index.js';
+import type { WorkspaceStore } from '../workspace/workspace-store.js';
 import { providerForModel } from '../providers/index.js';
 import { BUILTIN_TOOL_NAMES } from './schemas.js';
 import { AWARENESS_TOOL_NAMES } from '../awareness/index.js';
@@ -129,7 +130,7 @@ export function createStubParentSession(
 // sub-agent writes. If specific skills need memory write access, do it per-skill via a
 // buildPhaseRestrictedProvider-style opt-in builder (see nesting.ts around line 207), not by
 // extending this global default.
-export const CHILD_ALLOWED_TOOLS = [...BUILTIN_TOOL_NAMES, ...AWARENESS_TOOL_NAMES, 'memory_search', 'agent', 'skill'];
+export const CHILD_ALLOWED_TOOLS = [...BUILTIN_TOOL_NAMES, ...AWARENESS_TOOL_NAMES, 'memory_search', 'workspace_publish', 'agent', 'skill'];
 
 // Recon allowlist for a READ-ONLY skill's forked child. This is the tool half
 // of read-only-skill enforcement (the bash half is the dispatcher's
@@ -192,6 +193,12 @@ export interface CreateChildProviderFactoryOptions {
    * api.openai.com.
    */
   openaiBaseUrl?: string;
+  /**
+   * Shared workspace store forwarded to child providers so every child
+   * session registers the `workspace_publish` tool against the same
+   * in-memory store as the parent.
+   */
+  workspaceStore?: WorkspaceStore;
 }
 
 /**
@@ -228,6 +235,7 @@ export function createChildProviderFactory(
       return new OpenAICompatibleProvider({
         ...providerOpts,
         ...(opts.openaiBaseUrl !== undefined ? { baseURL: opts.openaiBaseUrl } : {}),
+        ...(opts.workspaceStore !== undefined ? { workspaceStore: opts.workspaceStore } : {}),
         readOnlyMemory: true,
       });
     }
@@ -235,7 +243,11 @@ export function createChildProviderFactory(
     // to recall prior facts but cannot persist new memory (no `memory_update` /
     // `procedure_write`). The parent session is the only writer; allowing writes
     // from subagents would cause uncoordinated fan-out into the shared store.
-    return new AnthropicDirectProvider({ ...providerOpts, readOnlyMemory: true });
+    return new AnthropicDirectProvider({
+      ...providerOpts,
+      ...(opts.workspaceStore !== undefined ? { workspaceStore: opts.workspaceStore } : {}),
+      readOnlyMemory: true,
+    });
   };
 }
 

--- a/src/agent/workspace/index.ts
+++ b/src/agent/workspace/index.ts
@@ -5,16 +5,6 @@
  * @module agent/workspace
  */
 
-// Integration plan (wired in a follow-up commit):
-// 1. provider-options.ts: add `workspaceStore?: WorkspaceStore` to AnthropicDirectProviderOptions
-// 2. provider-runtime.ts: instantiate WorkspaceStore in constructor (opts.workspaceStore ?? new WorkspaceStore())
-// 3. build-dispatcher.ts: add workspaceStore to BuildDispatcherDeps, register workspace handlers
-//    via createWorkspaceHandlers(deps.workspaceStore, opts.sessionId ?? '', deps.agentId)
-// 4. openai-compatible/index.ts: same as above for the OpenAI provider
-// 5. nesting.ts: add 'workspace_publish' to CHILD_ALLOWED_TOOLS
-// 6. fork-child-config.ts: call injectWorkspacePreamble after injectToolBudgetPreamble,
-//    passing entries from workspaceStore.queryRelevant(sessionId, taskPrompt)
-// 7. schemas.ts: add workspaceToolSchemas to ALL_TOOL_SCHEMAS
 
 export {
   WorkspaceStore,

--- a/src/agent/workspace/index.ts
+++ b/src/agent/workspace/index.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared agent workspace — per-session SQLite-backed scratchpad for sibling
+ * sub-agents to exchange structured findings.
+ *
+ * @module agent/workspace
+ */
+
+// Integration plan (wired in a follow-up commit):
+// 1. provider-options.ts: add `workspaceStore?: WorkspaceStore` to AnthropicDirectProviderOptions
+// 2. provider-runtime.ts: instantiate WorkspaceStore in constructor (opts.workspaceStore ?? new WorkspaceStore())
+// 3. build-dispatcher.ts: add workspaceStore to BuildDispatcherDeps, register workspace handlers
+//    via createWorkspaceHandlers(deps.workspaceStore, opts.sessionId ?? '', deps.agentId)
+// 4. openai-compatible/index.ts: same as above for the OpenAI provider
+// 5. nesting.ts: add 'workspace_publish' to CHILD_ALLOWED_TOOLS
+// 6. fork-child-config.ts: call injectWorkspacePreamble after injectToolBudgetPreamble,
+//    passing entries from workspaceStore.queryRelevant(sessionId, taskPrompt)
+// 7. schemas.ts: add workspaceToolSchemas to ALL_TOOL_SCHEMAS
+
+export {
+  WorkspaceStore,
+} from './workspace-store.js';
+export type {
+  WorkspaceEntryType,
+  WorkspaceEntry,
+  WorkspacePublishInput,
+  WorkspaceRelationType,
+} from './workspace-store.js';
+
+export {
+  workspacePublishTool,
+  workspaceToolSchemas,
+  createWorkspaceHandlers,
+} from './workspace-tools.js';
+
+export {
+  renderWorkspacePreamble,
+  injectWorkspacePreamble,
+} from './workspace-preamble.js';

--- a/src/agent/workspace/workspace-preamble.test.ts
+++ b/src/agent/workspace/workspace-preamble.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Tests for renderWorkspacePreamble and injectWorkspacePreamble (workspace-preamble.ts).
+ *
+ * @module agent/workspace/workspace-preamble.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderWorkspacePreamble, injectWorkspacePreamble } from './workspace-preamble.js';
+import type { WorkspaceEntry } from './workspace-store.js';
+import type { AgentConfig } from '../types.js';
+
+// ── Minimal stub for WorkspaceEntry ──────────────────────────────────────────
+
+function makeEntry(overrides: Partial<WorkspaceEntry> = {}): WorkspaceEntry {
+  return {
+    id: 1,
+    session_id: 'sess-1',
+    type: 'finding',
+    subject: null,
+    content: 'The cache layer uses LRU eviction.',
+    evidence: null,
+    confidence: 1.0,
+    agent_id: null,
+    relates_to: null,
+    relation_type: null,
+    created_at: '2026-08-18T00:00:00.000Z',
+    seq: 1,
+    ...overrides,
+  };
+}
+
+// ── renderWorkspacePreamble ───────────────────────────────────────────────────
+
+describe('renderWorkspacePreamble', () => {
+  it('renders header block', () => {
+    const output = renderWorkspacePreamble([makeEntry()]);
+    expect(output).toContain('# Workspace context');
+    expect(output).toContain('workspace_publish');
+  });
+
+  it('renders entry id and type', () => {
+    const output = renderWorkspacePreamble([makeEntry({ id: 7, type: 'decision' })]);
+    expect(output).toContain('#7 Decision');
+  });
+
+  it('renders confidence', () => {
+    const output = renderWorkspacePreamble([makeEntry({ confidence: 0.75 })]);
+    expect(output).toContain('confidence: 0.75');
+  });
+
+  it('renders agent_id when present', () => {
+    const output = renderWorkspacePreamble([makeEntry({ agent_id: 'my-agent' })]);
+    expect(output).toContain('agent: my-agent');
+  });
+
+  it('does not render agent when absent', () => {
+    const output = renderWorkspacePreamble([makeEntry({ agent_id: null })]);
+    expect(output).not.toContain('agent:');
+  });
+
+  it('renders subject when present', () => {
+    const output = renderWorkspacePreamble([makeEntry({ subject: 'auth refresh' })]);
+    expect(output).toContain('Subject: auth refresh');
+  });
+
+  it('does not render subject line when null', () => {
+    const output = renderWorkspacePreamble([makeEntry({ subject: null })]);
+    expect(output).not.toContain('Subject:');
+  });
+
+  it('renders content', () => {
+    const output = renderWorkspacePreamble([makeEntry({ content: 'Very important finding.' })]);
+    expect(output).toContain('Very important finding.');
+  });
+
+  it('renders evidence refs when valid JSON array', () => {
+    const output = renderWorkspacePreamble([
+      makeEntry({ evidence: JSON.stringify(['src/auth.ts:42', 'src/utils.ts:10']) }),
+    ]);
+    expect(output).toContain('Evidence: src/auth.ts:42, src/utils.ts:10');
+  });
+
+  it('omits evidence block when evidence is null', () => {
+    const output = renderWorkspacePreamble([makeEntry({ evidence: null })]);
+    expect(output).not.toContain('Evidence:');
+  });
+
+  it('omits evidence block when evidence is empty array', () => {
+    const output = renderWorkspacePreamble([
+      makeEntry({ evidence: JSON.stringify([]) }),
+    ]);
+    expect(output).not.toContain('Evidence:');
+  });
+
+  it('omits evidence block on malformed JSON (silently)', () => {
+    const output = renderWorkspacePreamble([makeEntry({ evidence: '{bad json' })]);
+    expect(output).not.toContain('Evidence:');
+  });
+
+  it('renders relation when relates_to + relation_type present', () => {
+    const output = renderWorkspacePreamble([
+      makeEntry({
+        relates_to: JSON.stringify([3, 5]),
+        relation_type: 'supports',
+      }),
+    ]);
+    expect(output).toContain('Relation: supports → #3, #5');
+  });
+
+  it('omits relation block when relates_to is null', () => {
+    const output = renderWorkspacePreamble([makeEntry({ relates_to: null, relation_type: null })]);
+    expect(output).not.toContain('Relation:');
+  });
+
+  it('renders dividers between entries', () => {
+    const output = renderWorkspacePreamble([makeEntry({ id: 1 }), makeEntry({ id: 2 })]);
+    // At least two '---' dividers expected
+    const dividers = output.match(/^---$/gm);
+    expect(dividers?.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('renders all valid entry types capitalised', () => {
+    const types: WorkspaceEntry['type'][] = [
+      'finding', 'evidence', 'hypothesis', 'decision', 'artifact', 'status',
+    ];
+    for (const type of types) {
+      const output = renderWorkspacePreamble([makeEntry({ type })]);
+      const capitalised = type[0]!.toUpperCase() + type.slice(1);
+      expect(output).toContain(`#1 ${capitalised}`);
+    }
+  });
+});
+
+// ── injectWorkspacePreamble ───────────────────────────────────────────────────
+
+describe('injectWorkspacePreamble', () => {
+  const baseConfig: AgentConfig = { model: 'sonnet' };
+
+  it('returns config unchanged when entries is empty', () => {
+    const result = injectWorkspacePreamble(baseConfig, []);
+    expect(result).toBe(baseConfig);
+  });
+
+  it('does not mutate the input config', () => {
+    const config: AgentConfig = { model: 'sonnet', systemPrompt: 'Hello' };
+    injectWorkspacePreamble(config, [makeEntry()]);
+    expect(config.systemPrompt).toBe('Hello');
+  });
+
+  it('injects into string systemPrompt with separator', () => {
+    const config: AgentConfig = { model: 'sonnet', systemPrompt: 'You are helpful.' };
+    const result = injectWorkspacePreamble(config, [makeEntry()]);
+    expect(result.systemPrompt).toContain('You are helpful.');
+    expect(result.systemPrompt).toContain('\n\n');
+    expect(result.systemPrompt).toContain('# Workspace context');
+  });
+
+  it('sets preamble as systemPrompt when string is empty', () => {
+    const config: AgentConfig = { model: 'sonnet', systemPrompt: '' };
+    const result = injectWorkspacePreamble(config, [makeEntry()]);
+    expect(result.systemPrompt).toContain('# Workspace context');
+    expect((result.systemPrompt as string).startsWith('#')).toBe(true);
+  });
+
+  it('injects when no systemPrompt set', () => {
+    const result = injectWorkspacePreamble(baseConfig, [makeEntry()]);
+    expect(result.systemPrompt).toContain('# Workspace context');
+  });
+
+  it('appends to preset systemPrompt append field', () => {
+    const config: AgentConfig = {
+      model: 'sonnet',
+      systemPrompt: { type: 'preset', promptId: 'repl', append: 'Existing append.' },
+    };
+    const result = injectWorkspacePreamble(config, [makeEntry()]);
+    const sp = result.systemPrompt as { type: string; append: string };
+    expect(sp.type).toBe('preset');
+    expect(sp.append).toContain('Existing append.');
+    expect(sp.append).toContain('# Workspace context');
+  });
+
+  it('sets append on preset when no prior append', () => {
+    const config: AgentConfig = {
+      model: 'sonnet',
+      systemPrompt: { type: 'preset', promptId: 'repl' },
+    };
+    const result = injectWorkspacePreamble(config, [makeEntry()]);
+    const sp = result.systemPrompt as { type: string; append: string };
+    expect(sp.append).toContain('# Workspace context');
+  });
+
+  it('preserves all other config fields unchanged', () => {
+    const config: AgentConfig = {
+      model: 'haiku',
+      systemPrompt: 'Hello',
+      maxTokens: 512,
+    };
+    const result = injectWorkspacePreamble(config, [makeEntry()]);
+    expect(result.model).toBe('haiku');
+    expect(result.maxTokens).toBe(512);
+  });
+});

--- a/src/agent/workspace/workspace-preamble.ts
+++ b/src/agent/workspace/workspace-preamble.ts
@@ -69,7 +69,17 @@ export function renderWorkspacePreamble(entries: WorkspaceEntry[]): string {
   }
 
   lines.push('---');
-  return lines.join('\n');
+  const full = lines.join('\n');
+
+  // Cap total preamble at 32 KiB to prevent sibling system-prompt bloat.
+  // Trim from the start (oldest entries) so the most-recent findings survive.
+  const MAX_BYTES = 32 * 1024;
+  if (full.length <= MAX_BYTES) return full;
+  const notice = '\n---\n[Workspace preamble truncated: too many entries. Earlier entries omitted.]\n';
+  const tail = full.slice(full.length - MAX_BYTES + notice.length);
+  const dividerIdx = tail.indexOf('\n---\n');
+  const aligned = dividerIdx >= 0 ? tail.slice(dividerIdx) : tail;
+  return notice + aligned;
 }
 
 /**

--- a/src/agent/workspace/workspace-preamble.ts
+++ b/src/agent/workspace/workspace-preamble.ts
@@ -1,0 +1,120 @@
+/**
+ * Workspace context preamble — formats shared workspace entries for injection
+ * into a forked child's system prompt.
+ *
+ * Pattern mirrors `src/agent/subagent/budget-preamble.ts`: a pure renderer
+ * and a config-mutating injector that handles the string / preset-object /
+ * undefined system-prompt union.
+ *
+ * @module agent/workspace/workspace-preamble
+ */
+
+import type { AgentConfig } from '../types/config-types.js';
+import type { WorkspaceEntry } from './workspace-store.js';
+
+/**
+ * Render workspace entries as a readable context block.
+ *
+ * Each entry appears between `---` dividers with its id, type, confidence,
+ * agent, subject, content, and evidence (when present).
+ */
+export function renderWorkspacePreamble(entries: WorkspaceEntry[]): string {
+  const lines: string[] = [
+    '# Workspace context (shared findings from sibling agents)',
+    '',
+    'The following findings were published by other agents working on this task.',
+    'Use them to avoid re-discovering known facts. If you discover something new',
+    'or contradictory, publish it with the workspace_publish tool.',
+  ];
+
+  for (const entry of entries) {
+    lines.push('');
+    lines.push('---');
+
+    // Header line: #id Type (confidence: X, agent: Y)
+    const meta: string[] = [];
+    meta.push(`confidence: ${entry.confidence.toFixed(2)}`);
+    if (entry.agent_id) meta.push(`agent: ${entry.agent_id}`);
+    const metaStr = meta.length > 0 ? ` (${meta.join(', ')})` : '';
+    const label = capitalise(entry.type);
+    lines.push(`#${entry.id} ${label}${metaStr}`);
+
+    if (entry.subject) {
+      lines.push(`Subject: ${entry.subject}`);
+    }
+
+    lines.push(entry.content);
+
+    if (entry.evidence) {
+      try {
+        const refs = JSON.parse(entry.evidence) as unknown;
+        if (Array.isArray(refs) && refs.length > 0) {
+          lines.push(`Evidence: ${(refs as string[]).join(', ')}`);
+        }
+      } catch {
+        // Malformed JSON — omit silently
+      }
+    }
+
+    if (entry.relates_to && entry.relation_type) {
+      try {
+        const ids = JSON.parse(entry.relates_to) as unknown;
+        if (Array.isArray(ids) && ids.length > 0) {
+          lines.push(`Relation: ${entry.relation_type} → #${(ids as number[]).join(', #')}`);
+        }
+      } catch {
+        // Malformed JSON — omit silently
+      }
+    }
+  }
+
+  lines.push('---');
+  return lines.join('\n');
+}
+
+/**
+ * Append the workspace context preamble to a forked child's system prompt.
+ *
+ * No-op (returns config unchanged) when `entries` is empty.
+ * Handles the same system-prompt union as `injectToolBudgetPreamble`:
+ *   - string → append with `\n\n`
+ *   - preset object → append to `sp.append`
+ *   - undefined → preamble becomes the system prompt
+ *
+ * Does not mutate the input — returns a shallow copy.
+ */
+export function injectWorkspacePreamble(
+  config: AgentConfig,
+  entries: WorkspaceEntry[],
+): AgentConfig {
+  if (entries.length === 0) return config;
+
+  const block = renderWorkspacePreamble(entries);
+  const sp = config.systemPrompt;
+
+  if (typeof sp === 'string') {
+    return sp.length > 0
+      ? { ...config, systemPrompt: `${sp}\n\n${block}` }
+      : { ...config, systemPrompt: block };
+  }
+
+  if (sp && typeof sp === 'object' && 'type' in sp && sp.type === 'preset') {
+    const existingAppend = sp.append ?? '';
+    return {
+      ...config,
+      systemPrompt: {
+        ...sp,
+        append: existingAppend.length > 0 ? `${existingAppend}\n\n${block}` : block,
+      },
+    };
+  }
+
+  // No system prompt set — preamble becomes the system prompt.
+  return { ...config, systemPrompt: block };
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function capitalise(s: string): string {
+  return s.length === 0 ? s : (s[0]?.toUpperCase() ?? '') + s.slice(1);
+}

--- a/src/agent/workspace/workspace-store.test.ts
+++ b/src/agent/workspace/workspace-store.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tests for WorkspaceStore: publish, queryRelevant, queryAll.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { WorkspaceStore } from './workspace-store.js';
+
+describe('WorkspaceStore', () => {
+  let store: WorkspaceStore;
+
+  beforeEach(() => {
+    store = new WorkspaceStore(':memory:');
+  });
+
+  // ── publish ────────────────────────────────────────────────────────────────
+
+  describe('publish', () => {
+    it('returns incrementing ids', () => {
+      const id1 = store.publish({ session_id: 'sess-1', type: 'finding', content: 'A' });
+      const id2 = store.publish({ session_id: 'sess-1', type: 'evidence', content: 'B' });
+      expect(id1).toBeGreaterThan(0);
+      expect(id2).toBeGreaterThan(id1);
+    });
+
+    it('auto-increments seq per session', () => {
+      store.publish({ session_id: 'sess-1', type: 'finding', content: 'A' });
+      store.publish({ session_id: 'sess-1', type: 'finding', content: 'B' });
+      store.publish({ session_id: 'sess-2', type: 'finding', content: 'C' });
+
+      const sess1 = store.queryAll('sess-1');
+      const sess2 = store.queryAll('sess-2');
+
+      expect(sess1[0]?.seq).toBe(1);
+      expect(sess1[1]?.seq).toBe(2);
+      expect(sess2[0]?.seq).toBe(1); // seq restarts for a new session
+    });
+
+    it('stores all fields correctly', () => {
+      const id = store.publish({
+        session_id: 'sess-1',
+        type: 'hypothesis',
+        subject: 'auth race',
+        content: 'Auth refresh may race',
+        evidence: ['src/auth.ts:141'],
+        confidence: 0.8,
+        agent_id: 'researcher-A',
+        relates_to: [1, 2],
+        relation_type: 'supports',
+      });
+
+      const entries = store.queryAll('sess-1');
+      const entry = entries.find((e) => e.id === id);
+      expect(entry).toBeDefined();
+      expect(entry?.type).toBe('hypothesis');
+      expect(entry?.subject).toBe('auth race');
+      expect(entry?.content).toBe('Auth refresh may race');
+      expect(entry?.evidence).toBe('["src/auth.ts:141"]');
+      expect(entry?.confidence).toBe(0.8);
+      expect(entry?.agent_id).toBe('researcher-A');
+      expect(entry?.relates_to).toBe('[1,2]');
+      expect(entry?.relation_type).toBe('supports');
+    });
+
+    it('defaults confidence to 1.0', () => {
+      const id = store.publish({ session_id: 'sess-1', type: 'status', content: 'OK' });
+      const entries = store.queryAll('sess-1');
+      const entry = entries.find((e) => e.id === id);
+      expect(entry?.confidence).toBe(1.0);
+    });
+  });
+
+  // ── queryAll ───────────────────────────────────────────────────────────────
+
+  describe('queryAll', () => {
+    it('returns entries in seq ascending order', () => {
+      store.publish({ session_id: 'sess-1', type: 'finding', content: 'First' });
+      store.publish({ session_id: 'sess-1', type: 'finding', content: 'Second' });
+      store.publish({ session_id: 'sess-1', type: 'finding', content: 'Third' });
+
+      const entries = store.queryAll('sess-1');
+      expect(entries.map((e) => e.content)).toEqual(['First', 'Second', 'Third']);
+    });
+
+    it('returns empty array for unknown session', () => {
+      expect(store.queryAll('no-such-session')).toEqual([]);
+    });
+
+    it('isolates entries by session', () => {
+      store.publish({ session_id: 'sess-1', type: 'finding', content: 'For sess-1' });
+      store.publish({ session_id: 'sess-2', type: 'finding', content: 'For sess-2' });
+
+      const sess1 = store.queryAll('sess-1');
+      expect(sess1).toHaveLength(1);
+      expect(sess1[0]?.content).toBe('For sess-1');
+    });
+  });
+
+  // ── queryRelevant ──────────────────────────────────────────────────────────
+
+  describe('queryRelevant', () => {
+    it('returns subject-matched entries when keywords overlap', () => {
+      store.publish({ session_id: 's', type: 'finding', subject: 'auth refresh', content: 'A' });
+      store.publish({ session_id: 's', type: 'finding', subject: 'database schema', content: 'B' });
+      store.publish({ session_id: 's', type: 'finding', subject: 'auth token', content: 'C' });
+
+      const results = store.queryRelevant('s', 'check the auth flow');
+      // Should match 'auth refresh' and 'auth token' but not 'database schema'
+      const contents = results.map((e) => e.content);
+      expect(contents).toContain('A');
+      expect(contents).toContain('C');
+      expect(contents).not.toContain('B');
+    });
+
+    it('falls back to all session entries when no subject matches', () => {
+      store.publish({ session_id: 's', type: 'finding', subject: 'payments', content: 'P' });
+      store.publish({ session_id: 's', type: 'status', content: 'S' });
+
+      // taskPrompt has no overlapping keywords with any subject
+      const results = store.queryRelevant('s', 'xyz-qrs-mno');
+      expect(results.length).toBeGreaterThan(0);
+    });
+
+    it('respects the limit parameter', () => {
+      for (let i = 0; i < 10; i++) {
+        store.publish({ session_id: 's', type: 'finding', content: `Entry ${i}` });
+      }
+      const results = store.queryRelevant('s', 'any query xyz', 3);
+      expect(results.length).toBeLessThanOrEqual(3);
+    });
+
+    it('defaults limit to 50', () => {
+      for (let i = 0; i < 60; i++) {
+        store.publish({ session_id: 's', type: 'finding', content: `Entry ${i}` });
+      }
+      const results = store.queryRelevant('s', 'xyz-no-match');
+      expect(results.length).toBe(50);
+    });
+
+    it('returns entries ordered by seq descending (most recent first)', () => {
+      store.publish({ session_id: 's', type: 'finding', subject: 'auth', content: 'Older' });
+      store.publish({ session_id: 's', type: 'finding', subject: 'auth', content: 'Newer' });
+
+      const results = store.queryRelevant('s', 'auth session check');
+      expect(results[0]?.content).toBe('Newer');
+      expect(results[1]?.content).toBe('Older');
+    });
+  });
+
+  // ── close ──────────────────────────────────────────────────────────────────
+
+  describe('close', () => {
+    it('closes without error', () => {
+      expect(() => store.close()).not.toThrow();
+    });
+  });
+});

--- a/src/agent/workspace/workspace-store.ts
+++ b/src/agent/workspace/workspace-store.ts
@@ -82,7 +82,7 @@ CREATE TABLE IF NOT EXISTS workspace_entries (
   seq INTEGER NOT NULL
 );
 
-CREATE INDEX IF NOT EXISTS idx_ws_session_seq ON workspace_entries(session_id, seq);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ws_session_seq ON workspace_entries(session_id, seq);
 `;
 
 // ── Store class ───────────────────────────────────────────────────────────────
@@ -123,25 +123,28 @@ export class WorkspaceStore {
    * `seq` is auto-incremented per session (max existing seq + 1, starting at 1).
    */
   publish(entry: WorkspacePublishInput): number {
-    const nextSeq = this.nextSeq(entry.session_id);
-    const stmt = this.db.prepare(`
-      INSERT INTO workspace_entries
-        (session_id, type, subject, content, evidence, confidence, agent_id, relates_to, relation_type, seq)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `);
-    const result = stmt.run(
-      entry.session_id,
-      entry.type,
-      entry.subject ?? null,
-      entry.content,
-      entry.evidence !== undefined ? JSON.stringify(entry.evidence) : null,
-      entry.confidence ?? 1.0,
-      entry.agent_id ?? null,
-      entry.relates_to !== undefined ? JSON.stringify(entry.relates_to) : null,
-      entry.relation_type ?? null,
-      nextSeq,
-    );
-    return Number(result.lastInsertRowid);
+    const txn = this.db.transaction(() => {
+      const nextSeq = this.nextSeq(entry.session_id);
+      const stmt = this.db.prepare(`
+        INSERT INTO workspace_entries
+          (session_id, type, subject, content, evidence, confidence, agent_id, relates_to, relation_type, seq)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `);
+      const result = stmt.run(
+        entry.session_id,
+        entry.type,
+        entry.subject ?? null,
+        entry.content,
+        entry.evidence !== undefined ? JSON.stringify(entry.evidence) : null,
+        entry.confidence ?? 1.0,
+        entry.agent_id ?? null,
+        entry.relates_to !== undefined ? JSON.stringify(entry.relates_to) : null,
+        entry.relation_type ?? null,
+        nextSeq,
+      );
+      return Number(result.lastInsertRowid);
+    });
+    return txn();
   }
 
   /**

--- a/src/agent/workspace/workspace-store.ts
+++ b/src/agent/workspace/workspace-store.ts
@@ -151,33 +151,49 @@ export class WorkspaceStore {
    * Query entries relevant to the given task prompt.
    *
    * Relevance: subject keyword overlap with `taskPrompt` words (≥3 chars).
-   * Falls back to all session entries when no subject matches.
+   * Falls back to all entries when no subject matches.
    * Always ordered by seq descending (most recent first). Capped at `limit`.
+   *
+   * When `sessionId` is `null`, the query scans all entries in the store
+   * regardless of which child published them. This is the correct mode for
+   * the fork-child-config preamble injection path: the store is already
+   * scoped to one root session (one `WorkspaceStore` instance per top-level
+   * session), and children publish under their own session IDs, so a
+   * session-filtered query would miss sibling findings.
    */
-  queryRelevant(sessionId: string, taskPrompt: string, limit = 50): WorkspaceEntry[] {
+  queryRelevant(sessionId: string | null, taskPrompt: string, limit = 50): WorkspaceEntry[] {
     const keywords = extractKeywords(taskPrompt);
 
     if (keywords.length > 0) {
       // Build a LIKE filter for subject overlap
       const conditions = keywords.map(() => `LOWER(COALESCE(subject,'')) LIKE ?`).join(' OR ');
-      const params: unknown[] = keywords.map((k) => `%${k}%`);
+      const likeParams: unknown[] = keywords.map((k) => `%${k}%`);
 
+      const sessionClause = sessionId !== null ? 'session_id = ? AND' : '';
       const sql = `
         SELECT * FROM workspace_entries
-        WHERE session_id = ? AND (${conditions})
+        WHERE ${sessionClause} (${conditions})
         ORDER BY seq DESC
         LIMIT ?
       `;
-      const rows = this.db.prepare(sql).all(sessionId, ...params, limit) as WorkspaceEntry[];
+      const params = sessionId !== null
+        ? [sessionId, ...likeParams, limit]
+        : [...likeParams, limit];
+      const rows = this.db.prepare(sql).all(...params) as WorkspaceEntry[];
       if (rows.length > 0) return rows;
     }
 
-    // Fallback: all entries for the session, most recent first
+    // Fallback: all entries (optionally filtered by session), most recent first
+    if (sessionId !== null) {
+      return this.db
+        .prepare(
+          'SELECT * FROM workspace_entries WHERE session_id = ? ORDER BY seq DESC LIMIT ?',
+        )
+        .all(sessionId, limit) as WorkspaceEntry[];
+    }
     return this.db
-      .prepare(
-        'SELECT * FROM workspace_entries WHERE session_id = ? ORDER BY seq DESC LIMIT ?',
-      )
-      .all(sessionId, limit) as WorkspaceEntry[];
+      .prepare('SELECT * FROM workspace_entries ORDER BY seq DESC LIMIT ?')
+      .all(limit) as WorkspaceEntry[];
   }
 
   /** All entries for a session, ordered by seq ascending. */
@@ -203,7 +219,12 @@ export class WorkspaceStore {
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-/** Extract lowercase search keywords (≥3 chars) from a prompt string. */
+/**
+ * Extract lowercase search keywords (≥3 chars) from a prompt string.
+ *
+ * Capped at 25 unique keywords to stay well under SQLite's expression-tree
+ * depth limit of 1000 (each keyword becomes one LIKE clause in an OR chain).
+ */
 function extractKeywords(prompt: string): string[] {
   return [
     ...new Set(
@@ -212,5 +233,5 @@ function extractKeywords(prompt: string): string[] {
         .split(/\W+/)
         .filter((w) => w.length >= 3),
     ),
-  ];
+  ].slice(0, 25);
 }

--- a/src/agent/workspace/workspace-store.ts
+++ b/src/agent/workspace/workspace-store.ts
@@ -1,0 +1,213 @@
+/**
+ * Per-session workspace store — SQLite-backed, ephemeral shared scratchpad.
+ *
+ * Lets sibling sub-agents publish structured findings (findings, evidence,
+ * hypotheses, decisions, artifacts, status) to a shared SQLite store for the
+ * duration of a session. Default path is `:memory:` — no persistence across
+ * sessions.
+ *
+ * WAL mode + busy_timeout mirror the cross-session memory-store pattern for
+ * safe concurrent access when multiple agents share one file-backed instance.
+ *
+ * @module agent/workspace/workspace-store
+ */
+
+import Database from 'better-sqlite3';
+import type BetterSqlite3 from 'better-sqlite3';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type WorkspaceEntryType =
+  | 'finding'
+  | 'evidence'
+  | 'hypothesis'
+  | 'decision'
+  | 'artifact'
+  | 'status';
+
+export type WorkspaceRelationType =
+  | 'supports'
+  | 'contradicts'
+  | 'depends_on'
+  | 'supersedes';
+
+/** A fully-hydrated workspace entry as returned by query methods. */
+export interface WorkspaceEntry {
+  id: number;
+  session_id: string;
+  type: WorkspaceEntryType;
+  subject: string | null;
+  content: string;
+  /** JSON-encoded array of file:line references, or null. */
+  evidence: string | null;
+  confidence: number;
+  agent_id: string | null;
+  /** JSON-encoded array of related entry IDs, or null. */
+  relates_to: string | null;
+  relation_type: WorkspaceRelationType | null;
+  created_at: string;
+  seq: number;
+}
+
+/** Input type for publishing a new entry — id/created_at/seq are auto-set. */
+export interface WorkspacePublishInput {
+  session_id: string;
+  type: WorkspaceEntryType;
+  subject?: string;
+  content: string;
+  /** File:line references, stored as a JSON array. */
+  evidence?: string[];
+  confidence?: number;
+  agent_id?: string;
+  /** IDs of related entries. */
+  relates_to?: number[];
+  relation_type?: WorkspaceRelationType;
+}
+
+// ── Schema ───────────────────────────────────────────────────────────────────
+
+const SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS workspace_entries (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id TEXT NOT NULL,
+  type TEXT NOT NULL CHECK(type IN ('finding','evidence','hypothesis','decision','artifact','status')),
+  subject TEXT,
+  content TEXT NOT NULL,
+  evidence TEXT,
+  confidence REAL DEFAULT 1.0,
+  agent_id TEXT,
+  relates_to TEXT,
+  relation_type TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  seq INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_ws_session_seq ON workspace_entries(session_id, seq);
+`;
+
+// ── Store class ───────────────────────────────────────────────────────────────
+
+export class WorkspaceStore {
+  private readonly db: BetterSqlite3.Database;
+
+  constructor(dbPath?: string) {
+    this.db = new Database(dbPath ?? ':memory:');
+    // busy_timeout: concurrent writers wait up to 5s rather than failing fast.
+    this.db.pragma('busy_timeout = 5000');
+    this.enableWalMode();
+    this.db.exec(SCHEMA_SQL);
+  }
+
+  /**
+   * WAL mode — tolerant of concurrent cold opens (same pattern as memory-store).
+   * Reads journal_mode first (lock-free) and skips the switch when already 'wal'.
+   */
+  private enableWalMode(): void {
+    const MAX_ATTEMPTS = 50;
+    const BACKOFF_MS = 20;
+    for (let attempt = 1; ; attempt++) {
+      try {
+        if (this.db.pragma('journal_mode', { simple: true }) === 'wal') return;
+        this.db.pragma('journal_mode = WAL');
+        return;
+      } catch (err) {
+        const busy = (err as { code?: string } | null)?.code === 'SQLITE_BUSY';
+        if (!busy || attempt >= MAX_ATTEMPTS) throw err;
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, BACKOFF_MS);
+      }
+    }
+  }
+
+  /**
+   * Publish a new workspace entry. Returns the assigned row id.
+   * `seq` is auto-incremented per session (max existing seq + 1, starting at 1).
+   */
+  publish(entry: WorkspacePublishInput): number {
+    const nextSeq = this.nextSeq(entry.session_id);
+    const stmt = this.db.prepare(`
+      INSERT INTO workspace_entries
+        (session_id, type, subject, content, evidence, confidence, agent_id, relates_to, relation_type, seq)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    const result = stmt.run(
+      entry.session_id,
+      entry.type,
+      entry.subject ?? null,
+      entry.content,
+      entry.evidence !== undefined ? JSON.stringify(entry.evidence) : null,
+      entry.confidence ?? 1.0,
+      entry.agent_id ?? null,
+      entry.relates_to !== undefined ? JSON.stringify(entry.relates_to) : null,
+      entry.relation_type ?? null,
+      nextSeq,
+    );
+    return Number(result.lastInsertRowid);
+  }
+
+  /**
+   * Query entries relevant to the given task prompt.
+   *
+   * Relevance: subject keyword overlap with `taskPrompt` words (≥3 chars).
+   * Falls back to all session entries when no subject matches.
+   * Always ordered by seq descending (most recent first). Capped at `limit`.
+   */
+  queryRelevant(sessionId: string, taskPrompt: string, limit = 50): WorkspaceEntry[] {
+    const keywords = extractKeywords(taskPrompt);
+
+    if (keywords.length > 0) {
+      // Build a LIKE filter for subject overlap
+      const conditions = keywords.map(() => `LOWER(COALESCE(subject,'')) LIKE ?`).join(' OR ');
+      const params: unknown[] = keywords.map((k) => `%${k}%`);
+
+      const sql = `
+        SELECT * FROM workspace_entries
+        WHERE session_id = ? AND (${conditions})
+        ORDER BY seq DESC
+        LIMIT ?
+      `;
+      const rows = this.db.prepare(sql).all(sessionId, ...params, limit) as WorkspaceEntry[];
+      if (rows.length > 0) return rows;
+    }
+
+    // Fallback: all entries for the session, most recent first
+    return this.db
+      .prepare(
+        'SELECT * FROM workspace_entries WHERE session_id = ? ORDER BY seq DESC LIMIT ?',
+      )
+      .all(sessionId, limit) as WorkspaceEntry[];
+  }
+
+  /** All entries for a session, ordered by seq ascending. */
+  queryAll(sessionId: string): WorkspaceEntry[] {
+    return this.db
+      .prepare('SELECT * FROM workspace_entries WHERE session_id = ? ORDER BY seq ASC')
+      .all(sessionId) as WorkspaceEntry[];
+  }
+
+  close(): void {
+    this.db.close();
+  }
+
+  // ── Private ──────────────────────────────────────────────────────────────
+
+  private nextSeq(sessionId: string): number {
+    const row = this.db
+      .prepare('SELECT MAX(seq) AS max_seq FROM workspace_entries WHERE session_id = ?')
+      .get(sessionId) as { max_seq: number | null } | undefined;
+    return (row?.max_seq ?? 0) + 1;
+  }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Extract lowercase search keywords (≥3 chars) from a prompt string. */
+function extractKeywords(prompt: string): string[] {
+  return [
+    ...new Set(
+      prompt
+        .toLowerCase()
+        .split(/\W+/)
+        .filter((w) => w.length >= 3),
+    ),
+  ];
+}

--- a/src/agent/workspace/workspace-tools.test.ts
+++ b/src/agent/workspace/workspace-tools.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for createWorkspaceHandlers (workspace-tools.ts).
+ *
+ * @module agent/workspace/workspace-tools.test
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { WorkspaceStore } from './workspace-store.js';
+import { createWorkspaceHandlers } from './workspace-tools.js';
+
+const DUMMY_SIGNAL = new AbortController().signal;
+
+describe('createWorkspaceHandlers', () => {
+  let store: WorkspaceStore;
+  const sessionId = 'test-session-1';
+  const agentId = 'agent-alpha';
+
+  beforeEach(() => {
+    store = new WorkspaceStore();
+  });
+
+  it('returns a map with a workspace_publish entry', () => {
+    const handlers = createWorkspaceHandlers(store, sessionId, agentId);
+    expect(handlers.has('workspace_publish')).toBe(true);
+    expect(handlers.size).toBe(1);
+  });
+
+  it('publish valid entry returns { published: true, id: <number> }', async () => {
+    const handlers = createWorkspaceHandlers(store, sessionId, agentId);
+    const handler = handlers.get('workspace_publish')!;
+
+    const result = await handler(
+      { type: 'finding', content: 'The auth module uses JWT.' },
+      DUMMY_SIGNAL,
+    );
+
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(result.content as string) as { published: boolean; id: number };
+    expect(parsed.published).toBe(true);
+    expect(typeof parsed.id).toBe('number');
+    expect(parsed.id).toBeGreaterThan(0);
+  });
+
+  it('publish with all optional fields succeeds', async () => {
+    const handlers = createWorkspaceHandlers(store, sessionId, agentId);
+    const handler = handlers.get('workspace_publish')!;
+
+    const result = await handler(
+      {
+        type: 'evidence',
+        content: 'Line 42 sets the timeout.',
+        subject: 'auth timeout',
+        evidence: ['src/auth.ts:42'],
+        confidence: 0.9,
+        relates_to: [1],
+        relation_type: 'supports',
+      },
+      DUMMY_SIGNAL,
+    );
+
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(result.content as string) as { published: boolean; id: number };
+    expect(parsed.published).toBe(true);
+  });
+
+  it('publish with missing type returns isError', async () => {
+    const handlers = createWorkspaceHandlers(store, sessionId, agentId);
+    const handler = handlers.get('workspace_publish')!;
+
+    const result = await handler(
+      { content: 'No type provided.' },
+      DUMMY_SIGNAL,
+    );
+
+    expect(result.isError).toBe(true);
+  });
+
+  it('publish with invalid type value returns isError', async () => {
+    const handlers = createWorkspaceHandlers(store, sessionId, agentId);
+    const handler = handlers.get('workspace_publish')!;
+
+    const result = await handler(
+      { type: 'invalid_type', content: 'Something.' },
+      DUMMY_SIGNAL,
+    );
+
+    expect(result.isError).toBe(true);
+  });
+
+  it('publish with missing content returns isError', async () => {
+    const handlers = createWorkspaceHandlers(store, sessionId, agentId);
+    const handler = handlers.get('workspace_publish')!;
+
+    const result = await handler(
+      { type: 'finding' },
+      DUMMY_SIGNAL,
+    );
+
+    expect(result.isError).toBe(true);
+  });
+
+  it('publish with empty content returns isError', async () => {
+    const handlers = createWorkspaceHandlers(store, sessionId, agentId);
+    const handler = handlers.get('workspace_publish')!;
+
+    const result = await handler(
+      { type: 'finding', content: '' },
+      DUMMY_SIGNAL,
+    );
+
+    expect(result.isError).toBe(true);
+  });
+
+  it('auto-fills agent_id from constructor arg', async () => {
+    const handlers = createWorkspaceHandlers(store, sessionId, agentId);
+    const handler = handlers.get('workspace_publish')!;
+
+    await handler(
+      { type: 'status', content: 'Working on it.' },
+      DUMMY_SIGNAL,
+    );
+
+    const entries = store.queryAll(sessionId);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.agent_id).toBe(agentId);
+  });
+
+  it('works without agentId (agent_id is null)', async () => {
+    const handlers = createWorkspaceHandlers(store, sessionId);
+    const handler = handlers.get('workspace_publish')!;
+
+    await handler(
+      { type: 'finding', content: 'No agent id.' },
+      DUMMY_SIGNAL,
+    );
+
+    const entries = store.queryAll(sessionId);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.agent_id).toBeNull();
+  });
+
+  it('published entry is retrievable from the store', async () => {
+    const handlers = createWorkspaceHandlers(store, sessionId, agentId);
+    const handler = handlers.get('workspace_publish')!;
+
+    const result = await handler(
+      { type: 'decision', content: 'Use Redis for caching.', subject: 'caching' },
+      DUMMY_SIGNAL,
+    );
+
+    const parsed = JSON.parse(result.content as string) as { published: boolean; id: number };
+    const entries = store.queryAll(sessionId);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.id).toBe(parsed.id);
+    expect(entries[0]!.content).toBe('Use Redis for caching.');
+    expect(entries[0]!.type).toBe('decision');
+  });
+});

--- a/src/agent/workspace/workspace-tools.ts
+++ b/src/agent/workspace/workspace-tools.ts
@@ -21,7 +21,7 @@ import { WorkspaceStore } from './workspace-store.js';
 export const workspacePublishTool: AnthropicToolDef = {
   name: 'workspace_publish',
   category: 'write',
-  concurrencySafe: true,
+  concurrencySafe: false,
   description:
     'Publish a structured finding to the shared session workspace so sibling agents can see it. ' +
     'Use this to surface discoveries, evidence, hypotheses, decisions, artifacts, or status updates ' +
@@ -113,6 +113,12 @@ export function createWorkspaceHandlers(
 
 // ── Input parsing ─────────────────────────────────────────────────────────────
 
+/** Max chars for workspace entry content before truncation at ingest. */
+const CONTENT_MAX_CHARS = 8192;
+/** Max chars for workspace entry subject before truncation at ingest. */
+const SUBJECT_MAX_CHARS = 256;
+const TRUNCATION_MARKER = ' … [truncated]';
+
 const VALID_TYPES = new Set([
   'finding',
   'evidence',
@@ -152,13 +158,20 @@ function parsePublishInput(input: unknown): ParsedPublishInput {
     );
   }
 
-  const content = raw['content'];
-  if (typeof content !== 'string' || content.length === 0) {
+  const contentRaw = raw['content'];
+  if (typeof contentRaw !== 'string' || contentRaw.length === 0) {
     throw new Error('workspace_publish: content is required');
   }
+  const content = contentRaw.length > CONTENT_MAX_CHARS
+    ? contentRaw.slice(0, CONTENT_MAX_CHARS) + TRUNCATION_MARKER
+    : contentRaw;
 
   const subject =
-    typeof raw['subject'] === 'string' ? raw['subject'] : undefined;
+    typeof raw['subject'] === 'string'
+      ? raw['subject'].length > SUBJECT_MAX_CHARS
+        ? raw['subject'].slice(0, SUBJECT_MAX_CHARS) + TRUNCATION_MARKER
+        : raw['subject']
+      : undefined;
 
   const evidence =
     Array.isArray(raw['evidence']) &&

--- a/src/agent/workspace/workspace-tools.ts
+++ b/src/agent/workspace/workspace-tools.ts
@@ -1,0 +1,193 @@
+/**
+ * Workspace tool schemas and handlers.
+ *
+ * Single tool: `workspace_publish` — lets sub-agents share structured findings
+ * with sibling agents within the same session. No query tool in v1; agents
+ * receive workspace context via the preamble injected into their system prompt.
+ *
+ * Pattern mirrors `src/agent/memory/memory-tools.ts`.
+ *
+ * @module agent/workspace/workspace-tools
+ */
+
+import type { AnthropicToolDef, ToolHandler } from '../tools/types.js';
+import type { WorkspacePublishInput, WorkspaceRelationType } from './workspace-store.js';
+import { WorkspaceStore } from './workspace-store.js';
+
+/**
+ * workspace_publish: Publish a structured finding to the shared session workspace.
+ * Sibling agents will see this entry in their workspace context preamble.
+ */
+export const workspacePublishTool: AnthropicToolDef = {
+  name: 'workspace_publish',
+  category: 'write',
+  concurrencySafe: true,
+  description:
+    'Publish a structured finding to the shared session workspace so sibling agents can see it. ' +
+    'Use this to surface discoveries, evidence, hypotheses, decisions, artifacts, or status updates ' +
+    'that other agents working on the same task should know about. ' +
+    'Entries appear in the workspace context preamble injected into sibling agent system prompts.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      type: {
+        type: 'string',
+        enum: ['finding', 'evidence', 'hypothesis', 'decision', 'artifact', 'status'],
+        description: 'The kind of entry being published.',
+      },
+      subject: {
+        type: 'string',
+        description:
+          'Optional short label for relevance routing — e.g. "auth refresh", "DB schema". ' +
+          'Agents querying the workspace by task keywords will match on this field.',
+      },
+      content: {
+        type: 'string',
+        description: 'The full text of the finding, evidence, or decision.',
+      },
+      evidence: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Optional file:line references backing this entry (e.g. ["src/auth.ts:141"]).',
+      },
+      confidence: {
+        type: 'number',
+        description: 'Confidence level 0–1 (default 1.0).',
+      },
+      relates_to: {
+        type: 'array',
+        items: { type: 'number' },
+        description: 'Optional IDs of related workspace entries.',
+      },
+      relation_type: {
+        type: 'string',
+        enum: ['supports', 'contradicts', 'depends_on', 'supersedes'],
+        description: 'Relationship to the entries listed in relates_to.',
+      },
+    },
+    required: ['type', 'content'],
+  },
+};
+
+/** All workspace tool schemas (v1: publish only). */
+export const workspaceToolSchemas: AnthropicToolDef[] = [workspacePublishTool];
+
+/**
+ * Create workspace tool handlers bound to a store + session.
+ *
+ * Returns a Map with one entry: `'workspace_publish'` → handler.
+ * The `agent_id` field is auto-filled from the optional `agentId` parameter.
+ */
+export function createWorkspaceHandlers(
+  store: WorkspaceStore,
+  sessionId: string,
+  agentId?: string,
+): Map<string, ToolHandler> {
+  const handlers = new Map<string, ToolHandler>();
+
+  const publishHandler: ToolHandler = async (input: unknown) => {
+    try {
+      const parsed = parsePublishInput(input);
+      const entry: WorkspacePublishInput = {
+        session_id: sessionId,
+        type: parsed.type,
+        content: parsed.content,
+        subject: parsed.subject,
+        evidence: parsed.evidence,
+        confidence: parsed.confidence,
+        agent_id: agentId,
+        relates_to: parsed.relates_to,
+        relation_type: parsed.relation_type,
+      };
+      const id = store.publish(entry);
+      return { content: JSON.stringify({ published: true, id }) };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { content: `workspace_publish error: ${message}`, isError: true };
+    }
+  };
+
+  handlers.set('workspace_publish', publishHandler);
+  return handlers;
+}
+
+// ── Input parsing ─────────────────────────────────────────────────────────────
+
+const VALID_TYPES = new Set([
+  'finding',
+  'evidence',
+  'hypothesis',
+  'decision',
+  'artifact',
+  'status',
+]);
+
+const VALID_RELATION_TYPES = new Set([
+  'supports',
+  'contradicts',
+  'depends_on',
+  'supersedes',
+]);
+
+interface ParsedPublishInput {
+  type: WorkspacePublishInput['type'];
+  content: string;
+  subject?: string;
+  evidence?: string[];
+  confidence?: number;
+  relates_to?: number[];
+  relation_type?: WorkspaceRelationType;
+}
+
+function parsePublishInput(input: unknown): ParsedPublishInput {
+  if (!input || typeof input !== 'object') {
+    throw new Error('workspace_publish: input must be an object');
+  }
+  const raw = input as Record<string, unknown>;
+
+  const type = raw['type'];
+  if (typeof type !== 'string' || !VALID_TYPES.has(type)) {
+    throw new Error(
+      `workspace_publish: type must be one of ${[...VALID_TYPES].join(', ')}`,
+    );
+  }
+
+  const content = raw['content'];
+  if (typeof content !== 'string' || content.length === 0) {
+    throw new Error('workspace_publish: content is required');
+  }
+
+  const subject =
+    typeof raw['subject'] === 'string' ? raw['subject'] : undefined;
+
+  const evidence =
+    Array.isArray(raw['evidence']) &&
+    (raw['evidence'] as unknown[]).every((e) => typeof e === 'string')
+      ? (raw['evidence'] as string[])
+      : undefined;
+
+  const confidence =
+    typeof raw['confidence'] === 'number' ? raw['confidence'] : undefined;
+
+  const relates_to =
+    Array.isArray(raw['relates_to']) &&
+    (raw['relates_to'] as unknown[]).every((n) => typeof n === 'number')
+      ? (raw['relates_to'] as number[])
+      : undefined;
+
+  const relationTypeRaw = raw['relation_type'];
+  const relation_type =
+    typeof relationTypeRaw === 'string' && VALID_RELATION_TYPES.has(relationTypeRaw)
+      ? (relationTypeRaw as WorkspaceRelationType)
+      : undefined;
+
+  return {
+    type: type as WorkspacePublishInput['type'],
+    content,
+    subject,
+    evidence,
+    confidence,
+    relates_to,
+    relation_type,
+  };
+}

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -28,15 +28,15 @@ import type { ScheduledTask } from '../../agent/daemon/triggers.js';
 import { parseThinking, parseEffort, getApiKey, getApiKeyForModel, getModel, getThinking, getEffort, parseProvider, getDefaultSubagentModel, getMaxToolUseIterations } from '../shared-helpers.js';
 import { loadSchedules, toScheduledTask } from '../../agent/daemon/schedule-store.js';
 import { AgentSession } from '../../agent/session.js';
-import { MemoryStore, injectHotMemory } from '../../agent/memory/index.js';
+import { MemoryStore, MEMORY_TOOL_NAMES, injectHotMemory } from '../../agent/memory/index.js';
 import { injectCompanionPrimer } from '../../agent/companion/index.js';
 import { wireExecutors } from '../../agent/session/wire-executors.js';
 import { ensurePluginEntrypointsLoaded } from '../../agent/tools/skill-bridge.js';
 import { createStubParentSession } from '../../agent/tools/nesting.js';
 import { AnthropicDirectProvider } from '../../agent/providers/anthropic-direct/index.js';
 import { BUILTIN_TOOL_NAMES } from '../../agent/tools/schemas.js';
-import { MEMORY_TOOL_NAMES } from '../../agent/memory/index.js';
 import { AWARENESS_TOOL_NAMES } from '../../agent/awareness/index.js';
+import { WorkspaceStore } from '../../agent/workspace/workspace-store.js';
 
 /**
  * Options for {@link buildDaemonSessionFactory}.
@@ -75,7 +75,7 @@ export function buildDaemonSessionFactory(
   // store is intentionally not closed here: the daemon owns it for its whole
   // process lifetime and the SIGINT/SIGTERM shutdown path ends in
   // process.exit(), which reclaims the descriptor.
-  let memoryStore: MemoryStore | undefined;
+  let memoryStore: MemoryStore | undefined, workspaceStore: WorkspaceStore | undefined;
   return (config: AgentConfig, ownedTraceWriter?: import('../../agent/trace/index.js').TraceWriter): AgentSession => {
     // Ephemeral abort controller — the daemon root session has no parent
     // to propagate cancellation from.
@@ -108,7 +108,7 @@ export function buildDaemonSessionFactory(
       // No backgroundRegistry: background dispatch is interactive-only.
     });
 
-    memoryStore ??= new MemoryStore();
+    memoryStore ??= new MemoryStore(); workspaceStore ??= new WorkspaceStore();
     const mcpManager = config.mcpManager;
     const mcpToolWireNames = mcpManager?.getMcpToolWireNames() ?? [];
 
@@ -116,7 +116,7 @@ export function buildDaemonSessionFactory(
       subagentExecutor,
       skillExecutor,
       composeExecutor,
-      memoryStore,
+      memoryStore, workspaceStore,
       model: String(opts.model),
       ...(opts.openaiBaseUrl !== undefined ? { openaiBaseUrl: opts.openaiBaseUrl } : {}),
       ...(mcpManager !== undefined ? { mcpManager } : {}),
@@ -127,7 +127,7 @@ export function buildDaemonSessionFactory(
       subagentExecutor,
       skillExecutor,
       composeExecutor,
-      memoryStore,
+      memoryStore, workspaceStore,
       surface: 'daemon',
       ...(mcpManager !== undefined ? { mcpManager } : {}),
     });

--- a/src/cli/commands/interactive/bootstrap-providers.ts
+++ b/src/cli/commands/interactive/bootstrap-providers.ts
@@ -1,5 +1,6 @@
 import type { ModelProvider } from '../../../agent/provider.js';
 import type { MemoryStore } from '../../../agent/memory/index.js';
+import type { WorkspaceStore } from '../../../agent/workspace/workspace-store.js';
 import type { SubagentExecutor } from '../../../agent/tools/subagent-executor.js';
 import type { SkillExecutor } from '../../../agent/tools/skill-executor.js';
 import type { ComposeExecutor } from '../../../agent/tools/compose-executor.js';
@@ -46,6 +47,7 @@ export function createReplProviders(a: {
   skillExecutor: SkillExecutor;
   composeExecutor: ComposeExecutor;
   memoryStore: MemoryStore;
+  workspaceStore?: WorkspaceStore;
   mcpManager: McpManager | undefined;
   fastModeController: FastModeController;
 }): { providerFactory: (m: string | undefined) => ModelProvider; startupProvider: ModelProvider } {
@@ -58,6 +60,7 @@ export function createReplProviders(a: {
       skillExecutor: a.skillExecutor,
       composeExecutor: a.composeExecutor,
       memoryStore: a.memoryStore,
+      ...(a.workspaceStore !== undefined ? { workspaceStore: a.workspaceStore } : {}),
       model: model !== undefined ? model : String(a.sessionModel),
       ...(a.cliConfig.openaiBaseUrl !== undefined ? { openaiBaseUrl: a.cliConfig.openaiBaseUrl } : {}),
       ...(a.mcpManager !== undefined ? { mcpManager: a.mcpManager } : {}),
@@ -71,6 +74,7 @@ export function createReplProviders(a: {
       skillExecutor: a.skillExecutor,
       composeExecutor: a.composeExecutor,
       memoryStore: a.memoryStore,
+      ...(a.workspaceStore !== undefined ? { workspaceStore: a.workspaceStore } : {}),
       surface: 'cli',
       fastModeController: a.fastModeController,
       ...(a.mcpManager !== undefined ? { mcpManager: a.mcpManager } : {}),

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -1,4 +1,5 @@
 import { MemoryStore } from '../../../agent/memory/index.js';
+import { WorkspaceStore } from '../../../agent/workspace/workspace-store.js';
 import { registerSurfaceSession } from '../../../agent/session/register-surface-session.js';
 import type { SlashContext } from '../../slash/types.js';
 import type { SessionRef } from '../../../agent/session-ref.js';
@@ -81,6 +82,7 @@ export async function bootstrapSession(
   });
 
   const sharedMemoryStore = new MemoryStore();
+  const sharedWorkspaceStore = new WorkspaceStore();
   const { FastModeController } = await import('../../../agent/fast-mode.js');
   const fastModeController = new FastModeController();
 
@@ -101,7 +103,7 @@ export async function bootstrapSession(
   // builder closes over `mcpManager`.
   const { providerFactory, startupProvider } = createReplProviders({
     options, cliConfig, sessionModel, subagentExecutor, skillExecutor, composeExecutor,
-    memoryStore: sharedMemoryStore, mcpManager, fastModeController,
+    memoryStore: sharedMemoryStore, workspaceStore: sharedWorkspaceStore, mcpManager, fastModeController,
   });
 
   // Stats, permission/thinking-UI seeding, startup banners (`trace:` /

--- a/src/cli/provider-parser.ts
+++ b/src/cli/provider-parser.ts
@@ -25,6 +25,8 @@ export type ParseProviderOptions = {
   composeExecutor?: import('../agent/tools/compose-executor.js').ComposeExecutor;
   /** Shared MemoryStore to pass into providers so only one SQLite DB is opened. */
   memoryStore?: import('../agent/memory/index.js').MemoryStore;
+  /** Shared WorkspaceStore so sibling sub-agents share one ephemeral scratchpad. */
+  workspaceStore?: import('../agent/workspace/workspace-store.js').WorkspaceStore;
   /**
    * Optional MCP manager. When supplied, every tool exposed by a
    * `connected` MCP server is added to the provider's allow-list AND
@@ -130,6 +132,7 @@ export function parseProvider(
       skillExecutor: opts?.skillExecutor,
       composeExecutor: opts?.composeExecutor,
       ...(opts?.memoryStore !== undefined ? { memoryStore: opts.memoryStore } : {}),
+      ...(opts?.workspaceStore !== undefined ? { workspaceStore: opts.workspaceStore } : {}),
       ...(opts?.mcpManager !== undefined ? { mcpManager: opts.mcpManager } : {}),
       ...(opts?.fastModeController !== undefined ? { fastModeController: opts.fastModeController } : {}),
     });
@@ -144,6 +147,7 @@ export function parseProvider(
       ...(opts?.skillExecutor !== undefined ? { skillExecutor: opts.skillExecutor } : {}),
       ...(opts?.composeExecutor !== undefined ? { composeExecutor: opts.composeExecutor } : {}),
       ...(opts?.memoryStore !== undefined ? { memoryStore: opts.memoryStore } : {}),
+      ...(opts?.workspaceStore !== undefined ? { workspaceStore: opts.workspaceStore } : {}),
       ...(opts?.mcpManager !== undefined ? { mcpManager: opts.mcpManager } : {}),
       ...(opts?.openaiBaseUrl !== undefined ? { baseURL: opts.openaiBaseUrl } : {}),
     });

--- a/src/telegram/create-session.ts
+++ b/src/telegram/create-session.ts
@@ -18,6 +18,7 @@ import { resolveModelId } from '../agent/session/model-resolution.js';
 import { getMaxOutputTokens, getMaxToolUseIterations, composeSystemPrompt } from '../cli/shared-helpers.js';
 import type { AgentConfig } from '../agent/types.js';
 import type { MemoryStore } from '../agent/memory/index.js';
+import { WorkspaceStore } from '../agent/workspace/workspace-store.js';
 import { createTelegramTraceWriter } from './construct-session.js';
 import { loadTelegramMcpManager } from './mcp-session.js';
 import { isOpenAiRoutedProvider, isXaiRoutedProvider } from './credentials.js';
@@ -35,6 +36,8 @@ export interface TelegramSessionFactoryOptions {
   telegramCwd: string | undefined;
   /** Bot-global memory store shared by every chat's hook bundle. */
   memoryStore: MemoryStore;
+  /** Bot-global workspace store shared by every session (one SQLite per bot process). */
+  workspaceStore?: WorkspaceStore;
   log?: (message: string) => void;
 }
 
@@ -45,6 +48,7 @@ export function createTelegramSessionFactory(
   options: TelegramSessionFactoryOptions,
 ): (sessionConfig: AgentConfig) => Promise<AgentSession> {
   const { config, frameworkBase, telegramCwd, memoryStore } = options;
+  const sharedWorkspaceStore = options.workspaceStore ?? new WorkspaceStore();
   const log = options.log ?? console.log;
 
   return async function createSession(sessionConfig: AgentConfig): Promise<AgentSession> {
@@ -98,6 +102,7 @@ export function createTelegramSessionFactory(
       traceWriter,
       mcpManager,
       memoryStore,
+      workspaceStore: sharedWorkspaceStore,
       reportSession: (session) => { returnedSession = session; },
     };
 

--- a/src/telegram/entry.ts
+++ b/src/telegram/entry.ts
@@ -24,6 +24,7 @@ import { TelegramBot } from './bot.js';
 import { parseAllowedChatIds } from './allowlist.js';
 import { validateBotToken } from './setup-wizard.js';
 import { MemoryStore } from '../agent/memory/index.js';
+import { WorkspaceStore } from '../agent/workspace/workspace-store.js';
 import { providerForModel } from '../agent/providers/index.js';
 import { loadConfig, loadTelegramConfig } from '../cli/config.js';
 import { getEnvConfigPath } from '../paths.js';
@@ -137,6 +138,7 @@ export async function main(): Promise<void> {
   }
 
   const sharedMemoryStore = new MemoryStore();
+  const sharedWorkspaceStore = new WorkspaceStore();
 
   // Optional working-directory override for every bot-spawned session.
   // When set, all per-chat AgentSessions (and their forked subagents)
@@ -166,6 +168,7 @@ export async function main(): Promise<void> {
       frameworkBase,
       telegramCwd,
       memoryStore: sharedMemoryStore,
+      workspaceStore: sharedWorkspaceStore,
     }),
   });
 
@@ -180,6 +183,7 @@ export async function main(): Promise<void> {
     clearInterval(statsInterval);
     await bot.stop();
     sharedMemoryStore.close();
+    sharedWorkspaceStore.close();
     console.log('✅ Bot stopped.');
     process.exit(0);
   };

--- a/src/telegram/session-anthropic.ts
+++ b/src/telegram/session-anthropic.ts
@@ -34,6 +34,7 @@ export async function buildAnthropicTelegramSession(
     traceWriter,
     mcpManager,
     memoryStore,
+    workspaceStore,
     reportSession,
   } = ctx;
 
@@ -94,6 +95,7 @@ export async function buildAnthropicTelegramSession(
     skillExecutor,
     composeExecutor,
     ...(mcpManager !== undefined ? { mcpManager } : {}),
+    workspaceStore,
     // Tag the presence file (~/.afk/state/presence/<id>.json) and
     // get_runtime_state as the Telegram surface. Without this the provider
     // defaults to 'cli' (anthropic-direct/index.ts) and `/watch`

--- a/src/telegram/session-context.ts
+++ b/src/telegram/session-context.ts
@@ -12,6 +12,7 @@
 import type { AgentSession } from '../agent/session.js';
 import type { AgentConfig } from '../agent/types.js';
 import type { MemoryStore } from '../agent/memory/index.js';
+import type { WorkspaceStore } from '../agent/workspace/workspace-store.js';
 import type { loadConfig } from '../cli/config.js';
 import type { createTelegramTraceWriter } from './construct-session.js';
 import type { loadTelegramMcpManager } from './mcp-session.js';
@@ -40,6 +41,8 @@ export interface TelegramSessionBuildContext {
   mcpManager: TelegramMcpManager;
   /** Bot-global store shared across every chat's hook bundle. */
   memoryStore: MemoryStore;
+  /** Bot-global workspace store; one SQLite per bot process, shared by all sessions. */
+  workspaceStore: WorkspaceStore;
   /**
    * Report the session the moment it is constructed.
    *

--- a/src/telegram/session-openai.ts
+++ b/src/telegram/session-openai.ts
@@ -32,6 +32,7 @@ export async function buildOpenAiTelegramSession(
     traceWriter,
     mcpManager,
     memoryStore,
+    workspaceStore,
     reportSession,
   } = ctx;
 
@@ -55,6 +56,7 @@ export async function buildOpenAiTelegramSession(
   const codexProvider = new OpenAICompatibleProvider({
     surface: 'telegram',
     ...(mcpManager !== undefined ? { mcpManager } : {}),
+    workspaceStore,
   });
   // Same AFK autonomous-safety wiring as the Anthropic branch (live mode getter
   // registers the afk-mode gate + tracks `/afk on`; afkPromptForApproval:false


### PR DESCRIPTION
## What

Adds a shared agent workspace — a per-session SQLite-backed scratchpad that lets sibling sub-agents share structured findings instead of each independently re-reading the same files.

## Why

Empirical observation: in multi-agent tasks, ~59% of file reads are duplicated across siblings because each agent starts from zero context about what its siblings already discovered. This workspace gives agents a way to publish findings that are automatically injected into sibling contexts.

## How

### Architecture (user-specified design decisions)

- **Retrieval**: harness-managed, automatically injected into each subagent's initial system prompt via `injectWorkspacePreamble()` (follows the `budget-preamble.ts` pattern)
- **Publication**: model-directed through an explicit `workspace_publish` tool
- **Query**: internal API only — intentionally excluded from v1 to minimize agent-policy confounds in the duplication experiment

### Implementation

**New files** (`src/agent/workspace/`):
- `workspace-store.ts` — SQLite store mirroring `MemoryStore` pattern. Six entry types: Finding, Evidence, Hypothesis, Decision, Artifact, Status. Per-root-session scope.
- `workspace-tools.ts` — `workspace_publish` tool schema + handler factory
- `workspace-preamble.ts` — queries relevant entries by keyword overlap on `subject` field + recency, injects as a `[workspace-context]` block into the child's system prompt
- `index.ts` — barrel export

**Modified files** (wiring):
- Both providers (`anthropic-direct`, `openai-compatible`) — accept optional `workspaceStore`, register `workspace_publish` handler, pass store through dispatcher deps
- `fork-child-config.ts` — injects workspace preamble alongside budget preamble at subagent fork time
- `nesting.ts` — forwards `workspaceStore` from parent to child
- `provider-schemas.ts` — registers workspace tool schema
- All three surface entry points (CLI REPL, Telegram, daemon) — create one `WorkspaceStore` per root session and pass it through

### Not included (next steps)
- Measurement harness to quantify file-read deduplication improvement
- Running the actual A/B experiment (control vs. workspace-enabled)
- `workspace_query` as a model tool (deferred to v2)

## Tests

47 new tests across 3 test files covering store CRUD, tool handler, preamble injection, and relevance filtering. Full suite passes (17,170 tests, 7 pre-existing failures unchanged).

## Verification

- `pnpm lint` ✅
- `pnpm test` ✅ (no new failures)
- `pnpm audit:filesize:check` ✅
- `pnpm audit:sdk:check` ✅
- `pnpm audit:env:check` ✅
- `pnpm audit:chalk:check` ✅
