### PR TITLE
fix(web): accessibility — focus-visible ring & WCAG AA contrast

### DIFF
--- a/src/web-server/frontend/approvals.css
+++ b/src/web-server/frontend/approvals.css
@@ -22,7 +22,7 @@
   letter-spacing: 0.06em; color: var(--warning);
   border: 1px solid var(--warning); border-radius: 4px; padding: 1px 6px;
 }
-.approval-source { font-family: var(--mono); font-size: 10px; color: var(--text-faint); }
+.approval-source { font-family: var(--mono); font-size: 10px; color: var(--text-dim); }
 .approval-title { font-size: 13px; line-height: 1.5; color: var(--text); }
 .approval-desc { font-size: 12px; line-height: 1.5; color: var(--text-dim); margin-top: 4px; }
 .approval-input {

--- a/src/web-server/frontend/styles.css
+++ b/src/web-server/frontend/styles.css
@@ -129,7 +129,8 @@ html, body {
   background: var(--bg-raised); border-left: 2px solid var(--accent);
   padding: 10px 14px; border-radius: 0 var(--radius) var(--radius) 0;
 }
-.msg-thinking { opacity: 0.75; font-style: italic; }
+.msg-thinking { font-style: italic; }
+.msg-thinking .msg-body { opacity: 0.75; }
 .msg-thinking summary { cursor: pointer; }
 .msg-error .msg-body { color: var(--error); }
 

--- a/src/web-server/frontend/styles.css
+++ b/src/web-server/frontend/styles.css
@@ -21,6 +21,8 @@
 }
 
 * { box-sizing: border-box; }
+:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+#prompt:focus-visible, .approval-input:focus-visible { outline: none; }
 
 html, body {
   margin: 0;
@@ -74,7 +76,7 @@ html, body {
 }
 .sidebar-head {
   padding: 12px 16px 8px; font-size: 11px; text-transform: uppercase;
-  letter-spacing: 0.08em; color: var(--text-faint);
+  letter-spacing: 0.08em; color: var(--text-dim);
   display: flex; align-items: center; justify-content: space-between; gap: 8px;
 }
 .new-session {
@@ -120,7 +122,7 @@ html, body {
 .msg { margin-bottom: 18px; max-width: 900px; }
 .msg-role {
   font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em;
-  color: var(--text-faint); margin-bottom: 5px;
+  color: var(--text-dim); margin-bottom: 5px;
 }
 .msg-body { white-space: pre-wrap; word-break: break-word; line-height: 1.6; }
 .msg-user .msg-body {
@@ -215,7 +217,7 @@ html, body {
 .tool-body { padding: 0 12px 12px; border-top: 1px solid var(--border); }
 .tool-label {
   font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em;
-  color: var(--text-faint); margin: 10px 0 4px;
+  color: var(--text-dim); margin: 10px 0 4px;
 }
 .tool-pre {
   margin: 0; padding: 10px; background: var(--bg-sunken); border-radius: 6px;


### PR DESCRIPTION
## Accessibility fixes: focus-visible ring & WCAG AA contrast

Closes audit items #2 and #5.

---

### Fix 1 — `:focus-visible` keyboard focus ring (audit #2)

The global `*` reset removed the browser's default outline without replacing it,
leaving all interactive elements (`.session-row`, `.tool-summary`, `.send`, `.stop`,
`.new-session`, `.approval-btn`, `.slash-row`, `.tool-more`) invisible to keyboard
users during tab navigation.

Added a single global rule in `styles.css`:

```css
:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
#prompt:focus-visible, .approval-input:focus-visible { outline: none; }
```

`#prompt` and `.approval-input` are excluded because they already show a visible
border-color change on focus (`:focus { border-color: var(--accent) }`), so a second
outline ring would be visually redundant.

---

### Fix 2 — WCAG AA contrast on `--text-faint` (audit #5)

`--text-faint` (`#6a6a7b`) on `--bg-raised` (`#0e0e14`) yields **3.63:1** — below the
4.5:1 minimum required by WCAG 2.1 AA for normal text.

Changed four informational (non-decorative) selectors to use `--text-dim` (`#9a9aab`),
which clears the AA bar at **≈5.5:1**:

| Selector | Location | Role |
|---|---|---|
| `.msg-role` | `styles.css` | Role labels ("you", "agent") |
| `.tool-label` | `styles.css` | Section labels ("input", "output") |
| `.sidebar-head` | `styles.css` | Sidebar section header |
| `.approval-source` | `approvals.css` | Tool source path on approval cards |

Truly decorative uses of `--text-faint` (`.session-time`, `.badge-readonly`,
`.status-closed`, placeholder text, `.md-image`, `.notice`, `.slash-badge`,
`.queue-btn`) are left unchanged — they carry no informational burden.

**Contrast improvement:** 3.63:1 → ~5.5:1 (WCAG AA ✓)

---

### Checklist
- [x] `pnpm build` passes (styles.css at 340 LOC, under 350 ceiling)
- [x] No new dependencies
- [x] No test files modified
