### PR TITLE
fix(web): SSE connection resilience

### DIFF
--- a/src/web-server/frontend/app.ts
+++ b/src/web-server/frontend/app.ts
@@ -49,6 +49,9 @@ let pendingTimer: ReturnType<typeof setInterval> | undefined;
  */
 let turnActive = false;
 
+/** True while the SSE transport is in a reconnecting state. */
+let sseReconnecting = false;
+
 function $(id: string): HTMLElement {
   const node = document.getElementById(id);
   if (!node) throw new Error(`missing #${id}`);
@@ -145,6 +148,7 @@ function selectSession(id: string): void {
   stream?.stop();
 
   turnActive = false;
+  sseReconnecting = false;
   renderSidebar($('sessions'), sessions, activeId, selectSession);
   renderTranscript($('transcript'), items);
   syncComposer();
@@ -189,6 +193,10 @@ function selectSession(id: string): void {
       node.textContent = status === 'ended' ? 'session ended' : status;
       node.className = `status status-${status}`;
       if (status === 'ended') turnActive = false;
+      // Disable the composer while the transport is reconnecting so prompts
+      // cannot be submitted against a broken stream.
+      sseReconnecting = status === 'reconnecting' || status === 'connecting';
+      syncComposer();
       syncStop();
     },
   });
@@ -207,17 +215,24 @@ function renderMeter(): void {
  * readonly session. Those sessions run in another OS process whose elicitation
  * handler is unreachable from here, so an enabled button would be one that can
  * never resolve — the server enforces the same boundary with a 409.
+ *
+ * Additionally, the composer is disabled while the SSE transport is reconnecting
+ * so a queued prompt cannot be sent against a broken stream.
  */
 function syncComposer(): void {
   const live = isLive();
   const input = $('prompt') as HTMLTextAreaElement;
   const send = $('send') as HTMLButtonElement;
-  input.disabled = !live;
-  send.disabled = !live;
-  input.placeholder = live
-    ? 'Message the agent…  (queues while it works)'
-    : 'Read-only — this session runs in another process';
+  const blocked = !live || sseReconnecting;
+  input.disabled = blocked;
+  send.disabled = blocked;
+  input.placeholder = !live
+    ? 'Read-only — this session runs in another process'
+    : sseReconnecting
+      ? 'Reconnecting…'
+      : 'Message the agent…  (queues while it works)';
   $('composer').classList.toggle('is-readonly', !live);
+  $('composer').classList.toggle('is-reconnecting', live && sseReconnecting);
 }
 
 /**

--- a/src/web-server/frontend/sse-client.ts
+++ b/src/web-server/frontend/sse-client.ts
@@ -23,7 +23,7 @@ export type StreamStatus = 'connecting' | 'open' | 'reconnecting' | 'closed' | '
 
 export interface StreamHandlers {
   onEvent: (data: unknown, meta: { id?: string }) => void;
-  onStatus?: (status: StreamStatus) => void;
+  onStatus?: (status: StreamStatus, reason?: string) => void;
 }
 
 const MAX_BACKOFF_MS = 15_000;
@@ -70,7 +70,23 @@ export class SessionStream {
         headers,
         signal: this.controller.signal,
       });
-      if (!res.ok || res.body === null) throw new Error(`stream failed: ${res.status}`);
+      // Permanent errors: stop and surface them, do not retry.
+      if (!res.ok) {
+        if (res.status === 401 || res.status === 403 || res.status === 404) {
+          this.stopped = true;
+          const reason =
+            res.status === 401
+              ? 'unauthorized'
+              : res.status === 403
+                ? 'forbidden'
+                : 'not-found';
+          this.handlers.onStatus?.('closed', reason);
+          return;
+        }
+        // 5xx and anything else: fall through to the catch block to retry.
+        throw new Error(`stream failed: ${res.status}`);
+      }
+      if (res.body === null) throw new Error(`stream failed: no body`);
 
       this.attempt = 0;
       this.handlers.onStatus?.('open');
@@ -128,7 +144,9 @@ export class SessionStream {
       return;
     }
     this.attempt += 1;
-    const delay = Math.min(BASE_BACKOFF_MS * 2 ** (this.attempt - 1), MAX_BACKOFF_MS);
+    // ±25% jitter prevents thundering-herd when multiple tabs reconnect together.
+    const jitter = 0.75 + Math.random() * 0.5;
+    const delay = Math.min(BASE_BACKOFF_MS * 2 ** (this.attempt - 1), MAX_BACKOFF_MS) * jitter;
     setTimeout(() => void this.connect(), delay);
   }
 }


### PR DESCRIPTION
Fixes three SSE connection resilience issues identified in the web UI audit.

## Fix 1: Stop reconnecting on permanent errors (audit #8)

**File:** `src/web-server/frontend/sse-client.ts`

Previously, any non-OK HTTP status fell into the `catch {}` block and rescheduled a reconnect indefinitely. A 401 (expired token) or 404 (deleted session) would retry every ~15s forever.

**Changes:**
- When `!res.ok`, inspect `res.status` before retrying.
- On **401/403** (auth errors): set `this.stopped = true`, call `onStatus('closed', reason)` — no retry.
- On **404** (session gone): set `this.stopped = true`, call `onStatus('closed', 'not-found')` — no retry.
- On **5xx** and network errors: throw, letting the existing `catch` block schedule the next retry as before.
- Extended `StreamHandlers.onStatus` signature to accept an optional second `reason?: string` argument for surfacing the cause without breaking any existing callers.

## Fix 2: Disable composer during SSE reconnect (audit #12)

**File:** `src/web-server/frontend/app.ts`

The send button and prompt textarea remained enabled while the SSE transport was reconnecting, allowing prompts to be queued against a broken stream.

**Changes:**
- Added module-level `sseReconnecting` boolean flag.
- In the SSE `onStatus` callback, set `sseReconnecting = true` when status is `'connecting'` or `'reconnecting'`; clear it otherwise; then call `syncComposer()`.
- `syncComposer()` now sets `input.disabled` / `send.disabled` when `sseReconnecting` is true (for live sessions), and sets the placeholder to `'Reconnecting…'` during that window.
- Added CSS class `is-reconnecting` on `#composer` for optional styling.
- `sseReconnecting` is reset to `false` when a new session is selected, so it never bleeds across selections.

## Fix 3: Add ±25% jitter to reconnect backoff (audit #27)

**File:** `src/web-server/frontend/sse-client.ts`

Pure exponential backoff causes multiple tabs that disconnect simultaneously to reconnect at the exact same intervals, creating a thundering herd against the server.

**Changes:**
- Applied a `±25%` multiplicative jitter to the computed delay:
  ```ts
  const jitter = 0.75 + Math.random() * 0.5;
  const delay = Math.min(BASE_BACKOFF_MS * 2 ** (this.attempt - 1), MAX_BACKOFF_MS) * jitter;
  ```
- Delay range: 375ms–18.75s (vs. 500ms–15s previously). The cap stays effectively the same in practice; the jitter spreads reconnects across a 7.5s window at max backoff.

## Verification

`pnpm build` passes cleanly. No new dependencies. No test files modified.
