### PR TITLE
fix(web): UI polish & consistency

### DIFF
--- a/src/web-server/frontend/app.ts
+++ b/src/web-server/frontend/app.ts
@@ -142,6 +142,7 @@ async function loadSessions(): Promise<void> {
 
 function selectSession(id: string): void {
   activeId = id;
+  const snapshotId = id;
   items = [];
   panel().clear();
   totals = { costUsd: 0, durationMs: 0, turns: 0 };
@@ -156,6 +157,7 @@ function selectSession(id: string): void {
 
   stream = new SessionStream(id, token, {
     onEvent: (data) => {
+      if (activeId !== snapshotId) return;
       const frame = data as { record?: LedgerRecordLike };
       const record = frame.record;
       if (!record) return;
@@ -184,6 +186,7 @@ function selectSession(id: string): void {
       renderMeter();
     },
     onStatus: (status) => {
+      if (activeId !== snapshotId) return;
       const node = $('status');
       // Report the session's end honestly. 'ended' means the ledger reached its
       // terminal record and no further frame can arrive, so the indicator must
@@ -257,12 +260,14 @@ async function createSession(): Promise<void> {
   const button = $('new-session') as HTMLButtonElement;
   button.disabled = true;
   button.textContent = 'starting…';
+  const snapshotId = activeId;
   try {
     const { session } = await api<{ session: { id: string } }>('/api/sessions', {
       method: 'POST',
       body: JSON.stringify({}),
     });
     await loadSessions();
+    if (activeId !== snapshotId && activeId !== session.id) return;
     selectSession(session.id);
   } catch (err: unknown) {
     $('status').textContent = err instanceof Error ? err.message : 'could not start session';

--- a/src/web-server/frontend/markdown-dom.ts
+++ b/src/web-server/frontend/markdown-dom.ts
@@ -158,7 +158,13 @@ function renderList(token: Tokens.List): HTMLElement {
 function renderCode(token: Tokens.Code): HTMLElement {
   const pre = el('pre', 'md-pre');
   const code = el('code');
-  if (token.lang) code.className = `md-lang-${token.lang.split(/\s+/)[0] ?? ''}`;
+  if (token.lang) {
+    const lang = token.lang.split(/\s+/)[0] ?? '';
+    if (lang) {
+      code.className = `md-lang-${lang}`;
+      pre.dataset['lang'] = lang;
+    }
+  }
   code.textContent = token.text;
   pre.appendChild(code);
   return pre;

--- a/src/web-server/frontend/render.ts
+++ b/src/web-server/frontend/render.ts
@@ -85,7 +85,11 @@ export function renderSidebar(
     // string. The working directory is the field that actually varies, so it is
     // rendered first and given the strongest treatment in the meta row.
     const dir = basename(s.cwd);
-    if (dir) meta.appendChild(el('span', 'session-cwd', dir));
+    if (dir) {
+      const cwdEl = el('span', 'session-cwd', dir);
+      cwdEl.title = s.cwd ?? dir;
+      meta.appendChild(cwdEl);
+    }
     // A readonly session lives in another OS process; its approvals are
     // unreachable from here. The badge is the user-facing half of that
     // contract — the composer is disabled to match.

--- a/src/web-server/frontend/styles.css
+++ b/src/web-server/frontend/styles.css
@@ -113,13 +113,13 @@ html, body {
   font-family: var(--mono); font-size: 10px; color: var(--text-dim);
   background: var(--bg-sunken); border: 1px solid var(--border);
   border-radius: 4px; padding: 1px 5px;
-  max-width: 96px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  max-width: 140px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 .empty { padding: 16px; color: var(--text-faint); }
 
 /* ── transcript ──────────────────────────────────────────────────────────── */
-.transcript { flex: 1; overflow-y: auto; padding: 20px; scroll-behavior: smooth; }
-.msg { margin-bottom: 18px; max-width: 900px; }
+.transcript { flex: 1; overflow-y: auto; padding: 20px; scroll-behavior: smooth; display: flex; flex-direction: column; align-items: center; }
+.msg { margin-bottom: 18px; max-width: 900px; width: 100%; }
 .msg-role {
   font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em;
   color: var(--text-dim); margin-bottom: 5px;
@@ -129,9 +129,9 @@ html, body {
   background: var(--bg-raised); border-left: 2px solid var(--accent);
   padding: 10px 14px; border-radius: 0 var(--radius) var(--radius) 0;
 }
-.msg-thinking { font-style: italic; }
-.msg-thinking .msg-body { opacity: 0.75; }
-.msg-thinking summary { cursor: pointer; }
+.msg-thinking { opacity: 1; font-style: italic; }
+.msg-thinking summary { opacity: 0.65; cursor: pointer; }
+.msg-thinking[open] .msg-body { margin-top: 8px; padding: 8px 12px; border-left: 2px solid var(--border); font-size: 13px; }
 .msg-error .msg-body { color: var(--error); }
 
 /*
@@ -174,13 +174,21 @@ html, body {
   background: var(--bg-sunken); border: 1px solid var(--border);
   border-radius: var(--radius); white-space: pre;
 }
+.md-pre[data-lang]::before {
+  content: attr(data-lang); display: block; text-align: right;
+  font-family: var(--mono); font-size: 10px; color: var(--text-faint);
+  margin-bottom: 6px; text-transform: uppercase; letter-spacing: 0.06em;
+}
 .md-pre code {
   font-family: var(--mono); font-size: 12px; line-height: 1.55;
   color: var(--text); background: none; border: 0; padding: 0; white-space: pre;
 }
 .md-quote {
-  margin: 0 0 10px; padding: 2px 0 2px 12px;
-  border-left: 2px solid var(--border); color: var(--text-dim);
+  margin: 0 0 10px; padding: 4px 0 4px 14px;
+  border-left: 3px solid color-mix(in srgb, var(--accent) 45%, transparent);
+  color: var(--text-dim);
+  background: color-mix(in srgb, var(--accent) 4%, transparent);
+  border-radius: 0 4px 4px 0;
 }
 .md-hr { border: 0; border-top: 1px solid var(--border); margin: 16px 0; }
 .md-link { color: var(--accent); text-decoration: underline; text-underline-offset: 2px; }
@@ -197,12 +205,14 @@ html, body {
 .notice {
   font-family: var(--mono); font-size: 11px; color: var(--text-faint);
   padding: 5px 0; border-top: 1px dashed var(--border); margin: 14px 0;
+  max-width: 900px; width: 100%;
 }
 
 /* ── tool calls ──────────────────────────────────────────────────────────── */
 .tool {
   border: 1px solid var(--border); border-radius: var(--radius);
   margin-bottom: 10px; background: var(--bg-raised); overflow: hidden;
+  max-width: 900px; width: 100%;
 }
 .tool-summary {
   display: flex; align-items: center; gap: 8px; padding: 8px 12px;
@@ -323,7 +333,9 @@ details[open] > .tool-summary::before { transform: rotate(90deg); }
 .send {
   background: var(--accent); color: #1a0d05; border: none; border-radius: var(--radius);
   padding: 10px 18px; font-weight: 600; cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, opacity 0.15s ease, filter 0.15s ease;
 }
+.send:hover:not(:disabled) { filter: brightness(1.06); }
 .send:disabled { background: var(--border); color: var(--text-faint); cursor: not-allowed; }
 .queue { display: flex; flex-direction: column; gap: 5px; margin-bottom: 8px; }
 .queue-row {


### PR DESCRIPTION
Seven targeted UI polish fixes for `afk web` addressing audit items #23–30.

## Changes

### #23 — Guard against stale `activeId` during async session switching (`app.ts`)
`selectSession()` and `createSession()` now capture `activeId` as a snapshot before any `await`. Both `onEvent` and `onStatus` callbacks, as well as the post-`loadSessions` call in `createSession`, bail early if `activeId` has changed by the time the async operation resolves — preventing stale SSE events from corrupting the newly-selected session's state.

### #24 — Language badge on fenced code blocks (`markdown-dom.ts`, `styles.css`)
When a fenced code block carries a language tag, `renderCode` now sets `pre.dataset.lang = lang`. A CSS `::before` pseudo-element on `.md-pre[data-lang]` renders the language name as a small uppercase label in the top-right corner of the block.

### #25 — Center transcript messages on wide viewports (`styles.css`)
`.transcript` now uses `display: flex; flex-direction: column; align-items: center` so its children stack in a centered column. `.msg`, `.tool`, and `.notice` each gain `max-width: 900px; width: 100%` so they fill to 900 px and then center on wider displays — matching the "comfortable reading width" pattern.

### #26 — Thinking block expansion padding (`styles.css`)
`<details class="msg-thinking">` is now fully opaque (`opacity: 1`) with the summary dimmed to `opacity: 0.65`. When expanded, the `.msg-body` inside gets top margin, left-border indent, and a smaller font size so it reads as secondary content without colliding with the summary label.

### #28 — Widen `session-cwd` and add tooltip (`styles.css`, `render.ts`)
The `.session-cwd` pill grows from `max-width: 96px` to `max-width: 140px`, exposing more of the directory name before truncation. In `render.ts`, the element's `title` attribute is set to the full `cwd` path so hovering reveals the complete path.

### #29 — Visible blockquote styling (`styles.css`)
`.md-quote` now sports a 3 px accent-tinted left border (45% opacity), a faint accent background tint (4% opacity), and `border-radius: 0 4px 4px 0` — replacing the near-invisible `--border`-colored hairline rule.

### #30 — Send button transition (`styles.css`)
The `.send` button gains a `transition` on `background`, `color`, and `opacity` (0.15 s ease), and a `brightness(1.06)` hover filter for tactile feedback without color-value duplication.
