### PR TITLE
perf(web): incremental transcript rendering

### DIFF
--- a/src/web-server/frontend/render-incremental.ts
+++ b/src/web-server/frontend/render-incremental.ts
@@ -1,0 +1,77 @@
+/**
+ * Incremental DOM diffing helpers for `renderTranscript`.
+ *
+ * Extracted here to keep render.ts under its 350-LOC ceiling.
+ * Private to the frontend package — not part of the public API.
+ *
+ * Steady-state cost is O(new items) instead of O(N) — the common case of one
+ * arriving SSE event appends a single node and leaves all prior nodes untouched.
+ *
+ * Full rebuild is triggered only when `items.length` is less than the current
+ * child count, which signals a session switch or reset. In that case the cache
+ * is cleared and all nodes are recreated from scratch.
+ */
+
+import type { TranscriptItem } from './view-model.js';
+
+/**
+ * Module-level cache: maps item.id → the DOM node that represents it.
+ *
+ * Keyed by a stable `item.id` that is assigned once at model creation time and
+ * never reassigned. The cache is cleared on a full rebuild (session switch /
+ * reset), so stale entries from a previous session never collide with a new one.
+ */
+const nodeCache = new Map<string, HTMLElement>();
+
+/**
+ * True when `item` should replace its existing DOM node rather than be skipped.
+ *
+ * Only tool items can change state after initial render (running → ok/error,
+ * or output arriving after the tool_use_detail). All other kinds are
+ * append-only once emitted.
+ */
+function itemChanged(item: TranscriptItem, existing: HTMLElement): boolean {
+  if (item.kind !== 'tool') return false;
+  // The node's class encodes the current status; compare it to the item's.
+  return existing.className !== `tool tool-${item.status}`;
+}
+
+/**
+ * Apply an incremental update to the transcript container.
+ *
+ * @param container - The scroll container holding transcript nodes.
+ * @param items     - Current ordered item list from the view-model.
+ * @param renderItem - Factory that converts a TranscriptItem to an HTMLElement.
+ *
+ * Scroll-pinning contract (preserved from the original full-rebuild behaviour):
+ *   - The CALLER samples `isPinnedToBottom` BEFORE this call — scroll position
+ *     is stable across incremental appends, unlike a full wipe.
+ *   - The CALLER calls `scrollToBottom` after this call when it was pinned.
+ */
+export function applyIncrementalUpdate(
+  container: HTMLElement,
+  items: TranscriptItem[],
+  renderItem: (item: TranscriptItem) => HTMLElement,
+): void {
+  // Full rebuild: session switch / reset detected by shrinking item count.
+  if (items.length < container.childElementCount) {
+    nodeCache.clear();
+    container.textContent = '';
+  }
+
+  for (const item of items) {
+    const existing = nodeCache.get(item.id);
+    if (existing === undefined) {
+      // New item — create and append.
+      const node = renderItem(item);
+      nodeCache.set(item.id, node);
+      container.appendChild(node);
+    } else if (itemChanged(item, existing)) {
+      // Existing item whose state changed (e.g. tool running → ok/error).
+      const node = renderItem(item);
+      nodeCache.set(item.id, node);
+      container.replaceChild(node, existing);
+    }
+    // Otherwise: item is unchanged — skip, O(1).
+  }
+}

--- a/src/web-server/frontend/render.ts
+++ b/src/web-server/frontend/render.ts
@@ -15,9 +15,12 @@
 import { stripAnsi } from './ansi-strip.js';
 import { renderMarkdown } from './markdown-dom.js';
 import type { TranscriptItem, ToolCallItem } from './view-model.js';
+import { applyIncrementalUpdate } from './render-incremental.js';
 
 /** Beyond this, tool output is collapsed behind a "show full" control. */
 const OUTPUT_PREVIEW_CHARS = 2_000;
+/** Beyond this, tool input is collapsed behind a "show full input" control. */
+const INPUT_PREVIEW_CHARS = 2_000;
 
 export interface SessionSummary {
   id: string;
@@ -101,9 +104,15 @@ export function renderSidebar(
   }
 }
 
+/**
+ * Incrementally update the transcript container.
+ *
+ * Delegates to `applyIncrementalUpdate` in render-incremental.ts.
+ * Steady-state cost: O(new items). Full rebuild only on session switch/reset.
+ * Scroll-pinning: caller samples `isPinnedToBottom` before and scrolls after.
+ */
 export function renderTranscript(container: HTMLElement, items: TranscriptItem[]): void {
-  container.textContent = '';
-  for (const item of items) container.appendChild(renderItem(item));
+  applyIncrementalUpdate(container, items, renderItem);
 }
 
 function renderItem(item: TranscriptItem): HTMLElement {
@@ -155,7 +164,23 @@ function renderTool(item: ToolCallItem): HTMLElement {
 
   if (item.inputPreview) {
     body.appendChild(el('div', 'tool-label', 'input'));
-    body.appendChild(el('pre', 'tool-pre', stripAnsi(item.inputPreview)));
+    const cleanInput = stripAnsi(item.inputPreview);
+    if (cleanInput.length > INPUT_PREVIEW_CHARS) {
+      const inputPre = el('pre', 'tool-pre', cleanInput.slice(0, INPUT_PREVIEW_CHARS));
+      body.appendChild(inputPre);
+      const moreInput = el(
+        'button',
+        'tool-more',
+        `Show full input (${cleanInput.length.toLocaleString()} chars)`,
+      );
+      moreInput.addEventListener('click', () => {
+        inputPre.textContent = cleanInput;
+        moreInput.remove();
+      });
+      body.appendChild(moreInput);
+    } else {
+      body.appendChild(el('pre', 'tool-pre', cleanInput));
+    }
   }
 
   // The honesty branch: "no output recorded" and "output produced nothing" are


### PR DESCRIPTION
## Summary

Two rendering performance fixes for the `afk web` browser UI: incremental transcript DOM updates (audit #1) and tool input preview capping (audit #22).

---

## Fix 1: Incremental DOM updates — O(N) → O(1) for steady-state events (audit #1)

**Before:** `renderTranscript()` called `container.textContent = ''` then rebuilt every DOM node from scratch on every arriving SSE event. With N items already rendered, each new event caused N node destructions + N+1 node creations — O(N) work to display one new line.

**After:** A stable `Map<string, HTMLElement>` (keyed by `item.id`, which is assigned once and never changes) caches every rendered node. On each call:
- **New items** (not in cache) → create node and append. O(1) per new item.
- **Changed items** (tool status transitions: `running` → `ok`/`error`) → replace the single node in place.
- **Unchanged items** → skip entirely.
- **Full rebuild** → triggered only when `items.length < container.childElementCount`, which signals a session switch or reset.

Steady-state with an active session (one SSE event arrives) now appends exactly one DOM node and leaves all prior nodes untouched. The scroll-pinning contract is preserved: the caller still samples `isPinnedToBottom` before and calls `scrollToBottom` after — this was always correct because incremental appends don't reset `scrollHeight`, unlike a full container wipe.

The incremental logic lives in `render-incremental.ts` (a private sibling module) to keep `render.ts` under its 350-LOC ceiling.

---

## Fix 2: Cap tool input preview at 2000 chars (audit #22)

**Before:** `renderTool()` rendered the full `inputPreview` string in an unbounded `<pre>`. A `write_file` call with a 2MB argument created a 2MB text node, causing layout thrash and scroll jank.

**After:** Mirrors the existing output-truncation pattern (`OUTPUT_PREVIEW_CHARS`). Input longer than 2000 chars is truncated to a `<pre>` preview; a `Show full input (N chars)` button expands it inline on click. No DOM allocation overhead for the common case (short tool args).

---

## Files changed

- `src/web-server/frontend/render.ts` — incremental `renderTranscript`, input preview cap in `renderTool`
- `src/web-server/frontend/render-incremental.ts` — new private module: `applyIncrementalUpdate` and the node cache

## Verification

- `pnpm build` passes (TypeScript + bundler)
- All 17,132 frontend and backend tests pass (1 pre-existing unrelated flaky test in `write-denylist.test.ts`)
- `render.ts` is 338 lines (under the 350-LOC ceiling)
