### PR TITLE
fix(test): unbreak CI — remove dead variable + fix jitter-sensitive timer

### DIFF
--- a/src/telegram/streaming.watchdog.test.ts
+++ b/src/telegram/streaming.watchdog.test.ts
@@ -193,7 +193,6 @@ describe('makeNextWithTimeout — apiRoundInFlight behavioral tests', () => {
       await vi.advanceTimersByTimeAsync(2);
       await rejection;
 
-      void resolveSecond; // silence unused var warning
     } finally {
       vi.useRealTimers();
     }

--- a/src/web-server/frontend/sse-client.test.ts
+++ b/src/web-server/frontend/sse-client.test.ts
@@ -132,7 +132,8 @@ describe('SessionStream — a dropped stream still reconnects', () => {
     await settle();
     expect(calls).toHaveLength(1);
 
-    await vi.advanceTimersByTimeAsync(600);
+    // BASE_BACKOFF_MS (500) × max jitter (1.25) = 625ms ceiling.
+    await vi.advanceTimersByTimeAsync(700);
     await settle();
 
     expect(calls.length).toBeGreaterThanOrEqual(2);
@@ -144,7 +145,8 @@ describe('SessionStream — a dropped stream still reconnects', () => {
 
     stream.start();
     await settle();
-    await vi.advanceTimersByTimeAsync(600);
+    // BASE_BACKOFF_MS (500) × max jitter (1.25) = 625ms ceiling.
+    await vi.advanceTimersByTimeAsync(700);
     await settle();
 
     expect(calls[0]?.headers['last-event-id']).toBeUndefined();


### PR DESCRIPTION
Two test bugs on `main` that fail every PR's CI:

## 1. `streaming.watchdog.test.ts` — `ReferenceError: resolveSecond is not defined`

Commit bed80a9f (#1163) removed the `let resolveSecond` declaration but
left behind `void resolveSecond;` at line 196. Every test run hits the
ReferenceError.

**Fix:** Remove the dead line.

## 2. `sse-client.test.ts` — `expected undefined to be '7'`

Commit ff24db4b (#1199) added ±25% reconnect jitter, making the first
reconnect delay range 375–625ms. The test advanced fake timers by only
600ms — below the 625ms ceiling — so ~50% of runs the reconnect hasn't
fired when the assertion checks for `calls[1]`.

**Fix:** Advance to 700ms (past the 625ms max) with a documenting comment.

## Impact

These two failures are blocking CI on **every open PR**. Of 18 open PRs,
6 show red CI — all traceable to these two tests. Merging this unblocks
the queue.
