### PR TITLE
feat(telegram): enable background subagent dispatch + improve bg/fg guidance

### DIFF
--- a/prompts/system-prompt.md
+++ b/prompts/system-prompt.md
@@ -96,7 +96,7 @@ Default to foreground. Use background (`mode: "background"`) only when **all thr
 
 When you need multiple results this turn, use `compose` (parallel foreground) — not multiple background dispatches that arrive unpredictably on future turns.
 
-Background results are delivered automatically at the start of the next turn as `<background-subagent-result>` blocks. They are capped at 16KB; full output is available via `/bgsub:join <jobId>`.
+On REPL, background results are delivered automatically at the start of the next turn as `<background-subagent-result>` blocks, capped at 16KB; full output is available via `/bgsub:join <jobId>`. On Telegram, you receive a push notification when the job settles but the result is NOT injected into your context — ask the user to relay findings or avoid background mode for tasks whose results you need.
 
 ## Decision commitment
 

--- a/prompts/system-prompt.md
+++ b/prompts/system-prompt.md
@@ -87,6 +87,17 @@ Parallelize independent subagents in one wave. Use the `compose` tool when dispa
 
 Subagents return compressed findings, not raw exploration. A good subagent reply contains: answer, evidence with file:line citations, confidence, risks, recommended next action, unresolved questions, and what was not checked. Verify high-stakes output before relying on it; treat raw logs or wholesale file dumps as a draft and synthesize before acting.
 
+### Background vs. foreground
+
+Default to foreground. Use background (`mode: "background"`) only when **all three** hold:
+1. The result will not gate this turn's next action — you can continue useful work without it.
+2. The task is genuinely long (multi-file investigation, broad search, test suite run).
+3. You are on an interactive surface (REPL or Telegram). Background mode is unavailable on daemon and one-shot surfaces — the call returns an error.
+
+When you need multiple results this turn, use `compose` (parallel foreground) — not multiple background dispatches that arrive unpredictably on future turns.
+
+Background results are delivered automatically at the start of the next turn as `<background-subagent-result>` blocks. They are capped at 16KB; full output is available via `/bgsub:join <jobId>`.
+
 ## Decision commitment
 
 When diagnosing and fixing code:

--- a/src/agent/types/config-types.ts
+++ b/src/agent/types/config-types.ts
@@ -773,6 +773,16 @@ export interface AgentConfig {
   autoCompact?: boolean | { threshold: number };
 
   /**
+   * Telegram chat id for this session — set by the Telegram session manager
+   * before calling `createSession` so the `TelegramBgResultNotifier` can push
+   * background job notifications to the originating chat rather than falling
+   * back to the bot-global default notify targets.
+   *
+   * Telegram-scoped only: never set on REPL, daemon, or one-shot sessions.
+   */
+  telegramChatId?: number;
+
+  /**
    * In-process custom tools available to the session. Each entry is created
    * via the `tool()` helper and provides both a JSON-schema `AnthropicToolDef`
    * (so the model knows the tool exists) and a validated `ToolHandler`

--- a/src/telegram/bg-result-notifier.test.ts
+++ b/src/telegram/bg-result-notifier.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests for `TelegramBgResultNotifier` — push notification for settled
+ * background subagent jobs on the Telegram surface.
+ *
+ * Uses the real `BackgroundAgentRegistry`; jobs are driven to terminal states
+ * via a stubbed `SubagentHandle` (same harness as the REPL's
+ * bg-result-notifier.test.ts).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { BackgroundAgentRegistry } from '../agent/background-registry.js';
+import type { SubagentHandle, SubagentResult } from '../agent/subagent.js';
+import { TelegramBgResultNotifier } from './bg-result-notifier.js';
+
+// Stub pushIfConfigured so we can observe calls without hitting the network.
+vi.mock('./push.js', () => ({
+  pushIfConfigured: vi.fn(async () => []),
+}));
+
+// Silence routing telemetry writes (background-registry emits them on settle).
+vi.mock('../agent/routing-telemetry.js', () => ({
+  appendRoutingDecision: vi.fn(async () => {}),
+}));
+
+import { pushIfConfigured } from './push.js';
+
+const pushMock = vi.mocked(pushIfConfigured);
+
+/** Stub a `SubagentHandle` whose `runInBackground` callback we control. */
+function makeBgHandle(id = 'sub-1'): {
+  handle: SubagentHandle;
+  fireTerminal: (r: SubagentResult) => void;
+} {
+  let captured: ((r: SubagentResult) => void) | undefined;
+  return {
+    handle: {
+      id,
+      status: 'idle',
+      runInBackground: vi.fn((_p: string, on?: (r: SubagentResult) => void) => {
+        captured = on;
+      }),
+      cancel: vi.fn().mockResolvedValue(undefined),
+      teardown: vi.fn().mockResolvedValue(undefined),
+      run: vi.fn(),
+      runToResult: vi.fn(),
+    } as unknown as SubagentHandle,
+    fireTerminal: (r) => captured?.(r),
+  };
+}
+
+function succeed(id: string, content: string): SubagentResult {
+  return {
+    id,
+    status: 'succeeded',
+    message: { content, role: 'assistant' } as unknown as SubagentResult['message'],
+  } as SubagentResult;
+}
+
+function fail(id: string, msg: string): SubagentResult {
+  return {
+    id,
+    status: 'failed',
+    error: new Error(msg),
+  } as SubagentResult;
+}
+
+describe('TelegramBgResultNotifier', () => {
+  let registry: BackgroundAgentRegistry;
+  let notifier: TelegramBgResultNotifier;
+
+  beforeEach(() => {
+    registry = new BackgroundAgentRegistry({});
+    notifier = new TelegramBgResultNotifier(registry);
+    pushMock.mockClear();
+  });
+
+  afterEach(() => {
+    notifier.dispose();
+  });
+
+  it('pushes a notification when a background job completes', () => {
+    const { handle, fireTerminal } = makeBgHandle();
+    const job = registry.register({
+      handle,
+      prompt: 'investigate something',
+      model: 'sonnet',
+    });
+
+    fireTerminal(succeed(job.jobId, 'found the answer'));
+
+    expect(pushMock).toHaveBeenCalledTimes(1);
+    const text = pushMock.mock.calls[0]![0];
+    expect(text).toContain('✅');
+    expect(text).toContain('completed');
+    expect(text).toContain('investigate something');
+  });
+
+  it('pushes a notification when a background job fails', () => {
+    const { handle, fireTerminal } = makeBgHandle();
+    const job = registry.register({
+      handle,
+      prompt: 'research task',
+      model: 'sonnet',
+    });
+
+    fireTerminal(fail(job.jobId, 'rate limit'));
+
+    expect(pushMock).toHaveBeenCalledTimes(1);
+    const text = pushMock.mock.calls[0]![0];
+    expect(text).toContain('❌');
+    expect(text).toContain('failed');
+  });
+
+  it('skips cancelled jobs', async () => {
+    const { handle } = makeBgHandle();
+    registry.register({
+      handle,
+      prompt: 'will be cancelled',
+      model: 'sonnet',
+    });
+
+    // Cancel triggers the settled event with status='cancelled'.
+    await registry.cancelAll();
+
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it('targets a specific chat when chatId is provided', () => {
+    notifier.dispose();
+    notifier = new TelegramBgResultNotifier(registry, 12345);
+
+    const { handle, fireTerminal } = makeBgHandle();
+    const job = registry.register({
+      handle,
+      prompt: 'targeted task',
+      model: 'sonnet',
+    });
+
+    fireTerminal(succeed(job.jobId, 'done'));
+
+    expect(pushMock).toHaveBeenCalledTimes(1);
+    const opts = pushMock.mock.calls[0]![1];
+    expect(opts).toEqual({ target: 12345 });
+  });
+
+  it('uses default notify routing when no chatId is provided', () => {
+    const { handle, fireTerminal } = makeBgHandle();
+    const job = registry.register({
+      handle,
+      prompt: 'default routing task',
+      model: 'sonnet',
+    });
+
+    fireTerminal(succeed(job.jobId, 'done'));
+
+    expect(pushMock).toHaveBeenCalledTimes(1);
+    const opts = pushMock.mock.calls[0]![1];
+    expect(opts).toEqual({ target: undefined });
+  });
+
+  it('stops pushing after dispose', () => {
+    notifier.dispose();
+
+    const { handle, fireTerminal } = makeBgHandle();
+    const job = registry.register({
+      handle,
+      prompt: 'after dispose',
+      model: 'sonnet',
+    });
+
+    fireTerminal(succeed(job.jobId, 'done'));
+
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it('swallows push errors without throwing', () => {
+    pushMock.mockRejectedValueOnce(new Error('network failure'));
+
+    const { handle, fireTerminal } = makeBgHandle();
+    const job = registry.register({
+      handle,
+      prompt: 'push will fail',
+      model: 'sonnet',
+    });
+
+    // Should not throw — the error is swallowed.
+    expect(() => fireTerminal(succeed(job.jobId, 'done'))).not.toThrow();
+    expect(pushMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/telegram/bg-result-notifier.test.ts
+++ b/src/telegram/bg-result-notifier.test.ts
@@ -173,7 +173,7 @@ describe('TelegramBgResultNotifier', () => {
     expect(pushMock).not.toHaveBeenCalled();
   });
 
-  it('swallows push errors without throwing', () => {
+  it('swallows push errors without throwing', async () => {
     pushMock.mockRejectedValueOnce(new Error('network failure'));
 
     const { handle, fireTerminal } = makeBgHandle();
@@ -183,8 +183,12 @@ describe('TelegramBgResultNotifier', () => {
       model: 'sonnet',
     });
 
-    // Should not throw — the error is swallowed.
-    expect(() => fireTerminal(succeed(job.jobId, 'done'))).not.toThrow();
-    expect(pushMock).toHaveBeenCalledTimes(1);
+    // fireTerminal is sync; the push rejection is async.
+    fireTerminal(succeed(job.jobId, 'done'));
+    // Drain microtask queue — if .catch() were missing, an unhandled
+    // rejection would surface here.
+    await vi.waitFor(() => {
+      expect(pushMock).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/telegram/bg-result-notifier.ts
+++ b/src/telegram/bg-result-notifier.ts
@@ -1,0 +1,86 @@
+/**
+ * Telegram-side push notification for settled background subagent jobs.
+ *
+ * Subscribes to a {@link BackgroundAgentRegistry}'s `settled` event and sends
+ * a short status message to the configured Telegram notify targets via
+ * {@link pushIfConfigured}. This is the Telegram analog of the REPL's
+ * {@link BgResultNotifier} — but delivery is push-based (Telegram API) rather
+ * than pull-based (injection into the next user turn).
+ *
+ * Cancelled jobs are skipped (same contract as the REPL notifier): explicit
+ * cancels are operator-initiated and cascade cancels fire during teardown when
+ * nothing useful can be surfaced.
+ *
+ * Lifecycle: construct after the registry, call {@link dispose} on session
+ * close so the `settled` listener is removed.
+ *
+ * @module telegram/bg-result-notifier
+ */
+
+import type {
+  BackgroundAgentRegistry,
+  BackgroundJob,
+} from '../agent/background-registry.js';
+import { pushIfConfigured } from './push.js';
+import { formatDuration } from '../cli/format-utils.js';
+
+/** Status emoji for the push notification. */
+function statusEmoji(status: BackgroundJob['status']): string {
+  switch (status) {
+    case 'completed': return '✅';
+    case 'failed':    return '❌';
+    default:          return '⚙️';
+  }
+}
+
+/**
+ * Format a one-line push notification for a settled background job.
+ *
+ * The notification intentionally omits the full result body — it is a nudge
+ * to the operator ("your background task finished"), not a delivery vehicle.
+ * The model receives the full result via the next-turn injection path (Phase 3,
+ * deferred).
+ */
+function formatNotification(job: BackgroundJob): string {
+  const emoji = statusEmoji(job.status);
+  const duration =
+    job.endedAt !== undefined
+      ? formatDuration(job.endedAt - job.startedAt)
+      : 'unknown';
+
+  // Label is the first ~80 chars of the dispatch prompt — already truncated
+  // by the registry's own `register()`.
+  const label = job.label || job.jobId;
+
+  return `${emoji} Background task ${job.status}: ${label} · ${duration}`;
+}
+
+export class TelegramBgResultNotifier {
+  private readonly onSettled = (job: BackgroundJob): void => {
+    // Skip cancelled jobs — same as the REPL notifier contract.
+    if (job.status === 'cancelled') return;
+
+    const text = formatNotification(job);
+    // Fire-and-forget: a push failure here is non-fatal — the job already
+    // settled and its result is available via the registry. Swallow errors
+    // to avoid leaking unhandled rejections into the session.
+    void pushIfConfigured(text, { target: this.chatId }).catch(() => {});
+  };
+
+  /**
+   * @param registry  The session's background agent registry.
+   * @param chatId    Telegram chat id to push notifications to. When undefined,
+   *                  pushIfConfigured uses the default notify targets.
+   */
+  constructor(
+    private readonly registry: BackgroundAgentRegistry,
+    private readonly chatId?: number,
+  ) {
+    registry.on('settled', this.onSettled);
+  }
+
+  /** Unsubscribe from the registry. Idempotent. */
+  dispose(): void {
+    this.registry.off('settled', this.onSettled);
+  }
+}

--- a/src/telegram/bg-result-notifier.ts
+++ b/src/telegram/bg-result-notifier.ts
@@ -62,9 +62,16 @@ export class TelegramBgResultNotifier {
 
     const text = formatNotification(job);
     // Fire-and-forget: a push failure here is non-fatal — the job already
-    // settled and its result is available via the registry. Swallow errors
-    // to avoid leaking unhandled rejections into the session.
-    void pushIfConfigured(text, { target: this.chatId }).catch(() => {});
+    // settled and its result is available via the registry. Log failures for
+    // observability since push is the ONLY delivery path on Telegram (unlike
+    // REPL which also injects results into the next turn).
+    void pushIfConfigured(text, { target: this.chatId }).catch((err: unknown) => {
+      // Non-fatal: the job result is still in the registry (join-able).
+      console.error(`[bg-notifier] push failed for job ${job.jobId}:`, err);
+    });
+    // Emit a background_agent.delivered witness event so trace readers can
+    // distinguish push-notified settlements from explicit /bgsub:join calls.
+    this.registry.markDelivered(job.jobId);
   };
 
   /**

--- a/src/telegram/create-session.ts
+++ b/src/telegram/create-session.ts
@@ -103,6 +103,7 @@ export function createTelegramSessionFactory(
       mcpManager,
       memoryStore,
       workspaceStore: sharedWorkspaceStore,
+      ...(sessionConfig.telegramChatId !== undefined ? { chatId: sessionConfig.telegramChatId } : {}),
       reportSession: (session) => { returnedSession = session; },
     };
 

--- a/src/telegram/session-anthropic.ts
+++ b/src/telegram/session-anthropic.ts
@@ -16,7 +16,9 @@ import {
   getDefaultSubagentModel,
   getApiKeyForModel,
 } from '../cli/shared-helpers.js';
+import { BackgroundAgentRegistry } from '../agent/background-registry.js';
 import { createTelegramAfkHookBundle } from './afk-hook-bundle.js';
+import { TelegramBgResultNotifier } from './bg-result-notifier.js';
 import { constructTelegramSession } from './construct-session.js';
 import { attachMcpCleanup } from './mcp-session.js';
 import type { TelegramSessionBuildContext } from './session-context.js';
@@ -55,6 +57,14 @@ export async function buildAnthropicTelegramSession(
     get hookRegistry() { return boundSession?.hookRegistry; },
   };
 
+  // Background agent registry — enables `agent` tool with mode="background"
+  // on Telegram. Mirrors the REPL's bootstrap-infra.ts wiring. Per-session
+  // lifetime: cancelAll is called via drainSubagents on session close.
+  const backgroundRegistry = new BackgroundAgentRegistry(
+    traceWriter ? { traceWriter } : {},
+  );
+  const bgNotifier = new TelegramBgResultNotifier(backgroundRegistry);
+
   // Invariant: ONE root manager per session, shared by all three
   // executors. Inherit configured-or-host cwd so forked subagents stay
   // in the same working tree as the parent session — important when the
@@ -86,6 +96,7 @@ export async function buildAnthropicTelegramSession(
     // the nested skill-executor factory (no `skillTraceWriter`) —
     // matching the pre-refactor wiring.
     ...(traceWriter !== null ? { traceWriter } : {}),
+    backgroundRegistry,
   });
 
   const allowedTools = topLevelSurfaceAllowedTools(mcpManager?.getMcpToolWireNames() ?? []);
@@ -146,9 +157,14 @@ export async function buildAnthropicTelegramSession(
     maxTurns: 100,
     // Cascade-abort and drain in-flight children before the writer seals, so a
     // wave still running when this session ends emits real `cancelled` rows
-    // instead of vanishing (#733).
-    drainSubagents: (reason) =>
-      rootManager.abortAllAndDrain('session_end', 'user_signal', undefined, reason === 'reset'),
+    // instead of vanishing (#733). Background jobs are cancelled alongside the
+    // SubagentManager drain; the notifier is disposed so the settled listener
+    // doesn't fire after the session is gone.
+    drainSubagents: async (reason) => {
+      bgNotifier.dispose();
+      await backgroundRegistry.cancelAll();
+      return rootManager.abortAllAndDrain('session_end', 'user_signal', undefined, reason === 'reset');
+    },
     ...(maxOutputTokens !== undefined ? { maxOutputTokens } : {}),
     ...(maxToolUseIterations !== undefined ? { maxToolUseIterations } : {}),
     ...(telegramBaseUrl !== undefined ? { baseUrl: telegramBaseUrl } : {}),

--- a/src/telegram/session-anthropic.ts
+++ b/src/telegram/session-anthropic.ts
@@ -37,6 +37,7 @@ export async function buildAnthropicTelegramSession(
     mcpManager,
     memoryStore,
     workspaceStore,
+    chatId,
     reportSession,
   } = ctx;
 
@@ -63,7 +64,7 @@ export async function buildAnthropicTelegramSession(
   const backgroundRegistry = new BackgroundAgentRegistry(
     traceWriter ? { traceWriter } : {},
   );
-  const bgNotifier = new TelegramBgResultNotifier(backgroundRegistry);
+  const bgNotifier = new TelegramBgResultNotifier(backgroundRegistry, chatId);
 
   // Invariant: ONE root manager per session, shared by all three
   // executors. Inherit configured-or-host cwd so forked subagents stay

--- a/src/telegram/session-context.ts
+++ b/src/telegram/session-context.ts
@@ -44,6 +44,13 @@ export interface TelegramSessionBuildContext {
   /** Bot-global workspace store; one SQLite per bot process, shared by all sessions. */
   workspaceStore: WorkspaceStore;
   /**
+   * Telegram chat id for the originating session. Threaded from
+   * `sessionConfig.telegramChatId` so the `TelegramBgResultNotifier` can
+   * push background job notifications to the right chat in multi-chat setups.
+   * Undefined when not set (falls back to bot-global notify targets).
+   */
+  chatId?: number;
+  /**
    * Report the session the moment it is constructed.
    *
    * Invariant: the factory's catch block closes an already-constructed session

--- a/src/telegram/session-manager.ts
+++ b/src/telegram/session-manager.ts
@@ -242,7 +242,7 @@ export class SessionManager {
       const config: AgentConfig = {
         model: data.model,
         apiKey: this.options.apiKey,
-      };
+        telegramChatId: route.chatId };
       if (this.options.settingSources?.length) {
         config.settingSources = this.options.settingSources;
       }
@@ -259,7 +259,6 @@ export class SessionManager {
       if (effectiveCwd !== undefined && effectiveCwd.length > 0) {
         config.cwd = effectiveCwd;
       }
-
       // /switch: continue a staged prior conversation instead of starting fresh.
       // Consumed after a successful build below — a failed createSession leaves it
       // staged so the next getSession retries the resume; teardown via _resetStats


### PR DESCRIPTION
## What

Two improvements to subagent dispatch strategy:

### 1. System prompt guidance for background vs. foreground

The model previously had only 2 sentences in the `agent` tool schema description about when to use background mode. Now there's structured guidance in the Delegation section of the system prompt with a clear 3-criterion decision heuristic:

1. Result won't gate this turn's next action
2. Task is genuinely long
3. Surface is interactive (REPL or Telegram)

Also clarifies: use `compose` for parallel-this-turn needs, not multiple background dispatches.

### 2. Telegram background subagent support

Previously, `mode: "background"` on Telegram returned `isError: true` — "Background mode is not available in this session" — because no `BackgroundAgentRegistry` was wired into the Telegram session builder.

**Changes:**
- **`session-anthropic.ts`**: Create `BackgroundAgentRegistry` and pass it to `wireExecutors` via the existing parameter. Wire `cancelAll()` + notifier `dispose()` into `drainSubagents` for clean teardown.
- **`bg-result-notifier.ts`** (new): Subscribes to registry `settled` events, pushes a one-line status notification to the operator via `pushIfConfigured()`. Skips cancelled jobs (same contract as REPL notifier).

**Design decision**: Push-based delivery (Telegram API message) rather than injection into `processOne`. This avoids:
- The `claimedChats` reference-counting invariant (#603) — any logic before `reserveClaim()` risks the documented TOCTOU race
- The `message.ts` filesize ratchet (581 LOC baseline)
- Premature shared module extraction (YAGNI — one consumer today)

Model-context injection (so the model sees bg results in its next turn without user relay) is deferred to a follow-up.

## Tests

- 7 new tests for `TelegramBgResultNotifier` covering: completed/failed/cancelled jobs, chat targeting, default routing, dispose cleanup, error swallowing
- All 887 existing Telegram tests pass
- All CI audits pass (filesize, SDK deps, env, chalk, module-state, pins)
