### PR TITLE
fix(workspace): omit disabled child preamble

### DIFF
--- a/src/agent/subagent/fork-child-config.ts
+++ b/src/agent/subagent/fork-child-config.ts
@@ -108,7 +108,7 @@ export function assembleChildConfig<T>(args: AssembleChildConfigArgs<T>): AgentC
     ? args.workspaceStore.queryRelevant(null, taskPrompt)
     : [];
 
-  return injectWorkspacePreamble(injectToolBudgetPreamble({
+  const assembled = injectToolBudgetPreamble({
     ...options.config,
     // Invariant (trace seal ownership): mark this session as a fork so it
     // never seals the SHARED witness trace. The whole tree shares ONE
@@ -300,5 +300,9 @@ export function assembleChildConfig<T>(args: AssembleChildConfigArgs<T>): AgentC
     ...(options.phaseRole === 'read-only'
       ? { provider: buildPhaseRestrictedProvider('read-only', effectiveChildModel) }
       : {}),
-  }), workspaceEntries);
+  });
+
+  return args.workspaceStore
+    ? injectWorkspacePreamble(assembled, workspaceEntries)
+    : assembled;
 }

--- a/src/agent/subagent/fork-helpers.test.ts
+++ b/src/agent/subagent/fork-helpers.test.ts
@@ -356,6 +356,18 @@ function makeArgs(
 }
 
 describe('assembleChildConfig', () => {
+  it('does not inject a workspace preamble when no workspace store is configured', () => {
+    const cfg = assembleChildConfig(makeArgs({
+      options: {
+        parent: { sessionId: 'p' },
+        config: { systemPrompt: 'Keep this prompt unchanged.' },
+        agentType: 't',
+      },
+    }));
+
+    expect(cfg.systemPrompt).toBe('Keep this prompt unchanged.');
+  });
+
   it('stamps isSubagentFork: true unconditionally', () => {
     const cfg = assembleChildConfig(makeArgs());
     expect(cfg.isSubagentFork).toBe(true);


### PR DESCRIPTION
### Motivation

- Prevent forked children from receiving a workspace preamble (and the `workspace_publish` cold-start hint) when the shared workspace is disabled so the control arm does not see a nonfunctional tool or misleading prompt text.

### Description

- In `assembleChildConfig` (`src/agent/subagent/fork-child-config.ts`) build the child config into `assembled` via `injectToolBudgetPreamble` and only call `injectWorkspacePreamble(assembled, workspaceEntries)` when `args.workspaceStore` is present, otherwise return `assembled` unchanged.
- Added a regression test in `src/agent/subagent/fork-helpers.test.ts` asserting that `systemPrompt` is preserved when no `workspaceStore` is configured.
- Changes touch `src/agent/subagent/fork-child-config.ts` and `src/agent/subagent/fork-helpers.test.ts` and were committed locally.

### Testing

- Ran `pnpm exec vitest run src/agent/subagent/fork-helpers.test.ts` and all tests passed (37 tests).
- Ran `pnpm lint` and `git diff --check`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a862d8aa92c832bb400b7e28e6359f1)