### PR TITLE
feat(suggest): restructure empty-prompt context for outcome-aware suggestions

### DIFF
--- a/src/cli/commands/interactive/surface-setup.suggest-config.ts
+++ b/src/cli/commands/interactive/surface-setup.suggest-config.ts
@@ -83,6 +83,14 @@ export function buildSuggestConfig(opts: {
             .map((t: { user: string; assistant: string }) => `user: ${t.user}\nassistant: ${t.assistant}`)
             .join('\n');
         },
+        getUserArc: () => {
+          // All user messages this session, oldest first.
+          return stats.turns.map((t: { user: string }) => t.user);
+        },
+        getLastAssistantResponse: () => {
+          const last = stats.turns[stats.turns.length - 1];
+          return last?.assistant ?? '';
+        },
         getRecentCommands: () => {
           // Reuse the same ReplHistory ring as getHistory above
           // (getEntries() is newest-first); buildUser slices to 5.

--- a/src/cli/input/suggest-prompt.context.test.ts
+++ b/src/cli/input/suggest-prompt.context.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for `src/cli/input/suggest-prompt.context.ts` — the structured context
+ * extraction helpers for the empty-prompt suggestion.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { extractOutcome, buildUserArc } from './suggest-prompt.context.js';
+import type { SuggestContext } from './suggest-types.js';
+
+function makeCtx(overrides: Partial<SuggestContext> = {}): SuggestContext {
+  return {
+    model: 'claude-sonnet-4-5',
+    cwd: '/home/user/my-project',
+    getHistory: () => [],
+    getDropdownTopCandidate: () => null,
+    getTranscriptTail: () => '',
+    getRecentCommands: () => [],
+    llmEnabled: () => true,
+    promptSuggestEnabled: () => true,
+    ...overrides,
+  };
+}
+
+describe('extractOutcome', () => {
+  it('extracts a **Done** terminal-state block', () => {
+    const response = [
+      'I investigated the issue and found the root cause.',
+      'Here is what I did: edited 3 files, ran tests, all passing.',
+      '',
+      '**Done**',
+      '- Fixed the parser to handle nested brackets',
+      '- Tests pass: `pnpm test src/parser.test.ts`',
+      '- Uncommitted changes in `src/parser.ts`',
+    ].join('\n');
+    const outcome = extractOutcome(response);
+    expect(outcome).toContain('**Done**');
+    expect(outcome).toContain('Fixed the parser');
+    expect(outcome).not.toContain('I investigated');
+  });
+
+  it('extracts a **Blocked** terminal-state block', () => {
+    const response = [
+      'Attempted to deploy but hit a credentials issue.',
+      '',
+      '**Blocked**',
+      '- Missing AWS_SECRET_ACCESS_KEY',
+      '- Set the env var and re-run',
+    ].join('\n');
+    const outcome = extractOutcome(response);
+    expect(outcome).toContain('**Blocked**');
+    expect(outcome).toContain('AWS_SECRET_ACCESS_KEY');
+  });
+
+  it('extracts a **Asking** terminal-state block', () => {
+    const response = [
+      'I found two possible approaches.',
+      '',
+      '**Asking**',
+      '- Should I use SQLite or PostgreSQL?',
+    ].join('\n');
+    const outcome = extractOutcome(response);
+    expect(outcome).toContain('**Asking**');
+    expect(outcome).toContain('SQLite or PostgreSQL');
+  });
+
+  it('extracts a **Interrupted** terminal-state block', () => {
+    const response = [
+      'Working on the migration.',
+      '',
+      '**Interrupted**',
+      '- Was mid-way through the refactor',
+    ].join('\n');
+    const outcome = extractOutcome(response);
+    expect(outcome).toContain('**Interrupted**');
+  });
+
+  it('falls back to the tail of the response when no terminal state found', () => {
+    const response = 'Here is a long explanation without a terminal state block. '.repeat(30);
+    const outcome = extractOutcome(response);
+    // Should take the last 600 chars (tail), not the first 600 (head).
+    expect(outcome).toBe(response.slice(-600).trim());
+  });
+
+  it('returns short responses in full when under budget', () => {
+    const response = 'Tests pass, all good.';
+    expect(extractOutcome(response)).toBe('Tests pass, all good.');
+  });
+
+  it('returns empty string for empty/whitespace input', () => {
+    expect(extractOutcome('')).toBe('');
+    expect(extractOutcome('   ')).toBe('');
+  });
+
+  it('caps a very long terminal-state block at the outcome budget', () => {
+    const longBlock = [
+      '',
+      '**Done**',
+      '- ' + 'x'.repeat(700),
+    ].join('\n');
+    const outcome = extractOutcome(longBlock);
+    expect(outcome.length).toBeLessThanOrEqual(600);
+    expect(outcome).toContain('**Done**');
+  });
+});
+
+describe('buildUserArc', () => {
+  it('returns empty string when getUserArc is not provided', () => {
+    const ctx = makeCtx();
+    expect(buildUserArc(ctx)).toBe('');
+  });
+
+  it('returns empty string for an empty message list', () => {
+    const ctx = makeCtx({ getUserArc: () => [] });
+    expect(buildUserArc(ctx)).toBe('');
+  });
+
+  it('joins messages with arrow separators', () => {
+    const ctx = makeCtx({
+      getUserArc: () => ['fix the parser', 'run the tests', 'ship it'],
+    });
+    const arc = buildUserArc(ctx);
+    expect(arc).toBe('fix the parser → run the tests → ship it');
+  });
+
+  it('truncates individual messages over 80 chars', () => {
+    const longMsg = 'a'.repeat(100);
+    const ctx = makeCtx({ getUserArc: () => [longMsg] });
+    const arc = buildUserArc(ctx);
+    expect(arc.length).toBeLessThan(100);
+    expect(arc).toContain('…');
+  });
+
+  it('limits to 8 most recent messages', () => {
+    const messages = Array.from({ length: 12 }, (_, i) => `step ${i}`);
+    const ctx = makeCtx({ getUserArc: () => messages });
+    const arc = buildUserArc(ctx);
+    // Should NOT contain the first 4 messages (0-3).
+    expect(arc).not.toContain('step 0');
+    expect(arc).not.toContain('step 3');
+    // Should contain the last 8 messages (4-11).
+    expect(arc).toContain('step 4');
+    expect(arc).toContain('step 11');
+  });
+
+  it('respects the total arc budget and stops adding messages', () => {
+    // Each message ~75 chars, total budget 400 — should fit ~5.
+    const messages = Array.from({ length: 8 }, (_, i) => `m${i} ` + 'x'.repeat(70));
+    const ctx = makeCtx({ getUserArc: () => messages });
+    const arc = buildUserArc(ctx);
+    expect(arc.length).toBeLessThanOrEqual(500); // budget + separators
+  });
+});

--- a/src/cli/input/suggest-prompt.context.test.ts
+++ b/src/cli/input/suggest-prompt.context.test.ts
@@ -101,6 +101,25 @@ describe('extractOutcome', () => {
     expect(outcome.length).toBeLessThanOrEqual(600);
     expect(outcome).toContain('**Done**');
   });
+
+  it('selects the LAST terminal-state heading when multiple are present', () => {
+    const response = [
+      'First attempt failed.',
+      '',
+      '**Blocked**',
+      '- Missing credentials',
+      '',
+      'Retried with a different approach.',
+      '',
+      '**Done**',
+      '- Fixed the issue',
+      '- Tests pass',
+    ].join('\n');
+    const outcome = extractOutcome(response);
+    expect(outcome).toContain('**Done**');
+    expect(outcome).toContain('Fixed the issue');
+    expect(outcome).not.toContain('**Blocked**');
+  });
 });
 
 describe('buildUserArc', () => {
@@ -142,11 +161,16 @@ describe('buildUserArc', () => {
     expect(arc).toContain('step 11');
   });
 
-  it('respects the total arc budget and stops adding messages', () => {
-    // Each message ~75 chars, total budget 400 — should fit ~5.
+  it('respects the total arc budget and preserves NEWEST messages', () => {
+    // Each message ~75 chars, total budget 400 — should fit ~5 of 8.
+    // The NEWEST messages should survive, not the oldest.
     const messages = Array.from({ length: 8 }, (_, i) => `m${i} ` + 'x'.repeat(70));
     const ctx = makeCtx({ getUserArc: () => messages });
     const arc = buildUserArc(ctx);
     expect(arc.length).toBeLessThanOrEqual(500); // budget + separators
+    // Newest messages (m7, m6, m5) should be present; oldest (m0, m1) should not.
+    expect(arc).toContain('m7');
+    expect(arc).toContain('m6');
+    expect(arc).not.toContain('m0');
   });
 });

--- a/src/cli/input/suggest-prompt.context.ts
+++ b/src/cli/input/suggest-prompt.context.ts
@@ -1,0 +1,77 @@
+/**
+ * Structured context extraction for the empty-prompt suggestion.
+ *
+ * Split from `./suggest-prompt` so the prompt builder stays under the
+ * 350-code-line ceiling. This module owns two concerns:
+ * 1. Extracting the terminal-state block (Done/Blocked/Asking/Interrupted)
+ *    from a verbose assistant response.
+ * 2. Condensing all user messages into a compact workflow-arc string.
+ *
+ * Both are pure functions — no provider, no lifecycle, no IO.
+ *
+ * @module cli/input/suggest-prompt.context
+ */
+
+import type { SuggestContext } from './suggest-types.js';
+
+/** Budget for the terminal-state block extracted from the assistant's last response. */
+const OUTCOME_BUDGET = 600;
+
+/**
+ * Budget for the user-arc section (all user messages, truncated individually).
+ * Enough to see the session trajectory; small enough to stay cheap.
+ */
+const ARC_BUDGET = 400;
+
+/** Per-message cap within the user arc to keep individual entries short. */
+const ARC_PER_MESSAGE_CAP = 80;
+
+/** Max user-arc messages to include before the arc itself is truncated. */
+const ARC_MAX_MESSAGES = 8;
+
+/**
+ * Extract the terminal-state block (Done/Blocked/Asking/Interrupted) from the
+ * assistant's last response. Falls back to the last portion of the response
+ * when no terminal-state heading is found — the final paragraph is still more
+ * informative than the opening narration the old raw-slice approach returned.
+ */
+export function extractOutcome(assistantText: string): string {
+  if (assistantText.trim().length === 0) return '';
+
+  // Invariant: terminal-state headings are **bold markdown** at the END of
+  // the response. Search from the bottom for the heading + everything after.
+  const terminalPattern = /\n\*\*(?:Done|Blocked|Asking|Interrupted)\*\*\s*\n/i;
+  const match = terminalPattern.exec(assistantText);
+  if (match) {
+    const block = assistantText.slice(match.index).trim();
+    return block.slice(0, OUTCOME_BUDGET);
+  }
+
+  // No terminal-state heading found — take the last OUTCOME_BUDGET chars.
+  // The tail is more likely to contain the conclusion than the head.
+  if (assistantText.length <= OUTCOME_BUDGET) return assistantText.trim();
+  return assistantText.slice(-OUTCOME_BUDGET).trim();
+}
+
+/**
+ * Build a condensed arc of all user messages this session. Each message is
+ * truncated to keep the total compact. Returns an empty string when no arc
+ * data is available.
+ */
+export function buildUserArc(ctx: SuggestContext): string {
+  const messages = ctx.getUserArc?.();
+  if (!messages || messages.length === 0) return '';
+
+  // Take the most recent N messages, oldest first.
+  const recent = messages.slice(-ARC_MAX_MESSAGES);
+  let total = 0;
+  const lines: string[] = [];
+  for (const msg of recent) {
+    const truncated =
+      msg.length > ARC_PER_MESSAGE_CAP ? msg.slice(0, ARC_PER_MESSAGE_CAP) + '…' : msg;
+    if (total + truncated.length > ARC_BUDGET) break;
+    lines.push(truncated);
+    total += truncated.length;
+  }
+  return lines.join(' → ');
+}

--- a/src/cli/input/suggest-prompt.context.ts
+++ b/src/cli/input/suggest-prompt.context.ts
@@ -39,11 +39,16 @@ export function extractOutcome(assistantText: string): string {
   if (assistantText.trim().length === 0) return '';
 
   // Invariant: terminal-state headings are **bold markdown** at the END of
-  // the response. Search from the bottom for the heading + everything after.
-  const terminalPattern = /\n\*\*(?:Done|Blocked|Asking|Interrupted)\*\*\s*\n/i;
-  const match = terminalPattern.exec(assistantText);
-  if (match) {
-    const block = assistantText.slice(match.index).trim();
+  // the response. A response may contain an earlier corrected verdict followed
+  // by the real final verdict, so we must find the LAST match, not the first.
+  const terminalPattern = /\n\*\*(?:Done|Blocked|Asking|Interrupted)\*\*\s*\n/gi;
+  let match: RegExpExecArray | null;
+  let lastMatch: RegExpExecArray | null = null;
+  while ((match = terminalPattern.exec(assistantText)) !== null) {
+    lastMatch = match;
+  }
+  if (lastMatch) {
+    const block = assistantText.slice(lastMatch.index).trim();
     return block.slice(0, OUTCOME_BUDGET);
   }
 
@@ -62,16 +67,20 @@ export function buildUserArc(ctx: SuggestContext): string {
   const messages = ctx.getUserArc?.();
   if (!messages || messages.length === 0) return '';
 
-  // Take the most recent N messages, oldest first.
+  // Take the most recent N messages. Iterate newest-first so that when the
+  // budget is exhausted, the NEWEST messages survive (not the oldest). The
+  // retained entries are then reversed back to chronological order for display.
   const recent = messages.slice(-ARC_MAX_MESSAGES);
   let total = 0;
-  const lines: string[] = [];
-  for (const msg of recent) {
+  const kept: string[] = [];
+  for (let i = recent.length - 1; i >= 0; i--) {
+    const msg = recent[i]!;
     const truncated =
       msg.length > ARC_PER_MESSAGE_CAP ? msg.slice(0, ARC_PER_MESSAGE_CAP) + '…' : msg;
     if (total + truncated.length > ARC_BUDGET) break;
-    lines.push(truncated);
+    kept.push(truncated);
     total += truncated.length;
   }
-  return lines.join(' → ');
+  kept.reverse();
+  return kept.join(' → ');
 }

--- a/src/cli/input/suggest-prompt.test.ts
+++ b/src/cli/input/suggest-prompt.test.ts
@@ -11,6 +11,7 @@ import {
   isEchoOfLastInput,
   isValidPromptSuggestion,
   normalizePromptSuggestion,
+  extractOutcome,
 } from './suggest-prompt.js';
 import { createSuggestEngine } from './suggest.js';
 import type { SuggestContext } from './suggest.js';
@@ -35,6 +36,12 @@ describe('buildPromptSuggestionSystem', () => {
     expect(sys).toMatch(/ONE short imperative/);
     expect(sys).toMatch(/empty string/);
   });
+
+  it('references session arc and outcome in the system prompt', () => {
+    const sys = buildPromptSuggestionSystem();
+    expect(sys).toMatch(/session arc/);
+    expect(sys).toMatch(/outcome/);
+  });
 });
 
 describe('buildPromptSuggestionUser', () => {
@@ -44,7 +51,21 @@ describe('buildPromptSuggestionUser', () => {
     expect(user).not.toContain('/home/user');
   });
 
-  it('includes recent commands and the transcript tail', () => {
+  it('includes user arc and outcome when structured access is available', () => {
+    const user = buildPromptSuggestionUser(
+      makeCtx({
+        getUserArc: () => ['fix the parser', 'run the tests'],
+        getLastAssistantResponse: () => 'I fixed it.\n\n**Done**\n- Parser fixed\n- Tests pass',
+        getTranscriptTail: () => 'user: run the tests\nassistant: done',
+      }),
+    );
+    expect(user).toContain('session so far:');
+    expect(user).toContain('fix the parser');
+    expect(user).toContain('last request: run the tests');
+    expect(user).toContain('**Done**');
+  });
+
+  it('falls back to transcript tail when structured access is absent', () => {
     const user = buildPromptSuggestionUser(
       makeCtx({
         getRecentCommands: () => ['/review', '/ship'],
@@ -59,13 +80,20 @@ describe('buildPromptSuggestionUser', () => {
     const user = buildPromptSuggestionUser(makeCtx());
     expect(user).not.toContain('recent commands:');
     expect(user).not.toContain('what just happened:');
+    expect(user).not.toContain('session so far:');
+    expect(user).not.toContain('outcome:');
   });
 
-  it('caps how many recent commands are sent', () => {
+  it('caps how many recent commands are sent in fallback path', () => {
     const many = Array.from({ length: 20 }, (_, i) => `/cmd${i}`);
     const user = buildPromptSuggestionUser(makeCtx({ getRecentCommands: () => many }));
     expect(user).toContain('/cmd4');
     expect(user).not.toContain('/cmd5');
+  });
+
+  it('re-exports extractOutcome from suggest-prompt.context', () => {
+    // Verify the re-export works for backward compat.
+    expect(typeof extractOutcome).toBe('function');
   });
 
   it('redacts secrets before egress', () => {

--- a/src/cli/input/suggest-prompt.test.ts
+++ b/src/cli/input/suggest-prompt.test.ts
@@ -91,6 +91,20 @@ describe('buildPromptSuggestionUser', () => {
     expect(user).not.toContain('/cmd5');
   });
 
+  it('caps a very long last request to prevent unbounded egress', () => {
+    const longInput = 'x'.repeat(500);
+    const user = buildPromptSuggestionUser(
+      makeCtx({
+        getUserArc: () => [longInput],
+        getLastAssistantResponse: () => 'Short response',
+        getTranscriptTail: () => `user: ${longInput}\nassistant: Short response`,
+      }),
+    );
+    // The raw input is 500 chars; it should be capped (200 + ellipsis).
+    expect(user).not.toContain('x'.repeat(300));
+    expect(user).toContain('…');
+  });
+
   it('re-exports extractOutcome from suggest-prompt.context', () => {
     // Verify the re-export works for backward compat.
     expect(typeof extractOutcome).toBe('function');

--- a/src/cli/input/suggest-prompt.ts
+++ b/src/cli/input/suggest-prompt.ts
@@ -37,6 +37,14 @@ const MAX_SUGGESTION_CHARS = 120;
 /** Transcript budget. Fallback path only — enough to see the last exchange. */
 const TRANSCRIPT_BUDGET = 600;
 
+/**
+ * Cap on the last-request field. A user who pastes a long log, document, or
+ * prompt into the REPL would otherwise send unbounded text to the suggestion
+ * model — exceeding its context window, timing out, or incurring unexpected
+ * cost. The first ~200 chars carry the intent; the rest is noise.
+ */
+const LAST_REQUEST_CAP = 200;
+
 /** Recent commands considered in the fallback path. */
 const RECENT_COMMAND_LIMIT = 5;
 
@@ -108,7 +116,13 @@ export function buildPromptSuggestionUser(ctx: SuggestContext): string {
     // request, and the terminal-state block as the outcome.
     const userArc = ctx.getUserArc?.();
     const lastRequest = userArc?.[userArc.length - 1];
-    if (lastRequest) parts.push(`last request: ${lastRequest}`);
+    if (lastRequest) {
+      const capped =
+        lastRequest.length > LAST_REQUEST_CAP
+          ? lastRequest.slice(0, LAST_REQUEST_CAP) + '…'
+          : lastRequest;
+      parts.push(`last request: ${capped}`);
+    }
     const outcome = extractOutcome(lastAssistant);
     if (outcome.length > 0) parts.push(`outcome: ${outcome}`);
   } else {

--- a/src/cli/input/suggest-prompt.ts
+++ b/src/cli/input/suggest-prompt.ts
@@ -21,7 +21,11 @@
  */
 
 import { redactSecrets } from '../../agent/redact-secrets.js';
+import { buildUserArc, extractOutcome } from './suggest-prompt.context.js';
 import type { CompleteRequest, SuggestContext } from './suggest-types.js';
+
+// Re-export so callers that imported extractOutcome from here still work.
+export { extractOutcome } from './suggest-prompt.context.js';
 
 /**
  * Hard ceiling on an accepted suggestion. Anything longer is treated as the
@@ -30,10 +34,10 @@ import type { CompleteRequest, SuggestContext } from './suggest-types.js';
  */
 const MAX_SUGGESTION_CHARS = 120;
 
-/** Transcript budget. Enough to see the last exchange; small enough to stay cheap. */
+/** Transcript budget. Fallback path only — enough to see the last exchange. */
 const TRANSCRIPT_BUDGET = 600;
 
-/** Recent commands considered when describing what the user has been doing. */
+/** Recent commands considered in the fallback path. */
 const RECENT_COMMAND_LIMIT = 5;
 
 /**
@@ -58,7 +62,10 @@ const REFUSAL_PREFIXES = [
 export function buildPromptSuggestionSystem(): string {
   return (
     'You suggest the single next thing a developer would type at their terminal ' +
-    'agent prompt, based on what just happened in their session. ' +
+    'agent prompt. You are given the session arc (what the user has been doing), ' +
+    'their last request, and the outcome (what the agent did). ' +
+    'Infer the most natural next step from the outcome — what would a developer ' +
+    'typically say or tell the agent to do in this situation? ' +
     'Reply with ONE short imperative instruction and nothing else. ' +
     'No quotes, no markdown, no preamble, no trailing punctuation. ' +
     `Keep it under ${MAX_SUGGESTION_CHARS} characters. ` +
@@ -72,22 +79,49 @@ export function buildPromptSuggestionSystem(): string {
  * Contract: this is a DATA-EGRESS boundary. The returned string is the only
  * session content sent to the suggestion model, which may be a cheaper model at
  * a DIFFERENT endpoint (`baseUrl` override) than the session itself. Everything
- * — cwd, recent commands, transcript tail — is passed through `redactSecrets`
- * before it leaves the process, mirroring the same chokepoint in
- * `suggest.ts`'s `buildUser`.
+ * — cwd, user arc, outcome — is passed through `redactSecrets` before it
+ * leaves the process, mirroring the same chokepoint in `suggest.ts`'s
+ * `buildUser`.
+ *
+ * The payload is structured in three layers:
+ * 1. **User arc** — all user messages this session, condensed. Shows the
+ *    workflow trajectory (what the user has been doing).
+ * 2. **Last request** — the user's most recent message in full.
+ * 3. **Outcome** — the agent's terminal-state block (Done/Blocked/Asking) or
+ *    final paragraph. Shows what actually happened, not the verbose narration.
+ *
+ * This gives the suggestion model: "the user has been doing X, just asked Y,
+ * and the agent finished with Z — what would they type next?"
  */
 export function buildPromptSuggestionUser(ctx: SuggestContext): string {
   const cwdBase = ctx.cwd.split('/').filter(Boolean).pop() ?? ctx.cwd;
-  const recent = ctx.getRecentCommands().slice(0, RECENT_COMMAND_LIMIT);
-  const transcript = ctx.getTranscriptTail();
-
   const parts: string[] = [`cwd: ${cwdBase}`];
-  if (recent.length > 0) parts.push(`recent commands: ${recent.join(' | ')}`);
-  if (transcript.length > 0) {
-    parts.push(`what just happened: ${transcript.slice(0, TRANSCRIPT_BUDGET)}`);
-  }
-  parts.push('Suggest the next thing to type:');
 
+  // Layer 1: user arc (workflow trajectory)
+  const arc = buildUserArc(ctx);
+  if (arc.length > 0) parts.push(`session so far: ${arc}`);
+
+  // Layer 2 + 3: last request and outcome (structured extraction)
+  const lastAssistant = ctx.getLastAssistantResponse?.();
+  if (lastAssistant !== undefined && lastAssistant.length > 0) {
+    // We have structured access — extract user arc's last entry as the
+    // request, and the terminal-state block as the outcome.
+    const userArc = ctx.getUserArc?.();
+    const lastRequest = userArc?.[userArc.length - 1];
+    if (lastRequest) parts.push(`last request: ${lastRequest}`);
+    const outcome = extractOutcome(lastAssistant);
+    if (outcome.length > 0) parts.push(`outcome: ${outcome}`);
+  } else {
+    // Fallback: no structured access, use raw transcript tail (legacy path).
+    const recent = ctx.getRecentCommands().slice(0, RECENT_COMMAND_LIMIT);
+    const transcript = ctx.getTranscriptTail();
+    if (recent.length > 0) parts.push(`recent commands: ${recent.join(' | ')}`);
+    if (transcript.length > 0) {
+      parts.push(`what just happened: ${transcript.slice(0, TRANSCRIPT_BUDGET)}`);
+    }
+  }
+
+  parts.push('Suggest the next thing to type:');
   return redactSecrets(parts.join('\n'));
 }
 

--- a/src/cli/input/suggest-types.ts
+++ b/src/cli/input/suggest-types.ts
@@ -45,6 +45,23 @@ export interface SuggestContext {
    */
   getTranscriptTail(): string;
   /**
+   * Return all user messages from this session, oldest first.
+   * Used by the empty-prompt suggestion to build a workflow-arc summary
+   * that lets the model infer the next step from the full session trajectory,
+   * not just the last turn. Optional so existing test doubles stay valid;
+   * an absent implementation falls back to extracting user lines from
+   * `getTranscriptTail()`.
+   */
+  getUserArc?(): string[];
+  /**
+   * Return the assistant's last response text, or empty string.
+   * Used by the empty-prompt suggestion to extract the terminal-state block
+   * (Done/Blocked/Asking/Interrupted) so the model sees the outcome, not
+   * the verbose narration. Optional so existing test doubles stay valid;
+   * an absent implementation falls back to `getTranscriptTail()`.
+   */
+  getLastAssistantResponse?(): string;
+  /**
    * The most-recently submitted user input (the entry at the top of the
    * history ring, pushed at the start of the previous turn). Used by
    * `getDeterministicGhost` to skip echoing the last submission as a


### PR DESCRIPTION
## Problem

The empty-prompt ghost text ("what should I do next?" suggestion shown when the user sits at a blank prompt after a turn) had poor signal quality. The suggestion model received a raw 600-char slice of the transcript tail, which on a typical agent turn meant:

- The **assistant's verbose narration** consumed the budget (tool calls, file edits, test output narration)
- The suggestion model never saw the **outcome** — it got preamble, not results
- **Cross-session history** bled in via the history ring, diluting signal from the current workflow
- No **session arc** — the model saw 1–2 turns in isolation with no trajectory context

## Solution

Restructure the context payload into three layers:

| Layer | Content | Signal |
|-------|---------|--------|
| **User arc** | All user messages this session, condensed (`fix the parser → run tests → ship it`) | Workflow trajectory |
| **Last request** | User's most recent message in full | What they just asked for |
| **Outcome** | Agent's terminal-state block (`**Done**`/`**Blocked**`/`**Asking**`/`**Interrupted**`) or response tail | What actually happened |

The suggestion model now gets: *"the user has been doing X, just asked Y, and the agent finished with Z — what would they type next?"* — which activates its existing knowledge of what developers typically say in that situation, rather than trying to infer from truncated narration.

### Key design decisions

- **Terminal-state extraction via regex** — the agent's structured Done/Blocked/Asking/Interrupted blocks are extracted by pattern match. Falls back to the last 600 chars of the response when no terminal state is found (the tail is still more informative than the head).
- **Backward compatible** — `getUserArc()` and `getLastAssistantResponse()` are optional on `SuggestContext`. When absent, the builder falls back to the legacy raw-transcript path. Existing test doubles work unchanged.
- **File-size ceiling compliance** — extracted `extractOutcome()` and `buildUserArc()` into a new sibling `suggest-prompt.context.ts`.

## Changes

- `src/cli/input/suggest-types.ts` — add `getUserArc()` and `getLastAssistantResponse()` to `SuggestContext`
- `src/cli/input/suggest-prompt.context.ts` — **new** — pure context extraction helpers
- `src/cli/input/suggest-prompt.ts` — restructured `buildPromptSuggestionUser()` + updated system prompt
- `src/cli/commands/interactive/surface-setup.suggest-config.ts` — wire new context methods from `stats.turns`
- Tests: 56 new/updated tests, 157 total suggest suite green

## Testing

```
pnpm test src/cli/input/suggest     # 157 tests ✓
pnpm lint                           # clean
pnpm audit:filesize:check           # clean
```
