### PR TITLE
feat(tui): plain-language pass on user-facing chrome for non-technical readability

### DIFF
--- a/src/agent/tool-category.ts
+++ b/src/agent/tool-category.ts
@@ -289,20 +289,20 @@ export function categorizeTool(name: string): ToolCategory {
 /**
  * Categories that represent "this call dispatches more work" rather than a
  * direct tool invocation. The tool-lane renderer appends a dim bracketed
- * tag (`[helper]`, `[skill]`, `[workflow]`) to entries in these categories so
+ * tag (`[worker]`, `[skill]`, `[workflow]`) to entries in these categories so
  * the dispatch class is legible as text alongside the glyph + color cues —
  * survives monochrome terminals and makes the taxonomy self-documenting in
  * the stream.
  *
  * Invariant: tag values are plain-language words, not internal jargon. The
  * scrollback transcript is routinely read by non-technical observers, so
- * `subagent` renders as `helper` and `dag` as `workflow` — an everyday reader
+ * `subagent` renders as `worker` and `dag` as `workflow` — an everyday reader
  * should never need to know what a DAG is to follow the activity feed. The
  * category KEYS stay canonical (`subagent`/`skill`/`dag`); only the
  * user-facing tag text is humanized here, at the single owning map.
  */
 const DISPATCH_CATEGORIES: Partial<Record<ToolCategory, string>> = {
-  subagent: 'helper',
+  subagent: 'worker',
   skill: 'skill',
   dag: 'workflow',
 };

--- a/src/agent/tool-category.ts
+++ b/src/agent/tool-category.ts
@@ -289,15 +289,22 @@ export function categorizeTool(name: string): ToolCategory {
 /**
  * Categories that represent "this call dispatches more work" rather than a
  * direct tool invocation. The tool-lane renderer appends a dim bracketed
- * tag (`[subagent]`, `[skill]`, `[dag]`) to entries in these categories so
+ * tag (`[helper]`, `[skill]`, `[workflow]`) to entries in these categories so
  * the dispatch class is legible as text alongside the glyph + color cues —
  * survives monochrome terminals and makes the taxonomy self-documenting in
  * the stream.
+ *
+ * Invariant: tag values are plain-language words, not internal jargon. The
+ * scrollback transcript is routinely read by non-technical observers, so
+ * `subagent` renders as `helper` and `dag` as `workflow` — an everyday reader
+ * should never need to know what a DAG is to follow the activity feed. The
+ * category KEYS stay canonical (`subagent`/`skill`/`dag`); only the
+ * user-facing tag text is humanized here, at the single owning map.
  */
 const DISPATCH_CATEGORIES: Partial<Record<ToolCategory, string>> = {
-  subagent: 'subagent',
+  subagent: 'helper',
   skill: 'skill',
-  dag: 'dag',
+  dag: 'workflow',
 };
 
 export function dispatchTagForCategory(cat: ToolCategory): string | undefined {

--- a/src/cli/_lib/stream-renderer-source.ts
+++ b/src/cli/_lib/stream-renderer-source.ts
@@ -132,7 +132,7 @@ function formatDoneSummary(source: SourceState): string {
   if (source.stats.toolUses) {
     stats.push(formatToolCallStat(source.stats.toolUses));
   }
-  if (source.stats.tokens) stats.push(`${formatTokens(source.stats.tokens)} tok`);
+  if (source.stats.tokens) stats.push(`${formatTokens(source.stats.tokens)} tokens`);
   const durationMs = source.responseMetadata?.['durationMs'];
   const wallMs = Date.now() - source.startedAt;
   if (typeof durationMs === 'number') {

--- a/src/cli/commands/interactive/__snapshots__/tool-lane.overlay.test.ts.snap
+++ b/src/cli/commands/interactive/__snapshots__/tool-lane.overlay.test.ts.snap
@@ -1,39 +1,39 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Spine renderer scenarios > ASCII fallback — AGENT_AFK_ASCII=1 swaps box-drawing for ASCII glyphs 1`] = `
-"o → Agent(ascii) [helper]
+"o → Agent(ascii) [worker]
 | +- ● Read("x.ts") — ✓ 10 lines
 | \\- Done (1 tool · 0.5s)"
 `;
 
 exports[`Spine renderer scenarios > abort — Agent without a Done synthetic still renders spine + children 1`] = `
-"◉ → Agent(aborted) [helper]
+"◉ → Agent(aborted) [worker]
 │ ╰─ ● Read("file.ts") — ✓ partial"
 `;
 
 exports[`Spine renderer scenarios > nested — Agent inside Agent: outer spine continues past inner block 1`] = `
-"◉ → Agent(mint) [helper]
+"◉ → Agent(mint) [worker]
 │ ├─ ● Read("daemon.ts") — ✓ 311 lines
-│ ├─ → Agent(gather) [helper]
+│ ├─ → Agent(gather) [worker]
 │ │ ├─ ● Read("cron.ts") — ✓ 42 lines
 │ │ ╰─ ● Grep("interval") — ✓ 6 matches
 │ ╰─ Done (4 tools · 8.0s)"
 `;
 
 exports[`Spine renderer scenarios > parallel — three sibling Agents each get their own turn-root + spine 1`] = `
-"◉ → Agent(anthropic-port) [helper]
+"◉ → Agent(anthropic-port) [worker]
 │ ├─ ✎ Edit("anthropic-port.ts") — ✓ edited
 │ ╰─ Done (1 tool · 2.0s)
-◉ → Agent(openai-port) [helper]
+◉ → Agent(openai-port) [worker]
 │ ├─ ✎ Edit("openai-port.ts") — ✓ edited
 │ ╰─ Done (1 tool · 2.0s)
-◉ → Agent(codex-port) [helper]
+◉ → Agent(codex-port) [worker]
 │ ├─ ✎ Edit("codex-port.ts") — ✓ edited
 │ ╰─ Done (1 tool · 2.0s)"
 `;
 
 exports[`Spine renderer scenarios > sequential — single subagent block renders ◉-rooted spine 1`] = `
-"◉ → Agent(diagnose) [helper]
+"◉ → Agent(diagnose) [worker]
 │ ├─ ● Read("abort-graph.ts") — ✓ 144 lines
 │ ╰─ Done (1 tool · 1.5s)"
 `;

--- a/src/cli/commands/interactive/__snapshots__/tool-lane.overlay.test.ts.snap
+++ b/src/cli/commands/interactive/__snapshots__/tool-lane.overlay.test.ts.snap
@@ -1,39 +1,39 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Spine renderer scenarios > ASCII fallback — AGENT_AFK_ASCII=1 swaps box-drawing for ASCII glyphs 1`] = `
-"o → Agent(ascii) [subagent]
+"o → Agent(ascii) [helper]
 | +- ● Read("x.ts") — ✓ 10 lines
 | \\- Done (1 tool · 0.5s)"
 `;
 
 exports[`Spine renderer scenarios > abort — Agent without a Done synthetic still renders spine + children 1`] = `
-"◉ → Agent(aborted) [subagent]
+"◉ → Agent(aborted) [helper]
 │ ╰─ ● Read("file.ts") — ✓ partial"
 `;
 
 exports[`Spine renderer scenarios > nested — Agent inside Agent: outer spine continues past inner block 1`] = `
-"◉ → Agent(mint) [subagent]
+"◉ → Agent(mint) [helper]
 │ ├─ ● Read("daemon.ts") — ✓ 311 lines
-│ ├─ → Agent(gather) [subagent]
+│ ├─ → Agent(gather) [helper]
 │ │ ├─ ● Read("cron.ts") — ✓ 42 lines
 │ │ ╰─ ● Grep("interval") — ✓ 6 matches
 │ ╰─ Done (4 tools · 8.0s)"
 `;
 
 exports[`Spine renderer scenarios > parallel — three sibling Agents each get their own turn-root + spine 1`] = `
-"◉ → Agent(anthropic-port) [subagent]
+"◉ → Agent(anthropic-port) [helper]
 │ ├─ ✎ Edit("anthropic-port.ts") — ✓ edited
 │ ╰─ Done (1 tool · 2.0s)
-◉ → Agent(openai-port) [subagent]
+◉ → Agent(openai-port) [helper]
 │ ├─ ✎ Edit("openai-port.ts") — ✓ edited
 │ ╰─ Done (1 tool · 2.0s)
-◉ → Agent(codex-port) [subagent]
+◉ → Agent(codex-port) [helper]
 │ ├─ ✎ Edit("codex-port.ts") — ✓ edited
 │ ╰─ Done (1 tool · 2.0s)"
 `;
 
 exports[`Spine renderer scenarios > sequential — single subagent block renders ◉-rooted spine 1`] = `
-"◉ → Agent(diagnose) [subagent]
+"◉ → Agent(diagnose) [helper]
 │ ├─ ● Read("abort-graph.ts") — ✓ 144 lines
 │ ╰─ Done (1 tool · 1.5s)"
 `;

--- a/src/cli/commands/interactive/__snapshots__/tool-lane.test.ts.snap
+++ b/src/cli/commands/interactive/__snapshots__/tool-lane.test.ts.snap
@@ -11,14 +11,14 @@ exports[`Snapshot pins — tool-lane-render.ts representative outputs > scenario
 exports[`Snapshot pins — tool-lane-render.ts representative outputs > scenario 3 — tool entry with error result 1`] = `"  $ Bash("npm test") — ✗ Error: 3 tests failed"`;
 
 exports[`Snapshot pins — tool-lane-render.ts representative outputs > scenario 4 — subagent Agent entry with children, completed 1`] = `
-"◉ → Agent(snap-researcher) [helper]
+"◉ → Agent(snap-researcher) [worker]
 │ ├─ ● Read("src/main.ts") — ✓ 88 lines
 │ ├─ ● Grep("TODO") — ✓ 7 matches
 │ ╰─ Done (2 tools · 3.1s)"
 `;
 
 exports[`Snapshot pins — tool-lane-render.ts representative outputs > scenario 5 — subagent Agent entry with overflow (4 children, MAX=3) 1`] = `
-"◉ → Agent(snap-overflower) [helper] — 4 tool calls
+"◉ → Agent(snap-overflower) [worker] — 4 tool calls
 │ ├─ … +1 (1 Read)
 │ ├─ $ Bash("snap1.ts") — ✓ snap-result-1
 │ ├─ ● Grep("snap2.ts") — ✓ snap-result-2

--- a/src/cli/commands/interactive/__snapshots__/tool-lane.test.ts.snap
+++ b/src/cli/commands/interactive/__snapshots__/tool-lane.test.ts.snap
@@ -11,14 +11,14 @@ exports[`Snapshot pins — tool-lane-render.ts representative outputs > scenario
 exports[`Snapshot pins — tool-lane-render.ts representative outputs > scenario 3 — tool entry with error result 1`] = `"  $ Bash("npm test") — ✗ Error: 3 tests failed"`;
 
 exports[`Snapshot pins — tool-lane-render.ts representative outputs > scenario 4 — subagent Agent entry with children, completed 1`] = `
-"◉ → Agent(snap-researcher) [subagent]
+"◉ → Agent(snap-researcher) [helper]
 │ ├─ ● Read("src/main.ts") — ✓ 88 lines
 │ ├─ ● Grep("TODO") — ✓ 7 matches
 │ ╰─ Done (2 tools · 3.1s)"
 `;
 
 exports[`Snapshot pins — tool-lane-render.ts representative outputs > scenario 5 — subagent Agent entry with overflow (4 children, MAX=3) 1`] = `
-"◉ → Agent(snap-overflower) [subagent] — 4 tool calls
+"◉ → Agent(snap-overflower) [helper] — 4 tool calls
 │ ├─ … +1 (1 Read)
 │ ├─ $ Bash("snap1.ts") — ✓ snap-result-1
 │ ├─ ● Grep("snap2.ts") — ✓ snap-result-2

--- a/src/cli/commands/interactive/plain-progress.test.ts
+++ b/src/cli/commands/interactive/plain-progress.test.ts
@@ -182,7 +182,7 @@ describe('plain-mode subagent lifecycle', () => {
     );
 
     expect(lines).toHaveLength(1);
-    expect(stripAnsi(lines[0]!)).toMatch(/agent research-agent started/);
+    expect(stripAnsi(lines[0]!)).toMatch(/helper research-agent started/);
   });
 
   it('emits a finish line on the done event', () => {

--- a/src/cli/commands/interactive/plain-progress.test.ts
+++ b/src/cli/commands/interactive/plain-progress.test.ts
@@ -182,7 +182,7 @@ describe('plain-mode subagent lifecycle', () => {
     );
 
     expect(lines).toHaveLength(1);
-    expect(stripAnsi(lines[0]!)).toMatch(/helper research-agent started/);
+    expect(stripAnsi(lines[0]!)).toMatch(/worker research-agent started/);
   });
 
   it('emits a finish line on the done event', () => {

--- a/src/cli/commands/interactive/plain-progress.ts
+++ b/src/cli/commands/interactive/plain-progress.ts
@@ -120,7 +120,7 @@ export function observePlainSubagentEvent(
   if (!state.subagentStartTimes.has(subagentId)) {
     state.subagentStartTimes.set(subagentId, Date.now());
     state.subagentLabels.set(subagentId, label);
-    writer.fn(palette.dim(`  ◦ agent ${label} started`));
+    writer.fn(palette.dim(`  ◦ helper ${label} started`));
   }
   const isTerminal = event.type === 'done' || event.type === 'error';
   if (isTerminal) {
@@ -130,6 +130,6 @@ export function observePlainSubagentEvent(
     state.subagentLabels.delete(subagentId);
     const durationStr = durationMs !== undefined ? ` · ${formatDuration(durationMs)}` : '';
     const statusStr = event.type === 'error' ? palette.error('failed') : palette.success('done');
-    writer.fn(palette.dim(`  ◦ agent ${label}${durationStr} · `) + statusStr);
+    writer.fn(palette.dim(`  ◦ helper ${label}${durationStr} · `) + statusStr);
   }
 }

--- a/src/cli/commands/interactive/plain-progress.ts
+++ b/src/cli/commands/interactive/plain-progress.ts
@@ -120,7 +120,7 @@ export function observePlainSubagentEvent(
   if (!state.subagentStartTimes.has(subagentId)) {
     state.subagentStartTimes.set(subagentId, Date.now());
     state.subagentLabels.set(subagentId, label);
-    writer.fn(palette.dim(`  ◦ helper ${label} started`));
+    writer.fn(palette.dim(`  ◦ worker ${label} started`));
   }
   const isTerminal = event.type === 'done' || event.type === 'error';
   if (isTerminal) {
@@ -130,6 +130,6 @@ export function observePlainSubagentEvent(
     state.subagentLabels.delete(subagentId);
     const durationStr = durationMs !== undefined ? ` · ${formatDuration(durationMs)}` : '';
     const statusStr = event.type === 'error' ? palette.error('failed') : palette.success('done');
-    writer.fn(palette.dim(`  ◦ helper ${label}${durationStr} · `) + statusStr);
+    writer.fn(palette.dim(`  ◦ worker ${label}${durationStr} · `) + statusStr);
   }
 }

--- a/src/cli/commands/interactive/progress-banner.test.ts
+++ b/src/cli/commands/interactive/progress-banner.test.ts
@@ -165,7 +165,7 @@ describe('progress-banner — terminal width clamping', () => {
       const joined = stripAnsi(lines.join('\n'));
       expect(joined).not.toContain('stopping…');
       // Normal streaming keeps the interrupt hint.
-      expect(joined).toContain('esc to interrupt · ctrl+b background');
+      expect(joined).toContain('esc to interrupt · ctrl+b to run in background');
     });
 
     it('does NOT show the stopping indicator when the flag is explicitly false', () => {

--- a/src/cli/commands/interactive/progress-banner.ts
+++ b/src/cli/commands/interactive/progress-banner.ts
@@ -5,22 +5,25 @@ import { extractLatestThinkingClause } from '../../_lib/stream-renderer-subagent
 import { truncateDisplayWidth } from '../../display.js';
 import { formatDuration, formatTokens, formatToolCallStat } from '../../format-utils.js';
 import { palette } from '../../palette.js';
+import { capToMeasure } from '../../render/measure.js';
 import { getTerminalWidth } from '../../terminal-size.js';
 import { styleForToolName } from '../../tool-category.js';
 import { shortenPaths } from './tool-lane-format-args.js';
 import { sanitizeLabel } from './tool-lane-format-sanitize.js';
 
 /**
- * Clamp a fully-styled ANSI string to the current terminal width (or the
+ * Clamp a fully-styled ANSI string to the active text measure (or the
  * provided `columns` override used in tests).  Leaves ANSI reset codes intact
  * so the caller's `palette.dim(…)` wrapper still closes correctly.
  *
- * Terminal width is read through `getTerminalWidth()` — never via raw
- * `process.stdout.columns` — so the 80-column fallback for non-TTY pipes is
- * centralised in `src/cli/terminal-size.ts`.
+ * Width is `capToMeasure(getTerminalWidth())` — the same ceiling the tool-lane
+ * applies via `toolLaneWidth()` — so the banner never extends past the
+ * tool-lane rows above it on wide terminals. When the measure is disabled
+ * (`AFK_TEXT_MEASURE=full`), `capToMeasure` returns the raw terminal width
+ * unchanged.
  */
 function clampToTerminal(line: string, columns?: number): string {
-  const cols = columns ?? getTerminalWidth();
+  const cols = columns ?? capToMeasure(getTerminalWidth());
   if (!Number.isFinite(cols) || cols <= 0) return line;
   return truncateDisplayWidth(line, cols);
 }
@@ -47,7 +50,7 @@ export function deriveProgressActivity(
   columns?: number,
 ): string | undefined {
   if (!thinkingBuffer) return undefined;
-  const cols = columns ?? getTerminalWidth();
+  const cols = columns ?? capToMeasure(getTerminalWidth());
   const clause = extractLatestThinkingClause(thinkingBuffer, Math.max(20, cols - 10));
   return clause || undefined;
 }

--- a/src/cli/commands/interactive/progress-banner.ts
+++ b/src/cli/commands/interactive/progress-banner.ts
@@ -135,7 +135,7 @@ export function formatProgressBanner(
     stats.push(`via ${color(`${glyph} ${sanitizeLabel(lastToolName)}`)}`);
   }
   if (toolUses) stats.push(formatToolCallStat(toolUses));
-  if (totalTokens) stats.push(`${formatTokens(totalTokens)} tok`);
+  if (totalTokens) stats.push(`${formatTokens(totalTokens)} tokens`);
   if (durationMs) stats.push(formatDuration(durationMs));
   // Parallel fan-out indicator: when more than one child is concurrently active
   // show "N running" so the operator knows a wide parallel batch is in flight
@@ -148,7 +148,7 @@ export function formatProgressBanner(
   }
   // Drop the interrupt hint once a stop is already in flight — the ESC has been
   // accepted, so "esc to interrupt" would misrepresent the current state.
-  if (!stopping) stats.push('esc to interrupt · ctrl+b background');
+  if (!stopping) stats.push('esc to interrupt · ctrl+b to run in background');
 
   const statsStr = stats.length > 0 ? ` (${stats.join(' · ')})` : '';
 
@@ -185,7 +185,7 @@ export function formatProgressSummary(event: ProgressEvent, columns?: number): s
   const { description, totalTokens, toolUses, durationMs } = event;
   const stats: string[] = [];
   if (toolUses) stats.push(formatToolCallStat(toolUses));
-  if (totalTokens) stats.push(`${formatTokens(totalTokens)} tok`);
+  if (totalTokens) stats.push(`${formatTokens(totalTokens)} tokens`);
   if (durationMs) stats.push(formatDuration(durationMs));
   const statsStr = stats.length > 0 ? ` (${stats.join(' · ')})` : '';
   return clampToTerminal(palette.dim(`  ◦ ${sanitizeLabel(description)}${statsStr}`), columns);

--- a/src/cli/commands/interactive/thinking-lane.test.ts
+++ b/src/cli/commands/interactive/thinking-lane.test.ts
@@ -87,7 +87,7 @@ describe('ThinkingLane — duration semantics', () => {
   });
 
   it('inlineSummary() honors the markEnded() cap', () => {
-    // Subagent Done rows surface `· thought Xs · N tok` via inlineSummary —
+    // Subagent Done rows surface `· thought Xs · N tokens` via inlineSummary —
     // the same fix must apply or the subagent annotation goes back to
     // reporting turn-end wall-clock.
     const lane = new ThinkingLane();
@@ -175,8 +175,8 @@ describe('ThinkingLane — per-phase interleaving (peekPhase / drainPhase)', () 
 
     // Cumulative methods (subagent / non-TTY paths) are unaffected by draining.
     expect(lane.peek()).toBe('alpha beta');
-    // 'alpha beta' = 10 chars → ceil(10/4) = 3 tok
-    expect(stripAnsi(lane.collapse() ?? '')).toContain('3 tok');
+    // 'alpha beta' = 10 chars → ceil(10/4) = 3 tokens
+    expect(stripAnsi(lane.collapse() ?? '')).toContain('3 tokens');
   });
 
   it('peekPhase()/drainPhase() are empty before any push', () => {
@@ -188,8 +188,8 @@ describe('ThinkingLane — per-phase interleaving (peekPhase / drainPhase)', () 
 
 describe('formatThoughtSummary', () => {
   it('renders sub-second durations in ms and ≥1s in s, with a token estimate', () => {
-    expect(stripAnsi(formatThoughtSummary(420, 320))).toContain('thought for 420ms · 80 tok');
-    expect(stripAnsi(formatThoughtSummary(1500, 320))).toContain('thought for 1.5s · 80 tok');
+    expect(stripAnsi(formatThoughtSummary(420, 320))).toContain('thought for 420ms · 80 tokens');
+    expect(stripAnsi(formatThoughtSummary(1500, 320))).toContain('thought for 1.5s · 80 tokens');
   });
 
   it('clamps negative durations (NTP step-back) to 0ms', () => {

--- a/src/cli/commands/interactive/thinking-lane.ts
+++ b/src/cli/commands/interactive/thinking-lane.ts
@@ -2,7 +2,7 @@ import { palette } from '../../palette.js';
 import { isDebugEnabled } from '../../../utils/debug.js';
 
 /**
- * Render the canonical `◆ thought for Xs · N tok` summary line. Shared by
+ * Render the canonical `◆ thought for Xs · N tokens` summary line. Shared by
  * {@link ThinkingLane.collapse} (turn-total, non-TTY/subagent) and the TTY
  * orchestrator's per-phase inline commit (see `commitThinkingPhase`) so both
  * read identically.
@@ -28,8 +28,8 @@ export function formatThoughtSummary(durationMs: number, charCount: number): str
  *   The "thought for Xs" line reports time spent ON THINKING, not wall-clock
  *   from first-thinking-byte to turn-end. Without {@link markEnded}, the
  *   duration would include text streaming and tool calls that happened after
- *   the thinking phase concluded — producing ~9 tok/s "duration" lines for a
- *   model that thinks at ~50–80 tok/s, which misleads the operator about
+ *   the thinking phase concluded — producing ~9 tokens/s "duration" lines for a
+ *   model that thinks at ~50–80 tokens/s, which misleads the operator about
  *   where the turn actually spent its budget.
  *
  *   Callers (orchestrator / subagent renderer) call {@link markEnded} on the
@@ -144,13 +144,13 @@ export class ThinkingLane {
     // Use the captured thinking→acting boundary when available; fall back to
     // wall-clock when the caller never signaled (e.g. pure-thinking turn with
     // no subsequent content or tool calls). formatThoughtSummary owns the 0-clamp
-    // (NTP step-back guard) and the shared "◆ thought for Xs · N tok" format.
+    // (NTP step-back guard) and the shared "◆ thought for Xs · N tokens" format.
     const end = this.endedAt ?? Date.now();
     return formatThoughtSummary(end - this.startedAt, this.buffer.length);
   }
 
   /**
-   * Compact inline form of the buffered thinking — "thought 1.5s · 320 tok"
+   * Compact inline form of the buffered thinking — "thought 1.5s · 320 tokens"
    * — for embedding into another summary line (e.g. a subagent's Done row).
    * Distinct from {@link collapse}: no leading whitespace, no glyph, no color,
    * and does NOT flip `hasEmitted` so the caller can still call collapse later

--- a/src/cli/commands/interactive/thinking-lane.ts
+++ b/src/cli/commands/interactive/thinking-lane.ts
@@ -18,7 +18,7 @@ export function formatThoughtSummary(durationMs: number, charCount: number): str
     : `${(duration / 1000).toFixed(1)}s`;
   // Rough token estimate: 1 token ~= 4 chars
   const tokenCount = Math.ceil(charCount / 4);
-  return `  ${palette.thinking('◆ thought for ' + durationStr + ' · ' + tokenCount + ' tok')}`;
+  return `  ${palette.thinking('◆ thought for ' + durationStr + ' · ' + tokenCount + ' tokens')}`;
 }
 
 /**
@@ -167,6 +167,6 @@ export class ThinkingLane {
       ? `${duration}ms`
       : `${(duration / 1000).toFixed(1)}s`;
     const tokenCount = Math.ceil(this.buffer.length / 4);
-    return `thought ${durationStr} · ${tokenCount} tok`;
+    return `thought ${durationStr} · ${tokenCount} tokens`;
   }
 }

--- a/src/cli/commands/interactive/tool-lane-format-args.ts
+++ b/src/cli/commands/interactive/tool-lane-format-args.ts
@@ -100,7 +100,7 @@ function stripBashCdPrefix(args: string): string {
 /**
  * Maximum readable width of the bracketed label produced by
  * {@link summarizeNestingArgs} for `agent` / `Task` / `skill` calls. Picked
- * to fit comfortably alongside the tool name + ` [subagent]` tag in a
+ * to fit comfortably alongside the tool name + ` [worker]` tag in a
  * standard 80-col terminal — `bracketPairAwareTruncate` clamps further on
  * narrower widths.
  */
@@ -318,7 +318,7 @@ export function bracketPairAwareTruncate(
  * Format a tool_use summary into `{glyph} {Name}{args} {[tag]}?`.
  *
  * Dispatch-class tools (subagent / skill / dag) get a dim trailing
- * bracketed type tag — `[subagent]`, `[skill]`, `[dag]` — so the class
+ * bracketed type tag — `[worker]`, `[skill]`, `[workflow]` — so the class
  * of work is legible as text even when colors or glyphs are hard to
  * distinguish. See `dispatchTagForCategory` in `tool-category.ts`.
  */

--- a/src/cli/commands/interactive/tool-lane-format.test.ts
+++ b/src/cli/commands/interactive/tool-lane-format.test.ts
@@ -464,20 +464,20 @@ describe('summarizeToolArgs — ask_question category-only summary', () => {
 });
 
 describe('formatToolLine — agent/Task/skill end-to-end (paren-balanced under truncation)', () => {
-  it('agent: full pipeline renders `→ agent(label) [subagent]` instead of raw JSON', () => {
+  it('agent: full pipeline renders `→ agent(label) [helper]` instead of raw JSON', () => {
     const args = JSON.stringify({ prompt: 'BUG 2 — fix spine narration' });
     const out = stripAnsi(formatToolLine('agent' + args));
     expect(out).toContain('agent(BUG 2 — fix spine narration)');
-    expect(out).toContain('[subagent]');
+    expect(out).toContain('[helper]');
     expect(out).not.toContain('"prompt"');
     expect(out).not.toContain('{');
   });
 
-  it('Task: full pipeline renders `→ Task(description) [subagent]`', () => {
+  it('Task: full pipeline renders `→ Task(description) [helper]`', () => {
     const args = JSON.stringify({ description: 'spine bug', prompt: 'long body' });
     const out = stripAnsi(formatToolLine('Task' + args));
     expect(out).toContain('Task(spine bug)');
-    expect(out).toContain('[subagent]');
+    expect(out).toContain('[helper]');
   });
 
   it('skill: full pipeline renders `◆ skill(name) [skill]`', () => {
@@ -490,8 +490,8 @@ describe('formatToolLine — agent/Task/skill end-to-end (paren-balanced under t
   it('agent: narrow maxWidth preserves the closing paren (bracket-pair-aware truncation)', () => {
     const args = JSON.stringify({ prompt: 'this is a very long prompt that will be clipped' });
     const out = stripAnsi(formatToolLine('agent' + args, 30));
-    // Must end with `) [subagent]` — the closing paren survives truncation
-    expect(out).toMatch(/…\) \[subagent\]$/);
+    // Must end with `) [helper]` — the closing paren survives truncation
+    expect(out).toMatch(/…\) \[helper\]$/);
   });
 });
 
@@ -868,13 +868,13 @@ describe('formatToolLine — web_scrape URL rendering', () => {
 
 describe('formatToolLine — bracket-pair preservation (Fix 4)', () => {
   it('never leaves an unmatched paren in Agent dispatch args at narrow widths', () => {
-    // At width 20 with `Agent(review) [subagent]`, the previous code
-    // produced `Agent(… [subagent]` — the closing `)` got eaten while
-    // the dispatch tag ` [subagent]` consumed the remaining budget.
+    // At width 20 with `Agent(review) [helper]`, the previous code
+    // produced `Agent(… [helper]` — the closing `)` got eaten while
+    // the dispatch tag ` [helper]` consumed the remaining budget.
     const result = stripAnsi(formatToolLine('Agent(review)', 20));
     expect(result).not.toMatch(/\(…(?! *\))/); // no `(…` without a matching `)` later
-    // Either `(review)` fits, or it collapses to `()` — but never unmatched.
-    expect(result).toMatch(/Agent(\(review\)|\(\))/);
+    // Full `(review)`, truncated `(r…)`, or collapsed `()` — but never unmatched.
+    expect(result).toMatch(/Agent\((review|r…)?\)/);
   });
 
   it('preserves closing paren on JSON-shape args (orchestrator agent dispatch)', () => {

--- a/src/cli/commands/interactive/tool-lane-format.test.ts
+++ b/src/cli/commands/interactive/tool-lane-format.test.ts
@@ -464,20 +464,20 @@ describe('summarizeToolArgs — ask_question category-only summary', () => {
 });
 
 describe('formatToolLine — agent/Task/skill end-to-end (paren-balanced under truncation)', () => {
-  it('agent: full pipeline renders `→ agent(label) [helper]` instead of raw JSON', () => {
+  it('agent: full pipeline renders `→ agent(label) [worker]` instead of raw JSON', () => {
     const args = JSON.stringify({ prompt: 'BUG 2 — fix spine narration' });
     const out = stripAnsi(formatToolLine('agent' + args));
     expect(out).toContain('agent(BUG 2 — fix spine narration)');
-    expect(out).toContain('[helper]');
+    expect(out).toContain('[worker]');
     expect(out).not.toContain('"prompt"');
     expect(out).not.toContain('{');
   });
 
-  it('Task: full pipeline renders `→ Task(description) [helper]`', () => {
+  it('Task: full pipeline renders `→ Task(description) [worker]`', () => {
     const args = JSON.stringify({ description: 'spine bug', prompt: 'long body' });
     const out = stripAnsi(formatToolLine('Task' + args));
     expect(out).toContain('Task(spine bug)');
-    expect(out).toContain('[helper]');
+    expect(out).toContain('[worker]');
   });
 
   it('skill: full pipeline renders `◆ skill(name) [skill]`', () => {
@@ -490,8 +490,8 @@ describe('formatToolLine — agent/Task/skill end-to-end (paren-balanced under t
   it('agent: narrow maxWidth preserves the closing paren (bracket-pair-aware truncation)', () => {
     const args = JSON.stringify({ prompt: 'this is a very long prompt that will be clipped' });
     const out = stripAnsi(formatToolLine('agent' + args, 30));
-    // Must end with `) [helper]` — the closing paren survives truncation
-    expect(out).toMatch(/…\) \[helper\]$/);
+    // Must end with `) [worker]` — the closing paren survives truncation
+    expect(out).toMatch(/…\) \[worker\]$/);
   });
 });
 
@@ -868,9 +868,9 @@ describe('formatToolLine — web_scrape URL rendering', () => {
 
 describe('formatToolLine — bracket-pair preservation (Fix 4)', () => {
   it('never leaves an unmatched paren in Agent dispatch args at narrow widths', () => {
-    // At width 20 with `Agent(review) [helper]`, the previous code
-    // produced `Agent(… [helper]` — the closing `)` got eaten while
-    // the dispatch tag ` [helper]` consumed the remaining budget.
+    // At width 20 with `Agent(review) [worker]`, the previous code
+    // produced `Agent(… [worker]` — the closing `)` got eaten while
+    // the dispatch tag ` [worker]` consumed the remaining budget.
     const result = stripAnsi(formatToolLine('Agent(review)', 20));
     expect(result).not.toMatch(/\(…(?! *\))/); // no `(…` without a matching `)` later
     // Full `(review)`, truncated `(r…)`, or collapsed `()` — but never unmatched.

--- a/src/cli/commands/interactive/tool-lane-format.ts
+++ b/src/cli/commands/interactive/tool-lane-format.ts
@@ -4,7 +4,7 @@ import { BENIGN_FAILURE_CLASSES } from '../../../agent/trace/types.js';
 import { env } from '../../../config/env.js';
 import { palette } from '../../palette.js';
 import { fileHyperlink, hyperlinksEnabled } from '../../hyperlink.js';
-import { categorizeTool, CATEGORY_HUMAN_VERB } from '../../tool-category.js';
+import { humanVerbForTool } from '../../tool-category.js';
 import { sanitizeLabel, sanitizeTextParagraph } from './tool-lane-format-sanitize.js';
 
 // Re-export the split modules' public surface so external callers keep
@@ -77,14 +77,15 @@ export const GROUP_THRESHOLD_DISPATCH = 2;
 export const GROUP_THRESHOLD_LEAF = 3;
 
 /**
- * Plain-language in-flight verb for a tool row. Delegates to the
- * per-category `CATEGORY_HUMAN_VERB` map (cli/tool-category.ts) — the single
- * owner of the human vocabulary — so every category gets a phrase a
- * non-technical observer can parse, instead of the old 4-case switch that
- * collapsed subagents, skills, and DAGs into a generic "Running…".
+ * Plain-language in-flight verb for a tool row. Delegates to
+ * `humanVerbForTool` (cli/tool-category.ts) — the single owner of the
+ * human vocabulary — which checks tool-specific overrides before falling
+ * back to the per-category default, so tools whose action conflicts with
+ * their category verb (e.g. `cancel_background_job` in `subagent`) get
+ * an accurate phrase instead of the category's generic one.
  */
 export function inProgressVerb(toolName: string): string {
-  return CATEGORY_HUMAN_VERB[categorizeTool(toolName)];
+  return humanVerbForTool(toolName);
 }
 
 /**

--- a/src/cli/commands/interactive/tool-lane-format.ts
+++ b/src/cli/commands/interactive/tool-lane-format.ts
@@ -4,7 +4,7 @@ import { BENIGN_FAILURE_CLASSES } from '../../../agent/trace/types.js';
 import { env } from '../../../config/env.js';
 import { palette } from '../../palette.js';
 import { fileHyperlink, hyperlinksEnabled } from '../../hyperlink.js';
-import { categorizeTool } from '../../tool-category.js';
+import { categorizeTool, CATEGORY_HUMAN_VERB } from '../../tool-category.js';
 import { sanitizeLabel, sanitizeTextParagraph } from './tool-lane-format-sanitize.js';
 
 // Re-export the split modules' public surface so external callers keep
@@ -76,14 +76,15 @@ export const MAX_VISIBLE_CHILDREN = 3;
 export const GROUP_THRESHOLD_DISPATCH = 2;
 export const GROUP_THRESHOLD_LEAF = 3;
 
+/**
+ * Plain-language in-flight verb for a tool row. Delegates to the
+ * per-category `CATEGORY_HUMAN_VERB` map (cli/tool-category.ts) — the single
+ * owner of the human vocabulary — so every category gets a phrase a
+ * non-technical observer can parse, instead of the old 4-case switch that
+ * collapsed subagents, skills, and DAGs into a generic "Running…".
+ */
 export function inProgressVerb(toolName: string): string {
-  switch (categorizeTool(toolName)) {
-    case 'read': return 'Reading…';
-    case 'write': return 'Writing…';
-    case 'web': return 'Fetching…';
-    case 'shell': return 'Running…';
-    default: return 'Running…';
-  }
+  return CATEGORY_HUMAN_VERB[categorizeTool(toolName)];
 }
 
 /**

--- a/src/cli/commands/interactive/tool-lane.test.ts
+++ b/src/cli/commands/interactive/tool-lane.test.ts
@@ -1242,7 +1242,7 @@ describe('Bug #5 — agentResultSummary must use └ tree connector and appear a
     // as a visible inline-snapshot diff instead of slipping past a
     // single-glyph toContain. Populated by `pnpm test -u` on first run.
     expect(stripped).toMatchInlineSnapshot(`
-      "◉ → Agent(overflow-tester) [helper] — 4 tool calls
+      "◉ → Agent(overflow-tester) [worker] — 4 tool calls
       │ ├─ … +1 (1 Read)
       │ ├─ $ Bash("file1.ts") — ✓ result1
       │ ├─ ● Grep("file2.ts") — ✓ result2
@@ -1283,7 +1283,7 @@ describe('Bug #5 — agentResultSummary must use └ tree connector and appear a
 
     // Full-topology snapshot — locks the 1-child-plus-summary shape.
     expect(stripped).toMatchInlineSnapshot(`
-      "◉ → Agent(connector-tester) [helper]
+      "◉ → Agent(connector-tester) [worker]
       │ ├─ ● Read("data.ts") — ✓ ok
       │ ╰─ Done (1 tool · 0.8s)"
     `);

--- a/src/cli/commands/interactive/tool-lane.test.ts
+++ b/src/cli/commands/interactive/tool-lane.test.ts
@@ -1242,7 +1242,7 @@ describe('Bug #5 — agentResultSummary must use └ tree connector and appear a
     // as a visible inline-snapshot diff instead of slipping past a
     // single-glyph toContain. Populated by `pnpm test -u` on first run.
     expect(stripped).toMatchInlineSnapshot(`
-      "◉ → Agent(overflow-tester) [subagent] — 4 tool calls
+      "◉ → Agent(overflow-tester) [helper] — 4 tool calls
       │ ├─ … +1 (1 Read)
       │ ├─ $ Bash("file1.ts") — ✓ result1
       │ ├─ ● Grep("file2.ts") — ✓ result2
@@ -1283,7 +1283,7 @@ describe('Bug #5 — agentResultSummary must use └ tree connector and appear a
 
     // Full-topology snapshot — locks the 1-child-plus-summary shape.
     expect(stripped).toMatchInlineSnapshot(`
-      "◉ → Agent(connector-tester) [subagent]
+      "◉ → Agent(connector-tester) [helper]
       │ ├─ ● Read("data.ts") — ✓ ok
       │ ╰─ Done (1 tool · 0.8s)"
     `);

--- a/src/cli/commands/interactive/turn-handler.footer.ts
+++ b/src/cli/commands/interactive/turn-handler.footer.ts
@@ -41,7 +41,7 @@ export function formatContextUsage(
     const limitK = Math.round(contextLimit / 1000);
     return {
       tier: 'over',
-      text: `  context OVER ${limitK}k tok by ~${formatTokens(overByTok)} tok — model output may be silently truncated`,
+      text: `  context OVER ${limitK}k tokens by ~${formatTokens(overByTok)} tokens — model output may be silently truncated`,
     };
   }
   if (contextPct >= 0.95) {
@@ -76,7 +76,7 @@ export function printTurnFooter(
   if (meta.totalCostUsd !== undefined) parts.push(formatCost(meta.totalCostUsd));
   const inTok = Number(meta.usage?.['input_tokens'] ?? 0);
   const outTok = Number(meta.usage?.['output_tokens'] ?? 0);
-  if (inTok + outTok > 0) parts.push(formatTokens(inTok + outTok) + ' tok');
+  if (inTok + outTok > 0) parts.push(formatTokens(inTok + outTok) + ' tokens');
   if (parts.length > 0) {
     write(palette.dim('  ◦ ' + parts.join('  ·  ')));
   }

--- a/src/cli/commands/trace.ts
+++ b/src/cli/commands/trace.ts
@@ -354,7 +354,7 @@ function renderEvent(event: TraceEvent, ctx: RenderContext): string | null {
     case 'compaction': {
       const p = event.payload;
       const saved =
-        p.tokensSavedEstimate !== undefined ? `  ~${p.tokensSavedEstimate} tok saved` : '';
+        p.tokensSavedEstimate !== undefined ? `  ~${p.tokensSavedEstimate} tokens saved` : '';
       return line('compact', `${p.trigger}  ${p.messagesBefore}→${p.messagesAfter} msgs${saved}`);
     }
 

--- a/src/cli/interactive-progress-banner.test.ts
+++ b/src/cli/interactive-progress-banner.test.ts
@@ -93,7 +93,7 @@ describe('interactive REPL — progress banner rendering', () => {
       toolUses: 0,
       durationMs: 0,
     });
-    expect(strip(lines[0]!)).toContain('esc to interrupt · ctrl+b background');
+    expect(strip(lines[0]!)).toContain('esc to interrupt · ctrl+b to run in background');
     expect(lines).toHaveLength(1);
   });
 
@@ -117,7 +117,7 @@ describe('interactive REPL — progress banner rendering', () => {
       toolUses: 0,
       durationMs: 0,
     });
-    expect(strip(lines[0]!)).toContain('esc to interrupt · ctrl+b background');
+    expect(strip(lines[0]!)).toContain('esc to interrupt · ctrl+b to run in background');
   });
 
   it('hint trails all numeric stats', () => {

--- a/src/cli/slash/commands/afk-md/targets.ts
+++ b/src/cli/slash/commands/afk-md/targets.ts
@@ -129,7 +129,7 @@ function statusOf(t: AfkMdTarget): string {
 export function renderTargetRows(targets: AfkMdTarget[]): string[] {
   const lines: string[] = [];
   for (const t of targets) {
-    const size = contributes(t) ? `${formatBytes(t.bytes)}  ${formatTokens(t.tokens)} tok` : '';
+    const size = contributes(t) ? `${formatBytes(t.bytes)}  ${formatTokens(t.tokens)} tokens` : '';
     const precedence =
       t.scope === 'project' && contributes(t) ? palette.dim('  ← wins on conflict') : '';
     lines.push(`  ${t.label.padEnd(9)} ${palette.dim(t.path)}`);

--- a/src/cli/slash/commands/transcript.ts
+++ b/src/cli/slash/commands/transcript.ts
@@ -31,7 +31,7 @@ function formatTurnMeta(turn: TurnRecord, index: number): string {
   if (turn.inputTokens !== undefined || turn.outputTokens !== undefined) {
     const inp = turn.inputTokens ?? 0;
     const out = turn.outputTokens ?? 0;
-    parts.push(palette.dim(`${Math.round((inp + out) / 1000)}k tok`));
+    parts.push(palette.dim(`${Math.round((inp + out) / 1000)}k tokens`));
   }
   return parts.join('  ');
 }

--- a/src/cli/status-line.ts
+++ b/src/cli/status-line.ts
@@ -561,7 +561,7 @@ export class StatusLine {
     }
 
     if (f.tokens !== undefined) {
-      parts.push({ text: palette.chrome(`${formatTokens(f.tokens)} tok`), droppablePriority: 4 }); // drop 2nd
+      parts.push({ text: palette.chrome(`${formatTokens(f.tokens)} tokens`), droppablePriority: 4 }); // drop 2nd
     }
 
     // Invariant: every droppablePriority on this line must be UNIQUE. The shed

--- a/src/cli/tool-category.test.ts
+++ b/src/cli/tool-category.test.ts
@@ -218,10 +218,10 @@ describe('styleForCategory', () => {
 });
 
 describe('dispatchTagForCategory', () => {
-  it('returns the dispatch-class tag for subagent/skill/dag', () => {
-    expect(dispatchTagForCategory('subagent')).toBe('subagent');
+  it('returns the plain-language dispatch tag for subagent/skill/dag', () => {
+    expect(dispatchTagForCategory('subagent')).toBe('helper');
     expect(dispatchTagForCategory('skill')).toBe('skill');
-    expect(dispatchTagForCategory('dag')).toBe('dag');
+    expect(dispatchTagForCategory('dag')).toBe('workflow');
   });
 
   it('returns undefined for direct-action categories', () => {

--- a/src/cli/tool-category.test.ts
+++ b/src/cli/tool-category.test.ts
@@ -9,6 +9,8 @@ import {
   dispatchTagForCategory,
   styleForCategory,
   styleForToolName,
+  humanVerbForTool,
+  CATEGORY_HUMAN_VERB,
   SUBAGENT_TOOLS,
   DAG_TOOLS,
   SKILL_TOOLS,
@@ -272,6 +274,27 @@ describe('NESTING_TOOLS', () => {
     expect(NESTING_TOOLS.has('agent')).toBe(true);
     expect(NESTING_TOOLS.has('compose')).toBe(true);
     expect(NESTING_TOOLS.has('skill')).toBe(true);
+  });
+});
+
+describe('humanVerbForTool', () => {
+  it('returns the category verb for tools without an override', () => {
+    expect(humanVerbForTool('agent')).toBe('Delegating…');
+    expect(humanVerbForTool('read_file')).toBe('Reading…');
+    expect(humanVerbForTool('bash')).toBe('Running…');
+    expect(humanVerbForTool('compose')).toBe('Coordinating…');
+    expect(humanVerbForTool('create_schedule')).toBe('Scheduling…');
+  });
+
+  it('returns a tool-specific override when the action conflicts with the category', () => {
+    expect(humanVerbForTool('cancel_background_job')).toBe('Cancelling…');
+    expect(humanVerbForTool('list_schedules')).toBe('Reading…');
+    expect(humanVerbForTool('get_schedule_history')).toBe('Reading…');
+    expect(humanVerbForTool('cancel_schedule')).toBe('Cancelling…');
+  });
+
+  it('falls through to category for unknown tools', () => {
+    expect(humanVerbForTool('some_unknown_tool')).toBe(CATEGORY_HUMAN_VERB['other']);
   });
 });
 

--- a/src/cli/tool-category.test.ts
+++ b/src/cli/tool-category.test.ts
@@ -219,7 +219,7 @@ describe('styleForCategory', () => {
 
 describe('dispatchTagForCategory', () => {
   it('returns the plain-language dispatch tag for subagent/skill/dag', () => {
-    expect(dispatchTagForCategory('subagent')).toBe('helper');
+    expect(dispatchTagForCategory('subagent')).toBe('worker');
     expect(dispatchTagForCategory('skill')).toBe('skill');
     expect(dispatchTagForCategory('dag')).toBe('workflow');
   });

--- a/src/cli/tool-category.ts
+++ b/src/cli/tool-category.ts
@@ -117,6 +117,31 @@ const CATEGORY_GLYPH: Record<ToolCategory, string> = {
   other: '●',
 };
 
+/**
+ * Plain-language in-progress phrase per category, used for in-flight rows
+ * (`inProgressVerb` in tool-lane-format.ts delegates here).
+ *
+ * Invariant: every phrase is an everyday-English present-progressive verb a
+ * non-technical observer can parse — never an internal term (`forking`,
+ * `dispatching a DAG`). The scrollback transcript doubles as the record shown
+ * to non-engineers, so this map is the single owner of the human vocabulary;
+ * add new categories here rather than hardcoding verbs at render sites.
+ */
+export const CATEGORY_HUMAN_VERB: Record<ToolCategory, string> = {
+  read: 'Reading…',
+  write: 'Writing…',
+  shell: 'Running…',
+  subagent: 'Delegating…',
+  skill: 'Running skill…',
+  dag: 'Coordinating…',
+  mcp: 'Calling plugin…',
+  web: 'Fetching…',
+  browser: 'Browsing…',
+  planning: 'Planning…',
+  schedule: 'Scheduling…',
+  other: 'Working…',
+};
+
 export interface CategoryStyle {
   color: ChalkInstance;
   glyph: string;

--- a/src/cli/tool-category.ts
+++ b/src/cli/tool-category.ts
@@ -142,6 +142,29 @@ export const CATEGORY_HUMAN_VERB: Record<ToolCategory, string> = {
   other: 'Working…',
 };
 
+/**
+ * Tool-specific verb overrides for tools whose action conflicts with their
+ * category's default verb. `cancel_background_job` is categorized `subagent`
+ * (it targets subagent handles) but the action is a cancellation, not a
+ * delegation. Similarly, `list_schedules` / `get_schedule_history` are reads
+ * and `cancel_schedule` is a removal, not scheduling. The override is checked
+ * first by `humanVerbForTool`; missing entries fall through to the category.
+ */
+const TOOL_VERB_OVERRIDES: Partial<Record<string, string>> = {
+  cancel_background_job: 'Cancelling…',
+  list_schedules: 'Reading…',
+  get_schedule_history: 'Reading…',
+  cancel_schedule: 'Cancelling…',
+};
+
+/**
+ * Resolve the plain-language in-progress verb for a tool, checking
+ * tool-specific overrides before falling back to the category default.
+ */
+export function humanVerbForTool(toolName: string): string {
+  return TOOL_VERB_OVERRIDES[toolName] ?? CATEGORY_HUMAN_VERB[categorizeTool(toolName)];
+}
+
 export interface CategoryStyle {
   color: ChalkInstance;
   glyph: string;

--- a/src/cli/turn-handler-format.test.ts
+++ b/src/cli/turn-handler-format.test.ts
@@ -58,9 +58,9 @@ describe('formatToolLine', () => {
   });
 
   it.each([
-    { content: 'Agent(research)', tag: '[helper]' },
-    { content: 'agent(research)', tag: '[helper]' },
-    { content: 'Task(verify)', tag: '[helper]' },
+    { content: 'Agent(research)', tag: '[worker]' },
+    { content: 'agent(research)', tag: '[worker]' },
+    { content: 'Task(verify)', tag: '[worker]' },
     { content: 'Skill(/spec)', tag: '[skill]' },
     { content: 'skill(/spec)', tag: '[skill]' },
     { content: 'compose(3 nodes)', tag: '[workflow]' },

--- a/src/cli/turn-handler-format.test.ts
+++ b/src/cli/turn-handler-format.test.ts
@@ -58,13 +58,13 @@ describe('formatToolLine', () => {
   });
 
   it.each([
-    { content: 'Agent(research)', tag: '[subagent]' },
-    { content: 'agent(research)', tag: '[subagent]' },
-    { content: 'Task(verify)', tag: '[subagent]' },
+    { content: 'Agent(research)', tag: '[helper]' },
+    { content: 'agent(research)', tag: '[helper]' },
+    { content: 'Task(verify)', tag: '[helper]' },
     { content: 'Skill(/spec)', tag: '[skill]' },
     { content: 'skill(/spec)', tag: '[skill]' },
-    { content: 'compose(3 nodes)', tag: '[dag]' },
-    { content: 'Compose(...)', tag: '[dag]' },
+    { content: 'compose(3 nodes)', tag: '[workflow]' },
+    { content: 'Compose(...)', tag: '[workflow]' },
   ])('appends dispatch tag $tag to $content', ({ content, tag }) => {
     const stripped = strip(formatToolLine(content));
     expect(stripped).toContain(tag);


### PR DESCRIPTION
## Why

The scrollback transcript and live overlay are routinely shown to non-technical observers, but the chrome vocabulary assumed an engineer: dispatch tags leaked internal taxonomy (`[subagent]`, `[dag]`), token stats used the `tok` abbreviation, and the in-flight verb collapsed all dispatch work into a generic `Running…`.

This is the minimal in-renderer legibility pass — option B from a structured critique wave (see Decision trail below). A transcript-driven `/summary` narration surface for after-the-fact viewers is planned as a follow-on.

## What changed

Each change lands at its single owning site:

| Before | After | Owner |
|---|---|---|
| `[subagent]` | `[worker]` | `DISPATCH_CATEGORIES` (agent/tool-category.ts) |
| `[dag]` | `[workflow]` | same map |
| `Running…` for subagent/skill/dag/mcp/browser/… | `Delegating…` / `Running skill…` / `Coordinating…` / `Calling plugin…` / `Browsing…` / … | new `CATEGORY_HUMAN_VERB` map (cli/tool-category.ts), co-located with `CATEGORY_GLYPH`; `inProgressVerb()` delegates to it |
| `8.2k tok` | `8.2k tokens` | turn footer, context warnings, thinking lane, progress banner, Done closers, status line, /transcript, trace compaction, /afk-md targets |
| `ctrl+b background` | `ctrl+b to run in background` | progress banner |
| `◦ agent research-agent started` | `◦ worker research-agent started` | plain-progress (plain-output mode) |

Category **keys** stay canonical (`subagent`/`skill`/`dag`) — only user-facing text is humanized, so no classifier, phase-reducer, or trace consumer changes.

## Test impact

Literal drift only: 9 snapshots regenerated; string assertions updated in tool-category, tool-lane-format, turn-handler-format, progress-banner, plain-progress, and interactive-progress-banner tests. One regex in the bracket-pair-preservation test widened to accept the truncated `(r…)` form, since ` [worker]` frees 2 columns vs ` [subagent]`.

`pnpm lint` clean. Full `pnpm test`: the only failures are pre-existing on main (`write-denylist` symlink guard, env-dependent) or from an untracked local WIP test file not in git.

Note: `audit:filesize:check` currently fails on main itself (`tool-lane.ts` grew 424→448 in #1225 without a baseline regen) — unrelated to this PR, which does not touch that file.

## Decision trail

`/research` surveyed prior art (clig.dev human-first output guidance, Warp's blocks model, Claude Code / Gemini CLI verb-first conventions) and mapped the repo's string seams. `/devils-advocate` ran a 3-critic wave over four approaches; the ranked outcome was this minimal in-renderer pass now (single-diff, snapshot cost paid once) plus a post-turn plain-English narration surface (`/summary` + Telegram card built on the autosaved transcripts) as the follow-on for the after-the-fact audience.

