### PR TITLE
fix(tui): restore prompt suggestion ghost after deleting back to empty

### DIFF
--- a/src/cli/terminal-compositor.ghost.test.ts
+++ b/src/cli/terminal-compositor.ghost.test.ts
@@ -718,14 +718,14 @@ describe('empty-prompt suggestion', () => {
     c.disarm();
   });
 
-  // ── Suggestion does not resurrect after the user moves on ────────────────
+  // ── Suggestion resurfaces when the user deletes back to empty ─────────────
   //
-  // The proposal lives in the ENGINE, and `updateGhost` re-reads it on every
-  // edit that lands back at an empty buffer. Clearing only `activeGhost`
-  // therefore looks correct for one frame and then re-offers the same ghost on
-  // the next backspace/Ctrl+U. These pin the engine-level clear.
+  // The proposal lives in the ENGINE. Typing hides it (the buffer is non-empty
+  // so the `buffer.length === 0` guard suppresses display), but does NOT clear
+  // it — so backspacing/Ctrl+U back to empty re-shows the same suggestion.
+  // Only ESC (dismissPromptGhost) and Tab (applyGhostAccept) clear permanently.
 
-  it('does not resurrect the suggestion when the user backspaces back to empty', async () => {
+  it('resurfaces the suggestion when the user backspaces back to empty', async () => {
     const engine = makeEngine({ promptSuggestion: 'run the tests' });
     const c = new TerminalCompositor({
       stdout, stdin,
@@ -736,7 +736,7 @@ describe('empty-prompt suggestion', () => {
     c.updateGhost();
     expect(c.activeGhost).toBe('run the tests');
 
-    // User starts typing — the proposal is implicitly declined.
+    // User starts typing — suggestion is hidden (not cleared).
     stdin.emit('keypress', 'x', { name: 'x', sequence: 'x' });
     expect(c.activeGhost).toBeNull();
 
@@ -744,12 +744,13 @@ describe('empty-prompt suggestion', () => {
     stdin.emit('keypress', undefined, { name: 'backspace' });
     expect(c.getBuffer().text).toBe('');
 
-    expect(engine.peekPromptSuggestion()).toBeNull();
-    expect(c.activeGhost).toBeNull();
+    // The suggestion reappears.
+    expect(engine.peekPromptSuggestion()).toBe('run the tests');
+    expect(c.activeGhost).toBe('run the tests');
     c.disarm();
   });
 
-  it('does not resurrect the suggestion after Ctrl+U clears a typed line', async () => {
+  it('resurfaces the suggestion after Ctrl+U clears a typed line', async () => {
     const engine = makeEngine({ promptSuggestion: 'run the tests' });
     const c = new TerminalCompositor({
       stdout, stdin,
@@ -765,8 +766,9 @@ describe('empty-prompt suggestion', () => {
     stdin.emit('keypress', 'u', { name: 'u', sequence: '\u0015', ctrl: true });
     expect(c.getBuffer().text).toBe('');
 
-    expect(engine.peekPromptSuggestion()).toBeNull();
-    expect(c.activeGhost).toBeNull();
+    // The suggestion reappears.
+    expect(engine.peekPromptSuggestion()).toBe('run the tests');
+    expect(c.activeGhost).toBe('run the tests');
     c.disarm();
   });
 

--- a/src/cli/terminal-compositor.ghost.ts
+++ b/src/cli/terminal-compositor.ghost.ts
@@ -112,14 +112,13 @@ export function updateGhost(self: AutocompleteHost): void {
     self.activeGhost = null;
   }
 
-  // The user has begun editing: retire the empty-prompt proposal for good.
-  // It is only ever readable at an empty buffer, so leaving it stored would
-  // make it RESURFACE the moment the buffer returns to empty — backspacing
-  // over a typed character, or Ctrl+U — long after the user implicitly
-  // declined it by typing something else.
-  if (buffer.length > 0) {
-    self.ghostEngine.clearPromptSuggestion?.();
-  }
+  // Contract: the empty-prompt proposal is NOT cleared when the user types.
+  // It is only visible at an empty buffer (the `buffer.length === 0` guard
+  // below suppresses it), so storing it while editing costs nothing — and
+  // lets it RESURFACE when the user backspaces/Ctrl+U back to empty, which
+  // is the desired UX. Permanent retirement happens only on explicit
+  // dismissal (ESC → dismissPromptGhost) or acceptance (Tab →
+  // applyGhostAccept), both of which call clearPromptSuggestion.
 
   // Tier 1: synchronous, always runs.
   const ctx = self.ghostGetContext();


### PR DESCRIPTION
## Problem

The empty-prompt suggestion (dim ghost text at an idle REPL prompt) disappears permanently when the user types anything and then deletes back to empty. Typing `x` then pressing Backspace leaves a blank prompt with no suggestion — the user has to wait for a new turn to get one.

## Root cause

`updateGhost()` called `clearPromptSuggestion()` whenever `buffer.length > 0`. Since `clear()` bumps the engine's invocation id, the stored suggestion is permanently gone and can never resurface — even when the buffer returns to empty via Backspace or Ctrl+U.

## Fix

Remove the eager `clearPromptSuggestion()` from the typing path. The suggestion is already naturally hidden while the buffer is non-empty (the `buffer.length === 0` guard at the peek site suppresses display), so keeping it stored costs nothing and lets it reappear on delete-to-empty.

The two intentional permanent-clear paths are unchanged:
- **ESC** at an empty prompt → `dismissPromptGhost()` clears for good
- **Tab** accept → `applyGhostAccept()` consumes and clears

## Changes

- `terminal-compositor.ghost.ts` — removed `clearPromptSuggestion()` from `updateGhost()`'s non-empty buffer branch
- `terminal-compositor.ghost.test.ts` — updated two tests from "does not resurrect" to "resurfaces" with matching assertions

## Testing

- `pnpm test src/cli/terminal-compositor.ghost.test.ts` — 28/28 pass
- `pnpm test src/cli/input/suggest.test.ts` — 80/80 pass
- `pnpm lint` — clean
