### PR TITLE
fix(test): bump builtin tool count 26 → 27 for extract_document

### DIFF
--- a/src/agent/tools/schemas.test.ts
+++ b/src/agent/tools/schemas.test.ts
@@ -7,8 +7,8 @@ import {
 import { cancelBackgroundJobTool } from './schemas.orchestration.js';
 
 describe('builtinToolSchemas', () => {
-  it('contains exactly 26 tools', () => {
-    expect(builtinToolSchemas).toHaveLength(26);
+  it('contains exactly 27 tools', () => {
+    expect(builtinToolSchemas).toHaveLength(27);
   });
 
   it('exports the expected tool names', () => {


### PR DESCRIPTION
PR #1164 added `extract_document` as builtin tool #27 but did not update the
hardcoded count assertion in `schemas.test.ts` (still `26`), breaking CI on
`main`.

One-line fix: `26` → `27`.
