### PR TITLE
fix(telegram): thread threadId through to background job notifications (#1220)

### DIFF
--- a/src/agent/types/config-types.ts
+++ b/src/agent/types/config-types.ts
@@ -783,6 +783,16 @@ export interface AgentConfig {
   telegramChatId?: number;
 
   /**
+   * Telegram topic thread id for this session — set alongside `telegramChatId`
+   * when the originating message arrived in a non-General supergroup topic.
+   * Threaded to `TelegramBgResultNotifier` so background job push notifications
+   * land in the correct topic thread rather than falling through to General.
+   *
+   * Telegram-scoped only: never set on REPL, daemon, or one-shot sessions.
+   */
+  telegramThreadId?: number;
+
+  /**
    * In-process custom tools available to the session. Each entry is created
    * via the `tool()` helper and provides both a JSON-schema `AnthropicToolDef`
    * (so the model knows the tool exists) and a validated `ToolHandler`

--- a/src/telegram/bg-result-notifier.test.ts
+++ b/src/telegram/bg-result-notifier.test.ts
@@ -143,6 +143,24 @@ describe('TelegramBgResultNotifier', () => {
     expect(opts).toEqual({ target: 12345 });
   });
 
+  it('passes messageThreadId when threadId is provided', () => {
+    notifier.dispose();
+    notifier = new TelegramBgResultNotifier(registry, 12345, 77);
+
+    const { handle, fireTerminal } = makeBgHandle();
+    const job = registry.register({
+      handle,
+      prompt: 'topic task',
+      model: 'sonnet',
+    });
+
+    fireTerminal(succeed(job.jobId, 'done'));
+
+    expect(pushMock).toHaveBeenCalledTimes(1);
+    const opts = pushMock.mock.calls[0]![1];
+    expect(opts).toEqual({ target: 12345, messageThreadId: 77 });
+  });
+
   it('uses default notify routing when no chatId is provided', () => {
     const { handle, fireTerminal } = makeBgHandle();
     const job = registry.register({

--- a/src/telegram/bg-result-notifier.ts
+++ b/src/telegram/bg-result-notifier.ts
@@ -65,7 +65,10 @@ export class TelegramBgResultNotifier {
     // settled and its result is available via the registry. Log failures for
     // observability since push is the ONLY delivery path on Telegram (unlike
     // REPL which also injects results into the next turn).
-    void pushIfConfigured(text, { target: this.chatId }).catch((err: unknown) => {
+    void pushIfConfigured(text, {
+      target: this.chatId,
+      ...(this.threadId !== undefined ? { messageThreadId: this.threadId } : {}),
+    }).catch((err: unknown) => {
       // Non-fatal: the job result is still in the registry (join-able).
       console.error(`[bg-notifier] push failed for job ${job.jobId}:`, err);
     });
@@ -78,10 +81,13 @@ export class TelegramBgResultNotifier {
    * @param registry  The session's background agent registry.
    * @param chatId    Telegram chat id to push notifications to. When undefined,
    *                  pushIfConfigured uses the default notify targets.
+   * @param threadId  Telegram topic thread id. When set, notifications are
+   *                  delivered to this specific topic thread instead of General.
    */
   constructor(
     private readonly registry: BackgroundAgentRegistry,
     private readonly chatId?: number,
+    private readonly threadId?: number,
   ) {
     registry.on('settled', this.onSettled);
   }

--- a/src/telegram/create-session.ts
+++ b/src/telegram/create-session.ts
@@ -107,6 +107,7 @@ export function createTelegramSessionFactory(
       memoryStore,
       workspaceStore,
       ...(sessionConfig.telegramChatId !== undefined ? { chatId: sessionConfig.telegramChatId } : {}),
+      ...(sessionConfig.telegramThreadId !== undefined ? { threadId: sessionConfig.telegramThreadId } : {}),
       reportSession: (session) => { returnedSession = session; },
     };
 

--- a/src/telegram/push.ts
+++ b/src/telegram/push.ts
@@ -188,6 +188,13 @@ export async function pushIfConfigured(
      * default routing (unchanged behavior).
      */
     target?: number | readonly number[];
+    /**
+     * Optional Telegram `message_thread_id` forwarded verbatim to `push()`.
+     * When set, the notification is delivered to the specified topic thread
+     * instead of General. Mirrors `PushOptions.messageThreadId` — see that
+     * field for Telegram's threading semantics. Omit for non-topic chats.
+     */
+    messageThreadId?: number;
   } = {},
 ): Promise<PushResult[] | null> {
   const token = env.TELEGRAM_BOT_TOKEN;
@@ -213,6 +220,7 @@ export async function pushIfConfigured(
         text: chunks[i] ?? '',
         ...(opts.replyMarkup !== undefined && i === 0 ? { replyMarkup: opts.replyMarkup } : {}),
         ...(opts.fetchImpl !== undefined ? { fetchImpl: opts.fetchImpl } : {}),
+        ...(opts.messageThreadId !== undefined ? { messageThreadId: opts.messageThreadId } : {}),
       };
       results.push(
         opts.markdown

--- a/src/telegram/session-anthropic.ts
+++ b/src/telegram/session-anthropic.ts
@@ -38,6 +38,7 @@ export async function buildAnthropicTelegramSession(
     memoryStore,
     workspaceStore,
     chatId,
+    threadId,
     reportSession,
   } = ctx;
 
@@ -64,7 +65,7 @@ export async function buildAnthropicTelegramSession(
   const backgroundRegistry = new BackgroundAgentRegistry(
     traceWriter ? { traceWriter } : {},
   );
-  const bgNotifier = new TelegramBgResultNotifier(backgroundRegistry, chatId);
+  const bgNotifier = new TelegramBgResultNotifier(backgroundRegistry, chatId, threadId);
 
   // Invariant: ONE root manager per session, shared by all three
   // executors. Inherit configured-or-host cwd so forked subagents stay

--- a/src/telegram/session-context.ts
+++ b/src/telegram/session-context.ts
@@ -51,6 +51,14 @@ export interface TelegramSessionBuildContext {
    */
   chatId?: number;
   /**
+   * Telegram topic thread id for the originating session. Threaded from
+   * `sessionConfig.telegramThreadId` so the `TelegramBgResultNotifier` passes
+   * `messageThreadId` to `pushIfConfigured` — ensuring background job
+   * notifications land in the correct topic thread rather than General.
+   * Undefined for General / topics-off sessions.
+   */
+  threadId?: number;
+  /**
    * Report the session the moment it is constructed.
    *
    * Invariant: the factory's catch block closes an already-constructed session

--- a/src/telegram/session-manager.ts
+++ b/src/telegram/session-manager.ts
@@ -242,7 +242,9 @@ export class SessionManager {
       const config: AgentConfig = {
         model: data.model,
         apiKey: this.options.apiKey,
-        telegramChatId: route.chatId };
+        telegramChatId: route.chatId,
+        ...(route.threadId !== undefined ? { telegramThreadId: route.threadId } : {}),
+      };
       if (this.options.settingSources?.length) {
         config.settingSources = this.options.settingSources;
       }


### PR DESCRIPTION
## Summary

Fixes #1220 — background job notifications now land in the originating topic thread instead of General.

## Problem

When a background subagent finishes in a topic thread, the push notification went to General (or the DM) because `threadId` was never plumbed through the session factory to the notifier.

## Fix

Threads `threadId` through the full chain:

1. **`AgentConfig`** (`src/agent/types/config-types.ts`) — added `telegramThreadId?: number`
2. **`TelegramSessionBuildContext`** (`src/telegram/session-context.ts`) — added `threadId?: number`
3. **`SessionManager`** (`src/telegram/session-manager.ts`) — passes `telegramThreadId: route.threadId` when building config
4. **`create-session.ts`** — threads `threadId` from `sessionConfig.telegramThreadId` into ctx
5. **`session-anthropic.ts`** — passes `threadId` to `TelegramBgResultNotifier`
6. **`TelegramBgResultNotifier`** (`src/telegram/bg-result-notifier.ts`) — accepts `threadId` and passes `messageThreadId` to `pushIfConfigured`
7. **`pushIfConfigured`** (`src/telegram/push.ts`) — forwards `messageThreadId` into each `push()` call

The low-level `push()` function already supported `messageThreadId` — only the parameter plumbing was missing.

## Testing

- New test in `bg-result-notifier.test.ts` asserting `messageThreadId` is forwarded when provided
- All existing tests pass
- `pnpm lint` clean
