### PR TITLE
fix(telegram): pass message_thread_id to elicitation keyboards (#1219)

### DIFF
--- a/src/telegram/elicitation-telegram.test.ts
+++ b/src/telegram/elicitation-telegram.test.ts
@@ -10,9 +10,11 @@
  *   - Unknown choice → answerCbQuery says so + does not resolve.
  *   - Abort signal aborts the pending promise as decline.
  *   - Form-mode requests with a 4-value enum render as 2×2 keyboard.
+ *   - message_thread_id is passed when a route with threadId is registered
+ *     in the elicitation-route registry (#1219).
  */
 
-import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 import {
   createTelegramElicitationHandler,
   composeTelegramElicitation,
@@ -22,11 +24,13 @@ import {
 import { ELICITATION_CALLBACK_PREFIX as ASK_QUESTION_PREFIX } from './elicitation-callback-data.js';
 import type { ElicitationHandler } from '../agent/elicitation-router.js';
 import type { ElicitationRequest, ElicitationResult } from '../agent/types/sdk-types.js';
+import { setElicitationRoute, clearElicitationRoute } from './elicitation-route-registry.js';
 
 interface SentMessage {
   chatId: number;
   text: string;
   reply_markup?: unknown;
+  message_thread_id?: number;
 }
 
 function makeStubBot(): {
@@ -41,7 +45,14 @@ function makeStubBot(): {
   const bot: any = {
     telegram: {
       sendMessage: async (chatId: number, text: string, opts: Record<string, unknown>) => {
-        sent.push({ chatId, text, reply_markup: opts['reply_markup'] });
+        sent.push({
+          chatId,
+          text,
+          reply_markup: opts['reply_markup'],
+          ...(opts['message_thread_id'] !== undefined
+            ? { message_thread_id: opts['message_thread_id'] as number }
+            : {}),
+        });
       },
     },
     action: (re: RegExp, handler: (ctx: any) => Promise<void>) => {
@@ -278,5 +289,59 @@ describe('elicitation coexistence (PR #477 B1/B2)', () => {
     expect(askMatcher.test(askTap)).toBe(true);
     // And the constants themselves differ.
     expect(ELICITATION_CALLBACK_PREFIX).not.toBe(ASK_QUESTION_PREFIX);
+  });
+});
+
+/**
+ * Regression for #1219: elicitation keyboards must carry message_thread_id
+ * when the originating session lives in a topic thread.
+ */
+describe('createTelegramElicitationHandler — topic thread routing (#1219)', () => {
+  const SESSION_ID = 'test-session-topic-1219';
+  const CHAT_ID = 999;
+  const THREAD_ID = 42;
+
+  afterEach(() => {
+    clearElicitationRoute(SESSION_ID);
+    _resetPendingForTests();
+  });
+
+  it('includes message_thread_id when a topic route is registered for the session', async () => {
+    setElicitationRoute(SESSION_ID, { chatId: CHAT_ID, threadId: THREAD_ID });
+
+    const stub = makeStubBot();
+    const handler = createTelegramElicitationHandler(stub.bot, new Set([CHAT_ID]));
+    const controller = new AbortController();
+
+    const p = handler(pathApprovalRequest(), {
+      signal: controller.signal,
+      sessionId: SESSION_ID,
+    });
+    await new Promise((r) => setImmediate(r));
+
+    expect(stub.sent).toHaveLength(1);
+    expect(stub.sent[0]?.message_thread_id).toBe(THREAD_ID);
+
+    controller.abort();
+    await p;
+  });
+
+  it('omits message_thread_id when no route is registered (General / no-topics fallback)', async () => {
+    // No setElicitationRoute call — simulates a non-topic chat or missing mapping.
+    const stub = makeStubBot();
+    const handler = createTelegramElicitationHandler(stub.bot, new Set([CHAT_ID]));
+    const controller = new AbortController();
+
+    const p = handler(pathApprovalRequest(), {
+      signal: controller.signal,
+      sessionId: 'unknown-session-id',
+    });
+    await new Promise((r) => setImmediate(r));
+
+    expect(stub.sent).toHaveLength(1);
+    expect(stub.sent[0]?.message_thread_id).toBeUndefined();
+
+    controller.abort();
+    await p;
   });
 });

--- a/src/telegram/elicitation-telegram.ts
+++ b/src/telegram/elicitation-telegram.ts
@@ -60,6 +60,8 @@ import type {
   ElicitationResult,
 } from '../agent/types/sdk-types.js';
 import { escapeRegExp } from '../utils/regexp.js';
+import { sendOptions } from './route.js';
+import { getElicitationRoute } from './elicitation-route-registry.js';
 
 /**
  * Prefix for path-approval / MCP elicitation callbacks. DISTINCT from the
@@ -113,6 +115,15 @@ export function createTelegramElicitationHandler(
     if (options.signal.aborted) {
       return { action: 'decline' };
     }
+    // Resolve the per-session route so the keyboard lands in the correct topic
+    // thread on a supergroup with topics. Falls back to bare chatId (General)
+    // when no mapping exists — same pattern as makeTelegramElicitationHandler.
+    const resolvedRoute =
+      options.sessionId !== undefined
+        ? getElicitationRoute(options.sessionId)
+        : undefined;
+    const threadOpts = resolvedRoute !== undefined ? sendOptions(resolvedRoute) : {};
+
     return new Promise<ElicitationResult>((resolve) => {
       const ulid = generateUlid();
       const enumValues = extractEnumValues(request);
@@ -130,6 +141,7 @@ export function createTelegramElicitationHandler(
         try {
           await bot.telegram.sendMessage(chatId, text, {
             reply_markup: keyboard,
+            ...threadOpts,
           });
         } catch (err) {
           log('[elicitation] sendMessage failed:', err);


### PR DESCRIPTION
## Summary

Fixes #1219 — MCP/path-approval elicitation keyboards now land in the correct topic thread on supergroups.

## Problem

`createTelegramElicitationHandler` in `src/telegram/elicitation-telegram.ts` sent keyboard prompts with no `message_thread_id`. In supergroups with topics, the permission prompt landed in General instead of the conversation thread where the session was active.

## Fix

The handler now resolves the originating session's `TelegramRoute` via `getElicitationRoute(options.sessionId)` at elicitation time and spreads `sendOptions(resolvedRoute)` — which emits `{ message_thread_id: threadId }` — into each `sendMessage` call.

This mirrors the pattern already used by the `ask_question` elicitation handler (`makeTelegramElicitationHandler`), which correctly computed `threadOpts = sendOptions(resolvedRoute)`.

## Testing

- 2 new regression tests for topic thread routing and General fallback
- All existing tests pass
- `pnpm lint` clean
