### PR TITLE
perf(plugins): memoize discovery walks and cap breadth (#990)

### DIFF
--- a/src/agent/plugins-scanner.ts
+++ b/src/agent/plugins-scanner.ts
@@ -22,6 +22,8 @@ import { existsSync, readFileSync, readdirSync, realpathSync, statSync } from 'f
 import { join, resolve as resolvePath } from 'path';
 import { getPluginsDir, getPluginsIndexPath } from '../paths.js';
 import { readIndex } from './plugins/index-store.js';
+import { _resetCommandFilesCache } from './plugins/command-files.js';
+import { _resetToolInjectorCache } from './plugins/tool-injector.js';
 
 const MAX_SCAN_DEPTH = 5;
 const MARKETPLACE_CACHE_SEGMENT = 'cache';
@@ -48,6 +50,8 @@ let scanCache: Map<string, readonly SdkPluginConfig[]> | undefined;
  */
 export function _resetPluginScanCache(): void {
   scanCache = undefined;
+  _resetCommandFilesCache();
+  _resetToolInjectorCache();
 }
 
 /**

--- a/src/agent/plugins/command-files.ts
+++ b/src/agent/plugins/command-files.ts
@@ -50,6 +50,24 @@ import { sanitizeForDisplay } from '../../utils/terminal-sanitize.js';
 /** Mirrors the depth cap in `extractPluginSkills` — cycle/runaway guard. */
 const MAX_DEPTH = 10;
 
+/** Breadth cap: bail out of a single plugin walk after this many entries. */
+const MAX_ENTRIES = 500;
+
+/**
+ * Process-lifetime memoization cache for `extractPluginCommands`, keyed by
+ * `pluginPath`. Invalidated by `_resetCommandFilesCache()`, which is called
+ * from `_resetPluginScanCache()` on install, uninstall, and `/reload-plugins`.
+ */
+const commandCache = new Map<string, PluginSkillMetadata[]>();
+
+/**
+ * Clear the in-memory command-files cache. Called from `_resetPluginScanCache`
+ * so that install/uninstall/reload also invalidates this walker's results.
+ */
+export function _resetCommandFilesCache(): void {
+  commandCache.clear();
+}
+
 /**
  * Control bytes — C0, DEL, and C1 — in a path segment.
  *
@@ -88,8 +106,17 @@ export function extractPluginCommands(
   pluginPath: string,
   knownToolNames?: ReadonlySet<string>,
 ): PluginSkillMetadata[] {
+  // Memoize per pluginPath. knownToolNames is caller-supplied context that
+  // doesn't change between the two call-sites within a single discovery pass,
+  // so keying only on pluginPath is correct. Cache is cleared on install/reload.
+  const cached = commandCache.get(pluginPath);
+  if (cached !== undefined) return cached;
+
   const root = join(pluginPath, 'commands');
-  if (!existsSync(root)) return [];
+  if (!existsSync(root)) {
+    commandCache.set(pluginPath, []);
+    return [];
+  }
 
   // Resolve the containment root's realpath ONCE, before the walk starts, and
   // thread it into every resolveContained call below instead of letting each
@@ -102,10 +129,12 @@ export function extractPluginCommands(
   try {
     realRoot = realpathSync(root);
   } catch {
+    commandCache.set(pluginPath, []);
     return [];
   }
 
   const out: DiscoveredCommand[] = [];
+  let entryCount = 0;
 
   function walk(dir: string, segments: string[], depth: number): void {
     if (depth > MAX_DEPTH) return;
@@ -116,6 +145,7 @@ export function extractPluginCommands(
       return;
     }
     for (const entry of entries) {
+      if (++entryCount > MAX_ENTRIES) return;
       if (entry.startsWith('.')) {
         if (env.AFK_DEBUG) process.stderr.write(`[afk] skipping dotfile: ${sanitizeForDisplay(join(dir, entry))}\n`);
         continue;
@@ -216,5 +246,6 @@ export function extractPluginCommands(
   // Codepoint order, not localeCompare: ICU collation varies by locale and
   // build, and this ordering is what makes collision resolution reproducible.
   out.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  commandCache.set(pluginPath, out);
   return out;
 }

--- a/src/agent/plugins/tool-injector.ts
+++ b/src/agent/plugins/tool-injector.ts
@@ -77,6 +77,24 @@ export interface PluginSkillMetadata {
   audience?: 'public' | 'internal';
 }
 
+/** Breadth cap: bail out of a single plugin walk after this many entries. */
+const MAX_ENTRIES = 500;
+
+/**
+ * Process-lifetime memoization cache for `extractPluginSkills`, keyed by
+ * `pluginPath`. Invalidated by `_resetToolInjectorCache()`, which is called
+ * from `_resetPluginScanCache()` on install, uninstall, and `/reload-plugins`.
+ */
+const skillCache = new Map<string, PluginSkillMetadata[]>();
+
+/**
+ * Clear the in-memory skill-walker cache. Called from `_resetPluginScanCache`
+ * so that install/uninstall/reload also invalidates this walker's results.
+ */
+export function _resetToolInjectorCache(): void {
+  skillCache.clear();
+}
+
 /**
  * Canonical mapping from legacy Claude Code tool aliases (case-insensitive)
  * to AFK tool names.
@@ -210,7 +228,14 @@ export function extractPluginSkills(
   pluginPath: string,
   knownToolNames?: ReadonlySet<string>,
 ): PluginSkillMetadata[] {
+  // Memoize per pluginPath. knownToolNames is caller-supplied context that
+  // doesn't change between call-sites within a single discovery pass, so
+  // keying only on pluginPath is correct. Cache is cleared on install/reload.
+  const cached = skillCache.get(pluginPath);
+  if (cached !== undefined) return cached;
+
   const skills: PluginSkillMetadata[] = [];
+  let entryCount = 0;
 
   function walkDirectory(dir: string, depth: number = 0): void {
     if (depth > 10) return; // Prevent infinite recursion
@@ -224,6 +249,7 @@ export function extractPluginSkills(
     }
 
     for (const name of entries) {
+      if (++entryCount > MAX_ENTRIES) return;
       if (name.startsWith('.')) continue;
       const fullPath = join(dir, name);
 
@@ -246,6 +272,7 @@ export function extractPluginSkills(
   }
 
   walkDirectory(pluginPath);
+  skillCache.set(pluginPath, skills);
   return skills;
 }
 


### PR DESCRIPTION
## Summary

Fixes #990 — plugin discovery walks are now memoized per `pluginPath` and bounded by both depth and breadth.

## Problem

Two plugin-discovery walks (`extractPluginCommands` and `extractPluginSkills`) were uncached and bounded only by depth (`MAX_DEPTH = 10`), never by total entry count. `extractPluginCommands` was called from both `collectSkillEntries` and `discoverPluginSkillBodies`, running the same filesystem walk twice per discovery pass.

## Fix

1. **Memoization**: Both functions now cache results in a `Map<string, Result>` keyed on `pluginPath`. Cache is invalidated by the existing `_resetPluginScanCache()` hook (already called on install).

2. **Breadth cap**: Added `MAX_ENTRIES = 500` to both walkers. The walk bails out when the total entry count exceeds this limit, preventing pathologically wide plugin directories from causing unbounded filesystem I/O.

### Files changed
- `src/agent/plugins/command-files.ts` — `commandCache` Map + `MAX_ENTRIES` cap + `_resetCommandFilesCache()` export
- `src/agent/plugins/tool-injector.ts` — `skillCache` Map + `MAX_ENTRIES` cap + `_resetToolInjectorCache()` export
- `src/agent/plugins-scanner.ts` — calls both reset functions from `_resetPluginScanCache()`

## Testing

- All existing plugin tests pass
- `pnpm lint` clean
