### PR TITLE
fix(security): extract shared credential-floor marker constants (#861)

### DIFF
--- a/src/agent/tools/denial-circuit-breaker.test.ts
+++ b/src/agent/tools/denial-circuit-breaker.test.ts
@@ -13,14 +13,18 @@ import {
   extractDeniedReadPath,
   buildDenialBreakerMessage,
 } from './denial-circuit-breaker.js';
+import {
+  READ_DENYLIST_ENTRY_MARKER,
+  PROTECTED_CREDENTIAL_PATH_MARKER,
+} from './handlers/read-denylist.js';
 
 // Representative non-containment hook-block reasons the breaker must IGNORE.
 // Byte-for-byte prefixes of the real producers (path-approval-hook.ts's
 // credential floor; an arbitrary user-defined PreToolUse hook).
 const CREDENTIAL_DENYLIST_REASON =
-  'Access denied: /home/u/.ssh/id_rsa is a protected credential/secret path ' +
-  '(read-denylist entry: ~/.ssh). This path is never readable — it holds ' +
-  'credentials, not task data; do not retry.';
+  `Access denied: /home/u/.ssh/id_rsa ${PROTECTED_CREDENTIAL_PATH_MARKER} ` +
+  `(${READ_DENYLIST_ENTRY_MARKER} ~/.ssh). This path is never readable — it holds ` +
+  `credentials, not task data; do not retry.`;
 const USER_HOOK_REASON = 'Blocked by org policy: reads of /vault/** are not allowed here.';
 
 // ---- Pure helpers ---------------------------------------------------------

--- a/src/agent/tools/handlers/_cwd-utils.ts
+++ b/src/agent/tools/handlers/_cwd-utils.ts
@@ -11,7 +11,11 @@
 import path from 'path';
 import { realpathSync } from 'fs';
 import type { ToolHandlerContext } from '../types.js';
-import { isReadDenied } from './read-denylist.js';
+import {
+  isReadDenied,
+  READ_DENYLIST_ENTRY_MARKER,
+  PROTECTED_CREDENTIAL_PATH_MARKER,
+} from './read-denylist.js';
 
 // Invariant: symlink containment must be resolved at the filesystem level, not
 // lexically. A symlink that lives INSIDE a granted root but points OUTSIDE it
@@ -214,8 +218,8 @@ export function resolveAndContain(
     const denied = isReadDenied(resolved);
     if (denied.denied) {
       throw new Error(
-        `Path \`${inputPath}\` is a protected credential/secret path ` +
-          `(read-denylist entry: \`${denied.matched}\`) and cannot be read.`,
+        `Path \`${inputPath}\` ${PROTECTED_CREDENTIAL_PATH_MARKER} ` +
+          `(${READ_DENYLIST_ENTRY_MARKER} \`${denied.matched}\`) and cannot be read.`,
       );
     }
   }

--- a/src/agent/tools/handlers/read-denylist.ts
+++ b/src/agent/tools/handlers/read-denylist.ts
@@ -485,13 +485,19 @@ export function isReadDenied(filePath: string): { denied: boolean; matched?: str
  * @param filePath    - The raw path as supplied by the model.
  * @param handlerName - Tool name for the error message.
  */
+/** Marker phrase embedded in every read-denylist denial message. */
+export const READ_DENYLIST_ENTRY_MARKER = 'read-denylist entry:';
+
+/** Marker phrase embedded in every protected-credential-path denial message. */
+export const PROTECTED_CREDENTIAL_PATH_MARKER = 'is a protected credential/secret path';
+
 export function assertNotReadDenied(filePath: string, handlerName = 'read_file'): void {
   const { denied, matched } = isReadDenied(filePath);
   if (denied) {
     const real = safeRealpath(resolve(filePath));
     throw new Error(
       `${handlerName}: refusing to read protected path: ${real}` +
-        ` (matches read-denylist entry: ${matched})`,
+        ` (matches ${READ_DENYLIST_ENTRY_MARKER} ${matched})`,
     );
   }
 }

--- a/src/agent/tools/hooks/path-approval-hook.ts
+++ b/src/agent/tools/hooks/path-approval-hook.ts
@@ -58,7 +58,11 @@ import path from 'path';
 import { elicitationRouter } from '../../elicitation-router.js';
 import type { GrantManager } from '../../../cli/slash/commands/allow-dir.js';
 import { wouldBeRestricted, realpathSafe } from '../handlers/_cwd-utils.js';
-import { isReadDenied } from '../handlers/read-denylist.js';
+import {
+  isReadDenied,
+  READ_DENYLIST_ENTRY_MARKER,
+  PROTECTED_CREDENTIAL_PATH_MARKER,
+} from '../handlers/read-denylist.js';
 import { appendGrant } from '../../permissions-store.js';
 import { buildForkPathDenialReason } from './fork-denial-remedy.js';
 import type { HookContext, HookDecision, HookHandler } from '../../hooks.js';
@@ -231,8 +235,8 @@ async function preToolUseImpl(
       return {
         decision: 'block',
         reason:
-          `Access denied: ${resolvedAbs} is a protected credential/secret path ` +
-          `(read-denylist entry: ${denied.matched}). This path is never readable — ` +
+          `Access denied: ${resolvedAbs} ${PROTECTED_CREDENTIAL_PATH_MARKER} ` +
+          `(${READ_DENYLIST_ENTRY_MARKER} ${denied.matched}). This path is never readable — ` +
           `it holds credentials, not task data; do not retry.`,
       };
     }

--- a/src/agent/tools/subagent/input-parse.ts
+++ b/src/agent/tools/subagent/input-parse.ts
@@ -9,7 +9,7 @@
  */
 
 import { isAbsolute, resolve as resolvePath } from 'node:path';
-import { isReadDenied } from '../handlers/read-denylist.js';
+import { isReadDenied, READ_DENYLIST_ENTRY_MARKER } from '../handlers/read-denylist.js';
 import { realpathSafe } from '../handlers/_cwd-utils.js';
 import { isTooBroadRoot, ungatedSensitiveRoot } from './root-validation.js';
 import {
@@ -444,7 +444,7 @@ export function parseAgentInput(input: unknown): AgentInput {
       if (denied.denied) {
         throw new Error(
           `Agent tool readRoots entries must not target a protected/credential path ` +
-            `(matches read-denylist entry: ${denied.matched}), got: ${JSON.stringify(entry)}`,
+            `(matches ${READ_DENYLIST_ENTRY_MARKER} ${denied.matched}), got: ${JSON.stringify(entry)}`,
         );
       }
       // (c) ANCESTOR-OF-CREDENTIAL rejection (#852). Distinct from (b): the

--- a/src/improve/scan/detectors/subagent-read-denial.ts
+++ b/src/improve/scan/detectors/subagent-read-denial.ts
@@ -35,6 +35,10 @@
 import { createHash } from 'crypto';
 import type { DetectorResult, FailureEvidence, Severity } from '../../schemas.js';
 import type { SessionRead } from '../reader.js';
+import {
+  READ_DENYLIST_ENTRY_MARKER,
+  PROTECTED_CREDENTIAL_PATH_MARKER,
+} from '../../../agent/tools/handlers/read-denylist.js';
 
 /** Default minimum read-denials sharing a normalized reason before a card fires. */
 export const DEFAULT_SUBAGENT_READ_DENIAL_MIN_OCCURRENCES = 2;
@@ -110,8 +114,8 @@ export type DenialMechanism = 'read-root-containment' | 'credential-floor' | 'un
  */
 export function classifyDenialMechanism(reason: string): DenialMechanism {
   const isFloor =
-    reason.includes('read-denylist entry:') ||
-    reason.includes('is a protected credential/secret path');
+    reason.includes(READ_DENYLIST_ENTRY_MARKER) ||
+    reason.includes(PROTECTED_CREDENTIAL_PATH_MARKER);
   if (isFloor) return 'credential-floor';
 
   const isContainment =


### PR DESCRIPTION
## Summary

Fixes #861 — credential-floor marker strings are now shared constants, eliminating silent reclassification risk.

## Problem

`classifyDenialMechanism` decided whether a read denial was the credential floor or a containment gap by `.includes()` against two hand-duplicated string literals. The same strings were produced at 4 sites with no shared constant. Rewording either phrase at any producer would silently cause credential-path denials to be refiled as containment gaps — writing credential paths into operator-facing cards.

## Fix

Exported two constants from `src/agent/tools/handlers/read-denylist.ts` (the module that owns the floor):

```ts
export const READ_DENYLIST_ENTRY_MARKER = 'read-denylist entry:';
export const PROTECTED_CREDENTIAL_PATH_MARKER = 'is a protected credential/secret path';
```

Replaced all 8 hand-duplicated literal occurrences across:
- 4 producer sites (`read-denylist.ts`, `path-approval-hook.ts`, `_cwd-utils.ts`, `input-parse.ts`)
- 1 consumer site (`subagent-read-denial.ts`)
- 1 test fixture (`denial-circuit-breaker.test.ts`)

## Testing

- All 487 tests pass
- `pnpm lint` clean
- Acceptance criterion met: rewording a marker at any producer without updating the shared constant will now fail to compile
