### PR TITLE
fix(telegram): surface hint when notify routing silently prefers DM over group (#1221)

### DIFF
--- a/src/telegram/notify-routing.test.ts
+++ b/src/telegram/notify-routing.test.ts
@@ -15,6 +15,8 @@ import {
   resolveConfiguredNotifyTargets,
   resolveChatTarget,
   loadChatAliases,
+  emitMixedAllowlistHintIfNeeded,
+  _resetMixedAllowlistHintForTest,
   type TelegramNotifyConfig,
 } from './notify-routing.js';
 import { isChatAllowed, parseAllowedChatIds } from './allowlist.js';
@@ -113,6 +115,72 @@ describe('resolvePrimaryChatId (pure)', () => {
   });
   it('returns undefined for an empty list', () => {
     expect(resolvePrimaryChatId([])).toBeUndefined();
+  });
+});
+
+describe('emitMixedAllowlistHintIfNeeded (one-time hint)', () => {
+  beforeEach(() => {
+    _resetMixedAllowlistHintForTest();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    _resetMixedAllowlistHintForTest();
+  });
+
+  it('emits a console.warn when DM and group are both present and no explicit primary', () => {
+    emitMixedAllowlistHintIfNeeded([123, -100200], undefined);
+    expect(console.warn).toHaveBeenCalledOnce();
+    expect(vi.mocked(console.warn).mock.calls[0]![0]).toMatch(
+      /AFK_TELEGRAM_PRIMARY_CHAT_ID/,
+    );
+  });
+
+  it('emits the hint only once per process even when called multiple times', () => {
+    emitMixedAllowlistHintIfNeeded([123, -100200], undefined);
+    emitMixedAllowlistHintIfNeeded([456, -100300], undefined);
+    expect(console.warn).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT emit when all allowed IDs are DMs (positive only)', () => {
+    emitMixedAllowlistHintIfNeeded([111, 222], undefined);
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it('does NOT emit when all allowed IDs are groups (negative only)', () => {
+    emitMixedAllowlistHintIfNeeded([-100200, -100300], undefined);
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it('does NOT emit when an explicit primary is set', () => {
+    emitMixedAllowlistHintIfNeeded([123, -100200], 123);
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it('does NOT emit for an empty allowlist', () => {
+    emitMixedAllowlistHintIfNeeded([], undefined);
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it('resolveNotifyTargets emits the hint on mixed allowlist without explicit primary', () => {
+    resolveNotifyTargets(new Set([123, -100200]));
+    expect(console.warn).toHaveBeenCalledOnce();
+  });
+
+  it('resolveNotifyTargets does NOT emit the hint when explicit primaryChatId is set', () => {
+    resolveNotifyTargets(new Set([123, -100200]), { primaryChatId: 123 });
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it('resolveNotifyTargets does NOT emit the hint in broadcast mode (no primary resolution)', () => {
+    resolveNotifyTargets(new Set([123, -100200]), { mode: 'broadcast' });
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it('resolveNotifyTargets still returns the correct DM target even when hint fires', () => {
+    const targets = resolveNotifyTargets(new Set([123, -100200]));
+    expect(targets).toEqual([123]);
   });
 });
 

--- a/src/telegram/notify-routing.ts
+++ b/src/telegram/notify-routing.ts
@@ -19,6 +19,14 @@ import { parseAllowedChatIds } from './allowlist.js';
 import { loadTelegramConfig } from '../cli/config.js';
 import { env } from '../config/env.js';
 
+/** Guard so the mixed-allowlist hint fires at most once per process. */
+let _mixedAllowlistHintEmitted = false;
+
+/** Reset the one-time hint guard — for use in tests only. */
+export function _resetMixedAllowlistHintForTest(): void {
+  _mixedAllowlistHintEmitted = false;
+}
+
 /** How notifications fan out across the allowed chats. */
 export type NotifyMode = 'primary' | 'broadcast' | 'custom';
 
@@ -56,6 +64,33 @@ export function resolvePrimaryChatId(
 }
 
 /**
+ * Emit a one-time hint when the allowlist contains both DM and group chats but
+ * no explicit primary is configured — so the user knows notifications are going
+ * to the DM and can set `AFK_TELEGRAM_PRIMARY_CHAT_ID` to change it.
+ *
+ * @internal Exported only for testing.
+ */
+export function emitMixedAllowlistHintIfNeeded(
+  allowed: readonly number[],
+  explicitPrimary: number | undefined,
+): void {
+  if (_mixedAllowlistHintEmitted) return;
+  if (explicitPrimary !== undefined && Number.isFinite(explicitPrimary) && explicitPrimary !== 0) {
+    return;
+  }
+  const hasDm = allowed.some((id) => id > 0);
+  const hasGroup = allowed.some((id) => id < 0);
+  if (hasDm && hasGroup) {
+    _mixedAllowlistHintEmitted = true;
+    console.warn(
+      '[telegram] AFK_TELEGRAM_ALLOWED_CHAT_IDS contains both a DM and a group chat. ' +
+        'Notifications will go to the DM (positive-id chat) by default. ' +
+        'Set AFK_TELEGRAM_PRIMARY_CHAT_ID to route notifications to a different chat.',
+    );
+  }
+}
+
+/**
  * Pure routing decision. Given the inbound allowlist and the notify config,
  * return the ordered, de-duplicated list of chat ids that should receive an
  * out-of-band notification. Never reads env or files.
@@ -82,6 +117,7 @@ export function resolveNotifyTargets(
     // misconfigured `custom` block still delivers somewhere sensible.
   }
 
+  emitMixedAllowlistHintIfNeeded(allowed, config.primaryChatId);
   const primary = resolvePrimaryChatId(allowed, config.primaryChatId);
   return primary !== undefined ? [primary] : [];
 }


### PR DESCRIPTION
## Summary

Fixes #1221 — users are now informed when notify routing silently prefers DM over group.

## Problem

When `AFK_TELEGRAM_ALLOWED_CHAT_IDS` contains both a group chat and a personal DM, all push notifications silently route to the DM. The workaround (`AFK_TELEGRAM_PRIMARY_CHAT_ID` or `telegram.notify.mode: broadcast`) exists but is invisible at the point where it matters.

## Fix

Added a one-time `console.warn` in `resolveNotifyTargets` that fires when:
- The allowlist contains both DM (positive) and group (negative) chat IDs
- `AFK_TELEGRAM_PRIMARY_CHAT_ID` is not explicitly set

The hint tells the user their notifications will go to the DM and how to override it. Default routing behavior is unchanged.

## Testing

- 10 new tests covering:
  - Hint fires on mixed allowlist
  - Fires only once per process
  - Silent on DM-only, group-only, explicit-primary, and empty lists
  - Integration with `resolveNotifyTargets`
  - Routing behavior unchanged
- All existing tests pass
- `pnpm lint` clean
