### PR TITLE
fix(security): bash guard SENSITIVE_PATH_SIGNAL covers relocated AFK_HOME (#778)

### DIFF
--- a/src/agent/tools/hooks/bash-restriction-hook.test.ts
+++ b/src/agent/tools/hooks/bash-restriction-hook.test.ts
@@ -893,6 +893,70 @@ describe('createBashRestrictionHook — relocated AFK_HOME parity', () => {
     expect(hook(ctx('cat ${HOME}/.afk/config/afk.env')).decision).toBe('block');
     expect(hook(ctx('cat ${HOME}/.ssh/id_rsa')).decision).toBe('block');
   });
+
+  // Issue #778 — SENSITIVE_PATH_SIGNAL misses a relocated AFK_HOME.
+  //
+  // Reachability: headless surface (no grant manager) + AFK_FORCE_BASH_INTERPRETER_GUARD=1
+  // + AFK_HOME relocated outside ~/.afk.
+  //
+  // On this path `restrictedSubstrings` is always `[]` (no grant manager wired),
+  // making `SENSITIVE_PATH_SIGNAL` the SOLE protection for the interpreter guard.
+  // But the signal has a hardcoded `.afk/config` fragment that only matches the
+  // default install.  A relocated config tree (`/opt/my-afk/config`) never
+  // contains the literal `.afk/` substring, so the signal returned false and the
+  // interpreter guard failed open — the command was not blocked.
+  //
+  // The fix adds a third check in `referencesSensitivePath`: test `scanned`
+  // against `relocatedAfkSensitiveRoots()` so the relocated tree is always covered.
+  describe('SENSITIVE_PATH_SIGNAL gap on headless + forceInterpreterGuard + relocated AFK_HOME (#778)', () => {
+    const headlessForced = createBashRestrictionHook({
+      getGrantManager: () => undefined, // headless — no grant manager
+      forceInterpreterGuard: true, // AFK_FORCE_BASH_INTERPRETER_GUARD=1
+    });
+
+    afterEach(() => {
+      delete process.env['AFK_HOME'];
+      _resetReadDenylistCacheForTests();
+    });
+
+    it('blocks a python -c that opens a file in the relocated config tree (#778)', () => {
+      // The relocated path contains no `.afk/` fragment — SENSITIVE_PATH_SIGNAL
+      // returns false. Before the fix, the interpreter guard therefore failed open.
+      const relocatedHome = '/opt/my-afk';
+      process.env['AFK_HOME'] = relocatedHome;
+
+      const cmd = `python -c "open('${relocatedHome}/config/afk.env').read()"`;
+      const decision = headlessForced(ctx(cmd));
+      expect(decision.decision).toBe('block');
+      expect(decision.reason).toContain('Interpreter');
+    });
+
+    it('blocks sh -c referencing the relocated config tree (#778)', () => {
+      const relocatedHome = '/opt/my-afk';
+      process.env['AFK_HOME'] = relocatedHome;
+
+      expect(headlessForced(ctx(`sh -c "cat ${relocatedHome}/config/afk.env"`)).decision).toBe(
+        'block',
+      );
+    });
+
+    it('does NOT block a pure-computation eval even with relocated AFK_HOME (#778)', () => {
+      // Pure computation: no sensitive path — must still pass through.
+      process.env['AFK_HOME'] = '/opt/my-afk';
+
+      expect(headlessForced(ctx('python -c "print(2**64)"')).decision).not.toBe('block');
+    });
+
+    it('does NOT block interpreter reads of relocatedHome non-config subdirs (#778)', () => {
+      // Only the config subtree is sensitive. state/, plugins/, logs/ must stay open.
+      const relocatedHome = '/opt/my-afk';
+      process.env['AFK_HOME'] = relocatedHome;
+
+      expect(
+        headlessForced(ctx(`python -c "open('${relocatedHome}/state/todos.json').read()"`)).decision,
+      ).not.toBe('block');
+    });
+  });
 });
 
 describe('createBashRestrictionHook — AFK_READ_DENYLIST extras reach the bash surface', () => {

--- a/src/agent/tools/hooks/bash-restriction-hook.ts
+++ b/src/agent/tools/hooks/bash-restriction-hook.ts
@@ -426,10 +426,25 @@ function scrubAllowlistedRefs(text: string, home: string, afkHome: string | unde
  * The lexical signal reads that same string rather than the raw command so the
  * exact-file carve-outs apply to both checks; normalization only ever expands
  * `~`/`$HOME` into the home path, which no signal fragment spans.
+ *
+ * Relocated-AFK_HOME gap: `SENSITIVE_PATH_SIGNAL` has a hardcoded `.afk/config`
+ * fragment that covers the default home install (`~/.afk/config`). When
+ * `AFK_HOME` is relocated (e.g. `/opt/my-afk`), the config tree becomes
+ * `/opt/my-afk/config` — a path that does NOT match `.afk/config`, so the
+ * signal returns false. On headless surfaces with `forceInterpreterGuard=1`,
+ * `restrictedSubstrings` is always `[]` (no grant manager), making the lexical
+ * signal the SOLE protection — which therefore misses the relocated tree. The
+ * third check below closes this gap by testing `scanned` against the runtime
+ * `relocatedAfkSensitiveRoots()` value whenever AFK_HOME is configured outside
+ * the default home directory.
  */
 function referencesSensitivePath(scanned: string, restrictedSubstrings: string[]): boolean {
   if (restrictedSubstrings.some((sub) => textMentionsPath(scanned, sub))) return true;
-  return SENSITIVE_PATH_SIGNAL.test(scanned);
+  if (SENSITIVE_PATH_SIGNAL.test(scanned)) return true;
+  // Relocated-AFK_HOME gap: when restrictedSubstrings is empty (headless, no
+  // grant manager) and the lexical signal misses a relocated config tree, fall
+  // back to a direct check against the runtime sensitive roots.
+  return relocatedAfkSensitiveRoots().some((root) => textMentionsPath(scanned, root));
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #778: `SENSITIVE_PATH_SIGNAL` in the bash restriction hook had a hardcoded `.afk/config` regex fragment that only matched the default AFK home install (`~/.afk/config`). When `AFK_HOME` is relocated (e.g. `/opt/my-afk`), the config tree becomes `/opt/my-afk/config` — a path that contains no `.afk/` substring and therefore never matched the signal.

This was the SOLE protection gap on headless surfaces with `AFK_FORCE_BASH_INTERPRETER_GUARD=1` and no grant manager wired: `restrictedSubstrings` is always `[]` on headless (no grant manager), making the lexical `SENSITIVE_PATH_SIGNAL` the sole check for the interpreter guard — which therefore silently failed open for relocated config trees.

## Root Cause

`referencesSensitivePath()` had two checks:

1. `restrictedSubstrings.some(...)` — empty `[]` on headless, so always false
2. `SENSITIVE_PATH_SIGNAL.test(scanned)` — hardcoded `.afk/config` fragment, misses `/opt/my-afk/config`

Result: `python -c "open('/opt/my-afk/config/afk.env').read()"` was not blocked on headless + `forceInterpreterGuard=1`.

## Fix

Added a third check in `referencesSensitivePath` that tests `scanned` against `relocatedAfkSensitiveRoots()` — the runtime-computed set of relocated config roots. This function already existed and was already used in `deriveRestrictedSubstrings`, so no new logic was needed, only closing the gap in `referencesSensitivePath`.

The fix is in `src/agent/tools/hooks/bash-restriction-hook.ts`:

```ts
function referencesSensitivePath(scanned: string, restrictedSubstrings: string[]): boolean {
  if (restrictedSubstrings.some((sub) => textMentionsPath(scanned, sub))) return true;
  if (SENSITIVE_PATH_SIGNAL.test(scanned)) return true;
  // Relocated-AFK_HOME gap (#778): when restrictedSubstrings is empty and the
  // lexical signal misses a relocated config tree, fall back to runtime roots.
  return relocatedAfkSensitiveRoots().some((root) => textMentionsPath(scanned, root));
}
```

## Tests Added

New nested describe block `SENSITIVE_PATH_SIGNAL gap on headless + forceInterpreterGuard + relocated AFK_HOME (#778)` inside the existing `createBashRestrictionHook — relocated AFK_HOME parity` block, covering:

- `python -c` opening a file in the relocated config tree is blocked
- `sh -c` referencing the relocated config tree is blocked
- Pure-computation evals still pass through (no regression)
- Non-config subdirs of relocated AFK_HOME (`state/`, etc.) remain readable

## Test Results

```
Tests  90 passed | 1 skipped (91)
```

The 1 skipped test is the win32-only `#852` cross-drive grant test — unrelated to this change.

## Reachability

Requires all three conditions simultaneously:

1. Headless surface (no grant manager — daemon, afk chat, subagent of headless session)
2. `AFK_FORCE_BASH_INTERPRETER_GUARD=1`
3. `AFK_HOME` relocated outside the default `~/.afk` path

## Files Changed

- `src/agent/tools/hooks/bash-restriction-hook.ts` — `referencesSensitivePath`: added third check against `relocatedAfkSensitiveRoots()`; expanded JSDoc to document the gap and the fix
- `src/agent/tools/hooks/bash-restriction-hook.test.ts` — 4 new test cases pinning the #778 fix under the exact reachability conditions
