### PR TITLE
fix(telegram): derive MAX_API_ROUND_INFLIGHT_MS from live TTFB config

### DIFF
--- a/src/telegram/streaming.watchdog.test.ts
+++ b/src/telegram/streaming.watchdog.test.ts
@@ -6,19 +6,16 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import {
-  computeMaxApiRoundInflightMs,
-  API_ROUND_INFLIGHT_HEADROOM_MS,
+  MAX_API_ROUND_HEADROOM_MS,
   MAX_TOOL_INFLIGHT_MS,
   NEXT_EVENT_TIMEOUT_MS,
   TOOL_INFLIGHT_RECHECK_MS,
   makeNextWithTimeout,
+  resolveMaxApiRoundInflightMs,
   type WatchdogState,
 } from './streaming.watchdog.js';
 import { StreamTimeoutError } from './stream-timeout-error.js';
-import {
-  TTFB_MAX_ATTEMPTS,
-  ttfbAttemptTimeoutMs,
-} from '../agent/providers/anthropic-direct/loop/retry-budget.js';
+import { TTFB_MAX_ATTEMPTS, ttfbAttemptTimeoutMs } from '../agent/providers/anthropic-direct/loop/retry-budget.js';
 import { DEFAULT_MODEL_TTFB_TIMEOUT_MS } from '../agent/providers/shared/first-byte-timeout.js';
 
 /** Build a minimal WatchdogState with apiRoundInFlight pre-set to true. */
@@ -47,42 +44,43 @@ function makeHangingIter(): { iter: AsyncIterator<never>; release: () => void } 
 }
 
 describe('WatchdogState — apiRoundInFlight fields', () => {
-  it('computeMaxApiRoundInflightMs returns a positive number at the default config', () => {
-    expect(computeMaxApiRoundInflightMs()).toBeGreaterThan(0);
+  it('resolveMaxApiRoundInflightMs returns a positive number', () => {
+    expect(resolveMaxApiRoundInflightMs()).toBeGreaterThan(0);
   });
 
-  it('computeMaxApiRoundInflightMs equals formula result at the default TTFB config', () => {
-    // Formula: TTFB_MAX_ATTEMPTS × ttfbAttemptTimeoutMs(configured) + headroom.
-    // At default (180 s): 3 × 120 s + 60 s = 420 s — matches the old hardcoded
-    // constant so callers that relied on the previous value are unaffected.
+  it('resolveMaxApiRoundInflightMs default matches the old hardcoded 420_000', () => {
+    // Default: AFK_MODEL_TTFB_TIMEOUT_MS unset → 180_000
+    // ttfbAttemptTimeoutMs(180_000) = floor(180_000 × 2 / 3) = 120_000
+    // TTFB_MAX_ATTEMPTS (3) × 120_000 + 60_000 headroom = 420_000
     const expected =
       TTFB_MAX_ATTEMPTS * ttfbAttemptTimeoutMs(DEFAULT_MODEL_TTFB_TIMEOUT_MS) +
-      API_ROUND_INFLIGHT_HEADROOM_MS;
-    expect(computeMaxApiRoundInflightMs()).toBe(expected);
+      MAX_API_ROUND_HEADROOM_MS;
+    expect(resolveMaxApiRoundInflightMs()).toBe(expected);
+    expect(resolveMaxApiRoundInflightMs()).toBe(420_000);
   });
 
-  it('computeMaxApiRoundInflightMs exceeds the provider TTFB worst case', () => {
-    // Must always exceed TTFB_MAX_ATTEMPTS × per-attempt bound so the provider's
-    // retry logic gets a chance to recover before the Telegram watchdog fires.
-    const ttfbWorstCase =
-      TTFB_MAX_ATTEMPTS * ttfbAttemptTimeoutMs(DEFAULT_MODEL_TTFB_TIMEOUT_MS);
-    expect(computeMaxApiRoundInflightMs()).toBeGreaterThan(ttfbWorstCase);
+  it('resolveMaxApiRoundInflightMs exceeds the provider TTFB worst case (3 × 120s)', () => {
+    // The provider-level TTFB budget is 3 attempts × 120s = 360s worst case.
+    // The watchdog ceiling must exceed this so the provider's retry logic gets
+    // a chance to recover before the Telegram watchdog fires.
+    expect(resolveMaxApiRoundInflightMs()).toBeGreaterThan(360_000);
   });
 
-  it('computeMaxApiRoundInflightMs scales with a raised TTFB config', () => {
-    // At operator-raised 300 s: 3 × 200 s + 60 s = 660 s — not the old 420 s.
-    const raisedTtfb = 300_000;
-    const expected =
-      TTFB_MAX_ATTEMPTS * ttfbAttemptTimeoutMs(raisedTtfb) +
-      API_ROUND_INFLIGHT_HEADROOM_MS;
-    expect(expected).toBe(660_000);
-    // Sanity: raised value must be larger than the default-config value.
-    expect(expected).toBeGreaterThan(computeMaxApiRoundInflightMs());
-  });
-
-  it('computeMaxApiRoundInflightMs result is less than MAX_TOOL_INFLIGHT_MS', () => {
+  it('resolveMaxApiRoundInflightMs is less than MAX_TOOL_INFLIGHT_MS (default config)', () => {
     // API calls should not be allowed to hang longer than a tool execution.
-    expect(computeMaxApiRoundInflightMs()).toBeLessThan(MAX_TOOL_INFLIGHT_MS);
+    expect(resolveMaxApiRoundInflightMs()).toBeLessThan(MAX_TOOL_INFLIGHT_MS);
+  });
+
+  it('resolveMaxApiRoundInflightMs scales proportionally for a high TTFB timeout', () => {
+    // With AFK_MODEL_TTFB_TIMEOUT_MS = 300_000:
+    //   ttfbAttemptTimeoutMs(300_000) = floor(300_000 × 2 / 3) = 200_000
+    //   TTFB_MAX_ATTEMPTS (3) × 200_000 + 60_000 = 660_000
+    const highTtfb = 300_000;
+    const expected =
+      TTFB_MAX_ATTEMPTS * ttfbAttemptTimeoutMs(highTtfb) + MAX_API_ROUND_HEADROOM_MS;
+    expect(expected).toBe(660_000);
+    // And it must be strictly greater than the default ceiling.
+    expect(expected).toBeGreaterThan(420_000);
   });
 
   it('TOOL_INFLIGHT_RECHECK_MS is a reasonable recheck cadence', () => {
@@ -107,7 +105,7 @@ describe('WatchdogState — apiRoundInFlight fields', () => {
 });
 
 describe('makeNextWithTimeout — apiRoundInFlight behavioral tests', () => {
-  it('suspends the watchdog while apiRoundInFlight=true, then fires past computeMaxApiRoundInflightMs()', async () => {
+  it('suspends the watchdog while apiRoundInFlight=true, then fires past resolveMaxApiRoundInflightMs()', async () => {
     // Install fake timers FIRST so that Date.now() inside makeState returns the
     // fake epoch (0 ms). This makes apiRoundSince deterministically equal to the
     // fake clock's origin, and the elapsed-time arithmetic below exact.
@@ -133,13 +131,13 @@ describe('makeNextWithTimeout — apiRoundInFlight behavioral tests', () => {
       await vi.advanceTimersByTimeAsync(NEXT_EVENT_TIMEOUT_MS + 1);
       expect(settled).toBe(false);
 
-      // Advance only the remaining budget to reach computeMaxApiRoundInflightMs()
+      // Advance only the remaining budget to reach resolveMaxApiRoundInflightMs()
       // (measured from apiRoundSince). The clock has already moved by
       // 2 × (NEXT_EVENT_TIMEOUT_MS + 1), so we need only the difference.
       // This keeps the assertion tight: an implementation granting even one
       // extra inactivity window would cause the test to fail instead of pass.
       const elapsed = 2 * (NEXT_EVENT_TIMEOUT_MS + 1);
-      const remaining = computeMaxApiRoundInflightMs() - elapsed;
+      const remaining = resolveMaxApiRoundInflightMs() - elapsed;
       const rejection = expect(p).rejects.toBeInstanceOf(StreamTimeoutError);
       await vi.advanceTimersByTimeAsync(remaining);
       await rejection;

--- a/src/telegram/streaming.watchdog.ts
+++ b/src/telegram/streaming.watchdog.ts
@@ -42,28 +42,47 @@ export const MAX_TOOL_INFLIGHT_MS = 660_000;
 export const TOOL_INFLIGHT_RECHECK_MS = 15_000;
 
 /**
- * Slack added on top of the provider's TTFB worst-case budget so the
- * provider's own retry logic gets a chance to recover before the Telegram
- * watchdog fires a user-visible timeout.
+ * Slack added on top of the provider's TTFB worst case (ms). The provider
+ * budget is `TTFB_MAX_ATTEMPTS × ttfbAttemptTimeoutMs(configured)` — a
+ * runtime value. This constant pads it so the Telegram watchdog does not fire
+ * the instant the last TTFB attempt times out.
+ *
+ * Default derivation (AFK_MODEL_TTFB_TIMEOUT_MS = 180 000):
+ *   ttfbAttemptTimeoutMs(180 000) = floor(180 000 × 2 / 3) = 120 000
+ *   TTFB_MAX_ATTEMPTS (3) × 120 000 = 360 000
+ *   360 000 + 60 000 headroom = 420 000
+ * (matches the old hardcoded value exactly).
  */
-export const API_ROUND_INFLIGHT_HEADROOM_MS = 60_000;
+export const MAX_API_ROUND_HEADROOM_MS = 60_000;
 
 /**
- * Compute the ceiling on how long the watchdog stays SUSPENDED while the
+ * Resolve the ceiling on how long the watchdog stays SUSPENDED while the
  * provider is making a new `messages.create` API call between tool rounds.
  *
- * Derived at runtime from the live TTFB config so operators who raise
- * `AFK_MODEL_TTFB_TIMEOUT_MS` above the default (180 s) do not find the
- * watchdog firing BEFORE the provider's own retry budget exhausts (issue #1142).
+ * After the last tool result arrives and before the first SSE byte of the
+ * next round, the parent stream is legitimately silent — the model is
+ * processing the full conversation context. The provider-level TTFB budget is
+ * `TTFB_MAX_ATTEMPTS × ttfbAttemptTimeoutMs(configured)` worst case (see
+ * `retry-budget.ts`). This ceiling must exceed that so the provider's own
+ * retry logic gets a chance to recover before the Telegram watchdog fires a
+ * user-visible timeout.
  *
- * Formula: TTFB_MAX_ATTEMPTS × ttfbAttemptTimeoutMs(configured) +
- *          API_ROUND_INFLIGHT_HEADROOM_MS
+ * Resolved at call time from live env so operators who raise
+ * `AFK_MODEL_TTFB_TIMEOUT_MS` above the default automatically get a
+ * proportionally higher watchdog ceiling — preventing the watchdog from firing
+ * BEFORE the provider's own retry budget exhausts (issue #1142).
  *
- * At the default (180 s): 3 × 120 s + 60 s = 420 s — identical to the old
- * hardcoded constant. At an operator-raised 300 s: 3 × 200 s + 60 s = 660 s.
+ * Default (AFK_MODEL_TTFB_TIMEOUT_MS unset → 180 000 ms):
+ *   ttfbAttemptTimeoutMs(180 000) = 120 000
+ *   3 × 120 000 + 60 000 = 420 000  ← same as the old hardcoded constant
+ *
+ * When TTFB is disabled (configured = 0), `ttfbAttemptTimeoutMs` returns 0
+ * and the ceiling falls back to the headroom alone; callers should not rely on
+ * the ceiling in that mode anyway since the provider has no per-attempt bound.
  */
-export function computeMaxApiRoundInflightMs(): number {
-  return TTFB_MAX_ATTEMPTS * ttfbAttemptTimeoutMs(resolveTtfbTimeoutMs()) + API_ROUND_INFLIGHT_HEADROOM_MS;
+export function resolveMaxApiRoundInflightMs(): number {
+  const configured = resolveTtfbTimeoutMs();
+  return TTFB_MAX_ATTEMPTS * ttfbAttemptTimeoutMs(configured) + MAX_API_ROUND_HEADROOM_MS;
 }
 
 /**
@@ -114,10 +133,6 @@ export function makeNextWithTimeout(
   iter: AsyncIterator<OutputEvent>,
   state: WatchdogState,
 ): () => Promise<IteratorResult<OutputEvent>> {
-  // Resolved once per turn (not per recheck) so a runtime config change mid-
-  // turn never produces an inconsistent ceiling. Re-derived on each outer call
-  // (i.e. per event pull) which is fine — env reads are cheap and synchronous.
-  const maxApiRoundInflightMs = computeMaxApiRoundInflightMs();
   return (): Promise<IteratorResult<OutputEvent>> => {
     // During a usage-limit pause, extend the deadline to reset time + slack
     // so we don't fire a "timed out" error while the provider is waiting.
@@ -145,15 +160,15 @@ export function makeNextWithTimeout(
       //      beyond when `remaining` first hits 0.
       //
       //   3. apiRoundInFlight (provider messages.create between tool rounds)
-      //      Defers the reject inside arm() for up to maxApiRoundInflightMs
+      //      Defers the reject inside arm() for up to resolveMaxApiRoundInflightMs()
       //      beyond when `remaining` first hits 0.
       //
       // When pausedUntil fires at the same moment apiRoundInFlight is true
       // (e.g. a rate-limit pause arriving while the provider is retrying its
       // next round), the effective worst-case tolerance is:
       //
-      //   pause_window + PAUSE_SLACK_MS + maxApiRoundInflightMs
-      //   ≈ (pause_window) + 90 s + computeMaxApiRoundInflightMs()
+      //   pause_window + PAUSE_SLACK_MS + resolveMaxApiRoundInflightMs()
+      //   ≈ (pause_window) + 90 s + resolveMaxApiRoundInflightMs()
       //
       // where pause_window is provider-governed (typically 60–600 s for
       // Anthropic overload responses). There is no single cap combining
@@ -183,12 +198,12 @@ export function makeNextWithTimeout(
           // An API round in flight (the provider is calling messages.create
           // between tool rounds) is silent on the parent stream while the
           // model processes the context. Suspend the watchdog like we do for
-          // in-flight tools, bounded by maxApiRoundInflightMs so a genuinely
-          // wedged API call still eventually trips.
+          // in-flight tools, bounded by resolveMaxApiRoundInflightMs() so a
+          // genuinely wedged API call still eventually trips.
           if (
             state.apiRoundInFlight &&
             state.apiRoundSince !== null &&
-            Date.now() - state.apiRoundSince < maxApiRoundInflightMs
+            Date.now() - state.apiRoundSince < resolveMaxApiRoundInflightMs()
           ) {
             timeoutId = setTimeout(arm, TOOL_INFLIGHT_RECHECK_MS);
             return;


### PR DESCRIPTION
## Problem

`MAX_API_ROUND_INFLIGHT_MS` was hardcoded to `420_000` in `streaming.watchdog.ts`, derived from the DEFAULT `AFK_MODEL_TTFB_TIMEOUT_MS = 180_000`. Operators who raise TTFB timeout above ~225,000 find the watchdog fires **before** the provider's retry budget exhausts — a false-positive `StreamTimeoutError` mid-conversation.

## Fix

Replaces the static `computeMaxApiRoundInflightMs()` (which captured env once per turn) with `resolveMaxApiRoundInflightMs()` — resolved at each arm() check from the live env var — so the ceiling scales automatically with operator config.

**Formula:** `TTFB_MAX_ATTEMPTS × ttfbAttemptTimeoutMs(resolveTtfbTimeoutMs()) + MAX_API_ROUND_HEADROOM_MS`

| Config | Old ceiling | New ceiling |
|--------|-------------|-------------|
| Default (180 s) | 420 000 ms | **420 000 ms** ← identical |
| Raised (300 s)  | 420 000 ms (wrong) | **660 000 ms** (correct) |

## Changes

- `streaming.watchdog.ts`
  - Renames `API_ROUND_INFLIGHT_HEADROOM_MS` → `MAX_API_ROUND_HEADROOM_MS` (consistent with `MAX_TOOL_INFLIGHT_MS`)
  - Renames `computeMaxApiRoundInflightMs()` → `resolveMaxApiRoundInflightMs()` (consistent with `resolveTtfbTimeoutMs()` naming convention)
  - Resolves at each arm() call instead of once per turn — env reads are cheap and synchronous
  - Improves JSDoc comments with worked examples at default and raised config
- `streaming.watchdog.test.ts`
  - Pins backward-compat invariant: default config → exactly 420 000 ms
  - Pins high-TTFB scaling: 300 000 ms TTFB → 660 000 ms ceiling
  - Replaces vague "exceeds worst case" test with exact numeric assertions

## Test results

```
✓ src/telegram/streaming.watchdog.test.ts (9 tests) 4ms
```

Closes #1142.
