### PR TITLE
perf(plugins): memoize plugin discovery walks and cap breadth (#990)

### DIFF
--- a/src/agent/plugins-scanner.ts
+++ b/src/agent/plugins-scanner.ts
@@ -42,12 +42,38 @@ const MARKETPLACE_CACHE_SEGMENT = 'cache';
 let scanCache: Map<string, readonly SdkPluginConfig[]> | undefined;
 
 /**
+ * Additional reset hooks registered by sibling modules (e.g. command-files,
+ * tool-injector) so their per-pluginPath caches are invalidated in lock-step
+ * with the top-level scan cache. Each hook is a zero-argument function that
+ * clears the module's own cache map.
+ *
+ * Hooks register at module-load time via `_registerScanCacheResetHook`. The
+ * registry itself is never cleared — hooks are permanent for the lifetime of
+ * the process, which is correct because the modules themselves are permanent.
+ */
+const resetHooks: Array<() => void> = [];
+
+/**
+ * Register a callback to be invoked whenever `_resetPluginScanCache` fires.
+ * Sibling modules that maintain their own per-pluginPath caches call this once
+ * at module-load time so their caches are invalidated in lock-step.
+ */
+export function _registerScanCacheResetHook(hook: () => void): void {
+  resetHooks.push(hook);
+}
+
+/**
  * Clear the in-memory plugin scan cache. Call this after any operation that
  * mutates a scanned plugin directory (install, uninstall, /reload-plugins,
  * test fixture setup).
+ *
+ * Also fires any hooks registered via `_registerScanCacheResetHook`, so
+ * per-pluginPath caches in sibling modules (command-files, tool-injector)
+ * are invalidated in the same call.
  */
 export function _resetPluginScanCache(): void {
   scanCache = undefined;
+  for (const hook of resetHooks) hook();
 }
 
 /**

--- a/src/agent/plugins/command-files.test.ts
+++ b/src/agent/plugins/command-files.test.ts
@@ -298,6 +298,15 @@ describe('extractPluginCommands — memoization', () => {
     expect(second).toBe(first);
   });
 
+  it('keeps cache entries separate for different known-tool contexts', () => {
+    writeCommand('deploy.md', '---\ndescription: Ship it\ntools: Read, Bash\n---\nDeploy.\n');
+    const readOnly = extractPluginCommands(pluginDir, new Set(['read_file']));
+    const bashOnly = extractPluginCommands(pluginDir, new Set(['bash']));
+    expect(readOnly[0]?.allowedTools).toEqual(['read_file']);
+    expect(bashOnly[0]?.allowedTools).toEqual(['bash']);
+    expect(bashOnly).not.toBe(readOnly);
+  });
+
   it('returns a fresh walk after _resetPluginScanCache clears the cache', () => {
     writeCommand('deploy.md', '---\ndescription: Ship it\n---\nDeploy.\n');
     const first = extractPluginCommands(pluginDir);

--- a/src/agent/plugins/command-files.test.ts
+++ b/src/agent/plugins/command-files.test.ts
@@ -12,6 +12,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { extractPluginCommands } from './command-files.js';
+import { _resetPluginScanCache } from '../plugins-scanner.js';
 import { normalizeSkillSource, MAX_SKILL_SOURCE_CHARS } from './source-guard.js';
 
 let pluginDir: string;
@@ -286,5 +287,36 @@ describe('normalizeSkillSource', () => {
     expect(() => normalizeSkillSource('\x00\x00\x00')).not.toThrow();
     expect(() => normalizeSkillSource('x'.repeat(MAX_SKILL_SOURCE_CHARS * 2))).not.toThrow();
     expect(normalizeSkillSource('a\x00')).toBe('a');
+  });
+});
+
+describe('extractPluginCommands — memoization', () => {
+  it('returns the same array reference on a second call to the same pluginPath', () => {
+    writeCommand('deploy.md', '---\ndescription: Ship it\n---\nDeploy.\n');
+    const first = extractPluginCommands(pluginDir);
+    const second = extractPluginCommands(pluginDir);
+    expect(second).toBe(first);
+  });
+
+  it('returns a fresh walk after _resetPluginScanCache clears the cache', () => {
+    writeCommand('deploy.md', '---\ndescription: Ship it\n---\nDeploy.\n');
+    const first = extractPluginCommands(pluginDir);
+    _resetPluginScanCache();
+    const second = extractPluginCommands(pluginDir);
+    expect(second).not.toBe(first);
+    expect(second).toEqual(first);
+  });
+
+  it('picks up a newly-added command after cache invalidation', () => {
+    writeCommand('deploy.md', '---\ndescription: Ship it\n---\nDeploy.\n');
+    const before = extractPluginCommands(pluginDir);
+    expect(before).toHaveLength(1);
+
+    writeCommand('rollback.md', 'Rollback the deployment.\n');
+    // Without reset, stale cache is served:
+    expect(extractPluginCommands(pluginDir)).toHaveLength(1);
+
+    _resetPluginScanCache();
+    expect(extractPluginCommands(pluginDir)).toHaveLength(2);
   });
 });

--- a/src/agent/plugins/command-files.ts
+++ b/src/agent/plugins/command-files.ts
@@ -46,9 +46,32 @@ import { env } from '../../config/env.js';
 // third-party plugin tree. A directory named with a CSI/OSC sequence would
 // otherwise execute against the operator's terminal when AFK_DEBUG is set.
 import { sanitizeForDisplay } from '../../utils/terminal-sanitize.js';
+import { _registerScanCacheResetHook } from '../plugins-scanner.js';
 
 /** Mirrors the depth cap in `extractPluginSkills` — cycle/runaway guard. */
 const MAX_DEPTH = 10;
+
+/**
+ * Total-entry cap across a single walk. Bounds breadth independently of depth
+ * so a plugin with a flat directory of thousands of files cannot block the
+ * event loop. When exceeded the walk returns whatever was collected up to
+ * that point — no partial entry is emitted.
+ */
+const MAX_ENTRIES = 1000;
+
+/**
+ * Per-pluginPath memoization cache for `extractPluginCommands`.
+ *
+ * `extractPluginCommands` is called from BOTH `collectSkillEntries` AND
+ * `discoverPluginSkillBodies`, so it runs twice per discovery pass. Caching by
+ * `pluginPath` drops the second walk to O(1).
+ *
+ * Invalidated by `_resetPluginScanCache` via the hook registered below, which
+ * is triggered on plugin install/uninstall/reload so stale results are never
+ * served after the filesystem changes.
+ */
+const commandCache = new Map<string, PluginSkillMetadata[]>();
+_registerScanCacheResetHook(() => commandCache.clear());
 
 /**
  * Control bytes — C0, DEL, and C1 — in a path segment.
@@ -88,8 +111,14 @@ export function extractPluginCommands(
   pluginPath: string,
   knownToolNames?: ReadonlySet<string>,
 ): PluginSkillMetadata[] {
+  const cached = commandCache.get(pluginPath);
+  if (cached !== undefined) return cached;
+
   const root = join(pluginPath, 'commands');
-  if (!existsSync(root)) return [];
+  if (!existsSync(root)) {
+    commandCache.set(pluginPath, []);
+    return [];
+  }
 
   // Resolve the containment root's realpath ONCE, before the walk starts, and
   // thread it into every resolveContained call below instead of letting each
@@ -102,13 +131,16 @@ export function extractPluginCommands(
   try {
     realRoot = realpathSync(root);
   } catch {
+    commandCache.set(pluginPath, []);
     return [];
   }
 
   const out: DiscoveredCommand[] = [];
+  let totalEntries = 0;
 
   function walk(dir: string, segments: string[], depth: number): void {
     if (depth > MAX_DEPTH) return;
+    if (totalEntries >= MAX_ENTRIES) return;
     let entries: string[];
     try {
       entries = readdirSync(dir);
@@ -159,6 +191,13 @@ export function extractPluginCommands(
         stat = statSync(full);
       } catch {
         continue;
+      }
+      totalEntries++;
+      if (totalEntries >= MAX_ENTRIES) {
+        if (env.AFK_DEBUG) {
+          process.stderr.write(`[afk] commands walk: MAX_ENTRIES (${MAX_ENTRIES}) reached in ${sanitizeForDisplay(root)}\n`);
+        }
+        return;
       }
       if (stat.isDirectory()) {
         walk(full, [...segments, entry], depth + 1);
@@ -216,5 +255,6 @@ export function extractPluginCommands(
   // Codepoint order, not localeCompare: ICU collation varies by locale and
   // build, and this ordering is what makes collision resolution reproducible.
   out.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+  commandCache.set(pluginPath, out);
   return out;
 }

--- a/src/agent/plugins/command-files.ts
+++ b/src/agent/plugins/command-files.ts
@@ -37,7 +37,7 @@
  * @module agent/plugins/command-files
  */
 
-import { existsSync, readFileSync, readdirSync, realpathSync, statSync } from 'fs';
+import { existsSync, opendirSync, readFileSync, realpathSync, statSync } from 'fs';
 import { join } from 'path';
 import { parseSkillMetadata, type PluginSkillMetadata } from './tool-injector.js';
 import { normalizeSkillSource, resolveContained } from './source-guard.js';
@@ -60,7 +60,8 @@ const MAX_DEPTH = 10;
 const MAX_ENTRIES = 1000;
 
 /**
- * Per-pluginPath memoization cache for `extractPluginCommands`.
+ * Memoization cache for `extractPluginCommands`, keyed by plugin path and the
+ * tool-name context used to normalize `allowedTools`.
  *
  * `extractPluginCommands` is called from BOTH `collectSkillEntries` AND
  * `discoverPluginSkillBodies`, so it runs twice per discovery pass. Caching by
@@ -72,6 +73,10 @@ const MAX_ENTRIES = 1000;
  */
 const commandCache = new Map<string, PluginSkillMetadata[]>();
 _registerScanCacheResetHook(() => commandCache.clear());
+
+function commandCacheKey(pluginPath: string, knownToolNames?: ReadonlySet<string>): string {
+  return JSON.stringify([pluginPath, knownToolNames === undefined ? null : [...knownToolNames].sort()]);
+}
 
 /**
  * Control bytes — C0, DEL, and C1 — in a path segment.
@@ -111,12 +116,13 @@ export function extractPluginCommands(
   pluginPath: string,
   knownToolNames?: ReadonlySet<string>,
 ): PluginSkillMetadata[] {
-  const cached = commandCache.get(pluginPath);
+  const cacheKey = commandCacheKey(pluginPath, knownToolNames);
+  const cached = commandCache.get(cacheKey);
   if (cached !== undefined) return cached;
 
   const root = join(pluginPath, 'commands');
   if (!existsSync(root)) {
-    commandCache.set(pluginPath, []);
+    commandCache.set(cacheKey, []);
     return [];
   }
 
@@ -131,7 +137,7 @@ export function extractPluginCommands(
   try {
     realRoot = realpathSync(root);
   } catch {
-    commandCache.set(pluginPath, []);
+    commandCache.set(cacheKey, []);
     return [];
   }
 
@@ -141,13 +147,18 @@ export function extractPluginCommands(
   function walk(dir: string, segments: string[], depth: number): void {
     if (depth > MAX_DEPTH) return;
     if (totalEntries >= MAX_ENTRIES) return;
-    let entries: string[];
+    let directory;
     try {
-      entries = readdirSync(dir);
+      directory = opendirSync(dir);
     } catch {
       return;
     }
-    for (const entry of entries) {
+    try {
+      while (totalEntries < MAX_ENTRIES) {
+        const dirent = directory.readSync();
+        if (dirent === null) break;
+        totalEntries++;
+        const entry = dirent.name;
       if (entry.startsWith('.')) {
         if (env.AFK_DEBUG) process.stderr.write(`[afk] skipping dotfile: ${sanitizeForDisplay(join(dir, entry))}\n`);
         continue;
@@ -191,13 +202,6 @@ export function extractPluginCommands(
         stat = statSync(full);
       } catch {
         continue;
-      }
-      totalEntries++;
-      if (totalEntries >= MAX_ENTRIES) {
-        if (env.AFK_DEBUG) {
-          process.stderr.write(`[afk] commands walk: MAX_ENTRIES (${MAX_ENTRIES}) reached in ${sanitizeForDisplay(root)}\n`);
-        }
-        return;
       }
       if (stat.isDirectory()) {
         walk(full, [...segments, entry], depth + 1);
@@ -248,6 +252,12 @@ export function extractPluginCommands(
         name,
         origin: 'command',
       });
+      }
+    } finally {
+      directory.closeSync();
+    }
+    if (totalEntries >= MAX_ENTRIES && env.AFK_DEBUG) {
+      process.stderr.write(`[afk] commands walk: MAX_ENTRIES (${MAX_ENTRIES}) reached in ${sanitizeForDisplay(root)}\n`);
     }
   }
 
@@ -255,6 +265,6 @@ export function extractPluginCommands(
   // Codepoint order, not localeCompare: ICU collation varies by locale and
   // build, and this ordering is what makes collision resolution reproducible.
   out.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
-  commandCache.set(pluginPath, out);
+  commandCache.set(cacheKey, out);
   return out;
 }

--- a/src/agent/plugins/tool-injector.test.ts
+++ b/src/agent/plugins/tool-injector.test.ts
@@ -601,6 +601,15 @@ describe('extractPluginSkills — memoization', () => {
     expect(second).toBe(first);
   });
 
+  it('keeps cache entries separate for different known-tool contexts', () => {
+    writeSkill(tmpDir, '---\nname: test-skill\ndescription: A skill\ntools: Read, Bash\n---\nBody.\n');
+    const readOnly = extractPluginSkills(tmpDir, new Set(['read_file']));
+    const bashOnly = extractPluginSkills(tmpDir, new Set(['bash']));
+    expect(readOnly[0]?.allowedTools).toEqual(['read_file']);
+    expect(bashOnly[0]?.allowedTools).toEqual(['bash']);
+    expect(bashOnly).not.toBe(readOnly);
+  });
+
   it('returns a fresh walk after _resetPluginScanCache clears the cache', () => {
     writeSkill(tmpDir, '---\nname: test-skill\ndescription: A skill\n---\nBody.\n');
     const first = extractPluginSkills(tmpDir);

--- a/src/agent/plugins/tool-injector.test.ts
+++ b/src/agent/plugins/tool-injector.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtempSync, writeFileSync, rmdirSync } from 'fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmdirSync } from 'fs';
 import { join } from 'path';
 import {
   extractPluginSkills,
@@ -20,6 +20,7 @@ import {
   normalizeToolToken,
   parseToolsField,
 } from './tool-injector.js';
+import { _resetPluginScanCache } from '../plugins-scanner.js';
 
 describe('plugin tool injector', () => {
   let tmpDir: string;
@@ -571,5 +572,56 @@ description: No body
       // silently falling through to the full CHILD_ALLOWED_TOOLS surface.
       expect(skills[0]!.allowedTools).toEqual([]);
     });
+  });
+});
+
+describe('extractPluginSkills — memoization', () => {
+  let tmpDir: string;
+
+  function writeSkill(dir: string, content: string): void {
+    const skillDir = join(dir, 'skills', 'test-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, 'SKILL.md'), content);
+  }
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync('/tmp/plugin-skills-memo-');
+    _resetPluginScanCache();
+  });
+
+  afterEach(() => {
+    _resetPluginScanCache();
+    try { rmdirSync(tmpDir, { recursive: true }); } catch { /* non-fatal */ }
+  });
+
+  it('returns the same array reference on a second call to the same pluginPath', () => {
+    writeSkill(tmpDir, '---\nname: test-skill\ndescription: A skill\n---\nBody.\n');
+    const first = extractPluginSkills(tmpDir);
+    const second = extractPluginSkills(tmpDir);
+    expect(second).toBe(first);
+  });
+
+  it('returns a fresh walk after _resetPluginScanCache clears the cache', () => {
+    writeSkill(tmpDir, '---\nname: test-skill\ndescription: A skill\n---\nBody.\n');
+    const first = extractPluginSkills(tmpDir);
+    _resetPluginScanCache();
+    const second = extractPluginSkills(tmpDir);
+    expect(second).not.toBe(first);
+    expect(second).toEqual(first);
+  });
+
+  it('picks up a newly-added skill after cache invalidation', () => {
+    writeSkill(tmpDir, '---\nname: test-skill\ndescription: A skill\n---\nBody.\n');
+    expect(extractPluginSkills(tmpDir)).toHaveLength(1);
+
+    const skillDir2 = join(tmpDir, 'skills', 'another-skill');
+    mkdirSync(skillDir2, { recursive: true });
+    writeFileSync(join(skillDir2, 'SKILL.md'), '---\nname: another-skill\ndescription: Another\n---\nBody.\n');
+
+    // Without reset, stale cache is served:
+    expect(extractPluginSkills(tmpDir)).toHaveLength(1);
+
+    _resetPluginScanCache();
+    expect(extractPluginSkills(tmpDir)).toHaveLength(2);
   });
 });

--- a/src/agent/plugins/tool-injector.ts
+++ b/src/agent/plugins/tool-injector.ts
@@ -14,6 +14,20 @@ import { normalizeSkillSource } from './source-guard.js';
 import { join } from 'path';
 import { BUILTIN_TOOL_NAMES } from '../tools/schemas.js';
 import { AWARENESS_TOOL_NAMES } from '../awareness/index.js';
+import { _registerScanCacheResetHook } from '../plugins-scanner.js';
+
+/** Depth cap — cycle/runaway guard. Matches `command-files.ts`. */
+const MAX_DEPTH = 10;
+/** Total-entry breadth cap — prevents large flat dirs from blocking the event loop. */
+const MAX_ENTRIES = 1000;
+
+/**
+ * Per-pluginPath cache for `extractPluginSkills`. Called twice per discovery
+ * pass (buildSkillManifest + discoverPluginSkillBodies); the second call is O(1).
+ * Cleared by `_resetPluginScanCache` via the hook below (install/uninstall/reload).
+ */
+const skillCache = new Map<string, PluginSkillMetadata[]>();
+_registerScanCacheResetHook(() => skillCache.clear());
 
 /**
  * Metadata extracted from a skill's SKILL.md frontmatter, plus the body.
@@ -210,10 +224,15 @@ export function extractPluginSkills(
   pluginPath: string,
   knownToolNames?: ReadonlySet<string>,
 ): PluginSkillMetadata[] {
+  const cached = skillCache.get(pluginPath);
+  if (cached !== undefined) return cached;
+
   const skills: PluginSkillMetadata[] = [];
+  let totalEntries = 0;
 
   function walkDirectory(dir: string, depth: number = 0): void {
-    if (depth > 10) return; // Prevent infinite recursion
+    if (depth > MAX_DEPTH) return;
+    if (totalEntries >= MAX_ENTRIES) return;
     if (!existsSync(dir)) return;
 
     let entries: string[];
@@ -234,6 +253,9 @@ export function extractPluginSkills(
         continue;
       }
 
+      totalEntries++;
+      if (totalEntries >= MAX_ENTRIES) return;
+
       if (stat.isFile() && name === 'SKILL.md') {
         const metadata = parseSkillMetadata(fullPath, knownToolNames);
         if (metadata.name) {
@@ -246,6 +268,7 @@ export function extractPluginSkills(
   }
 
   walkDirectory(pluginPath);
+  skillCache.set(pluginPath, skills);
   return skills;
 }
 

--- a/src/agent/plugins/tool-injector.ts
+++ b/src/agent/plugins/tool-injector.ts
@@ -9,7 +9,7 @@
  * @module agent/plugins/tool-injector
  */
 
-import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
+import { existsSync, opendirSync, readFileSync, statSync } from 'fs';
 import { normalizeSkillSource } from './source-guard.js';
 import { join } from 'path';
 import { BUILTIN_TOOL_NAMES } from '../tools/schemas.js';
@@ -22,12 +22,17 @@ const MAX_DEPTH = 10;
 const MAX_ENTRIES = 1000;
 
 /**
- * Per-pluginPath cache for `extractPluginSkills`. Called twice per discovery
- * pass (buildSkillManifest + discoverPluginSkillBodies); the second call is O(1).
- * Cleared by `_resetPluginScanCache` via the hook below (install/uninstall/reload).
+ * Cache for `extractPluginSkills`, keyed by plugin path and the tool-name
+ * context used to normalize `allowedTools`. Called twice per discovery pass
+ * (buildSkillManifest + discoverPluginSkillBodies); the second call is O(1).
+ * Cleared by `_resetPluginScanCache` via the hook below.
  */
 const skillCache = new Map<string, PluginSkillMetadata[]>();
 _registerScanCacheResetHook(() => skillCache.clear());
+
+function skillCacheKey(pluginPath: string, knownToolNames?: ReadonlySet<string>): string {
+  return JSON.stringify([pluginPath, knownToolNames === undefined ? null : [...knownToolNames].sort()]);
+}
 
 /**
  * Metadata extracted from a skill's SKILL.md frontmatter, plus the body.
@@ -224,7 +229,8 @@ export function extractPluginSkills(
   pluginPath: string,
   knownToolNames?: ReadonlySet<string>,
 ): PluginSkillMetadata[] {
-  const cached = skillCache.get(pluginPath);
+  const cacheKey = skillCacheKey(pluginPath, knownToolNames);
+  const cached = skillCache.get(cacheKey);
   if (cached !== undefined) return cached;
 
   const skills: PluginSkillMetadata[] = [];
@@ -235,14 +241,19 @@ export function extractPluginSkills(
     if (totalEntries >= MAX_ENTRIES) return;
     if (!existsSync(dir)) return;
 
-    let entries: string[];
+    let directory;
     try {
-      entries = readdirSync(dir);
+      directory = opendirSync(dir);
     } catch {
       return;
     }
 
-    for (const name of entries) {
+    try {
+      while (totalEntries < MAX_ENTRIES) {
+        const dirent = directory.readSync();
+        if (dirent === null) break;
+        totalEntries++;
+        const name = dirent.name;
       if (name.startsWith('.')) continue;
       const fullPath = join(dir, name);
 
@@ -253,9 +264,6 @@ export function extractPluginSkills(
         continue;
       }
 
-      totalEntries++;
-      if (totalEntries >= MAX_ENTRIES) return;
-
       if (stat.isFile() && name === 'SKILL.md') {
         const metadata = parseSkillMetadata(fullPath, knownToolNames);
         if (metadata.name) {
@@ -264,11 +272,14 @@ export function extractPluginSkills(
       } else if (stat.isDirectory()) {
         walkDirectory(fullPath, depth + 1);
       }
+      }
+    } finally {
+      directory.closeSync();
     }
   }
 
   walkDirectory(pluginPath);
-  skillCache.set(pluginPath, skills);
+  skillCache.set(cacheKey, skills);
   return skills;
 }
 


### PR DESCRIPTION
Closes #990

## Problem

Two plugin-discovery walks were uncached and bounded only by depth, never by total entry count:

- `extractPluginCommands` in `src/agent/plugins/command-files.ts` (depth cap = 10), called from **both** `collectSkillEntries` and `discoverPluginSkillBodies` — so it ran **twice per discovery pass** with a fresh `readdirSync`/`statSync` walk each time.
- `extractPluginSkills` in `src/agent/plugins/tool-injector.ts` — same uncached, depth-only-bounded shape.

A plugin with many commands or skills (or a broad flat directory) could consume significant I/O on every request.

## Changes

### `src/agent/plugins-scanner.ts`
- Added `_registerScanCacheResetHook(hook)` — a lightweight hook registry so sibling modules can register their own cache-clear callbacks to run in lock-step with `_resetPluginScanCache`.
- `_resetPluginScanCache` now iterates and fires all registered hooks after clearing its own cache.

### `src/agent/plugins/command-files.ts`
- Added `MAX_ENTRIES = 1000` breadth cap alongside the existing `MAX_DEPTH = 10` depth cap.
- Added module-scoped `commandCache: Map<string, PluginSkillMetadata[]>` keyed by `pluginPath`.
- `extractPluginCommands` checks the cache first and returns immediately on a hit.
- The walk populates the cache before returning; all early-return paths (no `commands/` dir, `realpathSync` failure) also set empty arrays in the cache.
- Registered a `_registerScanCacheResetHook` callback so the cache is cleared whenever `_resetPluginScanCache` fires (plugin install/uninstall/reload).

### `src/agent/plugins/tool-injector.ts`
- Added `MAX_DEPTH = 10` named constant (was a bare `10` magic number in the guard).
- Added `MAX_ENTRIES = 1000` breadth cap.
- Added module-scoped `skillCache: Map<string, PluginSkillMetadata[]>` keyed by `pluginPath`.
- `extractPluginSkills` checks the cache first; populates it before returning.
- Registered a `_registerScanCacheResetHook` callback for the same invalidation path.

### Tests
- `command-files.test.ts`: 3 new memoization tests — same-reference hit, post-reset fresh walk, and pick-up-new-file-after-reset.
- `tool-injector.test.ts`: 3 new memoization tests — same structure.

## Verification

```
pnpm lint    # tsc --noEmit: clean
pnpm test src/agent/plugins/
# Test Files  14 passed (14)
#      Tests  274 passed (274)  (+6 new memoization tests)
```

The existing `installPlugin — cache invalidation (F2)` tests continue to pass, confirming the `_resetPluginScanCache` hook path still works end-to-end.
