### PR TITLE
refactor(dispatcher): extract helpers from executeBatch to reduce nesting (#1074)

### DIFF
--- a/src/agent/tools/dispatcher.batch-process.ts
+++ b/src/agent/tools/dispatcher.batch-process.ts
@@ -5,6 +5,8 @@
  * branches of the batch loop:
  *  - {@link runConcurrentBatch} — `isConcurrencySafe` wave-admission loop.
  *  - {@link runSequentialBatch} — sequential (concurrency-unsafe) loop.
+ *  - {@link reconcileOutcomes} — post-wave result writing from settled promises.
+ *  - {@link stampBatchMetadata} — batch-membership annotation on each result.
  *
  * Both functions receive their dispatcher-state dependencies through an explicit
  * {@link BatchExecDeps} object rather than through closure, so the concerns are
@@ -86,6 +88,106 @@ function checkRepeatGuard(
   return verdict.result;
 }
 
+/**
+ * Per-call execution unit dispatched by `settleWithConcurrencyLimit`.
+ *
+ * Performs the per-call abort check inline so a call whose signal fires
+ * AFTER the wave is admitted still produces a clean abort result rather
+ * than being dispatched to `executeCore`. Returns `{ result, originalIndex }`
+ * so `reconcileOutcomes` can write results back at the correct position in
+ * a way that is order-independent.
+ */
+async function executeCallUnit(
+  batchIdx: number,
+  executableCalls: readonly IndexedCall[],
+  executeCore: BatchExecDeps['executeCore'],
+): Promise<{ result: ToolResult; originalIndex: number }> {
+  const { call, originalIndex } = executableCalls[batchIdx]!;
+  if (call.signal.aborted) {
+    return {
+      result: {
+        content: 'Tool call aborted',
+        isError: true,
+        failureClass: abortFailureClass(call.signal),
+      } as ToolResult,
+      originalIndex,
+    };
+  }
+  const result = await executeCore(call);
+  return { result, originalIndex };
+}
+
+// ---------------------------------------------------------------------------
+// Exported post-execution helpers (used by executeBatch in dispatcher.ts)
+// ---------------------------------------------------------------------------
+
+/**
+ * Write settled promise results back into the shared `results` array.
+ *
+ * Each fulfilled entry writes `value.result` at `value.originalIndex`.
+ * Each rejected entry constructs an error result; the original index is
+ * recovered via `wave[settled.indexOf(outcome)]` (rejection carries no payload
+ * by design — `executeCore` catches internally, so rejections are unexpected
+ * safety-net paths only).
+ *
+ * Invariant: `executeCore` never rejects today; this function retains the
+ * safety net for a future refactor that permits a rejection to escape.
+ *
+ * @internal Called only by {@link runConcurrentBatch}.
+ */
+export function reconcileOutcomes(
+  settled: PromiseSettledResult<{ result: ToolResult; originalIndex: number }>[],
+  wave: readonly number[],
+  executableCalls: readonly IndexedCall[],
+  results: ToolResult[],
+): void {
+  for (const outcome of settled) {
+    if (outcome.status === 'fulfilled') {
+      results[outcome.value.originalIndex] = outcome.value.result;
+    } else {
+      const msg =
+        outcome.reason instanceof Error ? outcome.reason.message : String(outcome.reason);
+      const batchIdx = wave[settled.indexOf(outcome)]!;
+      results[executableCalls[batchIdx]!.originalIndex] = {
+        content: `Tool execution error: ${msg}`,
+        isError: true,
+      };
+    }
+  }
+}
+
+/**
+ * Stamp batch-membership metadata onto each result in `batch.indices`.
+ *
+ * Downstream consumers (TUI tool-lane render + `tool_call` completed trace
+ * event) use `batchIndex`/`batchSize` to distinguish a genuine parallel wave
+ * from back-to-back sequential dispatches — which are otherwise
+ * indistinguishable once a fast root commits to scrollback ahead of a slow one.
+ * 1-based `batchIndex` = ordinal within the batch; `batchSize` = number of
+ * calls dispatched together. A concurrency-unsafe tool (bash, write_file, …)
+ * is always its own singleton batch, so it lands `batchSize=1` and is never
+ * badged. Blocked / short-circuited calls are excluded from `executableCalls`,
+ * so they correctly carry no batch info at all.
+ *
+ * @internal Called by {@link SessionToolDispatcher.executeBatch} after each
+ *   batch's execution branch completes.
+ */
+export function stampBatchMetadata(
+  batch: Batch,
+  executableCalls: readonly IndexedCall[],
+  results: ToolResult[],
+): void {
+  const batchSize = batch.indices.length;
+  for (let pos = 0; pos < batch.indices.length; pos++) {
+    const batchIdx = batch.indices[pos]!;
+    const r = results[executableCalls[batchIdx]!.originalIndex];
+    if (r) {
+      r.batchIndex = pos + 1;
+      r.batchSize = batchSize;
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Concurrent branch
 // ---------------------------------------------------------------------------
@@ -158,38 +260,10 @@ export async function runConcurrentBatch(
     const settled = await settleWithConcurrencyLimit(
       wave,
       deps.maxConcurrentSafeCalls,
-      async (batchIdx) => {
-        const { call, originalIndex } = executableCalls[batchIdx]!;
-        if (call.signal.aborted) {
-          return {
-            result: {
-              content: 'Tool call aborted',
-              isError: true,
-              failureClass: abortFailureClass(call.signal),
-            } as ToolResult,
-            originalIndex,
-          };
-        }
-        const result = await deps.executeCore(call);
-        return { result, originalIndex };
-      },
+      (batchIdx) => executeCallUnit(batchIdx, executableCalls, deps.executeCore),
     );
 
-    for (const outcome of settled) {
-      if (outcome.status === 'fulfilled') {
-        results[outcome.value.originalIndex] = outcome.value.result;
-      } else {
-        // Invariant: executeCore catches today; retain this safety net
-        // for a future refactor that permits a rejection to escape.
-        const msg =
-          outcome.reason instanceof Error ? outcome.reason.message : String(outcome.reason);
-        const batchIdx = wave[settled.indexOf(outcome)]!;
-        results[executableCalls[batchIdx]!.originalIndex] = {
-          content: `Tool execution error: ${msg}`,
-          isError: true,
-        };
-      }
-    }
+    reconcileOutcomes(settled, wave, executableCalls, results);
 
     // Apply observations only after every handler settles, and in the
     // batch's original call order rather than completion order.

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -53,7 +53,11 @@ import {
   type SuspectedLoopWindow,
 } from './suspected-loop-detector.js';
 import { RepeatFailureGuard } from './repeat-failure-guard.js';
-import { runConcurrentBatch, runSequentialBatch } from './dispatcher.batch-process.js';
+import {
+  runConcurrentBatch,
+  runSequentialBatch,
+  stampBatchMetadata,
+} from './dispatcher.batch-process.js';
 import type { IndexedCall, BatchExecDeps } from './dispatcher.batch-process.js';
 import { executeSubagentProviderTool, isSubagentProviderTool } from './dispatcher.subagent-tools.js';
 
@@ -1083,25 +1087,9 @@ export class SessionToolDispatcher implements ToolDispatcher {
         await runSequentialBatch(batch, executableCalls, results, batchDeps);
       }
 
-      // Stamp batch membership onto each result so downstream consumers
-      // (TUI tool-lane render + `tool_call` completed trace event) can tell a
-      // genuine parallel wave apart from back-to-back sequential dispatches —
-      // which are otherwise indistinguishable once a fast root commits to
-      // scrollback ahead of a slow one. 1-based `batchIndex` = ordinal within
-      // the batch; `batchSize` = number of calls dispatched together. A
-      // concurrency-unsafe tool (bash, write_file, …) is always its own
-      // singleton batch, so it lands batchSize=1 and is never badged. Blocked
-      // / short-circuited calls (permission, read-only-bash gate, circuit
-      // breaker) are excluded from `executableCalls`, so they correctly carry
-      // no batch info at all.
-      const batchSize = batch.indices.length;
-      batch.indices.forEach((batchIdx, pos) => {
-        const r = results[executableCalls[batchIdx]!.originalIndex];
-        if (r) {
-          r.batchIndex = pos + 1;
-          r.batchSize = batchSize;
-        }
-      });
+      // Stamp batch membership onto each result. See stampBatchMetadata in
+      // dispatcher.batch-process.ts for full rationale and field semantics.
+      stampBatchMetadata(batch, executableCalls, results);
     }
 
     // Reset-on-success (#546): if any call in this batch executed successfully,


### PR DESCRIPTION
Closes #1074

## Summary

Continues the nesting-reduction work from #1099 by extracting three additional named helpers into `dispatcher.batch-process.ts`.

### Helpers extracted

| Helper | Location | Removes |
|--------|----------|---------|
| `executeCallUnit(batchIdx, executableCalls, executeCore)` | `dispatcher.batch-process.ts` (internal) | Inline async closure inside `settleWithConcurrencyLimit` call in `runConcurrentBatch` — was adding 2 levels to every statement in the per-call unit |
| `reconcileOutcomes(settled, wave, executableCalls, results)` | `dispatcher.batch-process.ts` (exported) | Inline `for (const outcome of settled)` loop inside `runConcurrentBatch`'s `while` loop — the "post-batch outcome reconciliation" named in the issue |
| `stampBatchMetadata(batch, executableCalls, results)` | `dispatcher.batch-process.ts` (exported) | Inline `batch.indices.forEach` callback inside `executeBatch`'s `for (const batch of batches)` loop — stamps `batchIndex`/`batchSize` onto results |

Each helper takes explicit parameters rather than closing over enclosing locals, matching the issue's constraint.

### Nesting reduction

| File | Before | After |
|------|--------|-------|
| `dispatcher.batch-process.ts` max indent | 14 sp (7 levels) | 8 sp (4 levels) |
| `dispatcher.ts` max indent | 12 sp (unchanged) | 12 sp (unchanged) |
| `dispatcher.ts` line count | 1341 | 1329 (-12) |

### External API

Unchanged. `executeBatch`, `runConcurrentBatch`, `runSequentialBatch`, `BatchExecDeps`, `IndexedCall` signatures are identical. `reconcileOutcomes` and `stampBatchMetadata` are newly exported for testability.

## Test results

```
pnpm lint   — PASS (tsc --noEmit, no errors)
pnpm test src/agent/tools/dispatcher.test.ts — 119 passed | 1 skipped (120 total)
pnpm build  — PASS
```

The 1 skipped test is a pre-existing intentional skip unrelated to this change. The 1 flaky failure in `write-denylist.test.ts` (symlink repoint race) is pre-existing on main and unrelated.
