### PR TITLE
fix(xai-oauth): send valid Grok CLI version to proxy

### DIFF
--- a/docs/env-registry.json
+++ b/docs/env-registry.json
@@ -1110,6 +1110,14 @@
       "category": "model"
     },
     {
+      "name": "AFK_XAI_GROK_CLIENT_VERSION",
+      "description": "Override the semver sent as x-grok-client-version to the xAI OAuth CLI chat proxy. Use only if the proxy raises its required Grok CLI version before agent-afk is updated; invalid values fall back to the official Grok Build version file or built-in compatible default.",
+      "type": "string",
+      "required": false,
+      "example": "1.0.6",
+      "category": "model"
+    },
+    {
       "name": "AFK_XAI_OAUTH_BASE_URL",
       "description": "Base URL for xAI SuperGrok / SuperGrok Heavy / X Premium+ OAuth inference. Default https://cli-chat-proxy.grok.com/v1 (subscription path). Some accounts work on https://api.x.ai/v1 with OAuth — override if needed. Distinct from AFK_XAI_BASE_URL (API-key mode).",
       "type": "string",

--- a/docs/env-registry.md
+++ b/docs/env-registry.md
@@ -2,7 +2,7 @@
 
 Generated from `src/config/env.ts`. Do not edit by hand — run `pnpm scan:env` after changing the registry source.
 
-**167 vars** across 12 categories. Every `process.env[...]` read in `src/` outside `src/config/env.ts` is a CI failure (enforced by `pnpm audit:env:check`).
+**168 vars** across 12 categories. Every `process.env[...]` read in `src/` outside `src/config/env.ts` is a CI failure (enforced by `pnpm audit:env:check`).
 
 To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV_REGISTRY`), then run `pnpm scan:env`.
 
@@ -64,6 +64,7 @@ To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV
 | `AFK_VISION_MODELS` | string |  |  | `qwen2.5-vl,!gpt-4o-mini` | Comma-separated override for image (vision) capability detection on the openai-compatible provider. Each token force-enables a model id by exact or substring match (e.g. "qwen2.5-vl" matches a local VL id); prefix a token with "!" to force-disable. Use to send images to a local vision-language model AFK does not recognise by name, or to blacklist a mis-detected id. Built-in detection already covers gpt-4o/4.1/5.x, o1/o3/o4-mini, Claude, and common VL families. |
 | `AFK_WORKSPACE_DISABLED` | boolean |  | `0` | `1` | Disable the shared agent workspace (WorkspaceStore + workspace_publish/workspace_query tools + preamble injection). When set to 1, subagents do not get workspace tools and no workspace preamble is injected at fork time — each agent works in full isolation as before v5.133. Used as the control arm of the file-read deduplication A/B experiment. Default: workspace enabled (unset or 0). |
 | `AFK_XAI_BASE_URL` | string |  |  | `https://api.x.ai/v1` | Base URL for xAI API-key mode. Default https://api.x.ai/v1. The OpenAI SDK appends /chat/completions. |
+| `AFK_XAI_GROK_CLIENT_VERSION` | string |  |  | `1.0.6` | Override the semver sent as x-grok-client-version to the xAI OAuth CLI chat proxy. Use only if the proxy raises its required Grok CLI version before agent-afk is updated; invalid values fall back to the official Grok Build version file or built-in compatible default. |
 | `AFK_XAI_OAUTH_BASE_URL` | string |  |  | `https://cli-chat-proxy.grok.com/v1` | Base URL for xAI SuperGrok / SuperGrok Heavy / X Premium+ OAuth inference. Default https://cli-chat-proxy.grok.com/v1 (subscription path). Some accounts work on https://api.x.ai/v1 with OAuth — override if needed. Distinct from AFK_XAI_BASE_URL (API-key mode). |
 | `CLAUDE_MODEL` | string |  |  | `sonnet` | Legacy alias for AFK_MODEL — supported for back-compat with pre-AFK_* deployments. |
 

--- a/src/agent/providers/xai/endpoints.test.ts
+++ b/src/agent/providers/xai/endpoints.test.ts
@@ -38,6 +38,7 @@ describe('resolveXaiEndpoint', () => {
     expect(r.defaultHeaders['x-grok-client-version']).toBe('9.9.9');
     expect(r.defaultHeaders['x-grok-client-identifier']).toBe('grok-shell');
     expect(r.defaultHeaders['User-Agent']).toContain('9.9.9');
+    expect(r.defaultHeaders['x-grok-client-version']).not.toBe('agent-afk');
   });
 
   it('honors AFK_XAI_OAUTH_BASE_URL and skips proxy headers on api.x.ai', () => {

--- a/src/agent/providers/xai/endpoints.ts
+++ b/src/agent/providers/xai/endpoints.ts
@@ -32,7 +32,7 @@ export interface XaiEndpointResolution {
 export interface XaiEndpointDeps {
   /** Returns env value for key, or undefined. Defaults go through `env` (audit-env). */
   readEnv?: (key: string) => string | undefined;
-  /** Client version string for proxy identity headers. */
+  /** Internal compatibility/test seam for proxy identity headers. */
   clientVersion?: string;
   /**
    * Intentional xAI endpoint override (per-slot `baseUrl` only). Must NOT be

--- a/src/agent/providers/xai/headers.test.ts
+++ b/src/agent/providers/xai/headers.test.ts
@@ -1,8 +1,22 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
+  DEFAULT_GROK_CLI_COMPAT_VERSION,
   isCliChatProxyBaseUrl,
+  readOfficialGrokCliVersion,
   resolveGrokCliIdentityHeaders,
+  type GrokCliHeaderDeps,
 } from './headers.js';
+
+const VERSION_FILE = '/test-home/.grok/version.json';
+
+function deps(overrides: Partial<GrokCliHeaderDeps> = {}): GrokCliHeaderDeps {
+  return {
+    readEnv: () => undefined,
+    homeDir: () => '/test-home',
+    readFile: () => { throw new Error('version file unavailable'); },
+    ...overrides,
+  };
+}
 
 describe('isCliChatProxyBaseUrl', () => {
   it('matches the default CLI proxy host', () => {
@@ -16,12 +30,79 @@ describe('isCliChatProxyBaseUrl', () => {
 
 describe('resolveGrokCliIdentityHeaders', () => {
   it('sets CLI identity headers without Authorization or JWT material', () => {
-    const h = resolveGrokCliIdentityHeaders({ clientVersion: '1.0.0' });
+    const h = resolveGrokCliIdentityHeaders({ clientVersion: '1.0.0' }, deps());
     expect(h['X-XAI-Token-Auth']).toBe('xai-grok-cli');
     expect(h['x-grok-client-version']).toBe('1.0.0');
     expect(h['x-grok-client-identifier']).toBe('grok-shell');
-    expect(h['User-Agent']).toContain('agent-afk/1.0.0');
+    expect(h['User-Agent']).toContain('1.0.0');
     expect(h['Authorization']).toBeUndefined();
     expect(JSON.stringify(h)).not.toMatch(/eyJ/); // no JWT-looking blobs
+  });
+
+  it('uses the environment override ahead of the compatibility seam and version file', () => {
+    const readFile = vi.fn(() => JSON.stringify({ version: '1.0.5' }));
+    const h = resolveGrokCliIdentityHeaders(
+      { clientVersion: '1.0.4' },
+      deps({ readEnv: () => ' 1.0.6 ', readFile }),
+    );
+    expect(h['x-grok-client-version']).toBe('1.0.6');
+    expect(readFile).not.toHaveBeenCalled();
+  });
+
+  it.each(['agent-afk', '  '])('falls through invalid environment values to the official version file: %s', (override) => {
+    const h = resolveGrokCliIdentityHeaders(
+      {},
+      deps({
+        readEnv: () => override,
+        readFile: (filePath) => {
+          expect(filePath).toBe(VERSION_FILE);
+          return JSON.stringify({ version: ' 1.2.3-rc.1+build.42 ' });
+        },
+      }),
+    );
+    expect(h['x-grok-client-version']).toBe('1.2.3-rc.1+build.42');
+  });
+
+  it('uses the internal clientVersion seam only after no valid env override', () => {
+    const readFile = vi.fn(() => JSON.stringify({ version: '1.0.5' }));
+    const h = resolveGrokCliIdentityHeaders(
+      { clientVersion: '1.0.4' },
+      deps({ readFile }),
+    );
+    expect(h['x-grok-client-version']).toBe('1.0.4');
+    expect(readFile).not.toHaveBeenCalled();
+  });
+
+  it('falls through an invalid clientVersion seam to the official version file', () => {
+    const h = resolveGrokCliIdentityHeaders(
+      { clientVersion: 'agent-afk' },
+      deps({ readFile: () => JSON.stringify({ version: '1.0.5' }) }),
+    );
+    expect(h['x-grok-client-version']).toBe('1.0.5');
+  });
+
+  it.each([
+    'not-json',
+    JSON.stringify({}),
+    JSON.stringify({ version: 105 }),
+    JSON.stringify({ version: '1.0' }),
+    JSON.stringify({ version: '1.0.5garbage' }),
+  ])('uses the fallback for unusable official version data: %s', (contents) => {
+    const h = resolveGrokCliIdentityHeaders({}, deps({ readFile: () => contents }));
+    expect(h['x-grok-client-version']).toBe(DEFAULT_GROK_CLI_COMPAT_VERSION);
+  });
+
+  it('uses the fallback when the official version file cannot be read', () => {
+    const h = resolveGrokCliIdentityHeaders({}, deps());
+    expect(h['x-grok-client-version']).toBe(DEFAULT_GROK_CLI_COMPAT_VERSION);
+    expect(h['x-grok-client-version']).not.toBe('agent-afk');
+  });
+});
+
+describe('readOfficialGrokCliVersion', () => {
+  it('uses injected home and file dependencies', () => {
+    const readFile = vi.fn(() => JSON.stringify({ version: '1.0.5' }));
+    expect(readOfficialGrokCliVersion(deps({ readFile }))).toBe('1.0.5');
+    expect(readFile).toHaveBeenCalledWith(VERSION_FILE);
   });
 });

--- a/src/agent/providers/xai/headers.ts
+++ b/src/agent/providers/xai/headers.ts
@@ -6,19 +6,80 @@
  * Exact values are encapsulated here so they stay one-file tunable if the
  * proxy tightens checks.
  *
+ * Invariant: `x-grok-client-version` MUST be a semver the proxy can parse.
+ * The proxy was observed to reject versions below 0.1.202; sending the product
+ * name `agent-afk` yields HTTP 426 ("Your Grok CLI version (agent-afk) is
+ * outdated").
+ *
  * Safety: never put access tokens into these headers.
  *
  * @module agent/providers/xai/headers
  */
 
+import { readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { env } from '../../../config/env.js';
+
 /** Hostname of the subscription CLI chat proxy. */
 export const CLI_CHAT_PROXY_HOST = 'cli-chat-proxy.grok.com';
 
+/** Last-resort version when no operator or official-client version is usable. */
+export const DEFAULT_GROK_CLI_COMPAT_VERSION = '1.0.5';
+
+const GROK_CLI_VERSION_ENV = 'AFK_XAI_GROK_CLIENT_VERSION';
+
+// SemVer 2.0.0, including optional prerelease and build metadata.
+const SEMVER_RE = /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
 export interface GrokCliHeaderOptions {
-  /** agent-afk / Grok-CLI-compat version string. */
+  /** Internal compatibility seam; production resolution uses the sources below. */
   clientVersion?: string;
   /** Client identifier the proxy expects. */
   clientIdentifier?: string;
+}
+
+/** Injectable sources keep header resolution deterministic in unit tests. */
+export interface GrokCliHeaderDeps {
+  readEnv?: (key: typeof GROK_CLI_VERSION_ENV) => string | undefined;
+  readFile?: (filePath: string) => string;
+  homeDir?: () => string;
+}
+
+function validSemver(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed && SEMVER_RE.test(trimmed) ? trimmed : undefined;
+}
+
+/** Read `~/.grok/version.json` written by the official Grok Build CLI. */
+export function readOfficialGrokCliVersion(deps: GrokCliHeaderDeps = {}): string | undefined {
+  const readFile = deps.readFile ?? ((filePath: string) => readFileSync(filePath, 'utf-8'));
+  const homeDir = deps.homeDir ?? homedir;
+  try {
+    const raw = readFile(join(homeDir(), '.grok', 'version.json'));
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null) return undefined;
+    const version = (parsed as Record<string, unknown>)['version'];
+    if (typeof version !== 'string') return undefined;
+    return validSemver(version);
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveGrokCliVersion(
+  clientVersion: string | undefined,
+  deps: GrokCliHeaderDeps,
+): string {
+  const readEnv = deps.readEnv ?? ((key: typeof GROK_CLI_VERSION_ENV) => env[key]);
+  // This is the operator-facing precedence contract. clientVersion is an
+  // internal compatibility seam only; production callers do not supply it.
+  return (
+    validSemver(readEnv(GROK_CLI_VERSION_ENV))
+    ?? validSemver(clientVersion)
+    ?? readOfficialGrokCliVersion(deps)
+    ?? DEFAULT_GROK_CLI_COMPAT_VERSION
+  );
 }
 
 /**
@@ -43,13 +104,15 @@ export function isCliChatProxyBaseUrl(baseURL: string): boolean {
  */
 export function resolveGrokCliIdentityHeaders(
   opts: GrokCliHeaderOptions = {},
+  deps: GrokCliHeaderDeps = {},
 ): Record<string, string> {
-  const version = opts.clientVersion?.trim() || 'agent-afk';
+  const version = resolveGrokCliVersion(opts.clientVersion, deps);
   const identifier = opts.clientIdentifier?.trim() || 'grok-shell';
   return {
     'X-XAI-Token-Auth': 'xai-grok-cli',
     'x-grok-client-version': version,
     'x-grok-client-identifier': identifier,
-    'User-Agent': `agent-afk/${version} (grok-cli-compat)`,
+    // User-Agent is diagnostic; the proxy gates on x-grok-client-version.
+    'User-Agent': `agent-afk (grok-cli-compat/${version})`,
   };
 }

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -712,6 +712,14 @@ export const ENV_REGISTRY: readonly EnvVarMeta[] = [
     category: 'model',
   },
   {
+    name: 'AFK_XAI_GROK_CLIENT_VERSION',
+    description: 'Override the semver sent as x-grok-client-version to the xAI OAuth CLI chat proxy. Use only if the proxy raises its required Grok CLI version before agent-afk is updated; invalid values fall back to the official Grok Build version file or built-in compatible default.',
+    type: 'string',
+    required: false,
+    example: '1.0.6',
+    category: 'model',
+  },
+  {
     name: 'AFK_LOCAL_API_KEY',
     description: 'Placeholder API key for local Anthropic-compatible servers (vllm-mlx, etc.). Set when AFK_LOCAL_BASE_URL is configured.',
     type: 'string',
@@ -1764,6 +1772,7 @@ export const env = {
   get CODEX_API_KEY(): string | undefined { return process.env['CODEX_API_KEY']; },
   get XAI_API_KEY(): string | undefined { return process.env['XAI_API_KEY']; },
   get AFK_XAI_BASE_URL(): string | undefined { return process.env['AFK_XAI_BASE_URL']; },
+  get AFK_XAI_GROK_CLIENT_VERSION(): string | undefined { return process.env['AFK_XAI_GROK_CLIENT_VERSION']; },
   get AFK_XAI_OAUTH_BASE_URL(): string | undefined { return process.env['AFK_XAI_OAUTH_BASE_URL']; },
   get AFK_LOCAL_API_KEY(): string | undefined { return process.env['AFK_LOCAL_API_KEY']; },
   get AFK_LOCAL_BASE_URL(): string | undefined { return process.env['AFK_LOCAL_BASE_URL']; },


### PR DESCRIPTION
## Summary

Fixes #1104.

- Resolve the OAuth CLI-proxy x-grok-client-version header from a validated operator override, official Grok Build version file, or compatible fallback.
- Add AFK_XAI_GROK_CLIENT_VERSION as a non-secret model setting for future proxy version-floor increases.
- Preserve clientVersion only as an internal compatibility/test seam.
- Add deterministic dependency injection for environment lookup, home-directory resolution, and version-file reads.
- Regenerate the checked-in environment registry artifacts.

## Validation

- pnpm test: 910 test files passed; 17,395 tests passed; 3 skipped.
- pnpm lint: passed.
- pnpm audit:env:check: passed.
- pnpm scan:env:check: passed.
- git diff --check: passed.

## Live Verification Limitation

I exercised the source path with a distinct process-local AFK_XAI_GROK_CLIENT_VERSION=1.0.6 override and no AFK_MODEL override. The request reached cli-chat-proxy.grok.com and returned HTTP 403 for account credits/subscription entitlement, not the reported HTTP 426 version gate.

My SuperGrok Heavy usage was exhausted, so I could not complete a successful end-to-end Grok OAuth inference in agent-afk. The remaining live limitation is account entitlement, not the invalid CLI-version header addressed here.

## Attribution

Codex: gpt-5.6-terra (high)