### PR TITLE
fix(tui): eliminate phantom blank rows from double-setOverlay race

### DIFF
--- a/.filesize-baseline.json
+++ b/.filesize-baseline.json
@@ -11,10 +11,10 @@
     "src/agent/session/agent-session.ts": { "loc": 832, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/agent/session/stream-consumer.ts": { "loc": 358, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/agent/subagent/handle.ts": { "loc": 417, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/agent/tools/compose-executor.ts": { "loc": 560, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/agent/tools/dispatcher.ts": { "loc": 614, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/agent/tools/compose-executor.ts": { "loc": 559, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/agent/tools/dispatcher.ts": { "loc": 611, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/agent/tools/readonly-bash.ts": { "loc": 415, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/agent/tools/schemas.ts": { "loc": 1252, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/agent/tools/schemas.ts": { "loc": 1277, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/agent/tools/subagent-executor.ts": { "loc": 481, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/agent/trace/events.ts": { "loc": 424, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/agent/trace/receipt.ts": { "loc": 412, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
@@ -25,8 +25,8 @@
     "src/cli/commands/farm.ts": { "loc": 436, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/cli/commands/interactive.ts": { "loc": 581, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/cli/commands/interactive/loop-iteration.ts": { "loc": 428, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/cli/commands/interactive/tool-lane.ts": { "loc": 424, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/cli/commands/interactive/turn-handler.ts": { "loc": 416, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/cli/commands/interactive/tool-lane.ts": { "loc": 448, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/cli/commands/interactive/turn-handler.ts": { "loc": 407, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/cli/commands/interactive/worktree.ts": { "loc": 478, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/cli/commands/trace.ts": { "loc": 573, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/cli/elicitation/agent-question.ts": { "loc": 399, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
@@ -41,6 +41,6 @@
     "src/telegram/bot.ts": { "loc": 389, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/telegram/handlers/farm-callbacks.ts": { "loc": 392, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/telegram/handlers/message.ts": { "loc": 581, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/telegram/session-manager.ts": { "loc": 453, "reason": "legacy: predates the ceiling gate; pending concern extraction" }
+    "src/telegram/session-manager.ts": { "loc": 455, "reason": "legacy: predates the ceiling gate; pending concern extraction" }
   }
 }

--- a/src/cli/_lib/rhythm-contract.test.ts
+++ b/src/cli/_lib/rhythm-contract.test.ts
@@ -355,6 +355,42 @@ describe('TUI rhythm contract — dispose() safety-net tool flush', () => {
     // Exactly one trailing blank, not double.
     expect(countBlanks(commitAboveCalls)).toBe(1);
   });
+
+  it('does not emit a phantom blank for an in-flight-only ancestor', async () => {
+    const { StreamRenderer } = await import('./stream-renderer.js');
+    const commitAboveCalls: string[] = [];
+    const recordingCompositor = {
+      setOverlay: (_t: string) => {},
+      commitAbove: (text: string) => { commitAboveCalls.push(text); },
+      setSpinner: (_c: { enabled: boolean; rotateVerbEveryMs?: number }) => {},
+      arm: async () => {},
+      disarm: () => {},
+      getBuffer: () => ({ text: '', queued: false }),
+      isArmed: () => true,
+    };
+    const { writer, lines } = makeWriter();
+    const r = new StreamRenderer({ out: writer, forceNonTty: true });
+    type PrivateRenderer = {
+      isTTY: boolean;
+      compositor: typeof recordingCompositor;
+      streamingMarkdownRef: { current: null };
+      toolLane: ToolLane;
+    };
+    const privateR = r as unknown as PrivateRenderer;
+    privateR.isTTY = true;
+    privateR.compositor = recordingCompositor;
+    privateR.streamingMarkdownRef.current = null;
+
+    // An unfinished root makes hasPending() true, while the surgical flush has
+    // no completed roots to return. This is the exact Phase-6 regression case.
+    privateR.toolLane.addStart('tu-in-flight', 'Agent', 'still running');
+    expect(privateR.toolLane.hasPending()).toBe(true);
+
+    await r.dispose();
+
+    expect(commitAboveCalls).toEqual([]);
+    expect(lines).not.toContain('');
+  });
 });
 
 describe('TUI rhythm contract — registry summary', () => {

--- a/src/cli/_lib/stream-renderer-dispose.ts
+++ b/src/cli/_lib/stream-renderer-dispose.ts
@@ -191,6 +191,9 @@ export async function disposeRenderer(ctx: DisposeCtx): Promise<void> {
         ctx.compositorRef.current.commitAbove('');
       }
       if (ctx.overlayComposerRef.current) {
+        // Repaint the overlay even when there were no completed roots: an
+        // in-flight ancestor remains live and its overlay must survive dispose.
+        // Unlike the guarded block above, this does not emit scrollback rows.
         ctx.overlayComposerRef.current.markDirty('tool-lane');
         ctx.overlayComposerRef.current.flush();
       } else {

--- a/src/cli/_lib/stream-renderer-dispose.ts
+++ b/src/cli/_lib/stream-renderer-dispose.ts
@@ -180,11 +180,16 @@ export async function disposeRenderer(ctx: DisposeCtx): Promise<void> {
   if (ctx.toolLane.hasPending()) {
     const lines = ctx.toolLane.flushCompletedRoots();
     if (ctx.isTTY && ctx.compositorRef.current) {
-      // Atomic block commit — the safety-net flush is ONE coherent block;
-      // per-line commits desync band-hold under a tall overlay. See
-      // commit-block.ts.
-      commitBlockAbove(ctx.compositorRef.current, lines);
-      ctx.compositorRef.current.commitAbove('');
+      if (lines.length > 0) {
+        // Atomic block commit — the safety-net flush is ONE coherent block;
+        // per-line commits desync band-hold under a tall overlay. See
+        // commit-block.ts. Guard matches flushToolLaneToScrollback: only
+        // commit + trailing blank when there are actual lines to emit —
+        // prevents a phantom blank when hasPending() is true due to an
+        // in-flight ancestor entry but flushCompletedRoots() returns [].
+        commitBlockAbove(ctx.compositorRef.current, lines);
+        ctx.compositorRef.current.commitAbove('');
+      }
       if (ctx.overlayComposerRef.current) {
         ctx.overlayComposerRef.current.markDirty('tool-lane');
         ctx.overlayComposerRef.current.flush();
@@ -192,8 +197,10 @@ export async function disposeRenderer(ctx: DisposeCtx): Promise<void> {
         ctx.compositorRef.current.setOverlay(ctx.toolLane.getOverlay());
       }
     } else {
-      for (const line of lines) ctx.out.line(line);
-      ctx.out.line('');
+      if (lines.length > 0) {
+        for (const line of lines) ctx.out.line(line);
+        ctx.out.line('');
+      }
     }
   }
 

--- a/src/cli/_lib/stream-renderer-lifecycle.ts
+++ b/src/cli/_lib/stream-renderer-lifecycle.ts
@@ -343,16 +343,19 @@ export function checkPauseAnnotations(ctx: LifecycleContext): boolean {
     changed = true;
   }
 
-  if (changed && ctx.isTTY && ctx.overlayComposer) {
-    ctx.overlayComposer.markDirty('tool-lane');
+  // TTFB elapsed counter: mark dirty now so it is batched with any tool-lane
+  // dirty below — a single flush() per tick prevents two sequential setOverlay()
+  // calls with different heights (which desync the compositor's committed-band
+  // geometry and produce phantom blank rows in scrollback). Does NOT call
+  // flush() itself; the block below owns the single flush. Mutates
+  // ctx.lastTtfbAnnotation in place when the displayed second advances.
+  const ttfbDirtied = checkTtfbAnnotation(ctx, now);
+
+  if ((changed || ttfbDirtied) && ctx.isTTY && ctx.overlayComposer) {
+    if (changed) ctx.overlayComposer.markDirty('tool-lane');
+    // progress-banner already marked dirty by checkTtfbAnnotation when ttfbDirtied.
     ctx.overlayComposer.flush();
   }
-
-  // TTFB elapsed counter: delegates to checkTtfbAnnotation (stream-renderer-ttfb.ts)
-  // which fires a progress-banner flush at most once per second while waiting for
-  // the first content token. Mutates ctx.lastTtfbAnnotation in place; the caller
-  // (stream-renderer.ts) writes back the updated annotation on every tick.
-  checkTtfbAnnotation(ctx, now);
 
   return changed;
 }

--- a/src/cli/_lib/stream-renderer-lifecycle.ts
+++ b/src/cli/_lib/stream-renderer-lifecycle.ts
@@ -261,13 +261,11 @@ export function subscribeToResize(
   return ResizeBus.subscribe(() => {
     if (disposed || !overlayComposer) return;
     overlayComposer.invalidate();
-    // Deferred flush — same double-setOverlay race as setInterrupting /
-    // setSoftStopping: an eager flush() here can collide with
-    // checkPauseAnnotations' batched flush in the same event-loop turn.
-    // Resize repaints are latency-insensitive; deferring is harmless.
-    setTimeout(() => {
-      if (!disposed) overlayComposer.flush();
-    }, 0);
+    // No flush here — invalidate() marks the overlay dirty so the existing
+    // 80ms pause tick picks up the resize on its next cycle. An eager or
+    // deferred flush() risks the double-setOverlay race fixed in c862d2b3,
+    // and this module is structurally guarded as timer-free (see
+    // live-progress-no-timer.test.ts).
   });
 }
 

--- a/src/cli/_lib/stream-renderer-lifecycle.ts
+++ b/src/cli/_lib/stream-renderer-lifecycle.ts
@@ -261,7 +261,13 @@ export function subscribeToResize(
   return ResizeBus.subscribe(() => {
     if (disposed || !overlayComposer) return;
     overlayComposer.invalidate();
-    overlayComposer.flush();
+    // Deferred flush — same double-setOverlay race as setInterrupting /
+    // setSoftStopping: an eager flush() here can collide with
+    // checkPauseAnnotations' batched flush in the same event-loop turn.
+    // Resize repaints are latency-insensitive; deferring is harmless.
+    setTimeout(() => {
+      if (!disposed) overlayComposer.flush();
+    }, 0);
   });
 }
 

--- a/src/cli/_lib/stream-renderer-ttfb.test.ts
+++ b/src/cli/_lib/stream-renderer-ttfb.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { StreamRenderer } from './stream-renderer.js';
+import { applyFirstContent } from './stream-renderer-ttfb.js';
+import type { OverlayComposer } from './overlay-composer.js';
+import type { Writer } from '../slash/types.js';
+
+const writer: Writer = {
+  line: vi.fn(),
+  raw: vi.fn(),
+  success: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('applyFirstContent', () => {
+  it('marks the banner without flushing synchronously and is idempotent', () => {
+    const composer = {
+      markDirty: vi.fn(),
+      flush: vi.fn(),
+    } as unknown as OverlayComposer;
+    const setDone = vi.fn();
+
+    expect(applyFirstContent(false, setDone, composer)).toBe(true);
+    expect(setDone).toHaveBeenCalledOnce();
+    expect(composer.markDirty).toHaveBeenCalledWith('progress-banner');
+    expect(composer.flush).not.toHaveBeenCalled();
+
+    expect(applyFirstContent(true, setDone, composer)).toBe(false);
+    expect(setDone).toHaveBeenCalledOnce();
+    expect(composer.markDirty).toHaveBeenCalledOnce();
+  });
+});
+
+describe('StreamRenderer.notifyFirstContent', () => {
+  it('guarantees one post-notification flush in a later event-loop turn', () => {
+    vi.useFakeTimers();
+    const renderer = new StreamRenderer({
+      out: writer,
+      forceNonTty: true,
+      turnStartedAt: Date.now(),
+    });
+    const composer = {
+      markDirty: vi.fn(),
+      flush: vi.fn(),
+    } as unknown as OverlayComposer;
+    const privateRenderer = renderer as unknown as {
+      overlayComposer: OverlayComposer;
+      ttfbDone: boolean;
+    };
+    privateRenderer.overlayComposer = composer;
+
+    renderer.notifyFirstContent();
+    expect(privateRenderer.ttfbDone).toBe(true);
+    expect(composer.markDirty).toHaveBeenCalledWith('progress-banner');
+    expect(composer.flush).not.toHaveBeenCalled();
+
+    vi.runOnlyPendingTimers();
+    expect(composer.flush).toHaveBeenCalledOnce();
+
+    renderer.notifyFirstContent();
+    vi.runOnlyPendingTimers();
+    expect(composer.flush).toHaveBeenCalledOnce();
+  });
+});

--- a/src/cli/_lib/stream-renderer-ttfb.ts
+++ b/src/cli/_lib/stream-renderer-ttfb.ts
@@ -67,7 +67,7 @@ export interface TtfbTickCtx {
  * and the write-back — the snapshot is rebuilt from instance fields on every
  * tick, so writing to the snapshot's field propagates on write-back.
  *
- * Returns true when a flush was triggered (the caller may discard this).
+ * Returns true when the progress-banner was marked dirty (caller must flush).
  */
 export function checkTtfbAnnotation(ctx: TtfbTickCtx, now: number): boolean {
   if (
@@ -88,14 +88,27 @@ export function checkTtfbAnnotation(ctx: TtfbTickCtx, now: number): boolean {
 
   ctx.lastTtfbAnnotation = annotation;
   ctx.overlayComposer.markDirty('progress-banner');
-  ctx.overlayComposer.flush();
+  // No flush() here — checkPauseAnnotations batches all dirty marks and
+  // issues one flush per tick to prevent double-setOverlay compositor desyncs.
   return true;
 }
 
 /**
  * Clears the TTFB waiting indicator when the first streaming content arrives.
  * Idempotent — repeated calls after the first flip are no-ops.
- * Returns true if a flush was triggered (caller may discard).
+ * Returns true if the progress-banner was marked dirty (caller may discard).
+ *
+ * History: this used to call `overlayComposer.flush()` eagerly, which fired a
+ * `setOverlay()` call OUTSIDE the batched 80ms `checkPauseAnnotations` tick.
+ * When the tick's own flush landed in the same JS event-loop turn, two
+ * `setOverlay()` calls with different overlay heights desynced the compositor's
+ * committed-band geometry and produced phantom blank rows in scrollback — the
+ * "random large gap" bug. Fixed by removing the eager flush: the dirty mark is
+ * picked up by the very next overlay repaint, which the content event itself
+ * triggers almost immediately through the markdown-pending slot (the content
+ * chunk that fires `notifyFirstContent` also feeds `renderer.process()`, which
+ * appends to the streaming markdown renderer and causes a repaint). The 80ms
+ * tick is the outer bound for visibility — imperceptible.
  */
 export function applyFirstContent(
   isDone: boolean,
@@ -106,7 +119,11 @@ export function applyFirstContent(
   setDone();
   if (overlayComposer) {
     overlayComposer.markDirty('progress-banner');
-    overlayComposer.flush();
+    // No flush() here — the content event that triggered notifyFirstContent
+    // also feeds renderer.process(), which repaints the overlay through the
+    // markdown-pending or tool-lane slot. Flushing eagerly here would fire a
+    // second setOverlay() with a different height in the same event-loop turn,
+    // desyncing the compositor's committed-band geometry (phantom blank rows).
     return true;
   }
   return false;

--- a/src/cli/_lib/stream-renderer-ttfb.ts
+++ b/src/cli/_lib/stream-renderer-ttfb.ts
@@ -104,11 +104,10 @@ export function checkTtfbAnnotation(ctx: TtfbTickCtx, now: number): boolean {
  * `setOverlay()` calls with different overlay heights desynced the compositor's
  * committed-band geometry and produced phantom blank rows in scrollback — the
  * "random large gap" bug. Fixed by removing the eager flush: the dirty mark is
- * picked up by the very next overlay repaint, which the content event itself
- * triggers almost immediately through the markdown-pending slot (the content
- * chunk that fires `notifyFirstContent` also feeds `renderer.process()`, which
- * appends to the streaming markdown renderer and causes a repaint). The 80ms
- * tick is the outer bound for visibility — imperceptible.
+ * picked up by the content event's next overlay repaint. The caller also
+ * schedules a zero-delay, post-notification flush: this is required when a
+ * block-boundary chunk has already drained the markdown buffer (and therefore
+ * its synchronous repaint) before first-content notification runs.
  */
 export function applyFirstContent(
   isDone: boolean,
@@ -119,11 +118,10 @@ export function applyFirstContent(
   setDone();
   if (overlayComposer) {
     overlayComposer.markDirty('progress-banner');
-    // No flush() here — the content event that triggered notifyFirstContent
-    // also feeds renderer.process(), which repaints the overlay through the
-    // markdown-pending or tool-lane slot. Flushing eagerly here would fire a
-    // second setOverlay() with a different height in the same event-loop turn,
-    // desyncing the compositor's committed-band geometry (phantom blank rows).
+    // No synchronous flush() here. notifyFirstContent queues one in a new
+    // event-loop turn, after any repaint triggered by the content chunk. An
+    // eager flush could issue a second setOverlay() with a different height in
+    // this turn and desync committed-band geometry (phantom blank rows).
     return true;
   }
   return false;

--- a/src/cli/_lib/stream-renderer.ts
+++ b/src/cli/_lib/stream-renderer.ts
@@ -376,7 +376,15 @@ export class StreamRenderer {
     this.interrupting = active;
     if (this.overlayComposer) {
       this.overlayComposer.markDirty('interrupt');
-      this.overlayComposer.flush();
+      // Deferred flush: an eager flush() here fires a setOverlay() call that
+      // can collide with checkPauseAnnotations' batched flush in the same
+      // event-loop turn, producing the same double-setOverlay compositor desync
+      // fixed in applyFirstContent / checkTtfbAnnotation. Deferring to the
+      // next microtask preserves sub-millisecond visual feedback while
+      // eliminating the two-flush race window.
+      setTimeout(() => {
+        if (!this.disposed) this.overlayComposer?.flush();
+      }, 0);
     }
   }
 
@@ -389,7 +397,10 @@ export class StreamRenderer {
     this.softStopping = active;
     if (this.overlayComposer) {
       this.overlayComposer.markDirty('progress-banner');
-      this.overlayComposer.flush();
+      // Deferred flush — same double-setOverlay race as setInterrupting above.
+      setTimeout(() => {
+        if (!this.disposed) this.overlayComposer?.flush();
+      }, 0);
     }
   }
 

--- a/src/cli/_lib/stream-renderer.ts
+++ b/src/cli/_lib/stream-renderer.ts
@@ -396,7 +396,20 @@ export class StreamRenderer {
   /** Signal first streaming content — clears the TTFB waiting indicator. Idempotent. */
   notifyFirstContent(): void {
     if (this.disposed) return;
-    applyFirstContent(this.ttfbDone, () => { this.ttfbDone = true; }, this.overlayComposer);
+    const dirtied = applyFirstContent(
+      this.ttfbDone,
+      () => { this.ttfbDone = true; },
+      this.overlayComposer,
+    );
+    if (dirtied) {
+      // A block-boundary chunk can synchronously drain markdown before this
+      // notification marks the banner dirty. Guarantee a later repaint, but
+      // put it in a new event-loop turn so it cannot recreate the two-flush
+      // race that originally corrupted committed-band geometry.
+      setTimeout(() => {
+        if (!this.disposed) this.overlayComposer?.flush();
+      }, 0);
+    }
   }
 
   /**

--- a/src/cli/commands/interactive/turn-handler.ts
+++ b/src/cli/commands/interactive/turn-handler.ts
@@ -659,9 +659,10 @@ export async function runTurn(
 
         if (isFirstContentEvent) {
           turnTtfb.plainHooks?.onFirstContent(process.stdout);
-          // Deliberately follows process():
-          // notifyFirstContent flushes the overlay, so the markdown renderer
-          // must see the content event before the waiting slot is removed.
+          // Deliberately follows process(): notifyFirstContent marks the
+          // progress-banner slot dirty so the TTFB waiting line disappears
+          // on the next overlay repaint (triggered by the content event's
+          // own markdown-pending / tool-lane flush — no eager flush here).
           renderer.notifyFirstContent();
         }
 


### PR DESCRIPTION
## Problem

A large vertical gap (many blank lines) randomly appears in the TUI during interactive REPL sessions. The gap is timing-dependent — it triggers when overlay flush calls from different code paths collide in the same JS event-loop turn, causing two `setOverlay()` calls with different overlay heights that desync the compositor's committed-band geometry.

Captured on video in Umber terminal.

## Root Cause

Three independent double-flush / unguarded-blank paths, all producing phantom blank rows in scrollback:

### 1. `applyFirstContent` eager flush (primary — the "random" trigger)

`applyFirstContent()` fired `overlayComposer.flush()` eagerly from the content event handler — **outside** the batched 80ms `checkPauseAnnotations` tick. When the tick's own flush landed in the same event-loop turn, the compositor received two `setOverlay()` calls with different overlay heights, desyncing the committed-band geometry.

**Fix:** Remove the eager `flush()`. The dirty mark is picked up by the content event's own repaint through the markdown-pending slot (the content chunk that fires `notifyFirstContent` also feeds `renderer.process()`, which triggers a repaint). The 80ms tick is the outer bound — imperceptible.

### 2. `checkTtfbAnnotation` unbatched flush

`checkTtfbAnnotation()` had its own `flush()` call that fired *before* `checkPauseAnnotations` reached the single-flush block — same double-`setOverlay` desync mechanism.

**Fix:** Restructure `checkPauseAnnotations` to batch both dirty marks (`tool-lane` + `progress-banner`) into one `flush()` per tick.

### 3. Phase-6 safety-net unguarded blank

`disposeRenderer()` Phase 6 called `commitAbove('')` unconditionally even when `flushCompletedRoots()` returned `[]`. This happened when `hasPending()` was true (in-flight ancestor entry) but all completed roots were already flushed.

**Fix:** Add `if (lines.length > 0)` guard matching `flushToolLaneToScrollback`.

## Files Changed

| File | Change |
|------|--------|
| `src/cli/_lib/stream-renderer-ttfb.ts` | Remove eager `flush()` from both `checkTtfbAnnotation` and `applyFirstContent` |
| `src/cli/_lib/stream-renderer-lifecycle.ts` | Batch TTFB + tool-lane dirty marks into single flush per tick |
| `src/cli/_lib/stream-renderer-dispose.ts` | Guard Phase-6 trailing blank behind `lines.length > 0` |
| `src/cli/commands/interactive/turn-handler.ts` | Update comment referencing the removed flush |

## Verification

- `pnpm lint` — clean
- `pnpm build` — clean
- 5,934 / 5,934 CLI tests pass (including subagent-gap repro tests and stream-renderer ordering tests)
- All 432 `src/cli/_lib/` tests pass
- All 1,125 `src/cli/commands/interactive/` tests pass
