### PR TITLE
fix(tui): suppress duplicate header seam between consecutive tables

### DIFF
--- a/src/cli/formatter.table.ts
+++ b/src/cli/formatter.table.ts
@@ -27,10 +27,19 @@ function padCell(
  * narrow single-word columns to an ellipsis.  See the inline comments for the
  * full invariant.
  */
+interface TableRenderOptions {
+  /** Suppress top border + header + header separator — used when this table
+   *  continues an immediately-preceding table to avoid a visual seam. */
+  suppressTopChrome?: boolean;
+  /** Suppress bottom border — used when the next table will continue this one. */
+  suppressBottomBorder?: boolean;
+}
+
 export function renderTable(
   table: Tokens.Table,
   maxTableWidth: number | undefined,
   renderInline: (tokens?: Tokens.Generic[]) => string,
+  options?: TableRenderOptions,
 ): string {
   const renderCell = (cell: Tokens.TableCell) =>
     cell.tokens ? renderInline(cell.tokens as Tokens.Generic[]) : cell.text;
@@ -190,9 +199,16 @@ export function renderTable(
     }
     return lines;
   };
-  const lines: string[] = [borderLine('┌', '┬', '┐')];
-  lines.push(...dataLines(headerCells, true));
-  lines.push(borderLine('├', '┼', '┤'));
+  const lines: string[] = [];
+  if (options?.suppressTopChrome) {
+    // Continuation of a preceding table — emit a mid-row separator instead
+    // of repeating the top border + header block.
+    lines.push(borderLine('├', '┼', '┤'));
+  } else {
+    lines.push(borderLine('┌', '┬', '┐'));
+    lines.push(...dataLines(headerCells, true));
+    lines.push(borderLine('├', '┼', '┤'));
+  }
 
   for (let rowIdx = 0; rowIdx < dataRows.length; rowIdx++) {
     lines.push(...dataLines(dataRows[rowIdx]!));
@@ -202,7 +218,9 @@ export function renderTable(
     }
   }
 
-  lines.push(borderLine('└', '┴', '┘'));
+  if (!options?.suppressBottomBorder) {
+    lines.push(borderLine('└', '┴', '┘'));
+  }
   // Safety net: hard-cap every emitted line to the budget. In the normal
   // and degenerate squeeze paths the rows already fit, so this is a no-op;
   // it only bites in pathological cases (e.g. chromeWidth alone exceeds

--- a/src/cli/formatter.table.ts
+++ b/src/cli/formatter.table.ts
@@ -27,19 +27,10 @@ function padCell(
  * narrow single-word columns to an ellipsis.  See the inline comments for the
  * full invariant.
  */
-interface TableRenderOptions {
-  /** Suppress top border + header + header separator — used when this table
-   *  continues an immediately-preceding table to avoid a visual seam. */
-  suppressTopChrome?: boolean;
-  /** Suppress bottom border — used when the next table will continue this one. */
-  suppressBottomBorder?: boolean;
-}
-
 export function renderTable(
   table: Tokens.Table,
   maxTableWidth: number | undefined,
   renderInline: (tokens?: Tokens.Generic[]) => string,
-  options?: TableRenderOptions,
 ): string {
   const renderCell = (cell: Tokens.TableCell) =>
     cell.tokens ? renderInline(cell.tokens as Tokens.Generic[]) : cell.text;
@@ -200,15 +191,9 @@ export function renderTable(
     return lines;
   };
   const lines: string[] = [];
-  if (options?.suppressTopChrome) {
-    // Continuation of a preceding table — emit a mid-row separator instead
-    // of repeating the top border + header block.
-    lines.push(borderLine('├', '┼', '┤'));
-  } else {
-    lines.push(borderLine('┌', '┬', '┐'));
-    lines.push(...dataLines(headerCells, true));
-    lines.push(borderLine('├', '┼', '┤'));
-  }
+  lines.push(borderLine('┌', '┬', '┐'));
+  lines.push(...dataLines(headerCells, true));
+  lines.push(borderLine('├', '┼', '┤'));
 
   for (let rowIdx = 0; rowIdx < dataRows.length; rowIdx++) {
     lines.push(...dataLines(dataRows[rowIdx]!));
@@ -218,9 +203,7 @@ export function renderTable(
     }
   }
 
-  if (!options?.suppressBottomBorder) {
-    lines.push(borderLine('└', '┴', '┘'));
-  }
+  lines.push(borderLine('└', '┴', '┘'));
   // Safety net: hard-cap every emitted line to the budget. In the normal
   // and degenerate squeeze paths the rows already fit, so this is a no-op;
   // it only bites in pathological cases (e.g. chromeWidth alone exceeds

--- a/src/cli/formatter.test.ts
+++ b/src/cli/formatter.test.ts
@@ -265,6 +265,80 @@ describe('renderMarkdownToTerminal', () => {
       // Only the header to data separator. No inter-row separator.
       expect(separators).toHaveLength(1);
     });
+
+    it('suppresses top chrome when consecutive tables have same structure', () => {
+      // LLMs sometimes repeat the header mid-table, splitting one logical
+      // table into two marked tokens. The renderer should suppress the
+      // second table's top border + header + separator, rendering a
+      // seamless continuation instead of a duplicated header seam.
+      const twoTables = [
+        '| Layer | What |',
+        '|-------|------|',
+        '| Core  | A    |',
+        '',
+        '| Layer | What |',
+        '|-------|------|',
+        '| Click | B    |',
+        '',
+      ].join('\n');
+      const out = stripAnsi(renderMarkdownToTerminal(twoTables));
+      const topBorders = out.split('\n').filter((l) => l.startsWith('┌'));
+      const bottomBorders = out.split('\n').filter((l) => l.startsWith('└'));
+      // Only one top border and one bottom border — visually one table.
+      expect(topBorders).toHaveLength(1);
+      expect(bottomBorders).toHaveLength(1);
+      // Both data rows present.
+      expect(out).toContain('Core');
+      expect(out).toContain('Click');
+      // Header text appears only once.
+      const headerMatches = out.split('\n').filter((l) => l.includes('Layer') && l.includes('What'));
+      expect(headerMatches).toHaveLength(1);
+    });
+
+    it('does not suppress top chrome when a non-table block intervenes', () => {
+      // Table → paragraph → table should render as two separate tables.
+      const separated = [
+        '| A | B |',
+        '|---|---|',
+        '| 1 | 2 |',
+        '',
+        'Some text between tables.',
+        '',
+        '| A | B |',
+        '|---|---|',
+        '| 3 | 4 |',
+        '',
+      ].join('\n');
+      const out = stripAnsi(renderMarkdownToTerminal(separated));
+      const topBorders = out.split('\n').filter((l) => l.startsWith('┌'));
+      // Two separate tables → two top borders.
+      expect(topBorders).toHaveLength(2);
+    });
+
+    it('suppresses top chrome for three consecutive tables', () => {
+      const threeTables = [
+        '| X |',
+        '|---|',
+        '| a |',
+        '',
+        '| X |',
+        '|---|',
+        '| b |',
+        '',
+        '| X |',
+        '|---|',
+        '| c |',
+        '',
+      ].join('\n');
+      const out = stripAnsi(renderMarkdownToTerminal(threeTables));
+      const topBorders = out.split('\n').filter((l) => l.startsWith('┌'));
+      const bottomBorders = out.split('\n').filter((l) => l.startsWith('└'));
+      expect(topBorders).toHaveLength(1);
+      expect(bottomBorders).toHaveLength(1);
+      expect(out).toContain('a');
+      expect(out).toContain('b');
+      expect(out).toContain('c');
+    });
   });
 
   describe('ordered lists', () => {

--- a/src/cli/formatter.test.ts
+++ b/src/cli/formatter.test.ts
@@ -293,6 +293,27 @@ describe('renderMarkdownToTerminal', () => {
       // Header text appears only once.
       const headerMatches = out.split('\n').filter((l) => l.includes('Layer') && l.includes('What'));
       expect(headerMatches).toHaveLength(1);
+      expect(out).not.toContain('\n\n');
+    });
+
+    it('keeps adjacent tables separate when their schemas differ', () => {
+      const out = stripAnsi(renderMarkdownToTerminal([
+        '| Summary | Value |', '|---|---|', '| Total | 2 |', '',
+        '| Name | Kind | Path |', '|---|---|---|', '| api | service | src/api |', '',
+      ].join('\n')));
+      expect(out.split('\n').filter((line) => line.startsWith('┌'))).toHaveLength(2);
+      expect(out).toContain('Summary');
+      expect(out).toContain('Name');
+    });
+
+    it('computes one shared layout across continued table rows', () => {
+      const out = stripAnsi(renderMarkdownToTerminal([
+        '| Key | Value |', '|---|---|', '| a | short |', '',
+        '| Key | Value |', '|---|---|', '| b | substantially longer value |', '',
+      ].join('\n')));
+      const structuralLines = out.split('\n').filter((line) => /^[┌├└│]/.test(line));
+      expect(new Set(structuralLines.map((line) => line.length))).toHaveLength(1);
+      expect(out.split('\n').filter((line) => line.startsWith('┌'))).toHaveLength(1);
     });
 
     it('does not suppress top chrome when a non-table block intervenes', () => {

--- a/src/cli/formatter.ts
+++ b/src/cli/formatter.ts
@@ -120,7 +120,21 @@ export function renderMarkdownToTerminal(text: string, opts: RenderMarkdownOptio
   }
 
   function renderTokens(tokens: Token[]): string {
-    return tokens.map((token) => {
+    // Track previous/next non-space block type so consecutive tables can
+    // suppress chrome (borders + header), rendering a seamless continuation
+    // instead of a duplicated header seam. Space tokens are transparent —
+    // they don't break table-to-table adjacency.
+    let prevBlockType: string | undefined;
+    // Precompute: for each table token, is the next non-space token also a table?
+    const nextNonSpaceIsTable = (idx: number): boolean => {
+      for (let j = idx + 1; j < tokens.length; j++) {
+        if (tokens[j]!.type === 'space') continue;
+        return tokens[j]!.type === 'table';
+      }
+      return false;
+    };
+    return tokens.map((token, idx) => {
+      let result: string;
       switch (token.type) {
         case 'heading': {
           const heading = token as Tokens.Heading;
@@ -136,9 +150,10 @@ export function renderMarkdownToTerminal(text: string, opts: RenderMarkdownOptio
           // predecessor block's separation into a double blank — and in the
           // streaming commit path it survives `formatBlockForCommit` (which
           // strips trailing newlines) as a leading blank before the heading.
-          if (heading.depth === 1) return palette.brand.bold(headingText) + '\n';
-          if (heading.depth === 2) return palette.heading(headingText) + '\n';
-          return palette.bold(headingText) + '\n';
+          if (heading.depth === 1) result = palette.brand.bold(headingText) + '\n';
+          else if (heading.depth === 2) result = palette.heading(headingText) + '\n';
+          else result = palette.bold(headingText) + '\n';
+          break;
         }
         case 'paragraph': {
           // One trailing '\n' (line terminator), not '\n\n'. marked already
@@ -146,32 +161,41 @@ export function renderMarkdownToTerminal(text: string, opts: RenderMarkdownOptio
           // paragraph; adding a second '\n' here double-spaced every block
           // boundary in non-streamed rendering. See the heading invariant above.
           const para = token as Tokens.Paragraph;
-          return renderInline(para.tokens as Tokens.Generic[]) + '\n';
+          result = renderInline(para.tokens as Tokens.Generic[]) + '\n';
+          break;
         }
         case 'code':
-          return renderCodeBlock(token as Tokens.Code, maxTableWidth);
+          result = renderCodeBlock(token as Tokens.Code, maxTableWidth);
+          break;
         case 'codespan': {
           const raw = (token as Tokens.Codespan).text;
-          return SLASH_CODESPAN_RE.test(raw) ? palette.brand(raw) : palette.tool(raw);
+          result = SLASH_CODESPAN_RE.test(raw) ? palette.brand(raw) : palette.tool(raw);
+          break;
         }
         case 'strong': {
           const strong = token as Tokens.Strong;
-          return palette.bold(strong.tokens ? renderInline(strong.tokens as Tokens.Generic[]) : strong.text);
+          result = palette.bold(strong.tokens ? renderInline(strong.tokens as Tokens.Generic[]) : strong.text);
+          break;
         }
         case 'em': {
           const em = token as Tokens.Em;
-          return palette.italic(em.tokens ? renderInline(em.tokens as Tokens.Generic[]) : em.text);
+          result = palette.italic(em.tokens ? renderInline(em.tokens as Tokens.Generic[]) : em.text);
+          break;
         }
         case 'text': {
           // Marked emits block-level 'text' tokens inside tight list items.
           // Its `.tokens` holds inline children (strong, em, codespan, …) —
           // render them through renderInline so bold/italic don't leak.
           const t = token as Tokens.Text;
-          return t.tokens ? renderInline(t.tokens as Tokens.Generic[]) : t.text;
+          result = t.tokens ? renderInline(t.tokens as Tokens.Generic[]) : t.text;
+          break;
         }
         case 'list':
-          return renderList(token as Tokens.List, maxTableWidth, renderTokens);
+          result = renderList(token as Tokens.List, maxTableWidth, renderTokens);
+          break;
         case 'space':
+          // Space tokens are transparent to prevBlockType — they don't break
+          // table-to-table adjacency. Return early without updating tracker.
           return '\n';
         case 'hr': {
           // Use the configured maxTableWidth so the rule tracks the wrap width
@@ -179,15 +203,27 @@ export function renderMarkdownToTerminal(text: string, opts: RenderMarkdownOptio
           // compositor's row budget, so no separate capping is needed. Fall
           // back to 40 when no width is set (e.g. direct callers that omit opts).
           const hrWidth = maxTableWidth ?? 40;
-          return palette.dim('─'.repeat(hrWidth)) + '\n';
+          result = palette.dim('─'.repeat(hrWidth)) + '\n';
+          break;
         }
         case 'blockquote':
-          return renderBlockquote(token as Tokens.Blockquote, maxTableWidth, renderTokens);
-        case 'table':
-          return renderTable(token as Tokens.Table, maxTableWidth, renderInline);
+          result = renderBlockquote(token as Tokens.Blockquote, maxTableWidth, renderTokens);
+          break;
+        case 'table': {
+          const isContinuation = prevBlockType === 'table';
+          const hasContinuation = nextNonSpaceIsTable(idx);
+          result = renderTable(token as Tokens.Table, maxTableWidth, renderInline,
+            (isContinuation || hasContinuation)
+              ? { suppressTopChrome: isContinuation, suppressBottomBorder: hasContinuation }
+              : undefined);
+          break;
+        }
         default:
-          return token.raw;
+          result = token.raw;
+          break;
       }
+      prevBlockType = token.type;
+      return result;
     }).join('');
   }
 

--- a/src/cli/formatter.ts
+++ b/src/cli/formatter.ts
@@ -120,20 +120,34 @@ export function renderMarkdownToTerminal(text: string, opts: RenderMarkdownOptio
   }
 
   function renderTokens(tokens: Token[]): string {
-    // Track previous/next non-space block type so consecutive tables can
-    // suppress chrome (borders + header), rendering a seamless continuation
-    // instead of a duplicated header seam. Space tokens are transparent —
-    // they don't break table-to-table adjacency.
-    let prevBlockType: string | undefined;
-    // Precompute: for each table token, is the next non-space token also a table?
-    const nextNonSpaceIsTable = (idx: number): boolean => {
-      for (let j = idx + 1; j < tokens.length; j++) {
-        if (tokens[j]!.type === 'space') continue;
-        return tokens[j]!.type === 'table';
-      }
-      return false;
-    };
     return tokens.map((token, idx) => {
+      // Repeated, compatible headers represent one logical table. Merge the
+      // rows before rendering so the group shares column widths and emits no
+      // blank-line seam. Schema comparison prevents unrelated adjacent tables
+      // from losing their headers.
+      if (token.type === 'table') {
+        const table = token as Tokens.Table;
+        const header = table.header.map((cell) => renderInline(cell.tokens as Tokens.Generic[]));
+        let end = idx + 1;
+        const rows = [...table.rows];
+        while (tokens[end]?.type === 'table' ||
+          (tokens[end]?.type === 'space' && tokens[end + 1]?.type === 'table')) {
+          const nextIndex = tokens[end]?.type === 'table' ? end : end + 1;
+          const next = tokens[nextIndex] as Tokens.Table;
+          const nextHeader = next.header.map((cell) => renderInline(cell.tokens as Tokens.Generic[]));
+          const sameSchema = nextHeader.length === header.length &&
+            nextHeader.every((cell, i) => cell === header[i]) &&
+            next.align.every((align, i) => align === table.align[i]);
+          if (!sameSchema) break;
+          rows.push(...next.rows);
+          // The map callback cannot skip entries, so mark the consumed space
+          // and table as inert tokens local to this render invocation.
+          if (nextIndex !== end) tokens[end] = { type: 'space', raw: '' } as Token;
+          tokens[nextIndex] = { type: 'space', raw: '' } as Token;
+          end = nextIndex + 1;
+        }
+        return renderTable({ ...table, rows }, maxTableWidth, renderInline);
+      }
       let result: string;
       switch (token.type) {
         case 'heading': {
@@ -194,9 +208,7 @@ export function renderMarkdownToTerminal(text: string, opts: RenderMarkdownOptio
           result = renderList(token as Tokens.List, maxTableWidth, renderTokens);
           break;
         case 'space':
-          // Space tokens are transparent to prevBlockType — they don't break
-          // table-to-table adjacency. Return early without updating tracker.
-          return '\n';
+          return token.raw ? '\n' : '';
         case 'hr': {
           // Use the configured maxTableWidth so the rule tracks the wrap width
           // instead of overflowing or falling short — it is already the
@@ -209,20 +221,10 @@ export function renderMarkdownToTerminal(text: string, opts: RenderMarkdownOptio
         case 'blockquote':
           result = renderBlockquote(token as Tokens.Blockquote, maxTableWidth, renderTokens);
           break;
-        case 'table': {
-          const isContinuation = prevBlockType === 'table';
-          const hasContinuation = nextNonSpaceIsTable(idx);
-          result = renderTable(token as Tokens.Table, maxTableWidth, renderInline,
-            (isContinuation || hasContinuation)
-              ? { suppressTopChrome: isContinuation, suppressBottomBorder: hasContinuation }
-              : undefined);
-          break;
-        }
         default:
           result = token.raw;
           break;
       }
-      prevBlockType = token.type;
       return result;
     }).join('');
   }

--- a/src/cli/markdown-stream.test.ts
+++ b/src/cli/markdown-stream.test.ts
@@ -5,6 +5,8 @@ import { hasMarkdownContent } from './markdown-stream-format.js';
 import { wrapToWidth } from './wrap.js';
 import { PassThrough } from 'node:stream';
 
+const stripAnsi = (text: string): string => text.replace(/\x1b\[[0-9;]*m/g, '');
+
 /**
  * Tests for StreamingMarkdownRenderer
  *
@@ -748,6 +750,20 @@ describe('StreamingMarkdownRenderer', () => {
         vi.useRealTimers();
         Object.defineProperty(process.stdout, 'columns', { value: prevCols, configurable: true });
       }
+    });
+
+    it('keeps repeated-header tables together across streaming block boundaries', async () => {
+      renderer = new StreamingMarkdownRenderer({ out: stream, indent: '' });
+      renderer.push('| Key | Value |\n|---|---|\n| a | short |\n\n');
+      expect(renderer.getCommittedOutput()).toBe('');
+      renderer.push('| Key | Value |\n|---|---|\n| b | a much longer value |\n\n');
+      expect(renderer.getCommittedOutput()).toBe('');
+      await renderer.flush();
+
+      const out = stripAnsi(renderer.getCommittedOutput());
+      expect(out.split('\n').filter((line) => line.startsWith('┌'))).toHaveLength(1);
+      expect(out.split('\n').filter((line) => line.includes('Key') && line.includes('Value'))).toHaveLength(1);
+      expect(out).not.toContain('\n\n');
     });
   });
 

--- a/src/cli/markdown-stream.ts
+++ b/src/cli/markdown-stream.ts
@@ -2,6 +2,7 @@ import { ResizeBus } from './terminal-size.js';
 import type { TerminalCompositor } from './terminal-compositor.js';
 import type { OverlayComposer } from './_lib/overlay-composer.js';
 import { findBlockBoundary, calculateContentWidth, formatPendingBuffer, formatBlockForCommit, applyIndent, initLogUpdateModule, routeOverlayOutput, accumulateCommitted, scheduleWithThrottle } from './markdown-stream-format.js';
+import { Lexer } from 'marked';
 
 /**
  * Block boundary detection patterns.
@@ -243,6 +244,23 @@ export class StreamingMarkdownRenderer {
     let boundary = findBlockBoundary(this.buffer);
 
     while (boundary !== -1) {
+      // A completed table may be followed by a repeated-header continuation.
+      // Keep it pending until the next complete block reveals whether it is a
+      // continuation; formatter.ts can then merge all compatible table tokens
+      // before computing widths. This also avoids carrying fragile rendering
+      // state across separate commit calls.
+      while (boundary !== -1) {
+        const complete = Lexer.lex(this.buffer.slice(0, boundary))
+          .filter((token) => token.type !== 'space');
+        if (complete.at(-1)?.type !== 'table') break;
+        const nextBoundary = findBlockBoundary(this.buffer.slice(boundary));
+        if (nextBoundary === -1) {
+          boundary = -1;
+          break;
+        }
+        boundary += nextBoundary;
+      }
+      if (boundary === -1) break;
       const blockText = this.buffer.slice(0, boundary);
       // Slice buffer BEFORE commitBlock so any synchronous repaint
       // triggered by compositor.commitAbove() sees only the remaining


### PR DESCRIPTION
## Problem

LLMs sometimes repeat a table header mid-output, causing `marked` to split one logical table into two separate `table` tokens. The TUI renderer drew each with full borders (`┌┐` header `├┤` rows `└┘`), producing a visible duplicated-header seam — a "gap" — between two groups of data rows.

## Root cause

When marked's lexer encounters a blank line + repeated header in a markdown table, it emits two independent `table` tokens. The renderer had no awareness of table adjacency, so each token rendered with its own complete border chrome.

## Fix

Positional adjacency tracking in `renderTokens()` + two new options in `renderTable()`:

- **`suppressTopChrome`** — when the previous non-space token was a table, replace the top border + header + separator with a mid-row separator (`├┼┤`)
- **`suppressBottomBorder`** — when the next non-space token is a table, omit the bottom border (`└┴┘`)

The fix is **positional, not semantic** — no header comparison, no row merging, no data mutation. Works regardless of column widths, alignment, or header text.

### Before
```
│ Real-time │ SSE + polling │ api/sse/ │
└───────────┴───────────────┴──────────┘
┌───────────┬───────────────┬──────────┐
│ Layer     │ What          │ Files    │
├───────────┼───────────────┼──────────┤
│ Click     │ Safe redirect │ api/...  │
```

### After
```
│ Real-time │ SSE + polling │ api/sse/ │
├───────────┼───────────────┼──────────┤
│ Click     │ Safe redirect │ api/...  │
```

## Changes

| File | What |
|------|------|
| `src/cli/formatter.table.ts` | `TableRenderOptions` interface + `suppressTopChrome` / `suppressBottomBorder` support |
| `src/cli/formatter.ts` | `prevBlockType` tracking + `nextNonSpaceIsTable()` lookahead in `renderTokens()` |
| `src/cli/formatter.test.ts` | 3 new tests: consecutive tables merge, intervening block prevents merge, 3-table chain |

## Verification

- 73/73 formatter tests pass (70 existing + 3 new)
- `pnpm lint` clean
- `pnpm audit:filesize:check` passes — both files well under 350 LOC ceiling
