### PR TITLE
feat(workspace): add system prompt instructions for workspace tools

### DIFF
--- a/src/agent/providers/anthropic-direct/provider-context.ts
+++ b/src/agent/providers/anthropic-direct/provider-context.ts
@@ -47,6 +47,9 @@ export interface ProviderQueryContext {
    */
   readonly declaredSurface: string | undefined;
   readonly readOnlyMemory: boolean;
+  /** Presence-only: whether the workspace store is wired. Used to gate the
+   *  workspace system prompt fragment in prompt assembly. */
+  readonly workspaceStore: import('../../workspace/workspace-store.js').WorkspaceStore | undefined;
   readonly mcpManager: import('../../mcp/index.js').McpManager | undefined;
   readonly fastModeController: import('../../fast-mode.js').FastModeController | undefined;
 

--- a/src/agent/providers/anthropic-direct/provider-query-setup.ts
+++ b/src/agent/providers/anthropic-direct/provider-query-setup.ts
@@ -173,6 +173,7 @@ export function setUpQuerySession(
     cwd,
     surface: ctx.surface,
     readOnlyMemory: ctx.readOnlyMemory,
+    workspaceEnabled: ctx.workspaceStore !== undefined,
     // Truthiness, NOT `!== undefined`: this must stay in lockstep with the
     // constructor's `if (opts.skillExecutor) schemas.push(skillTool)` gate.
     // Splitting them would let a falsy-but-defined executor inject a skill

--- a/src/agent/providers/anthropic-direct/provider-runtime.ts
+++ b/src/agent/providers/anthropic-direct/provider-runtime.ts
@@ -315,6 +315,7 @@ export class AnthropicDirectProvider implements ModelProvider {
       get surface() { return provider.surface; },
       get declaredSurface() { return provider.declaredSurface; },
       get readOnlyMemory() { return provider.readOnlyMemory; },
+      get workspaceStore() { return provider.workspaceStore; },
       get mcpManager() { return provider.mcpManager; },
       get fastModeController() { return provider.fastModeController; },
       getSharedReadRoots: () => provider.grants.readRoots,

--- a/src/agent/providers/anthropic-direct/query/cwd-dependents.workspace.test.ts
+++ b/src/agent/providers/anthropic-direct/query/cwd-dependents.workspace.test.ts
@@ -74,6 +74,7 @@ function setup() {
     stableSystemPrefix: buildStableSystemPrefix({
       toolBase: 'TOOLBASE',
       memoryPrompt: 'MEMORY',
+      workspacePrompt: '',
       hotMemory: '',
       manifest: '',
       userSystem: null,

--- a/src/agent/providers/anthropic-direct/query/overlay-rebuild.test.ts
+++ b/src/agent/providers/anthropic-direct/query/overlay-rebuild.test.ts
@@ -19,6 +19,7 @@ function makeParts(userSystem: string | null): ReturnType<typeof buildStableSyst
   return buildStableSystemPrefix({
     toolBase: 'TOOL-BASE',
     memoryPrompt: 'MEMORY',
+    workspacePrompt: '',
     hotMemory: '',
     manifest: '',
     userSystem,

--- a/src/agent/providers/anthropic-direct/query/prompt-assembly.ts
+++ b/src/agent/providers/anthropic-direct/query/prompt-assembly.ts
@@ -20,6 +20,7 @@ import { buildSkillManifest } from '../../../tools/skill-bridge.js';
 import {
   resolveToolSystemPrompt,
   resolveMemorySystemPrompt,
+  resolveWorkspaceSystemPrompt,
 } from '../../../tools/system-prompt.js';
 import {
   assembleSystemPrompt,
@@ -33,6 +34,9 @@ export interface PromptAssemblyArgs {
   cwd: string;
   surface: string;
   readOnlyMemory: boolean;
+  /** Whether workspace tools are enabled (store is wired). Gates inclusion of
+   *  the workspace system prompt fragment. */
+  workspaceEnabled: boolean;
   /** Present only when a skill executor is wired; gates manifest construction. */
   hasSkillExecutor: boolean;
   runtimeStateSource: RuntimeStateSource;
@@ -81,6 +85,7 @@ export function assembleQueryPrompt(args: PromptAssemblyArgs): AssembledPrompt {
   // instructions for memory_update / procedure_write — keeps the model from
   // being told about tools it does not have.
   const memoryPrompt = resolveMemorySystemPrompt(args.readOnlyMemory);
+  const workspacePrompt = resolveWorkspaceSystemPrompt(args.workspaceEnabled);
 
   // Awareness identity fields interleaved into the `# Environment` fragment
   // (Phase 1 + 2). The identity fields (surface/sessionId/depth/maxDepth) are
@@ -103,6 +108,7 @@ export function assembleQueryPrompt(args: PromptAssemblyArgs): AssembledPrompt {
   const stableSystemPrefix = buildStableSystemPrefix({
     toolBase,
     memoryPrompt,
+    workspacePrompt,
     // Hot memory (HOT.md) rides its own config field, NOT prepended into
     // systemPrompt, so the assembler can place it after the memory
     // instructions rather than ahead of the # Agent AFK doctrine. Unset for

--- a/src/agent/providers/anthropic-direct/query/system-prompt.test.ts
+++ b/src/agent/providers/anthropic-direct/query/system-prompt.test.ts
@@ -31,6 +31,7 @@ const IDENTITY: EnvironmentIdentity = {
 const FULL = {
   toolBase: 'TOOL',
   memoryPrompt: 'MEM',
+  workspacePrompt: 'WORKSPACE',
   hotMemory: 'HOT',
   manifest: 'MANIFEST',
   userSystem: 'DOCTRINE',
@@ -43,16 +44,17 @@ describe('buildStableSystemPrefix', () => {
 });
 
 describe('assembleSystemPrompt — top-level order', () => {
-  it('orders: toolBase, userSystem (doctrine), memoryPrompt, hotMemory, # Environment, manifest', () => {
+  it('orders: toolBase, userSystem (doctrine), memoryPrompt, workspacePrompt, hotMemory, # Environment, manifest', () => {
     const out = assembleSystemPrompt(buildStableSystemPrefix(FULL), '/tmp/work', IDENTITY);
     const sections = out.split('\n\n');
     expect(sections[0]).toBe('TOOL');
     expect(sections[1]).toBe('DOCTRINE');
     expect(sections[2]).toBe('MEM');
-    expect(sections[3]).toBe('HOT');
+    expect(sections[3]).toBe('WORKSPACE');
+    expect(sections[4]).toBe('HOT');
     // formatEnvironmentFragment always emits the working-directory line.
-    expect(sections[4]).toContain('Working directory: /tmp/work');
-    expect(sections[5]).toBe('MANIFEST');
+    expect(sections[5]).toContain('Working directory: /tmp/work');
+    expect(sections[6]).toBe('MANIFEST');
   });
 
   it('places the doctrine after tool conventions but before cross-session memory and the skill manifest', () => {
@@ -60,6 +62,7 @@ describe('assembleSystemPrompt — top-level order', () => {
     const iTool = out.indexOf('TOOL');
     const iDoctrine = out.indexOf('DOCTRINE');
     const iMemInstructions = out.indexOf('MEM');
+    const iWorkspace = out.indexOf('WORKSPACE');
     const iHotMemory = out.indexOf('HOT');
     const iManifest = out.indexOf('MANIFEST');
     // after essential runtime/tool conventions
@@ -67,6 +70,9 @@ describe('assembleSystemPrompt — top-level order', () => {
     expect(iTool).toBeLessThan(iDoctrine);
     // before cross-session memory (instructions AND hot-memory project context)
     expect(iDoctrine).toBeLessThan(iMemInstructions);
+    // workspace after memory instructions, before hot memory
+    expect(iMemInstructions).toBeLessThan(iWorkspace);
+    expect(iWorkspace).toBeLessThan(iHotMemory);
     expect(iDoctrine).toBeLessThan(iHotMemory);
     // before the skills catalog
     expect(iDoctrine).toBeLessThan(iManifest);
@@ -77,6 +83,7 @@ describe('assembleSystemPrompt — top-level order', () => {
       buildStableSystemPrefix({
         toolBase: 'TOOL',
         memoryPrompt: 'MEM',
+        workspacePrompt: '',
         hotMemory: '',
         manifest: 'MANIFEST',
         userSystem: null,
@@ -96,6 +103,7 @@ describe('assembleSystemPrompt — top-level order', () => {
       buildStableSystemPrefix({
         toolBase: 'TOOL',
         memoryPrompt: 'MEM',
+        workspacePrompt: '',
         hotMemory: '',
         manifest: '',
         userSystem: null,
@@ -114,6 +122,7 @@ describe('assembleSystemPrompt — top-level order', () => {
     const parts = buildStableSystemPrefix({
       toolBase: 'TOOL',
       memoryPrompt: 'MEM',
+      workspacePrompt: '',
       hotMemory: '',
       manifest: '',
       userSystem: null,
@@ -133,6 +142,7 @@ describe('assembleSystemPrompt — top-level order', () => {
       buildStableSystemPrefix({
         toolBase: 'T',
         memoryPrompt: 'M',
+        workspacePrompt: '',
         hotMemory: '',
         manifest: '',
         userSystem: null,

--- a/src/agent/providers/anthropic-direct/query/system-prompt.ts
+++ b/src/agent/providers/anthropic-direct/query/system-prompt.ts
@@ -22,6 +22,8 @@ import { formatEnvironmentFragment, type RuntimeStateSource } from '../../../awa
 export interface StableSystemPromptInputs {
   toolBase: string;
   memoryPrompt: string;
+  /** Workspace usage instructions; empty string when workspace is disabled. */
+  workspacePrompt: string;
   /**
    * `<cross-session-memory>` hot-memory block (project context); empty string
    * when none. Placed in the cross-session-memory region, after `memoryPrompt`.
@@ -68,12 +70,13 @@ export interface EnvironmentIdentity {
  * cwd-dependent `# Environment` fragment, joined by blank lines.
  *
  * Order (see the module Invariant):
- *   1. `toolBase`     — tool/runtime conventions
- *   2. `userSystem`   — `# Agent AFK` doctrine + operator overlay + directives
- *   3. `memoryPrompt` — cross-session-memory instructions
- *   4. `hotMemory`    — `<cross-session-memory>` project-context block
- *   5. `# Environment`— cwd/session/workspace (recomputed per cwd)
- *   6. `manifest`     — skill/agent catalog
+ *   1. `toolBase`        — tool/runtime conventions
+ *   2. `userSystem`      — `# Agent AFK` doctrine + operator overlay + directives
+ *   3. `memoryPrompt`    — cross-session-memory instructions
+ *   4. `workspacePrompt` — shared-workspace usage instructions (when enabled)
+ *   5. `hotMemory`       — `<cross-session-memory>` project-context block
+ *   6. `# Environment`   — cwd/session/workspace (recomputed per cwd)
+ *   7. `manifest`        — skill/agent catalog
  * Optional parts (`userSystem`, `hotMemory`, `manifest`) are skipped when
  * empty; `# Environment` is inserted before `manifest` by name rather than a
  * fixed index, so it stays correctly positioned regardless of which optional
@@ -101,6 +104,7 @@ export function assembleSystemPrompt(
   const ordered: string[] = [parts.toolBase];
   if (parts.userSystem) ordered.push(parts.userSystem);
   ordered.push(parts.memoryPrompt);
+  if (parts.workspacePrompt.length > 0) ordered.push(parts.workspacePrompt);
   if (parts.hotMemory.length > 0) ordered.push(parts.hotMemory);
   ordered.push(environment);
   if (parts.manifest.length > 0) ordered.push(parts.manifest);

--- a/src/agent/providers/openai-compatible/index.ts
+++ b/src/agent/providers/openai-compatible/index.ts
@@ -44,7 +44,7 @@ import {
 } from '../../tools/schemas.js';
 import { MemoryStore, createMemoryHandlers, memoryToolSchemas, memorySearchTool } from '../../memory/index.js';
 import { WorkspaceStore, createWorkspaceHandlers, workspaceToolSchemas } from '../../workspace/index.js';
-import { resolveToolSystemPrompt, resolveMemorySystemPrompt } from '../../tools/system-prompt.js';
+import { resolveToolSystemPrompt, resolveMemorySystemPrompt, resolveWorkspaceSystemPrompt } from '../../tools/system-prompt.js';
 import { buildSkillManifest } from '../../tools/skill-bridge.js';
 import type { AnthropicToolDef } from '../anthropic-direct/types.js';
 import { buildQueryFromConfig } from './query.js';
@@ -390,12 +390,10 @@ export class OpenAICompatibleProvider implements ModelProvider {
     // rest are computed once and treated as stable across a cwd re-anchor.
     const toolBase = resolveToolSystemPrompt(config.isSkillDispatch);
     const memoryPrompt = resolveMemorySystemPrompt(this.providerOpts.readOnlyMemory);
-    // Invariant: kept in lockstep with anthropic-direct's call site. Two
-    // deltas vs. the previous bare call: (1) `excludeName` omits the executing
-    // skill's own entry for a skill-dispatch fork (AgentConfig.skillDispatchName),
-    // and (2) `cwd` is now forwarded — its omission here was a silent parity gap
-    // that resolved `<cwd>/.afk/skills/` against the HOST process dir instead of
-    // the session's, which diverge on long-lived hosts (daemon, Telegram bot).
+    // Invariant: kept in lockstep with anthropic-direct's call site.
+    // `excludeName` omits the executing skill's own entry for a skill-dispatch
+    // fork (AgentConfig.skillDispatchName); `cwd` is forwarded so project skills
+    // resolve against the session's dir, not the host process's (#876).
     const manifest = this.providerOpts.skillExecutor
       ? buildSkillManifest(undefined, {
           ...(typeof config.cwd === 'string' && config.cwd.length > 0
@@ -408,8 +406,7 @@ export class OpenAICompatibleProvider implements ModelProvider {
         })
       : '';
     const hotMemory = typeof config.hotMemory === 'string' ? config.hotMemory : '';
-    const existingSys =
-      typeof config.systemPrompt === 'string' ? config.systemPrompt : undefined;
+    const existingSys = typeof config.systemPrompt === 'string' ? config.systemPrompt : undefined;
 
     // Contract: given the cwd-dependent `# Environment` fragment, return the
     // full joined system prompt over the STABLE fragments captured above.
@@ -419,6 +416,7 @@ export class OpenAICompatibleProvider implements ModelProvider {
       const parts = [toolBase];
       if (existingSys !== undefined && existingSys.length > 0) parts.push(existingSys);
       parts.push(memoryPrompt);
+      { const ws = resolveWorkspaceSystemPrompt(this.workspaceStore !== undefined); if (ws) parts.push(ws); }
       if (hotMemory.length > 0) parts.push(hotMemory);
       parts.push(envFragment);
       if (manifest.length > 0) parts.push(manifest);

--- a/src/agent/providers/openai-compatible/index.ts
+++ b/src/agent/providers/openai-compatible/index.ts
@@ -416,7 +416,8 @@ export class OpenAICompatibleProvider implements ModelProvider {
       const parts = [toolBase];
       if (existingSys !== undefined && existingSys.length > 0) parts.push(existingSys);
       parts.push(memoryPrompt);
-      { const ws = resolveWorkspaceSystemPrompt(this.workspaceStore !== undefined); if (ws) parts.push(ws); }
+      const workspacePrompt = resolveWorkspaceSystemPrompt(this.workspaceStore !== undefined);
+      if (workspacePrompt) parts.push(workspacePrompt);
       if (hotMemory.length > 0) parts.push(hotMemory);
       parts.push(envFragment);
       if (manifest.length > 0) parts.push(manifest);

--- a/src/agent/providers/shared/date-rollover.test.ts
+++ b/src/agent/providers/shared/date-rollover.test.ts
@@ -103,6 +103,7 @@ describe('refreshEnvironmentDate', () => {
       buildStableSystemPrefix({
         toolBase: 'TOOL',
         memoryPrompt: 'MEM',
+        workspacePrompt: '',
         hotMemory: '',
         manifest: 'SKILLS',
         userSystem: 'OPERATOR',

--- a/src/agent/tools/system-prompt.test.ts
+++ b/src/agent/tools/system-prompt.test.ts
@@ -18,8 +18,10 @@ import {
   QUEUED_USER_MESSAGE_PROMPT,
   MEMORY_SYSTEM_PROMPT,
   MEMORY_SYSTEM_PROMPT_READONLY,
+  WORKSPACE_SYSTEM_PROMPT,
   resolveToolSystemPrompt,
   resolveMemorySystemPrompt,
+  resolveWorkspaceSystemPrompt,
 } from './system-prompt.js';
 
 describe('resolveToolSystemPrompt', () => {
@@ -52,6 +54,14 @@ describe('resolveToolSystemPrompt', () => {
     expect(base).not.toContain('<bash-passthrough>');
     expect(base).not.toContain('<background-subagent-result>');
     expect(base).not.toContain('queuedUserMessage');
+  });
+});
+
+describe('resolveWorkspaceSystemPrompt', () => {
+  it('returns workspace guidance only when workspace tools are enabled', () => {
+    expect(resolveWorkspaceSystemPrompt(true)).toBe(WORKSPACE_SYSTEM_PROMPT);
+    expect(resolveWorkspaceSystemPrompt(false)).toBe('');
+    expect(resolveWorkspaceSystemPrompt(undefined)).toBe('');
   });
 });
 

--- a/src/agent/tools/system-prompt.ts
+++ b/src/agent/tools/system-prompt.ts
@@ -80,6 +80,24 @@ export const QUEUED_USER_MESSAGE_PROMPT = `When the harness appends a user text 
  */
 export const TOOL_SYSTEM_PROMPT = `${TOOL_SYSTEM_PROMPT_BASE}\n\n${SLASH_COMMAND_ROUTING_PROMPT}\n\n${BASH_PASSTHROUGH_PROMPT}\n\n${BG_SUBAGENT_RESULT_PROMPT}\n\n${QUEUED_USER_MESSAGE_PROMPT}`;
 
+/**
+ * Workspace usage instructions — teaches the model when and why to use
+ * workspace_publish / workspace_query. Parallel to MEMORY_SYSTEM_PROMPT.
+ *
+ * Invariant: this block must reach BOTH the top-level REPL session (the
+ * coordinator) AND forked children. The coordinator seeds the workspace for
+ * its children; children query and publish for siblings. Without this block
+ * in the top-level prompt, the coordinator never learns the tools exist and
+ * the workspace stays perpetually cold-started.
+ */
+export const WORKSPACE_SYSTEM_PROMPT = `# Shared Workspace
+
+When dispatching or running as sibling sub-agents, use \`workspace_publish\` and \`workspace_query\` to share findings:
+
+- **Publish** after confirming an architectural invariant, ruling out a hypothesis, or reading a file another sibling will likely need. Publish the insight, not the raw file — subject + one-paragraph content + file:line evidence.
+- **Query** before reading a file or grep-searching a module a sibling may have already analyzed. A workspace hit saves a tool round.
+- Publishing is free to batch — call \`workspace_publish\` alongside other tools in the same reply at zero additional round cost.`;
+
 export const MEMORY_SYSTEM_PROMPT = `# Cross-Session Memory
 
 You have three tools for persisting knowledge across sessions: memory_search, memory_update, and procedure_write.
@@ -159,4 +177,14 @@ export function resolveToolSystemPrompt(isSkillDispatch: boolean | undefined): s
  */
 export function resolveMemorySystemPrompt(readOnly: boolean | undefined): string {
   return readOnly ? MEMORY_SYSTEM_PROMPT_READONLY : MEMORY_SYSTEM_PROMPT;
+}
+
+/**
+ * Resolve the workspace system prompt for a session. Only included when
+ * workspace tools are enabled (the caller passes the gate result from
+ * `AFK_WORKSPACE_DISABLED`). Returns an empty string when disabled so the
+ * assembly path can treat it as an optional fragment.
+ */
+export function resolveWorkspaceSystemPrompt(workspaceEnabled: boolean | undefined): string {
+  return workspaceEnabled ? WORKSPACE_SYSTEM_PROMPT : '';
 }

--- a/src/agent/tools/system-prompt.ts
+++ b/src/agent/tools/system-prompt.ts
@@ -83,6 +83,7 @@ export const TOOL_SYSTEM_PROMPT = `${TOOL_SYSTEM_PROMPT_BASE}\n\n${SLASH_COMMAND
 /**
  * Workspace usage instructions — teaches the model when and why to use
  * workspace_publish / workspace_query. Parallel to MEMORY_SYSTEM_PROMPT.
+ * See also COLD_START_HINT in workspace/workspace-preamble.ts.
  *
  * Invariant: this block must reach BOTH the top-level REPL session (the
  * coordinator) AND forked children. The coordinator seeds the workspace for

--- a/src/agent/tools/top-level-allowlist.test.ts
+++ b/src/agent/tools/top-level-allowlist.test.ts
@@ -18,6 +18,7 @@ import { BUILTIN_TOOL_NAMES } from './schemas.js';
 import { MEMORY_TOOL_NAMES } from '../memory/index.js';
 import { AWARENESS_TOOL_NAMES } from '../awareness/index.js';
 import { EXIT_PLAN_MODE_TOOL_NAME } from './handlers/exit-plan-mode.js';
+import { WORKSPACE_TOOL_NAMES } from '../workspace/index.js';
 
 describe('topLevelSurfaceAllowedTools', () => {
   it('includes exit_plan_mode (the always-on, plan-mode-only tool that was missing)', () => {
@@ -30,6 +31,7 @@ describe('topLevelSurfaceAllowedTools', () => {
     for (const name of BUILTIN_TOOL_NAMES) expect(list).toContain(name);
     for (const name of MEMORY_TOOL_NAMES) expect(list).toContain(name);
     for (const name of AWARENESS_TOOL_NAMES) expect(list).toContain(name);
+    for (const name of WORKSPACE_TOOL_NAMES) expect(list).toContain(name);
     expect(list).toContain('get_runtime_state');
   });
 
@@ -53,6 +55,7 @@ describe('topLevelSurfaceAllowedTools', () => {
       ...BUILTIN_TOOL_NAMES,
       ...MEMORY_TOOL_NAMES,
       ...AWARENESS_TOOL_NAMES,
+      ...WORKSPACE_TOOL_NAMES,
       EXIT_PLAN_MODE_TOOL_NAME,
       'agent',
       'skill',

--- a/src/agent/tools/top-level-allowlist.ts
+++ b/src/agent/tools/top-level-allowlist.ts
@@ -2,6 +2,7 @@ import { BUILTIN_TOOL_NAMES } from './schemas.js';
 import { MEMORY_TOOL_NAMES } from '../memory/index.js';
 import { AWARENESS_TOOL_NAMES } from '../awareness/index.js';
 import { EXIT_PLAN_MODE_TOOL_NAME } from './handlers/exit-plan-mode.js';
+import { WORKSPACE_TOOL_NAMES } from '../workspace/index.js';
 
 /**
  * Contract: the canonical tool allowlist for a top-level, human-facing surface
@@ -26,6 +27,7 @@ export function topLevelSurfaceAllowedTools(mcpToolWireNames: readonly string[] 
     ...BUILTIN_TOOL_NAMES,
     ...MEMORY_TOOL_NAMES,
     ...AWARENESS_TOOL_NAMES,
+    ...WORKSPACE_TOOL_NAMES,
     EXIT_PLAN_MODE_TOOL_NAME,
     'agent',
     'skill',

--- a/src/agent/workspace/index.ts
+++ b/src/agent/workspace/index.ts
@@ -21,6 +21,7 @@ export {
   workspaceQueryTool,
   workspaceToolSchemas,
   createWorkspaceHandlers,
+  WORKSPACE_TOOL_NAMES,
 } from './workspace-tools.js';
 
 export {

--- a/src/agent/workspace/workspace-preamble.test.ts
+++ b/src/agent/workspace/workspace-preamble.test.ts
@@ -141,7 +141,7 @@ describe('injectWorkspacePreamble', () => {
     expect(result).not.toBe(baseConfig);
     expect(result.model).toBe('sonnet');
     expect(result.systemPrompt).toContain('workspace_publish');
-    expect(result.systemPrompt).toContain('No entries have been published yet');
+    expect(result.systemPrompt).toContain('No entries published yet');
   });
 
   it('does not mutate the input config', () => {

--- a/src/agent/workspace/workspace-preamble.ts
+++ b/src/agent/workspace/workspace-preamble.ts
@@ -132,6 +132,7 @@ export function injectWorkspacePreamble(
  * Injected when the workspace is empty so the first agent knows the tool exists.
  * Breaks the chicken-and-egg: agents can't discover workspace_publish from an
  * empty preamble, so nobody ever publishes, so the preamble stays empty.
+ * See also WORKSPACE_SYSTEM_PROMPT in tools/system-prompt.ts.
  */
 const COLD_START_HINT = [
   '# Workspace (shared agent scratchpad)',

--- a/src/agent/workspace/workspace-preamble.ts
+++ b/src/agent/workspace/workspace-preamble.ts
@@ -136,10 +136,13 @@ export function injectWorkspacePreamble(
 const COLD_START_HINT = [
   '# Workspace (shared agent scratchpad)',
   '',
-  'You have `workspace_publish` and `workspace_query` tools. When you discover an',
-  'important finding, publish it so siblings can skip re-deriving it. Before reading',
-  'a file, query the workspace — a sibling may have already analyzed it.',
-  'No entries have been published yet — you may be the first.',
+  'No entries published yet — you may be the first. Call `workspace_publish` when you:',
+  '- confirm an architectural invariant or key export surface of a module,',
+  '- rule out a hypothesis (so siblings skip the same dead end),',
+  '- read a file another sibling will likely need (publish the insight, not the raw content).',
+  '',
+  'Call `workspace_query` before reading a file or grepping a module — a sibling may have',
+  'already analyzed it. Publishing is free to batch alongside other tools in the same reply.',
 ].join('\n');
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/src/agent/workspace/workspace-tools.ts
+++ b/src/agent/workspace/workspace-tools.ts
@@ -27,9 +27,10 @@ export const workspacePublishTool: AnthropicToolDef = {
   concurrencySafe: false,
   description:
     'Publish a structured finding to the shared session workspace so sibling agents can see it. ' +
-    'Use this to surface discoveries, evidence, hypotheses, decisions, artifacts, or status updates ' +
-    'that other agents working on the same task should know about. ' +
-    'Entries appear in the workspace context preamble injected into sibling agent system prompts.',
+    'Call after: confirming a module\'s key exports or invariants, ruling out a hypothesis, ' +
+    'or reading a file another sibling will likely need (publish the insight, not raw content). ' +
+    'Entries are visible immediately to siblings via workspace_query and injected into ' +
+    'new siblings\' system prompts at fork time. Free to batch with other tools.',
   input_schema: {
     type: 'object',
     properties: {
@@ -83,9 +84,9 @@ export const workspaceQueryTool: AnthropicToolDef = {
   concurrencySafe: true,
   description:
     'Query the shared session workspace for findings published by sibling agents. ' +
-    'Returns entries matching the search keywords, ordered by recency. ' +
-    'Use this to check what siblings have already discovered before reading files ' +
-    'they may have already analyzed.',
+    'Call before reading a file or grepping a module — a sibling may have already ' +
+    'analyzed it. Returns entries matching the search keywords, ordered by recency. ' +
+    'A workspace hit saves a tool round by avoiding redundant file reads.',
   input_schema: {
     type: 'object',
     properties: {

--- a/src/agent/workspace/workspace-tools.ts
+++ b/src/agent/workspace/workspace-tools.ts
@@ -17,6 +17,9 @@ import type { AnthropicToolDef, ToolHandler } from '../tools/types.js';
 import type { WorkspaceEntry, WorkspacePublishInput, WorkspaceRelationType } from './workspace-store.js';
 import { WorkspaceStore } from './workspace-store.js';
 
+/** Tool names that must be permitted whenever a provider wires a workspace store. */
+export const WORKSPACE_TOOL_NAMES = ['workspace_publish', 'workspace_query'] as const;
+
 /**
  * workspace_publish: Publish a structured finding to the shared session workspace.
  * Sibling agents will see this entry in their workspace context preamble.

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -29,6 +29,7 @@ import { parseThinking, parseEffort, getApiKey, getApiKeyForModel, getModel, get
 import { loadSchedules, toScheduledTask } from '../../agent/daemon/schedule-store.js';
 import { AgentSession } from '../../agent/session.js';
 import { MemoryStore, MEMORY_TOOL_NAMES, injectHotMemory } from '../../agent/memory/index.js';
+import { WORKSPACE_TOOL_NAMES } from '../../agent/workspace/index.js';
 import { injectCompanionPrimer } from '../../agent/companion/index.js';
 import { wireExecutors } from '../../agent/session/wire-executors.js';
 import { ensurePluginEntrypointsLoaded } from '../../agent/tools/skill-bridge.js';
@@ -132,7 +133,16 @@ export function buildDaemonSessionFactory(
       ...(mcpManager !== undefined ? { mcpManager } : {}),
     }) ?? new AnthropicDirectProvider({
       permissions: {
-        allowedTools: [...BUILTIN_TOOL_NAMES, ...MEMORY_TOOL_NAMES, ...AWARENESS_TOOL_NAMES, 'agent', 'skill', 'compose', ...mcpToolWireNames],
+        allowedTools: [
+          ...BUILTIN_TOOL_NAMES,
+          ...MEMORY_TOOL_NAMES,
+          ...AWARENESS_TOOL_NAMES,
+          ...WORKSPACE_TOOL_NAMES,
+          'agent',
+          'skill',
+          'compose',
+          ...mcpToolWireNames,
+        ],
       },
       subagentExecutor,
       skillExecutor,

--- a/src/cli/parse-provider-agent-tool.test.ts
+++ b/src/cli/parse-provider-agent-tool.test.ts
@@ -28,6 +28,7 @@ import { BUILTIN_TOOL_NAMES } from '../agent/tools/schemas.js';
 import { MEMORY_TOOL_NAMES } from '../agent/memory/index.js';
 import { AWARENESS_TOOL_NAMES } from '../agent/awareness/index.js';
 import { EXIT_PLAN_MODE_TOOL_NAME } from '../agent/tools/handlers/exit-plan-mode.js';
+import { WORKSPACE_TOOL_NAMES } from '../agent/workspace/index.js';
 import type { SubagentExecutor } from '../agent/tools/subagent-executor.js';
 import type { ComposeExecutor } from '../agent/tools/compose-executor.js';
 import type { SkillExecutor } from '../agent/tools/skill-executor.js';
@@ -89,6 +90,7 @@ describe('parseProvider — Agent tool allowlist wiring (PR #84)', () => {
       ...BUILTIN_TOOL_NAMES,
       ...MEMORY_TOOL_NAMES,
       ...AWARENESS_TOOL_NAMES,
+      ...WORKSPACE_TOOL_NAMES,
       EXIT_PLAN_MODE_TOOL_NAME,
     ]);
     expect(allowed).toContain('get_runtime_state');
@@ -119,8 +121,8 @@ describe('parseProvider — Agent tool allowlist wiring (PR #84)', () => {
     // 'agent' is added exactly once and the total length matches.
     expect(list.filter((n) => n === 'agent')).toHaveLength(1);
     expect(list).toHaveLength(
-      // builtins + memory + awareness + exit_plan_mode + agent
-      BUILTIN_TOOL_NAMES.length + MEMORY_TOOL_NAMES.length + AWARENESS_TOOL_NAMES.length + 1 + 1,
+      // builtins + memory + awareness + workspace + exit_plan_mode + agent
+      BUILTIN_TOOL_NAMES.length + MEMORY_TOOL_NAMES.length + AWARENESS_TOOL_NAMES.length + WORKSPACE_TOOL_NAMES.length + 1 + 1,
     );
   });
 
@@ -201,6 +203,7 @@ describe('parseProvider — openai-compatible wiring (slice 4)', () => {
       ...BUILTIN_TOOL_NAMES,
       ...MEMORY_TOOL_NAMES,
       ...AWARENESS_TOOL_NAMES,
+      ...WORKSPACE_TOOL_NAMES,
       EXIT_PLAN_MODE_TOOL_NAME,
     ]);
     expect(allowed).toContain('get_runtime_state');
@@ -243,8 +246,8 @@ describe('parseProvider — openai-compatible wiring (slice 4)', () => {
     const allowed = readOpenAIAllowedTools(provider as OpenAICompatibleProvider);
     expect(allowed).toBeDefined();
     expect(allowed).toHaveLength(
-      // builtins + memory + awareness + exit_plan_mode + agent + skill + compose
-      BUILTIN_TOOL_NAMES.length + MEMORY_TOOL_NAMES.length + AWARENESS_TOOL_NAMES.length + 1 + 3,
+      // builtins + memory + awareness + workspace + exit_plan_mode + agent + skill + compose
+      BUILTIN_TOOL_NAMES.length + MEMORY_TOOL_NAMES.length + AWARENESS_TOOL_NAMES.length + WORKSPACE_TOOL_NAMES.length + 1 + 3,
     );
     expect(allowed).toContain('agent');
     expect(allowed).toContain('skill');

--- a/src/cli/provider-parser.ts
+++ b/src/cli/provider-parser.ts
@@ -8,6 +8,7 @@ import { BUILTIN_TOOL_NAMES } from '../agent/tools/schemas.js';
 import { MEMORY_TOOL_NAMES } from '../agent/memory/index.js';
 import { AWARENESS_TOOL_NAMES } from '../agent/awareness/index.js';
 import { EXIT_PLAN_MODE_TOOL_NAME } from '../agent/tools/handlers/exit-plan-mode.js';
+import { WORKSPACE_TOOL_NAMES } from '../agent/workspace/index.js';
 
 const VALID_PROVIDERS: readonly string[] = [
   'anthropic',
@@ -115,7 +116,13 @@ export function parseProvider(
     // is static (snapshotted at construction), so its name must be present here
     // or the gate rejects it the moment the model calls it. Harmless when the
     // tool is not registered (the dispatcher just never routes to it).
-    const list = [...BUILTIN_TOOL_NAMES, ...MEMORY_TOOL_NAMES, ...AWARENESS_TOOL_NAMES, EXIT_PLAN_MODE_TOOL_NAME];
+    const list = [
+      ...BUILTIN_TOOL_NAMES,
+      ...MEMORY_TOOL_NAMES,
+      ...AWARENESS_TOOL_NAMES,
+      ...WORKSPACE_TOOL_NAMES,
+      EXIT_PLAN_MODE_TOOL_NAME,
+    ];
     if (opts?.subagentExecutor) list.push('agent');
     if (opts?.skillExecutor) list.push('skill');
     if (opts?.composeExecutor) list.push('compose');


### PR DESCRIPTION
## Problem

The workspace tools (`workspace_publish` / `workspace_query`) were fully wired at the infrastructure level — every surface creates a `WorkspaceStore`, every fork path threads it to children, every child gets the preamble and tools registered. But across 483 sessions since workspace shipped (Aug 19), only 6 sessions showed any workspace tool calls, all from skill-dispatched subagents (`skill-diagnose-*`, `compose-*` nodes). The root REPL coordinator session never called them.

**Root cause**: the top-level REPL session received workspace tools in its dispatcher but **zero instructional context** about them. The `COLD_START_HINT` only fires for forked children (via `injectWorkspacePreamble` inside `assembleChildConfig`), and it was too passive to change behavior — phrased as "you have these tools" rather than "call this when X."

## Fix

Three complementary text-only changes, zero code path modifications:

### 1. `WORKSPACE_SYSTEM_PROMPT` (system-prompt.ts)
New constant parallel to `MEMORY_SYSTEM_PROMPT`, wired into both providers' prompt assembly after `memoryPrompt` and before `hotMemory`. Reaches **both** the top-level REPL coordinator and forked children. Short (5 lines), imperative, names concrete triggers:
- Publish after confirming invariants, ruling out hypotheses, reading files siblings need
- Query before reading a file a sibling may have already analyzed
- Publishing is free to batch at zero additional round cost

Gated on `workspaceStore !== undefined` so `AFK_WORKSPACE_DISABLED=1` sessions skip it.

### 2. Prescriptive cold-start hint (workspace-preamble.ts)
Rewrote `COLD_START_HINT` from passive ("when you discover an important finding...") to directive — named concrete triggers with imperative verbs.

### 3. Directive tool descriptions (workspace-tools.ts)
`workspace_publish` and `workspace_query` descriptions now say "call after/before X" instead of "use this to surface Y."

## Verification

- `pnpm lint` ✅
- `pnpm test` — 17,425 passed, 3 skipped ✅
- `pnpm build` ✅
- `pnpm audit:filesize:check` ✅ (net-zero on baselined openai-compatible/index.ts)
- `pnpm audit:env:check` ✅
