### PR TITLE
fix(xai): enforce version floor on ~/.grok/version.json reads

### DIFF
--- a/src/agent/providers/xai/headers.test.ts
+++ b/src/agent/providers/xai/headers.test.ts
@@ -97,6 +97,42 @@ describe('resolveGrokCliIdentityHeaders', () => {
     expect(h['x-grok-client-version']).toBe(DEFAULT_GROK_CLI_COMPAT_VERSION);
     expect(h['x-grok-client-version']).not.toBe('agent-afk');
   });
+
+  it('falls through to DEFAULT when version file is below the floor (stale install)', () => {
+    // 0.1.200 is below the floor of 1.0.5 — must fall through to DEFAULT
+    const h = resolveGrokCliIdentityHeaders(
+      {},
+      deps({ readFile: () => JSON.stringify({ version: '0.1.200' }) }),
+    );
+    expect(h['x-grok-client-version']).toBe(DEFAULT_GROK_CLI_COMPAT_VERSION);
+  });
+
+  it('accepts a version file exactly at the floor', () => {
+    // 1.0.5 is exactly at floor — must be accepted as-is
+    const h = resolveGrokCliIdentityHeaders(
+      {},
+      deps({ readFile: () => JSON.stringify({ version: '1.0.5' }) }),
+    );
+    expect(h['x-grok-client-version']).toBe('1.0.5');
+  });
+
+  it('accepts a version file above the floor', () => {
+    // 2.3.1 is clearly above the floor — must be accepted
+    const h = resolveGrokCliIdentityHeaders(
+      {},
+      deps({ readFile: () => JSON.stringify({ version: '2.3.1' }) }),
+    );
+    expect(h['x-grok-client-version']).toBe('2.3.1');
+  });
+
+  it('does not floor the environment override (operator precedence contract)', () => {
+    // AFK_XAI_GROK_CLIENT_VERSION below the floor must still be honoured when set
+    const h = resolveGrokCliIdentityHeaders(
+      {},
+      deps({ readEnv: () => '0.1.200' }),
+    );
+    expect(h['x-grok-client-version']).toBe('0.1.200');
+  });
 });
 
 describe('readOfficialGrokCliVersion', () => {

--- a/src/agent/providers/xai/headers.ts
+++ b/src/agent/providers/xai/headers.ts
@@ -51,6 +51,17 @@ function validSemver(value: string | undefined): string | undefined {
   return trimmed && SEMVER_RE.test(trimmed) ? trimmed : undefined;
 }
 
+/** Returns `version` if it is ≥ `floor`, otherwise `undefined`. */
+function aboveFloor(version: string | undefined, floor: string): string | undefined {
+  if (!version) return undefined;
+  const parse = (s: string): number[] => s.split('.').map(Number);
+  const [vMaj = 0, vMin = 0, vPat = 0] = parse(version);
+  const [fMaj = 0, fMin = 0, fPat = 0] = parse(floor);
+  if (vMaj !== fMaj) return vMaj > fMaj ? version : undefined;
+  if (vMin !== fMin) return vMin > fMin ? version : undefined;
+  return vPat >= fPat ? version : undefined;
+}
+
 /** Read `~/.grok/version.json` written by the official Grok Build CLI. */
 export function readOfficialGrokCliVersion(deps: GrokCliHeaderDeps = {}): string | undefined {
   const readFile = deps.readFile ?? ((filePath: string) => readFileSync(filePath, 'utf-8'));
@@ -77,7 +88,7 @@ function resolveGrokCliVersion(
   return (
     validSemver(readEnv(GROK_CLI_VERSION_ENV))
     ?? validSemver(clientVersion)
-    ?? readOfficialGrokCliVersion(deps)
+    ?? aboveFloor(readOfficialGrokCliVersion(deps), DEFAULT_GROK_CLI_COMPAT_VERSION)
     ?? DEFAULT_GROK_CLI_COMPAT_VERSION
   );
 }


### PR DESCRIPTION
🤖 Automated fix (hourly issue sweep)

Closes #1245

## What changed

Added an `aboveFloor()` helper to `src/agent/providers/xai/headers.ts` that compares a resolved version against `DEFAULT_GROK_CLI_COMPAT_VERSION` and falls through to the default when the file version is below the proxy's minimum. This prevents a stale `~/.grok/version.json` (e.g. containing `0.1.200`) from shadowing the known-good default (`1.0.5`) and causing HTTP 426 rejections. The env override (`AFK_XAI_GROK_CLIENT_VERSION`) and `clientVersion` parameter are intentionally NOT floored — the operator precedence contract is preserved.

Added 4 test cases covering: below-floor fallthrough, exact-floor acceptance, above-floor acceptance, and env-override exemption.

## Test verification
- `pnpm lint` ✅
- `pnpm test` ✅ (912 files, 17,436 tests passed)

---
*Generated by the hourly issue-tackle automation — a maintainer will review before merge.*
