### PR TITLE
fix(verdict-card): populate structured fields and improve fallback display

### DIFF
--- a/src/agent/routing-directive.test.ts
+++ b/src/agent/routing-directive.test.ts
@@ -215,6 +215,7 @@ describe('assembleSystemPrompt', () => {
       expect(verdict?.kind).toBe('done');
       expect(verdict?.whatWasDone).toContain('CacheManager');
       expect(verdict?.evidence).toContain('47 tests');
+      expect(verdict?.whatChanged).toContain('src/cache/manager.ts created');
     });
 
     it('parses a Blocked response shaped like the directive prescribes', () => {

--- a/src/agent/routing-directive.ts
+++ b/src/agent/routing-directive.ts
@@ -100,26 +100,26 @@ export const END_OF_TURN_DIRECTIVE = `[end-of-turn protocol]
 Every turn must end in one externally identifiable terminal state. AFK users need inspectable artifacts, not ceremony. Write each bullet as a single sentence.
 
 **Done**
-- What was done
-- Evidence that exists, named by a durable location (file path, commit SHA, trace path, test output, or memory key) — never transcript-only
-- What changed in the world
-- Anything still pending or deferred, with why
+- What was done: <one-sentence summary>
+- Evidence: <durable location — file path, commit SHA, trace path, test output, or memory key; never transcript-only>
+- What changed: <world-state delta>
+- Deferred: <anything still pending, with why; or "none">
 - If files were written or edited but no \`git commit\` ran, say so explicitly — name the uncommitted paths and why (e.g. awaiting review); do not imply clean completion while the work sits uncommitted in the worktree.
 
 **Blocked**
-- What blocks
-- What must change to unblock
-- What has already been done
+- What blocks: <the blocker>
+- What must change to unblock: <the unblock condition>
+- What has already been done: <progress so far>
 
 **Asking**
-- One precise question
-- The assumption it resolves
-- What you will do once answered
+- Question: <one precise question>
+- Assumption it resolves: <what answering clarifies>
+- Once answered: <what you will do>
 
 **Interrupted**
-- What you were doing
-- Where state was saved
-- What resumption requires
+- What you were doing: <the in-progress task>
+- Where state was saved: <location>
+- What resumption requires: <prerequisites>
 
 Never end a turn mid-loop without one of these. The terminal-state heading must be the last block of the response, with no trailing prose after it.`;
 

--- a/src/cli/commands/interactive/terminal-state.test.ts
+++ b/src/cli/commands/interactive/terminal-state.test.ts
@@ -98,11 +98,12 @@ describe('parseTerminalState — recognition', () => {
 });
 
 describe('parseTerminalState — bullet field mapping', () => {
-  it('done: maps "What was done", "Evidence", "Deferred" via substring match', () => {
-    const text = `prose\n\nDone\n- What was done: built the parser\n- Evidence that exists: see tests/parse.test.ts\n- Pending: integrate with renderer`;
+  it('done: maps each labelled field independently via substring match', () => {
+    const text = `prose\n\nDone\n- What was done: built the parser\n- Evidence that exists: see tests/parse.test.ts\n- What changed in the world: terminal verdicts are now parsed\n- Pending: integrate with renderer`;
     const v = parseTerminalState(text);
     expect(v?.whatWasDone).toBe('built the parser');
     expect(v?.evidence).toBe('see tests/parse.test.ts');
+    expect(v?.whatChanged).toBe('terminal verdicts are now parsed');
     expect(v?.deferred).toBe('integrate with renderer');
   });
 

--- a/src/cli/commands/interactive/terminal-state.ts
+++ b/src/cli/commands/interactive/terminal-state.ts
@@ -45,8 +45,10 @@ export interface TerminalState {
   kind: TerminalKind;
   /** Done: "What was done". */
   whatWasDone?: string;
-  /** Done: "Evidence that exists" / "What changed in the world". */
+  /** Done: "Evidence that exists". */
   evidence?: string;
+  /** Done: "What changed in the world". */
+  whatChanged?: string;
   /** Done: "Anything still pending or deferred, with why". */
   deferred?: string;
   /** Blocked: "What blocks". */
@@ -242,8 +244,10 @@ function mapBulletsToFields(
       const out: Partial<TerminalState> = {};
       const whatWasDone = find('what was done', 'what i did', 'completed', 'done');
       if (whatWasDone !== undefined) out.whatWasDone = whatWasDone;
-      const evidence = find('evidence', 'what changed', 'change', 'artifact', 'output');
+      const evidence = find('evidence', 'artifact', 'output');
       if (evidence !== undefined) out.evidence = evidence;
+      const whatChanged = find('what changed', 'world-state', 'world state', 'change');
+      if (whatChanged !== undefined) out.whatChanged = whatChanged;
       const deferred = find('pending', 'deferred', 'follow-up', 'followup', 'next');
       if (deferred !== undefined) out.deferred = deferred;
       return out;

--- a/src/cli/commands/interactive/verdict-card.test.ts
+++ b/src/cli/commands/interactive/verdict-card.test.ts
@@ -124,12 +124,12 @@ describe('renderVerdictCard', () => {
     expect(out).toContain('finished everything');
   });
 
-  // ── Item #9: synthesized one-line fallback ────────────────────────────────
+  // ── Fallback body rendering ───────────────────────────────────────────────
   //
-  // When no structured rows are parsed, the card should display ONLY the first
-  // non-empty line of rawBody — not all prose lines. This keeps the card
-  // compact when the model wrote a paragraph as its verdict body.
-  it('shows only the first non-empty rawBody line when no labelled fields are present (Item #9)', () => {
+  // When no structured rows are parsed, the card shows up to 5 non-empty body
+  // lines so the verdict card still carries substance. Capped to keep the card
+  // from sprawling on long unstructured responses.
+  it('shows up to 5 non-empty rawBody lines when no labelled fields are present', () => {
     const state: TerminalState = {
       kind: 'done',
       rawBody: [
@@ -140,15 +140,30 @@ describe('renderVerdictCard', () => {
     };
     const out = stripAnsi(renderVerdictCard(state));
 
-    // First line present.
+    // All three lines present (under the 5-line cap).
     expect(out).toContain('This is the first line of the verdict.');
-    // Subsequent prose lines must NOT appear in the card — card is a glance
-    // surface, not a prose viewer.
-    expect(out).not.toContain('second line with more detail');
-    expect(out).not.toContain('third line');
+    expect(out).toContain('second line with more detail');
+    expect(out).toContain('third line');
   });
 
-  it('ignores leading blank lines when selecting the first rawBody line (Item #9)', () => {
+  it('caps fallback body at 5 lines', () => {
+    const state: TerminalState = {
+      kind: 'done',
+      rawBody: Array.from({ length: 8 }, (_, i) => `Line ${i + 1} of the body`).join('\n'),
+    };
+    const out = stripAnsi(renderVerdictCard(state));
+
+    // First 5 present.
+    for (let i = 1; i <= 5; i++) {
+      expect(out).toContain(`Line ${i} of the body`);
+    }
+    // Lines 6+ excluded.
+    expect(out).not.toContain('Line 6');
+    expect(out).not.toContain('Line 7');
+    expect(out).not.toContain('Line 8');
+  });
+
+  it('ignores leading blank lines when selecting fallback body lines', () => {
     const state: TerminalState = {
       kind: 'asking',
       rawBody: [
@@ -160,10 +175,9 @@ describe('renderVerdictCard', () => {
     };
     const out = stripAnsi(renderVerdictCard(state));
 
-    // The first *non-empty* line is used.
+    // Both non-empty lines present.
     expect(out).toContain('Which database should I use?');
-    // The blank/whitespace-only lines and follow-on prose must not appear.
-    expect(out).not.toContain('More context about the question');
+    expect(out).toContain('More context about the question');
   });
 
   it('falls back to "<kind> (no structured fields)" when rawBody is empty (Item #9)', () => {

--- a/src/cli/commands/interactive/verdict-card.test.ts
+++ b/src/cli/commands/interactive/verdict-card.test.ts
@@ -45,6 +45,7 @@ describe('renderVerdictCard', () => {
       kind: 'done',
       whatWasDone: 'shipped feature X',
       evidence: 'tests pass',
+      whatChanged: 'feature X is available to users',
       rawBody: '',
     };
     const out = stripAnsi(renderVerdictCard(state));
@@ -53,6 +54,8 @@ describe('renderVerdictCard', () => {
     expect(out).toContain('shipped feature X');
     expect(out).toContain('evidence');
     expect(out).toContain('tests pass');
+    expect(out).toContain('changed');
+    expect(out).toContain('feature X is available to users');
     expect(out).toContain('Objective satisfied');
   });
 

--- a/src/cli/commands/interactive/verdict-card.ts
+++ b/src/cli/commands/interactive/verdict-card.ts
@@ -174,6 +174,7 @@ function collectRows(state: TerminalState): Row[] {
     case 'done':
       push('done', state.whatWasDone);
       push('evidence', state.evidence);
+      push('changed', state.whatChanged);
       // Skip a deferred row that merely echoes the done field — models
       // sometimes emit identical text for both, producing a confusing
       // duplicate row in the card.

--- a/src/cli/commands/interactive/verdict-card.ts
+++ b/src/cli/commands/interactive/verdict-card.ts
@@ -112,17 +112,19 @@ export function renderVerdictCard(state: TerminalState): string {
   const lines: string[] = [top, blankRow];
 
   if (rows.length === 0) {
-    // No structured fields parsed. Item #9: synthesize a single-line summary
-    // from the first non-empty rawBody line rather than dumping all prose into
-    // the card — the card is a glance surface, not a prose viewer. The full
-    // assistant text is already in scrollback above this card.
-    //
-    // Using the first non-empty line (not the whole body) keeps the card
-    // compact on long unstructured responses (e.g. the model wrote a paragraph
-    // as its verdict body — a common failure mode when the system prompt isn't
-    // followed strictly). Full prose remains readable in scrollback.
-    const firstLine = state.rawBody.split('\n').find(l => l.trim().length > 0)?.trim() ?? '';
-    const summary = firstLine.length > 0 ? firstLine : `${state.kind} (no structured fields)`;
+    // No structured fields parsed — the model's bullets lacked the colon
+    // separator the parser needs, or it wrote free-form prose. Show up to
+    // MAX_FALLBACK_LINES non-empty body lines so the card still carries the
+    // substance of the verdict. Capping keeps the card from sprawling when the
+    // model wrote a long paragraph; the full text is always in scrollback.
+    const MAX_FALLBACK_LINES = 5;
+    const bodyLines = state.rawBody
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0)
+      .slice(0, MAX_FALLBACK_LINES);
+    const summary =
+      bodyLines.length > 0 ? bodyLines.join('\n') : `${state.kind} (no structured fields)`;
     const wrapped = wrapToWidth(renderCardLine(summary), innerW).split('\n');
     for (const wl of wrapped) {
       lines.push(pipe + '  ' + padDisplayRight(wl, innerW) + '  ' + pipe);


### PR DESCRIPTION
## Problem

The Done verdict card at the bottom of REPL turns often appeared nearly empty — showing just a single dim line instead of the structured content the model wrote.

**Root cause:** The end-of-turn directive told the model to write bullets without colons (`- What was done`) but the terminal-state parser requires a colon to split bullets into `{label, value}` pairs. Without colons, `mapBulletsToFields` skips every bullet (line 232: `if (b.label === '') continue;`), leaving all structured fields (`whatWasDone`, `evidence`, `deferred`) as `undefined`. The card fell back to showing only the first raw body line.

## Fix

Two complementary changes:

### 1. Directive uses colon format (primary fix)
`routing-directive.ts` — bullet labels now include colons so the parser can extract structured fields:
```
- What was done: <one-sentence summary>
- Evidence: <durable location>
- What changed: <world-state delta>
- Deferred: <anything pending, with why>
```

### 2. Improved fallback display (resilience)
`verdict-card.ts` — when no structured fields are parsed, show up to 5 non-empty body lines instead of only the first. Makes the card resilient even when models deviate from the colon format.

## Verification

- All 84 tests pass across `terminal-state.test.ts`, `verdict-card.test.ts`, and `routing-directive.test.ts`
- Existing end-to-end contract tests in `routing-directive.test.ts` already used colons — they continue passing
- Updated verdict-card tests to cover the new multi-line fallback behavior and the 5-line cap
- `pnpm lint` clean, `fix:pins:check` clean
