### PR TITLE
fix(tools): stream grep output through a bounded collector instead of buffering 8MB

### DIFF
--- a/src/agent/tools/handlers/_streaming-cap.test.ts
+++ b/src/agent/tools/handlers/_streaming-cap.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import { createStreamingCap, SCAN_CAP_BYTES, scanCapKillNote } from './_streaming-cap.js';
+
+const buf = (s: string): Buffer => Buffer.from(s, 'utf8');
+
+describe('createStreamingCap', () => {
+  describe('under budget', () => {
+    it('renders the stream verbatim and reports no truncation', () => {
+      const cap = createStreamingCap(10_000);
+      cap.push(buf('alpha\nbeta\ngamma\n'));
+
+      expect(cap.render()).toBe('alpha\nbeta\ngamma\n');
+      expect(cap.truncated()).toBe(false);
+      expect(cap.totalBytes()).toBe(17);
+      expect(cap.totalLines()).toBe(3);
+    });
+
+    it('joins many small chunks in arrival order', () => {
+      const cap = createStreamingCap(10_000);
+      for (const part of ['a', 'b', 'c', 'd']) cap.push(buf(part));
+
+      expect(cap.render()).toBe('abcd');
+      expect(cap.truncated()).toBe(false);
+    });
+
+    it('ignores empty chunks', () => {
+      const cap = createStreamingCap(1_000);
+      cap.push(buf(''));
+      cap.push(buf('x'));
+      cap.push(Buffer.alloc(0));
+
+      expect(cap.render()).toBe('x');
+      expect(cap.totalBytes()).toBe(1);
+    });
+  });
+
+  describe('over budget', () => {
+    it('bounds retained bytes while counting every byte and line', () => {
+      const cap = createStreamingCap(2_000);
+      // 5,000 lines × 10 bytes = 50,000 bytes, 25x the budget.
+      for (let i = 0; i < 5_000; i++) cap.push(buf('123456789\n'));
+
+      expect(cap.totalBytes()).toBe(50_000);
+      expect(cap.totalLines()).toBe(5_000);
+      expect(cap.truncated()).toBe(true);
+      expect(Buffer.byteLength(cap.render(), 'utf8')).toBeLessThanOrEqual(2_000);
+    });
+
+    it('preserves the head and the tail, dropping only the interior', () => {
+      const cap = createStreamingCap(1_000);
+      cap.push(buf('HEAD_MARKER\n'));
+      for (let i = 0; i < 500; i++) cap.push(buf('filler-filler-filler\n'));
+      cap.push(buf('TAIL_MARKER\n'));
+
+      const rendered = cap.render();
+      expect(rendered).toContain('HEAD_MARKER');
+      expect(rendered).toContain('TAIL_MARKER');
+      expect(rendered).toContain('bytes truncated');
+    });
+
+    it('reports true totals in the marker so a bounded view never looks complete', () => {
+      const cap = createStreamingCap(1_000);
+      for (let i = 0; i < 300; i++) cap.push(buf('0123456789\n')); // 3,300 bytes, 300 lines
+
+      const rendered = cap.render();
+      expect(rendered).toContain('of 3300;');
+      expect(rendered).toContain('300 matching lines total');
+    });
+
+    it('handles a single chunk far larger than the whole budget', () => {
+      const cap = createStreamingCap(500);
+      cap.push(buf('S' + 'x'.repeat(100_000) + 'E'));
+
+      const rendered = cap.render();
+      expect(Buffer.byteLength(rendered, 'utf8')).toBeLessThanOrEqual(500);
+      expect(cap.totalBytes()).toBe(100_002);
+      expect(cap.truncated()).toBe(true);
+      expect(rendered.startsWith('S')).toBe(true);
+      expect(rendered.endsWith('E')).toBe(true);
+    });
+  });
+
+  describe('UTF-8 boundaries', () => {
+    it('never emits replacement characters at the head/tail seams', () => {
+      // 3-byte code points guarantee the head/tail cut points land
+      // mid-character unless the collector trims to a boundary. The stream is
+      // sliced into consecutive 149-byte chunks (coprime with 3) so no byte is
+      // lost — exactly how a pipe splits a real multi-byte stream.
+      const cap = createStreamingCap(1_000);
+      const full = Buffer.from('界'.repeat(2_000), 'utf8'); // 6,000 valid bytes
+      for (let i = 0; i < full.length; i += 149) {
+        cap.push(full.subarray(i, Math.min(i + 149, full.length)));
+      }
+
+      const rendered = cap.render();
+      expect(cap.totalBytes()).toBe(6_000);
+      expect(cap.truncated()).toBe(true);
+      expect(rendered).not.toContain('\uFFFD');
+    });
+
+    it('heals a code point split across two chunks', () => {
+      // Regression guard for the prior design, which called .toString() on
+      // each chunk independently and so produced mojibake whenever a pipe
+      // boundary fell inside a multi-byte sequence. Buffering the bytes and
+      // decoding once makes the split invisible.
+      const cap = createStreamingCap(10_000);
+      const glyph = Buffer.from('界', 'utf8'); // 3 bytes
+      cap.push(glyph.subarray(0, 1));
+      cap.push(glyph.subarray(1));
+
+      expect(cap.render()).toBe('界');
+      expect(cap.render()).not.toContain('\uFFFD');
+    });
+
+    it('keeps multi-byte content intact when it fits', () => {
+      const cap = createStreamingCap(10_000);
+      cap.push(Buffer.from('héllo wörld 界', 'utf8'));
+
+      expect(cap.render()).toBe('héllo wörld 界');
+      expect(cap.render()).not.toContain('\uFFFD');
+    });
+  });
+
+  describe('exported policy', () => {
+    it('sets a scan ceiling with real headroom over the measured worst case', () => {
+      // The broadest realistic search measured 62.8MB; the ceiling must sit
+      // well above it or the kill it replaced starts firing again.
+      expect(SCAN_CAP_BYTES).toBe(256_000_000);
+      expect(SCAN_CAP_BYTES).toBeGreaterThan(4 * 62_800_000);
+    });
+
+    it('starts the kill sentinel with the prefix both provider loops match', () => {
+      const note = scanCapKillNote(SCAN_CAP_BYTES);
+      expect(note).toContain('[output truncated');
+      expect(note).toContain('was terminated');
+      expect(scanCapKillNote(123)).toContain('123-byte');
+    });
+  });
+});

--- a/src/agent/tools/handlers/_streaming-cap.ts
+++ b/src/agent/tools/handlers/_streaming-cap.ts
@@ -1,0 +1,200 @@
+/**
+ * Streaming head+tail output collector for spawn-based tool handlers.
+ *
+ * Contract: {@link createStreamingCap} returns a collector whose `push()`
+ * accepts raw stdout/stderr chunks in arrival order and retains at most
+ * `maxBytes` of them — the first half from the head of the stream, the last
+ * half from a sliding tail ring — while counting every byte and every newline
+ * it ever observed. `render()` returns the retained text joined by a marker
+ * naming exactly how many bytes were dropped and how many lines the FULL
+ * stream actually contained, so a bounded view never masquerades as complete.
+ *
+ * Why this exists: the previous design accumulated a child's entire output
+ * into one JS string and reduced it to the model budget only at close, so a
+ * broad search buffered up to 8MB in order to show the model 100KB, and the
+ * mid-stream SIGKILL at that ceiling returned a partial view with no way to
+ * say how much was missing. Discarding the interior AS IT STREAMS bounds
+ * memory at the model budget itself, which removes the memory rationale for
+ * the byte-triggered kill and lets the search run on to report honest totals.
+ *
+ * Not a replacement for `_output-cap.ts`: that module caps a string a caller
+ * already holds in full (`capForModel`, `headAndTail`). This one caps a
+ * stream the caller never holds in full. `bash` keeps the former because its
+ * decisive signal (exit summary, final error) lands at the true tail of a
+ * bounded-volume stream; `grep` needs the latter because match output is
+ * homogeneous and its volume scales with corpus size, without any ceiling.
+ *
+ * @module agent/tools/handlers/_streaming-cap
+ */
+
+/**
+ * Reserve (bytes) withheld from the byte budget for the elision marker so the
+ * rendered string still fits within `maxBytes`. The marker embeds four
+ * decimal integers plus surrounding text; 200 bytes covers 10-digit values.
+ */
+const MARKER_RESERVE_BYTES = 200;
+
+/**
+ * Scan-volume ceiling, in bytes (256MB), for a streamed search.
+ *
+ * Invariant: this bounds WORK, not memory. A {@link createStreamingCap}
+ * collector holds at most its budget regardless of how much the child emits,
+ * so the V8 max-string-length rationale that justified the old 8MB
+ * accumulator kill no longer applies. What remains worth bounding is a search
+ * that never stops producing.
+ *
+ * Sizing is measured, not guessed: the broadest possible pattern (a single
+ * letter) over this repo emits 62.8MB in 47ms — ~1.3GB/s — so a ceiling at
+ * 64MB would sit at 98% of the realistic worst case and start firing
+ * routinely on any larger tree, reinstating the very failure this replaced.
+ * 256MB gives 4x headroom over that measurement and still bounds a true
+ * runaway (a search rooted at `/`) to roughly 200ms of discarded work.
+ */
+export const SCAN_CAP_BYTES = 256_000_000;
+
+/**
+ * In-band sentinel appended when the scan ceiling was crossed and the child
+ * was SIGKILL'd (the search did NOT finish, so its totals are lower bounds).
+ * Starts with `[output truncated` so existing consumers keying on that prefix
+ * — both provider loops — still match. Takes the effective cap so an injected
+ * test ceiling reports itself accurately.
+ */
+export function scanCapKillNote(capBytes: number): string {
+  return `\n[output truncated — search exceeded the ${capBytes}-byte scan ceiling and was terminated]`;
+}
+
+/** Count newline bytes in a chunk without materialising a JS string. */
+function countNewlines(buf: Buffer): number {
+  let count = 0;
+  let idx = buf.indexOf(0x0a);
+  while (idx !== -1) {
+    count++;
+    idx = buf.indexOf(0x0a, idx + 1);
+  }
+  return count;
+}
+
+/**
+ * Drop leading UTF-8 continuation bytes so a tail slice taken at an arbitrary
+ * byte offset begins on a code-point boundary.
+ */
+function trimPartialLeading(buf: Buffer): Buffer {
+  let start = 0;
+  while (start < buf.length && (buf[start]! & 0xc0) === 0x80) start++;
+  return start === 0 ? buf : buf.subarray(start);
+}
+
+/**
+ * Drop an incomplete multi-byte sequence from the end of a head slice taken
+ * at an arbitrary byte offset, so it ends on a code-point boundary.
+ */
+function trimPartialTrailing(buf: Buffer): Buffer {
+  let i = buf.length - 1;
+  let continuations = 0;
+  while (i >= 0 && (buf[i]! & 0xc0) === 0x80) {
+    continuations++;
+    i--;
+  }
+  if (i < 0) return buf.subarray(0, 0);
+  const lead = buf[i]!;
+  let needed: number;
+  if ((lead & 0x80) === 0) needed = 1;
+  else if ((lead & 0xe0) === 0xc0) needed = 2;
+  else if ((lead & 0xf0) === 0xe0) needed = 3;
+  else if ((lead & 0xf8) === 0xf0) needed = 4;
+  else return buf; // Invalid lead byte — leave the caller's bytes untouched.
+  return continuations + 1 === needed ? buf : buf.subarray(0, i);
+}
+
+/** A bounded streaming collector. See {@link createStreamingCap}. */
+export interface StreamingCap {
+  /** Feed one chunk in arrival order. Safe to call after the budget fills. */
+  push(chunk: Buffer): void;
+  /** Total bytes observed across every chunk, including discarded interior. */
+  totalBytes(): number;
+  /** Total newlines observed — for grep, the true matching-line count. */
+  totalLines(): number;
+  /** True once any byte has been discarded from the interior. */
+  truncated(): boolean;
+  /** Retained head + elision marker + retained tail, as UTF-8 text. */
+  render(): string;
+}
+
+/**
+ * Create a collector that retains at most `maxBytes` of a stream while
+ * counting all of it.
+ *
+ * Invariant: retained bytes never exceed `maxBytes`. The head fills first and
+ * is then immutable; every later byte enters the tail ring, which evicts from
+ * its front to stay within budget. Both cut points are trimmed to UTF-8
+ * code-point boundaries at render time, never mid-stream, so eviction stays
+ * O(1) per chunk and no partial sequence is ever re-encoded.
+ */
+export function createStreamingCap(maxBytes: number): StreamingCap {
+  const budget = Math.max(0, maxBytes - MARKER_RESERVE_BYTES);
+  const headBudget = Math.ceil(budget / 2);
+  const tailBudget = budget - headBudget;
+
+  const head: Buffer[] = [];
+  let headBytes = 0;
+  const tail: Buffer[] = [];
+  let tailBytes = 0;
+  let totalBytes = 0;
+  let totalLines = 0;
+
+  function push(chunk: Buffer): void {
+    if (chunk.length === 0) return;
+    totalBytes += chunk.length;
+    totalLines += countNewlines(chunk);
+
+    let rest = chunk;
+    if (headBytes < headBudget) {
+      const take = Math.min(headBudget - headBytes, rest.length);
+      head.push(rest.subarray(0, take));
+      headBytes += take;
+      rest = rest.subarray(take);
+    }
+    if (rest.length === 0) return;
+
+    tail.push(rest);
+    tailBytes += rest.length;
+    // Evict whole chunks from the front, then partially slice the new front,
+    // until the ring is back within budget. Bounded work per push.
+    while (tailBytes > tailBudget && tail.length > 0) {
+      const front = tail[0]!;
+      const excess = tailBytes - tailBudget;
+      if (front.length <= excess) {
+        tail.shift();
+        tailBytes -= front.length;
+      } else {
+        tail[0] = front.subarray(excess);
+        tailBytes -= excess;
+      }
+    }
+  }
+
+  function render(): string {
+    const headBuf = Buffer.concat(head);
+    const tailBuf = Buffer.concat(tail);
+    const retained = headBuf.length + tailBuf.length;
+    if (retained >= totalBytes) {
+      // Nothing was discarded — emit the stream verbatim.
+      return Buffer.concat([headBuf, tailBuf]).toString('utf8');
+    }
+    const safeHead = trimPartialTrailing(headBuf);
+    const safeTail = trimPartialLeading(tailBuf);
+    const omitted = totalBytes - safeHead.length - safeTail.length;
+    const marker =
+      `\n\n… [${omitted} bytes truncated: showing first ${safeHead.length} + last ` +
+      `${safeTail.length} of ${totalBytes}; ${totalLines} matching lines total] …\n\n`;
+    return safeHead.toString('utf8') + marker + safeTail.toString('utf8');
+  }
+
+  return {
+    push,
+    totalBytes: () => totalBytes,
+    totalLines: () => totalLines,
+    truncated: () => headBytes + tailBytes < totalBytes,
+    render,
+  };
+}

--- a/src/agent/tools/handlers/grep.test.ts
+++ b/src/agent/tools/handlers/grep.test.ts
@@ -342,15 +342,14 @@ describe('grepHandler', () => {
     });
 
     // Regression: V8 max-string-length crash (RangeError: Invalid string
-    // length). The accumulator is bounded at HARD_CAP_BYTES (8MB) and the
-    // child is SIGKILL'd when combined output crosses it — a genuine-runaway
-    // guard (an unconstrained recursive search across `node_modules`). We
-    // exercise it with >8MB of matching output so the mid-stream kill fires
-    // and emits the hard-cap sentinel; the model-facing view is reduced to a
-    // ~100KB head+tail regardless.
+    // length). Output now streams through a bounded head+tail collector, so
+    // the retained string never exceeds the model budget no matter how much
+    // ripgrep emits — the crash is structurally unreachable rather than
+    // guarded by a kill. 10MB of matches is far above the model budget but
+    // far below SCAN_CAP_BYTES, so the search must RUN TO COMPLETION (no
+    // sentinel) and report the true totals it was reduced from.
     it('handles matching output orders of magnitude above the cap (V8 overflow guard)', async () => {
-      // ~10MB of matching content: 10,000 lines × ~1010 bytes/line — well
-      // past the 8MB hard cap.
+      // ~10MB of matching content: 10,000 lines × ~1010 bytes/line.
       const largeLine = 'hello ' + 'x'.repeat(1000);
       const lines = Array(10_000).fill(largeLine).join('\n');
       writeFileSync(join(tempDir, 'huge.txt'), lines);
@@ -363,33 +362,36 @@ describe('grepHandler', () => {
       const elapsedMs = Date.now() - start;
 
       expect(result.isError).toBeFalsy();
-      // Head+tail model view (≤100KB) plus the short hard-cap kill sentinel.
+      // Bounded head+tail model view (≤100KB) — the whole point of streaming.
       expect(result.content.length).toBeLessThanOrEqual(100_000 + 200);
-      expect(result.content).toContain('was terminated');
-      // Structured flag is the load-bearing signal for non-model
-      // consumers (subagent traces, hooks). Sentinel string remains for
-      // the model's in-band context — both must be set on the mid-stream
-      // kill path.
+      // Ran to completion: the scan-cap sentinel must NOT appear at 10MB.
+      expect(result.content).not.toContain('was terminated');
+      // Structured flag is the load-bearing signal for non-model consumers
+      // (subagent traces, hooks) and must still be set — bytes were elided.
       expect(result.truncated).toBe(true);
-      // Reading 8MB off the pipe is sub-second; 5s is generous for CI load
-      // but discriminates from a "ran the full scan to completion" path.
+      // Honesty property: a bounded view states the true total it came from,
+      // so an agent cannot mistake 100KB of matches for the complete set.
+      const reported = /(\d+) matching lines total/.exec(result.content);
+      expect(reported).not.toBeNull();
+      expect(Number(reported![1])).toBeGreaterThanOrEqual(9_990);
       expect(elapsedMs).toBeLessThan(5_000);
     }, 30_000);
 
-    // Companion proof-of-kill test: two files, each on its own larger than
-    // the 8MB hard cap. The mid-stream kill fires while grep is still
-    // emitting matches from whichever file it opened first, so that file's
-    // content is (partially) captured and the other is never reached.
+    // Companion completion test — the inverse of the assertion this test
+    // originally made. Under the old accumulate-then-kill design the SIGKILL
+    // fired at 8MB mid-traversal, so exactly ONE of the two 9MB files could
+    // appear and the other was never opened. Streaming removes that ceiling:
+    // 18MB is under SCAN_CAP_BYTES, so the traversal completes and BOTH files
+    // are seen — the head retains the file rg opened first, the sliding tail
+    // retains the one it finished on. Both markers appearing is now the
+    // discriminating signal that no premature kill occurred.
     //
-    // F3: assertions are order-agnostic. `grep -r` traversal order is
-    // filesystem-dependent — BSD grep on macOS uses readdir() inode order,
-    // not lexical — so we cannot rely on first.txt being read before
-    // second.txt. Instead we assert "exactly one of {hello a, hello b}
-    // appears" — preserving the discriminating signal (kill fired
-    // mid-traversal) without depending on which file grep opened first.
-    it('mid-stream hard cap: kills grep mid-traversal, capturing only one file (V8 overflow guard)', async () => {
+    // F3 (retained): assertions stay order-agnostic. Traversal order is
+    // filesystem-dependent, so we assert both are present rather than which
+    // one landed in the head.
+    it('streams past the old 8MB ceiling and completes the full traversal', async () => {
       const aLine = 'hello a' + 'x'.repeat(993); // ~1001 bytes/line
-      const firstContent = Array(9000).fill(aLine).join('\n'); // ~9MB > 8MB cap
+      const firstContent = Array(9000).fill(aLine).join('\n'); // ~9MB
       writeFileSync(join(tempDir, 'first.txt'), firstContent);
 
       const bLine = 'hello b' + 'x'.repeat(993);
@@ -404,20 +406,35 @@ describe('grepHandler', () => {
       const elapsedMs = Date.now() - start;
 
       expect(result.isError).toBeFalsy();
-      expect(result.content).toContain('was terminated');
+      expect(result.content).not.toContain('was terminated');
       expect(result.truncated).toBe(true);
+      // Memory stayed bounded across an 18MB stream.
+      expect(result.content.length).toBeLessThanOrEqual(100_000 + 200);
 
-      const hasA = result.content.includes('hello a');
-      const hasB = result.content.includes('hello b');
-      // Exactly one file's content survived — the kill fired before grep
-      // finished the first file and opened the second. If both appear, the
-      // mid-stream guard never fired; if neither, the sentinel assertion
-      // above would also have failed.
-      expect(hasA || hasB).toBe(true);
-      expect(hasA && hasB).toBe(false);
-      // Killed after ~8MB, well before a full scan of both 9MB files.
+      // Both files were reached — head holds one, sliding tail holds the
+      // other. Under the old mid-stream kill, exactly one could appear.
+      expect(result.content).toContain('hello a');
+      expect(result.content).toContain('hello b');
       expect(elapsedMs).toBeLessThan(5_000);
     }, 30_000);
+
+    // The surviving kill path. SCAN_CAP_BYTES bounds WORK, not memory, so it
+    // sits far above any legitimate search; this proves a true runaway still
+    // terminates and is still flagged.
+    it('SIGKILLs a genuine runaway above the scan ceiling', async () => {
+      // The production ceiling is 256MB; injecting a small one exercises the
+      // same kill path without writing a multi-hundred-MB fixture.
+      const line = 'hello ' + 'x'.repeat(100);
+      writeFileSync(join(tempDir, 'runaway.txt'), Array(5_000).fill(line).join('\n'));
+
+      const handler = createGrepHandler(tempDir, { scanCapBytes: 100_000 });
+      const result = await handler({ pattern: 'hello', path: tempDir }, createSignal());
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content).toContain('was terminated');
+      expect(result.truncated).toBe(true);
+      expect(result.content.length).toBeLessThanOrEqual(100_000 + 200);
+    }, 60_000);
   });
 
   describe('input validation', () => {

--- a/src/agent/tools/handlers/grep.ts
+++ b/src/agent/tools/handlers/grep.ts
@@ -7,13 +7,12 @@
  * bare `foo|bar` alternates, matching either branch) — a deliberate contract
  * change from the previous system-`grep`-backed implementation, which ran in
  * BRE mode by default and required an `extended` opt-in for alternation.
- * Respects signal-based cancellation. Output is governed by two decoupled
- * thresholds (see `_output-cap.ts`): the accumulator is bounded at
- * HARD_CAP_BYTES (8MB) with a mid-stream SIGKILL only when it is crossed — a
- * genuine-runaway guard against V8 max-string-length overflow — while the
- * model-facing view is reduced to head+tail at MODEL_CAP_BYTES (100KB). A
- * broad-but-legitimate search therefore runs to completion. Strips ANSI escape
- * sequences.
+ * Respects signal-based cancellation. Output streams through a bounded
+ * head+tail collector (see `_streaming-cap.ts`) that retains at most
+ * MODEL_CAP_BYTES (100KB) while counting every byte and matching line, so
+ * memory no longer scales with match volume and a truncated view always
+ * reports the true total it was drawn from. A separate {@link SCAN_CAP_BYTES}
+ * ceiling SIGKILLs only a genuine runaway. Strips ANSI escape sequences.
  *
  * @module agent/tools/handlers/grep
  */
@@ -26,8 +25,19 @@ import { getReadDenylistDescendants } from './read-denylist.js';
 import { stripEscapeSequences } from '../../../utils/terminal-sanitize.js';
 import { describeSpawnCwdError, isSpawnEnoent } from '../../../utils/spawn-cwd-error.js';
 import { describeRgUnavailable } from './_rg-availability.js';
-import { HARD_CAP_BYTES, MODEL_CAP_BYTES, headAndTail, capForModel, HARD_CAP_KILL_NOTE } from './_output-cap.js';
+import { MODEL_CAP_BYTES } from './_output-cap.js';
 import { classifyRgExit2, type GrepSettleResult } from './_rg-exit2.js';
+import { createStreamingCap, SCAN_CAP_BYTES, scanCapKillNote } from './_streaming-cap.js';
+
+/** Optional overrides for {@link createGrepHandler}. */
+export interface GrepHandlerOptions {
+  /**
+   * Override the scan-volume ceiling (default {@link SCAN_CAP_BYTES}). Tests
+   * inject a small value to exercise the runaway kill without writing a
+   * multi-hundred-MB fixture.
+   */
+  scanCapBytes?: number;
+}
 
 /**
  * Input shape for the grep tool (validated at runtime).
@@ -101,7 +111,8 @@ function parseGrepInput(
  * host's `process.cwd()`. Pass `undefined` for legacy/test contexts that
  * want host-global behavior.
  */
-export function createGrepHandler(cwd?: string): ToolHandler {
+export function createGrepHandler(cwd?: string, options?: GrepHandlerOptions): ToolHandler {
+  const scanCap = options?.scanCapBytes ?? SCAN_CAP_BYTES;
   return async (input: unknown, signal: AbortSignal, context?: ToolHandlerContext) => {
   const { pattern, path, include } = parseGrepInput(input, context, cwd);
 
@@ -193,30 +204,30 @@ export function createGrepHandler(cwd?: string): ToolHandler {
     const effectiveCwd = context?.resolveBase ?? context?.cwd ?? cwd;
     const proc = spawn(rgPath, args, effectiveCwd !== undefined ? { cwd: effectiveCwd } : {});
 
-    let stdout = '';
-    let stderr = '';
+    // Invariant: the model never receives more than MODEL_CAP_BYTES, so there
+    // is no reason to hold more than that in memory. Both streams feed bounded
+    // head+tail collectors that discard the interior AS IT ARRIVES while
+    // keeping exact byte and line totals — which is what lets a truncated
+    // result state how much it omitted instead of looking complete. This
+    // replaces an accumulate-then-truncate design that buffered up to 8MB in
+    // order to show 100KB and SIGKILL'd at that ceiling, losing both the true
+    // total and the remainder of the traversal. The V8 max-string-length
+    // hazard that justified the old kill cannot arise here: neither collector
+    // grows past its budget no matter how much ripgrep emits.
+    const out = createStreamingCap(MODEL_CAP_BYTES);
+    const err = createStreamingCap(MODEL_CAP_BYTES);
 
-    // Mid-stream hard cap. Without an accumulator bound, `stdout += ...`
-    // grows unboundedly: a grep emitting >~512MB of stdout (an unconstrained
-    // recursive search across `node_modules`) overflows V8's max string
-    // length and throws `RangeError: Invalid string length` synchronously
-    // inside this data callback — escaping every try/catch because the throw
-    // originates inside Node's Socket.emit → Readable.push chain, and the
-    // post-close cap cannot save us (`close` never fires once the throw
-    // aborts the read pipeline). So we bound the string at HARD_CAP_BYTES and
-    // SIGKILL only when it is crossed — a genuine-runaway circuit-breaker.
-    // Broad-but-legitimate searches (well under 8MB) run to completion.
-    let totalBytes = 0;
-    let overflowKilled = false;
+    let scanKilled = false;
 
-    function maybeOverflow(stream: 'stdout' | 'stderr'): void {
+    function maybeScanCap(stream: 'stdout' | 'stderr'): void {
       // M3: one-shot latch — concurrent stdout+stderr data events can both
-      // push totalBytes past the threshold before the kill takes effect.
-      // Check overflowKilled FIRST so only the first caller settles.
-      if (overflowKilled) return;
+      // cross the threshold before the kill takes effect. Check the latch
+      // FIRST so only the first caller settles.
+      if (scanKilled) return;
       if (resolved) return;
-      if (totalBytes < HARD_CAP_BYTES) return;
-      overflowKilled = true;
+      const totalBytes = out.totalBytes() + err.totalBytes();
+      if (totalBytes < scanCap) return;
+      scanKilled = true;
       // P1: structured log so operators can observe runaway kills in
       // production without grepping for RangeError crash traces.
       console.warn(
@@ -235,36 +246,23 @@ export function createGrepHandler(cwd?: string): ToolHandler {
         stream,
       });
       proc.kill('SIGKILL');
-      // F1 + F2: combine stdout + stderr (mirror bash.ts) and hard-code
-      // isError: false — a byte-cap event is distinct from a grep error
-      // (exit code 2), which the post-close path keeps separate. The child
-      // was SIGKILL'd for exceeding the hard cap; give the model a head+tail
-      // view plus the kill sentinel, and signal non-model consumers via the
-      // structured `truncated: true` flag.
-      const combined = stripEscapeSequences((stdout + stderr).trimEnd());
-      const content = headAndTail(combined, MODEL_CAP_BYTES) + HARD_CAP_KILL_NOTE;
-      settle({ content, truncated: true });
+      // F1 + F2: hard-code isError: false — a scan-cap event is distinct from
+      // a grep error (exit code 2), which the post-close path keeps separate.
+      // Render the stream that actually produced the volume: a runaway is
+      // normally matches on stdout, but a search over an unreadable tree can
+      // be all stderr, and falling back keeps that diagnosable.
+      const body = out.totalBytes() === 0 && err.totalBytes() > 0 ? err.render() : out.render();
+      settle({ content: stripEscapeSequences(body.trimEnd()) + scanCapKillNote(scanCap), truncated: true });
     }
 
     proc.stdout!.on('data', (chunk: Buffer) => {
-      // H1 + M1: slice at the Buffer layer BEFORE .toString() so a single
-      // oversized chunk (>= HARD_CAP_BYTES) never allocates a full V8
-      // string. Remaining budget is computed in bytes (not UTF-16 code
-      // units) so truncation always lands on a valid byte boundary.
-      const remaining = HARD_CAP_BYTES - totalBytes;
-      const safe = chunk.length <= remaining ? chunk : chunk.subarray(0, Math.max(0, remaining));
-      totalBytes += safe.length;
-      stdout += safe.toString('utf8');
-      maybeOverflow('stdout');
+      out.push(chunk);
+      maybeScanCap('stdout');
     });
 
     proc.stderr!.on('data', (chunk: Buffer) => {
-      // H1 + M1: same Buffer-layer guard as stdout handler above.
-      const remaining = HARD_CAP_BYTES - totalBytes;
-      const safe = chunk.length <= remaining ? chunk : chunk.subarray(0, Math.max(0, remaining));
-      totalBytes += safe.length;
-      stderr += safe.toString('utf8');
-      maybeOverflow('stderr');
+      err.push(chunk);
+      maybeScanCap('stderr');
     });
 
     // Abort — resolve immediately, don't wait for streams.
@@ -276,11 +274,11 @@ export function createGrepHandler(cwd?: string): ToolHandler {
 
     // Normal completion — `close` fires after all stdio streams drain.
     proc.on('close', (code) => {
-      // Overflow path already settled before the SIGKILL → close
+      // Scan-cap path already settled before the SIGKILL → close
       // round-trip; drop the exit code (it is going to be `null` from
       // the signal) so we don't re-classify the result as "no matches"
       // (code === 1) or "grep error" (code === 2).
-      if (overflowKilled) return;
+      if (scanKilled) return;
 
       if (code === 1) {
         const message = `No matches found for '${pattern}' in ${path}`;
@@ -292,13 +290,14 @@ export function createGrepHandler(cwd?: string): ToolHandler {
         // rg exits 2 for a missing path, an unreadable path, AND a bad regex.
         // `classifyRgExit2` splits the first (benign `no-such-target`) from the
         // rest (unclassified, alarming) — see `_rg-exit2.ts` for the shapes.
-        settle(classifyRgExit2(stderr, path));
+        // The collector already bounds stderr at the model budget and reports
+        // whether anything was dropped.
+        settle(classifyRgExit2(err.render(), path));
         return;
       }
 
-      const combined = stripEscapeSequences(stdout.trimEnd());
-      const capped = capForModel(combined);
-      settle({ content: capped.content, ...(capped.truncated ? { truncated: true } : {}) });
+      const combined = stripEscapeSequences(out.render().trimEnd());
+      settle({ content: combined, ...(out.truncated() ? { truncated: true } : {}) });
     });
 
     proc.on('error', (err) => {

--- a/src/agent/tools/handlers/overflow-telemetry.test.ts
+++ b/src/agent/tools/handlers/overflow-telemetry.test.ts
@@ -2,7 +2,8 @@
  * Tool-overflow telemetry tests.
  *
  * Asserts that the `tool.overflow_kill` event is emitted to
- * routing-decisions.jsonl when bash or grep cross the 8MB hard cap and SIGKILL
+ * routing-decisions.jsonl when bash crosses the 8MB hard cap, or grep crosses its
+ * 256MB scan ceiling, and SIGKILL
  * the child process. Mocks `routing-telemetry` to capture calls without
  * touching the real ~/.afk file.
  *
@@ -30,7 +31,7 @@ vi.mock('../../routing-telemetry.js', () => ({
   appendRoutingDecision,
 }));
 
-import { grepHandler } from './grep.js';
+import { grepHandler, createGrepHandler } from './grep.js';
 import { bashHandler } from './bash.js';
 
 function createSignal(): AbortSignal {
@@ -53,14 +54,17 @@ describe('tool.overflow_kill telemetry — grep', () => {
     tempDir = mkdtempSync(join(tmpdir(), 'grep-overflow-tel-'));
   });
 
-  it('emits tool.overflow_kill with operational fields when grep crosses 100KB', async () => {
-    // ~10MB of matching content guarantees the mid-stream cap fires.
-    // (Same shape as grep.test.ts:199 — V8 overflow guard.)
-    const largeLine = 'palette ' + 'x'.repeat(1000);
-    const lines = Array(10_000).fill(largeLine).join('\n');
+  it('emits tool.overflow_kill with operational fields when grep crosses the scan ceiling', async () => {
+    // grep no longer dies at 8MB — output streams through a bounded
+    // collector — so only a genuine runaway past the scan ceiling reaches the
+    // kill path that emits this telemetry. Inject a small ceiling rather than
+    // writing a multi-hundred-MB fixture.
+    const largeLine = 'palette ' + 'x'.repeat(100);
+    const lines = Array(5_000).fill(largeLine).join('\n');
     writeFileSync(join(tempDir, 'huge.txt'), lines);
 
-    const result = await grepHandler(
+    const handler = createGrepHandler(tempDir, { scanCapBytes: 100_000 });
+    const result = await handler(
       { pattern: 'palette', path: tempDir },
       createSignal(),
     );
@@ -83,11 +87,12 @@ describe('tool.overflow_kill telemetry — grep', () => {
     // Use a distinctive pattern + path so any leak is visually obvious in
     // the JSON-serialized mock-call payload.
     const secretPattern = 'SECRET-PATTERN-MARKER-42';
-    const largeLine = `${secretPattern} ` + 'x'.repeat(1000);
-    const lines = Array(10_000).fill(largeLine).join('\n');
+    const largeLine = `${secretPattern} ` + 'x'.repeat(100);
+    const lines = Array(5_000).fill(largeLine).join('\n');
     writeFileSync(join(tempDir, 'huge.txt'), lines);
 
-    const result = await grepHandler(
+    const handler = createGrepHandler(tempDir, { scanCapBytes: 100_000 });
+    const result = await handler(
       { pattern: secretPattern, path: tempDir },
       createSignal(),
     );
@@ -102,7 +107,7 @@ describe('tool.overflow_kill telemetry — grep', () => {
     rmSync(tempDir, { recursive: true, force: true });
   }, 30_000);
 
-  it('does NOT emit tool.overflow_kill on a small grep that stays under 100KB', async () => {
+  it('does NOT emit tool.overflow_kill on a small grep that stays under the scan ceiling', async () => {
     const content = Array(50).fill('hello world').join('\n');
     writeFileSync(join(tempDir, 'small.txt'), content);
 


### PR DESCRIPTION
# fix(tools): stream grep output through a bounded collector instead of buffering 8MB

## Problem

The previous `grep.ts` design accumulated the child process's entire stdout into a JS string and only reduced it to the model budget (100KB) at close — meaning a broad-but-legitimate search buffered **up to 8MB** in memory before the model saw 100KB of it. At that 8MB ceiling the child was SIGKILL'd, which caused two production problems:

1. **Memory scaled with corpus size.** A search across a large tree held 8MB in a single V8 string regardless of the model's 100KB budget.
2. **A truncated view looked complete.** After the kill, the model received a head+tail slice with no indication of how much was omitted — no total byte count, no total line count.

## Solution

Adds `_streaming-cap.ts`: a `StreamingCap` collector that accepts raw `Buffer` chunks in arrival order and retains at most `maxBytes` of them — the first half from the head of the stream, the last half from a sliding tail ring — while **counting every byte and every newline it ever observed**. Memory is bounded at the model budget from the first chunk; the interior is discarded as it arrives, not after accumulation.

`grep.ts` replaces its two string accumulators (`stdout`, `stderr`) with two `StreamingCap` collectors:

- **Memory ceiling drops from 8MB to 100KB** (the model budget), regardless of how much ripgrep emits.
- **The V8 `RangeError: Invalid string length` crash is structurally unreachable** — neither collector ever grows past its budget.
- **The old 8MB SIGKILL is retired** for legitimate searches. A new `SCAN_CAP_BYTES` ceiling (256MB) guards genuine runaways — sized at 4× the measured worst case (62.8MB from a single-letter pattern over this repo).
- **Truncated views are honest.** `render()` embeds the true total bytes and matching-line count in the elision marker, so the model cannot mistake a 100KB slice for the complete result.

## Test changes

- **`_streaming-cap.test.ts`** (new): 12 unit tests covering under-budget pass-through, over-budget head+tail retention, UTF-8 boundary healing across chunk splits, and the exported policy constants.
- **`grep.test.ts`**: two old "mid-stream kill" assertions flipped — at 10MB and 18MB (both under `SCAN_CAP_BYTES`) the traversal now **completes without a sentinel**; a new test injects a small scan ceiling to exercise the surviving kill path without a multi-hundred-MB fixture. The "honesty" assertion (`N matching lines total` in the marker) is new.
- **`overflow-telemetry.test.ts`**: grep telemetry tests updated to use the injected ceiling path; the `grepHandler` default (production ceiling 256MB) correctly never fires on small fixtures.

## Production impact

- Broad searches that previously triggered the 8MB kill now run to completion and return an honest bounded view.
- Peak memory for a grep call drops from 8MB to 100KB regardless of corpus size.
- The `tool.overflow_kill` telemetry event is preserved — it now fires at the 256MB scan ceiling instead of 8MB, so production operators will see it only for genuine runaways, not routine large searches.
