### PR TITLE
fix(verdict-card): preserve and render Done 'What changed' field

### DIFF
--- a/src/agent/routing-directive.test.ts
+++ b/src/agent/routing-directive.test.ts
@@ -215,6 +215,7 @@ describe('assembleSystemPrompt', () => {
       expect(verdict?.kind).toBe('done');
       expect(verdict?.whatWasDone).toContain('CacheManager');
       expect(verdict?.evidence).toContain('47 tests');
+      expect(verdict?.whatChanged).toContain('src/cache/manager.ts created');
     });
 
     it('parses a Blocked response shaped like the directive prescribes', () => {

--- a/src/cli/commands/interactive/terminal-state.test.ts
+++ b/src/cli/commands/interactive/terminal-state.test.ts
@@ -98,11 +98,12 @@ describe('parseTerminalState — recognition', () => {
 });
 
 describe('parseTerminalState — bullet field mapping', () => {
-  it('done: maps "What was done", "Evidence", "Deferred" via substring match', () => {
-    const text = `prose\n\nDone\n- What was done: built the parser\n- Evidence that exists: see tests/parse.test.ts\n- Pending: integrate with renderer`;
+  it('done: maps each labelled field independently via substring match', () => {
+    const text = `prose\n\nDone\n- What was done: built the parser\n- Evidence that exists: see tests/parse.test.ts\n- What changed in the world: terminal verdicts are now parsed\n- Pending: integrate with renderer`;
     const v = parseTerminalState(text);
     expect(v?.whatWasDone).toBe('built the parser');
     expect(v?.evidence).toBe('see tests/parse.test.ts');
+    expect(v?.whatChanged).toBe('terminal verdicts are now parsed');
     expect(v?.deferred).toBe('integrate with renderer');
   });
 

--- a/src/cli/commands/interactive/terminal-state.ts
+++ b/src/cli/commands/interactive/terminal-state.ts
@@ -45,8 +45,10 @@ export interface TerminalState {
   kind: TerminalKind;
   /** Done: "What was done". */
   whatWasDone?: string;
-  /** Done: "Evidence that exists" / "What changed in the world". */
+  /** Done: "Evidence that exists". */
   evidence?: string;
+  /** Done: "What changed in the world". */
+  whatChanged?: string;
   /** Done: "Anything still pending or deferred, with why". */
   deferred?: string;
   /** Blocked: "What blocks". */
@@ -242,8 +244,10 @@ function mapBulletsToFields(
       const out: Partial<TerminalState> = {};
       const whatWasDone = find('what was done', 'what i did', 'completed', 'done');
       if (whatWasDone !== undefined) out.whatWasDone = whatWasDone;
-      const evidence = find('evidence', 'what changed', 'change', 'artifact', 'output');
+      const evidence = find('evidence', 'artifact', 'output');
       if (evidence !== undefined) out.evidence = evidence;
+      const whatChanged = find('what changed', 'world-state', 'world state', 'change');
+      if (whatChanged !== undefined) out.whatChanged = whatChanged;
       const deferred = find('pending', 'deferred', 'follow-up', 'followup', 'next');
       if (deferred !== undefined) out.deferred = deferred;
       return out;

--- a/src/cli/commands/interactive/verdict-card.test.ts
+++ b/src/cli/commands/interactive/verdict-card.test.ts
@@ -45,6 +45,7 @@ describe('renderVerdictCard', () => {
       kind: 'done',
       whatWasDone: 'shipped feature X',
       evidence: 'tests pass',
+      whatChanged: 'feature X is available to users',
       rawBody: '',
     };
     const out = stripAnsi(renderVerdictCard(state));
@@ -53,6 +54,8 @@ describe('renderVerdictCard', () => {
     expect(out).toContain('shipped feature X');
     expect(out).toContain('evidence');
     expect(out).toContain('tests pass');
+    expect(out).toContain('changed');
+    expect(out).toContain('feature X is available to users');
     expect(out).toContain('Objective satisfied');
   });
 

--- a/src/cli/commands/interactive/verdict-card.ts
+++ b/src/cli/commands/interactive/verdict-card.ts
@@ -174,6 +174,7 @@ function collectRows(state: TerminalState): Row[] {
     case 'done':
       push('done', state.whatWasDone);
       push('evidence', state.evidence);
+      push('changed', state.whatChanged);
       // Skip a deferred row that merely echoes the done field — models
       // sometimes emit identical text for both, producing a confusing
       // duplicate row in the card.


### PR DESCRIPTION
### Motivation

- The Done terminal-state "What changed" bullet was being lost because the parser folded it into the Evidence lookup, causing world-state deltas to be invisible on verdict surfaces. 
- Ensure the verdict card displays the world-state delta as a distinct, visible row so end-of-turn summaries are not silently truncated.

### Description

- Add a dedicated `whatChanged` field to the `TerminalState` interface and parse `What changed` independently from `Evidence` in `mapBulletsToFields`. 
- Render a separate `changed` row for Done cards by adding `push('changed', state.whatChanged)` in `collectRows` so the world-state delta appears alongside `done`, `evidence`, and `deferred`. 
- Update tests to cover the parsing and rendering of the new field in `terminal-state.test.ts`, `verdict-card.test.ts`, and `routing-directive.test.ts` to lock the directive contract. 
- Minor parser needle adjustments: remove `'what changed'` from the Evidence search and add explicit needles for the new `whatChanged` lookup so bullets map one-to-one to fields.

### Testing

- ✅ Ran `pnpm test:file src/cli/commands/interactive/terminal-state.test.ts src/cli/commands/interactive/verdict-card.test.ts src/agent/routing-directive.test.ts` and all tests passed (84 tests). 
- ✅ Ran `pnpm lint` and type checks succeeded. 
- ✅ Ran `pnpm fix:pins:check` and hash pins are up to date.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8c24a7cef0832ba4a6b00f51abdd5d)