### PR TITLE
test(xai): add endpoint-layer tests for GrokCliHeaderDeps forwarding (#1244)

### DIFF
--- a/src/agent/providers/xai/endpoints.test.ts
+++ b/src/agent/providers/xai/endpoints.test.ts
@@ -8,7 +8,19 @@ import {
   DEFAULT_XAI_OAUTH_BASE_URL,
   resolveXaiEndpoint,
 } from './endpoints.js';
-import { CLI_CHAT_PROXY_HOST } from './headers.js';
+import { CLI_CHAT_PROXY_HOST, type GrokCliHeaderDeps } from './headers.js';
+
+/** Build a fully-isolated GrokCliHeaderDeps — no real env or filesystem. */
+function headerDeps(overrides: Partial<GrokCliHeaderDeps> = {}): GrokCliHeaderDeps {
+  return {
+    readEnv: () => undefined,
+    homeDir: () => '/test-home',
+    readFile: () => {
+      throw new Error('version file unavailable');
+    },
+    ...overrides,
+  };
+}
 
 describe('resolveXaiEndpoint', () => {
   it('defaults API-key mode to api.x.ai without proxy headers', () => {
@@ -88,5 +100,77 @@ describe('resolveXaiEndpoint', () => {
       },
     });
     expect(r.baseURL).toBe(DEFAULT_XAI_API_BASE_URL);
+  });
+});
+
+describe('resolveXaiEndpoint — GrokCliHeaderDeps forwarding', () => {
+  // Verify that headerDeps.readEnv is forwarded through the oauth default path.
+  it('forwards headerDeps.readEnv env-override through the oauth default path', () => {
+    const r = resolveXaiEndpoint('oauth', {
+      readEnv: () => undefined,
+      headerDeps: headerDeps({ readEnv: () => '2.0.0' }),
+    });
+    expect(r.proxyHeadersApplied).toBe(true);
+    expect(r.defaultHeaders['x-grok-client-version']).toBe('2.0.0');
+    expect(r.defaultHeaders['User-Agent']).toBe('agent-afk (grok-cli-compat/2.0.0)');
+  });
+
+  // Verify that headerDeps.readFile (version file fallback) is forwarded through
+  // the oauth default path when no env override is present.
+  it('forwards headerDeps.readFile version-file fallback through the oauth default path', () => {
+    const r = resolveXaiEndpoint('oauth', {
+      readEnv: () => undefined,
+      headerDeps: headerDeps({
+        readFile: () => JSON.stringify({ version: '3.1.4' }),
+        homeDir: () => '/injected-home',
+      }),
+    });
+    expect(r.proxyHeadersApplied).toBe(true);
+    expect(r.defaultHeaders['x-grok-client-version']).toBe('3.1.4');
+  });
+
+  // Verify the same forwarding when the proxy is reached via baseUrlOverride.
+  it('forwards headerDeps.readEnv env-override through the baseUrlOverride proxy path', () => {
+    const r = resolveXaiEndpoint('apikey', {
+      baseUrlOverride: `https://${CLI_CHAT_PROXY_HOST}/v1`,
+      headerDeps: headerDeps({ readEnv: () => '4.5.6' }),
+    });
+    expect(r.proxyHeadersApplied).toBe(true);
+    expect(r.defaultHeaders['x-grok-client-version']).toBe('4.5.6');
+    expect(r.defaultHeaders['User-Agent']).toBe('agent-afk (grok-cli-compat/4.5.6)');
+  });
+
+  // Verify the same forwarding through the oauth env-override path
+  // (AFK_XAI_OAUTH_BASE_URL still resolves to the proxy host).
+  it('forwards headerDeps.readEnv through the oauth AFK_XAI_OAUTH_BASE_URL path', () => {
+    const r = resolveXaiEndpoint('oauth', {
+      readEnv: (k) =>
+        k === 'AFK_XAI_OAUTH_BASE_URL' ? `https://${CLI_CHAT_PROXY_HOST}/v1` : undefined,
+      headerDeps: headerDeps({ readEnv: () => '5.0.0' }),
+    });
+    expect(r.proxyHeadersApplied).toBe(true);
+    expect(r.defaultHeaders['x-grok-client-version']).toBe('5.0.0');
+  });
+
+  // When headerDeps has no valid sources, the endpoint falls back to
+  // DEFAULT_GROK_CLI_COMPAT_VERSION — the internal seam is still honoured.
+  it('falls through to clientVersion seam when headerDeps has no valid env or file', () => {
+    const r = resolveXaiEndpoint('oauth', {
+      readEnv: () => undefined,
+      clientVersion: '7.7.7',
+      headerDeps: headerDeps(), // readEnv returns undefined, readFile throws
+    });
+    expect(r.proxyHeadersApplied).toBe(true);
+    expect(r.defaultHeaders['x-grok-client-version']).toBe('7.7.7');
+  });
+
+  // Lock the User-Agent format: agent-afk (grok-cli-compat/<version>)
+  it('emits the expected User-Agent format (format lock)', () => {
+    const r = resolveXaiEndpoint('oauth', {
+      readEnv: () => undefined,
+      clientVersion: '1.2.3',
+      headerDeps: headerDeps(),
+    });
+    expect(r.defaultHeaders['User-Agent']).toBe('agent-afk (grok-cli-compat/1.2.3)');
   });
 });

--- a/src/agent/providers/xai/endpoints.ts
+++ b/src/agent/providers/xai/endpoints.ts
@@ -10,7 +10,11 @@
  */
 
 import { env } from '../../../config/env.js';
-import { isCliChatProxyBaseUrl, resolveGrokCliIdentityHeaders } from './headers.js';
+import {
+  isCliChatProxyBaseUrl,
+  resolveGrokCliIdentityHeaders,
+  type GrokCliHeaderDeps,
+} from './headers.js';
 
 /** Auth mode selects which default endpoint + header policy apply. */
 export type XaiAuthMode = 'apikey' | 'oauth';
@@ -39,6 +43,13 @@ export interface XaiEndpointDeps {
    * global `AFK_OPENAI_BASE_URL` — that hijacks Grok onto OpenAI shims.
    */
   baseUrlOverride?: string;
+  /**
+   * Injectable sources for Grok CLI header resolution (env override, version
+   * file, home dir). Forwarded verbatim to `resolveGrokCliIdentityHeaders` so
+   * endpoint-layer tests can control the full version-resolution chain without
+   * touching real env vars or the filesystem.
+   */
+  headerDeps?: GrokCliHeaderDeps;
 }
 
 /** Default env reader — only xAI endpoint vars; uses the typed `env` object. */
@@ -72,7 +83,7 @@ export function resolveXaiEndpoint(
     return {
       baseURL,
       defaultHeaders: useProxyHeaders
-        ? resolveGrokCliIdentityHeaders({ clientVersion: deps.clientVersion })
+        ? resolveGrokCliIdentityHeaders({ clientVersion: deps.clientVersion }, deps.headerDeps)
         : {},
       mode,
       proxyHeadersApplied: useProxyHeaders,
@@ -94,7 +105,7 @@ export function resolveXaiEndpoint(
   const baseURL = stripTrailingSlash((raw && raw.trim()) || DEFAULT_XAI_OAUTH_BASE_URL);
   const useProxyHeaders = isCliChatProxyBaseUrl(baseURL);
   const defaultHeaders = useProxyHeaders
-    ? resolveGrokCliIdentityHeaders({ clientVersion: deps.clientVersion })
+    ? resolveGrokCliIdentityHeaders({ clientVersion: deps.clientVersion }, deps.headerDeps)
     : {};
   return {
     baseURL,


### PR DESCRIPTION
## Summary

Adds `headerDeps?: GrokCliHeaderDeps` to `XaiEndpointDeps` and forwards it to `resolveGrokCliIdentityHeaders` at both call sites in `resolveXaiEndpoint`. Adds 6 endpoint-layer tests exercising the full DI chain.

## Problem

PR #1242 introduced `GrokCliHeaderDeps` for deterministic testing of the Grok CLI version resolution chain, but the deps were not forwarded through the `endpoints.ts` → `headers.ts` boundary. Production behavior was correct (defaults work), but endpoint-layer tests could not inject fake env overrides or version files through the `resolveXaiEndpoint` call chain.

## Changes

**`src/agent/providers/xai/endpoints.ts`** (fix):
- Added `headerDeps?: GrokCliHeaderDeps` field to `XaiEndpointDeps` interface
- Forwarded `deps.headerDeps` as the second arg to `resolveGrokCliIdentityHeaders` at both proxy-header call sites

**`src/agent/providers/xai/endpoints.test.ts`** (6 new tests):
1. `readEnv` env-override through oauth default path
2. `readFile` version-file fallback through oauth default path
3. `readEnv` env-override through `baseUrlOverride` proxy path
4. `readEnv` env-override through `AFK_XAI_OAUTH_BASE_URL` path
5. `clientVersion` seam fall-through when `headerDeps` has no valid sources
6. User-Agent format lock assertion

## Verification

- `pnpm build`: clean
- `pnpm test endpoints.test.ts`: 14/14 tests pass (8 original + 6 new)

Closes #1244
