### PR TITLE
fix(telegram): route auto-subscribe watch output to active topic thread (#1222)

### DIFF
--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -447,6 +447,87 @@ describe('TelegramBot', () => {
         vi.restoreAllMocks();
       }
     });
+
+    test('auto-subscribe routes to active topic thread when sessionManager reports one (#1222)', async () => {
+      // Regression for #1222: auto-subscribe always used sendOptions({ chatId })
+      // which routes to General, ignoring the chat's active topic. The fix calls
+      // sessionManager.getActiveThreadId(chatId) and threads the result through
+      // sendOptions so output lands in the correct topic.
+      const sendMessageMock = vi.fn(async () => ({ message_id: 1, text: '', date: 0, chat: { id: 12345 } }));
+      (bot as any).bot.telegram.sendMessage = sendMessageMock;
+
+      // Simulate: the chat has an active topic thread (threadId = 42).
+      vi.spyOn((bot as any).sessionManager, 'getActiveThreadId').mockReturnValue(42);
+
+      const presence = await import('../agent/awareness/presence.js');
+      const presenceSpy = vi.spyOn(presence, 'readLivePresenceFiles').mockResolvedValue([
+        { surface: 'cli', afk: true, sessionId: 'session-topic', cwd: '/tmp', model: 'claude', pid: 3, startedAt: '' },
+      ] as Awaited<ReturnType<typeof presence.readLivePresenceFiles>>);
+
+      let capturedSend: ((msg: string) => Promise<void>) | undefined;
+      vi.spyOn((bot as any).watchManager, 'start').mockImplementation(
+        (_chatId: number, _sessionId: string, send: (msg: string) => Promise<void>) => {
+          capturedSend = send;
+        },
+      );
+      vi.spyOn((bot as any).watchManager, 'watching').mockReturnValue(undefined);
+      vi.spyOn((bot as any).watchManager, 'getWatched').mockReturnValue(undefined);
+
+      try {
+        await (bot as any).runAutoSubscribeTick();
+
+        expect(capturedSend).toBeDefined();
+        await capturedSend!('watch output');
+
+        expect(sendMessageMock).toHaveBeenCalledTimes(1);
+        const [calledChatId, calledText, calledOpts] = sendMessageMock.mock.calls[0] as [number, string, unknown];
+        expect(calledChatId).toBe(12345);
+        expect(calledText).toBe('watch output');
+        // Topic thread → sendOptions must carry message_thread_id = 42.
+        expect(calledOpts).toEqual({ message_thread_id: 42 });
+      } finally {
+        presenceSpy.mockRestore();
+        vi.restoreAllMocks();
+      }
+    });
+
+    test('auto-subscribe falls back to General when no active topic thread exists (#1222 backward-compat)', async () => {
+      // Non-topic chats (getActiveThreadId returns undefined) must be unaffected:
+      // sendOptions receives a bare { chatId } route and returns {} (no thread id).
+      const sendMessageMock = vi.fn(async () => ({ message_id: 1, text: '', date: 0, chat: { id: 12345 } }));
+      (bot as any).bot.telegram.sendMessage = sendMessageMock;
+
+      vi.spyOn((bot as any).sessionManager, 'getActiveThreadId').mockReturnValue(undefined);
+
+      const presence = await import('../agent/awareness/presence.js');
+      const presenceSpy = vi.spyOn(presence, 'readLivePresenceFiles').mockResolvedValue([
+        { surface: 'cli', afk: true, sessionId: 'session-no-topic', cwd: '/tmp', model: 'claude', pid: 4, startedAt: '' },
+      ] as Awaited<ReturnType<typeof presence.readLivePresenceFiles>>);
+
+      let capturedSend: ((msg: string) => Promise<void>) | undefined;
+      vi.spyOn((bot as any).watchManager, 'start').mockImplementation(
+        (_chatId: number, _sessionId: string, send: (msg: string) => Promise<void>) => {
+          capturedSend = send;
+        },
+      );
+      vi.spyOn((bot as any).watchManager, 'watching').mockReturnValue(undefined);
+      vi.spyOn((bot as any).watchManager, 'getWatched').mockReturnValue(undefined);
+
+      try {
+        await (bot as any).runAutoSubscribeTick();
+
+        expect(capturedSend).toBeDefined();
+        await capturedSend!('general watch');
+
+        const [, , calledOpts] = sendMessageMock.mock.calls[0] as [number, string, unknown];
+        // General → sendOptions returns {} (no message_thread_id).
+        expect(calledOpts).toEqual({});
+        expect(calledOpts).not.toHaveProperty('message_thread_id');
+      } finally {
+        presenceSpy.mockRestore();
+        vi.restoreAllMocks();
+      }
+    });
   });
 
   describe('stats', () => {

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -614,14 +614,18 @@ export class TelegramBot {
       // one REPL session per operator).
       for (const sessionId of afkSessionIds) {
         if (this.watchManager.watching(chatId) === sessionId) continue; // already watching
-        // Invariant: auto-subscribe has no inbound message context, so the
-        // route defaults to the General topic (no threadId). sendOptions()
-        // returns {} for General, which is byte-identical to the bare send —
-        // non-topic chats are unaffected. Topic-aware chats route to General;
-        // the manual /watch command targets the specific topic instead.
+        // Fix #1222: look up the most recently active topic thread for this
+        // chat so watch output routes to the correct topic instead of always
+        // falling through to General. getActiveThreadId returns undefined for
+        // non-topic chats (or chats with no topic sessions), making sendOptions
+        // return {} — byte-identical to the pre-fix General-only behaviour and
+        // fully backward-compatible with all non-topic chats. (#1023 introduced
+        // sendOptions; #1222 threads the chatId's active topic through it.)
+        const threadId = this.sessionManager.getActiveThreadId(chatId);
+        const autoRoute = threadId !== undefined ? { chatId, threadId } : { chatId };
         const send = async (msg: string): Promise<void> => {
           for (const part of splitLongMessage(msg)) {
-            await this.bot.telegram.sendMessage(chatId, part, sendOptions({ chatId })); // #1023
+            await this.bot.telegram.sendMessage(chatId, part, sendOptions(autoRoute));
           }
         };
         this.watchManager.start(chatId, sessionId, send);

--- a/src/telegram/session-manager.test.ts
+++ b/src/telegram/session-manager.test.ts
@@ -1317,3 +1317,67 @@ describe('SessionManager — session registry wiring', () => {
     expect(fresh?.model).toBe('haiku');
   });
 });
+
+// ---------------------------------------------------------------------------
+// getActiveThreadId — fix for issue #1222
+// ---------------------------------------------------------------------------
+describe('SessionManager — getActiveThreadId', () => {
+  // Tests for the method that surfaces the most recently active topic thread id
+  // for a given chat, used by the auto-subscribe loop (#1222 fix).
+  useUnsetAfkHome();
+
+  let testDataDir: string;
+  let manager: SessionManager;
+
+  beforeEach(() => {
+    const entropy = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    testDataDir = join(tmpdir(), `afk-tg-ati-${entropy}`);
+    manager = new SessionManager({
+      dataDir: testDataDir,
+      apiKey: 'test-key',
+      defaultModel: 'sonnet',
+      createSession: async () => ({ state: 'idle' } as IAgentSession),
+    });
+  });
+
+  afterEach(async () => {
+    await manager.closeAll().catch(() => {});
+    if (existsSync(testDataDir)) rmSync(testDataDir, { recursive: true, force: true });
+  });
+
+  test('returns undefined when the chat has no sessions at all', () => {
+    expect(manager.getActiveThreadId(999)).toBeUndefined();
+  });
+
+  test('returns undefined when the chat only has a General session (no threadId)', async () => {
+    // sessionData is populated by getSession — mimics the real message-handler flow.
+    await manager.getSession({ chatId: 100 });
+    expect(manager.getActiveThreadId(100)).toBeUndefined();
+  });
+
+  test('returns the threadId when a single topic session exists', async () => {
+    await manager.getSession({ chatId: 200, threadId: 5 });
+    expect(manager.getActiveThreadId(200)).toBe(5);
+  });
+
+  test('returns the most recently active threadId when multiple topics exist', async () => {
+    // Both topics must be getSession'd so sessionData entries exist.
+    await manager.getSession({ chatId: 300, threadId: 10 });
+    // Small delay so the ISO lastActivity timestamps differ.
+    await new Promise((r) => setTimeout(r, 2));
+    await manager.getSession({ chatId: 300, threadId: 20 });
+    expect(manager.getActiveThreadId(300)).toBe(20);
+  });
+
+  test('ignores General sessions and picks the only topic when both exist', async () => {
+    await manager.getSession({ chatId: 400 });
+    await manager.getSession({ chatId: 400, threadId: 7 });
+    expect(manager.getActiveThreadId(400)).toBe(7);
+  });
+
+  test('is scoped to chatId — does not bleed across chats', async () => {
+    await manager.getSession({ chatId: 500, threadId: 3 });
+    // Different chat — getActiveThreadId must NOT return chat 500's threadId for chat 501.
+    expect(manager.getActiveThreadId(501)).toBeUndefined();
+  });
+});

--- a/src/telegram/session-manager.ts
+++ b/src/telegram/session-manager.ts
@@ -914,6 +914,35 @@ export class SessionManager {
   }
 
   /**
+   * Return the most recently active topic thread id for a given chat, or
+   * `undefined` when the chat has no topic sessions (non-topic chat, or all
+   * sessions belong to General).
+   *
+   * Used by the auto-subscribe loop to route watch output to the correct topic
+   * thread without an inbound message context. The lookup scans `sessionData`
+   * (in-memory, populated from disk on start) for all entries that share
+   * `chatId` and carry a `threadId`, then picks the entry with the most-recent
+   * `lastActivity` timestamp.
+   *
+   * Backward-compatible: returns `undefined` for any chat that has never used
+   * Telegram topics, leaving the downstream `sendOptions` call equivalent to
+   * the pre-fix General-only behaviour.
+   *
+   * @param chatId - Telegram chat id to look up
+   * @returns The most recently active topic thread id for this chat, or `undefined`
+   */
+  getActiveThreadId(chatId: number): number | undefined {
+    let best: SessionData | undefined;
+    for (const data of this.sessionData.values()) {
+      if (data.chatId !== chatId || data.threadId === undefined) continue;
+      if (best === undefined || data.lastActivity > best.lastActivity) {
+        best = data;
+      }
+    }
+    return best?.threadId;
+  }
+
+  /**
    * Count sessions that are mid-turn (not idle and not closed).
    *
    * Used by the version-drift watchdog to defer the upgrade-exit while a


### PR DESCRIPTION
## Summary

Routes auto-subscribe watch output to the operator's active topic thread instead of always landing in General.

## Problem

In Telegram supergroups with topics, auto-subscribed watch output always routed to the General topic because `sendOptions({ chatId })` had no `threadId`. The manual `/watch` command was fixed in PR #1125, but the auto-subscribe path was left targeting General since there's no originating message context.

## Fix

**`src/telegram/session-manager.ts`** — Added `getActiveThreadId(chatId)`:
- Scans in-memory `sessionData` for entries matching the chat that have a `threadId`
- Returns the `threadId` from the most recently active entry (by `lastActivity`)
- Returns `undefined` for non-topic chats → backward-compatible

**`src/telegram/bot.ts`** — In `runAutoSubscribeTick`:
- Calls `this.sessionManager.getActiveThreadId(chatId)` to get the active thread
- Builds a route with `threadId` when available, passes to `sendOptions()`
- General/non-topic chats produce `{}` — byte-identical to pre-fix behavior

## Tests (8 new)

- **`session-manager.test.ts`** — 6 unit tests for `getActiveThreadId`: no sessions, General-only, single topic, most-recently-active topic, general+topic mix, cross-chat isolation
- **`bot.test.ts`** — 2 integration tests: topic-thread routing and General fallback backward-compat

## Verification

- `pnpm build`: clean
- `pnpm test`: 913 test files, 17,475 tests pass

Closes #1222
