### PR TITLE
fix(providers): add xAI/Grok models to /model picker and docs (#1105)

### DIFF
--- a/src/agent/session/model-slots.test.ts
+++ b/src/agent/session/model-slots.test.ts
@@ -192,7 +192,7 @@ describe('MODEL_ALIASES_HINT (single source of truth for the /model picker)', ()
   it('is derived from the tiers + identity aliases, in the documented order', () => {
     expect(MODEL_ALIASES_HINT).toEqual([
       'local', 'small', 'medium', 'large',
-      'opus', 'opus_1m', 'sonnet', 'sonnet_1m', 'haiku', 'fable',
+      'opus', 'opus_1m', 'sonnet', 'sonnet_1m', 'haiku', 'fable', 'grok',
     ]);
   });
 });

--- a/src/agent/session/model-slots.test.ts
+++ b/src/agent/session/model-slots.test.ts
@@ -443,7 +443,7 @@ describe('coerceSlotBindingInput', () => {
     if (!resName.ok) expect(resName.error).toMatch(/control characters/);
   });
   it('rejects names that shadow built-in aliases (slot keys, legacy aliases, auto, direct aliases)', () => {
-    for (const reserved of ['local', 'small', 'medium', 'large', 'haiku', 'sonnet', 'opus', 'auto', 'fable']) {
+    for (const reserved of ['local', 'small', 'medium', 'large', 'haiku', 'sonnet', 'opus', 'auto', 'fable', 'grok']) {
       const res = coerceSlotBindingInput({ id: 'glm-5.2', name: reserved });
       expect(res.ok).toBe(false);
       if (!res.ok) expect(res.error).toMatch(/shadow a built-in alias/);

--- a/src/agent/session/model-slots.ts
+++ b/src/agent/session/model-slots.ts
@@ -8,7 +8,8 @@
  * user-defined custom names also resolve onto these tier positions.
  *
  * IDENTITY vs. TIER: the built-in Claude handles (`haiku`/`sonnet`/`opus`/
- * `fable`/`*_1m`) are FIXED-IDENTITY aliases ({@link DIRECT_MODEL_ALIASES}) that
+ * `fable`/`*_1m`) and the xAI handle (`grok`) are FIXED-IDENTITY aliases
+ * ({@link DIRECT_MODEL_ALIASES}) that
  * always resolve to one concrete model — they are NOT tier aliases and are never
  * rebound by slot config. This prevents rebinding a capability tier (e.g.
  * `medium` → an OpenAI model) from silently hijacking the `sonnet` handle. Only
@@ -17,7 +18,7 @@
  * Resolution precedence for any model input string:
  *   1. custom name    — a user-assigned `name` on a binding      (tier; {@link slotForInput})
  *   2. neutral name   — `local` | `small` | `medium` | `large`   (tier; {@link slotForInput})
- *   3. identity alias — haiku/sonnet/opus/fable/*_1m → fixed id   ({@link resolveBinding})
+ *   3. identity alias — haiku/sonnet/opus/fable/*_1m/grok → fixed id   ({@link resolveBinding})
  *   4. otherwise      — raw concrete id or the `auto` sentinel (passthrough)
  *
  * Bindings are process-global config (one afk.config.json + env per process),

--- a/src/agent/session/model-slots.ts
+++ b/src/agent/session/model-slots.ts
@@ -115,6 +115,12 @@ export const CLAUDE_SONNET_ID = 'claude-sonnet-4-6';
 export const CLAUDE_OPUS_ID = 'claude-opus-5';
 /** Claude Fable 5 wire id — Anthropic's most-capable widely-released model. */
 export const CLAUDE_FABLE_5_ID = 'claude-fable-5';
+/**
+ * Current xAI Grok flagship wire id — the concrete target for the `grok`
+ * short alias. Update this constant when a new flagship ships; the alias
+ * table, `/model` picker, and docs all follow from this single definition.
+ */
+export const GROK_FLAGSHIP_ID = 'grok-4.6';
 
 /**
  * Default tier bindings — an unconfigured install behaves identically to the
@@ -162,6 +168,10 @@ export const DIRECT_MODEL_ALIASES: Readonly<Record<string, string>> = {
   sonnet_1m: CLAUDE_SONNET_ID,
   haiku: CLAUDE_HAIKU_ID,
   fable: CLAUDE_FABLE_5_ID,
+  // xAI Grok flagship alias — a stable short handle that tracks
+  // GROK_FLAGSHIP_ID so upgrading the default Grok model is a one-line
+  // change. Not a capability tier: `grok` always resolves to one pinned id.
+  grok: GROK_FLAGSHIP_ID,
 };
 
 /**

--- a/src/agent/session/model-validate.test.ts
+++ b/src/agent/session/model-validate.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Tests for the shared model-argument validation predicate.
+ * @module agent/session/model-validate.test
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isValidModelArg } from './model-validate.js';
+
+describe('isValidModelArg', () => {
+  it('accepts the grok alias (DIRECT_MODEL_ALIASES entry)', () => {
+    expect(isValidModelArg('grok')).toBe(true);
+  });
+
+  it('accepts grok-4.6 (xai wire id passthrough)', () => {
+    expect(isValidModelArg('grok-4.6')).toBe(true);
+  });
+
+  it('accepts grok-4.5 (xai wire id passthrough)', () => {
+    expect(isValidModelArg('grok-4.5')).toBe(true);
+  });
+
+  it('accepts claude-sonnet-4-6 (Anthropic wire id)', () => {
+    expect(isValidModelArg('claude-sonnet-4-6')).toBe(true);
+  });
+
+  it('accepts sonnet (direct alias)', () => {
+    expect(isValidModelArg('sonnet')).toBe(true);
+  });
+
+  it('accepts small (slot name)', () => {
+    expect(isValidModelArg('small')).toBe(true);
+  });
+
+  it('rejects not-a-model (unknown string)', () => {
+    expect(isValidModelArg('not-a-model')).toBe(false);
+  });
+
+  it('rejects grokk (typo)', () => {
+    expect(isValidModelArg('grokk')).toBe(false);
+  });
+});

--- a/src/agent/session/model-validate.ts
+++ b/src/agent/session/model-validate.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared model-argument validation for all `/model`-switching surfaces
+ * (REPL, Telegram, and any future surface).
+ *
+ * Centralises the accept/reject predicate so REPL and Telegram cannot drift —
+ * both import {@link isValidModelArg} rather than re-implementing it.
+ *
+ * @module agent/session/model-validate
+ */
+
+import { providerForModel } from '../providers/index.js';
+import { MODEL_ALIASES_HINT, resolveBinding, slotForInput } from './model-slots.js';
+import type { AgentModelInput } from '../types.js';
+
+/**
+ * Returns `true` when `model` is a valid, routable model argument that the
+ * `/model` command (REPL or Telegram) should accept:
+ *
+ * - A known alias or slot tier name (from {@link MODEL_ALIASES_HINT})
+ * - A user-defined custom slot name (resolved by {@link slotForInput})
+ * - An `openai-compatible` wire id (any `org/model`, GPT, o-series, etc.)
+ * - An `xai` / `xai-oauth` wire id (`grok-*` family)
+ * - A raw Anthropic wire id (`claude-*`)
+ *
+ * Bare unknown strings (typos, unsupported providers) return `false` — they
+ * would silently reach the provider layer and surface as opaque API errors.
+ */
+export function isValidModelArg(model: AgentModelInput): boolean {
+  if (MODEL_ALIASES_HINT.includes(model)) return true;
+  if (slotForInput(model) !== undefined) return true;
+  const routed = providerForModel(model);
+  if (routed === 'openai-compatible') return true;
+  if (routed === 'xai' || routed === 'xai-oauth') return true;
+  // Raw Anthropic wire id (e.g. `claude-sonnet-4-6`, `claude-opus-5`).
+  const resolvedId = resolveBinding(model).id.trim().toLowerCase();
+  return resolvedId.startsWith('claude-') || resolvedId.startsWith('claude_');
+}

--- a/src/cli/slash/commands/info.ts
+++ b/src/cli/slash/commands/info.ts
@@ -17,15 +17,13 @@ import { formatCost, formatTokens } from '../../format-utils.js';
 import { cacheHitRate } from '../../commands/trace-usage-format.js';
 import { contextLimitFor, MODEL_CONTEXT_LIMITS } from '../../model-limits.js';
 import { renderDebugBanner } from '../../debug-banner.js';
-import { providerForModel } from '../../../agent/providers/index.js';
 import { isModelAvailable } from '../../../agent/auth/model-availability.js';
 import { fetchSubscriptionUsage, type UsageWindow } from '../../../agent/subscription-usage.js';
 import {
   MODEL_ALIASES_HINT,
-  resolveBinding,
-  slotForInput,
   unconfiguredSlotError,
 } from '../../../agent/session/model-slots.js';
+import { isValidModelArg } from '../../../agent/session/model-validate.js';
 import { runPicker } from '../../render/picker.js';
 import type { SlashCommand, SlashContext } from '../types.js';
 import type { AgentModelInput } from '../../../agent/types.js';
@@ -272,19 +270,11 @@ const historyCmd: SlashCommand = {
  * Writes all user-facing output via ctx.out; never throws.
  */
 async function switchModel(ctx: SlashContext, target: string): Promise<void> {
-  // Accept slot tier names / configured custom names, the built-in Claude
-  // identity aliases, a raw Anthropic wire id (e.g. `claude-sonnet-5`), OR full
-  // HF-style org/model ids (routed openai-compatible). Bare unknown strings
-  // (e.g. typos) are rejected — they'd silently fall through to anthropic-direct
-  // and produce an unhelpful API error at turn time.
-  const isKnownAlias = MODEL_ALIASES_HINT.includes(target);
-  const isSlotName = slotForInput(target) !== undefined;
-  const isOpenAICompatibleId = providerForModel(target) === 'openai-compatible';
-  // The resolved id's `claude-` prefix is the confident raw-Claude-id signal;
-  // aliases already resolve to a claude- id too, so this also covers them.
-  const resolvedId = resolveBinding(target).id.trim().toLowerCase();
-  const isClaudeWireId = resolvedId.startsWith('claude-') || resolvedId.startsWith('claude_');
-  if (!isKnownAlias && !isSlotName && !isOpenAICompatibleId && !isClaudeWireId) {
+  // Accept slot tier names / configured custom names, the built-in identity
+  // aliases (claude-*, grok-*, gpt-*, org/model HF ids, …). Bare unknown
+  // strings (e.g. typos) are rejected — they'd silently fall through to a
+  // provider and produce an unhelpful API error at turn time.
+  if (!isValidModelArg(target)) {
     ctx.out.warn(`Unknown model: ${target}. Aliases: ${MODEL_ALIASES_HINT.join(', ')}  (or a full model id)`);
     return;
   }

--- a/src/telegram/handlers/commands.model-validate.ts
+++ b/src/telegram/handlers/commands.model-validate.ts
@@ -1,8 +1,11 @@
 /**
- * Accept/reject matrix for Telegram `/model <id>` (aliases, slots, wire ids).
+ * Compatibility shim re-exporting {@link isValidModelArg} from
+ * `agent/session/model-validate` for Telegram command handlers.
  *
- * Delegates to the shared {@link isValidModelArg} helper so REPL and Telegram
- * cannot drift — both surfaces accept exactly the same set of model arguments.
+ * The primary implementation lives in `agent/session/model-validate`; this
+ * module is a thin re-export so Telegram handler imports do not need to reach
+ * into the agent layer directly. REPL and Telegram accept exactly the same set
+ * of model arguments — both delegate to the shared predicate.
  *
  * @module telegram/handlers/commands.model-validate
  */

--- a/src/telegram/handlers/commands.model-validate.ts
+++ b/src/telegram/handlers/commands.model-validate.ts
@@ -1,25 +1,16 @@
 /**
  * Accept/reject matrix for Telegram `/model <id>` (aliases, slots, wire ids).
  *
+ * Delegates to the shared {@link isValidModelArg} helper so REPL and Telegram
+ * cannot drift — both surfaces accept exactly the same set of model arguments.
+ *
  * @module telegram/handlers/commands.model-validate
  */
 
-import { providerForModel } from '../../agent/providers/index.js';
-import {
-  MODEL_ALIASES_HINT,
-  resolveBinding,
-  slotForInput,
-} from '../../agent/session/model-slots.js';
+import { isValidModelArg } from '../../agent/session/model-validate.js';
 import type { AgentModelInput } from '../../agent/types.js';
 
 /** True when `model` is a known alias, slot name, or routable full wire id. */
 export function isValidTelegramModelArg(model: AgentModelInput): boolean {
-  if (MODEL_ALIASES_HINT.includes(model)) return true;
-  if (slotForInput(model) !== undefined) return true;
-  const routed = providerForModel(model);
-  if (routed === 'openai-compatible') return true;
-  if (routed === 'xai' || routed === 'xai-oauth') return true;
-  // Raw Anthropic wire id (e.g. `claude-sonnet-5`).
-  const resolvedId = resolveBinding(model).id.trim().toLowerCase();
-  return resolvedId.startsWith('claude-') || resolvedId.startsWith('claude_');
+  return isValidModelArg(model);
 }

--- a/website/content/docs/configuration/models-providers.mdx
+++ b/website/content/docs/configuration/models-providers.mdx
@@ -41,14 +41,14 @@ Talks to the xAI inference API. Selected automatically for:
 
 Two auth modes:
 
-- **`xai`** — API-key mode. Set `AFK_XAI_API_KEY` (or `XAI_API_KEY`).
+- **`xai`** — API-key mode. Set `XAI_API_KEY`.
 - **`xai-oauth`** — SuperGrok / SuperGrok Heavy / X Premium+ subscription OAuth
   via the Grok CLI chat proxy. No API key needed; uses the OAuth credential
-  written by `grok login`. Force this mode by setting `AFK_XAI_OAUTH=1` or
-  binding a slot with `provider: "xai-oauth"`.
+  written by `grok login`. Force this mode by binding a slot with
+  `provider: "xai-oauth"`.
 
 ```bash
-export AFK_XAI_API_KEY=xai-...
+export XAI_API_KEY=xai-...
 afk chat "summarise this diff" --model grok-4.6
 # or use the short alias
 afk i --model grok

--- a/website/content/docs/configuration/models-providers.mdx
+++ b/website/content/docs/configuration/models-providers.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Models & Providers"
-description: "How agent-afk routes model names to providers, and how to use Anthropic, OpenAI, and local OpenAI-compatible shims."
+description: "How agent-afk routes model names to providers, and how to use Anthropic, OpenAI, xAI, and local OpenAI-compatible shims."
 ---
 
-`agent-afk` speaks to two provider families through a single abstraction in
+`agent-afk` speaks to three provider families through a single abstraction in
 `src/agent/providers/`. The routing happens automatically based on the model
 name — no global `AFK_PROVIDER` needed in the common case.
 
@@ -31,6 +31,37 @@ endpoint via `AFK_OPENAI_BASE_URL`). Selected automatically for:
   underlying `@openai/codex-sdk` harness has been removed and this now
   resolves to the same `openai-compatible` provider. Still accepted for
   back-compat; will be removed in a future major release.
+
+### xai / xai-oauth
+
+Talks to the xAI inference API. Selected automatically for:
+
+- `grok-*` model IDs (e.g. `grok-4.6`, `grok-4.5`)
+- The `grok` short alias (resolves to the current flagship — `grok-4.6`)
+
+Two auth modes:
+
+- **`xai`** — API-key mode. Set `AFK_XAI_API_KEY` (or `XAI_API_KEY`).
+- **`xai-oauth`** — SuperGrok / SuperGrok Heavy / X Premium+ subscription OAuth
+  via the Grok CLI chat proxy. No API key needed; uses the OAuth credential
+  written by `grok login`. Force this mode by setting `AFK_XAI_OAUTH=1` or
+  binding a slot with `provider: "xai-oauth"`.
+
+```bash
+export AFK_XAI_API_KEY=xai-...
+afk chat "summarise this diff" --model grok-4.6
+# or use the short alias
+afk i --model grok
+```
+
+```jsonc
+// afk.config.json — bind a slot to Grok
+{
+  "models": {
+    "large": { "id": "grok-4.6", "provider": "xai" }
+  }
+}
+```
 
 ### chatgpt-oauth (per-slot)
 
@@ -74,7 +105,7 @@ works for a single-model setup.
 Set the default for all sessions:
 
 ```bash
-export AFK_MODEL=sonnet          # or: haiku, opus, fable, gpt-5, etc.
+export AFK_MODEL=sonnet          # or: haiku, opus, fable, grok, gpt-5, etc.
 ```
 
 Override for a single call:
@@ -89,6 +120,8 @@ Switch mid-session in the REPL:
 
 ```
 /model gpt-5.5       # next turn routes to openai-compatible
+/model grok-4.6      # next turn routes to xai
+/model grok          # same — short alias for the current Grok flagship
 /model sonnet        # next turn routes back to anthropic-direct
 ```
 
@@ -109,7 +142,7 @@ export AFK_PROVIDER=openai-compatible   # all models routed to OpenAI compat
 ```
 
 Accepted values: `anthropic`, `anthropic-direct`, `openai`, `openai-compatible`,
-`openai-codex`. The `--provider` CLI flag wins when both are set.
+`openai-codex`, `xai`, `xai-oauth`. The `--provider` CLI flag wins when both are set.
 
 `AFK_PROVIDER` is now an escape hatch, not a requirement. Omit it to let the
 router pick automatically per model.
@@ -122,13 +155,15 @@ router pick automatically per model.
 | `opus` / `opus_1m` | Complex reasoning, multi-step planning, long contexts | anthropic-direct |
 | `sonnet` / `sonnet_1m` | Balanced — the `medium` tier's default model | anthropic-direct |
 | `haiku` | Fast and cheap, best for simple tasks | anthropic-direct |
+| `grok` | Current Grok flagship — resolves to `grok-4.6` | xai |
 
 `sonnet_1m` and `opus_1m` resolve to the same fixed model ID as their base
 alias (`sonnet`/`opus` respectively) — like all identity aliases, they are not
 tiers, so "resolve to the same tier" no longer applies. The 1M context window
 is handled by the model itself; passing the `_1m` suffix routes to the same
-pinned model ID. Source: `src/agent/session/model-slots.ts`
-(`DIRECT_MODEL_ALIASES`).
+pinned model ID. `grok` resolves to `GROK_FLAGSHIP_ID` in
+`src/agent/session/model-slots.ts`; upgrade the flagship by updating that one
+constant. Source: `DIRECT_MODEL_ALIASES` in `src/agent/session/model-slots.ts`.
 
 You can also pass any raw model ID accepted by the provider (e.g.
 `claude-opus-5`, `gpt-5`, `claude-haiku-4-5-20251001`).


### PR DESCRIPTION
## Summary

Fixes #1105 — `/model grok-4.6` (and the new `grok` alias) now work in the REPL `/model` picker.

### Root cause

`switchModel` in `src/cli/slash/commands/info.ts` validated model arguments with an inline predicate that checked for `openai-compatible` routing but omitted the `xai` / `xai-oauth` check that already existed in the Telegram surface (`isValidTelegramModelArg`). Any `grok-*` wire id hit the "unknown model" rejection path.

### Changes

| File | What changed |
|------|-------------|
| `src/agent/session/model-slots.ts` | Added `GROK_FLAGSHIP_ID = 'grok-4.6'` constant; added `grok` entry to `DIRECT_MODEL_ALIASES` (→ `GROK_FLAGSHIP_ID`); `MODEL_ALIASES_HINT` and `RESERVED_NAMES` derive from `DIRECT_MODEL_ALIASES` and pick it up automatically |
| `src/agent/session/model-validate.ts` | **New file** — shared `isValidModelArg` helper used by both REPL and Telegram so the two surfaces cannot drift again |
| `src/cli/slash/commands/info.ts` | `switchModel` now delegates to `isValidModelArg` (removes the inline predicate; drops the now-unused `providerForModel` / `resolveBinding` / `slotForInput` imports) |
| `src/telegram/handlers/commands.model-validate.ts` | `isValidTelegramModelArg` becomes a thin re-export of `isValidModelArg` |
| `src/agent/session/model-slots.test.ts` | Update `MODEL_ALIASES_HINT` snapshot test to include `grok` |
| `website/content/docs/configuration/models-providers.mdx` | Add xAI provider section, `grok` alias table row, REPL switch examples, and accepted `AFK_PROVIDER` values |

### Verification

- `pnpm lint` (tsc --noEmit) — clean
- `pnpm test` — 17 473 passed, 3 skipped, 0 failed (all 913 test files)
- `pnpm audit:filesize:check` — no new violations (2 pre-existing GREW entries in unrelated files)

### How to use

```
# Short alias (current flagship = grok-4.6)
/model grok

# Explicit wire id
/model grok-4.6

# CLI flag
afk chat "…" --model grok-4.6
afk i --model grok

# Env var
export AFK_MODEL=grok
```
