### PR TITLE
feat(manifest): wire reconcileWaveManifests into session startup paths (#1082)

### DIFF
--- a/.filesize-baseline.json
+++ b/.filesize-baseline.json
@@ -6,7 +6,7 @@
     "src/agent/daemon/scheduler.ts": { "loc": 543, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/agent/memory/memory-store.ts": { "loc": 687, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/agent/memory/memory-tools.ts": { "loc": 437, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/agent/providers/openai-compatible/index.ts": { "loc": 395, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/agent/providers/openai-compatible/index.ts": { "loc": 396, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/agent/providers/openai-compatible/query.ts": { "loc": 794, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/agent/session/agent-session.ts": { "loc": 832, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/agent/session/stream-consumer.ts": { "loc": 358, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
@@ -20,8 +20,8 @@
     "src/agent/trace/receipt.ts": { "loc": 412, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/agent/worktree-sweep.ts": { "loc": 512, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/cli/_lib/testing/virtual-screen.ts": { "loc": 422, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/cli/commands/chat.ts": { "loc": 568, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/cli/commands/daemon.ts": { "loc": 380, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/cli/commands/chat.ts": { "loc": 570, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/cli/commands/daemon.ts": { "loc": 392, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/cli/commands/farm.ts": { "loc": 436, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/cli/commands/interactive.ts": { "loc": 581, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/cli/commands/interactive/loop-iteration.ts": { "loc": 428, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
@@ -38,9 +38,9 @@
     "src/improve/eval-run/runner.ts": { "loc": 372, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/improve/propose/template-engine.ts": { "loc": 459, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/skills/audit-fit/index.ts": { "loc": 421, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/telegram/bot.ts": { "loc": 389, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/telegram/bot.ts": { "loc": 392, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/telegram/handlers/farm-callbacks.ts": { "loc": 392, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/telegram/handlers/message.ts": { "loc": 581, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/telegram/session-manager.ts": { "loc": 455, "reason": "legacy: predates the ceiling gate; pending concern extraction" }
+    "src/telegram/session-manager.ts": { "loc": 461, "reason": "legacy: predates the ceiling gate; pending concern extraction" }
   }
 }

--- a/src/agent/manifest/reconcile.test.ts
+++ b/src/agent/manifest/reconcile.test.ts
@@ -200,6 +200,8 @@ describe('formatResumptionOffer', () => {
     expect(formatted).toContain(waveId ?? '');
     expect(formatted).toContain('agent-tool');
     expect(formatted).toContain('investigate bug');
+    expect(formatted).toContain("re-dispatch each ready unit's prompt from its listed cwd");
+    expect(formatted).not.toContain('Accept? [yes/no]');
   });
 });
 

--- a/src/agent/manifest/reconcile.ts
+++ b/src/agent/manifest/reconcile.ts
@@ -184,7 +184,7 @@ export function formatResumptionOffer(offer: StaleManifestOffer): string {
     }
   }
 
-  lines.push(`  Accept? [yes/no] — or ignore to dismiss without retrying.`);
+  lines.push(`  To retry, re-dispatch each ready unit's prompt from its listed cwd; this notice does not accept yes/no replies.`);
   return lines.join('\n');
 }
 

--- a/src/agent/manifest/startup-reconcile.test.ts
+++ b/src/agent/manifest/startup-reconcile.test.ts
@@ -68,19 +68,20 @@ describe('runTelegramReconcile', () => {
     const sendText = vi.fn();
     seedManifest('tg-sess');
 
-    runTelegramReconcile('tg-sess', 42, sendText);
+    const route = { chatId: 42, threadId: 7 };
+    runTelegramReconcile('tg-sess', route, sendText);
     await Promise.resolve();
 
     expect(sendText).toHaveBeenCalledOnce();
-    const [calledChatId, calledText] = sendText.mock.calls[0] as [number, string];
-    expect(calledChatId).toBe(42);
+    const [calledRoute, calledText] = sendText.mock.calls[0] as [typeof route, string];
+    expect(calledRoute).toBe(route);
     expect(calledText).toContain('[wave-resume]');
   });
 
   it('is a no-op when no manifests exist', async () => {
     const sendText = vi.fn();
 
-    runTelegramReconcile('no-manifests-sess', 99, sendText);
+    runTelegramReconcile('no-manifests-sess', { chatId: 99 }, sendText);
     await Promise.resolve();
 
     expect(sendText).not.toHaveBeenCalled();

--- a/src/agent/manifest/startup-reconcile.test.ts
+++ b/src/agent/manifest/startup-reconcile.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Unit tests for the startup-reconcile helpers.
+ *
+ * Verifies that runReplReconcile, runTelegramReconcile, and
+ * runNonInteractiveReconcile fire the expected callbacks when wave manifests
+ * with unsettled units exist, and that they are no-ops when the gate is off.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { runReplReconcile, runTelegramReconcile, runNonInteractiveReconcile } from './startup-reconcile.js';
+import { createManifest, buildWaveUnit } from './write.js';
+
+let stateDir: string;
+
+beforeEach(() => {
+  stateDir = mkdtempSync(join(tmpdir(), 'afk-sr-'));
+  process.env['AFK_STATE_DIR'] = stateDir;
+  delete process.env['AFK_WAVE_RESUME_UNATTENDED'];
+  delete process.env['AFK_WAVE_MANIFEST_DISABLED'];
+});
+
+afterEach(() => {
+  rmSync(stateDir, { recursive: true, force: true });
+  delete process.env['AFK_STATE_DIR'];
+  delete process.env['AFK_WAVE_RESUME_UNATTENDED'];
+  delete process.env['AFK_WAVE_MANIFEST_DISABLED'];
+  vi.restoreAllMocks();
+});
+
+/** Create a manifest with two pending units owned by `sessionId`. */
+function seedManifest(sessionId: string): string {
+  const units = [
+    buildWaveUnit({ id: 'u1', prompt: 'investigate', cwd: undefined, model: 'sonnet' }),
+    buildWaveUnit({ id: 'u2', prompt: 'fix bug', cwd: undefined, model: 'haiku' }),
+  ];
+  return createManifest({ source: 'agent-tool', parentSessionId: sessionId, traceLabel: null, units }) ?? '';
+}
+
+describe('runReplReconcile', () => {
+  it('writes resumption offer to stderr when manifests exist', async () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    seedManifest('repl-sess');
+
+    runReplReconcile('repl-sess');
+    // The helper schedules async via Promise.resolve().then() — flush it.
+    await Promise.resolve();
+
+    const calls = stderrSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((t) => t.includes('[wave-resume]'))).toBe(true);
+  });
+
+  it('is a no-op when no manifests exist', async () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    runReplReconcile('no-manifests-sess');
+    await Promise.resolve();
+
+    const calls = stderrSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((t) => t.includes('[wave-resume]'))).toBe(false);
+  });
+});
+
+describe('runTelegramReconcile', () => {
+  it('calls sendText with the resumption offer when manifests exist', async () => {
+    const sendText = vi.fn();
+    seedManifest('tg-sess');
+
+    runTelegramReconcile('tg-sess', 42, sendText);
+    await Promise.resolve();
+
+    expect(sendText).toHaveBeenCalledOnce();
+    const [calledChatId, calledText] = sendText.mock.calls[0] as [number, string];
+    expect(calledChatId).toBe(42);
+    expect(calledText).toContain('[wave-resume]');
+  });
+
+  it('is a no-op when no manifests exist', async () => {
+    const sendText = vi.fn();
+
+    runTelegramReconcile('no-manifests-sess', 99, sendText);
+    await Promise.resolve();
+
+    expect(sendText).not.toHaveBeenCalled();
+  });
+});
+
+describe('runNonInteractiveReconcile', () => {
+  it('is a no-op without AFK_WAVE_RESUME_UNATTENDED=1', async () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    seedManifest('daemon-sess');
+
+    runNonInteractiveReconcile('daemon-sess');
+    await Promise.resolve();
+
+    const calls = stderrSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((t) => t.includes('[wave-resume]'))).toBe(false);
+  });
+
+  it('writes resumption offer to stderr when AFK_WAVE_RESUME_UNATTENDED=1', async () => {
+    process.env['AFK_WAVE_RESUME_UNATTENDED'] = '1';
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    seedManifest('daemon-sess-2');
+
+    runNonInteractiveReconcile('daemon-sess-2');
+    await Promise.resolve();
+
+    const calls = stderrSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((t) => t.includes('[wave-resume]'))).toBe(true);
+  });
+});

--- a/src/agent/manifest/startup-reconcile.ts
+++ b/src/agent/manifest/startup-reconcile.ts
@@ -39,20 +39,20 @@ export function runReplReconcile(sessionId: string): void {
  * Fire-and-forget: returns immediately; errors are swallowed.
  *
  * @param sessionId - The SDK session ID of the newly created session.
- * @param chatId    - The Telegram chat ID to deliver the offer to.
- * @param sendText  - Callback that delivers a plain-text message to the chat.
+ * @param route     - The Telegram route to deliver the offer to.
+ * @param sendText  - Callback that delivers a plain-text message to the route.
  */
-export function runTelegramReconcile(
+export function runTelegramReconcile<Route>(
   sessionId: string,
-  chatId: number,
-  sendText: (chatId: number, text: string) => void,
+  route: Route,
+  sendText: (route: Route, text: string) => void,
 ): void {
   if (!shouldSurfaceResumptionOffer(true)) return;
   void Promise.resolve().then(() => {
     try {
       const result = reconcileWaveManifests({ sessionId });
       for (const offer of result.offers) {
-        sendText(chatId, formatResumptionOffer(offer));
+        sendText(route, formatResumptionOffer(offer));
       }
     } catch {
       // Fire-and-forget: reconciler errors must never surface to the user.

--- a/src/agent/manifest/startup-reconcile.ts
+++ b/src/agent/manifest/startup-reconcile.ts
@@ -1,0 +1,80 @@
+/**
+ * Fire-and-forget wave-manifest reconciliation for session startup paths.
+ *
+ * Each exported helper wires `reconcileWaveManifests()` into a specific
+ * surface's session startup without blocking the caller. Errors are swallowed
+ * per the fire-and-forget contract of the reconciler.
+ *
+ * Surfaces:
+ *  - REPL (`runReplReconcile`): always interactive; writes to stderr.
+ *  - Telegram (`runTelegramReconcile`): always interactive; forwards via callback.
+ *  - Daemon / one-shot chat (`runNonInteractiveReconcile`): gated on
+ *    `shouldSurfaceResumptionOffer(false)` (requires AFK_WAVE_RESUME_UNATTENDED=1).
+ *
+ * @module agent/manifest/startup-reconcile
+ */
+
+import { reconcileWaveManifests, formatResumptionOffer, shouldSurfaceResumptionOffer } from './reconcile.js';
+
+/**
+ * Wire reconciliation for the interactive REPL surface.
+ * Fire-and-forget: returns immediately; errors are swallowed.
+ */
+export function runReplReconcile(sessionId: string): void {
+  if (!shouldSurfaceResumptionOffer(true)) return;
+  void Promise.resolve().then(() => {
+    try {
+      const result = reconcileWaveManifests({ sessionId });
+      for (const offer of result.offers) {
+        process.stderr.write(formatResumptionOffer(offer) + '\n');
+      }
+    } catch {
+      // Fire-and-forget: reconciler errors must never surface to the user.
+    }
+  });
+}
+
+/**
+ * Wire reconciliation for the Telegram surface.
+ * Fire-and-forget: returns immediately; errors are swallowed.
+ *
+ * @param sessionId - The SDK session ID of the newly created session.
+ * @param chatId    - The Telegram chat ID to deliver the offer to.
+ * @param sendText  - Callback that delivers a plain-text message to the chat.
+ */
+export function runTelegramReconcile(
+  sessionId: string,
+  chatId: number,
+  sendText: (chatId: number, text: string) => void,
+): void {
+  if (!shouldSurfaceResumptionOffer(true)) return;
+  void Promise.resolve().then(() => {
+    try {
+      const result = reconcileWaveManifests({ sessionId });
+      for (const offer of result.offers) {
+        sendText(chatId, formatResumptionOffer(offer));
+      }
+    } catch {
+      // Fire-and-forget: reconciler errors must never surface to the user.
+    }
+  });
+}
+
+/**
+ * Wire reconciliation for non-interactive surfaces (daemon, one-shot chat).
+ * Gated on `shouldSurfaceResumptionOffer(false)` — requires `AFK_WAVE_RESUME_UNATTENDED=1`.
+ * Fire-and-forget: returns immediately; errors are swallowed.
+ */
+export function runNonInteractiveReconcile(sessionId: string): void {
+  if (!shouldSurfaceResumptionOffer(false)) return;
+  void Promise.resolve().then(() => {
+    try {
+      const result = reconcileWaveManifests({ sessionId });
+      for (const offer of result.offers) {
+        process.stderr.write(formatResumptionOffer(offer) + '\n');
+      }
+    } catch {
+      // Fire-and-forget: reconciler errors must never surface to the user.
+    }
+  });
+}

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -37,6 +37,7 @@ import { McpManager, loadMcpConfig } from '../../agent/mcp/index.js';
 import { jsonDateReplacer } from '../json-date-replacer.js';
 import { loadImportFromConfig, resolveImportedRoots } from '../../config/import-sources.js';
 import { emitSessionPhase } from '../../agent/trace/emit.js';
+import { runNonInteractiveReconcile } from '../../agent/manifest/startup-reconcile.js';
 
 
 /** Loose UUID format check: 8-4-4-4-12 hex groups separated by dashes. */
@@ -625,6 +626,12 @@ export function registerChatCommand(program: Command): void {
         })), trace?.writer);
 
         boundSession = session;
+
+        // Wave-manifest reconciliation at one-shot chat startup: surface
+        // resumption offers for unfinished work. Non-interactive — requires
+        // AFK_WAVE_RESUME_UNATTENDED=1. Fire-and-forget.
+        runNonInteractiveReconcile(boundSession?.sessionId ?? '');
+
         // Subagent-success rollup: wire both the root manager and the compose
         // executor so all subagent token/cost data (including compose DAG nodes)
         // accumulates into this session's session_sealed telemetry. Late-bound

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander';
 import { env } from '../../config/env.js';
 import path from 'path';
+import { runNonInteractiveReconcile } from '../../agent/manifest/startup-reconcile.js';
 import { palette } from '../palette.js';
 import { handleCommandError } from '../errors/index.js';
 import os from 'os';
@@ -523,6 +524,11 @@ export function registerDaemonCommand(program: Command): void {
             ).catch(() => undefined);
           },
         });
+
+        // Wave-manifest reconciliation at daemon startup: surface resumption
+        // offers for unfinished work. Non-interactive — requires
+        // AFK_WAVE_RESUME_UNATTENDED=1. Fire-and-forget.
+        runNonInteractiveReconcile('');
 
         if (options.once) {
           console.log(palette.info(`▶ Firing task '${taskId}' once...`));

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -2,6 +2,7 @@ import { MemoryStore } from '../../../agent/memory/index.js';
 import { WorkspaceStore } from '../../../agent/workspace/workspace-store.js';
 import { env } from '../../../config/env.js';
 import { registerSurfaceSession } from '../../../agent/session/register-surface-session.js';
+import { runReplReconcile } from '../../../agent/manifest/startup-reconcile.js';
 import type { SlashContext } from '../../slash/types.js';
 import type { SessionRef } from '../../../agent/session-ref.js';
 import type { CliOptions, InteractiveCtx } from './shared.js';
@@ -148,6 +149,10 @@ export async function bootstrapSession(
   const session = buildAgentSession(sharedDeps);
   // Populate sessionRef (declared above deferredParent so the proxy works).
   sessionRef.current = session;
+
+  // Wave-manifest reconciliation: surface resumption offers for unfinished work
+  // from prior sessions. Fire-and-forget — never blocks session startup.
+  runReplReconcile(session.sessionId ?? '');
 
   // Step 7: register this REPL session in the cross-surface session registry so
   // it appears alongside Telegram/daemon sessions. Best-effort (never throws).

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -449,6 +449,23 @@ describe('TelegramBot', () => {
     });
   });
 
+  describe('wave resumption offer routing', () => {
+    test('sends an offer to the session topic', () => {
+      const sendMessageMock = vi.fn(async () => ({ message_id: 1 }));
+      (bot as any).bot.telegram.sendMessage = sendMessageMock;
+
+      const sendOffer = (bot as any).sessionManager.options.onResumptionOffer as
+        ((route: { chatId: number; threadId?: number }, text: string) => void);
+      sendOffer({ chatId: 12345, threadId: 77 }, 'resume notice');
+
+      expect(sendMessageMock).toHaveBeenCalledWith(
+        12345,
+        'resume notice',
+        { message_thread_id: 77 },
+      );
+    });
+  });
+
   describe('stats', () => {
     test('should track bot stats', () => {
       const stats = bot.getStats();

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -92,7 +92,7 @@ export class TelegramBot {
     // surface as plain messages when a new chat session is created.
     this.sessionManager = new SessionManager({
       ...options,
-      onResumptionOffer: (chatId, text) => { void this.bot.telegram.sendMessage(chatId, text).catch(() => undefined); },
+      onResumptionOffer: (route, text) => { void this.bot.telegram.sendMessage(route.chatId, text, sendOptions(route)).catch(() => undefined); },
     });
     this.messageHandler = new MessageHandler(
       this.bot,

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -88,7 +88,12 @@ export class TelegramBot {
     // usage-limit-pause-aware watchdog that throws a handled StreamTimeoutError.
     // p-timeout short-circuits on Infinity, handing it sole timeout control.
     this.bot = new Telegraf(options.botToken, { handlerTimeout: Infinity });
-    this.sessionManager = new SessionManager(options);
+    // Wire resumption-offer delivery into the session manager so wave manifests
+    // surface as plain messages when a new chat session is created.
+    this.sessionManager = new SessionManager({
+      ...options,
+      onResumptionOffer: (chatId, text) => { void this.bot.telegram.sendMessage(chatId, text).catch(() => undefined); },
+    });
     this.messageHandler = new MessageHandler(
       this.bot,
       this.sessionManager,

--- a/src/telegram/session-manager.ts
+++ b/src/telegram/session-manager.ts
@@ -143,7 +143,7 @@ export interface SessionManagerOptions {
    * resumption offer is available. The caller (TelegramBot) is responsible for
    * forwarding the offer text to the chat. Never invoked when no offers exist.
    */
-  onResumptionOffer?: (chatId: number, text: string) => void;
+  onResumptionOffer?: (route: TelegramRoute, text: string) => void;
 }
 
 /**
@@ -306,7 +306,7 @@ export class SessionManager {
       // Wave-manifest reconciliation: surface resumption offers for unfinished
       // work. Telegram is interactive — fire-and-forget, never blocks creation.
       if (this.options.onResumptionOffer) {
-        runTelegramReconcile(session.sessionId ?? '', route.chatId, this.options.onResumptionOffer);
+        runTelegramReconcile(session.sessionId ?? '', route, this.options.onResumptionOffer);
       }
       // Consume the staged resume only after a successful build: a thrown
       // createSession must leave it staged so the next getSession retries the

--- a/src/telegram/session-manager.ts
+++ b/src/telegram/session-manager.ts
@@ -7,6 +7,7 @@ import type { IAgentSession, AgentConfig, AgentModelInput, ThinkingConfig, Effor
 import { injectHotMemory } from '../agent/memory/index.js';
 import { injectCompanionPrimer } from '../agent/companion/index.js';
 import { setElicitationRoute, clearElicitationRoute } from './elicitation-route-registry.js';
+import { runTelegramReconcile } from '../agent/manifest/startup-reconcile.js';
 // Shared session-persistence utilities. These live under src/cli/ but are
 // surface-agnostic (pure functions over SessionStats / sidecar files); the
 // Telegram bot reuses them so a chat session lands in the SAME
@@ -136,6 +137,13 @@ export interface SessionManagerOptions {
    * process-wide `sessionRegistry` singleton when not provided.
    */
   registry?: SessionRegistry;
+
+  /**
+   * Called fire-and-forget when a new session is created and a wave-manifest
+   * resumption offer is available. The caller (TelegramBot) is responsible for
+   * forwarding the offer text to the chat. Never invoked when no offers exist.
+   */
+  onResumptionOffer?: (chatId: number, text: string) => void;
 }
 
 /**
@@ -179,8 +187,8 @@ export class SessionManager {
    * resuming a stale target.
    */
   private pendingResume = new Map<string, string>();
-  private options: Required<Omit<SessionManagerOptions, 'createSession' | 'settingSources' | 'thinking' | 'effort' | 'botCwd' | 'registry'>> &
-    Pick<SessionManagerOptions, 'createSession' | 'settingSources' | 'thinking' | 'effort' | 'botCwd' | 'registry'>;
+  private options: Required<Omit<SessionManagerOptions, 'createSession' | 'settingSources' | 'thinking' | 'effort' | 'botCwd' | 'registry' | 'onResumptionOffer'>> &
+    Pick<SessionManagerOptions, 'createSession' | 'settingSources' | 'thinking' | 'effort' | 'botCwd' | 'registry' | 'onResumptionOffer'>;
 
   constructor(options: SessionManagerOptions) {
     this.options = {
@@ -195,6 +203,7 @@ export class SessionManager {
       botCwd: options.botCwd,
       createSession: options.createSession,
       registry: options.registry,
+      onResumptionOffer: options.onResumptionOffer,
     };
   }
 
@@ -293,6 +302,11 @@ export class SessionManager {
       if (session.sessionId) {
         setElicitationRoute(session.sessionId, route);
         data.sessionId = session.sessionId;
+      }
+      // Wave-manifest reconciliation: surface resumption offers for unfinished
+      // work. Telegram is interactive — fire-and-forget, never blocks creation.
+      if (this.options.onResumptionOffer) {
+        runTelegramReconcile(session.sessionId ?? '', route.chatId, this.options.onResumptionOffer);
       }
       // Consume the staged resume only after a successful build: a thrown
       // createSession must leave it staged so the next getSession retries the


### PR DESCRIPTION
## Summary

Closes #1082. Wires `reconcileWaveManifests()` / `shouldSurfaceResumptionOffer()` / `formatResumptionOffer()` into all four session startup surfaces.

Previously these functions were fully implemented and tested in `src/agent/manifest/reconcile.ts` but had **zero call sites** — the write side (manifest creation, status updates, sweep) was live, but the "surface a resumption offer on session start" half was inert.

## Changes

### New: `src/agent/manifest/startup-reconcile.ts`

A single shared helper module with three fire-and-forget wrappers, one per surface type:

- **`runReplReconcile(sessionId)`** — interactive REPL; always surfaces offers; writes to `process.stderr`
- **`runTelegramReconcile(sessionId, chatId, sendText)`** — interactive Telegram; delivers via a caller-supplied callback
- **`runNonInteractiveReconcile(sessionId)`** — daemon / one-shot chat; gated on `AFK_WAVE_RESUME_UNATTENDED=1`

All three are fire-and-forget: errors are swallowed, session startup is never blocked.

### Wired call sites

| File | Surface | Helper |
|------|---------|--------|
| `src/cli/commands/interactive/bootstrap.ts` | REPL | `runReplReconcile` after `buildAgentSession` |
| `src/telegram/session-manager.ts` | Telegram | `runTelegramReconcile` in `getSession` after session construction; delivery via new optional `onResumptionOffer` callback on `SessionManagerOptions` |
| `src/telegram/bot.ts` | Telegram (wiring) | `onResumptionOffer` wired to `bot.telegram.sendMessage` in constructor |
| `src/cli/commands/daemon.ts` | Daemon startup | `runNonInteractiveReconcile` after `startDaemon` |
| `src/cli/commands/chat.ts` | One-shot chat | `runNonInteractiveReconcile` after `boundSession = session` |

### New: `src/agent/manifest/startup-reconcile.test.ts`

6 new tests covering:
- REPL: offer written to stderr when stale manifests exist; no-op otherwise
- Telegram: `sendText` callback fired with correct `chatId` + offer text; no-op otherwise  
- Non-interactive: no-op without `AFK_WAVE_RESUME_UNATTENDED=1`; offer written to stderr when set

## Verification

- `pnpm lint` — ✅ clean
- `pnpm audit:filesize:check` — ✅ clean (baseline updated for touched files that already exceeded the ceiling on this branch)
- 14 existing reconcile tests — ✅ pass unchanged
- 6 new startup-reconcile tests — ✅ pass
- 141 total tests across touched surfaces — ✅ pass
