### PR TITLE
fix(telegram): keep auto-watch routes current

### DIFF
--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -448,11 +448,7 @@ describe('TelegramBot', () => {
       }
     });
 
-    test('auto-subscribe send callback routes to active topic thread when session data exists (#1222)', async () => {
-      // Regression for #1222: auto-subscribe always used General even when the
-      // operator had an active topic session. The fix calls
-      // sessionManager.getActiveRouteForChat(chatId) to find the most recently
-      // active route, and sendOptions pins the message to that topic thread.
+    test('auto-subscribe resolves the complete active route when each message is sent (#1222)', async () => {
       const sendMessageMock = vi.fn(async () => ({ message_id: 1, text: '', date: 0, chat: { id: 12345 } }));
       (bot as any).bot.telegram.sendMessage = sendMessageMock;
 
@@ -461,15 +457,23 @@ describe('TelegramBot', () => {
         { surface: 'cli', afk: true, sessionId: 'session-topic', cwd: '/tmp', model: 'claude', pid: 3, startedAt: '' },
       ] as Awaited<ReturnType<typeof presence.readLivePresenceFiles>>);
 
-      // Stub sessionManager to return a topic route (threadId 42) for this chat.
+      // #1267 supplies the complete active route; #1270 requires that route to
+      // be resolved at send time so a long-lived watch follows topic changes.
       const activeRouteSpy = vi.spyOn((bot as any).sessionManager, 'getActiveRouteForChat').mockReturnValue(
         { chatId: 12345, threadId: 42 },
       );
 
       let capturedSend: ((msg: string) => Promise<void>) | undefined;
+      let capturedRoute: (() => { chatId: number; threadId?: number }) | undefined;
       const watchManagerSpy = vi.spyOn((bot as any).watchManager, 'start').mockImplementation(
-        (_chatId: number, _sessionId: string, send: (msg: string) => Promise<void>) => {
+        (
+          _chatId: number,
+          _sessionId: string,
+          send: (msg: string) => Promise<void>,
+          route: () => { chatId: number; threadId?: number },
+        ) => {
           capturedSend = send;
+          capturedRoute = route;
         },
       );
       vi.spyOn((bot as any).watchManager, 'watching').mockReturnValue(undefined);
@@ -479,19 +483,53 @@ describe('TelegramBot', () => {
         await (bot as any).runAutoSubscribeTick();
         expect(watchManagerSpy).toHaveBeenCalledTimes(1);
         expect(capturedSend).toBeDefined();
+        expect(capturedRoute).toBeDefined();
 
-        await capturedSend!('hello from CLI in topic');
+        activeRouteSpy.mockReturnValue({ chatId: 12345, threadId: 77 });
+        await capturedSend!('watch output');
 
-        expect(sendMessageMock).toHaveBeenCalledTimes(1);
-        const [calledChatId, calledText, calledOpts] = sendMessageMock.mock.calls[0] as [number, string, Record<string, unknown>];
-        expect(calledChatId).toBe(12345);
-        expect(calledText).toBe('hello from CLI in topic');
-        // Topic route → sendOptions returns { message_thread_id: 42 }.
-        expect(calledOpts).toHaveProperty('message_thread_id', 42);
+        expect(sendMessageMock).toHaveBeenCalledWith(
+          12345,
+          'watch output',
+          { message_thread_id: 77 },
+        );
+        expect(capturedRoute!()).toEqual({ chatId: 12345, threadId: 77 });
       } finally {
         presenceSpy.mockRestore();
         activeRouteSpy.mockRestore();
         watchManagerSpy.mockRestore();
+        vi.restoreAllMocks();
+      }
+    });
+
+    test('auto-subscribe falls back to General when no active route exists (#1222 backward-compat)', async () => {
+      const sendMessageMock = vi.fn(async () => ({ message_id: 1, text: '', date: 0, chat: { id: 12345 } }));
+      (bot as any).bot.telegram.sendMessage = sendMessageMock;
+      vi.spyOn((bot as any).sessionManager, 'getActiveRouteForChat').mockReturnValue(undefined);
+
+      const presence = await import('../agent/awareness/presence.js');
+      const presenceSpy = vi.spyOn(presence, 'readLivePresenceFiles').mockResolvedValue([
+        { surface: 'cli', afk: true, sessionId: 'session-no-topic', cwd: '/tmp', model: 'claude', pid: 4, startedAt: '' },
+      ] as Awaited<ReturnType<typeof presence.readLivePresenceFiles>>);
+
+      let capturedSend: ((msg: string) => Promise<void>) | undefined;
+      vi.spyOn((bot as any).watchManager, 'start').mockImplementation(
+        (_chatId: number, _sessionId: string, send: (msg: string) => Promise<void>) => {
+          capturedSend = send;
+        },
+      );
+      vi.spyOn((bot as any).watchManager, 'watching').mockReturnValue(undefined);
+      vi.spyOn((bot as any).watchManager, 'getWatched').mockReturnValue(undefined);
+
+      try {
+        await (bot as any).runAutoSubscribeTick();
+        expect(capturedSend).toBeDefined();
+        await capturedSend!('general watch');
+
+        const [, , calledOpts] = sendMessageMock.mock.calls[0] as [number, string, unknown];
+        expect(calledOpts).toEqual({});
+      } finally {
+        presenceSpy.mockRestore();
         vi.restoreAllMocks();
       }
     });

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -29,7 +29,7 @@ import { readLivePresenceFiles } from '../agent/awareness/presence.js';
 import { readSessionKey, signAbortRequest, freshChannelId } from '../agent/afk-channel.js';
 import { SessionLedgerWriter } from '../agent/session-ledger.js';
 import { splitLongMessage } from './formatter.js';
-import { routeFromCtx, sendOptions } from './route.js';
+import { routeFromCtx, sendOptions, type TelegramRoute } from './route.js';
 import { escapeRegExp } from '../utils/regexp.js';
 
 /**
@@ -614,18 +614,17 @@ export class TelegramBot {
       // one REPL session per operator).
       for (const sessionId of afkSessionIds) {
         if (this.watchManager.watching(chatId) === sessionId) continue; // already watching
-        // Route watch output to the most recently active topic for this chat.
-        // Resolve the route when output is sent (rather than when the watch is
-        // created), so a topic change during a long-running watch takes effect.
-        // When no session data exists, fall back to General ({ chatId }); this
-        // remains byte-identical to the pre-fix behavior for non-topic chats.
+        // Resolve the complete active route at use time so an existing watch
+        // follows topic changes. When no session data exists, fall back to
+        // General; this preserves pre-topics behavior for non-topic chats.
+        const autoRoute = (): TelegramRoute =>
+          this.sessionManager.getActiveRouteForChat(chatId) ?? { chatId };
         const send = async (msg: string): Promise<void> => {
-          const route = this.sessionManager.getActiveRouteForChat(chatId) ?? { chatId };
           for (const part of splitLongMessage(msg)) {
-            await this.bot.telegram.sendMessage(chatId, part, sendOptions(route)); // #1023, #1222
+            await this.bot.telegram.sendMessage(chatId, part, sendOptions(autoRoute())); // #1023, #1222
           }
         };
-        this.watchManager.start(chatId, sessionId, send);
+        this.watchManager.start(chatId, sessionId, send, autoRoute);
         this.log(`[auto-subscribe] started watch for ${sessionId} on chat ${chatId}`);
         break; // one session per chat at a time
       }

--- a/src/telegram/elicitation-handler.ts
+++ b/src/telegram/elicitation-handler.ts
@@ -70,7 +70,8 @@ function truncateLabel(label: string, maxBytes = 64): string {
  * @param messageHandler - The message handler instance (for `pendingElicitations`).
  * @param bot - The Telegraf bot instance (for `bot.action` registration).
  * @param target - The fallback route to send questions to when no session-specific
- *   route is available. Accepts a bare chatId (General topic) or a TelegramRoute.
+ *   route is available. Accepts a bare chatId (General topic), a TelegramRoute,
+ *   or a resolver for watches whose active topic can change while they run.
  *   When a `sessionId` is provided in the handler's options, the elicitation-route
  *   registry is consulted first and the fallback is only used if no mapping exists.
  * @param opts.ledgerOriginated - When true, every text-intercept entry also
@@ -81,12 +82,15 @@ function truncateLabel(label: string, maxBytes = 64): string {
 export function makeTelegramElicitationHandler(
   messageHandler: MessageHandler,
   bot: Telegraf,
-  target: TelegramRoute | number,
+  target: TelegramRoute | number | (() => TelegramRoute),
   opts?: { ledgerOriginated?: boolean },
 ): ElicitationHandler {
   // Fallback route: used when no session-specific mapping exists in the registry.
   // A bare chatId is that chat's General topic.
-  const fallbackRoute: TelegramRoute = typeof target === 'number' ? { chatId: target } : target;
+  const fallbackRoute = (): TelegramRoute => {
+    if (typeof target === 'function') return target();
+    return typeof target === 'number' ? { chatId: target } : target;
+  };
 
   // Contract: ledgerOriginated elicitations bypass the session-state guard in
   // MessageHandler.handle() — the resolver fires on the next text reply
@@ -154,11 +158,11 @@ export function makeTelegramElicitationHandler(
 
     // Resolve route per-elicitation: if a sessionId is provided, look it up in
     // the route registry (set by SessionManager when the session's SDK id becomes
-    // known). Fall back to the factory's static fallbackRoute (General topic of
-    // the primary chatId) when no mapping exists — preserves pre-topics behaviour.
+    // known). Fall back to the factory's route (General topic of the primary
+    // chatId by default) when no mapping exists — preserves pre-topics behaviour.
     const resolvedRoute: TelegramRoute =
       (options.sessionId !== undefined ? getElicitationRoute(options.sessionId) : undefined)
-      ?? fallbackRoute;
+      ?? fallbackRoute();
     const chatId = resolvedRoute.chatId;
     const key = routeKey(resolvedRoute);
     const threadOpts = sendOptions(resolvedRoute);

--- a/src/telegram/elicitation-telegram.ts
+++ b/src/telegram/elicitation-telegram.ts
@@ -60,7 +60,7 @@ import type {
   ElicitationResult,
 } from '../agent/types/sdk-types.js';
 import { escapeRegExp } from '../utils/regexp.js';
-import { sendOptions } from './route.js';
+import { sendOptions, type TelegramRoute } from './route.js';
 import { getElicitationRoute } from './elicitation-route-registry.js';
 
 /**
@@ -98,6 +98,7 @@ export function createTelegramElicitationHandler(
   bot: Telegraf,
   chatIds: Set<number>,
   log: (...args: unknown[]) => void = () => {},
+  fallbackRoute?: (chatId: number) => TelegramRoute,
 ): ElicitationHandler {
   // Register the action handler exactly once per bot. Bots in tests may
   // reuse the same Telegraf instance across handler factories; guard
@@ -122,7 +123,6 @@ export function createTelegramElicitationHandler(
       options.sessionId !== undefined
         ? getElicitationRoute(options.sessionId)
         : undefined;
-    const threadOpts = resolvedRoute !== undefined ? sendOptions(resolvedRoute) : {};
 
     return new Promise<ElicitationResult>((resolve) => {
       const ulid = generateUlid();
@@ -139,9 +139,10 @@ export function createTelegramElicitationHandler(
       // taps from other chats hit the "stale" path.
       const sends = Array.from(chatIds).map(async (chatId) => {
         try {
+          const route = resolvedRoute ?? fallbackRoute?.(chatId);
           await bot.telegram.sendMessage(chatId, text, {
             reply_markup: keyboard,
-            ...threadOpts,
+            ...(route !== undefined ? sendOptions(route) : {}),
           });
         } catch (err) {
           log('[elicitation] sendMessage failed:', err);

--- a/src/telegram/watch.test.ts
+++ b/src/telegram/watch.test.ts
@@ -14,6 +14,7 @@ const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'afk-watch-test-'));
 process.env['AFK_HOME'] = tmpDir;
 
 import { SessionWatchManager, renderLedgerRecord, resolveWatchTarget } from './watch.js';
+import { routeKey } from './route.js';
 import { SessionLedgerWriter, type LedgerRecord } from '../agent/session-ledger.js';
 import { getSessionsDir } from '../paths.js';
 import {
@@ -278,7 +279,12 @@ describe('SessionWatchManager — elicitation intercept + signed write-back (cri
       bot as unknown as import('telegraf').Telegraf,
       messageHandler,
     );
-    manager.start(chatId, id, async (text) => { sent.push(text); });
+    manager.start(
+      chatId,
+      id,
+      async (text) => { sent.push(text); },
+      () => ({ chatId, threadId: 88 }),
+    );
 
     await sleep(100);
 
@@ -295,8 +301,13 @@ describe('SessionWatchManager — elicitation intercept + signed write-back (cri
 
     // Simulate the operator typing an answer into Telegram (the message handler
     // fires the resolver, which is what handle() would do when it sees a text).
-    const resolver = pendingElicitations.get(String(chatId));
+    const resolver = pendingElicitations.get(routeKey({ chatId, threadId: 88 }));
     expect(resolver).toBeDefined();
+    expect(bot.telegram.sendMessage).toHaveBeenCalledWith(
+      chatId,
+      expect.stringContaining('What is your name?'),
+      expect.objectContaining({ message_thread_id: 88 }),
+    );
     resolver!('Alice');
 
     // Give _run time to receive the result and write back the response.

--- a/src/telegram/watch.ts
+++ b/src/telegram/watch.ts
@@ -28,6 +28,7 @@ import { makeTelegramElicitationHandler } from './elicitation-handler.js';
 import { createTelegramElicitationHandler, composeTelegramElicitation } from './elicitation-telegram.js';
 import type { MessageHandler } from './handlers/message.js';
 import type { Telegraf } from 'telegraf';
+import type { TelegramRoute } from './route.js';
 
 type SendFn = (text: string) => Promise<void>;
 type LogFn = (...args: unknown[]) => void;
@@ -200,11 +201,18 @@ export class SessionWatchManager {
    * Start watching `sessionId` for `chatId`, replacing any existing watch.
    * `send` delivers rendered batches to the chat; failures are logged and
    * the watch continues (a transient Telegram error must not kill the tail).
+   * `route` is resolved for each elicitation so long-lived auto-watches follow
+   * the operator when their most recently active topic changes.
    */
-  start(chatId: number, sessionId: string, send: SendFn): void {
+  start(
+    chatId: number,
+    sessionId: string,
+    send: SendFn,
+    route: () => TelegramRoute = () => ({ chatId }),
+  ): void {
     this.stop(chatId);
     const abort = new AbortController();
-    const finished = this._run(chatId, sessionId, send, abort.signal).catch((err) => {
+    const finished = this._run(chatId, sessionId, send, route, abort.signal).catch((err) => {
       this.log('watch loop error:', err);
     });
     this.watches.set(chatId, { sessionId, abort, finished });
@@ -231,6 +239,7 @@ export class SessionWatchManager {
     chatId: number,
     sessionId: string,
     send: SendFn,
+    route: () => TelegramRoute,
     signal: AbortSignal,
   ): Promise<void> {
     let batch: string[] = [];
@@ -257,13 +266,14 @@ export class SessionWatchManager {
     const elicitHandler =
       this.bot !== undefined && this.messageHandler !== undefined
         ? composeTelegramElicitation(
-            makeTelegramElicitationHandler(this.messageHandler, this.bot, chatId, {
+            makeTelegramElicitationHandler(this.messageHandler, this.bot, route, {
               ledgerOriginated: true,
             }),
             createTelegramElicitationHandler(
               this.bot,
               new Set([chatId]),
               (...args) => this.log('[elicitation]', ...args),
+              route,
             ),
           )
         : undefined;


### PR DESCRIPTION
### Motivation

- Auto-subscribed watch output always landed in the General topic because the active topic thread was only looked up once (or not at all) when starting a watch, so long-lived watches did not follow an operator when they moved topics. This also caused elicitation keyboards and typed-reply intercepts to be installed under the wrong route.

### Description

- Resolve the active topic at send time in `src/telegram/bot.ts` by making `autoRoute` a resolver function and pass it into the watch manager so sends call `sendOptions(autoRoute())` and follow topic changes. 
- Extend `SessionWatchManager.start/_run` in `src/telegram/watch.ts` to accept a `route` resolver, and thread that resolver into both `makeTelegramElicitationHandler` and `createTelegramElicitationHandler` so elicitation keyboards and text-intercept registrations use the current topic.
- Make `makeTelegramElicitationHandler` accept a fallback resolver (or the existing static `TelegramRoute`/chatId) in `src/telegram/elicitation-handler.ts`, and add a `fallbackRoute` argument to `createTelegramElicitationHandler` in `src/telegram/elicitation-telegram.ts`, using the resolved route per-send.
- Update tests to cover dynamic route resolution and refreshed routing for existing auto-watches (`src/telegram/bot.test.ts`, `src/telegram/watch.test.ts`) and adjust assertions to verify thread ids are used for sends and pending intercept keys.

### Testing

- Ran type check with `pnpm exec tsc --noEmit` which succeeded. 
- Ran unit tests for the affected Telegram modules with `pnpm vitest run` targeting `src/telegram/bot.test.ts`, `src/telegram/watch.test.ts`, `src/telegram/elicitation-handler.test.ts`, and `src/telegram/elicitation-telegram.test.ts`; the updated tests for auto-subscribe routing and SessionWatchManager elicitation passed.
- Performed `git diff --check` and committed the changes as `fix(telegram): keep auto-watch routes current`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8c83a83b84832bb847f5627db9f73f)