### PR TITLE
feat(model): add OpenAI models to /model picker (#1258)

### DIFF
--- a/src/agent/session/model-slots.test.ts
+++ b/src/agent/session/model-slots.test.ts
@@ -15,6 +15,7 @@ import {
   DIRECT_MODEL_ALIASES,
   getSlotBindings,
   MODEL_ALIASES_HINT,
+  OPENAI_MODEL_HINTS,
   parseModelsConfig,
   resetSlotBindings,
   resolveBinding,
@@ -188,12 +189,43 @@ describe('fixed-identity Claude aliases (sonnet/opus/haiku decoupled from tiers,
   });
 });
 
+describe('OPENAI_MODEL_HINTS', () => {
+  it('contains the curated OpenAI wire ids', () => {
+    expect(OPENAI_MODEL_HINTS).toContain('gpt-4.1');
+    expect(OPENAI_MODEL_HINTS).toContain('gpt-4o');
+    expect(OPENAI_MODEL_HINTS).toContain('o3');
+    expect(OPENAI_MODEL_HINTS).toContain('o4-mini');
+    expect(OPENAI_MODEL_HINTS).toContain('gpt-5.5');
+    expect(OPENAI_MODEL_HINTS).toContain('codex-mini');
+  });
+
+  it('all entries start with a known OpenAI pattern', () => {
+    for (const id of OPENAI_MODEL_HINTS) {
+      const ok = id.startsWith('gpt-') || id.startsWith('o') || id.startsWith('codex');
+      expect(ok, `${id} should match a known OpenAI prefix`).toBe(true);
+    }
+  });
+});
+
 describe('MODEL_ALIASES_HINT (single source of truth for the /model picker)', () => {
-  it('is derived from the tiers + identity aliases, in the documented order', () => {
+  it('is derived from the tiers + identity aliases + OpenAI hints, in the documented order', () => {
     expect(MODEL_ALIASES_HINT).toEqual([
+      // Capability tiers (SLOT_NAMES)
       'local', 'small', 'medium', 'large',
+      // Fixed-identity Claude/xAI aliases (DIRECT_MODEL_ALIASES)
       'opus', 'opus_1m', 'sonnet', 'sonnet_1m', 'haiku', 'fable', 'grok',
+      // Curated OpenAI wire ids (OPENAI_MODEL_HINTS)
+      'gpt-4.1', 'gpt-4.1-mini', 'gpt-4.1-nano',
+      'gpt-4o', 'gpt-4o-mini',
+      'o3', 'o3-mini', 'o4-mini',
+      'gpt-5.5', 'codex-mini',
     ]);
+  });
+
+  it('includes all OPENAI_MODEL_HINTS entries', () => {
+    for (const id of OPENAI_MODEL_HINTS) {
+      expect(MODEL_ALIASES_HINT).toContain(id);
+    }
   });
 });
 

--- a/src/agent/session/model-slots.test.ts
+++ b/src/agent/session/model-slots.test.ts
@@ -191,12 +191,10 @@ describe('fixed-identity Claude aliases (sonnet/opus/haiku decoupled from tiers,
 
 describe('OPENAI_MODEL_HINTS', () => {
   it('contains the curated OpenAI wire ids', () => {
-    expect(OPENAI_MODEL_HINTS).toContain('gpt-4.1');
-    expect(OPENAI_MODEL_HINTS).toContain('gpt-4o');
-    expect(OPENAI_MODEL_HINTS).toContain('o3');
-    expect(OPENAI_MODEL_HINTS).toContain('o4-mini');
+    expect(OPENAI_MODEL_HINTS).toContain('gpt-5.6-sol');
+    expect(OPENAI_MODEL_HINTS).toContain('gpt-5.6-terra');
+    expect(OPENAI_MODEL_HINTS).toContain('gpt-5.6-luna');
     expect(OPENAI_MODEL_HINTS).toContain('gpt-5.5');
-    expect(OPENAI_MODEL_HINTS).toContain('codex-mini');
   });
 
   it('all entries start with a known OpenAI pattern', () => {
@@ -215,10 +213,8 @@ describe('MODEL_ALIASES_HINT (single source of truth for the /model picker)', ()
       // Fixed-identity Claude/xAI aliases (DIRECT_MODEL_ALIASES)
       'opus', 'opus_1m', 'sonnet', 'sonnet_1m', 'haiku', 'fable', 'grok',
       // Curated OpenAI wire ids (OPENAI_MODEL_HINTS)
-      'gpt-4.1', 'gpt-4.1-mini', 'gpt-4.1-nano',
-      'gpt-4o', 'gpt-4o-mini',
-      'o3', 'o3-mini', 'o4-mini',
-      'gpt-5.5', 'codex-mini',
+      'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna',
+      'gpt-5.5',
     ]);
   });
 

--- a/src/agent/session/model-slots.ts
+++ b/src/agent/session/model-slots.ts
@@ -176,18 +176,47 @@ export const DIRECT_MODEL_ALIASES: Readonly<Record<string, string>> = {
 };
 
 /**
+ * Curated OpenAI model ids surfaced in the `/model` picker. Wire ids only —
+ * no short aliases (OpenAI has no stable short alias layer like `sonnet`).
+ * Ordered current-flagship → reasoning → mini/nano so the most-common choices
+ * appear first. `gpt-4o` is included as the widely-known baseline.
+ *
+ * This list is deliberately narrow: it covers models agent-afk already has
+ * explicit metadata for (context limits, capability flags, max-output overrides
+ * in `model-limits.ts` / `model-capabilities.ts`). Any raw OpenAI id not listed
+ * here is still accepted at the `/model` surface — this is the discoverable
+ * subset, not the whole acceptable set.
+ */
+export const OPENAI_MODEL_HINTS: readonly string[] = [
+  'gpt-4.1',
+  'gpt-4.1-mini',
+  'gpt-4.1-nano',
+  'gpt-4o',
+  'gpt-4o-mini',
+  'o3',
+  'o3-mini',
+  'o4-mini',
+  'gpt-5.5',
+  'codex-mini',
+];
+
+/**
  * User-facing model handles shown by the `/model` picker (REPL + Telegram) and
- * accepted by name. DERIVED from the two stable layers — the capability TIERS
- * ({@link SLOT_NAMES}) plus the fixed-identity aliases ({@link DIRECT_MODEL_ALIASES})
- * — so the discoverable list can never drift from what actually resolves. This
- * is the single source of truth: both the CLI (`/model`) and Telegram surfaces
- * import it rather than re-declaring it. Raw wire ids and `org/model` ids are
- * also accepted at the `/model` surface (this list is the discoverable subset,
- * not the whole acceptable set).
+ * accepted by name. DERIVED from three stable layers:
+ *   1. Capability TIERS ({@link SLOT_NAMES})
+ *   2. Fixed-identity Claude/xAI aliases ({@link DIRECT_MODEL_ALIASES})
+ *   3. Curated OpenAI wire ids ({@link OPENAI_MODEL_HINTS})
+ *
+ * The three-part ordering keeps Claude/tier handles at the top (most users),
+ * followed by OpenAI models. Raw wire ids and `org/model` ids are also accepted
+ * at the `/model` surface — this list is the discoverable subset, not the whole
+ * acceptable set. Both the CLI (`/model`) and Telegram surfaces import it rather
+ * than re-declaring it; it is the single source of truth for the picker.
  */
 export const MODEL_ALIASES_HINT: readonly string[] = [
   ...SLOT_NAMES,
   ...Object.keys(DIRECT_MODEL_ALIASES),
+  ...OPENAI_MODEL_HINTS,
 ];
 
 /**

--- a/src/agent/session/model-slots.ts
+++ b/src/agent/session/model-slots.ts
@@ -178,8 +178,8 @@ export const DIRECT_MODEL_ALIASES: Readonly<Record<string, string>> = {
 /**
  * Curated OpenAI model ids surfaced in the `/model` picker. Wire ids only —
  * no short aliases (OpenAI has no stable short alias layer like `sonnet`).
- * Ordered current-flagship → reasoning → mini/nano so the most-common choices
- * appear first. `gpt-4o` is included as the widely-known baseline.
+ * Ordered flagship → balanced → mini so the most-common choices appear first.
+ * `gpt-5.5` is included as the prior-generation baseline.
  *
  * This list is deliberately narrow: it covers models agent-afk already has
  * explicit metadata for (context limits, capability flags, max-output overrides
@@ -188,16 +188,10 @@ export const DIRECT_MODEL_ALIASES: Readonly<Record<string, string>> = {
  * subset, not the whole acceptable set.
  */
 export const OPENAI_MODEL_HINTS: readonly string[] = [
-  'gpt-4.1',
-  'gpt-4.1-mini',
-  'gpt-4.1-nano',
-  'gpt-4o',
-  'gpt-4o-mini',
-  'o3',
-  'o3-mini',
-  'o4-mini',
+  'gpt-5.6-sol',
+  'gpt-5.6-terra',
+  'gpt-5.6-luna',
   'gpt-5.5',
-  'codex-mini',
 ];
 
 /**


### PR DESCRIPTION
## Problem

The `/model` picker was only populated from `MODEL_ALIASES_HINT`, which contained only the four capability tiers (`local`/`small`/`medium`/`large`) and the fixed-identity Claude/xAI aliases (`haiku`/`sonnet`/`opus`/`fable`/`grok`). OpenAI models explicitly supported elsewhere in the codebase (context limits in `model-limits.ts`, capability flags in `model-capabilities.ts`, provider routing in `providers/index.ts`) were absent — users had to remember and type full wire ids manually.

## Solution

Extract a curated `OPENAI_MODEL_HINTS` constant and spread it into `MODEL_ALIASES_HINT` after the existing Claude/xAI entries.

**Picker now shows 15 entries** (up from 11):

| Section | Entries |
|---|---|
| Capability tiers | `local`, `small`, `medium`, `large` |
| Claude/xAI aliases | `opus`, `opus_1m`, `sonnet`, `sonnet_1m`, `haiku`, `fable`, `grok` |
| OpenAI (new) | `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5` |

The curated set covers only models with full codebase metadata (context limits, max output, capability flags). Superseded models (`gpt-4.1`, `gpt-4o`, `o3`, `o4-mini`, `codex-mini`) are dropped from the picker but still accepted as raw wire ids at the `/model` surface.

## Files changed

- **`src/agent/session/model-slots.ts`** — add `OPENAI_MODEL_HINTS` export (4 wire ids), spread into `MODEL_ALIASES_HINT`, update JSDoc to document the three-part derivation
- **`src/agent/session/model-slots.test.ts`** — import `OPENAI_MODEL_HINTS`, add two new test cases for it, update the `MODEL_ALIASES_HINT` snapshot

## Tests

```
✓ src/agent/session/model-slots.test.ts (57 tests)
pnpm lint ✓ (tsc --noEmit clean)
```

Closes #1258
