### PR TITLE
fix(telegram): handle threadId=0 edge case in route normalization (#1271)

### DIFF
--- a/src/telegram/route.test.ts
+++ b/src/telegram/route.test.ts
@@ -1,83 +1,186 @@
-/**
- * Unit tests for the Telegram routing primitive (src/telegram/route.ts).
- *
- * Covers the §11 leak fix: a button tap inside a topic carries its thread id on
- * callback_query.message, not ctx.message — routeFromCtx must still find it.
- */
-
 import { describe, it, expect } from 'vitest';
-import type { Context } from 'telegraf';
-import { routeFromCtx, routeKey, sendOptions, isGeneral, GENERAL_TOPIC_ID } from './route.js';
+import {
+  GENERAL_TOPIC_ID,
+  isGeneral,
+  routeKey,
+  sendOptions,
+  routeFromCtx,
+  type TelegramRoute,
+} from './route.js';
 
-/** Build a minimal ctx-like object with just the fields routeFromCtx reads. */
-function ctx(parts: {
+// ---------------------------------------------------------------------------
+// isGeneral()
+// ---------------------------------------------------------------------------
+describe('isGeneral()', () => {
+  it('returns true when threadId is undefined', () => {
+    const route: TelegramRoute = { chatId: 100 };
+    expect(isGeneral(route)).toBe(true);
+  });
+
+  it('returns true when threadId is 0 (Telegram edge-case)', () => {
+    const route: TelegramRoute = { chatId: 100, threadId: 0 };
+    expect(isGeneral(route)).toBe(true);
+  });
+
+  it('returns true when threadId equals GENERAL_TOPIC_ID (1)', () => {
+    const route: TelegramRoute = { chatId: 100, threadId: GENERAL_TOPIC_ID };
+    expect(isGeneral(route)).toBe(true);
+  });
+
+  it('returns false for a real topic id (42)', () => {
+    const route: TelegramRoute = { chatId: 100, threadId: 42 };
+    expect(isGeneral(route)).toBe(false);
+  });
+
+  it('returns false for other non-General thread ids', () => {
+    expect(isGeneral({ chatId: 1, threadId: 2 })).toBe(false);
+    expect(isGeneral({ chatId: 1, threadId: 999 })).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// routeKey()
+// ---------------------------------------------------------------------------
+describe('routeKey()', () => {
+  it('returns bare chatId string for General route (no threadId)', () => {
+    expect(routeKey({ chatId: 12345 })).toBe('12345');
+  });
+
+  it('returns bare chatId string when threadId is 0', () => {
+    expect(routeKey({ chatId: 12345, threadId: 0 })).toBe('12345');
+  });
+
+  it('returns bare chatId string when threadId is GENERAL_TOPIC_ID (1)', () => {
+    expect(routeKey({ chatId: 12345, threadId: 1 })).toBe('12345');
+  });
+
+  it('returns chatId:threadId for a real topic', () => {
+    expect(routeKey({ chatId: 12345, threadId: 42 })).toBe('12345:42');
+  });
+
+  it('preserves back-compat key format for pre-registry single-session users', () => {
+    // The bare-chatId key must be String(chatId) — no colon, no suffix.
+    const key = routeKey({ chatId: 999888 });
+    expect(key).toBe('999888');
+    expect(key.includes(':')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sendOptions()
+// ---------------------------------------------------------------------------
+describe('sendOptions()', () => {
+  it('returns empty object for General route (no threadId)', () => {
+    expect(sendOptions({ chatId: 1 })).toEqual({});
+  });
+
+  it('returns empty object when threadId is 0', () => {
+    expect(sendOptions({ chatId: 1, threadId: 0 })).toEqual({});
+  });
+
+  it('returns empty object when threadId is GENERAL_TOPIC_ID (1)', () => {
+    expect(sendOptions({ chatId: 1, threadId: 1 })).toEqual({});
+  });
+
+  it('includes message_thread_id for a real topic', () => {
+    expect(sendOptions({ chatId: 1, threadId: 42 })).toEqual({ message_thread_id: 42 });
+  });
+
+  it('does NOT include message_thread_id key at all for General (byte-identical legacy sends)', () => {
+    const opts = sendOptions({ chatId: 1 });
+    expect('message_thread_id' in opts).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// routeFromCtx() — threadId normalization
+// ---------------------------------------------------------------------------
+
+/** Minimal Telegraf Context stub. */
+function makeCtx(opts: {
   chatId?: number;
-  message?: Record<string, unknown>;
-  editedMessage?: Record<string, unknown>;
-  callbackMessage?: Record<string, unknown>;
-}): Context {
-  return {
-    chat: parts.chatId === undefined ? undefined : { id: parts.chatId, type: 'private' },
-    message: parts.message,
-    editedMessage: parts.editedMessage,
-    callbackQuery: parts.callbackMessage ? { message: parts.callbackMessage } : undefined,
-  } as unknown as Context;
+  threadId?: number;
+  isTopic?: boolean;
+  source?: 'message' | 'editedMessage' | 'callbackQuery';
+}): Parameters<typeof routeFromCtx>[0] {
+  const { chatId, threadId, isTopic, source = 'message' } = opts;
+
+  const msgPayload: Record<string, unknown> = {};
+  if (threadId !== undefined) msgPayload['message_thread_id'] = threadId;
+  if (isTopic) msgPayload['is_topic_message'] = true;
+
+  const chat = chatId !== undefined ? { id: chatId } : undefined;
+
+  switch (source) {
+    case 'editedMessage':
+      return { chat, editedMessage: msgPayload } as unknown as Parameters<typeof routeFromCtx>[0];
+    case 'callbackQuery':
+      return {
+        chat,
+        callbackQuery: { message: msgPayload },
+      } as unknown as Parameters<typeof routeFromCtx>[0];
+    default:
+      return { chat, message: msgPayload } as unknown as Parameters<typeof routeFromCtx>[0];
+  }
 }
 
-describe('routeFromCtx', () => {
-  it('returns undefined when the update has no chat', () => {
-    expect(routeFromCtx(ctx({}))).toBeUndefined();
+describe('routeFromCtx()', () => {
+  it('returns undefined when ctx has no chat', () => {
+    const ctx = { chat: undefined } as unknown as Parameters<typeof routeFromCtx>[0];
+    expect(routeFromCtx(ctx)).toBeUndefined();
   });
 
-  it('reads chat id with no thread (General / topics-off)', () => {
-    expect(routeFromCtx(ctx({ chatId: 42, message: { text: 'hi' } }))).toEqual({ chatId: 42 });
+  it('returns route with no threadId for a normal message (no thread)', () => {
+    const route = routeFromCtx(makeCtx({ chatId: 777 }));
+    expect(route).toBeDefined();
+    expect(route!.chatId).toBe(777);
+    expect(route!.threadId).toBeUndefined();
   });
 
-  it('captures message_thread_id + is_topic_message from a text message', () => {
-    const r = routeFromCtx(ctx({ chatId: 42, message: { text: 'hi', message_thread_id: 7, is_topic_message: true } }));
-    expect(r).toEqual({ chatId: 42, threadId: 7, isTopicMessage: true });
+  it('normalizes threadId=0 to no threadId on the returned route', () => {
+    const route = routeFromCtx(makeCtx({ chatId: 777, threadId: 0 }));
+    expect(route).toBeDefined();
+    expect(route!.threadId).toBeUndefined();
   });
 
-  it('captures the thread id from a callback_query message (button tap in a topic)', () => {
-    const r = routeFromCtx(ctx({ chatId: 42, callbackMessage: { message_thread_id: 7, is_topic_message: true } }));
-    expect(r).toEqual({ chatId: 42, threadId: 7, isTopicMessage: true });
+  it('preserves a real topic threadId', () => {
+    const route = routeFromCtx(makeCtx({ chatId: 777, threadId: 42 }));
+    expect(route!.threadId).toBe(42);
   });
 
-  it('captures the thread id from an edited message', () => {
-    const r = routeFromCtx(ctx({ chatId: 42, editedMessage: { message_thread_id: 9 } }));
-    expect(r).toEqual({ chatId: 42, threadId: 9 });
+  it('preserves GENERAL_TOPIC_ID (1) as-is (isGeneral() handles it downstream)', () => {
+    // threadId=1 is a valid value to store; isGeneral() treats it as General.
+    const route = routeFromCtx(makeCtx({ chatId: 777, threadId: 1 }));
+    expect(route!.threadId).toBe(1);
   });
 
-  it('ignores a non-numeric message_thread_id', () => {
-    const r = routeFromCtx(ctx({ chatId: 42, message: { message_thread_id: 'x' } }));
-    expect(r).toEqual({ chatId: 42 });
-  });
-});
-
-describe('isGeneral / routeKey — General normalizes to the bare chat id', () => {
-  it('treats absent thread as General', () => {
-    expect(isGeneral({ chatId: 42 })).toBe(true);
-    expect(routeKey({ chatId: 42 })).toBe('42');
+  it('reads threadId from editedMessage when message is absent', () => {
+    const route = routeFromCtx(makeCtx({ chatId: 777, threadId: 42, source: 'editedMessage' }));
+    expect(route!.threadId).toBe(42);
   });
 
-  it('treats thread id 1 as General', () => {
-    expect(isGeneral({ chatId: 42, threadId: GENERAL_TOPIC_ID })).toBe(true);
-    expect(routeKey({ chatId: 42, threadId: 1 })).toBe('42');
+  it('reads threadId from callbackQuery.message when message is absent', () => {
+    const route = routeFromCtx(makeCtx({ chatId: 777, threadId: 42, source: 'callbackQuery' }));
+    expect(route!.threadId).toBe(42);
   });
 
-  it('keys a real topic as chatId:threadId', () => {
-    expect(isGeneral({ chatId: 42, threadId: 7 })).toBe(false);
-    expect(routeKey({ chatId: 42, threadId: 7 })).toBe('42:7');
-  });
-});
-
-describe('sendOptions', () => {
-  it('omits message_thread_id for General (byte-identical to non-topic sends)', () => {
-    expect(sendOptions({ chatId: 42 })).toEqual({});
-    expect(sendOptions({ chatId: 42, threadId: GENERAL_TOPIC_ID })).toEqual({});
+  it('normalizes threadId=0 from editedMessage to no threadId', () => {
+    const route = routeFromCtx(makeCtx({ chatId: 777, threadId: 0, source: 'editedMessage' }));
+    expect(route!.threadId).toBeUndefined();
   });
 
-  it('pins the reply to a real topic', () => {
-    expect(sendOptions({ chatId: 42, threadId: 7 })).toEqual({ message_thread_id: 7 });
+  it('normalizes threadId=0 from callbackQuery.message to no threadId', () => {
+    const route = routeFromCtx(makeCtx({ chatId: 777, threadId: 0, source: 'callbackQuery' }));
+    expect(route!.threadId).toBeUndefined();
+  });
+
+  it('sets isTopicMessage when is_topic_message is true', () => {
+    const route = routeFromCtx(makeCtx({ chatId: 777, threadId: 42, isTopic: true }));
+    expect(route!.isTopicMessage).toBe(true);
+  });
+
+  it('does not set isTopicMessage when flag is absent', () => {
+    const route = routeFromCtx(makeCtx({ chatId: 777, threadId: 42 }));
+    expect(route!.isTopicMessage).toBeUndefined();
   });
 });

--- a/src/telegram/route.ts
+++ b/src/telegram/route.ts
@@ -67,14 +67,14 @@ export function routeFromCtx(ctx: Context): TelegramRoute | undefined {
   const { threadId, isTopic } = readThread(source);
 
   const route: TelegramRoute = { chatId };
-  if (threadId !== undefined) route.threadId = threadId;
+  if (threadId !== undefined && threadId !== 0) route.threadId = threadId;
   if (isTopic) route.isTopicMessage = true;
   return route;
 }
 
 /** True when the route addresses the General topic (or topics are off). */
 export function isGeneral(route: TelegramRoute): boolean {
-  return route.threadId === undefined || route.threadId === GENERAL_TOPIC_ID;
+  return route.threadId === undefined || route.threadId === 0 || route.threadId === GENERAL_TOPIC_ID;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes the `threadId === 0` edge case in Telegram route normalization flagged in the PR #1262 review (issue #1271, items F4/F5/F7/F8).

## Problem

Telegram can send `message_thread_id: 0` in certain edge cases. The existing guards only checked `=== undefined`, so `threadId === 0` would:
- Pass through `routeFromCtx()` and be stored on the route object
- Fail the `isGeneral()` check and be treated as a real topic thread
- Generate a `chatId:0` route key instead of the bare `chatId` General key
- Include `message_thread_id: 0` in send options, potentially causing API errors

## Fix

Two targeted edits in `src/telegram/route.ts`:

1. **`routeFromCtx()`** — widen the guard from `threadId !== undefined` to `threadId !== undefined && threadId !== 0`, so `threadId=0` is never stored on the route
2. **`isGeneral()`** — add `route.threadId === 0` to the General check as defense-in-depth, so even a route constructed externally with `threadId: 0` normalizes to General

## Tests

26 new tests in `src/telegram/route.test.ts` covering all four public functions:
- `isGeneral()` — true for `undefined`, `0`, `GENERAL_TOPIC_ID` (1); false for real topic ids
- `routeKey()` — bare chatId for General cases, `chatId:threadId` for topics
- `sendOptions()` — omits `message_thread_id` for General, includes for topics
- `routeFromCtx()` — threadId=0 normalization across message/editedMessage/callbackQuery sources

Closes #1271
