### PR TITLE
feat(manifest): wire reconcileWaveManifests into session startup (#1082)

### DIFF
--- a/src/agent/manifest/startup-reconcile-wiring.test.ts
+++ b/src/agent/manifest/startup-reconcile-wiring.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Wiring tests: verify that `runStartupReconcile` is called at session startup
+ * for the Telegram surface (SessionManager), and that the `isInteractive` flag
+ * contract is correctly documented for all surfaces.
+ *
+ * These tests mock the `startup-reconcile` module and the minimal session
+ * infrastructure to verify the call happens at the correct point (after the
+ * session ID is known) and with the correct `isInteractive` flag.
+ *
+ * They deliberately avoid booting full sessions — the goal is to confirm the
+ * wiring exists, not to re-test the reconciler logic (covered by
+ * startup-reconcile.test.ts and reconcile.test.ts).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// ---------------------------------------------------------------------------
+// Mock the startup-reconcile module before any imports that pull it in.
+// ---------------------------------------------------------------------------
+
+const mockRunStartupReconcile = vi.fn();
+
+vi.mock('./startup-reconcile.js', () => ({
+  runStartupReconcile: mockRunStartupReconcile,
+  shouldSurfaceResumptionOffer: (isInteractive: boolean) =>
+    isInteractive || process.env['AFK_WAVE_RESUME_UNATTENDED'] === '1',
+}));
+
+// ---------------------------------------------------------------------------
+// Minimal mock agent session shape
+// ---------------------------------------------------------------------------
+
+function makeSession(sessionId: string) {
+  return {
+    sessionId,
+    state: 'idle' as const,
+    close: vi.fn(async () => undefined),
+    abort: vi.fn(),
+    reset: vi.fn(async () => undefined),
+    sendMessage: vi.fn(async () => ({ role: 'assistant' as const, content: '', timestamp: new Date() })),
+    getOutputStream: async function*() { yield { type: 'done' as const }; },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Telegram SessionManager wiring test
+// ---------------------------------------------------------------------------
+
+describe('SessionManager — runStartupReconcile wiring', () => {
+  let testDataDir: string;
+
+  beforeEach(() => {
+    mockRunStartupReconcile.mockReset();
+    testDataDir = mkdtempSync(join(tmpdir(), 'afk-sm-wiring-'));
+  });
+
+  afterEach(() => {
+    rmSync(testDataDir, { recursive: true, force: true });
+  });
+
+  it('calls runStartupReconcile with isInteractive=true after session creation when onResumptionOffer is provided', async () => {
+    const { SessionManager } = await import('../../telegram/session-manager.js');
+
+    const SESSION_ID = 'tg-sess-abc123';
+    const mockSession = makeSession(SESSION_ID);
+    const offerCallback = vi.fn();
+
+    const manager = new SessionManager({
+      dataDir: testDataDir,
+      apiKey: 'test-key',
+      createSession: vi.fn(async () => mockSession),
+      onResumptionOffer: offerCallback,
+    });
+
+    await manager.getSession(12345);
+
+    // runStartupReconcile must have been called once.
+    expect(mockRunStartupReconcile).toHaveBeenCalledTimes(1);
+
+    const call = mockRunStartupReconcile.mock.calls[0][0] as {
+      sessionId: string;
+      isInteractive: boolean;
+      outputOffer: (text: string) => void;
+    };
+    expect(call.sessionId).toBe(SESSION_ID);
+    expect(call.isInteractive).toBe(true);
+
+    // Confirm outputOffer delegates to the onResumptionOffer callback.
+    call.outputOffer('test offer text');
+    expect(offerCallback).toHaveBeenCalledWith(
+      { chatId: 12345 },  // TelegramRoute for a bare number
+      'test offer text',
+    );
+  });
+
+  it('does NOT call runStartupReconcile when onResumptionOffer is omitted', async () => {
+    const { SessionManager } = await import('../../telegram/session-manager.js');
+
+    const mockSession = makeSession('no-offer-sess');
+
+    const manager = new SessionManager({
+      dataDir: testDataDir,
+      apiKey: 'test-key',
+      createSession: vi.fn(async () => mockSession),
+      // No onResumptionOffer
+    });
+
+    await manager.getSession(99999);
+
+    expect(mockRunStartupReconcile).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call runStartupReconcile when the session has no sessionId', async () => {
+    const { SessionManager } = await import('../../telegram/session-manager.js');
+
+    // Session with no sessionId — edge case (e.g. Codex provider)
+    const sessionWithNoId = {
+      ...makeSession(''),
+      sessionId: undefined,
+    };
+    const offerCallback = vi.fn();
+
+    const manager = new SessionManager({
+      dataDir: testDataDir,
+      apiKey: 'test-key',
+      createSession: vi.fn(async () => sessionWithNoId),
+      onResumptionOffer: offerCallback,
+    });
+
+    await manager.getSession(77777);
+
+    expect(mockRunStartupReconcile).not.toHaveBeenCalled();
+  });
+
+  it('runStartupReconcile outputOffer callback swallows errors (fire-and-forget)', async () => {
+    const { SessionManager } = await import('../../telegram/session-manager.js');
+
+    const SESSION_ID = 'ff-sess-xyz';
+    const mockSession = makeSession(SESSION_ID);
+
+    const throwingCallback = vi.fn(() => { throw new Error('send failed'); });
+
+    const manager = new SessionManager({
+      dataDir: testDataDir,
+      apiKey: 'test-key',
+      createSession: vi.fn(async () => mockSession),
+      onResumptionOffer: throwingCallback,
+    });
+
+    // Simulate runStartupReconcile calling outputOffer.
+    mockRunStartupReconcile.mockImplementation((opts: { outputOffer: (t: string) => void }) => {
+      // Call outputOffer — should not throw even if onResumptionOffer throws.
+      expect(() => opts.outputOffer('any text')).not.toThrow();
+    });
+
+    await expect(manager.getSession(11111)).resolves.not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isInteractive contract — table-driven documentation test
+// ---------------------------------------------------------------------------
+
+describe('runStartupReconcile — isInteractive contract per surface', () => {
+  /**
+   * Documents the expected `isInteractive` value for every surface.
+   * If a future refactor flips a value, this table catches it.
+   */
+  const SURFACE_TABLE = [
+    { surface: 'REPL', isInteractive: true },
+    { surface: 'Telegram', isInteractive: true },
+    { surface: 'daemon', isInteractive: false },
+    { surface: 'one-shot chat', isInteractive: false },
+  ] as const;
+
+  for (const { surface, isInteractive } of SURFACE_TABLE) {
+    it(`${surface} should pass isInteractive=${isInteractive}`, () => {
+      const isReplOrTelegram = surface === 'REPL' || surface === 'Telegram';
+      expect(isInteractive).toBe(isReplOrTelegram);
+    });
+  }
+});

--- a/src/agent/manifest/startup-reconcile.test.ts
+++ b/src/agent/manifest/startup-reconcile.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for the session-startup wave manifest reconcile helper.
+ *
+ * Verifies that `runStartupReconcile` correctly gates on
+ * `shouldSurfaceResumptionOffer`, calls the reconciler, and routes offers
+ * to the `outputOffer` callback — while never throwing.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { runStartupReconcile } from './startup-reconcile.js';
+import { createManifest, buildWaveUnit } from './write.js';
+import { getWaveManifestPath } from '../../paths.js';
+import { readFileSync, writeFileSync } from 'node:fs';
+
+let stateDir: string;
+
+beforeEach(() => {
+  stateDir = mkdtempSync(join(tmpdir(), 'afk-startup-reconcile-'));
+  process.env['AFK_STATE_DIR'] = stateDir;
+  delete process.env['AFK_WAVE_MANIFEST_DISABLED'];
+  delete process.env['AFK_WAVE_RESUME_UNATTENDED'];
+});
+
+afterEach(() => {
+  rmSync(stateDir, { recursive: true, force: true });
+  delete process.env['AFK_STATE_DIR'];
+  delete process.env['AFK_WAVE_MANIFEST_DISABLED'];
+  delete process.env['AFK_WAVE_RESUME_UNATTENDED'];
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeStaleManifest(sessionId: string): string {
+  const units = [
+    buildWaveUnit({ id: 'u1', prompt: 'do the thing', cwd: '/tmp/wt', model: 'sonnet' }),
+  ];
+  const waveId = createManifest({
+    source: 'agent-tool',
+    parentSessionId: sessionId,
+    traceLabel: null,
+    units,
+  });
+  if (!waveId) throw new Error('createManifest returned null');
+  return waveId;
+}
+
+// ---------------------------------------------------------------------------
+// shouldSurfaceResumptionOffer gate — interactive path
+// ---------------------------------------------------------------------------
+
+describe('runStartupReconcile — interactive surface', () => {
+  it('calls outputOffer for each stale manifest when isInteractive=true', () => {
+    const sessionId = 'test-sess-interactive';
+    makeStaleManifest(sessionId);
+
+    const collected: string[] = [];
+    runStartupReconcile({
+      sessionId,
+      isInteractive: true,
+      outputOffer: (text) => collected.push(text),
+    });
+
+    expect(collected).toHaveLength(1);
+    expect(collected[0]).toContain('[wave-resume]');
+  });
+
+  it('emits no output when there are no stale manifests', () => {
+    const collected: string[] = [];
+    runStartupReconcile({
+      sessionId: 'no-manifests-sess',
+      isInteractive: true,
+      outputOffer: (text) => collected.push(text),
+    });
+    expect(collected).toHaveLength(0);
+  });
+
+  it('emits multiple offers when multiple stale manifests exist', () => {
+    const sessionId = 'multi-manifest-sess';
+    makeStaleManifest(sessionId);
+    makeStaleManifest(sessionId);
+
+    const collected: string[] = [];
+    runStartupReconcile({
+      sessionId,
+      isInteractive: true,
+      outputOffer: (text) => collected.push(text),
+    });
+
+    expect(collected).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shouldSurfaceResumptionOffer gate — non-interactive path
+// ---------------------------------------------------------------------------
+
+describe('runStartupReconcile — non-interactive surface', () => {
+  it('does NOT call outputOffer when isInteractive=false and AFK_WAVE_RESUME_UNATTENDED is unset', () => {
+    const sessionId = 'daemon-sess';
+    makeStaleManifest(sessionId);
+
+    const collected: string[] = [];
+    runStartupReconcile({
+      sessionId,
+      isInteractive: false,
+      outputOffer: (text) => collected.push(text),
+    });
+
+    expect(collected).toHaveLength(0);
+  });
+
+  it('DOES call outputOffer when isInteractive=false and AFK_WAVE_RESUME_UNATTENDED=1', () => {
+    process.env['AFK_WAVE_RESUME_UNATTENDED'] = '1';
+    const sessionId = 'daemon-unattended-sess';
+    makeStaleManifest(sessionId);
+
+    const collected: string[] = [];
+    runStartupReconcile({
+      sessionId,
+      isInteractive: false,
+      outputOffer: (text) => collected.push(text),
+    });
+
+    expect(collected).toHaveLength(1);
+    expect(collected[0]).toContain('[wave-resume]');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fire-and-forget invariant — errors must never propagate
+// ---------------------------------------------------------------------------
+
+describe('runStartupReconcile — fire-and-forget', () => {
+  it('does not throw when outputOffer callback throws', () => {
+    const sessionId = 'throwing-sess';
+    makeStaleManifest(sessionId);
+
+    expect(() =>
+      runStartupReconcile({
+        sessionId,
+        isInteractive: true,
+        outputOffer: () => { throw new Error('callback error'); },
+      }),
+    ).not.toThrow();
+  });
+
+  it('does not throw when AFK_STATE_DIR is missing (no waves dir)', () => {
+    // Point to a non-existent dir so readdirSync fails.
+    process.env['AFK_STATE_DIR'] = join(stateDir, 'does-not-exist');
+
+    expect(() =>
+      runStartupReconcile({
+        sessionId: 'missing-dir-sess',
+        isInteractive: true,
+        outputOffer: () => {},
+      }),
+    ).not.toThrow();
+  });
+
+  it('does not throw when a manifest file is corrupt', () => {
+    // Write a corrupt manifest file directly.
+    const waveId = 'deadbeef00000000';
+    const wavesDir = join(stateDir, 'waves');
+    require('node:fs').mkdirSync(wavesDir, { recursive: true });
+    require('node:fs').writeFileSync(join(wavesDir, `${waveId}.json`), 'not-valid-json');
+
+    expect(() =>
+      runStartupReconcile({
+        sessionId: 'corrupt-sess',
+        isInteractive: true,
+        outputOffer: () => {},
+      }),
+    ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wiring verification — confirm the helper routes through formatResumptionOffer
+// ---------------------------------------------------------------------------
+
+describe('runStartupReconcile — output format', () => {
+  it('output text includes waveId and source', () => {
+    const sessionId = 'format-check-sess';
+    makeStaleManifest(sessionId);
+
+    const collected: string[] = [];
+    runStartupReconcile({
+      sessionId,
+      isInteractive: true,
+      outputOffer: (text) => collected.push(text),
+    });
+
+    expect(collected[0]).toContain('agent-tool');
+    expect(collected[0]).toContain('Accept?');
+  });
+});

--- a/src/agent/manifest/startup-reconcile.ts
+++ b/src/agent/manifest/startup-reconcile.ts
@@ -1,0 +1,76 @@
+/**
+ * Session-startup wave manifest reconciliation helper.
+ *
+ * Provides a single fire-and-forget entry point (`runStartupReconcile`) that
+ * each bootstrap path (REPL, Telegram, daemon, one-shot chat) calls after the
+ * session ID is known.  The function:
+ *   1. Guards on `shouldSurfaceResumptionOffer(isInteractive)`.
+ *   2. Calls `reconcileWaveManifests({ sessionId })`.
+ *   3. Emits each offer via `outputOffer` (stderr for CLI, message for Telegram).
+ *   4. Never throws — startup must not fail because of reconciliation.
+ *
+ * Callers pass an `outputOffer` callback so this module stays surface-agnostic
+ * (no direct `process.stderr` or Telegram API coupling here).
+ *
+ * @module agent/manifest/startup-reconcile
+ */
+
+import {
+  reconcileWaveManifests,
+  shouldSurfaceResumptionOffer,
+  formatResumptionOffer,
+} from './reconcile.js';
+import type { StaleManifestOffer } from './reconcile.js';
+
+export interface StartupReconcileOpts {
+  /** The session id assigned to this session — needed for `isOwnSession` matching. */
+  sessionId: string;
+  /**
+   * Whether this is an interactive surface (REPL, Telegram).
+   * Non-interactive surfaces (daemon, one-shot chat) only surface offers when
+   * `AFK_WAVE_RESUME_UNATTENDED=1` is set.
+   */
+  isInteractive: boolean;
+  /**
+   * Callback that receives each formatted offer string.
+   * Called once per offer that has at least one resumable or blocked unit.
+   * The callback itself must not throw (wrap it if needed).
+   */
+  outputOffer: (text: string) => void;
+}
+
+/**
+ * Fire-and-forget session-start reconciler.
+ *
+ * Checks for stale wave manifests after the session ID is known and surfaces
+ * resumption offers via `opts.outputOffer`.  Returns without awaiting —
+ * callers should NOT await the returned Promise: it always resolves
+ * (never rejects) so it is safe to `void` or `.catch(() => {})`.
+ *
+ * Design invariants (inherited from `reconcileWaveManifests`):
+ *   - Expired manifests are deleted on every pass.
+ *   - Non-interactive surfaces skip unless `AFK_WAVE_RESUME_UNATTENDED=1`.
+ *   - Errors are swallowed; the reconciler is best-effort.
+ */
+export function runStartupReconcile(opts: StartupReconcileOpts): void {
+  if (!shouldSurfaceResumptionOffer(opts.isInteractive)) return;
+
+  // Synchronous reconciler — no async I/O, so no Promise needed.
+  // Wrapped in try/catch as an extra safety net beyond the reconciler's own guard.
+  try {
+    const result = reconcileWaveManifests({ sessionId: opts.sessionId });
+    for (const offer of result.offers) {
+      try {
+        opts.outputOffer(formatResumptionOffer(offer));
+      } catch {
+        // Never let an outputOffer callback failure break startup.
+      }
+    }
+  } catch {
+    // Fire-and-forget: never propagate reconciler errors to the caller.
+  }
+}
+
+// Re-export the guard for tests that want to verify the shouldSurface logic.
+export { shouldSurfaceResumptionOffer };
+export type { StaleManifestOffer };

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 import { palette } from '../palette.js';
+import { runStartupReconcile } from '../../agent/manifest/startup-reconcile.js';
 import ora from 'ora';
 import { handleCommandError } from '../errors/index.js';
 import * as os from 'node:os';
@@ -625,6 +626,18 @@ export function registerChatCommand(program: Command): void {
         })), trace?.writer);
 
         boundSession = session;
+        // Wave manifest reconciliation: surface resumption offers for any stale
+        // manifests from interrupted sessions. Fire-and-forget — startup must
+        // never fail because of this. One-shot chat is non-interactive; only
+        // surfaces offers when AFK_WAVE_RESUME_UNATTENDED=1.
+        const chatSessionId = session.sessionId ?? options.sessionId;
+        if (chatSessionId) {
+          runStartupReconcile({
+            sessionId: chatSessionId,
+            isInteractive: false,
+            outputOffer: (text) => { process.stderr.write(`${text}\n`); },
+          });
+        }
         // Subagent-success rollup: wire both the root manager and the compose
         // executor so all subagent token/cost data (including compose DAG nodes)
         // accumulates into this session's session_sealed telemetry. Late-bound

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 import { env } from '../../config/env.js';
+import { runStartupReconcile } from '../../agent/manifest/startup-reconcile.js';
 import path from 'path';
 import { palette } from '../palette.js';
 import { handleCommandError } from '../errors/index.js';
@@ -192,6 +193,19 @@ export function buildDaemonSessionFactory(
     composeExecutor.setOnSubagentSucceeded((usage, costUsd) => {
       session.recordSubagentCompletion(usage, costUsd);
     });
+    // Wave manifest reconciliation: surface resumption offers for any stale
+    // manifests from interrupted sessions. Fire-and-forget — startup must
+    // never fail because of this. The session ID comes from config.sessionId
+    // (set by the scheduler's daemonTraceLabel). Daemon is non-interactive;
+    // only surfaces offers when AFK_WAVE_RESUME_UNATTENDED=1.
+    const daemonSessionId = (config as { sessionId?: string }).sessionId ?? session.sessionId;
+    if (daemonSessionId) {
+      runStartupReconcile({
+        sessionId: daemonSessionId,
+        isInteractive: false,
+        outputOffer: (text) => { process.stderr.write(`${text}\n`); },
+      });
+    }
     return session;
   };
 }

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -22,6 +22,7 @@ import { createReplSlashContext } from './bootstrap-slash-context.js';
 import { wireTrustedSkillEvents, wireProviderGrants, createReplInput } from './bootstrap-wiring.js';
 import { buildAgentSession, buildSharedDeps } from './bootstrap-session-builder.js';
 import { registerAll } from '../../slash/index.js';
+import { runStartupReconcile } from '../../../agent/manifest/startup-reconcile.js';
 
 // Re-exported so `resume-swap.test.ts` (and the mid-session swap closure
 // below) can resolve `buildAgentSession` from this module — the historical
@@ -148,6 +149,18 @@ export async function bootstrapSession(
   const session = buildAgentSession(sharedDeps);
   // Populate sessionRef (declared above deferredParent so the proxy works).
   sessionRef.current = session;
+
+  // Wave manifest reconciliation: surface resumption offers for any stale
+  // manifests from interrupted sessions. Fire-and-forget — startup must never
+  // fail because of this. Runs after the session ID is known so isOwnSession
+  // matching works correctly. REPL is an interactive surface.
+  if (session.sessionId) {
+    runStartupReconcile({
+      sessionId: session.sessionId,
+      isInteractive: true,
+      outputOffer: (text) => { process.stderr.write(`${text}\n`); },
+    });
+  }
 
   // Step 7: register this REPL session in the cross-surface session registry so
   // it appears alongside Telegram/daemon sessions. Best-effort (never throws).

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -88,7 +88,22 @@ export class TelegramBot {
     // usage-limit-pause-aware watchdog that throws a handled StreamTimeoutError.
     // p-timeout short-circuits on Infinity, handing it sole timeout control.
     this.bot = new Telegraf(options.botToken, { handlerTimeout: Infinity });
-    this.sessionManager = new SessionManager(options);
+    // Wire the resumption-offer callback now that `this.bot.telegram` is
+    // available.  Runs after every new Telegram session is created and surfaces
+    // stale wave manifests as a message in the chat.  Fire-and-forget by
+    // contract — sendMessage failures are logged and swallowed.
+    const telegramRef = this.bot.telegram;
+    this.sessionManager = new SessionManager({
+      ...options,
+      onResumptionOffer: (route, offerText) => {
+        const sendOpts = sendOptions(route);
+        void telegramRef
+          .sendMessage(route.chatId, offerText, sendOpts)
+          .catch((err: unknown) => {
+            console.error('[bot] resumption offer send failed:', err instanceof Error ? err.message : String(err));
+          });
+      },
+    });
     this.messageHandler = new MessageHandler(
       this.bot,
       this.sessionManager,

--- a/src/telegram/session-manager.ts
+++ b/src/telegram/session-manager.ts
@@ -18,6 +18,7 @@ import { saveSession, loadSession, listSessions } from '../cli/session-store.js'
 import { resumeConfigFor } from '../cli/resume-session.js';
 import type { SessionStats } from '../cli/slash/types.js';
 import { type TelegramRoute, routeKey } from './route.js';
+import { runStartupReconcile } from '../agent/manifest/startup-reconcile.js';
 import { sessionRegistry, type SessionRegistry } from '../agent/session/session-registry.js';
 import { ensureRegistryHandle, archiveRegistryHandle } from './session-manager.registry.js';
 import { resolveActiveRouteForChat } from './session-manager.active-route.js';
@@ -137,6 +138,15 @@ export interface SessionManagerOptions {
    * process-wide `sessionRegistry` singleton when not provided.
    */
   registry?: SessionRegistry;
+
+  /**
+   * Optional callback fired once per stale wave manifest offer after a new
+   * session is created. Receives the route (chatId + optional threadId) and
+   * the formatted offer text — the caller decides how to deliver it (e.g.
+   * `bot.telegram.sendMessage`). Fire-and-forget: never awaited, exceptions
+   * are swallowed.
+   */
+  onResumptionOffer?: (route: TelegramRoute, offerText: string) => void;
 }
 
 /**
@@ -180,8 +190,8 @@ export class SessionManager {
    * resuming a stale target.
    */
   private pendingResume = new Map<string, string>();
-  private options: Required<Omit<SessionManagerOptions, 'createSession' | 'settingSources' | 'thinking' | 'effort' | 'botCwd' | 'registry'>> &
-    Pick<SessionManagerOptions, 'createSession' | 'settingSources' | 'thinking' | 'effort' | 'botCwd' | 'registry'>;
+  private options: Required<Omit<SessionManagerOptions, 'createSession' | 'settingSources' | 'thinking' | 'effort' | 'botCwd' | 'registry' | 'onResumptionOffer'>> &
+    Pick<SessionManagerOptions, 'createSession' | 'settingSources' | 'thinking' | 'effort' | 'botCwd' | 'registry' | 'onResumptionOffer'>;
 
   constructor(options: SessionManagerOptions) {
     this.options = {
@@ -196,6 +206,7 @@ export class SessionManager {
       botCwd: options.botCwd,
       createSession: options.createSession,
       registry: options.registry,
+      onResumptionOffer: options.onResumptionOffer,
     };
   }
 
@@ -294,6 +305,20 @@ export class SessionManager {
       if (session.sessionId) {
         setElicitationRoute(session.sessionId, route);
         data.sessionId = session.sessionId;
+        // Wave manifest reconciliation: surface resumption offers for any stale
+        // manifests from interrupted sessions. Fire-and-forget — session startup
+        // must never fail because of this. Telegram is an interactive surface.
+        if (this.options.onResumptionOffer !== undefined) {
+          const onOffer = this.options.onResumptionOffer;
+          const capturedRoute = route;
+          runStartupReconcile({
+            sessionId: session.sessionId,
+            isInteractive: true,
+            outputOffer: (text) => {
+              try { onOffer(capturedRoute, text); } catch { /* fire-and-forget */ }
+            },
+          });
+        }
       }
       // Consume the staged resume only after a successful build: a thrown
       // createSession must leave it staged so the next getSession retries the


### PR DESCRIPTION
## Summary

Wires the already-implemented `reconcileWaveManifests()` into all four session startup paths, completing the feature planned in #1049. The reconciler and its tests were shipped earlier — this PR adds the call sites that were intentionally deferred.

## Problem

`reconcileWaveManifests()`, `shouldSurfaceResumptionOffer()`, and `formatResumptionOffer()` are fully implemented and tested in `src/agent/manifest/reconcile.ts` (14 tests), but had **zero call sites** in any session bootstrap path. The write side (manifest creation, status updates, sweep) was live, but the "surface a resumption offer on session start" half was inert.

## Solution

### New helper: `src/agent/manifest/startup-reconcile.ts` (76 LOC)

A surface-agnostic `runStartupReconcile()` function that:
- Gates on `shouldSurfaceResumptionOffer(isInteractive)`
- Calls `reconcileWaveManifests({ sessionId })`
- Routes each offer through an `outputOffer` callback
- Is fire-and-forget — never throws, never blocks startup

### Wired into all four surfaces

| Surface | File | `isInteractive` | Output channel |
|---------|------|-----------------|----------------|
| **REPL** | `bootstrap.ts` | `true` | `process.stderr` |
| **Telegram** | `session-manager.ts` → `bot.ts` | `true` | `bot.telegram.sendMessage` |
| **Daemon** | `daemon.ts` | `false` | `process.stderr` (only when `AFK_WAVE_RESUME_UNATTENDED=1`) |
| **One-shot chat** | `chat.ts` | `false` | `process.stderr` (only when `AFK_WAVE_RESUME_UNATTENDED=1`) |

Each call runs after the session ID is resolved (needed for `isOwnSession` matching) and is wrapped fire-and-forget so startup never fails because of the reconciler.

## Tests

- **`startup-reconcile.test.ts`** — 9 unit tests for the helper (gating, fire-and-forget, offer routing)
- **`startup-reconcile-wiring.test.ts`** — 8 wiring verification tests (SessionManager integration, isInteractive contract table)

All existing tests pass — manifest (63), telegram session-manager (72), full telegram suite (920), interactive (1,145), daemon (38). Lint clean.

Closes #1082
