### PR TITLE
fix(security): default interactive CLI to contained permission mode

### DIFF
--- a/src/agent/tools/subagent/child-config.test.ts
+++ b/src/agent/tools/subagent/child-config.test.ts
@@ -773,11 +773,11 @@ describe('permission-mode inheritance (ADR-0001 premise — previously pinned by
     expect(metadata.permissionMode).toBe('default');
   });
 
-  it('leaves the child contained even though every top-level surface defaults to bypass', () => {
-    // Parent side: the CLI default really is a containment-disabling mode.
-    expect(DEFAULT_CLI_PERMISSION_MODE).toBe('bypassPermissions');
-    expect(pathContainmentBypassed(DEFAULT_CLI_PERMISSION_MODE)).toBe(true);
-    // Child side: resolves to 'default', which does NOT disable containment.
+  it('confirms both CLI and child default to contained mode', () => {
+    // Parent side: the CLI default is now contained (flipped from bypass in #1283).
+    expect(DEFAULT_CLI_PERMISSION_MODE).toBe('default');
+    expect(pathContainmentBypassed(DEFAULT_CLI_PERMISSION_MODE)).toBe(false);
+    // Child side: also resolves to 'default'.
     const { childConfig } = buildChildConfig(baseArgs());
     const { metadata } = buildInitialState(childConfig, 'sonnet');
     expect(pathContainmentBypassed(metadata.permissionMode)).toBe(false);

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -160,7 +160,7 @@ export function registerChatCommand(program: Command): void {
     .option('--session-id <uuid>', 'Assign a specific UUID to this session (creates new; errors if already exists)')
     .option('--post <targets>', 'Headless publish of the final assistant message: github, telegram, or github,telegram')
     .option('--post-pr <ref>', 'PR number, URL, or branch for --post github (defaults to the current-branch PR)')
-    .option('--dangerously-skip-permissions', 'Force bypass mode (already the default for new installs): skip path-approval prompts; read/write ANY path with no confirmation (permissionMode=bypassPermissions). Disable persistently with `afk config set permissionMode default`. Does not affect ask_question.')
+    .option('--dangerously-skip-permissions', 'Skip path-approval prompts: read/write ANY path with no confirmation (permissionMode=bypassPermissions). Disable persistently with `afk config set permissionMode default`. Does not affect ask_question.')
     .action(async (rawMessage: string | undefined, options: {
       model: AgentModelInput;
       stream: boolean;
@@ -593,7 +593,7 @@ export function registerChatCommand(program: Command): void {
           isNonInteractive: true,
           // Permission mode: --dangerously-skip-permissions forces bypass; else
           // the resolved afk.config.json `permissionMode` (loadConfig now always
-          // returns one — DEFAULT_CLI_PERMISSION_MODE = bypass for new installs,
+          // returns one — DEFAULT_CLI_PERMISSION_MODE = contained for new installs,
           // overridable by the config key). Always defined, so chat never falls
           // through to the session-layer 'default'.
           ...(options.dangerouslySkipPermissions

--- a/src/cli/commands/interactive.ts
+++ b/src/cli/commands/interactive.ts
@@ -236,7 +236,7 @@ export function registerInteractiveCommand(program: Command): void {
     )
     .option('--provider <name>', "Provider to use: anthropic|anthropic-direct|openai|openai-compatible|xai|xai-oauth. Default: auto-selected by model")
     .option('--dump-prompt [path]', 'Dump resolved SDK prompt+options+provenance to file (default: ~/.afk/logs/prompt-dump-<ISO>.json) or "stderr"')
-    .option('--dangerously-skip-permissions', 'Force bypass mode (already the default for new installs): skip path-approval prompts; read/write ANY path with no confirmation. Toggle live with Shift+Tab (permission-mode cycle); disable persistently with `afk config set permissionMode default`. Does not affect ask_question.')
+    .option('--dangerously-skip-permissions', 'Skip path-approval prompts: read/write ANY path with no confirmation. Toggle live with Shift+Tab (permission-mode cycle); disable persistently with `afk config set permissionMode default`. Does not affect ask_question.')
     .option(
       '--mcp-config <path>',
       'Path to an additional MCP config file (highest priority — merges over ~/.afk/config/mcp.json, project-local .mcp.json, and plugin-contributed configs). File format identical to mcp.json.',

--- a/src/cli/commands/interactive/bootstrap-surface.ts
+++ b/src/cli/commands/interactive/bootstrap-surface.ts
@@ -53,8 +53,8 @@ export function createReplSurface(a: {
   }
   // Initial permission mode: --dangerously-skip-permissions wins, else the
   // resolved afk.config.json `permissionMode` (loadConfig now always returns one
-  // — DEFAULT_CLI_PERMISSION_MODE = bypass for new installs, overridable by the
-  // config key). Stamped on stats so the status-line badge + the plan/AFK/bypass
+  // — DEFAULT_CLI_PERMISSION_MODE = contained for new installs, overridable by
+  // the config key). Stamped on stats so the status-line badge + the plan/AFK/bypass
   // gate getters reflect it from turn 1; the session is constructed with the same
   // value via sharedDeps. The `!== undefined` guard is retained defensively.
   const initialPermissionMode = a.options.dangerouslySkipPermissions

--- a/src/cli/config.test.ts
+++ b/src/cli/config.test.ts
@@ -1444,11 +1444,11 @@ describe('loadConfig() — permissionMode default (new-install bypass)', () => {
     _resetConfigCache();
   });
 
-  it('defaults to bypassPermissions when afk.config.json sets no permissionMode', () => {
+  it('defaults to contained mode when afk.config.json sets no permissionMode', () => {
     mockConfig({});
-    expect(loadConfig().permissionMode).toBe('bypassPermissions');
+    expect(loadConfig().permissionMode).toBe('default');
     // The exported constant is the single source of truth.
-    expect(DEFAULT_CLI_PERMISSION_MODE).toBe('bypassPermissions');
+    expect(DEFAULT_CLI_PERMISSION_MODE).toBe('default');
     expect(loadConfig().permissionMode).toBe(DEFAULT_CLI_PERMISSION_MODE);
   });
 
@@ -1462,19 +1462,19 @@ describe('loadConfig() — permissionMode default (new-install bypass)', () => {
     expect(loadConfig().permissionMode).toBe('plan');
   });
 
-  it('falls back to the bypass default when permissionMode is garbage (invalid ignored)', () => {
+  it('falls back to the contained default when permissionMode is garbage (invalid ignored)', () => {
     mockConfig({ permissionMode: 'totally-not-a-mode' });
-    expect(loadConfig().permissionMode).toBe('bypassPermissions');
+    expect(loadConfig().permissionMode).toBe('default');
   });
 
   it('an explicit overrides.permissionMode still wins over the default', () => {
     mockConfig({});
-    expect(loadConfig({ permissionMode: 'default' }).permissionMode).toBe('default');
+    expect(loadConfig({ permissionMode: 'bypassPermissions' }).permissionMode).toBe('bypassPermissions');
   });
 
-  it('resolveCliPermissionMode() returns the bypass default when unset, and the config value when set', () => {
+  it('resolveCliPermissionMode() returns the contained default when unset, and the config value when set', () => {
     mockConfig({});
-    expect(resolveCliPermissionMode()).toBe('bypassPermissions');
+    expect(resolveCliPermissionMode()).toBe('default');
     _resetConfigCache();
     mockConfig({ permissionMode: 'plan' });
     expect(resolveCliPermissionMode()).toBe('plan');

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -96,7 +96,7 @@ export function loadTelegramConfig(): NonNullable<CliConfig['telegram']> {
 /**
  * Resolve the effective CLI permission mode for display / status surfaces:
  * the afk.config.json `permissionMode` when set, else the new-install default
- * (`DEFAULT_CLI_PERMISSION_MODE` = bypass). Reads the memoized JSON directly so
+ * (`DEFAULT_CLI_PERMISSION_MODE` = contained). Reads the memoized JSON directly so
  * it is side-effect-free and never throws on the `local-*`-model guard that the
  * full `loadConfig` enforces — same rationale as `loadTelegramConfig`. This is
  * the canonical answer to "what mode would a fresh `afk chat`/`afk i` run in?"
@@ -185,7 +185,7 @@ export function loadConfig(overrides?: Partial<CliConfig>, cwd: string = process
     ...(merged.systemPrompt !== undefined ? { systemPrompt: merged.systemPrompt } : {}),
     ...(systemPromptSource !== undefined ? { systemPromptSource } : {}),
     ...(shadowedAfkMdPaths !== undefined ? { shadowedAfkMdPaths } : {}),
-    // New-install default is bypass (DEFAULT_CLI_PERMISSION_MODE); an explicit
+    // New-install default is contained (DEFAULT_CLI_PERMISSION_MODE); an explicit
     // afk.config.json / env / override `permissionMode` still wins.
     permissionMode: merged.permissionMode ?? DEFAULT_CLI_PERMISSION_MODE,
     ...(merged.autoRouting !== undefined ? { autoRouting: merged.autoRouting } : {}),

--- a/src/cli/config/types.ts
+++ b/src/cli/config/types.ts
@@ -415,12 +415,15 @@ export const DEFAULT_CONFIG: Omit<CliConfig, 'apiKey'> = {
 /**
  * Invariant: the CLI-surface default permission mode. When `afk.config.json`
  * sets no `permissionMode`, the human-driven CLI surfaces (`afk chat` and
- * `afk interactive`) start in `bypassPermissions` — path containment and the
- * path-approval prompt are OFF, so the agent reads/writes anywhere with no
- * confirmation. This is the new-install default and it persists every session
- * until the operator changes it (`afk config set permissionMode default`, a
- * `permissionMode` key in afk.config.json, `--dangerously-skip-permissions`, or
- * the live `/bypass` toggle).
+ * `afk interactive`) start in `default` — path containment is ON, the agent
+ * prompts before writing outside the working directory. Pass
+ * `--dangerously-skip-permissions` or `afk config set permissionMode
+ * bypassPermissions` to opt into unrestricted mode.
+ *
+ * History: prior to #1283 this defaulted to `bypassPermissions`, meaning a
+ * fresh `npm install -g agent-afk && afk i` could write anywhere with no
+ * prompt. Telegram already defaulted to `'default'` with hook-based
+ * enforcement; this change aligns the CLI surfaces to the same posture.
  *
  * Scope is deliberately narrow: this default lives at the loadConfig() layer,
  * which only `afk chat` + `afk interactive` consume via `cliConfig.permissionMode`.
@@ -430,4 +433,4 @@ export const DEFAULT_CONFIG: Omit<CliConfig, 'apiKey'> = {
  * subagents that inherit no explicit mode all remain contained. The daemon sets
  * `bypassPermissions` explicitly and is unaffected.
  */
-export const DEFAULT_CLI_PERMISSION_MODE: PermissionMode = 'bypassPermissions';
+export const DEFAULT_CLI_PERMISSION_MODE: PermissionMode = 'default';


### PR DESCRIPTION
## What

Flip the default CLI permission mode from `bypassPermissions` to `default` (contained).

A fresh `npm install -g agent-afk` followed by `afk i` previously started with write-anywhere, no prompt. This aligns interactive CLI to the same contained posture Telegram already uses.

## Why

- Auto-publish-on-merge + write-anywhere-no-prompt on first run is a legitimate attack surface
- Telegram already defaults to `'default'` with hook-based enforcement — the right answer existed on one surface but not the other
- `--dangerously-skip-permissions` becomes meaningful as an opt-in instead of being a no-op

## Changes

| File | Change |
|------|--------|
| `src/cli/config/types.ts` | `DEFAULT_CLI_PERMISSION_MODE`: `'bypassPermissions'` → `'default'` |
| `src/cli/commands/chat.ts` | Help text + comment updated |
| `src/cli/commands/interactive.ts` | Help text updated |
| `src/cli/commands/interactive/bootstrap-surface.ts` | Comment updated |
| `src/cli/config.ts` | Comments updated |
| `src/cli/config.test.ts` | 3 test assertions updated to expect `'default'` |
| `src/agent/tools/subagent/child-config.test.ts` | 1 test updated — now asserts both CLI and child default to contained |

## What's unchanged

- Daemon's explicit `bypassPermissions` in `scheduler.ts:750` — headless, no human to prompt
- Telegram's `'default'` mode — already correct
- `afk config set permissionMode bypassPermissions` — still works for power users who want the old behavior
- `--dangerously-skip-permissions` flag — still forces bypass per-run

Closes #1283
