### PR TITLE
feat(cli): add /copy slash command with render-time code block capture

### DIFF
--- a/.filesize-baseline.json
+++ b/.filesize-baseline.json
@@ -24,13 +24,13 @@
     "src/cli/commands/daemon.ts": { "loc": 392, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/cli/commands/farm.ts": { "loc": 436, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/cli/commands/interactive.ts": { "loc": 581, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/cli/commands/interactive/loop-iteration.ts": { "loc": 428, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/cli/commands/interactive/loop-iteration.ts": { "loc": 430, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/cli/commands/interactive/tool-lane.ts": { "loc": 448, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/cli/commands/interactive/turn-handler.ts": { "loc": 407, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/cli/commands/interactive/turn-handler.ts": { "loc": 411, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/cli/commands/interactive/worktree.ts": { "loc": 478, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/cli/commands/trace.ts": { "loc": 573, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/cli/elicitation/agent-question.ts": { "loc": 399, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/cli/slash/commands/info.ts": { "loc": 450, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/cli/slash/commands/info.ts": { "loc": 443, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/cli/terminal-compositor.input-dispatch.ts": { "loc": 507, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/config/env.ts": { "loc": 1804, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/config/import-sources.ts": { "loc": 373, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
@@ -38,9 +38,9 @@
     "src/improve/eval-run/runner.ts": { "loc": 372, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/improve/propose/template-engine.ts": { "loc": 459, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/skills/audit-fit/index.ts": { "loc": 421, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/telegram/bot.ts": { "loc": 392, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/telegram/bot.ts": { "loc": 394, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/telegram/handlers/farm-callbacks.ts": { "loc": 392, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/telegram/handlers/message.ts": { "loc": 581, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/telegram/session-manager.ts": { "loc": 461, "reason": "legacy: predates the ceiling gate; pending concern extraction" }
+    "src/telegram/session-manager.ts": { "loc": 468, "reason": "legacy: predates the ceiling gate; pending concern extraction" }
   }
 }

--- a/src/cli/code-block-register.test.ts
+++ b/src/cli/code-block-register.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  registerCodeBlock,
+  getCodeBlocks,
+  getCodeBlock,
+  resetCodeBlockRegister,
+} from './code-block-register.js';
+
+beforeEach(() => {
+  resetCodeBlockRegister();
+});
+
+describe('code-block-register', () => {
+  it('starts empty', () => {
+    expect(getCodeBlocks()).toHaveLength(0);
+    expect(getCodeBlock(1)).toBeUndefined();
+  });
+
+  it('registers blocks with 1-based indices', () => {
+    const i1 = registerCodeBlock('bash', 'echo hello');
+    const i2 = registerCodeBlock('python', 'print("hi")');
+    expect(i1).toBe(1);
+    expect(i2).toBe(2);
+    expect(getCodeBlocks()).toHaveLength(2);
+  });
+
+  it('retrieves blocks by 1-based index', () => {
+    registerCodeBlock('bash', 'echo hello');
+    registerCodeBlock('python', 'print("hi")');
+    const block = getCodeBlock(2);
+    expect(block).toEqual({ index: 2, lang: 'python', text: 'print("hi")' });
+  });
+
+  it('returns undefined for out-of-range index', () => {
+    registerCodeBlock('bash', 'echo hello');
+    expect(getCodeBlock(0)).toBeUndefined();
+    expect(getCodeBlock(2)).toBeUndefined();
+  });
+
+  it('resets the register', () => {
+    registerCodeBlock('bash', 'echo hello');
+    registerCodeBlock('python', 'print("hi")');
+    resetCodeBlockRegister();
+    expect(getCodeBlocks()).toHaveLength(0);
+    // New registrations start at 1 again.
+    const i = registerCodeBlock('text', 'foo');
+    expect(i).toBe(1);
+  });
+});

--- a/src/cli/code-block-register.ts
+++ b/src/cli/code-block-register.ts
@@ -1,0 +1,48 @@
+/**
+ * Turn-scoped register of code blocks emitted by the markdown renderer.
+ *
+ * `renderCodeBlock()` pushes each block's raw text here at render time —
+ * before ANSI codes and gutter decoration are applied — so `/copy N` can
+ * retrieve clean, paste-ready source without re-parsing the markdown.
+ *
+ * The register is module-level mutable state. This is acceptable because
+ * the REPL is single-threaded and turns are sequential. Call
+ * `resetCodeBlockRegister()` at each turn boundary to prevent stale
+ * entries from leaking across turns.
+ */
+
+export interface CodeBlockEntry {
+  /** 1-based index within the current turn. */
+  index: number;
+  /** Language tag from the fence (e.g. "python", "bash"), or "text". */
+  lang: string;
+  /** Raw source text — no ANSI, no gutter decoration. */
+  text: string;
+}
+
+const blocks: CodeBlockEntry[] = [];
+
+/**
+ * Record a code block and return its 1-based index.
+ * Called by `renderCodeBlock` at render time.
+ */
+export function registerCodeBlock(lang: string, text: string): number {
+  const index = blocks.length + 1;
+  blocks.push({ index, lang, text });
+  return index;
+}
+
+/** All blocks registered in the current turn. */
+export function getCodeBlocks(): readonly CodeBlockEntry[] {
+  return blocks;
+}
+
+/** Retrieve a single block by 1-based index, or undefined if out of range. */
+export function getCodeBlock(n: number): CodeBlockEntry | undefined {
+  return blocks[n - 1];
+}
+
+/** Clear the register. Call at each turn boundary. */
+export function resetCodeBlockRegister(): void {
+  blocks.length = 0;
+}

--- a/src/cli/commands/interactive/loop-iteration.ts
+++ b/src/cli/commands/interactive/loop-iteration.ts
@@ -34,6 +34,7 @@ import type { InputSurface } from '../../input/input-surface.js';
 import type { ReplHistory } from '../../input/history.js';
 import { buildPrompt, type TurnState } from './repl-loop-shared.js';
 import type { FooterSubsystems } from './footer-subsystems.js';
+import { resetCodeBlockRegister } from '../../code-block-register.js';
 
 /** Per-handler timeout for the post-turn Stop notification. Tighter than the
  *  registry default (HOOK_HANDLER_TIMEOUT_MS = 30s) because Stop fires every
@@ -624,6 +625,9 @@ export async function runInputLoop(
       // onTerminalState re-sets these during runTurn when a verdict parses.
       currentTerminalKind = undefined;
       currentDoneHasEvidence = undefined;
+      // Clear the code-block register so `/copy N` indices match the blocks
+      // rendered in THIS turn, not a prior one.
+      resetCodeBlockRegister();
       await runTurn({ text: runText, attachments }, ctx.session.current, ctx.stats, {
         setInFlight(v: boolean) { turnState.turnInFlight = v; },
         // Forward the promotion seam so Ctrl+B can background a running

--- a/src/cli/formatter.block.ts
+++ b/src/cli/formatter.block.ts
@@ -2,6 +2,7 @@ import { type Token, type Tokens } from 'marked';
 import { wrapToWidth } from './wrap.js';
 import { highlightCode } from './syntax-highlight.js';
 import { palette } from './palette.js';
+import { registerCodeBlock } from './code-block-register.js';
 
 /**
  * Render a blockquote token to ANSI-styled terminal output.
@@ -95,15 +96,23 @@ export function renderCodeBlock(
     // gap after an empty fence in the non-streamed render paths.
     return palette.dim(`│ ${label}`) + '\n';
   }
+  // Register the raw text before any ANSI decoration so `/copy N` can
+  // retrieve clean, paste-ready source. The index is 1-based per turn.
+  const blockIndex = registerCodeBlock(lang, code.text);
+
   const highlighted = highlightCode(code.text, lang);
   const bodyLines = highlighted.split('\n');
   // Drop trailing empty line so adjacent blocks don't double-space.
   if (bodyLines.length > 0 && bodyLines[bodyLines.length - 1] === '') bodyLines.pop();
   const gutter = palette.dim('│ ');
   const body = bodyLines.map((line) => gutter + line).join('\n');
-  // Language tag only when explicitly given; no literal "[code]" header
-  // when the fence has no language. The dim left gutter visually marks
-  // the block (mirrors the blockquote convention above).
-  const header = code.lang ? palette.dim(`│ ${code.lang}`) + '\n' : '';
+  // Language tag + copy hint. The `/cp N` hint tells the user which index
+  // to pass to `/copy` to grab this block. When there is no explicit
+  // language tag, emit a bare hint line instead of no header at all —
+  // the hint is the point.
+  const copyHint = palette.dim(` ── /cp ${blockIndex}`);
+  const header = code.lang
+    ? palette.dim(`│ ${code.lang}`) + copyHint + '\n'
+    : palette.dim('│') + copyHint + '\n';
   return header + body + '\n';
 }

--- a/src/cli/slash/commands/copy.test.ts
+++ b/src/cli/slash/commands/copy.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../../clipboard.js', () => ({
+  copyToClipboard: vi.fn(),
+}));
+
+vi.mock('../../code-block-register.js', () => ({
+  getCodeBlock: vi.fn(),
+  getCodeBlocks: vi.fn(),
+}));
+
+import { copyCmd } from './copy.js';
+import { copyToClipboard } from '../../clipboard.js';
+import { getCodeBlock, getCodeBlocks } from '../../code-block-register.js';
+import type { SlashContext, SessionStats } from '../types.js';
+
+const mockedCopy = vi.mocked(copyToClipboard);
+const mockedGetBlock = vi.mocked(getCodeBlock);
+const mockedGetBlocks = vi.mocked(getCodeBlocks);
+
+let origIsTTY: boolean | undefined;
+
+function makeStats(assistant?: string): SessionStats {
+  const turns = assistant
+    ? [{ user: 'hi', assistant, timestamp: Date.now() }]
+    : [];
+  return {
+    totalTurns: turns.length,
+    totalCostUsd: 0,
+    unpricedTurns: 0,
+    totalTokens: 0,
+    totalDurationMs: 0,
+    sessionStartTime: Date.now(),
+    turnCosts: [],
+    turnTokens: [],
+    turns: turns as unknown as SessionStats['turns'],
+    model: 'sonnet',
+    permissionMode: 'default',
+  } as unknown as SessionStats;
+}
+
+interface CtxResult {
+  ctx: SlashContext;
+  lines: string[];
+}
+
+function makeCtx(opts: { assistant?: string; interactive?: boolean } = {}): CtxResult {
+  const lines: string[] = [];
+  const ctx = {
+    session: { current: {} },
+    stats: makeStats(opts.assistant),
+    out: {
+      line: (t = ''): void => { lines.push(`LINE:${t}`); },
+      raw: (t: string): void => { lines.push(`RAW:${t}`); },
+      success: (t: string): void => { lines.push(`SUCCESS:${t}`); },
+      info: (t: string): void => { lines.push(`INFO:${t}`); },
+      warn: (t: string): void => { lines.push(`WARN:${t}`); },
+      error: (t: string): void => { lines.push(`ERROR:${t}`); },
+    },
+    ui: { clearScreen: vi.fn(), repaintStatusLine: vi.fn() },
+    // requestResume present = interactive REPL surface
+    ...(opts.interactive !== false ? { requestResume: vi.fn() } : {}),
+  } as unknown as SlashContext;
+  return { ctx, lines };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  origIsTTY = process.stdout.isTTY;
+  (process.stdout as { isTTY?: boolean }).isTTY = true;
+});
+
+afterEach(() => {
+  (process.stdout as { isTTY?: boolean }).isTTY = origIsTTY;
+});
+
+describe('/copy slash command', () => {
+  it('returns continue and warns when no turns exist', async () => {
+    const { ctx, lines } = makeCtx({ assistant: undefined });
+    const result = await copyCmd.handler(ctx, '');
+    expect(result).toBe('continue');
+    expect(lines.some((l) => l.includes('Nothing to copy'))).toBe(true);
+  });
+
+  it('returns continue and warns on non-interactive surface', async () => {
+    const { ctx, lines } = makeCtx({ assistant: 'hello world', interactive: false });
+    const result = await copyCmd.handler(ctx, '');
+    expect(result).toBe('continue');
+    expect(lines.some((l) => l.includes('Clipboard not available'))).toBe(true);
+    expect(mockedCopy).not.toHaveBeenCalled();
+  });
+
+  it('returns continue and warns when stdout is not a TTY', async () => {
+    (process.stdout as { isTTY?: boolean }).isTTY = false;
+    const { ctx, lines } = makeCtx({ assistant: 'hello world' });
+    const result = await copyCmd.handler(ctx, '');
+    expect(result).toBe('continue');
+    expect(lines.some((l) => l.includes('Clipboard not available'))).toBe(true);
+    expect(mockedCopy).not.toHaveBeenCalled();
+  });
+
+  it('copies the last assistant response with no args', async () => {
+    const text = '# Hello\n\nSome markdown response';
+    mockedCopy.mockReturnValue(true);
+    const { ctx, lines } = makeCtx({ assistant: text });
+    const result = await copyCmd.handler(ctx, '');
+    expect(result).toBe('continue');
+    expect(mockedCopy).toHaveBeenCalledWith(text);
+    expect(lines.some((l) => l.startsWith('SUCCESS:') && l.includes('Copied last response'))).toBe(true);
+  });
+
+  it('shows fallback message when clipboard write fails', async () => {
+    mockedCopy.mockReturnValue(false);
+    const { ctx, lines } = makeCtx({ assistant: 'some text' });
+    const result = await copyCmd.handler(ctx, '');
+    expect(result).toBe('continue');
+    expect(lines.some((l) => l.includes('Clipboard write failed'))).toBe(true);
+  });
+
+  it('copies a specific code block by index', async () => {
+    mockedGetBlock.mockReturnValue({ index: 2, lang: 'python', text: 'print("hello")' });
+    mockedCopy.mockReturnValue(true);
+    const { ctx, lines } = makeCtx({ assistant: 'Here is code:\n```python\nprint("hello")\n```' });
+    const result = await copyCmd.handler(ctx, '2');
+    expect(result).toBe('continue');
+    expect(mockedGetBlock).toHaveBeenCalledWith(2);
+    expect(mockedCopy).toHaveBeenCalledWith('print("hello")');
+    expect(lines.some((l) => l.startsWith('SUCCESS:') && l.includes('block 2'))).toBe(true);
+  });
+
+  it('warns when block index is out of range', async () => {
+    mockedGetBlock.mockReturnValue(undefined);
+    mockedGetBlocks.mockReturnValue([
+      { index: 1, lang: 'bash', text: 'echo hi' },
+    ]);
+    const { ctx, lines } = makeCtx({ assistant: 'some response' });
+    const result = await copyCmd.handler(ctx, '5');
+    expect(result).toBe('continue');
+    expect(lines.some((l) => l.includes('Block 5 not found') && l.includes('1 code block'))).toBe(true);
+  });
+
+  it('warns when no code blocks exist and a block index is requested', async () => {
+    mockedGetBlock.mockReturnValue(undefined);
+    mockedGetBlocks.mockReturnValue([]);
+    const { ctx, lines } = makeCtx({ assistant: 'just prose' });
+    const result = await copyCmd.handler(ctx, '1');
+    expect(result).toBe('continue');
+    expect(lines.some((l) => l.includes('No code blocks'))).toBe(true);
+  });
+
+  it('warns on unrecognized non-numeric argument', async () => {
+    const { ctx, lines } = makeCtx({ assistant: 'hello' });
+    const result = await copyCmd.handler(ctx, 'banana');
+    expect(result).toBe('continue');
+    expect(lines.some((l) => l.includes('Unknown argument'))).toBe(true);
+  });
+});

--- a/src/cli/slash/commands/copy.ts
+++ b/src/cli/slash/commands/copy.ts
@@ -1,0 +1,110 @@
+/**
+ * /copy (alias /cp) — copy agent output to the system clipboard.
+ *
+ * Two modes:
+ *   - `/copy`     — copies the last assistant turn's raw markdown (the whole
+ *                   response, clean of ANSI and tool-lane chrome).
+ *   - `/copy N`   — copies the Nth code block from the last turn, using the
+ *                   render-time register populated by `renderCodeBlock()`. The
+ *                   index matches the dim `/cp N` hint shown on each code block
+ *                   header, so users never have to count.
+ *
+ * Gated on interactive REPL + TTY (same guard as /fork) so Telegram/daemon
+ * callers never fire OSC 52 escape bytes at the wrong terminal.
+ */
+
+import { palette } from '../../palette.js';
+import { copyToClipboard } from '../../clipboard.js';
+import { getCodeBlock, getCodeBlocks } from '../../code-block-register.js';
+import type { SlashCommand } from '../types.js';
+
+export const copyCmd: SlashCommand = {
+  name: '/copy',
+  aliases: ['/cp'],
+  summary: 'Copy last response or a code block to clipboard',
+  usage: '/copy [N]',
+  hint: 'When you need to paste agent output into another terminal or editor. Use /cp N to grab a specific code block — the index is shown on each block header.',
+  async handler(ctx, args) {
+    const { stats, out } = ctx;
+
+    // Interactive-surface guard (same as /fork): only attempt clipboard on a
+    // local interactive REPL with a real TTY. Without this, a Telegram/daemon
+    // caller on a host with its own TTY would fire OSC 52 escape bytes into
+    // the host's terminal while claiming "copied" to the remote user.
+    const interactive =
+      typeof ctx.requestResume === 'function' && process.stdout.isTTY === true;
+
+    if (!interactive) {
+      out.warn('Clipboard not available on this surface — use /transcript to review output.');
+      return 'continue';
+    }
+
+    // Guard: need at least one completed turn.
+    if (stats.turns.length === 0) {
+      out.info('Nothing to copy — no assistant responses yet.');
+      return 'continue';
+    }
+
+    const lastTurn = stats.turns[stats.turns.length - 1];
+    const assistantText = lastTurn?.assistant;
+    if (!assistantText) {
+      out.info('Last turn has no assistant response.');
+      return 'continue';
+    }
+
+    const trimmed = args.trim();
+
+    // `/copy N` — grab a specific code block by index.
+    if (trimmed && /^\d+$/.test(trimmed)) {
+      const n = parseInt(trimmed, 10);
+      const block = getCodeBlock(n);
+      if (!block) {
+        const all = getCodeBlocks();
+        if (all.length === 0) {
+          out.info('No code blocks in the last response.');
+        } else {
+          out.warn(
+            `Block ${n} not found — last response has ${all.length} code block${all.length === 1 ? '' : 's'} ` +
+            `(1–${all.length}).`,
+          );
+        }
+        return 'continue';
+      }
+
+      const copied = copyToClipboard(block.text);
+      if (copied) {
+        const lines = block.text.split('\n').length;
+        out.success(
+          `Copied block ${n} ` +
+          palette.dim(`(${block.lang}, ${lines} line${lines === 1 ? '' : 's'})`) +
+          palette.dim(' to clipboard'),
+        );
+      } else {
+        out.warn('Clipboard write failed — the block content is in /transcript.');
+      }
+      return 'continue';
+    }
+
+    // Unrecognized non-empty arg — help the user.
+    if (trimmed) {
+      out.warn(`Unknown argument "${trimmed}". Usage: /copy (whole response) or /copy N (code block N).`);
+      return 'continue';
+    }
+
+    // `/copy` (no args) — copy the whole last assistant response.
+    const copied = copyToClipboard(assistantText);
+    if (copied) {
+      const chars = assistantText.length;
+      const lines = assistantText.split('\n').length;
+      out.success(
+        `Copied last response ` +
+        palette.dim(`(${chars} chars, ${lines} line${lines === 1 ? '' : 's'})`) +
+        palette.dim(' to clipboard'),
+      );
+    } else {
+      out.warn('Clipboard write failed — the full response is in /transcript.');
+    }
+
+    return 'continue';
+  },
+};

--- a/src/cli/slash/index.ts
+++ b/src/cli/slash/index.ts
@@ -34,6 +34,7 @@ import { editorCmd } from './commands/editor.js';
 import { afkMdCmd } from './commands/afk-md.js';
 import { searchCmd } from './commands/search.js';
 import { diffCmd } from './commands/diff.js';
+import { copyCmd } from './commands/copy.js';
 import { configDoctorCommands } from './commands/config-doctor.js';
 import { registerStaticPluginSkillCommands } from './plugin-skills.js';
 import { registerStaticPluginAgentCommands } from './plugin-agents.js';
@@ -69,6 +70,7 @@ export function registerAll(): void {
   register(afkMdCmd);
   register(searchCmd);
   register(diffCmd);
+  register(copyCmd);
   for (const cmd of configDoctorCommands) register(cmd);
   // Placeholders for plugin-backed commands. The real lists get registered
   // after `session.waitForInitialization()` resolves, via


### PR DESCRIPTION
## Summary

Users frequently need to copy specific pieces of agent output — shell commands, code snippets, draft text — to paste into another terminal or editor. Terminal selection fights ANSI escape codes, unicode gutters, and tool-lane chrome, so users resort to asking the agent to "save to a .txt file and open it."

This PR adds a `/copy` (alias `/cp`) slash command with **render-time code block capture**: every code block gets a dim `/cp N` hint in its header, and the user can type `/cp 2` to copy that exact block clean to clipboard.

## What changed

### New: Code block register (`src/cli/code-block-register.ts`)

A turn-scoped module-level register that `renderCodeBlock()` pushes into at render time — before ANSI codes and gutter decoration are applied. Cleared at each turn boundary via `resetCodeBlockRegister()`.

### New: `/copy` slash command (`src/cli/slash/commands/copy.ts`)

Two modes:
- **`/copy`** (no args) — copies the last assistant turn's raw markdown to clipboard
- **`/copy N`** — copies the Nth code block from the register (index shown on each block header)

Gated on interactive REPL + TTY (same `requestResume` + `isTTY` guard as `/fork`) so Telegram/daemon callers never fire OSC 52 at the wrong terminal.

### Changed: Code block header (`src/cli/formatter.block.ts`)

Every non-empty code block header now includes a dim copy hint:

```
│ python ── /cp 1
│ import sys
│ print(sys.version)
```

Blocks without an explicit language tag still show the hint:

```
│ ── /cp 2
│ some unlabelled code
```

### Changed: Turn boundary reset (`src/cli/commands/interactive/loop-iteration.ts`)

`resetCodeBlockRegister()` runs alongside the existing per-turn resets (verdict capture clear) so `/copy N` indices always match the blocks rendered in the current turn.

## Design decisions

This was shaped by a devil's-advocate critique wave (pragmatist / paranoid / architect lenses):

- **Rejected**: three-mode `/copy` with Lexer re-parsing (over-engineered before usage data)
- **Rejected**: render-time keybinds per block (correct long-term but prohibitive blast radius — couples render geometry to event dispatch)
- **Chosen**: hybrid — capture at render time (architect's insight) delivered via slash command (paranoid's blast radius). Minimal new code, zero re-parsing.

## Tests

- 5 tests for `code-block-register.ts` (register/retrieve/reset lifecycle)
- 9 tests for `/copy` (no turns, non-interactive surface, non-TTY, whole response, clipboard failure, block by index, out-of-range, no blocks, bad args)
- All 75 existing formatter tests pass
- All 99 existing markdown streaming tests pass
- All CI audit gates pass (filesize, module-state, chalk, env, pins)

## Deferred work

- #1286 — `/copy plain` mode for Slack/email-friendly output (strip markdown syntax)
- #1287 — Render-time artifact capture for non-code copyable regions (commands, drafts, tables)
