### PR TITLE
fix(tools): cap list_directory output at 500 entries

### DIFF
--- a/src/agent/tools/handlers/list-directory.test.ts
+++ b/src/agent/tools/handlers/list-directory.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, beforeEach, afterEach } from 'vitest';
 import { promises as fs } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { listDirectoryHandler } from './list-directory.js';
+import { listDirectoryHandler, MAX_ENTRIES } from './list-directory.js';
 import type { ToolHandlerContext } from '../types.js';
 
 describe('listDirectoryHandler', () => {
@@ -207,6 +207,41 @@ describe('listDirectoryHandler', () => {
     const lines = result.content.split('\n').map((l) => l.trim()).filter(Boolean);
     expect(lines).not.toContain('.');
     expect(lines).not.toContain('..');
+  });
+
+  it('caps output at MAX_ENTRIES and appends a marker', async () => {
+    const total = MAX_ENTRIES + 50;
+    const promises: Promise<void>[] = [];
+    for (let i = 0; i < total; i++) {
+      promises.push(fs.writeFile(join(tmpDir, `file-${String(i).padStart(5, '0')}.txt`), ''));
+    }
+    await Promise.all(promises);
+
+    const result = await listDirectoryHandler({ path: tmpDir }, new AbortController().signal);
+
+    expect(result.isError).not.toBe(true);
+    const lines = result.content.split('\n');
+    // MAX_ENTRIES data lines + 1 cap marker line
+    expect(lines).toHaveLength(MAX_ENTRIES + 1);
+    expect(lines[lines.length - 1]).toBe(
+      `[results capped at ${MAX_ENTRIES} entries — ${total} total in directory]`,
+    );
+  });
+
+  it('returns all entries when count equals MAX_ENTRIES', async () => {
+    const promises: Promise<void>[] = [];
+    for (let i = 0; i < MAX_ENTRIES; i++) {
+      promises.push(fs.writeFile(join(tmpDir, `f-${String(i).padStart(5, '0')}.txt`), ''));
+    }
+    await Promise.all(promises);
+
+    const result = await listDirectoryHandler({ path: tmpDir }, new AbortController().signal);
+
+    expect(result.isError).not.toBe(true);
+    const lines = result.content.split('\n');
+    expect(lines).toHaveLength(MAX_ENTRIES);
+    // No cap marker
+    expect(result.content).not.toContain('[results capped');
   });
 });
 

--- a/src/agent/tools/handlers/list-directory.ts
+++ b/src/agent/tools/handlers/list-directory.ts
@@ -5,6 +5,11 @@
  * Directories are suffixed with `/`, files are plain names. Entries are sorted
  * alphabetically with directories first.
  *
+ * Invariant: output is capped at {@link MAX_ENTRIES} entries (matching the glob
+ * tool's 500-entry convention). Directories with thousands of entries — like
+ * `~/.afk/state/sessions/` (15k+) — would otherwise inject 600KB+ into the
+ * context window and overflow smaller models in a single tool result.
+ *
  * @module agent/tools/handlers/list-directory
  */
 
@@ -12,6 +17,13 @@ import { promises as fs } from 'fs';
 import type { ToolHandler, ToolHandlerContext } from '../types.js';
 import { resolveAndContain } from './_cwd-utils.js';
 import { fsErrorToToolResult } from './_fs-error.js';
+
+/**
+ * Maximum entries returned before truncation. Matches glob's 500-entry cap
+ * so model-facing tools have a consistent ceiling. The full readdir runs
+ * regardless — only the returned string is capped.
+ */
+export const MAX_ENTRIES = 500;
 
 /**
  * Validates input and lists a directory.
@@ -77,8 +89,13 @@ const listDirectoryImpl = async (
       return { content: '(empty directory)' };
     }
 
-    // Join with newlines
-    const content = sorted.join('\n');
+    // Cap output to prevent context-window overflow on huge directories.
+    const total = sorted.length;
+    const capped = sorted.slice(0, MAX_ENTRIES);
+    let content = capped.join('\n');
+    if (total > MAX_ENTRIES) {
+      content += `\n[results capped at ${MAX_ENTRIES} entries — ${total} total in directory]`;
+    }
     return { content };
   } catch (err) {
     // Handle specific error types


### PR DESCRIPTION
## Problem

`list_directory` had no output cap. When a model called it on a directory with
thousands of entries (e.g. `~/.afk/state/sessions/` with 15,936 files), the
handler returned the entire listing verbatim — 618KB of text injected into the
context window as a single tool result.

On a local Qwen model with a 262K-token context window, this single tool result
consumed ~200K tokens and pushed the session to 571K total, producing an
unrecoverable `400 Prompt too long` error. Manual `/compact` could not help
because the tool result sat inside the kept tail (last 2 user turns) that
compaction structurally protects.

Every other discovery tool already has a cap:
- `glob`: 500 results
- `grep` / `bash`: 100KB head+tail via `_output-cap.ts`

`list_directory` was the only unbounded one.

## Fix

Cap `list_directory` output at 500 entries (matching `glob`'s convention).
When a directory exceeds the cap, the first 500 sorted entries are returned
with a marker:

```
[results capped at 500 entries — 15936 total in directory]
```

The full `readdir` still runs — only the returned string is truncated. The
cap is exported as `MAX_ENTRIES` for test access.

## Tests

Two new test cases:
- **Over cap**: 550 files → returns 501 lines (500 entries + marker), marker
  includes exact total count.
- **At cap boundary**: exactly 500 files → returns all 500, no marker.

All 20 existing + 2 new tests pass. `pnpm lint` and `pnpm audit:filesize:check`
clean.
