### PR TITLE
fix(plugins): skip node_modules in plugin skill discovery walk

### DIFF
--- a/src/agent/plugins/tool-injector.ts
+++ b/src/agent/plugins/tool-injector.ts
@@ -254,7 +254,7 @@ export function extractPluginSkills(
         if (dirent === null) break;
         totalEntries++;
         const name = dirent.name;
-      if (name.startsWith('.')) continue;
+      if (name.startsWith('.') || name === 'node_modules') continue;
       const fullPath = join(dir, name);
 
       let stat;


### PR DESCRIPTION
## Problem

Plugin skills from the `awa-dev` plugin (`/embody`, `/orient`, `/voice-match`, `/name-check`, `/checkpoint`, `/premise-gate`) were silently missing from the session skill manifest.

## Root cause

`extractPluginSkills` in `tool-injector.ts` walks a plugin directory tree recursively to find `SKILL.md` files, with a `MAX_ENTRIES = 1000` safety cap. It descends directories in filesystem order (alphabetical on most systems):

```
awa-dev/
  agents/       ← scanned first
  commands/
  hooks/
  scripts/      ← contains harvest/node_modules/ (3,831 entries)
  skills/       ← never reached
```

The walker exhausts its 1,000-entry budget inside `scripts/harvest/node_modules/` and returns zero skills. The existing skip logic handles dot-prefixed directories (`.git`, `.claude-plugin`) but not `node_modules`.

## Fix

One-line addition: skip `node_modules` directories in the walk, alongside the existing `.` prefix check.

## Verification

- Before fix: `extractPluginSkills(awa-dev)` → 0 skills
- After fix: `extractPluginSkills(awa-dev)` → 7 skills (all discovered)
- `buildSkillManifest()` now includes all 7 awa-dev skills
- 42 tool-injector tests pass ✓
- 72 skill-bridge tests pass ✓
- `pnpm lint` clean ✓
