### PR TITLE
docs(prompt): expand irreversible-action examples for service install and production proxies (#1281)

### DIFF
--- a/prompts/system-prompt.md
+++ b/prompts/system-prompt.md
@@ -62,7 +62,15 @@ The transcript is not a user channel. AFK users see bridge messages, files, comm
 
 ## Constraints
 
-- **Irreversible actions require explicit recent intent.** Examples: deleting files or branches, force-pushing, dropping data, messaging third parties, calling paid APIs, or modifying shared systems.
+- **Irreversible actions require explicit recent intent.** Examples: deleting files
+  or branches, force-pushing, dropping data, messaging third parties, calling paid
+  APIs, modifying shared systems, installing OS services or persistent daemons
+  (launchctl, systemctl — use `/service-setup`), or making HTTP requests with
+  side-effects to production APIs (including through localhost proxies).
+- **Never invoke `launchctl`, `systemctl`, or write to `~/Library/LaunchAgents/`
+  or `~/.config/systemd/user/` directly.** Use `afk service install` or invoke
+  `/service-setup`. Direct invocation produces untracked persistent processes that
+  survive reboots and are not recorded in agent state.
 - **Tool schemas are authoritative.** Required fields are required. If a value is unknown, fetch it or ask. Do not guess.
 - **Do not skip Observe or Update to save tokens.** Stale-state errors cost more than the tokens saved.
 - **Parallelize independent calls; sequence dependent ones.**


### PR DESCRIPTION
## Summary

Expands the system prompt's irreversible-action constraint to cover two action classes that the 2026-08-24 incident demonstrated are consequential:

1. **OS service installation** — `launchctl bootstrap`, `systemctl enable`, writing to `~/Library/LaunchAgents/`. More durable than `rm -rf` (which was already listed) since it persists across reboots and session boundaries.
2. **Production API writes through localhost proxies** — `curl -X POST http://localhost:8080/api/...` where the localhost server forwards to a production endpoint.

### Changes

- Expanded the existing irreversible-action examples line to include service installation and production proxy writes
- Added a new hard constraint: never invoke `launchctl`/`systemctl` or write to LaunchAgents/systemd paths directly — use `afk service install` or `/service-setup`

### Companion issues

- #1279 — mechanical BLOCK-tier patterns for launchctl/systemctl (has open PR #1298)
- #1280 — OBSERVE/BASH_HIGH for curl writes (separate PR incoming)

This is the **prompt-layer** complement: it shapes intent so the agent doesn't attempt these actions in the first place, reducing friction from blocked commands.

Closes #1281.
