### PR TITLE
fix(cli): guard code-block register with enabled flag (#1289)

### DIFF
--- a/src/cli/code-block-register.test.ts
+++ b/src/cli/code-block-register.test.ts
@@ -4,19 +4,25 @@ import {
   getCodeBlocks,
   getCodeBlock,
   resetCodeBlockRegister,
+  enableCodeBlockRegister,
+  disableCodeBlockRegister,
 } from './code-block-register.js';
 
 beforeEach(() => {
+  // Always start each test with a clean, disabled register.
+  disableCodeBlockRegister();
   resetCodeBlockRegister();
 });
 
 describe('code-block-register', () => {
   it('starts empty', () => {
+    enableCodeBlockRegister();
     expect(getCodeBlocks()).toHaveLength(0);
     expect(getCodeBlock(1)).toBeUndefined();
   });
 
   it('registers blocks with 1-based indices', () => {
+    enableCodeBlockRegister();
     const i1 = registerCodeBlock('bash', 'echo hello');
     const i2 = registerCodeBlock('python', 'print("hi")');
     expect(i1).toBe(1);
@@ -25,6 +31,7 @@ describe('code-block-register', () => {
   });
 
   it('retrieves blocks by 1-based index', () => {
+    enableCodeBlockRegister();
     registerCodeBlock('bash', 'echo hello');
     registerCodeBlock('python', 'print("hi")');
     const block = getCodeBlock(2);
@@ -32,12 +39,14 @@ describe('code-block-register', () => {
   });
 
   it('returns undefined for out-of-range index', () => {
+    enableCodeBlockRegister();
     registerCodeBlock('bash', 'echo hello');
     expect(getCodeBlock(0)).toBeUndefined();
     expect(getCodeBlock(2)).toBeUndefined();
   });
 
   it('resets the register', () => {
+    enableCodeBlockRegister();
     registerCodeBlock('bash', 'echo hello');
     registerCodeBlock('python', 'print("hi")');
     resetCodeBlockRegister();
@@ -45,5 +54,49 @@ describe('code-block-register', () => {
     // New registrations start at 1 again.
     const i = registerCodeBlock('text', 'foo');
     expect(i).toBe(1);
+  });
+
+  // --- enabled flag tests (issue #1289) ---
+
+  it('registerCodeBlock is a no-op when disabled (default)', () => {
+    // Register is disabled in beforeEach — no enable() call here.
+    const idx = registerCodeBlock('bash', 'echo hello');
+    expect(idx).toBe(0);
+    expect(getCodeBlocks()).toHaveLength(0);
+    expect(getCodeBlock(1)).toBeUndefined();
+  });
+
+  it('registerCodeBlock works when enabled', () => {
+    enableCodeBlockRegister();
+    const idx = registerCodeBlock('bash', 'echo hello');
+    expect(idx).toBe(1);
+    expect(getCodeBlocks()).toHaveLength(1);
+    expect(getCodeBlock(1)).toEqual({ index: 1, lang: 'bash', text: 'echo hello' });
+  });
+
+  it('disableCodeBlockRegister makes registerCodeBlock a no-op again', () => {
+    enableCodeBlockRegister();
+    registerCodeBlock('bash', 'echo first');
+    disableCodeBlockRegister();
+    const idx = registerCodeBlock('python', 'print("second")');
+    // Should not have been registered.
+    expect(idx).toBe(0);
+    expect(getCodeBlocks()).toHaveLength(1);
+    expect(getCodeBlock(2)).toBeUndefined();
+  });
+
+  it('resetCodeBlockRegister clears blocks regardless of enabled state', () => {
+    enableCodeBlockRegister();
+    registerCodeBlock('bash', 'echo hello');
+    expect(getCodeBlocks()).toHaveLength(1);
+    resetCodeBlockRegister();
+    expect(getCodeBlocks()).toHaveLength(0);
+  });
+
+  it('enable is idempotent — calling it twice does not double-register', () => {
+    enableCodeBlockRegister();
+    enableCodeBlockRegister();
+    registerCodeBlock('bash', 'echo hello');
+    expect(getCodeBlocks()).toHaveLength(1);
   });
 });

--- a/src/cli/code-block-register.ts
+++ b/src/cli/code-block-register.ts
@@ -9,6 +9,13 @@
  * the REPL is single-threaded and turns are sequential. Call
  * `resetCodeBlockRegister()` at each turn boundary to prevent stale
  * entries from leaking across turns.
+ *
+ * Registration is gated on an `enabled` flag (default: `false`).  Only
+ * the REPL loop enables registration (via `enableCodeBlockRegister()`)
+ * alongside `resetCodeBlockRegister()`.  All other render paths — daemon,
+ * subagent, one-shot, Telegram — leave the flag off, so
+ * `registerCodeBlock()` is a no-op and the `blocks` array never accumulates
+ * entries on non-REPL surfaces.
  */
 
 export interface CodeBlockEntry {
@@ -21,12 +28,31 @@ export interface CodeBlockEntry {
 }
 
 const blocks: CodeBlockEntry[] = [];
+let enabled = false;
+
+/**
+ * Enable registration.  Call once at REPL session start (alongside or
+ * immediately before `resetCodeBlockRegister()`).  No-op if already enabled.
+ */
+export function enableCodeBlockRegister(): void {
+  enabled = true;
+}
+
+/**
+ * Disable registration.  After this call `registerCodeBlock()` is a no-op
+ * again and no new entries are added to the register.
+ */
+export function disableCodeBlockRegister(): void {
+  enabled = false;
+}
 
 /**
  * Record a code block and return its 1-based index.
  * Called by `renderCodeBlock` at render time.
+ * No-op (returns 0) when the register is disabled.
  */
 export function registerCodeBlock(lang: string, text: string): number {
+  if (!enabled) return 0;
   const index = blocks.length + 1;
   blocks.push({ index, lang, text });
   return index;

--- a/src/cli/commands/interactive/loop-iteration.ts
+++ b/src/cli/commands/interactive/loop-iteration.ts
@@ -34,7 +34,7 @@ import type { InputSurface } from '../../input/input-surface.js';
 import type { ReplHistory } from '../../input/history.js';
 import { buildPrompt, type TurnState } from './repl-loop-shared.js';
 import type { FooterSubsystems } from './footer-subsystems.js';
-import { resetCodeBlockRegister } from '../../code-block-register.js';
+import { enableCodeBlockRegister, resetCodeBlockRegister } from '../../code-block-register.js';
 
 /** Per-handler timeout for the post-turn Stop notification. Tighter than the
  *  registry default (HOOK_HANDLER_TIMEOUT_MS = 30s) because Stop fires every
@@ -673,8 +673,11 @@ export async function runInputLoop(
       // onTerminalState re-sets these during runTurn when a verdict parses.
       currentTerminalKind = undefined;
       currentDoneHasEvidence = undefined;
-      // Clear the code-block register so `/copy N` indices match the blocks
-      // rendered in THIS turn, not a prior one.
+      // Enable and clear the code-block register so `/copy N` indices match
+      // the blocks rendered in THIS turn, not a prior one.  enableCodeBlockRegister()
+      // is idempotent after the first turn; calling it here ensures it is set
+      // before the first runTurn and stays set for every subsequent turn.
+      enableCodeBlockRegister();
       resetCodeBlockRegister();
       await runTurn({ text: runText, attachments }, ctx.session.current, ctx.stats, {
         setInFlight(v: boolean) { turnState.turnInFlight = v; },


### PR DESCRIPTION
## Summary

Guards the code-block register with an `enabled` flag so it only accumulates entries on REPL surfaces where `/copy` can consume them.

### Problem

`registerCodeBlock()` was called unconditionally inside `renderCodeBlock()` — every surface that renders markdown (one-shot `afk chat`, `/transcript` re-rendering, streaming renderer) populated the module-scope `blocks` array in `code-block-register.ts`. Only the REPL loop called `resetCodeBlockRegister()`. Non-REPL paths accumulated entries without bound — a resource leak in long-lived daemon processes.

### Fix

- Added `enabled` flag (default `false`) to `code-block-register.ts`
- `registerCodeBlock()` is a no-op when disabled — the blocks array never grows on non-REPL surfaces
- Exported `enableCodeBlockRegister()` / `disableCodeBlockRegister()` 
- REPL loop enables the register at the turn boundary alongside the existing reset

### Tests

- 5 new tests covering the enabled flag: no-op when disabled, works when enabled, disable re-gates, reset is flag-independent, enable is idempotent
- All 10 tests pass (5 existing + 5 new)

Closes #1289.
