### PR TITLE
docs: document credibility signal policy — PR/test counts over npm downloads (#1282)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,22 @@ pass `pnpm lint` (`tsc --noEmit`) before submitting.
 - No source code under `src/` imports from any model SDK directly — only through `src/agent/providers/`.
 - After adding an `@anthropic-ai/sdk` import, run `pnpm audit:sdk:update-lock` and fill in the `reason` field.
 
+## Credibility signals — no download badges
+
+Do **not** add npm download-count badges (e.g. `shields.io/npm/dm/agent-afk`) to
+README.md, the website, or any documentation. The npm download counter is inflated by
+registry mirrors and security scanners and does not reflect real adoption.
+
+Preferred signals (all unfakeable and publicly auditable on GitHub):
+
+- **Merged PRs** — each is a date-stamped public event.
+- **Test file count** — each `*.test.ts` must pass CI.
+- **Published versions** — visible on npmjs.com.
+- **Custom CI audit gates** — project-specific invariant checks under `tests/`.
+
+See [`docs/decisions/0003-credibility-signals-no-download-counts.md`](docs/decisions/0003-credibility-signals-no-download-counts.md)
+for the full rationale.
+
 ## Submitting a pull request
 
 1. Fork the repo and create a branch from `main`.

--- a/docs/decisions/0003-credibility-signals-no-download-counts.md
+++ b/docs/decisions/0003-credibility-signals-no-download-counts.md
@@ -1,0 +1,52 @@
+# ADR 0003 — Credibility signals: PR/test counts over npm downloads
+
+Status: **Accepted**
+
+Closes issue #1282.
+
+---
+
+## Context
+
+The npm "downloads last month" counter for `agent-afk` is inflated by registry
+mirrors and security scanners. A spot-check of the download log found that 636
+of 905 versions with any downloads had exactly **1** download — the mirror
+signature pattern. The raw download number therefore tells a prospective user
+nothing meaningful about real adoption.
+
+Carrying a download-count badge (e.g. `shields.io/npm/dm/agent-afk`) on the
+README or website would:
+
+- Present a number that is mostly mirror noise as a trust signal.
+- Create an ongoing maintenance obligation to explain why the figure fluctuates
+  even when no real users showed up.
+- Undermine the project's stated commitment to accuracy and auditability.
+
+## Decision
+
+**npm download counts are not used as credibility signals anywhere in this
+project** — not in README.md badges, not in the website landing page, not in
+documentation prose, and not in any marketing copy.
+
+The following signals are preferred because they are **unfakeable** and directly
+reflect real work:
+
+| Signal | Why it's trustworthy |
+|---|---|
+| **Merged PRs** (~915+) | Every merge is a public, auditable, date-stamped event on GitHub. |
+| **Test files** (~899+) | A count of `*.test.ts` files under `src/` and `tests/` that CI must pass. |
+| **Published versions** (~916+) | Each version is a real release decision, visible on npmjs.com. |
+| **Custom CI audit gates** (10+) | Named test files in `tests/` that audit project-specific invariants (deps, function size, terminal width, chalk SGR, etc.). |
+
+## Consequences
+
+1. The README badge row **does not** include an npm-downloads badge and
+   **must not** gain one in future PRs.
+2. The website (`website/`) **does not** cite download counts in any stats
+   section and must not add them.
+3. If a future contributor wants to add a download badge, the preferred
+   response is to link to this ADR and suggest one of the signals in the table
+   above instead.
+4. Periodic re-evaluation is fine (e.g. if npm publishes a verified-human
+   download API), but the bar is: the number must be unfakeable by automated
+   scanners.


### PR DESCRIPTION
## Summary

Documents the decision to never use npm download counts as credibility signals, and records the preferred alternatives.

### Problem

The npm "downloads last month" number is inflated by registry mirrors and security scanners. Per-version data shows 636 of 905 versions with downloads have exactly 1 download (mirror signature), and top versions plateau at 196–210 downloads each (flat distribution, not power-law).

### Changes

1. **New ADR** (`docs/decisions/0003-credibility-signals-no-download-counts.md`) — records the decision with evidence and the four preferred unfakeable signals:
   - 915+ merged PRs (sole maintainer)
   - 899+ test files
   - 916+ published versions
   - 10+ custom CI audit gates

2. **CONTRIBUTING.md** — new section under Code style conventions naming the preferred signals and linking to the ADR.

### Verification

- Confirmed no download badges exist in README.md or website content (the issue noted this — confirmed it's still true)
- `pnpm lint` clean

Closes #1282.
