### PR TITLE
fix(providers): run microcompaction unconditionally after compaction (#1293)

### DIFF
--- a/src/agent/providers/anthropic-direct/query/compact-handler.microcompact.test.ts
+++ b/src/agent/providers/anthropic-direct/query/compact-handler.microcompact.test.ts
@@ -12,7 +12,7 @@
  * fresh user turn `findCompactionBoundary` returns -1, so `retry` and
  * `traceWriter` are never dereferenced. That makes this a pure in-memory test.
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import type { MessageParam } from '@anthropic-ai/sdk/resources';
 import { compactHistory } from './compact-handler.js';
 import { createSessionState, type SessionState } from './session-state.js';
@@ -150,5 +150,93 @@ describe('compactHistory — microcompaction fallback wiring', () => {
     // Three fresh user turns, keepLastN=2 → boundary points at turn 3 (> 0), so
     // findCompactionBoundary does NOT return -1 → the fallback is not the path.
     expect(findCompactionBoundary(messages, 2)).toBeGreaterThan(0);
+  });
+});
+
+describe('compactHistory — microcompaction runs after successful compaction', () => {
+  const KEEP = 'AFK_MICROCOMPACT_KEEP_LAST';
+  const BYTES = 'AFK_MICROCOMPACT_TOOL_RESULT_BYTES';
+  beforeEach(() => {
+    delete process.env[KEEP];
+    delete process.env[BYTES];
+  });
+  afterEach(() => {
+    delete process.env[KEEP];
+    delete process.env[BYTES];
+  });
+
+  /**
+   * History with enough fresh user turns so normal compaction finds a boundary
+   * AND a large tool result in the kept tail that microcompaction should clear.
+   *
+   * Shape (keepLastN=2):
+   *   u1 / a1                — older turn (summarized away)
+   *   u2 / a2 / use(t1) / result(t1, 20KB) — kept tail: t1 is large → micro target
+   *   u3                     — second kept fresh turn
+   *
+   * findCompactionBoundary returns > 0, so the network path fires; we stub it.
+   */
+  function historyWithLargeTailResult(): MessageParam[] {
+    const bigContent = 'x'.repeat(20_000);
+    return [
+      { role: 'user', content: 'u1' },
+      { role: 'assistant', content: 'a1' },
+      { role: 'user', content: 'u2' },
+      { role: 'assistant', content: [{ type: 'tool_use', id: 't1', name: 'read_file', input: {} }] },
+      {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 't1', content: bigContent }],
+      },
+      { role: 'user', content: 'u3' },
+    ];
+  }
+
+  /** Minimal stub that streams a single text_delta event carrying the summary. */
+  async function* stubStream(summary: string) {
+    yield {
+      type: 'content_block_delta',
+      delta: { type: 'text_delta', text: summary },
+    };
+  }
+
+  it('clears large tool results in the kept tail even when compaction succeeds', async () => {
+    // keepLast=0 → no results protected → all oversized results are candidates.
+    process.env[KEEP] = '0';
+    // Low threshold so our 20KB content qualifies.
+    process.env[BYTES] = '100';
+
+    const messages = historyWithLargeTailResult();
+    // Sanity: boundary is positive so the summarization path runs.
+    expect(findCompactionBoundary(messages, 2)).toBeGreaterThan(0);
+
+    const messagesCreateMock = vi.fn(() => stubStream('COMPRESSED'));
+    const fakeRetry = {
+      client: { messages: { create: messagesCreateMock } },
+      authMode: 'api-key',
+    } as unknown as RetryLayer;
+
+    const state = makeState(messages);
+    const result = await compactHistory({
+      state,
+      abort: new AbortCoordinator(),
+      retry: fakeRetry,
+      initSessionId: 'test-session',
+    });
+
+    // Normal compaction ran — the summarizer was called.
+    expect(messagesCreateMock).toHaveBeenCalledTimes(1);
+    // The result reports a successful compaction (not just microcompacted).
+    expect(result.compacted).toBe(true);
+
+    // The large tool result in the kept tail was also cleared by microcompaction.
+    const toolResultMsg = state.messages.find((m) => {
+      if (!Array.isArray(m.content)) return false;
+      const block = m.content[0] as { type?: string };
+      return block?.type === 'tool_result';
+    });
+    expect(toolResultMsg).toBeDefined();
+    const block = (toolResultMsg!.content as Array<{ type?: string; content?: unknown }>)[0];
+    expect(typeof block.content).toBe('string');
+    expect(isMicrocompactPlaceholder(block.content as string)).toBe(true);
   });
 });

--- a/src/agent/providers/anthropic-direct/query/compact-handler.ts
+++ b/src/agent/providers/anthropic-direct/query/compact-handler.ts
@@ -231,6 +231,12 @@ export async function compactHistory(
     tokensSavedEstimate,
   });
 
+  // Deterministic microcompaction: run unconditionally after a successful
+  // compaction so large tool results in the kept tail are also cleared.
+  // The sentinel guard inside microcompactToolResults (`isMicrocompactPlaceholder`)
+  // prevents double-clearing any block that was already replaced in a prior pass.
+  microcompactToolResults(state.messages, readMicrocompactOptions());
+
   return {
     compacted: true,
     messagesBefore,

--- a/src/agent/providers/openai-compatible/compact.test.ts
+++ b/src/agent/providers/openai-compatible/compact.test.ts
@@ -3,14 +3,14 @@
  * `compactOpenAIHistory` handler (bail paths + successful in-place splice),
  * driven by a stubbed summarizer so no network is touched.
  */
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   compactOpenAIHistory,
   isFreshUserTurn,
   openaiCompactionOps,
   type CompactOpenAIHistoryDeps,
 } from './compact.js';
-import { COMPACT_ACK_TEXT, COMPACT_SUMMARY_HEADER } from '../shared/compaction.js';
+import { COMPACT_ACK_TEXT, COMPACT_SUMMARY_HEADER, isMicrocompactPlaceholder } from '../shared/compaction.js';
 import type { OpenAIMessage } from './messages.js';
 
 describe('openai isFreshUserTurn', () => {
@@ -180,5 +180,71 @@ describe('compactOpenAIHistory', () => {
     const prev = priorTurns[toolIdx - 1] as { role?: string; tool_calls?: Array<{ id?: string }> };
     expect(prev.role).toBe('assistant');
     expect(prev.tool_calls?.some((tc) => tc.id === 't2')).toBe(true);
+  });
+});
+
+describe('compactOpenAIHistory — microcompaction runs after successful compaction', () => {
+  const KEEP = 'AFK_MICROCOMPACT_KEEP_LAST';
+  const BYTES = 'AFK_MICROCOMPACT_TOOL_RESULT_BYTES';
+  beforeEach(() => {
+    delete process.env[KEEP];
+    delete process.env[BYTES];
+  });
+  afterEach(() => {
+    delete process.env[KEEP];
+    delete process.env[BYTES];
+  });
+
+  /**
+   * History with enough fresh user turns for normal compaction to succeed AND
+   * a large tool result in the kept tail that microcompaction should clear.
+   *
+   * Shape (keepLastN=2):
+   *   u1 / a1            — older turn (summarized away)
+   *   u2 / a2 / tool(t1) — sits in the kept tail: t1 is large → microcompact target
+   *   u3                 — second kept fresh turn
+   *
+   * Boundary lands on u2 (index 2), so t1 survives in the tail and is a
+   * microcompaction candidate once microcompact runs after the successful splice.
+   */
+  function historyWithLargeTailResult(): OpenAIMessage[] {
+    const bigContent = 'x'.repeat(20_000);
+    return [
+      { role: 'user', content: 'u1' },
+      { role: 'assistant', content: 'a1' },
+      { role: 'user', content: 'u2' },
+      {
+        role: 'assistant',
+        content: '',
+        tool_calls: [{ id: 't1', type: 'function', function: { name: 'read_file', arguments: '{}' } }],
+      } as unknown as OpenAIMessage,
+      { role: 'tool', content: bigContent, tool_call_id: 't1' },
+      { role: 'user', content: 'u3' },
+    ];
+  }
+
+  it('clears large tool results in the kept tail even when compaction succeeds', async () => {
+    // keepLast=0 → no results protected → all oversized results are candidates.
+    process.env[KEEP] = '0';
+    // Low threshold so our 20KB content qualifies.
+    process.env[BYTES] = '100';
+
+    const priorTurns = historyWithLargeTailResult();
+    const summarize = vi.fn(async () => 'COMPRESSED');
+    const result = await compactOpenAIHistory(
+      deps({ priorTurns, summarize }),
+    );
+
+    // Normal compaction ran (summarizer was called).
+    expect(summarize).toHaveBeenCalledTimes(1);
+    // The compaction result reports success (turn-granular summarization landed).
+    expect(result.compacted).toBe(true);
+
+    // The large tool result in the kept tail was also cleared by microcompaction.
+    const toolMsg = priorTurns.find((m) => m.role === 'tool');
+    expect(toolMsg).toBeDefined();
+    const content = toolMsg!.content;
+    const text = typeof content === 'string' ? content : '';
+    expect(isMicrocompactPlaceholder(text)).toBe(true);
   });
 });

--- a/src/agent/providers/openai-compatible/compact.ts
+++ b/src/agent/providers/openai-compatible/compact.ts
@@ -305,28 +305,24 @@ export async function compactOpenAIHistory(
     deps.clearAbort(controller);
   }
 
-  // Deterministic fallback: when turn-granular summarization found nothing to do
-  // (short-but-full session — huge tool payloads inside the one kept turn), clear
-  // large/old tool_result CONTENT in place. Additive: the summarization success
-  // path above is untouched; this only runs on the no-op reasons.
-  if (
-    !result.compacted &&
-    (result.reason === 'history-too-short' || result.reason === 'nothing-to-summarize')
-  ) {
-    const opts = resolveMicrocompactOptions(
-      env.AFK_MICROCOMPACT_TOOL_RESULT_BYTES,
-      env.AFK_MICROCOMPACT_KEEP_LAST,
-    );
-    const { blocksCleared, bytesReclaimed } = microcompactToolResults(deps.priorTurns, opts);
-    if (blocksCleared > 0) {
-      return {
-        compacted: false,
-        reason: 'microcompacted',
-        messagesBefore,
-        messagesAfter: deps.priorTurns.length,
-        microcompaction: { blocksCleared, bytesReclaimed },
-      };
-    }
+  // Deterministic microcompaction: after any compaction attempt, clear large/old
+  // tool_result CONTENT in place. The sentinel guard inside microcompactToolResults
+  // (`isMicrocompactPlaceholder`) prevents double-clearing blocks that were already
+  // replaced in a prior pass. This runs unconditionally so a single large tool result
+  // in the kept tail is never immune — even when turn-granular compaction succeeded.
+  const opts = resolveMicrocompactOptions(
+    env.AFK_MICROCOMPACT_TOOL_RESULT_BYTES,
+    env.AFK_MICROCOMPACT_KEEP_LAST,
+  );
+  const { blocksCleared, bytesReclaimed } = microcompactToolResults(deps.priorTurns, opts);
+  if (blocksCleared > 0 && !result.compacted) {
+    return {
+      compacted: false,
+      reason: 'microcompacted',
+      messagesBefore,
+      messagesAfter: deps.priorTurns.length,
+      microcompaction: { blocksCleared, bytesReclaimed },
+    };
   }
 
   return result;

--- a/src/agent/providers/openai-compatible/query.test.ts
+++ b/src/agent/providers/openai-compatible/query.test.ts
@@ -1689,25 +1689,21 @@ describe('OpenAICompatibleQuery — ProviderQuery surface', () => {
     await collect(q);
 
     // 1st compact: not yet latched, so it attempts the summarize and is refused.
-    // The core reports a safe no-op and the latch engages. (The core's own
-    // microcompaction fallback does NOT run on a summarization failure, so every
-    // oversized tool result is still present for the next call.)
+    // The latch engages. microcompaction now runs unconditionally after any
+    // compaction attempt (PR #1293), so eligible tool results (older than the
+    // keepLast=4 window) are cleared immediately on this first call.
     const first = await q.compact();
     expect(first.compacted).toBe(false);
-    expect(first.reason).not.toBe('microcompacted');
+    expect(first.reason).toBe('microcompacted');
+    expect(first.microcompaction?.blocksCleared).toBeGreaterThan(0);
+    expect(first.microcompaction?.bytesReclaimed).toBeGreaterThan(0);
 
-    // 2nd compact: takes the latched path — which must still microcompact rather
-    // than short-circuiting on the latch alone.
+    // 2nd compact: takes the latched path. The oldest tool results were already
+    // cleared by the first compact, and the remaining four are inside the
+    // protected window — nothing left to reclaim, so the latch reason surfaces.
     const second = await q.compact();
     expect(second.compacted).toBe(false);
-    expect(second.reason).toBe('microcompacted');
-    expect(second.microcompaction?.blocksCleared).toBeGreaterThan(0);
-    expect(second.microcompaction?.bytesReclaimed).toBeGreaterThan(0);
-
-    // 3rd compact: every remaining result is inside the protected window, so
-    // there is nothing left to reclaim and the latch reason surfaces.
-    const third = await q.compact();
-    expect(third.reason).toBe('responses-compaction-unavailable');
+    expect(second.reason).toBe('responses-compaction-unavailable');
     q.close();
     installMockClient();
   });


### PR DESCRIPTION
## Summary

Makes microcompaction run unconditionally after compaction in both providers, not only as a fallback on no-op compaction results.

### Problem

Microcompaction (deterministic clearing of large/old tool-result content) only ran when compaction returned `history-too-short` or `nothing-to-summarize`. When compaction "succeeded" — even trivially (e.g. saving 1,306 tokens while a 618KB tool result sat untouched in the kept tail) — microcompaction never fired.

A single large tool result landing in the last 2 user turns (the kept tail that compaction structurally protects) was immune to both mechanisms.

### Fix

- **openai-compatible/compact.ts** — Removed the `!result.compacted && (reason === 'history-too-short' || reason === 'nothing-to-summarize')` guard. Microcompaction now always runs after compaction.
- **anthropic-direct/compact-handler.ts** — Added `microcompactToolResults()` call after successful `applyCompaction`, before returning the compacted result.

The guard against double-clearing is already built in: microcompaction skips blocks carrying the placeholder sentinel (`isMicrocompactPlaceholder`), so running it after a successful compaction is a safe no-op when there's nothing left to clear.

### Tests

- OpenAI: new test proving microcompaction clears a 20KB tool result in the kept tail even when compaction succeeds (12/12 pass)
- Anthropic: matching test with stubbed `messages.create` (4/4 pass)

Closes #1293.
