### PR TITLE
fix(providers): seed context-overflow guard from restored session usage (#1294)

### DIFF
--- a/src/agent/providers/anthropic-direct/provider-query-build.ts
+++ b/src/agent/providers/anthropic-direct/provider-query-build.ts
@@ -58,6 +58,13 @@ export function buildProviderQuery(
   // making the id known earlier.
   const resumedSessionId = resolvedSessionId;
   const initialMessages = resumeHistoryToMessages(config.resumeHistory);
+  // Seed the context-overflow guard from the last stored turn's token count
+  // (#1294). The last turn of resumeHistory carries `inputTokens` when the
+  // session was saved with a recent enough sidecar; absent on legacy sidecars.
+  // Conservative: prefer over-estimate (triggers compaction) over under-estimate
+  // (lets a full context reach the wire and get rejected with HTTP 400).
+  const lastResumedTurn = config.resumeHistory?.at(-1);
+  const initialUsageInputTokens = lastResumedTurn?.inputTokens;
 
   const cwdDependentsFactory = ctx.externalTools
     ? undefined
@@ -116,6 +123,7 @@ export function buildProviderQuery(
     toolDispatcher: queryDispatcher,
     ...(resumedSessionId !== undefined ? { sessionId: resumedSessionId } : {}),
     ...(initialMessages !== undefined ? { initialMessages } : {}),
+    ...(initialUsageInputTokens !== undefined ? { initialUsageInputTokens } : {}),
     model,
     // Preserve the requested alias (e.g. opus_1m) so context-window lookups
     // recover the 1M window. `model` above is the resolved wire id, which is

--- a/src/agent/providers/anthropic-direct/query-options.ts
+++ b/src/agent/providers/anthropic-direct/query-options.ts
@@ -54,6 +54,17 @@ export interface AnthropicDirectQueryOptions {
   toolDispatcher: ToolDispatcher;
   sessionId?: string;
   initialMessages?: MessageParam[];
+  /**
+   * Conservative token estimate seeded from the last completed turn of a
+   * restored session (#1294). When non-zero, used as the initial `lastUsage`
+   * so the context-overflow guard fires correctly on the first resumed turn
+   * instead of being skipped (the guard skips when `lastUsage` is null,
+   * treating it as a fresh session with no prior context to check against).
+   * Callers MUST over-estimate rather than under-estimate: a false positive
+   * triggers compaction (recoverable) while a false negative lets a full
+   * context reach the wire and get rejected with HTTP 400.
+   */
+  initialUsageInputTokens?: number;
   model: string;
   /**
    * The model the caller requested — a short alias (`opus_1m`, `sonnet`, …)

--- a/src/agent/providers/anthropic-direct/query-runtime.ts
+++ b/src/agent/providers/anthropic-direct/query-runtime.ts
@@ -183,6 +183,7 @@ export class AnthropicDirectQuery implements ProviderQuery {
       toolDispatcher: opts.toolDispatcher,
       ...(opts.initialMessages ? { initialMessages: opts.initialMessages } : {}),
       ...(opts.autoCompactThreshold !== undefined ? { autoCompactThreshold: opts.autoCompactThreshold } : {}),
+      ...(opts.initialUsageInputTokens !== undefined ? { initialUsageInputTokens: opts.initialUsageInputTokens } : {}),
     });
     this.abort = new AbortCoordinator();
   }

--- a/src/agent/providers/anthropic-direct/query/session-state-resume.test.ts
+++ b/src/agent/providers/anthropic-direct/query/session-state-resume.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for #1294: context-overflow guard seeded from restored session usage.
+ *
+ * `createSessionState({ initialUsageInputTokens })` — when a session is
+ * resumed with a non-zero token estimate, `lastUsage` must be seeded so the
+ * overflow guard fires correctly on the first turn instead of being skipped.
+ *
+ * Coverage:
+ *   1. Fresh session (no initialUsageInputTokens) → lastUsage starts null.
+ *   2. Resumed session with token count → lastUsage seeded with inputTokens.
+ *   3. Zero token count is treated as absent (null, same as fresh session).
+ *   4. seeded lastUsage triggers the overflow guard when the context is full.
+ *   5. Seeded lastUsage does NOT trigger the guard when there is headroom.
+ *   6. A turn completing normally overwrites the seeded value.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createSessionState } from './session-state.js';
+import { guardContextOverflow, contextWindowTokensUsed } from '../../../providers/shared/auto-compact.js';
+
+// Minimal stub that satisfies the ToolDispatcher interface without importing
+// the real implementation — avoids pulling the full provider graph into a unit test.
+const STUB_DISPATCHER = {} as unknown as import('../tool-dispatcher.js').ToolDispatcher;
+
+function makeMinimalOpts() {
+  return {
+    model: 'claude-test',
+    permissionMode: 'default',
+    userSystem: null,
+    toolDispatcher: STUB_DISPATCHER,
+  } as const;
+}
+
+// ─── lastUsage initialization ─────────────────────────────────────────────────
+
+describe('createSessionState — lastUsage initialization (#1294)', () => {
+  it('starts as null for a fresh session (no initialUsageInputTokens)', () => {
+    const state = createSessionState(makeMinimalOpts());
+    expect(state.lastUsage).toBeNull();
+  });
+
+  it('starts as null when initialUsageInputTokens is 0', () => {
+    const state = createSessionState({ ...makeMinimalOpts(), initialUsageInputTokens: 0 });
+    expect(state.lastUsage).toBeNull();
+  });
+
+  it('seeds lastUsage.inputTokens when initialUsageInputTokens is non-zero', () => {
+    const state = createSessionState({ ...makeMinimalOpts(), initialUsageInputTokens: 50_000 });
+    expect(state.lastUsage).not.toBeNull();
+    expect(state.lastUsage?.inputTokens).toBe(50_000);
+  });
+
+  it('seeded lastUsage carries the expected shape (stopReason null, not an error)', () => {
+    const state = createSessionState({ ...makeMinimalOpts(), initialUsageInputTokens: 100_000 });
+    expect(state.lastUsage?.stopReason).toBeNull();
+    expect(state.lastUsage?.isError).toBe(false);
+    expect(state.lastUsage?.resultSubtype).toBe('success');
+  });
+
+  it('does not seed lastUsage when initialUsageInputTokens is absent', () => {
+    const state = createSessionState({ ...makeMinimalOpts() });
+    expect(state.lastUsage).toBeNull();
+  });
+});
+
+// ─── overflow guard interaction ───────────────────────────────────────────────
+
+describe('seeded lastUsage + guardContextOverflow (#1294)', () => {
+  it('throws when seeded inputTokens + maxOutput > contextLimit (guard fires on resume)', () => {
+    // Simulate: haiku 200k window, 64k output ceiling.
+    // Restored session had 137k input tokens → 137k + 64k = 201k > 200k → must throw.
+    const state = createSessionState({ ...makeMinimalOpts(), initialUsageInputTokens: 137_000 });
+    const usedTokens = contextWindowTokensUsed(state.lastUsage ?? {});
+    expect(() =>
+      guardContextOverflow(usedTokens, 64_000, 200_000, 'claude-haiku'),
+    ).toThrow(/Context-window overflow/);
+  });
+
+  it('does NOT throw when seeded inputTokens + maxOutput <= contextLimit (headroom available)', () => {
+    // 100k input + 64k output = 164k < 200k → safe.
+    const state = createSessionState({ ...makeMinimalOpts(), initialUsageInputTokens: 100_000 });
+    const usedTokens = contextWindowTokensUsed(state.lastUsage ?? {});
+    expect(() =>
+      guardContextOverflow(usedTokens, 64_000, 200_000, 'claude-haiku'),
+    ).not.toThrow();
+  });
+
+  it('does NOT throw when lastUsage is null (fresh or legacy session without seeding)', () => {
+    // No initialUsageInputTokens → lastUsage null → knownInputTokens = 0 → guard skips.
+    const state = createSessionState(makeMinimalOpts());
+    const usedTokens = contextWindowTokensUsed(state.lastUsage ?? {});
+    // usedTokens will be 0 (no usage at all) → guard must not throw.
+    expect(() =>
+      guardContextOverflow(usedTokens, 64_000, 200_000, 'claude-haiku'),
+    ).not.toThrow();
+  });
+
+  it('seeded value is overwritten once the first real turn completes', () => {
+    // After a real turn the provider updates lastUsage with actual data;
+    // the seeded value is no longer in play. This is a behaviour invariant —
+    // the state field is mutable and callers replace it freely.
+    const state = createSessionState({ ...makeMinimalOpts(), initialUsageInputTokens: 99_000 });
+    expect(state.lastUsage?.inputTokens).toBe(99_000);
+
+    // Simulate a completed turn writing real usage:
+    state.lastUsage = { inputTokens: 50_000, outputTokens: 1_000, stopReason: 'end_turn', resultSubtype: 'success', isError: false };
+    expect(state.lastUsage?.inputTokens).toBe(50_000);
+  });
+});

--- a/src/agent/providers/anthropic-direct/query/session-state.ts
+++ b/src/agent/providers/anthropic-direct/query/session-state.ts
@@ -132,7 +132,23 @@ export function createSessionState(opts: {
   toolDispatcher: ToolDispatcher;
   initialMessages?: MessageParam[];
   autoCompactThreshold?: number;
+  /**
+   * Conservative token estimate seeded from the last completed turn of a
+   * restored session (#1294). When non-zero, used as the initial `lastUsage`
+   * so the context-overflow guard fires correctly on the first resumed turn
+   * instead of being skipped (the guard skips when `lastUsage` is null,
+   * treating it as a fresh session with no prior context to check against).
+   *
+   * Callers MUST over-estimate rather than under-estimate: a false positive
+   * triggers compaction (recoverable) while a false negative lets an
+   * already-full context reach the wire and get rejected with HTTP 400.
+   */
+  initialUsageInputTokens?: number;
 }): SessionState {
+  const initialLastUsage: ProviderUsage | null =
+    opts.initialUsageInputTokens !== undefined && opts.initialUsageInputTokens > 0
+      ? { inputTokens: opts.initialUsageInputTokens, stopReason: null, resultSubtype: 'success', isError: false }
+      : null;
   return {
     messages: opts.initialMessages ? [...opts.initialMessages] : [],
     currentModel: opts.model,
@@ -140,7 +156,7 @@ export function createSessionState(opts: {
     currentPermissionMode: opts.permissionMode,
     userSystem: opts.userSystem,
     toolDispatcher: opts.toolDispatcher,
-    lastUsage: null,
+    lastUsage: initialLastUsage,
     closed: false,
     autoCompactThreshold: opts.autoCompactThreshold,
   };

--- a/src/agent/providers/openai-compatible/query-resume.test.ts
+++ b/src/agent/providers/openai-compatible/query-resume.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Tests for #1294: context-overflow guard seeded on OpenAI-compatible session
+ * resume.
+ *
+ * When a session is resumed (`config.resumeHistory` non-empty with inputTokens
+ * set on the last turn), the OpenAICompatibleQuery constructor must seed
+ * `this.lastUsage` so the overflow guard (#962) fires on the first resumed
+ * turn instead of being skipped.
+ *
+ * Coverage:
+ *   1. Fresh session → getContextUsage() reports 0 tokens (lastUsage null).
+ *   2. Resumed session with inputTokens → getContextUsage() reports seeded count.
+ *   3. Zero inputTokens on last turn → treated as absent (no seeding).
+ *   4. Legacy sidecar (no inputTokens) → no seeding (guard skipped, unchanged).
+ *   5. After the first real turn completes, the seeded value is replaced.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { AgentConfig, ResumeHistoryTurn } from '../../types/config-types.js';
+import {
+  __setOpenAIClientFactory,
+  __setRetryBaseDelay,
+  OpenAICompatibleQuery,
+  type OpenAIClientFactory,
+} from './query.js';
+import type { OpenAIChunk } from './translate.js';
+
+// ─── minimal mock client ──────────────────────────────────────────────────────
+
+let pendingChunks: OpenAIChunk[] = [];
+
+function installMockClient() {
+  const factory: OpenAIClientFactory = () =>
+    ({
+      chat: {
+        completions: {
+          create: async () => ({
+            [Symbol.asyncIterator]() {
+              return pendingChunks[Symbol.asyncIterator]();
+            },
+          }),
+        },
+      },
+    }) as ReturnType<OpenAIClientFactory>;
+  __setOpenAIClientFactory(factory);
+}
+
+function clearMockClient() {
+  __setOpenAIClientFactory(undefined);
+  pendingChunks = [];
+}
+
+// Minimal done-chunk that simulates a text response.
+function makeDoneChunks(text = 'ok'): OpenAIChunk[] {
+  return [
+    {
+      choices: [{ delta: { content: text }, finish_reason: null, index: 0 }],
+      usage: null,
+    } as unknown as OpenAIChunk,
+    {
+      choices: [{ delta: {}, finish_reason: 'stop', index: 0 }],
+      usage: { prompt_tokens: 50, completion_tokens: 5, total_tokens: 55 },
+    } as unknown as OpenAIChunk,
+  ];
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function makeConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    model: 'gpt-4o-mini',
+    ...overrides,
+  } as AgentConfig;
+}
+
+function buildQuery(config: AgentConfig): OpenAICompatibleQuery {
+  const { promptStream, auth } = (() => {
+    let resolve!: () => void;
+    // A prompt stream that never yields (we never send a turn in most tests).
+    const stream: AsyncIterable<{ content: string }> = {
+      [Symbol.asyncIterator]() {
+        return {
+          async next() {
+            await new Promise<void>((r) => { resolve = r; });
+            return { value: { content: 'hi' }, done: false };
+          },
+          async return() {
+            resolve?.();
+            return { value: undefined as never, done: true };
+          },
+        };
+      },
+    };
+    return {
+      promptStream: stream as unknown as AgentConfig['promptStream'],
+      auth: { apiKey: 'test-key', source: 'env' as const },
+    };
+  })();
+
+  // Build via the exported constructor directly (mirrors how query.test.ts works).
+  return new OpenAICompatibleQuery({
+    auth,
+    model: config.model as string ?? 'gpt-4o-mini',
+    synthesizedSessionId: 'test-session',
+    promptStream: promptStream as never,
+    config,
+  });
+}
+
+// ─── tests ───────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  installMockClient();
+  __setRetryBaseDelay?.(0);
+});
+afterEach(() => {
+  clearMockClient();
+});
+
+describe('OpenAICompatibleQuery — lastUsage seeded from resumeHistory (#1294)', () => {
+  it('fresh session: getContextUsage() returns 0 totalTokens (lastUsage null)', async () => {
+    const q = buildQuery(makeConfig());
+    const usage = await q.getContextUsage();
+    expect(usage.totalTokens).toBe(0);
+    expect(usage.apiUsage).toBeNull();
+  });
+
+  it('resumed session: getContextUsage() reflects seeded inputTokens from last turn', async () => {
+    const resumeHistory: ResumeHistoryTurn[] = [
+      { user: 'first question', assistant: 'first answer' },
+      { user: 'second question', assistant: 'second answer', inputTokens: 120_000 },
+    ];
+    const q = buildQuery(makeConfig({ resumeHistory }));
+    const usage = await q.getContextUsage();
+    // totalTokens is derived from contextWindowTokensUsed(lastUsage), which for
+    // a seeded usage with only inputTokens falls back to inputTokens + 0 = 120_000.
+    expect(usage.totalTokens).toBe(120_000);
+    expect(usage.apiUsage).not.toBeNull();
+    expect(usage.apiUsage?.input_tokens).toBe(120_000);
+  });
+
+  it('only the LAST turn inputTokens is used (earlier turns are ignored)', async () => {
+    // inputTokens on earlier turns should not pollute the seeded value.
+    const resumeHistory: ResumeHistoryTurn[] = [
+      { user: 'q1', assistant: 'a1', inputTokens: 999_000 }, // earlier turn — ignored
+      { user: 'q2', assistant: 'a2', inputTokens: 50_000 },  // last turn — used
+    ];
+    const q = buildQuery(makeConfig({ resumeHistory }));
+    const usage = await q.getContextUsage();
+    expect(usage.totalTokens).toBe(50_000);
+  });
+
+  it('zero inputTokens on last turn: treated as absent (no seeding)', async () => {
+    const resumeHistory: ResumeHistoryTurn[] = [
+      { user: 'hi', assistant: 'hello', inputTokens: 0 },
+    ];
+    const q = buildQuery(makeConfig({ resumeHistory }));
+    const usage = await q.getContextUsage();
+    // Zero → treated as absent → no seeding → totalTokens 0.
+    expect(usage.totalTokens).toBe(0);
+    expect(usage.apiUsage).toBeNull();
+  });
+
+  it('legacy sidecar (no inputTokens on last turn): no seeding (backward compat)', async () => {
+    // Older sidecars don't have inputTokens on turns.
+    const resumeHistory: ResumeHistoryTurn[] = [
+      { user: 'old question', assistant: 'old answer' },
+    ];
+    const q = buildQuery(makeConfig({ resumeHistory }));
+    const usage = await q.getContextUsage();
+    expect(usage.totalTokens).toBe(0);
+    expect(usage.apiUsage).toBeNull();
+  });
+
+  it('empty resumeHistory: no seeding (same as fresh session)', async () => {
+    const q = buildQuery(makeConfig({ resumeHistory: [] }));
+    const usage = await q.getContextUsage();
+    expect(usage.totalTokens).toBe(0);
+  });
+});

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -271,6 +271,11 @@ export class OpenAICompatibleQuery implements ProviderQuery {
    * `anthropic-direct/query.ts:186` so the REPL status line gets a real
    * context-% reading on OpenAI models instead of falling through to the
    * sampler's local-stats approximation.
+   *
+   * Seeded from the last stored turn's token count on session resume (#1294)
+   * so the context-overflow guard fires correctly on the first resumed turn
+   * instead of being skipped (the guard skips when `lastUsage` is null,
+   * treating it as a fresh session with no prior context to check against).
    */
   private lastUsage: ProviderUsage | null = null;
 
@@ -322,6 +327,21 @@ export class OpenAICompatibleQuery implements ProviderQuery {
     this.useOpenAIPricing =
       (wire.baseURL === undefined && opts.baseURL === undefined) ||
       (isGrokModelId(opts.model) && opts.config.forceXaiOAuth !== true);
+
+    // Seed the context-overflow guard from the last stored turn's token count
+    // (#1294). The last turn of resumeHistory carries `inputTokens` when the
+    // session was saved with a recent enough sidecar; absent on legacy sidecars.
+    // Conservative: over-estimate (triggers compaction) > under-estimate
+    // (lets a full context reach the wire, rejected with HTTP 400).
+    const lastResumedTurn = opts.config.resumeHistory?.at(-1);
+    if (lastResumedTurn?.inputTokens !== undefined && lastResumedTurn.inputTokens > 0) {
+      this.lastUsage = {
+        inputTokens: lastResumedTurn.inputTokens,
+        stopReason: null,
+        resultSubtype: 'success',
+        isError: false,
+      };
+    }
 
     if (opts.auth.apiKey === null) {
       this.client = null as unknown as OpenAI;

--- a/src/agent/types/config-types.ts
+++ b/src/agent/types/config-types.ts
@@ -34,6 +34,14 @@ export interface ToolConfig {
 export interface ResumeHistoryTurn {
   user: string;
   assistant: string;
+  /**
+   * Context-window token count from the last completed turn before resume
+   * (i.e. `contextWindowTokens ?? inputTokens` from the stored TurnRecord).
+   * Used to seed `lastUsage` on session restore so the context-overflow guard
+   * (#1294) fires correctly on the first resumed turn instead of being skipped.
+   * Optional for backward compat — absent on history entries that predate the fix.
+   */
+  inputTokens?: number;
 }
 
 /**

--- a/src/cli/resume-session.test.ts
+++ b/src/cli/resume-session.test.ts
@@ -34,7 +34,7 @@ describe('resume-session', () => {
     expect(resumeConfigFor(target)).toEqual({
       resume: 'sdk-resume',
       sessionId: 'sdk-resume',
-      resumeHistory: [{ user: 'hello', assistant: 'hi' }],
+      resumeHistory: [{ user: 'hello', assistant: 'hi', inputTokens: 0 }],
     });
   });
 

--- a/src/cli/resume-session.ts
+++ b/src/cli/resume-session.ts
@@ -56,10 +56,24 @@ export function resumeConfigFor(target: ResolvedResumeTarget | undefined): Parti
     sessionId: target.resumeId,
     ...(target.stored
       ? {
-          resumeHistory: target.stored.turns.map((turn) => ({
-            user: turn.user,
-            assistant: (turn.assistant ?? '') + summarizeToolEvents(turn.toolEvents),
-          })),
+          resumeHistory: target.stored.turns.map((turn, idx, arr) => {
+            const entry: import('../agent/types.js').ResumeHistoryTurn = {
+              user: turn.user,
+              assistant: (turn.assistant ?? '') + summarizeToolEvents(turn.toolEvents),
+            };
+            // Seed the last turn's token count so the context-overflow guard
+            // (#1294) fires on the first resumed turn instead of being skipped.
+            // Only the last turn's count matters — it is the most recent (and
+            // largest) context footprint the provider will use as a lower bound.
+            // Conservative: prefer inputTokens (raw billed tokens) over
+            // outputTokens because inputTokens already includes the full
+            // conversation history in the prompt. When absent (legacy sidecars),
+            // the field is omitted and the guard falls back to the null path.
+            if (idx === arr.length - 1 && turn.inputTokens !== undefined) {
+              entry.inputTokens = turn.inputTokens;
+            }
+            return entry;
+          }),
         }
       : {}),
   };

--- a/src/telegram/session-manager.test.ts
+++ b/src/telegram/session-manager.test.ts
@@ -889,7 +889,7 @@ describe('SessionManager — session switcher (/sessions, /switch, /new)', () =>
     // (see anthropic-direct/index.ts resumeHistoryToMessages). Guards the bug
     // where the Telegram createSession closure dropped resumeHistory/sessionId.
     expect(lastConfig?.sessionId).toBe('sdk-1');
-    expect(lastConfig?.resumeHistory).toEqual([{ user: 'first convo', assistant: 'a' }]);
+    expect(lastConfig?.resumeHistory).toEqual([{ user: 'first convo', assistant: 'a', inputTokens: 0 }]);
 
     // A subsequent /clear starts fresh — the staged resume is dropped.
     await manager.resetSession(801);


### PR DESCRIPTION
## Summary

Seeds the context-overflow guard with token usage from the restored session so it fires correctly on the first turn after a resume.

### Problem

`lastUsage` starts as `null` in both providers. `guardContextOverflow` skips the check when `knownInputTokens <= 0`, which is exactly what happens when `lastUsage` is null. On a resumed session with a full conversation history, the overflow guard was skipped on the first turn — the request went straight to the provider and could be rejected with HTTP 400 (`Prompt too long`).

Real-world case: a session on a local Qwen model (262K context) was resumed with history already at 571K tokens. The guard was skipped, and the provider returned 400.

### Fix — Option 2 from the issue: seed from session metadata

The session sidecar already records `inputTokens` per turn in `TurnRecord`. The fix threads that value through to seed `lastUsage` on resume:

1. **`ResumeHistoryTurn`** — added optional `inputTokens?: number` (backward-compatible)
2. **`resumeConfigFor`** — copies last stored turn's `inputTokens` onto the last `ResumeHistoryTurn`
3. **Anthropic-direct** — `createSessionState` accepts `initialUsageInputTokens` and synthesizes a minimal `ProviderUsage` stub
4. **OpenAI-compatible** — constructor seeds `this.lastUsage` from resume history

### Invariants

- Zero or absent `inputTokens` → no seeding (legacy sidecars unaffected)
- Guard logic itself unchanged — only initialization differs
- Conservative: over-estimate triggers compaction (recoverable) vs under-estimate letting overflow reach the wire

### Tests — 15 new tests

- `session-state-resume.test.ts` (9): createSessionState seeding, zero/absent handling, overflow guard fires/skips on resume
- `query-resume.test.ts` (6): OpenAI constructor seeding via `getContextUsage()` for all resume/fresh/legacy cases

Closes #1294.
