### PR TITLE
test(telegram): add unit tests for streaming handlers and progress modules

### DIFF
--- a/src/telegram/streaming.handlers.test.ts
+++ b/src/telegram/streaming.handlers.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Tests for the Telegram streaming event handlers.
+ *
+ * Covers:
+ * - handlePaused: countdown interval, autoResume, accountId
+ * - handleResumed: clears interval, resume message
+ * - handleDone: terminal flags, deliverClean vs sendOrEdit, onComplete
+ * - handleError: flags, rethrows
+ * - deliverOverflow: guard, overflow replies, TelegramError handling
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TelegramError } from 'telegraf';
+import type { Context } from 'telegraf';
+import type { Message } from 'telegraf/types';
+import {
+  handlePaused,
+  handleResumed,
+  handleDone,
+  handleError,
+  deliverOverflow,
+  PAUSE_COUNTDOWN_INTERVAL_MS,
+  type StreamState,
+  type HandlerParams,
+} from './streaming.handlers.js';
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('./streaming.sender.js', () => ({
+  sendOrEdit: vi.fn(async () => {}),
+  deliverClean: vi.fn(async () => true),
+  replyWithFloodRetryImpl: vi.fn(async () => {}),
+  splitLongMessage: vi.fn((text: string) => [text]),
+  DELIVERY_TRUNCATED_NOTICE: '⚠️ Message truncated due to rate limit.',
+}));
+vi.mock('./streaming.retry.js', () => ({
+  replyWithFloodRetry: vi.fn(async () => {}),
+}));
+vi.mock('./formatter.js', () => ({
+  splitLongMessage: vi.fn((text: string) => [text]),
+  markdownToTelegramHtml: vi.fn((text: string) => text),
+}));
+
+import { sendOrEdit, deliverClean } from './streaming.sender.js';
+import { replyWithFloodRetry as replyWithFloodRetryImpl } from './streaming.retry.js';
+import { splitLongMessage } from './formatter.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCtx(): Context {
+  return {
+    chat: { id: 42, type: 'private' as const },
+    reply: vi.fn(async () => ({ message_id: 1, text: '', chat: { id: 42 }, date: 0 })),
+    telegram: {
+      editMessageText: vi.fn(async () => true),
+      deleteMessage: vi.fn(async () => true),
+      sendMessage: vi.fn(async () => ({ message_id: 2, text: '', chat: { id: 42 }, date: 0 })),
+    },
+  } as unknown as Context;
+}
+
+function makeState(overrides: Partial<StreamState> = {}): StreamState {
+  return {
+    sentMessage: null, lastEditAt: 0, accumulated: '', answerText: '',
+    pausedUntil: null, countdownInterval: null, editInFlight: false,
+    lastCountdownBucket: -1, sawTerminalEvent: false, progressEntries: [],
+    progressRounds: 0, turnEnded: false, progressTimer: null,
+    turnStartedAt: Date.now(), ...overrides,
+  };
+}
+
+function makeParams(ctx: Context, state: StreamState, overrides: Partial<HandlerParams> = {}): HandlerParams {
+  return {
+    state, ctx, chatId: 42, cleanFinal: false,
+    livePreview: () => state.accumulated,
+    finalBody: () => state.accumulated,
+    clearProgressTimer: vi.fn(),
+    renderActivityReceipt: vi.fn(() => ''),
+    onComplete: undefined, logger: vi.fn(), ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// handlePaused
+// ---------------------------------------------------------------------------
+
+describe('handlePaused', () => {
+  beforeEach(() => { vi.useFakeTimers(); vi.mocked(sendOrEdit).mockResolvedValue(undefined); });
+  afterEach(() => { vi.useRealTimers(); vi.clearAllMocks(); });
+
+  it('sends pause message with reset time when resetsAt provided', async () => {
+    const state = makeState();
+    const resetsAt = new Date(Date.now() + 60 * 60 * 1_000);
+    await handlePaused({ resetsAt, autoResume: true }, makeParams(makeCtx(), state));
+    const msg = vi.mocked(sendOrEdit).mock.calls[0]![3] as string;
+    expect(msg).toContain('Usage paused');
+    expect(msg).toContain('Resets at');
+  });
+
+  it('uses "send again" copy when autoResume=false', async () => {
+    const state = makeState();
+    const resetsAt = new Date(Date.now() + 30 * 60 * 1_000);
+    await handlePaused({ resetsAt, autoResume: false }, makeParams(makeCtx(), state));
+    expect(vi.mocked(sendOrEdit).mock.calls[0]![3]).toContain('send again');
+  });
+
+  it('appends Account line when accountId provided', async () => {
+    const state = makeState();
+    await handlePaused({ accountId: 'alice@example.com', autoResume: true }, makeParams(makeCtx(), state));
+    expect(vi.mocked(sendOrEdit).mock.calls[0]![3]).toContain('Account: alice@example.com');
+  });
+
+  it('arms countdown interval only when pausedUntil !== null and autoResume=true', async () => {
+    const state = makeState();
+    const resetsAt = new Date(Date.now() + 60 * 60 * 1_000);
+    await handlePaused({ resetsAt, autoResume: true }, makeParams(makeCtx(), state));
+    expect(state.countdownInterval).not.toBeNull();
+  });
+
+  it('does NOT arm interval when autoResume=false', async () => {
+    const state = makeState();
+    await handlePaused({ resetsAt: new Date(Date.now() + 3600_000), autoResume: false }, makeParams(makeCtx(), state));
+    expect(state.countdownInterval).toBeNull();
+  });
+
+  it('does NOT arm interval when resetsAt is null', async () => {
+    const state = makeState();
+    await handlePaused({ resetsAt: null, autoResume: true }, makeParams(makeCtx(), state));
+    expect(state.countdownInterval).toBeNull();
+  });
+
+  it('interval skips edit when editInFlight=true', async () => {
+    const state = makeState();
+    await handlePaused({ resetsAt: new Date(Date.now() + 120 * 60_000), autoResume: true }, makeParams(makeCtx(), state));
+    vi.mocked(sendOrEdit).mockClear();
+    state.editInFlight = true;
+    await vi.advanceTimersByTimeAsync(PAUSE_COUNTDOWN_INTERVAL_MS + 1);
+    expect(sendOrEdit).not.toHaveBeenCalled();
+  });
+
+  it('interval skips edit when bucket unchanged', async () => {
+    const state = makeState();
+    await handlePaused({ resetsAt: new Date(Date.now() + 120 * 60_000), autoResume: true }, makeParams(makeCtx(), state));
+    vi.mocked(sendOrEdit).mockClear();
+    // After PAUSE_COUNTDOWN_INTERVAL_MS: 120min - 5min = 115min → bucket = floor(115/5) = 23
+    state.lastCountdownBucket = 23;
+    await vi.advanceTimersByTimeAsync(PAUSE_COUNTDOWN_INTERVAL_MS + 1);
+    expect(sendOrEdit).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleResumed
+// ---------------------------------------------------------------------------
+
+describe('handleResumed', () => {
+  beforeEach(() => { vi.mocked(sendOrEdit).mockResolvedValue(undefined); });
+  afterEach(() => { vi.clearAllMocks(); });
+
+  it('clears and nulls countdownInterval', async () => {
+    const state = makeState({ countdownInterval: setInterval(() => {}, 9999) });
+    await handleResumed({}, makeParams(makeCtx(), state));
+    expect(state.countdownInterval).toBeNull();
+  });
+
+  it('nulls pausedUntil', async () => {
+    const state = makeState({ pausedUntil: new Date() });
+    await handleResumed({}, makeParams(makeCtx(), state));
+    expect(state.pausedUntil).toBeNull();
+  });
+
+  it('sends "Resumed on X" when hotSwapped and accountId provided', async () => {
+    const state = makeState();
+    await handleResumed({ hotSwapped: true, accountId: 'alice@example.com' }, makeParams(makeCtx(), state));
+    expect(vi.mocked(sendOrEdit).mock.calls[0]![3]).toContain('Resumed on alice@example.com');
+  });
+
+  it('sends plain "Resumed" otherwise', async () => {
+    const state = makeState();
+    await handleResumed({ hotSwapped: false }, makeParams(makeCtx(), state));
+    const msg = vi.mocked(sendOrEdit).mock.calls[0]![3] as string;
+    expect(msg).toContain('Resumed');
+    expect(msg).not.toContain('on ');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleDone
+// ---------------------------------------------------------------------------
+
+describe('handleDone', () => {
+  beforeEach(() => {
+    vi.mocked(sendOrEdit).mockResolvedValue(undefined);
+    vi.mocked(deliverClean).mockResolvedValue(true);
+  });
+  afterEach(() => { vi.clearAllMocks(); });
+
+  it('sets sawTerminalEvent=true and turnEnded=true', async () => {
+    const state = makeState();
+    await handleDone(undefined, makeParams(makeCtx(), state));
+    expect(state.sawTerminalEvent).toBe(true);
+    expect(state.turnEnded).toBe(true);
+  });
+
+  it('calls clearProgressTimer and clears countdownInterval', async () => {
+    const state = makeState({ countdownInterval: setInterval(() => {}, 9999) });
+    const clearProgressTimer = vi.fn();
+    await handleDone(undefined, makeParams(makeCtx(), state, { clearProgressTimer }));
+    expect(clearProgressTimer).toHaveBeenCalledOnce();
+    expect(state.countdownInterval).toBeNull();
+  });
+
+  it('cleanFinal + non-empty answerText → calls deliverClean and deletes preview', async () => {
+    const sentMessage = { message_id: 99, text: '', chat: { id: 42 }, date: 0 } as Message.TextMessage;
+    const ctx = makeCtx();
+    const state = makeState({ answerText: 'Final answer', sentMessage });
+    await handleDone(undefined, makeParams(ctx, state, { cleanFinal: true }));
+    expect(deliverClean).toHaveBeenCalledOnce();
+    expect(ctx.telegram.deleteMessage).toHaveBeenCalledWith(42, 99);
+    expect(state.sentMessage).toBeNull();
+  });
+
+  it('cleanFinal + empty answerText → falls to sendOrEdit', async () => {
+    const state = makeState({ answerText: '' });
+    await handleDone(undefined, makeParams(makeCtx(), state, {
+      cleanFinal: true, finalBody: () => 'progress',
+    }));
+    expect(deliverClean).not.toHaveBeenCalled();
+    expect(sendOrEdit).toHaveBeenCalledOnce();
+  });
+
+  it('non-cleanFinal → sendOrEdit with finalBody', async () => {
+    const state = makeState();
+    await handleDone(undefined, makeParams(makeCtx(), state, {
+      cleanFinal: false, finalBody: () => 'answer body',
+    }));
+    expect(sendOrEdit).toHaveBeenCalledOnce();
+    expect(vi.mocked(sendOrEdit).mock.calls[0]![3]).toBe('answer body');
+  });
+
+  it('calls onComplete with answerText and metadata', async () => {
+    const state = makeState({ answerText: 'hello' });
+    const onComplete = vi.fn(async () => {});
+    const metadata = { model: 'test' } as never;
+    await handleDone(metadata, makeParams(makeCtx(), state, { onComplete }));
+    expect(onComplete).toHaveBeenCalledWith('hello', metadata);
+  });
+
+  it('catches onComplete errors, logs, does not rethrow', async () => {
+    const state = makeState();
+    const onComplete = vi.fn(async () => { throw new Error('boom'); });
+    const logger = vi.fn();
+    await expect(handleDone(undefined, makeParams(makeCtx(), state, { onComplete, logger }))).resolves.toBe(true);
+    expect(logger).toHaveBeenCalled();
+  });
+
+  it('returns true', async () => {
+    const result = await handleDone(undefined, makeParams(makeCtx(), makeState()));
+    expect(result).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleError
+// ---------------------------------------------------------------------------
+
+describe('handleError', () => {
+  afterEach(() => { vi.clearAllMocks(); });
+
+  it('sets sawTerminalEvent=true and turnEnded=true', () => {
+    const state = makeState();
+    try { handleError(new Error('test'), makeParams(makeCtx(), state)); } catch {}
+    expect(state.sawTerminalEvent).toBe(true);
+    expect(state.turnEnded).toBe(true);
+  });
+
+  it('clears timers', () => {
+    const state = makeState({ countdownInterval: setInterval(() => {}, 9999) });
+    const clearProgressTimer = vi.fn();
+    try { handleError(new Error('test'), makeParams(makeCtx(), state, { clearProgressTimer })); } catch {}
+    expect(clearProgressTimer).toHaveBeenCalledOnce();
+    expect(state.countdownInterval).toBeNull();
+  });
+
+  it('rethrows the error', () => {
+    const err = new Error('streaming error');
+    expect(() => handleError(err, makeParams(makeCtx(), makeState()))).toThrow(err);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deliverOverflow
+// ---------------------------------------------------------------------------
+
+describe('deliverOverflow', () => {
+  const preview = { message_id: 1, text: '', chat: { id: 42 }, date: 0 } as Message.TextMessage;
+
+  beforeEach(() => {
+    vi.mocked(splitLongMessage).mockImplementation((t: string) => [t]);
+    vi.mocked(replyWithFloodRetryImpl).mockResolvedValue(undefined);
+  });
+  afterEach(() => { vi.clearAllMocks(); });
+
+  it('no-op when cleanFinal=true and answerText non-empty', async () => {
+    const ctx = makeCtx();
+    await deliverOverflow(ctx, true, 'answer', 'finalBody', preview);
+    expect(ctx.reply).not.toHaveBeenCalled();
+  });
+
+  it('no-op when only 1 chunk', async () => {
+    vi.mocked(splitLongMessage).mockReturnValueOnce(['single']);
+    await deliverOverflow(makeCtx(), false, '', 'text', preview);
+    expect(replyWithFloodRetryImpl).not.toHaveBeenCalled();
+  });
+
+  it('sends overflow chunks [1..] as replies', async () => {
+    vi.mocked(splitLongMessage).mockReturnValueOnce(['c0', 'c1', 'c2']);
+    await deliverOverflow(makeCtx(), false, '', 'long text', preview);
+    expect(replyWithFloodRetryImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('no-op when preview is null', async () => {
+    vi.mocked(splitLongMessage).mockReturnValueOnce(['c0', 'c1']);
+    await deliverOverflow(makeCtx(), false, '', 'text', null);
+    expect(replyWithFloodRetryImpl).not.toHaveBeenCalled();
+  });
+
+  it('catches TelegramError → replies DELIVERY_TRUNCATED_NOTICE', async () => {
+    const ctx = makeCtx();
+    vi.mocked(splitLongMessage).mockReturnValueOnce(['c0', 'c1']);
+    vi.mocked(replyWithFloodRetryImpl).mockRejectedValueOnce(
+      new TelegramError({ error_code: 429, description: 'Too Many Requests: retry after 30' }),
+    );
+    await deliverOverflow(ctx, false, '', 'long text', preview);
+    expect(ctx.reply).toHaveBeenCalledWith(expect.stringContaining('truncated'));
+  });
+
+  it('rethrows non-TelegramError', async () => {
+    vi.mocked(splitLongMessage).mockReturnValueOnce(['c0', 'c1']);
+    const netErr = new Error('Network lost');
+    vi.mocked(replyWithFloodRetryImpl).mockRejectedValueOnce(netErr);
+    await expect(deliverOverflow(makeCtx(), false, '', 'long text', preview)).rejects.toBe(netErr);
+  });
+});

--- a/src/telegram/streaming.progress.test.ts
+++ b/src/telegram/streaming.progress.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Tests for the Telegram streaming progress helpers.
+ *
+ * Covers:
+ * - handleProgressEvent: progressRounds, dedup, cap, gate logic, timer arming
+ * - makeSubagentSink: bumpActivity, tool_use_detail, done, other events
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Context } from 'telegraf';
+import {
+  handleProgressEvent,
+  makeSubagentSink,
+  type ProgressState,
+} from './streaming.progress.js';
+import { MAX_PROGRESS_ENTRIES } from './streaming.preview.js';
+import type { OutputEvent, SubagentProgressMeta } from '../agent/types.js';
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('./streaming.sender.js', () => ({
+  sendOrEdit: vi.fn(async () => {}),
+  deliverClean: vi.fn(async () => true),
+  replyWithFloodRetryImpl: vi.fn(async () => {}),
+  splitLongMessage: vi.fn((text: string) => [text]),
+}));
+
+vi.mock('./streaming.watchdog.js', () => ({
+  armProgressGateTimer: vi.fn((delayMs: number, cb: () => void) => setTimeout(cb, delayMs)),
+  PROGRESS_START_DELAY_MS: 5_000,
+}));
+
+vi.mock('./streaming.activity.js', () => ({
+  formatTelegramActivity: vi.fn((_d?: string, _t?: string) => 'Working'),
+  formatTelegramAgentLabel: vi.fn((label: string) => `[${label}]`),
+  humanizeToolActivity: vi.fn((name: string) => name),
+  MAX_SUBAGENT_PREVIEW_LINES: 4,
+}));
+
+import { sendOrEdit } from './streaming.sender.js';
+import { armProgressGateTimer } from './streaming.watchdog.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCtx(): Context {
+  return {
+    chat: { id: 42, type: 'private' as const },
+    reply: vi.fn(async () => ({ message_id: 1, text: '', chat: { id: 42 }, date: 0 })),
+    telegram: {
+      editMessageText: vi.fn(async () => true),
+    },
+  } as unknown as Context;
+}
+
+function makeProgressState(overrides: Partial<ProgressState> = {}): ProgressState {
+  return {
+    sentMessage: null,
+    lastEditAt: 0,
+    accumulated: '',
+    progressEntries: [],
+    progressRounds: 0,
+    progressTimer: null,
+    turnEnded: false,
+    editInFlight: false,
+    turnStartedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function makeProgressEvent(description = 'Searching', lastToolName = 'bash') {
+  return { progress: { description, lastToolName } };
+}
+
+// ---------------------------------------------------------------------------
+// handleProgressEvent
+// ---------------------------------------------------------------------------
+
+describe('handleProgressEvent — progressRounds', () => {
+  afterEach(() => { vi.clearAllMocks(); });
+
+  it('increments progressRounds unconditionally', async () => {
+    const ctx = makeCtx();
+    const state = makeProgressState();
+    await handleProgressEvent(
+      makeProgressEvent(), state, true, 0, ctx, 42,
+      () => '', () => {}, () => {},
+    );
+    expect(state.progressRounds).toBe(1);
+  });
+
+  it('increments progressRounds even when gate is closed', async () => {
+    const ctx = makeCtx();
+    const state = makeProgressState({ progressTimer: setTimeout(() => {}, 9999) });
+    await handleProgressEvent(
+      makeProgressEvent(), state, false, 99999, ctx, 42,
+      () => '', () => {}, () => {},
+    );
+    expect(state.progressRounds).toBe(1);
+  });
+});
+
+describe('handleProgressEvent — deduplication', () => {
+  afterEach(() => { vi.clearAllMocks(); });
+
+  it('deduplicates consecutive same-label entries', async () => {
+    const ctx = makeCtx();
+    const state = makeProgressState();
+    await handleProgressEvent(
+      makeProgressEvent('Searching', 'bash'), state, true, 0, ctx, 42,
+      () => '', () => {}, () => {},
+    );
+    await handleProgressEvent(
+      makeProgressEvent('Searching', 'bash'), state, true, 0, ctx, 42,
+      () => '', () => {}, () => {},
+    );
+    // Only one entry because label is the same
+    expect(state.progressEntries).toHaveLength(1);
+  });
+
+  it('pushes new entry when label differs', async () => {
+    const ctx = makeCtx();
+    const state = makeProgressState();
+    await handleProgressEvent(
+      makeProgressEvent('A', 'bash'), state, true, 0, ctx, 42,
+      () => '', () => {}, () => {},
+    );
+    // Change the formatTelegramActivity mock return for second call
+    const { formatTelegramActivity } = await import('./streaming.activity.js');
+    vi.mocked(formatTelegramActivity).mockReturnValueOnce('DifferentActivity');
+    await handleProgressEvent(
+      makeProgressEvent('B', 'grep'), state, true, 0, ctx, 42,
+      () => '', () => {}, () => {},
+    );
+    expect(state.progressEntries.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('handleProgressEvent — cap', () => {
+  afterEach(() => { vi.clearAllMocks(); });
+
+  it(`caps progressEntries at MAX_PROGRESS_ENTRIES (${MAX_PROGRESS_ENTRIES})`, async () => {
+    const ctx = makeCtx();
+    const state = makeProgressState();
+    const { formatTelegramActivity } = await import('./streaming.activity.js');
+    // Each call produces a unique label so no dedup
+    let counter = 0;
+    vi.mocked(formatTelegramActivity).mockImplementation(() => `Activity-${counter++}`);
+    for (let i = 0; i <= MAX_PROGRESS_ENTRIES + 2; i++) {
+      await handleProgressEvent(
+        makeProgressEvent(`unique-${i}`, `tool-${i}`), state, true, 0, ctx, 42,
+        () => '', () => {}, () => {},
+      );
+    }
+    expect(state.progressEntries.length).toBeLessThanOrEqual(MAX_PROGRESS_ENTRIES);
+  });
+});
+
+describe('handleProgressEvent — gate logic', () => {
+  beforeEach(() => { vi.useFakeTimers(); vi.mocked(sendOrEdit).mockResolvedValue(undefined); });
+  afterEach(() => { vi.useRealTimers(); vi.clearAllMocks(); });
+
+  it('gate-open: calls sendOrEdit and clears timer', async () => {
+    const ctx = makeCtx();
+    const state = makeProgressState();
+    const clearProgressTimer = vi.fn();
+    await handleProgressEvent(
+      makeProgressEvent(), state, true, 0, ctx, 42,
+      () => 'preview', () => {}, clearProgressTimer,
+    );
+    expect(sendOrEdit).toHaveBeenCalledOnce();
+    expect(clearProgressTimer).toHaveBeenCalledOnce();
+  });
+
+  it('gate-closed + elapsed >= delay: opens gate, calls sendOrEdit', async () => {
+    const ctx = makeCtx();
+    const state = makeProgressState({ turnStartedAt: Date.now() - 10_000 });
+    const setProgressGateOpen = vi.fn();
+    await handleProgressEvent(
+      makeProgressEvent(), state, false, 5_000, ctx, 42,
+      () => 'preview', setProgressGateOpen, () => {},
+    );
+    expect(setProgressGateOpen).toHaveBeenCalledWith(true);
+    expect(sendOrEdit).toHaveBeenCalledOnce();
+  });
+
+  it('gate-closed + timer null: arms timer via armProgressGateTimer', async () => {
+    const ctx = makeCtx();
+    const state = makeProgressState({ progressTimer: null });
+    await handleProgressEvent(
+      makeProgressEvent(), state, false, 99999, ctx, 42,
+      () => 'preview', () => {}, () => {},
+    );
+    expect(armProgressGateTimer).toHaveBeenCalledOnce();
+    // Timer should be set on state
+    expect(state.progressTimer).not.toBeNull();
+  });
+
+  it('gate-closed + timer already set: does not arm second timer', async () => {
+    const ctx = makeCtx();
+    const existingTimer = setTimeout(() => {}, 9999);
+    const state = makeProgressState({ progressTimer: existingTimer });
+    await handleProgressEvent(
+      makeProgressEvent(), state, false, 99999, ctx, 42,
+      () => 'preview', () => {}, () => {},
+    );
+    expect(armProgressGateTimer).not.toHaveBeenCalled();
+    clearTimeout(existingTimer);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// makeSubagentSink
+// ---------------------------------------------------------------------------
+
+describe('makeSubagentSink', () => {
+  beforeEach(() => { vi.mocked(sendOrEdit).mockResolvedValue(undefined); });
+  afterEach(() => { vi.clearAllMocks(); });
+
+  function makeSinkArgs() {
+    const ctx = makeCtx();
+    const state = makeProgressState();
+    const bumpActivity = vi.fn();
+    const subagentState = { subagentSteps: 0, recentSubagentSteps: [] as string[] };
+    const sink = makeSubagentSink(state, ctx, 42, () => 'preview', bumpActivity, subagentState);
+    return { ctx, state, bumpActivity, subagentState, sink };
+  }
+
+  const meta: SubagentProgressMeta = { subagentId: 'child-1', agentType: 'research-agent' };
+
+  it('returns a function', () => {
+    const { sink } = makeSinkArgs();
+    expect(typeof sink).toBe('function');
+  });
+
+  it('always calls bumpActivity', () => {
+    const { sink, bumpActivity } = makeSinkArgs();
+    const event: OutputEvent = { type: 'done' };
+    sink(event, meta);
+    expect(bumpActivity).toHaveBeenCalledOnce();
+  });
+
+  it('tool_use_detail: increments subagentSteps', () => {
+    const { sink, subagentState } = makeSinkArgs();
+    const event: OutputEvent = {
+      type: 'chunk',
+      chunk: { type: 'tool_use_detail', toolUseId: 'u1', toolName: 'bash', toolInput: '{}' },
+    };
+    sink(event, meta);
+    expect(subagentState.subagentSteps).toBe(1);
+  });
+
+  it('tool_use_detail: pushes a label to recentSubagentSteps', () => {
+    const { sink, subagentState } = makeSinkArgs();
+    const event: OutputEvent = {
+      type: 'chunk',
+      chunk: { type: 'tool_use_detail', toolUseId: 'u1', toolName: 'bash', toolInput: '{}' },
+    };
+    sink(event, meta);
+    expect(subagentState.recentSubagentSteps).toHaveLength(1);
+  });
+
+  it('tool_use_detail: caps recentSubagentSteps at MAX_SUBAGENT_PREVIEW_LINES', () => {
+    const { sink, subagentState } = makeSinkArgs();
+    const event: OutputEvent = {
+      type: 'chunk',
+      chunk: { type: 'tool_use_detail', toolUseId: 'u1', toolName: 'bash', toolInput: '{}' },
+    };
+    for (let i = 0; i < 10; i++) sink(event, meta);
+    // MAX_SUBAGENT_PREVIEW_LINES = 4 per mock
+    expect(subagentState.recentSubagentSteps.length).toBeLessThanOrEqual(4);
+  });
+
+  it('tool_use_detail: calls sendOrEdit', () => {
+    const { sink } = makeSinkArgs();
+    const event: OutputEvent = {
+      type: 'chunk',
+      chunk: { type: 'tool_use_detail', toolUseId: 'u1', toolName: 'bash', toolInput: '{}' },
+    };
+    sink(event, meta);
+    // sendOrEdit is called async via void — flush microtasks
+    return Promise.resolve().then(() => {
+      expect(sendOrEdit).toHaveBeenCalled();
+    });
+  });
+
+  it('done: calls sendOrEdit without incrementing steps', () => {
+    const { sink, subagentState } = makeSinkArgs();
+    const event: OutputEvent = { type: 'done' };
+    sink(event, meta);
+    expect(subagentState.subagentSteps).toBe(0);
+    return Promise.resolve().then(() => {
+      expect(sendOrEdit).toHaveBeenCalled();
+    });
+  });
+
+  it('other event types: only calls bumpActivity, no send', async () => {
+    const { sink, bumpActivity, subagentState } = makeSinkArgs();
+    const event: OutputEvent = { type: 'stream_retry' };
+    sink(event, meta);
+    await Promise.resolve();
+    expect(bumpActivity).toHaveBeenCalledOnce();
+    expect(subagentState.subagentSteps).toBe(0);
+    expect(sendOrEdit).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
🤖 Automated fix (hourly issue sweep)

Closes #1123

## What changed

Added unit tests for the two remaining untested Telegram streaming sibling modules extracted in PR #1110:

- **`streaming.handlers.test.ts`** (348 lines, 29 tests) — covers `handlePaused`, `handleResumed`, `handleDone`, `handleError`, and `deliverOverflow` including timer arming, countdown intervals, cleanFinal vs non-cleanFinal paths, onComplete callbacks, and overflow chunk delivery.

- **`streaming.progress.test.ts`** (309 lines, 17 tests) — covers `handleProgressEvent` (rounds increment, dedup, cap, gate-open/closed paths, timer arming) and `makeSubagentSink` (bumpActivity, tool_use_detail step tracking, preview cap, done events).

This completes the test coverage gap for all four streaming sibling modules (`watchdog` and `sender` tests already existed).

## Test verification
- `pnpm lint` ✅
- `pnpm test` ✅ (923 files, 17749 passed, 0 failed)

---
*Generated by the hourly issue-tackle automation — a maintainer will review before merge.*
