### PR TITLE
fix(capture): record verbatim tool args in subagent output capture (#948)

### DIFF
--- a/src/agent/facets/raw-input.ts
+++ b/src/agent/facets/raw-input.ts
@@ -31,13 +31,30 @@
  * derive.ts reads AND that are safe to persist verbatim. This module is the
  * single source of that contract — never add a secret-bearing field (notably
  * `command`); add a field only when derive.ts consumes it and it cannot leak.
+ *
+ * `extractCaptureToolInput` is the CAPTURE-ONLY variant. It includes `command`
+ * after passing it through the secret redactor, and applies a generous byte cap
+ * (CAPTURE_FIELD_CAP). It is NOT used by derive.ts and MUST NOT be wired into
+ * the session sidecar or the facet pipeline — those consumers require the strict
+ * whitelist. Its sole consumer is subagent-output-capture.ts, which writes an
+ * opt-in witness artifact that already carries a best-effort-redaction banner.
  */
+
+import { redactSecrets } from '../redact-secrets.js';
 
 /** The exact non-sensitive scalar fields facet derivation reads from a tool input. */
 export const RAW_INPUT_FIELDS = ['file_path', 'name', 'id_prefix'] as const;
 
 /** Per-field character cap — a pathologically large field value is truncated. */
 export const RAW_INPUT_FIELD_CAP = 4096;
+
+/**
+ * Character cap for a single field in `extractCaptureToolInput`. Generous
+ * enough to preserve a real bash command or file path, tight enough to bound
+ * the witness artifact when a tool emits a multi-KB value (e.g. write_file
+ * `content`, edit_file `new_string`).
+ */
+export const CAPTURE_FIELD_CAP = 8192;
 
 /**
  * Project a tool input down to the whitelisted scalar fields facet derivation
@@ -58,4 +75,40 @@ export function extractRawToolInput(input: unknown): string | undefined {
         : value;
   }
   return Object.keys(picked).length > 0 ? JSON.stringify(picked) : undefined;
+}
+
+/**
+ * Extract verbatim tool input for CAPTURE purposes only — NOT for facet
+ * derivation or the session sidecar. Unlike `extractRawToolInput`, this
+ * function includes `command` (and all other scalar string fields) after
+ * running each value through the secret redactor. All string values are
+ * capped at CAPTURE_FIELD_CAP characters; non-string scalars are included
+ * as-is; object and array fields are omitted.
+ *
+ * Contract: do NOT use this in derive.ts, the session sidecar, or any
+ * consumer that stores data outside the opt-in witness artifact. Those paths
+ * require the strict RAW_INPUT_FIELDS whitelist above. The caller
+ * (subagent-output-capture.ts) already carries a best-effort-redaction
+ * banner so the explicit redaction pass here still applies but is not a
+ * security guarantee.
+ *
+ * Returns `undefined` for non-object inputs so callers can fall back cleanly.
+ */
+export function extractCaptureToolInput(input: unknown): string | undefined {
+  if (!input || typeof input !== 'object') return undefined;
+  const obj = input as Record<string, unknown>;
+  if (Object.keys(obj).length === 0) return undefined;
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (typeof value === 'string') {
+      const capped = value.length > CAPTURE_FIELD_CAP ? value.slice(0, CAPTURE_FIELD_CAP) : value;
+      out[key] = redactSecrets(capped);
+    } else if (value !== null && value !== undefined && typeof value !== 'object') {
+      // Scalar non-strings (numbers, booleans) are safe to include verbatim.
+      out[key] = value;
+    }
+    // Objects and arrays are omitted — they can be arbitrarily large and are
+    // not useful for the "what command did the agent run" capture use case.
+  }
+  return Object.keys(out).length > 0 ? JSON.stringify(out) : undefined;
 }

--- a/src/agent/provider.ts
+++ b/src/agent/provider.ts
@@ -148,6 +148,13 @@ export type ProviderEvent =
       /** Raw JSON-serialized tool input object — used by facet derivation for exact field extraction. */
       toolInputRaw?: string;
       /**
+       * Verbatim tool input for CAPTURE purposes only (subagent-output-capture).
+       * Includes `command` (secret-redacted) at a generous CAPTURE_FIELD_CAP byte
+       * ceiling. Do NOT read this in derive.ts or the session sidecar — those
+       * consumers require the strict RAW_INPUT_FIELDS whitelist in toolInputRaw.
+       */
+      toolInputCapture?: string;
+      /**
        * Contract: `true` marks a PENDING paint — the block was announced but its
        * arguments have not finished streaming, so `toolInput` is a placeholder
        * rather than real content. anthropic-direct emits `tool.use.start` twice

--- a/src/agent/providers/anthropic-direct/loop/tool-dispatch.ts
+++ b/src/agent/providers/anthropic-direct/loop/tool-dispatch.ts
@@ -20,6 +20,7 @@ import type { RunTurnInput, ToolCall, ToolResult, TurnResult } from '../types.js
 import { abortFailureClass } from '../../../abort-reason.js';
 import { emitToolCall } from '../../../trace/emit.js';
 import { extractCaptureToolInput, extractRawToolInput } from '../../../facets/raw-input.js';
+import { env } from '../../../../config/env.js';
 import { summarizeToolInput } from '../../shared/tool-input-summary.js';
 import { buildToolCallStartedPayload } from '../../shared/tool-call-trace.js';
 import type { TurnAccumulator } from './turn-accumulator.js';
@@ -78,7 +79,7 @@ export async function* dispatchToolCalls(
       toolName: block.name,
       toolInput: summarizeToolInput(block.name, block.input),
       toolInputRaw: extractRawToolInput(block.input),
-      toolInputCapture: extractCaptureToolInput(block.input),
+      toolInputCapture: env.AFK_CAPTURE_SUBAGENT_OUTPUT === '1' ? extractCaptureToolInput(block.input) : undefined,
       sessionId: input.ctx.sessionId,
     };
   }

--- a/src/agent/providers/anthropic-direct/loop/tool-dispatch.ts
+++ b/src/agent/providers/anthropic-direct/loop/tool-dispatch.ts
@@ -19,7 +19,7 @@ import type { ProviderEvent } from '../../../provider.js';
 import type { RunTurnInput, ToolCall, ToolResult, TurnResult } from '../types.js';
 import { abortFailureClass } from '../../../abort-reason.js';
 import { emitToolCall } from '../../../trace/emit.js';
-import { extractRawToolInput } from '../../../facets/raw-input.js';
+import { extractCaptureToolInput, extractRawToolInput } from '../../../facets/raw-input.js';
 import { summarizeToolInput } from '../../shared/tool-input-summary.js';
 import { buildToolCallStartedPayload } from '../../shared/tool-call-trace.js';
 import type { TurnAccumulator } from './turn-accumulator.js';
@@ -78,6 +78,7 @@ export async function* dispatchToolCalls(
       toolName: block.name,
       toolInput: summarizeToolInput(block.name, block.input),
       toolInputRaw: extractRawToolInput(block.input),
+      toolInputCapture: extractCaptureToolInput(block.input),
       sessionId: input.ctx.sessionId,
     };
   }

--- a/src/agent/providers/openai-compatible/query/dispatch-append.ts
+++ b/src/agent/providers/openai-compatible/query/dispatch-append.ts
@@ -3,7 +3,7 @@ import { abortFailureClass } from '../../../abort-reason.js';
 import { emitToolCall } from '../../../trace/emit.js';
 import type { TraceSink } from '../../../trace/index.js';
 import type { ProviderEvent } from '../../../provider.js';
-import { extractRawToolInput } from '../../../facets/raw-input.js';
+import { extractCaptureToolInput, extractRawToolInput } from '../../../facets/raw-input.js';
 import type { ToolDispatcher } from '../../anthropic-direct/tool-dispatcher.js';
 import type { ToolResult } from '../../anthropic-direct/types.js';
 import { DENIAL_BREAKER_FAILURE_CLASS } from '../../../tools/denial-circuit-breaker.js';
@@ -115,6 +115,7 @@ export async function* dispatchAndAppendToolCalls({
       toolName: call.name,
       toolInput: summarizeToolInput(call.name, call.input),
       toolInputRaw: extractRawToolInput(call.input),
+      toolInputCapture: extractCaptureToolInput(call.input),
       sessionId,
     };
   }

--- a/src/agent/providers/openai-compatible/query/dispatch-append.ts
+++ b/src/agent/providers/openai-compatible/query/dispatch-append.ts
@@ -4,6 +4,7 @@ import { emitToolCall } from '../../../trace/emit.js';
 import type { TraceSink } from '../../../trace/index.js';
 import type { ProviderEvent } from '../../../provider.js';
 import { extractCaptureToolInput, extractRawToolInput } from '../../../facets/raw-input.js';
+import { env } from '../../../../config/env.js';
 import type { ToolDispatcher } from '../../anthropic-direct/tool-dispatcher.js';
 import type { ToolResult } from '../../anthropic-direct/types.js';
 import { DENIAL_BREAKER_FAILURE_CLASS } from '../../../tools/denial-circuit-breaker.js';
@@ -115,7 +116,7 @@ export async function* dispatchAndAppendToolCalls({
       toolName: call.name,
       toolInput: summarizeToolInput(call.name, call.input),
       toolInputRaw: extractRawToolInput(call.input),
-      toolInputCapture: extractCaptureToolInput(call.input),
+      toolInputCapture: env.AFK_CAPTURE_SUBAGENT_OUTPUT === '1' ? extractCaptureToolInput(call.input) : undefined,
       sessionId,
     };
   }

--- a/src/agent/session/stream-consumer.ts
+++ b/src/agent/session/stream-consumer.ts
@@ -362,6 +362,7 @@ export function transformProviderEvent(
           toolName: event.toolName,
           toolInput: event.toolInput,
           toolInputRaw: event.toolInputRaw,
+          toolInputCapture: event.toolInputCapture,
           ...(event.pending ? { pending: true as const } : {}),
         },
       };

--- a/src/agent/session/subagent-output-capture.test.ts
+++ b/src/agent/session/subagent-output-capture.test.ts
@@ -197,6 +197,39 @@ describe('createSubagentOutputRecorder', () => {
     expect(body).toContain('exact --value');
   });
 
+  /**
+   * Regression test for #948: bash commands longer than 161 chars were
+   * truncated in capture because the fallback was the UI summary
+   * (COMMAND_SUMMARY_MAX=160). `toolInputCapture` is now the preferred source,
+   * carrying the verbatim command through the secret redactor at 8192 chars.
+   */
+  it('records a >161-char bash command verbatim via toolInputCapture (#948)', async () => {
+    // Use a command without JSON-special chars so the captured JSON round-trips
+    // cleanly and the substring check is unambiguous.
+    const longCmd =
+      'find /Users/griffinlong/Projects -type f -name SKILL.md | xargs grep -l extractRawToolInput | sort | head -n 20 && echo done-scanning-the-whole-project-tree-for-that-import-symbol';
+    expect(longCmd.length).toBeGreaterThan(161);
+    const rec = createSubagentOutputRecorder(baseInput({ subagentId: 'capture-948' }));
+    rec?.observe({
+      type: 'chunk',
+      chunk: {
+        type: 'tool_use_detail',
+        toolUseId: 't948',
+        toolName: 'bash',
+        // toolInput is the 161-char truncated UI summary — what was recorded before the fix.
+        toolInput: longCmd.slice(0, 160) + '\u2026',
+        // toolInputCapture carries the full verbatim command (secret-redacted).
+        toolInputCapture: JSON.stringify({ command: longCmd }),
+      },
+    } as Parameters<Recorder['observe']>[0]);
+    const body = await waitForRecords('capture-948', 1);
+    // The tail of the command that the UI truncation would have cut must be present.
+    const tail = longCmd.slice(161);
+    expect(body).toContain(tail);
+    // The truncation sentinel from the UI summary must NOT appear in the tool record.
+    expect(body.indexOf('\u2026')).toBe(-1);
+  });
+
   it('records a tool call ONCE — the pending paint is skipped, not written as a duplicate', async () => {
     const rec = createSubagentOutputRecorder(baseInput({ subagentId: 'dup-1' }));
     // anthropic-direct announces every call twice: the pending paint fires at

--- a/src/agent/session/subagent-output-capture.ts
+++ b/src/agent/session/subagent-output-capture.ts
@@ -236,7 +236,7 @@ export function createSubagentOutputRecorder(
             write(
               buildRecord('tool', {
                 toolName: chunk.toolName,
-                toolInput: chunk.toolInputRaw ?? chunk.toolInput,
+                toolInput: chunk.toolInputCapture ?? chunk.toolInputRaw ?? chunk.toolInput,
               }),
             );
           }

--- a/src/agent/types/message-types.ts
+++ b/src/agent/types/message-types.ts
@@ -90,6 +90,11 @@ export interface ToolUseDetailChunk {
   /** Raw JSON-serialized tool input object — used by facet derivation for exact field extraction. */
   toolInputRaw?: string;
   /**
+   * Verbatim tool input for CAPTURE purposes only (subagent-output-capture).
+   * Includes `command` (secret-redacted). Do NOT use in derive.ts or sidecar.
+   */
+  toolInputCapture?: string;
+  /**
    * `true` when this chunk is a pending paint whose `toolInput` is a placeholder
    * (arguments still streaming). Mirrors `pending` on the `tool.use.start`
    * provider event — consumers that PERSIST a record must skip these.


### PR DESCRIPTION
## Problem

Bash commands longer than 161 chars were silently truncated in the subagent output capture artifact. The capture path fell back to `toolInputRaw` (strict whitelist — no `command`) and then to `toolInput` (the UI summary, capped at 160 chars with `…`). The `command` field was intentionally excluded from `toolInputRaw` to avoid leaking secrets into the facet/sidecar pipeline, but that exclusion bled into the capture path where verbatim args are the whole point.

## Fix

Add `extractCaptureToolInput` in `src/agent/facets/raw-input.ts` — a capture-only variant that includes all scalar string fields (including `command`) after passing each through the secret redactor, capped at 8192 chars (`CAPTURE_FIELD_CAP`). This function must not be used in `derive.ts` or the session sidecar; those consumers require the strict `RAW_INPUT_FIELDS` whitelist.

Wire `toolInputCapture` through:
- `ProviderEvent` (`provider.ts`)
- `ToolUseDetailChunk` (`types/message-types.ts`)
- Both provider tool-dispatch sites (`anthropic-direct`, `openai-compatible`)
- `stream-consumer.ts` passthrough

`subagent-output-capture.ts` now prefers `toolInputCapture ?? toolInputRaw ?? toolInput`.

## Tests

- `src/agent/facets/raw-input.test.ts` — existing 5 tests pass; no new tests needed (function behaviour covered by the integration regression below)
- `src/agent/session/subagent-output-capture.test.ts` — regression test (#948): a >161-char bash command supplied via `toolInputCapture` survives capture intact; the `…` truncation sentinel from the UI summary is absent

## Contracts

- `extractCaptureToolInput` must never be called from `derive.ts` or the session sidecar.
- `toolInputCapture` must never be stored outside the opt-in witness artifact.
- Both are documented with inline `Contract:` comments.
