### PR TITLE
feat(cli): add /copy plain mode for Slack/email-friendly output (#1286)

### DIFF
--- a/src/cli/slash/commands/copy.strip-markdown.ts
+++ b/src/cli/slash/commands/copy.strip-markdown.ts
@@ -115,8 +115,12 @@ export function stripMarkdown(input: string): string {
     // --- Unordered list items: - / * / + at start of line ---
     line = line.replace(/^(\s*)[-*+]\s+/, (_m, indent: string) => `${indent}• `);
 
-    // --- Inline code: `…` → content ---
-    line = line.replace(/`([^`]+)`/g, '$1');
+    // --- Inline code: `…` → placeholder (protect content from emphasis transforms) ---
+    const codeSpans: string[] = [];
+    line = line.replace(/`([^`]+)`/g, (_m, content: string) => {
+      codeSpans.push(content);
+      return `\x00CS${codeSpans.length - 1}\x00`;
+    });
 
     // --- Bold: **…** or __…__ ---
     line = line.replace(/\*\*(.+?)\*\*/g, '$1');
@@ -125,6 +129,10 @@ export function stripMarkdown(input: string): string {
     // --- Italic: *…* or _…_ (must not be __ or **) ---
     line = line.replace(/\*([^*]+)\*/g, '$1');
     line = line.replace(/_([^_]+)_/g, '$1');
+
+    // --- Restore inline code placeholders ---
+    // eslint-disable-next-line no-control-regex
+    line = line.replace(/\x00CS(\d+)\x00/g, (_m, idx: string) => codeSpans[Number(idx)] ?? '');
 
     // Trim trailing whitespace.
     out.push(line.trimEnd());

--- a/src/cli/slash/commands/copy.strip-markdown.ts
+++ b/src/cli/slash/commands/copy.strip-markdown.ts
@@ -1,0 +1,147 @@
+/**
+ * Strips markdown syntax from a string so the result is suitable for
+ * plain-text contexts (Slack, email, SMS).
+ *
+ * Rules (applied in order):
+ *   - ANSI escape sequences → removed
+ *   - Fenced code blocks (``` … ```) → content indented 2 spaces; fence lines dropped
+ *   - H1 headings (# …)  → UPPERCASE text, blank line below
+ *   - H2 headings (## …) → UPPERCASE text, blank line below
+ *   - H3–H6 headings     → text only (no case transform)
+ *   - Horizontal rules (---, ***) → blank line
+ *   - Bold (**text** or __text__) → text
+ *   - Italic (*text* or _text_)   → text
+ *   - Inline code (`text`)        → text
+ *   - Unordered list items (- / * / +) → • item
+ *   - Ordered list items (1. …)  → kept as-is (number preserved)
+ *   - Blockquote markers (> )    → stripped
+ *   - Trailing whitespace per line → trimmed
+ *   - Runs of 3+ blank lines → collapsed to 2
+ *
+ * Does NOT parse links or images (angle-bracket, reference, or
+ * [label](url) forms) — those are left as-is; the plain-text consumer
+ * can see the label and URL without extra work.
+ */
+
+// Contract: input is arbitrary assistant text (may contain ANSI from stream
+// renderer fragments that escaped stripping). Output is pure UTF-8 plaintext
+// with no ANSI codes and no markdown syntax characters for the transforms above.
+
+// eslint-disable-next-line no-control-regex
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
+
+/** Strip all ANSI SGR escape sequences. */
+function stripAnsi(s: string): string {
+  return s.replace(ANSI_RE, '');
+}
+
+/** Convert a heading line's text to uppercase (H1/H2 only). */
+function headingToUppercase(text: string): string {
+  return text.toUpperCase();
+}
+
+/**
+ * Strip markdown from `input` and return plain text.
+ * The function is pure — no module state, no side effects.
+ */
+export function stripMarkdown(input: string): string {
+  // 1. Remove ANSI codes.
+  const clean = stripAnsi(input);
+
+  const lines = clean.split('\n');
+  const out: string[] = [];
+
+  let inFence = false;
+  let fenceLang = '';
+
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i] ?? '';
+
+    // --- Fenced code block handling ---
+    const fenceMatch = /^(`{3,}|~{3,})(\w*)/.exec(raw);
+    if (fenceMatch && !inFence) {
+      inFence = true;
+      fenceLang = fenceMatch[2] ?? '';
+      // Emit a label line instead of the fence marker.
+      if (fenceLang) {
+        out.push(`[${fenceLang}]`);
+      }
+      continue;
+    }
+    if (inFence) {
+      if (fenceMatch) {
+        // Closing fence — exit block mode.
+        inFence = false;
+        fenceLang = '';
+      } else {
+        // Inside a fence — indent 2 spaces, no further transforms.
+        out.push(`  ${raw}`);
+      }
+      continue;
+    }
+
+    let line = raw;
+
+    // --- Horizontal rule (---, ***, ___) → blank ---
+    if (/^(\s*[-*_]){3,}\s*$/.test(line)) {
+      out.push('');
+      continue;
+    }
+
+    // --- ATX headings ---
+    const h1 = /^#{1}\s+(.+)/.exec(line);
+    const h2 = /^#{2}\s+(.+)/.exec(line);
+    const hN = /^#{3,6}\s+(.+)/.exec(line);
+    if (h1 && !h2) {
+      const text = headingToUppercase((h1[1] ?? '').trim());
+      out.push(text);
+      out.push('');
+      continue;
+    }
+    if (h2) {
+      const text = headingToUppercase((h2[1] ?? '').trim());
+      out.push(text);
+      out.push('');
+      continue;
+    }
+    if (hN) {
+      out.push((hN[1] ?? '').trim());
+      continue;
+    }
+
+    // --- Blockquote marker ---
+    line = line.replace(/^>\s?/, '');
+
+    // --- Unordered list items: - / * / + at start of line ---
+    line = line.replace(/^(\s*)[-*+]\s+/, (_m, indent: string) => `${indent}• `);
+
+    // --- Inline code: `…` → content ---
+    line = line.replace(/`([^`]+)`/g, '$1');
+
+    // --- Bold: **…** or __…__ ---
+    line = line.replace(/\*\*(.+?)\*\*/g, '$1');
+    line = line.replace(/__(.+?)__/g, '$1');
+
+    // --- Italic: *…* or _…_ (must not be __ or **) ---
+    line = line.replace(/\*([^*]+)\*/g, '$1');
+    line = line.replace(/_([^_]+)_/g, '$1');
+
+    // Trim trailing whitespace.
+    out.push(line.trimEnd());
+  }
+
+  // Collapse runs of 3+ blank lines to 2.
+  const collapsed: string[] = [];
+  let blanks = 0;
+  for (const l of out) {
+    if (l.trim() === '') {
+      blanks++;
+      if (blanks <= 2) collapsed.push(l);
+    } else {
+      blanks = 0;
+      collapsed.push(l);
+    }
+  }
+
+  return collapsed.join('\n').trimEnd();
+}

--- a/src/cli/slash/commands/copy.test.ts
+++ b/src/cli/slash/commands/copy.test.ts
@@ -12,6 +12,7 @@ vi.mock('../../code-block-register.js', () => ({
 import { copyCmd } from './copy.js';
 import { copyToClipboard } from '../../clipboard.js';
 import { getCodeBlock, getCodeBlocks } from '../../code-block-register.js';
+import { stripMarkdown } from './copy.strip-markdown.js';
 import type { SlashContext, SessionStats } from '../types.js';
 
 const mockedCopy = vi.mocked(copyToClipboard);
@@ -118,7 +119,7 @@ describe('/copy slash command', () => {
   });
 
   it('copies a specific code block by index', async () => {
-    mockedGetBlock.mockReturnValue({ index: 2, lang: 'python', text: 'print("hello")' });
+    mockedGetBlock.mockReturnValue({ index: 2, type: 'code_block', lang: 'python', text: 'print("hello")' });
     mockedCopy.mockReturnValue(true);
     const { ctx, lines } = makeCtx({ assistant: 'Here is code:\n```python\nprint("hello")\n```' });
     const result = await copyCmd.handler(ctx, '2');
@@ -131,7 +132,7 @@ describe('/copy slash command', () => {
   it('warns when block index is out of range', async () => {
     mockedGetBlock.mockReturnValue(undefined);
     mockedGetBlocks.mockReturnValue([
-      { index: 1, lang: 'bash', text: 'echo hi' },
+      { index: 1, type: 'code_block', lang: 'bash', text: 'echo hi' },
     ]);
     const { ctx, lines } = makeCtx({ assistant: 'some response' });
     const result = await copyCmd.handler(ctx, '5');
@@ -153,5 +154,101 @@ describe('/copy slash command', () => {
     const result = await copyCmd.handler(ctx, 'banana');
     expect(result).toBe('continue');
     expect(lines.some((l) => l.includes('Unknown argument'))).toBe(true);
+  });
+
+  it('/copy plain strips markdown before copying', async () => {
+    const text = '# Hello\n\n**bold** and _italic_\n\n```js\nconsole.log("hi");\n```';
+    mockedCopy.mockReturnValue(true);
+    const { ctx, lines } = makeCtx({ assistant: text });
+    const result = await copyCmd.handler(ctx, 'plain');
+    expect(result).toBe('continue');
+    // Should NOT be called with the raw markdown — must be the stripped version.
+    const calledWith = mockedCopy.mock.calls[0]?.[0] ?? '';
+    expect(calledWith).not.toContain('**');
+    expect(calledWith).not.toContain('# Hello');
+    expect(calledWith).toContain('HELLO');
+    expect(lines.some((l) => l.startsWith('SUCCESS:') && l.includes('plain'))).toBe(true);
+  });
+
+  it('/copy plain shows clipboard failure message', async () => {
+    mockedCopy.mockReturnValue(false);
+    const { ctx, lines } = makeCtx({ assistant: '**bold**' });
+    const result = await copyCmd.handler(ctx, 'plain');
+    expect(result).toBe('continue');
+    expect(lines.some((l) => l.includes('Clipboard write failed'))).toBe(true);
+  });
+});
+
+describe('stripMarkdown', () => {
+  it('converts H1 to uppercase', () => {
+    const result = stripMarkdown('# My Title\n\nSome text.');
+    expect(result).toContain('MY TITLE');
+    expect(result).not.toContain('# My Title');
+    expect(result).toContain('Some text.');
+  });
+
+  it('converts H2 to uppercase', () => {
+    const result = stripMarkdown('## Section Header\n\nParagraph.');
+    expect(result).toContain('SECTION HEADER');
+    expect(result).not.toContain('## Section Header');
+    expect(result).toContain('Paragraph.');
+  });
+
+  it('strips bold (**text**) markers', () => {
+    const result = stripMarkdown('This is **important** text.');
+    expect(result).toBe('This is important text.');
+  });
+
+  it('strips italic (*text*) markers', () => {
+    const result = stripMarkdown('This is *emphasized* text.');
+    expect(result).toBe('This is emphasized text.');
+  });
+
+  it('converts fenced code block to indented block with language label', () => {
+    const input = '```python\nprint("hello")\n```';
+    const result = stripMarkdown(input);
+    expect(result).toContain('[python]');
+    expect(result).toContain('  print("hello")');
+    expect(result).not.toContain('```');
+  });
+
+  it('converts fenced code block without language to indented block', () => {
+    const input = '```\nsome code\n```';
+    const result = stripMarkdown(input);
+    expect(result).toContain('  some code');
+    expect(result).not.toContain('```');
+  });
+
+  it('converts unordered list items to bullet •', () => {
+    const result = stripMarkdown('- apple\n- banana\n- cherry');
+    expect(result).toBe('• apple\n• banana\n• cherry');
+  });
+
+  it('strips inline code backticks', () => {
+    const result = stripMarkdown('Run `npm install` first.');
+    expect(result).toBe('Run npm install first.');
+  });
+
+  it('replaces horizontal rules with blank lines', () => {
+    const result = stripMarkdown('Above\n\n---\n\nBelow');
+    expect(result).not.toContain('---');
+  });
+
+  it('collapses 3+ consecutive blank lines to 2', () => {
+    const result = stripMarkdown('A\n\n\n\n\nB');
+    // At most 2 consecutive blank lines between A and B
+    expect(result).not.toMatch(/A\n\n\n\n/);
+    expect(result).toContain('A');
+    expect(result).toContain('B');
+  });
+
+  it('strips ANSI escape sequences', () => {
+    const result = stripMarkdown('\x1b[32mGreen text\x1b[0m');
+    expect(result).toBe('Green text');
+  });
+
+  it('strips blockquote markers', () => {
+    const result = stripMarkdown('> This is a quote.\n> And another line.');
+    expect(result).toBe('This is a quote.\nAnd another line.');
   });
 });

--- a/src/cli/slash/commands/copy.test.ts
+++ b/src/cli/slash/commands/copy.test.ts
@@ -251,4 +251,19 @@ describe('stripMarkdown', () => {
     const result = stripMarkdown('> This is a quote.\n> And another line.');
     expect(result).toBe('This is a quote.\nAnd another line.');
   });
+
+  it('preserves underscores inside inline code spans', () => {
+    const result = stripMarkdown('Use `__init__.py` in Python');
+    expect(result).toContain('__init__.py');
+  });
+
+  it('preserves snake_case identifiers inside inline code spans', () => {
+    const result = stripMarkdown('The `snake_case_value` variable');
+    expect(result).toContain('snake_case_value');
+  });
+
+  it('preserves markdown-like content inside inline code spans', () => {
+    const result = stripMarkdown('Run `**bold_cmd**` now');
+    expect(result).toContain('**bold_cmd**');
+  });
 });

--- a/src/cli/slash/commands/copy.ts
+++ b/src/cli/slash/commands/copy.ts
@@ -1,13 +1,15 @@
 /**
  * /copy (alias /cp) — copy agent output to the system clipboard.
  *
- * Two modes:
- *   - `/copy`     — copies the last assistant turn's raw markdown (the whole
- *                   response, clean of ANSI and tool-lane chrome).
- *   - `/copy N`   — copies the Nth code block from the last turn, using the
- *                   render-time register populated by `renderCodeBlock()`. The
- *                   index matches the dim `/cp N` hint shown on each code block
- *                   header, so users never have to count.
+ * Three modes:
+ *   - `/copy`       — copies the last assistant turn's raw markdown (the whole
+ *                     response, clean of ANSI and tool-lane chrome).
+ *   - `/copy N`     — copies the Nth code block from the last turn, using the
+ *                     render-time register populated by `renderCodeBlock()`. The
+ *                     index matches the dim `/cp N` hint shown on each code block
+ *                     header, so users never have to count.
+ *   - `/copy plain` — strips markdown syntax first; suitable for Slack, email,
+ *                     and other plain-text contexts.
  *
  * Gated on interactive REPL + TTY (same guard as /fork) so Telegram/daemon
  * callers never fire OSC 52 escape bytes at the wrong terminal.
@@ -16,14 +18,15 @@
 import { palette } from '../../palette.js';
 import { copyToClipboard } from '../../clipboard.js';
 import { getCodeBlock, getCodeBlocks } from '../../code-block-register.js';
+import { stripMarkdown } from './copy.strip-markdown.js';
 import type { SlashCommand } from '../types.js';
 
 export const copyCmd: SlashCommand = {
   name: '/copy',
   aliases: ['/cp'],
   summary: 'Copy last response or a code block to clipboard',
-  usage: '/copy [N]',
-  hint: 'When you need to paste agent output into another terminal or editor. Use /cp N to grab a specific code block — the index is shown on each block header.',
+  usage: '/copy [N|plain]',
+  hint: 'When you need to paste agent output into another terminal or editor. Use /cp N to grab a specific code block — the index is shown on each block header. Use /copy plain for Slack/email-friendly output.',
   async handler(ctx, args) {
     const { stats, out } = ctx;
 
@@ -85,9 +88,27 @@ export const copyCmd: SlashCommand = {
       return 'continue';
     }
 
+    // `/copy plain` — strip markdown, then copy.
+    if (trimmed === 'plain') {
+      const plain = stripMarkdown(assistantText);
+      const copied = copyToClipboard(plain);
+      if (copied) {
+        const chars = plain.length;
+        const lines = plain.split('\n').length;
+        out.success(
+          `Copied last response (plain) ` +
+          palette.dim(`(${chars} chars, ${lines} line${lines === 1 ? '' : 's'})`) +
+          palette.dim(' to clipboard'),
+        );
+      } else {
+        out.warn('Clipboard write failed — the full response is in /transcript.');
+      }
+      return 'continue';
+    }
+
     // Unrecognized non-empty arg — help the user.
     if (trimmed) {
-      out.warn(`Unknown argument "${trimmed}". Usage: /copy (whole response) or /copy N (code block N).`);
+      out.warn(`Unknown argument "${trimmed}". Usage: /copy (whole response), /copy N (code block N), or /copy plain (strip markdown).`);
       return 'continue';
     }
 


### PR DESCRIPTION
## Summary

Adds `/copy plain` mode to the `/copy` slash command. Strips markdown syntax before writing to clipboard, producing output suitable for Slack, email, and SMS.

## Changes

- `copy.strip-markdown.ts` (new, 147 lines) — pure `stripMarkdown(input)` function; handles ANSI removal, fenced code blocks → indented, H1/H2 → UPPERCASE, bold/italic/inline-code stripped, list bullets → •, blockquotes, horizontal rules, blank-line collapse.
- `copy.ts` — imports `stripMarkdown`, adds `if (trimmed === 'plain')` branch between the numeric-index check and the unrecognized-arg guard; updates doc comment, `usage`, and `hint`.
- `copy.test.ts` — 14 new test cases: 2 integration tests for `/copy plain` (success + clipboard failure) and 12 unit tests for `stripMarkdown` covering all documented transforms.

## Test results

```
✓ src/cli/slash/commands/copy.test.ts (23 tests) 5ms
```

`pnpm lint` and `pnpm test` pass clean.

## Usage

```
/copy plain
```

Copies the last assistant response with markdown stripped — headings become UPPERCASE, bold/italic markers removed, fenced code blocks indented, list bullets converted to `•`.
