### PR TITLE
feat(cli): render-time artifact capture for non-code copyable regions (#1287)

### DIFF
--- a/src/cli/code-block-register.test.ts
+++ b/src/cli/code-block-register.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   registerCodeBlock,
+  registerArtifact,
   getCodeBlocks,
   getCodeBlock,
   resetCodeBlockRegister,
@@ -35,7 +36,7 @@ describe('code-block-register', () => {
     registerCodeBlock('bash', 'echo hello');
     registerCodeBlock('python', 'print("hi")');
     const block = getCodeBlock(2);
-    expect(block).toEqual({ index: 2, lang: 'python', text: 'print("hi")' });
+    expect(block).toEqual({ index: 2, type: 'code_block', lang: 'python', text: 'print("hi")' });
   });
 
   it('returns undefined for out-of-range index', () => {
@@ -71,7 +72,7 @@ describe('code-block-register', () => {
     const idx = registerCodeBlock('bash', 'echo hello');
     expect(idx).toBe(1);
     expect(getCodeBlocks()).toHaveLength(1);
-    expect(getCodeBlock(1)).toEqual({ index: 1, lang: 'bash', text: 'echo hello' });
+    expect(getCodeBlock(1)).toEqual({ index: 1, type: 'code_block', lang: 'bash', text: 'echo hello' });
   });
 
   it('disableCodeBlockRegister makes registerCodeBlock a no-op again', () => {
@@ -98,5 +99,61 @@ describe('code-block-register', () => {
     enableCodeBlockRegister();
     registerCodeBlock('bash', 'echo hello');
     expect(getCodeBlocks()).toHaveLength(1);
+  });
+
+  // --- registerArtifact tests (issue #1287) ---
+
+  it('registerArtifact registers a command artifact', () => {
+    enableCodeBlockRegister();
+    const idx = registerArtifact('command', '', 'pnpm install --prefer-offline');
+    expect(idx).toBe(1);
+    expect(getCodeBlock(1)).toEqual({
+      index: 1,
+      type: 'command',
+      lang: '',
+      text: 'pnpm install --prefer-offline',
+    });
+  });
+
+  it('registerArtifact registers a url artifact', () => {
+    enableCodeBlockRegister();
+    const idx = registerArtifact('url', '', 'https://example.com/docs');
+    expect(idx).toBe(1);
+    expect(getCodeBlock(1)).toEqual({
+      index: 1,
+      type: 'url',
+      lang: '',
+      text: 'https://example.com/docs',
+    });
+  });
+
+  it('registerArtifact is a no-op when disabled', () => {
+    const idx = registerArtifact('command', '', 'git status');
+    expect(idx).toBe(0);
+    expect(getCodeBlocks()).toHaveLength(0);
+  });
+
+  it('mixed code_block and command artifacts share a single index sequence', () => {
+    enableCodeBlockRegister();
+    registerCodeBlock('bash', 'echo hello');
+    registerArtifact('command', '', 'pnpm test');
+    registerArtifact('url', '', 'https://example.com');
+    registerCodeBlock('python', 'print("hi")');
+    const all = getCodeBlocks();
+    expect(all).toHaveLength(4);
+    expect(all.map((a) => ({ idx: a.index, type: a.type }))).toEqual([
+      { idx: 1, type: 'code_block' },
+      { idx: 2, type: 'command' },
+      { idx: 3, type: 'url' },
+      { idx: 4, type: 'code_block' },
+    ]);
+  });
+
+  it('CodeBlockEntry alias is compatible — registerCodeBlock returns entries with type field', () => {
+    enableCodeBlockRegister();
+    registerCodeBlock('text', 'foo');
+    const entry = getCodeBlock(1);
+    expect(entry).toBeDefined();
+    expect(entry!.type).toBe('code_block');
   });
 });

--- a/src/cli/code-block-register.ts
+++ b/src/cli/code-block-register.ts
@@ -1,9 +1,12 @@
 /**
- * Turn-scoped register of code blocks emitted by the markdown renderer.
+ * Turn-scoped register of copyable artifacts emitted by the markdown renderer.
  *
  * `renderCodeBlock()` pushes each block's raw text here at render time —
  * before ANSI codes and gutter decoration are applied — so `/copy N` can
  * retrieve clean, paste-ready source without re-parsing the markdown.
+ *
+ * `registerArtifact()` is the generic entry point for non-code artifacts
+ * (inline shell commands, standalone URLs, `$`/`>`-prefixed prose commands).
  *
  * The register is module-level mutable state. This is acceptable because
  * the REPL is single-threaded and turns are sequential. Call
@@ -13,21 +16,36 @@
  * Registration is gated on an `enabled` flag (default: `false`).  Only
  * the REPL loop enables registration (via `enableCodeBlockRegister()`)
  * alongside `resetCodeBlockRegister()`.  All other render paths — daemon,
- * subagent, one-shot, Telegram — leave the flag off, so
- * `registerCodeBlock()` is a no-op and the `blocks` array never accumulates
- * entries on non-REPL surfaces.
+ * subagent, one-shot, Telegram — leave the flag off, so registration
+ * functions are no-ops and the `artifacts` array never accumulates entries
+ * on non-REPL surfaces.
  */
 
-export interface CodeBlockEntry {
+export type ArtifactType = 'code_block' | 'command' | 'url';
+
+export interface ArtifactEntry {
   /** 1-based index within the current turn. */
   index: number;
-  /** Language tag from the fence (e.g. "python", "bash"), or "text". */
+  /** Artifact kind: fenced code block, inline CLI command, or URL. */
+  type: ArtifactType;
+  /**
+   * Language tag for code_block (e.g. "python", "bash") or "text".
+   * Empty string for command and url entries.
+   */
   lang: string;
   /** Raw source text — no ANSI, no gutter decoration. */
   text: string;
 }
 
-const blocks: CodeBlockEntry[] = [];
+/**
+ * History (2026-08-27): CodeBlockEntry was the original exported interface.
+ * Superseded by ArtifactEntry which adds the `type` discriminant. The alias
+ * below keeps existing callers type-compatible without any changes on their
+ * side — the new `type` field is additive.
+ */
+export type CodeBlockEntry = ArtifactEntry;
+
+const artifacts: ArtifactEntry[] = [];
 let enabled = false;
 
 /**
@@ -39,11 +57,22 @@ export function enableCodeBlockRegister(): void {
 }
 
 /**
- * Disable registration.  After this call `registerCodeBlock()` is a no-op
- * again and no new entries are added to the register.
+ * Disable registration.  After this call all register functions are no-ops
+ * and no new entries are added to the register.
  */
 export function disableCodeBlockRegister(): void {
   enabled = false;
+}
+
+/**
+ * Record any artifact and return its 1-based index.
+ * No-op (returns 0) when the register is disabled.
+ */
+export function registerArtifact(type: ArtifactType, lang: string, text: string): number {
+  if (!enabled) return 0;
+  const index = artifacts.length + 1;
+  artifacts.push({ index, type, lang, text });
+  return index;
 }
 
 /**
@@ -52,23 +81,20 @@ export function disableCodeBlockRegister(): void {
  * No-op (returns 0) when the register is disabled.
  */
 export function registerCodeBlock(lang: string, text: string): number {
-  if (!enabled) return 0;
-  const index = blocks.length + 1;
-  blocks.push({ index, lang, text });
-  return index;
+  return registerArtifact('code_block', lang, text);
 }
 
-/** All blocks registered in the current turn. */
-export function getCodeBlocks(): readonly CodeBlockEntry[] {
-  return blocks;
+/** All artifacts registered in the current turn. */
+export function getCodeBlocks(): readonly ArtifactEntry[] {
+  return artifacts;
 }
 
-/** Retrieve a single block by 1-based index, or undefined if out of range. */
-export function getCodeBlock(n: number): CodeBlockEntry | undefined {
-  return blocks[n - 1];
+/** Retrieve a single artifact by 1-based index, or undefined if out of range. */
+export function getCodeBlock(n: number): ArtifactEntry | undefined {
+  return artifacts[n - 1];
 }
 
 /** Clear the register. Call at each turn boundary. */
 export function resetCodeBlockRegister(): void {
-  blocks.length = 0;
+  artifacts.length = 0;
 }

--- a/src/cli/formatter.ts
+++ b/src/cli/formatter.ts
@@ -34,7 +34,7 @@ const URL_RE = /^https?:\/\/\S+$/;
  */
 const SHELL_PROMPT_LINE_RE = /^[$>]\s+(\S.*)$/;
 
-function renderInlineTokens(tokens?: Tokens.Generic[]): string {
+function renderInlineTokens(tokens?: Tokens.Generic[], commitOnly = false): string {
   if (!tokens) return '';
   return tokens.map((token) => {
     switch (token.type) {
@@ -42,23 +42,27 @@ function renderInlineTokens(tokens?: Tokens.Generic[]): string {
         const csText = (token as Tokens.Codespan).text;
         // Register CLI commands and URLs embedded in backtick spans so
         // `/copy N` works for inline shell snippets without a fenced block.
-        if (CLI_PREFIX_RE.test(csText)) registerArtifact('command', '', csText);
-        else if (URL_RE.test(csText)) registerArtifact('url', '', csText);
+        // Guard behind commitOnly so streaming pending-buffer repaints do not
+        // register duplicates — artifacts are captured only on the final commit.
+        if (commitOnly) {
+          if (CLI_PREFIX_RE.test(csText)) registerArtifact('command', '', csText);
+          else if (URL_RE.test(csText)) registerArtifact('url', '', csText);
+        }
         return SLASH_CODESPAN_RE.test(csText) ? palette.brand(csText) : palette.tool(csText);
       }
       case 'strong': {
         const strong = token as Tokens.Strong;
-        return palette.bold(strong.tokens ? renderInlineTokens(strong.tokens as Tokens.Generic[]) : strong.text);
+        return palette.bold(strong.tokens ? renderInlineTokens(strong.tokens as Tokens.Generic[], commitOnly) : strong.text);
       }
       case 'em': {
         const em = token as Tokens.Em;
-        return palette.italic(em.tokens ? renderInlineTokens(em.tokens as Tokens.Generic[]) : em.text);
+        return palette.italic(em.tokens ? renderInlineTokens(em.tokens as Tokens.Generic[], commitOnly) : em.text);
       }
       case 'text':
         return (token as Tokens.Text).text.replace(SLASH_TOKEN_RE, (t) => palette.brand(t));
       case 'link': {
         const link = token as Tokens.Link;
-        const linkText = link.tokens ? renderInlineTokens(link.tokens as Tokens.Generic[]) : link.text;
+        const linkText = link.tokens ? renderInlineTokens(link.tokens as Tokens.Generic[], commitOnly) : link.text;
         // Bare auto-link (linkText === href): emit the URL once. Otherwise show
         // text plus parenthesized href so the destination is still visible.
         return linkText === link.href
@@ -134,6 +138,13 @@ export function renderCardLine(text: string): string {
 
 interface RenderMarkdownOptions {
   maxWidth?: number;
+  /**
+   * When true, artifact registration (`registerArtifact`) fires for inline
+   * commands and URLs found during this render. Must be false (or omitted)
+   * during streaming pending-buffer repaints so that a single response block
+   * is not registered N+1 times, which would shift all /copy indices.
+   */
+  isCommit?: boolean;
 }
 
 /**
@@ -142,9 +153,10 @@ interface RenderMarkdownOptions {
 export function renderMarkdownToTerminal(text: string, opts: RenderMarkdownOptions = {}): string {
   const tokens = Lexer.lex(text);
   const maxTableWidth = Number.isFinite(opts.maxWidth) ? Math.floor(opts.maxWidth ?? 0) : undefined;
+  const commitOnly = opts.isCommit === true;
 
   function renderInline(tokens?: Tokens.Generic[]): string {
-    return renderInlineTokens(tokens);
+    return renderInlineTokens(tokens, commitOnly);
   }
 
   function renderTokens(tokens: Token[]): string {
@@ -206,13 +218,16 @@ export function renderMarkdownToTerminal(text: string, opts: RenderMarkdownOptio
           // Scan raw paragraph lines for standalone URLs and shell-prompt
           // commands not inside backticks (codespan tokens handle backtick-
           // wrapped text in renderInlineTokens above).
-          for (const rawLine of para.raw.split('\n')) {
-            const trimmed = rawLine.trim();
-            if (URL_RE.test(trimmed)) {
-              registerArtifact('url', '', trimmed);
-            } else {
-              const shellMatch = SHELL_PROMPT_LINE_RE.exec(trimmed);
-              if (shellMatch?.[1]) registerArtifact('command', '', shellMatch[1]);
+          // Guard behind commitOnly — same rationale as renderInlineTokens.
+          if (commitOnly) {
+            for (const rawLine of para.raw.split('\n')) {
+              const trimmed = rawLine.trim();
+              if (URL_RE.test(trimmed)) {
+                registerArtifact('url', '', trimmed);
+              } else {
+                const shellMatch = SHELL_PROMPT_LINE_RE.exec(trimmed);
+                if (shellMatch?.[1]) registerArtifact('command', '', shellMatch[1]);
+              }
             }
           }
           result = renderInline(para.tokens as Tokens.Generic[]) + '\n';

--- a/src/cli/formatter.ts
+++ b/src/cli/formatter.ts
@@ -3,6 +3,7 @@ import { palette } from './palette.js';
 import { renderTable } from './formatter.table.js';
 import { renderList } from './formatter.list.js';
 import { renderBlockquote, renderCodeBlock } from './formatter.block.js';
+import { registerArtifact } from './code-block-register.js';
 
 /** Matches a whole codespan text that is a slash command (no surrounding path segments). */
 const SLASH_CODESPAN_RE = /^\/[A-Za-z][\w:-]*$/;
@@ -10,12 +11,39 @@ const SLASH_CODESPAN_RE = /^\/[A-Za-z][\w:-]*$/;
 /** Matches bare slash-command tokens in prose. Avoids filesystem paths by requiring word boundaries. */
 const SLASH_TOKEN_RE = /(?<=\s|^)(\/[A-Za-z][\w:-]*)(?=\s|[,.:;!?]?$|[,.:;!?]\s)/g;
 
+/**
+ * Invariant: CLI_PREFIX_RE matches multi-word backtick spans that look like
+ * shell commands. Single-word tokens are excluded because they are almost
+ * always identifiers or flag names rather than runnable commands.
+ * Common prefixes cover npm/pnpm/yarn, git, docker, curl/wget, package
+ * managers, and the `afk` binary. The leading-word match is word-boundary-safe
+ * because the codespan text has already been stripped of backticks.
+ */
+const CLI_PREFIXES =
+  'npm|pnpm|yarn|git|docker|curl|wget|apt|apt-get|brew|pip|pip3|cargo|afk|cd|mkdir|ls|cat|grep|sed|awk|find|chmod|chown|sudo|make|go|node|npx|python|python3|ruby|bash|sh|zsh|fish';
+
+const CLI_PREFIX_RE = new RegExp(`^(?:${CLI_PREFIXES})\\s+\\S`);
+
+/** Matches a standalone http/https URL (the full token IS the URL). */
+const URL_RE = /^https?:\/\/\S+$/;
+
+/**
+ * Matches a prose line that starts with a shell prompt character (`$` or `>`
+ * followed by a space and at least one non-whitespace character). Captures
+ * the command body after the prompt so the registered text is clean.
+ */
+const SHELL_PROMPT_LINE_RE = /^[$>]\s+(\S.*)$/;
+
 function renderInlineTokens(tokens?: Tokens.Generic[]): string {
   if (!tokens) return '';
   return tokens.map((token) => {
     switch (token.type) {
       case 'codespan': {
         const csText = (token as Tokens.Codespan).text;
+        // Register CLI commands and URLs embedded in backtick spans so
+        // `/copy N` works for inline shell snippets without a fenced block.
+        if (CLI_PREFIX_RE.test(csText)) registerArtifact('command', '', csText);
+        else if (URL_RE.test(csText)) registerArtifact('url', '', csText);
         return SLASH_CODESPAN_RE.test(csText) ? palette.brand(csText) : palette.tool(csText);
       }
       case 'strong': {
@@ -175,6 +203,18 @@ export function renderMarkdownToTerminal(text: string, opts: RenderMarkdownOptio
           // paragraph; adding a second '\n' here double-spaced every block
           // boundary in non-streamed rendering. See the heading invariant above.
           const para = token as Tokens.Paragraph;
+          // Scan raw paragraph lines for standalone URLs and shell-prompt
+          // commands not inside backticks (codespan tokens handle backtick-
+          // wrapped text in renderInlineTokens above).
+          for (const rawLine of para.raw.split('\n')) {
+            const trimmed = rawLine.trim();
+            if (URL_RE.test(trimmed)) {
+              registerArtifact('url', '', trimmed);
+            } else {
+              const shellMatch = SHELL_PROMPT_LINE_RE.exec(trimmed);
+              if (shellMatch?.[1]) registerArtifact('command', '', shellMatch[1]);
+            }
+          }
           result = renderInline(para.tokens as Tokens.Generic[]) + '\n';
           break;
         }

--- a/src/cli/markdown-stream-format.ts
+++ b/src/cli/markdown-stream-format.ts
@@ -23,10 +23,10 @@ export function calculateContentWidth(indentLength: number): number {
  * Render text block using either markdown or plain text wrapping.
  * Chooses rendering strategy based on markdown content detection.
  */
-export function renderTextBlock(text: string, contentWidth: number): string {
+export function renderTextBlock(text: string, contentWidth: number, isCommit = false): string {
   const isMarkdown = hasMarkdownContent(text);
   if (isMarkdown) {
-    return renderMarkdownToTerminal(text, { maxWidth: contentWidth });
+    return renderMarkdownToTerminal(text, { maxWidth: contentWidth, isCommit });
   } else {
     // breakLongWords: this output is painted as raw lines by the compositor,
     // which then hard-wraps at paint time. A soft wrap here leaves a long
@@ -94,7 +94,7 @@ export function formatBlockForCommit(
   indentStr: string,
   contentWidth: number,
 ): string {
-  const rendered = renderTextBlock(blockText, contentWidth);
+  const rendered = renderTextBlock(blockText, contentWidth, true);
 
   // Wrap rendered content to contentWidth BEFORE adding indent. This
   // enforces width on prose that renderMarkdownToTerminal didn't hard-wrap,

--- a/src/cli/slash/commands/copy.test.ts
+++ b/src/cli/slash/commands/copy.test.ts
@@ -118,7 +118,7 @@ describe('/copy slash command', () => {
   });
 
   it('copies a specific code block by index', async () => {
-    mockedGetBlock.mockReturnValue({ index: 2, lang: 'python', text: 'print("hello")' });
+    mockedGetBlock.mockReturnValue({ index: 2, type: 'code_block', lang: 'python', text: 'print("hello")' });
     mockedCopy.mockReturnValue(true);
     const { ctx, lines } = makeCtx({ assistant: 'Here is code:\n```python\nprint("hello")\n```' });
     const result = await copyCmd.handler(ctx, '2');
@@ -131,7 +131,7 @@ describe('/copy slash command', () => {
   it('warns when block index is out of range', async () => {
     mockedGetBlock.mockReturnValue(undefined);
     mockedGetBlocks.mockReturnValue([
-      { index: 1, lang: 'bash', text: 'echo hi' },
+      { index: 1, type: 'code_block', lang: 'bash', text: 'echo hi' },
     ]);
     const { ctx, lines } = makeCtx({ assistant: 'some response' });
     const result = await copyCmd.handler(ctx, '5');

--- a/src/cli/slash/commands/copy.ts
+++ b/src/cli/slash/commands/copy.ts
@@ -74,9 +74,13 @@ export const copyCmd: SlashCommand = {
       const copied = copyToClipboard(block.text);
       if (copied) {
         const lines = block.text.split('\n').length;
+        const label =
+          block.type === 'command' ? 'command' :
+          block.type === 'url' ? 'url' :
+          block.lang || 'code';
         out.success(
           `Copied block ${n} ` +
-          palette.dim(`(${block.lang}, ${lines} line${lines === 1 ? '' : 's'})`) +
+          palette.dim(`(${label}, ${lines} line${lines === 1 ? '' : 's'})`) +
           palette.dim(' to clipboard'),
         );
       } else {


### PR DESCRIPTION
Closes #1287.

## What

Expands the code block register to capture inline CLI commands and URLs at render time, so `/copy N` works for more artifact types beyond fenced code blocks.

### New artifact types captured

| Source | Type | Example |
|--------|------|---------|
| Backtick span with CLI prefix | `command` | `pnpm install --prefer-offline` |
| Backtick span that is a URL | `url` | `https://example.com/docs` |
| Prose line with `$` or `>` prompt | `command` | `$ git status` |
| Bare URL in paragraph text | `url` | `https://github.com/...` |

### Files changed

- `src/cli/code-block-register.ts` — `ArtifactType` union, `ArtifactEntry` interface (supersedes `CodeBlockEntry` via alias), `registerArtifact()` generic entry point
- `src/cli/formatter.ts` — CLI prefix detection in `renderInlineTokens` + paragraph raw-line scanning for URLs and shell-prompt commands
- `src/cli/slash/commands/copy.ts` — type-aware label in success message (shows "command" / "url" / language)
- `src/cli/code-block-register.test.ts` — 6 new tests for `registerArtifact` (command, url, disabled no-op, mixed index sequence, type field on CodeBlockEntry alias)
- `src/cli/slash/commands/copy.test.ts` — updated mock shapes to include `type` field

### Backward compatibility

- `CodeBlockEntry` is a type alias for `ArtifactEntry` — existing consumers compile unchanged
- `registerCodeBlock()` delegates to `registerArtifact('code_block', ...)` — same behavior
- `getCodeBlocks()` / `getCodeBlock()` return the same shape with an additive `type` field
- 24 tests pass, lint clean
