### PR TITLE
refactor(render): extract formatElapsed + statusBadge shared primitives

### DIFF
--- a/src/cli/commands/interactive/tool-lane-format.ts
+++ b/src/cli/commands/interactive/tool-lane-format.ts
@@ -3,6 +3,7 @@ import type { ToolFailureClass } from '../../../agent/trace/types.js';
 import { BENIGN_FAILURE_CLASSES } from '../../../agent/trace/types.js';
 import { env } from '../../../config/env.js';
 import { palette } from '../../palette.js';
+import { statusBadge } from '../../render/status-badge.js';
 import { fileHyperlink, hyperlinksEnabled } from '../../hyperlink.js';
 import { humanVerbForTool } from '../../tool-category.js';
 import { sanitizeLabel, sanitizeTextParagraph } from './tool-lane-format-sanitize.js';
@@ -43,8 +44,8 @@ export {
  * it was benign, and guessing in that direction hides real breakage.
  */
 export function doneGlyph(isError: boolean | undefined, failureClass?: ToolFailureClass): string {
-  if (!isError) return palette.success('✓');
-  return isBenignFailure(failureClass) ? palette.warning('⊘') : palette.error('✗');
+  if (!isError) return statusBadge('done');
+  return isBenignFailure(failureClass) ? statusBadge('blocked') : statusBadge('error');
 }
 
 /**

--- a/src/cli/render/index.ts
+++ b/src/cli/render/index.ts
@@ -20,3 +20,5 @@ export * from './box.js';
 export * from './subagent-status-bar.js';
 export * from './stream-progress.js';
 export * from './error-card.js';
+export * from './status-badge.js';
+export * from './utils.js';

--- a/src/cli/render/status-badge.test.ts
+++ b/src/cli/render/status-badge.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { stripAnsi } from '../display.js';
+import { statusBadge, type BadgeStatus } from './status-badge.js';
+
+const ALL_STATUSES: BadgeStatus[] = ['running', 'done', 'error', 'blocked', 'warn'];
+
+describe('statusBadge', () => {
+  it.each(ALL_STATUSES)('returns a non-empty string for status "%s"', (status) => {
+    const result = statusBadge(status);
+    expect(result).toBeTruthy();
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it.each(ALL_STATUSES)('strips to a non-empty plain glyph for status "%s"', (status) => {
+    const plain = stripAnsi(statusBadge(status));
+    // After stripping ANSI the glyph itself must survive
+    expect(plain.length).toBeGreaterThan(0);
+  });
+
+  it('renders the correct glyph for "done"', () => {
+    expect(stripAnsi(statusBadge('done'))).toBe('✓');
+  });
+
+  it('renders the correct glyph for "error"', () => {
+    expect(stripAnsi(statusBadge('error'))).toBe('✗');
+  });
+
+  it('renders the correct glyph for "blocked"', () => {
+    expect(stripAnsi(statusBadge('blocked'))).toBe('⊘');
+  });
+
+  it('renders the correct glyph for "warn"', () => {
+    expect(stripAnsi(statusBadge('warn'))).toBe('⚠');
+  });
+
+  it('renders the correct glyph for "running"', () => {
+    expect(stripAnsi(statusBadge('running'))).toBe('●');
+  });
+
+  it('done and error render different glyphs', () => {
+    expect(stripAnsi(statusBadge('done'))).not.toBe(stripAnsi(statusBadge('error')));
+  });
+
+  it('error and blocked render different glyphs', () => {
+    expect(stripAnsi(statusBadge('error'))).not.toBe(stripAnsi(statusBadge('blocked')));
+  });
+
+  it('all statuses render distinct glyphs', () => {
+    const glyphs = ALL_STATUSES.map((s) => stripAnsi(statusBadge(s)));
+    const unique = new Set(glyphs);
+    expect(unique.size).toBe(ALL_STATUSES.length);
+  });
+});

--- a/src/cli/render/status-badge.ts
+++ b/src/cli/render/status-badge.ts
@@ -1,0 +1,46 @@
+import { palette } from '../palette.js';
+
+// ─── StatusBadge ──────────────────────────────────────────────────────────────
+
+/**
+ * The set of semantic states a status badge can represent.
+ *
+ * - `running`  — in-flight / active (spinner / progress context)
+ * - `done`     — completed successfully
+ * - `error`    — failed (real fault, not a deliberate refusal)
+ * - `blocked`  — deliberately refused / benign failure (system said no)
+ * - `warn`     — caution / degraded / partial
+ */
+export type BadgeStatus = 'running' | 'done' | 'error' | 'blocked' | 'warn';
+
+/**
+ * Render a coloured glyph for the given status.
+ *
+ * Returns a short ANSI string — glyph only, no surrounding whitespace —
+ * suitable for embedding in any single-line or tabular render context.
+ *
+ * Invariant: resolved at CALL TIME, never hoisted into module-level consts.
+ * `palette` is a live view over the active theme (see palette.ts) — capturing
+ * `palette.success('✓')` at import time freezes the glyph to the theme that
+ * was active at module load. Resolving per-call keeps glyphs in lock-step
+ * with `applyTheme()` (mirrors `buildSyntaxTheme()` in syntax-theme.ts).
+ *
+ * Glyph choices:
+ * - `running`  → `●`  (chrome  — neutral, in-motion feel)
+ * - `done`     → `✓`  (success — check mark)
+ * - `error`    → `✗`  (error   — cross)
+ * - `blocked`  → `⊘`  (warning — deliberate refusal, not a fault)
+ * - `warn`     → `⚠`  (warning — caution)
+ *
+ * @param status - The semantic state to represent.
+ * @returns Single-glyph ANSI string.
+ */
+export function statusBadge(status: BadgeStatus): string {
+  switch (status) {
+    case 'running':  return palette.chrome('●');
+    case 'done':     return palette.success('✓');
+    case 'error':    return palette.error('✗');
+    case 'blocked':  return palette.warning('⊘');
+    case 'warn':     return palette.warning('⚠');
+  }
+}

--- a/src/cli/render/stream-progress.ts
+++ b/src/cli/render/stream-progress.ts
@@ -1,4 +1,5 @@
 import { palette } from '../palette.js';
+import { formatElapsed } from './utils.js';
 
 // ─── Stream Progress ─────────────────────────────────────────────────────────
 
@@ -72,14 +73,4 @@ function formatCost(cents: number): string {
   if (cents < 1) return `$${(cents / 100).toFixed(4)}`;
   if (cents < 100) return `$${(cents / 100).toFixed(2)}`;
   return `$${(cents / 100).toFixed(0)}`;
-}
-
-/** Format elapsed milliseconds as a compact human string. */
-function formatElapsed(ms: number): string {
-  if (ms < 1000) return '<1s';
-  const s = Math.floor(ms / 1000);
-  if (s < 60) return `${s}s`;
-  const m = Math.floor(s / 60);
-  const rem = s % 60;
-  return rem > 0 ? `${m}m ${rem}s` : `${m}m`;
 }

--- a/src/cli/render/subagent-status-bar.ts
+++ b/src/cli/render/subagent-status-bar.ts
@@ -1,6 +1,7 @@
 import { displayWidth, truncateDisplayWidth } from '../display.js';
 import { getTerminalWidth } from '../terminal-size.js';
 import { palette } from '../palette.js';
+import { formatElapsed } from './utils.js';
 
 // ─── Subagent Status Bar ─────────────────────────────────────────────────────
 
@@ -116,14 +117,4 @@ export interface SubagentStatusBarSpec {
   batchSize?: number;
 }
 
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
-/** Format elapsed milliseconds as a compact human string. */
-function formatElapsed(ms: number): string {
-  if (ms < 1000) return '<1s';
-  const s = Math.floor(ms / 1000);
-  if (s < 60) return `${s}s`;
-  const m = Math.floor(s / 60);
-  const rem = s % 60;
-  return rem > 0 ? `${m}m ${rem}s` : `${m}m`;
-}
+// ─── Helpers are now imported from utils.ts ──────────────────────────────────

--- a/src/cli/render/utils.ts
+++ b/src/cli/render/utils.ts
@@ -10,3 +10,19 @@ export function maxInnerBoxWidth(): number {
 export function truncateDisplay(s: string, maxWidth: number): string {
   return truncateDisplayWidth(s, maxWidth);
 }
+
+/**
+ * Format elapsed milliseconds as a compact human string.
+ *
+ * Examples: `<1s`, `4s`, `1m 23s`, `2m`
+ *
+ * Pure function — no side effects, no imports needed beyond this module.
+ */
+export function formatElapsed(ms: number): string {
+  if (ms < 1000) return '<1s';
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  const rem = s % 60;
+  return rem > 0 ? `${m}m ${rem}s` : `${m}m`;
+}


### PR DESCRIPTION
## Summary

Extracts two duplicated render primitives into shared modules. Closes #1322.

## Changes

### `formatElapsed` deduplication
The same `formatElapsed(ms: number): string` helper (`<1s` / `4s` / `1m 23s` / `2m`) was copy-pasted in both `stream-progress.ts` and `subagent-status-bar.ts`. Moved to `src/cli/render/utils.ts` and both files now import from there.

### `statusBadge` primitive (`src/cli/render/status-badge.ts`)
New pure function `statusBadge(status: BadgeStatus): string` covering five semantic states:

| Status    | Glyph | Palette role   |
|-----------|-------|----------------|
| `running` | `●`   | `palette.chrome`   |
| `done`    | `✓`   | `palette.success`  |
| `error`   | `✗`   | `palette.error`    |
| `blocked` | `⊘`   | `palette.warning`  |
| `warn`    | `⚠`   | `palette.warning`  |

Exported from `src/cli/render/index.ts` barrel.

### Call site update
`tool-lane-format.ts` `doneGlyph()` now delegates to `statusBadge('done')`, `statusBadge('error')`, and `statusBadge('blocked')` — visually identical output, single source of truth.

## Tests
- `src/cli/render/status-badge.test.ts` — 18 tests: all variants return non-empty strings, correct glyphs, all glyphs distinct
- All 242 existing render tests pass

## Constraints satisfied
- ✅ All new/modified files under 350 LOC ceiling
- ✅ Palette semantic roles only, never raw chalk
- ✅ Exported from barrel
- ✅ Pure functions
