### PR TITLE
fix(tasks): address v2 review follow-ups

### DIFF
--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -23,6 +23,7 @@ import { createReplSlashContext } from './bootstrap-slash-context.js';
 import { wireTrustedSkillEvents, wireProviderGrants, createReplInput } from './bootstrap-wiring.js';
 import { buildAgentSession, buildSharedDeps } from './bootstrap-session-builder.js';
 import { registerAll } from '../../slash/index.js';
+import { setTasksIctx } from '../../slash/commands/tasks.js';
 
 // Re-exported so `resume-swap.test.ts` (and the mid-session swap closure
 // below) can resolve `buildAgentSession` from this module — the historical
@@ -351,6 +352,10 @@ export async function bootstrapSession(
   ctx.teardownTrustedSkillEvents = wireTrustedSkillEvents(completionWriter, trustedSkillLedger);
 
   registerAll();
+
+  // Wire the InteractiveCtx into /tasks so viewingTaskId is set correctly
+  // when the user opens a task view (#1332).
+  setTasksIctx(ctx);
 
   // Wire /allow-dir to the startup provider's grant API so the slash command
   // can mutate read/write roots across turns. Must run AFTER registerAll()

--- a/src/cli/commands/interactive/task-view-mode.ts
+++ b/src/cli/commands/interactive/task-view-mode.ts
@@ -185,6 +185,10 @@ export async function enterTaskViewMode(entry: TaskViewEntry): Promise<void> {
     wireEscapeToExit(entry);
     // Clear viewingTaskId since we are not blocking in a tail loop.
     if (ictx) ictx.viewingTaskId = undefined;
+    // Clear the soft-stop handler we just installed — callers in the disk
+    // path return immediately and never enter a tail loop, so the handler
+    // must not linger as a stale closure (#1331).
+    entry.ctx.setSoftStopHandler?.(null);
     return;
   }
 

--- a/src/cli/commands/interactive/task-view.test.ts
+++ b/src/cli/commands/interactive/task-view.test.ts
@@ -271,3 +271,99 @@ describe('enterTaskViewMode — disk fallback', () => {
     expect(lines.some(l => l.includes('complete') && l.includes('Esc'))).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// enterTaskViewMode — live tail (running subagent, #1333)
+// ---------------------------------------------------------------------------
+
+describe('enterTaskViewMode — live tail', () => {
+  /** Build a running handle whose output stream resolves naturally. */
+  function makeRunningHandle(id: string, events: import('../../../agent/types/session-types.js').OutputEvent[] = []): SubagentHandle {
+    const h = makeHandle(id, 'running');
+    // Override getOutputStream to yield the provided events then finish.
+    (h.session as unknown as { getOutputStream: ReturnType<typeof vi.fn> }).getOutputStream =
+      vi.fn().mockImplementation(async function* () {
+        for (const e of events) {
+          yield e;
+        }
+      });
+    return h;
+  }
+
+  it('natural stream completion → exitTaskViewMode called, FOOTER_COMPLETE emitted', async () => {
+    const h = makeRunningHandle('h-tail-done');
+    const manager = makeManager([h]);
+    const { ctx, lines } = makeCtx();
+    const ictx = makeICtx({ viewingTaskId: 'h-tail-done' });
+
+    await enterTaskViewMode({ id: 'h-tail-done', manager, sessionLabel: 'lbl', ctx, ictx });
+
+    // After natural completion: viewingTaskId is cleared by exitTaskViewMode.
+    expect(ictx.viewingTaskId).toBeUndefined();
+    // FOOTER_COMPLETE text should appear in the output.
+    expect(lines.some(l => l.includes('complete') && !l.includes('running'))).toBe(true);
+    // repaintStatusLine should have been called by exitTaskViewMode.
+    expect(ctx.ui.repaintStatusLine).toHaveBeenCalled();
+  });
+
+  it('Esc/abort fired → exitTaskViewMode NOT called from the finally branch', async () => {
+    // Build a stream that never resolves on its own (blocks until aborted).
+    let abortFn: (() => void) | null = null;
+    const h = makeHandle('h-tail-esc', 'running');
+    (h.session as unknown as { getOutputStream: ReturnType<typeof vi.fn> }).getOutputStream =
+      vi.fn().mockImplementation(async function* () {
+        // Hang until the AbortController fires.
+        await new Promise<void>((res) => { abortFn = res; });
+        // After abort, yield nothing more — stream ends.
+      });
+
+    const manager = makeManager([h]);
+    const { ctx } = makeCtx();
+    const ictx = makeICtx();
+
+    // Capture the override handler that enterTaskViewMode installs for the tail.
+    let installedHandler: (() => void) | null = null;
+    const setSoftStopHandler = vi.fn().mockImplementation((fn: (() => void) | null) => {
+      installedHandler = fn;
+    });
+    const { ctx: ctxEsc } = makeCtx();
+    ctxEsc.setSoftStopHandler = setSoftStopHandler;
+
+    // Start enterTaskViewMode without awaiting — it will block on the stream.
+    const viewPromise = enterTaskViewMode({ id: 'h-tail-esc', manager, sessionLabel: 'lbl', ctx: ctxEsc, ictx });
+
+    // Flush microtasks so the tail loop starts and installs the override handler.
+    await new Promise(r => setTimeout(r, 0));
+
+    // Fire the Esc handler (simulates pressing Esc while tailing).
+    expect(installedHandler).not.toBeNull();
+    installedHandler?.();
+    // Also unblock the stream so the async generator can finish.
+    abortFn?.();
+
+    await viewPromise;
+
+    // The abort path in wireEscapeToExit → exitTaskViewMode clears viewingTaskId.
+    expect(ictx.viewingTaskId).toBeUndefined();
+  });
+
+  it('setSoftStopHandler override is wired for the running subagent tail loop', async () => {
+    const h = makeRunningHandle('h-wire');
+    const manager = makeManager([h]);
+
+    const handlerCalls: Array<(() => void) | null> = [];
+    const { ctx } = makeCtx();
+    ctx.setSoftStopHandler = vi.fn().mockImplementation((fn: (() => void) | null) => {
+      handlerCalls.push(fn);
+    });
+
+    await enterTaskViewMode({ id: 'h-wire', manager, sessionLabel: 'lbl', ctx });
+
+    // At least two setSoftStopHandler calls: the initial wireEscapeToExit call
+    // is immediately overridden by the running-tail-specific handler, then
+    // cleared (null) on natural completion.
+    expect(handlerCalls.length).toBeGreaterThanOrEqual(2);
+    // The final call must pass null to clear the handler.
+    expect(handlerCalls[handlerCalls.length - 1]).toBeNull();
+  });
+});

--- a/src/cli/commands/interactive/task-view.ts
+++ b/src/cli/commands/interactive/task-view.ts
@@ -1,28 +1,22 @@
 /**
  * Task-view replay renderer.
  *
- * Renders a subagent's conversation history to a terminal string via two
- * input paths:
+ * Renders a subagent's conversation history (in-memory Message[] path) to a
+ * terminal string. Emits a header box, the body, and a footer separator,
+ * and returns a fully-assembled string so callers can page, write, or stream
+ * it as they see fit.
  *
- *   - Memory path  — takes a `Message[]` array already held in memory and
- *     renders each message using renderMarkdownToTerminal.
- *
- *   - Disk path    — takes an `AsyncIterable<OutputEvent>` (produced by
- *     BgJobLogReader.readEvents()) and renders events with formatOutputEvent.
- *
- * Both paths emit a header box, the body, and a footer separator, and both
- * return a fully-assembled string so callers can page, write, or stream it
- * as they see fit.
+ * Disk-path rendering (streaming OutputEvent replay) is handled by
+ * `replayDiskEvents` in task-view-mode.ts, which streams events directly to
+ * ctx.out line-by-line.
  *
  * @module cli/commands/interactive/task-view
  */
 
 import { palette } from '../../palette.js';
 import { renderMarkdownToTerminal } from '../../formatter.js';
-import { formatOutputEvent } from '../../output-event-format.js';
 import { getTerminalWidth } from '../../terminal-size.js';
 import type { Message } from '../../../agent/types/message-types.js';
-import type { OutputEvent } from '../../../agent/types/session-types.js';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -45,16 +39,9 @@ export interface TaskViewHeader {
   turnCount?: number;
 }
 
-export interface TaskViewOptions {
-  /** Maximum number of disk events to render (default 500). */
-  maxEvents?: number;
-}
-
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
-
-const DEFAULT_MAX_EVENTS = 500;
 /** Truncation limit for tool input / result previews (characters). */
 const CONTENT_PREVIEW_CHARS = 200;
 
@@ -230,49 +217,7 @@ export function renderMessagesView(
   return sections.join('\n');
 }
 
-/**
- * Render a subagent conversation from a disk OutputEvent replay stream.
- *
- * Contract: reads up to `options.maxEvents` (default 500) events, formats
- * each with formatOutputEvent (null returns are skipped), and returns a
- * fully assembled terminal string (header + body + footer) with a trailing
- * newline.
- */
-export async function renderEventsView(
-  header: TaskViewHeader,
-  events: AsyncIterable<OutputEvent>,
-  options?: TaskViewOptions,
-): Promise<string> {
-  const limit = options?.maxEvents ?? DEFAULT_MAX_EVENTS;
-  const lines: string[] = [];
-  let count = 0;
-  let truncated = false;
-
-  for await (const event of events) {
-    if (count >= limit) {
-      truncated = true;
-      break;
-    }
-    const formatted = formatOutputEvent(event);
-    if (formatted !== null) {
-      lines.push(formatted);
-      count++;
-    }
-  }
-
-  const sections: string[] = [buildHeader(header), ''];
-
-  if (lines.length > 0) {
-    sections.push(lines.join('\n'));
-  } else {
-    sections.push(palette.dim('  (no events recorded)'));
-  }
-
-  if (truncated) {
-    sections.push('');
-    sections.push(palette.dim(`  [truncated — showing first ${limit} events]`));
-  }
-
-  sections.push('', buildFooter());
-  return sections.join('\n');
-}
+// renderEventsView was removed — it was a dead export with zero callers (#1335).
+// Disk-path rendering is handled by replayDiskEvents in task-view-mode.ts,
+// which streams events line-by-line to ctx.out and does not share the
+// "return full string" contract of this module's memory-path API.

--- a/src/cli/slash/commands/tasks.ts
+++ b/src/cli/slash/commands/tasks.ts
@@ -33,6 +33,7 @@ import {
   enterTaskViewMode,
   type TaskViewEntry,
 } from '../../commands/interactive/task-view-mode.js';
+import type { InteractiveCtx } from '../../commands/interactive/shared.js';
 
 // ---------------------------------------------------------------------------
 // Module-scope registry refs
@@ -40,6 +41,7 @@ import {
 
 let managerRef: SubagentManager | undefined;
 let sessionLabelRef: string | undefined;
+let ictxRef: InteractiveCtx | undefined;
 
 /**
  * Wire the SubagentManager and session label into this module.
@@ -50,10 +52,20 @@ export function setTasksRegistry(manager: SubagentManager, sessionLabel: string)
   sessionLabelRef = sessionLabel;
 }
 
+/**
+ * Wire the InteractiveCtx so that `/tasks:view` can populate
+ * `viewingTaskId` on the active REPL context (#1332).
+ * Called once from bootstrapSession after `ctx` is constructed.
+ */
+export function setTasksIctx(ictx: InteractiveCtx): void {
+  ictxRef = ictx;
+}
+
 /** Reset refs — used by tests to isolate module-scope state between cases. */
 export function resetTasksRegistry(): void {
   managerRef = undefined;
   sessionLabelRef = undefined;
+  ictxRef = undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -276,8 +288,12 @@ export const tasksCmd: SlashCommand = {
               manager,
               sessionLabel,
               ctx,
+              ictx: ictxRef,
             };
-            void enterTaskViewMode(entry).then(resolve).catch(() => resolve());
+            void enterTaskViewMode(entry).then(resolve).catch((e) => {
+              ctx.out.error?.(`task view error: ${String(e)}`);
+              resolve();
+            });
           }
         } else if (str === '\x1b' || str === '\x03') {
           // Esc or Ctrl-C — exit to main prompt.
@@ -346,6 +362,7 @@ export const tasksViewCmd: SlashCommand = {
       manager,
       sessionLabel,
       ctx,
+      ictx: ictxRef,
     };
 
     await enterTaskViewMode(entry);


### PR DESCRIPTION
## Summary

Addresses all five follow-up issues from PR #1313 review.

Closes #1331, #1332, #1333, #1334, #1335.

## Changes

### #1331 — Stale soft-stop handler after disk-path view exit (medium bug)

**`src/cli/commands/interactive/task-view-mode.ts`**

Added `entry.ctx.setSoftStopHandler?.(null)` before the early `return` in the disk-only path of `enterTaskViewMode`. Previously `wireEscapeToExit` installed a closure that was never cleaned up — the disk path returns immediately without entering a tail loop, leaving a stale handler wired to the surface.

### #1332 — viewingTaskId tracking inoperative (medium bug)

**`src/cli/slash/commands/tasks.ts`**, **`src/cli/commands/interactive/bootstrap.ts`**

Added a `setTasksIctx(ictx: InteractiveCtx)` export and `ictxRef` module-level variable to `tasks.ts`. Called from `bootstrap.ts` after `ctx` is constructed. Threaded `ictx: ictxRef` into both `TaskViewEntry` constructions (list→Enter path and direct `/tasks:view` path) so `viewingTaskId` is correctly set and cleared during task view mode.

### #1333 — Add live tail tests (low)

**`src/cli/commands/interactive/task-view.test.ts`**

Added three test cases under `enterTaskViewMode — live tail`:
1. Natural stream completion → `exitTaskViewMode` called, `FOOTER_COMPLETE` emitted, `viewingTaskId` cleared
2. Esc/abort fires → abort handler invoked, `viewingTaskId` cleared via `wireEscapeToExit` path
3. `setSoftStopHandler` override is wired correctly — final call passes `null` to clear handler on natural completion

### #1334 — Silent .catch() swallows errors (nit bug)

**`src/cli/slash/commands/tasks.ts`**

Changed `.catch(() => resolve())` to `.catch((e) => { ctx.out.error?.(\`task view error: \${String(e)}\`); resolve(); })` so errors are surfaced via the `OutputSink.error` channel instead of being silently discarded.

### #1335 — renderEventsView is dead code (low)

**`src/cli/commands/interactive/task-view.ts`**

Removed the `renderEventsView` export (confirmed zero callers with grep). Also removed the now-unused `TaskViewOptions` interface, `DEFAULT_MAX_EVENTS` constant, and `formatOutputEvent`/`OutputEvent` imports that existed solely to support it. Updated module doc comment accordingly.

## Test Results

```
✓ src/cli/slash/commands/tasks.test.ts (13 tests) 11ms
✓ src/cli/commands/interactive/task-view.test.ts (20 tests) 14ms

Test Files  2 passed (2)
     Tests  33 passed (33)
```

`pnpm lint` passes (tsc --noEmit clean). All touched files are within the 350 code-line ceiling.
