### PR TITLE
feat(render): add ToolCard component

### DIFF
--- a/src/cli/render/index.ts
+++ b/src/cli/render/index.ts
@@ -21,3 +21,4 @@ export * from './stream-progress.js';
 export * from './error-card.js';
 export * from './status-badge.js';
 export * from './utils.js';
+export * from './tool-card.js';

--- a/src/cli/render/tool-card.test.ts
+++ b/src/cli/render/tool-card.test.ts
@@ -210,6 +210,23 @@ describe('toolCard – width truncation', () => {
     const diffLine = stripAnsi(ls.find((l) => l.includes('+1')) ?? '');
     expect(diffLine.trimEnd().length).toBeLessThanOrEqual(62);
   });
+
+  it('sanitizes control characters in diff.file (BEL, ANSI escape)', () => {
+    // diff.file with embedded BEL (\x07) and ANSI escape sequence
+    const maliciousFile = 'src/\x07evil\x1b[31mred\x1b[0m.ts';
+    const out = stripAnsi(
+      toolCard({
+        toolName: 'edit_file',
+        status: 'done',
+        diff: { added: 1, removed: 1, file: maliciousFile },
+      }),
+    );
+    // Control characters must not appear in output
+    expect(out).not.toMatch(/[\x07]/);
+    expect(out).not.toMatch(/\x1b/);
+    // File path is still present in sanitized form
+    expect(out).toContain('evil');
+  });
 });
 
 // ─── Minimal spec ────────────────────────────────────────────────────────────

--- a/src/cli/render/tool-card.test.ts
+++ b/src/cli/render/tool-card.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect } from 'vitest';
+import { stripAnsi } from '../display.js';
+import { toolCard } from './tool-card.js';
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+/** Strip ANSI codes and split into lines for easy assertions. */
+function lines(output: string): string[] {
+  return stripAnsi(output).split('\n');
+}
+
+// ─── Status variants ─────────────────────────────────────────────────────────
+
+describe('toolCard – status variants', () => {
+  it('running: renders ● glyph', () => {
+    const out = stripAnsi(toolCard({ toolName: 'bash', status: 'running' }));
+    expect(out).toContain('●');
+    expect(out).toContain('bash');
+  });
+
+  it('done: renders ✓ glyph', () => {
+    const out = stripAnsi(toolCard({ toolName: 'read_file', status: 'done' }));
+    expect(out).toContain('✓');
+  });
+
+  it('error: renders ✗ glyph', () => {
+    const out = stripAnsi(toolCard({ toolName: 'write_file', status: 'error' }));
+    expect(out).toContain('✗');
+  });
+
+  it('blocked: renders ⊘ glyph', () => {
+    const out = stripAnsi(toolCard({ toolName: 'bash', status: 'blocked' }));
+    expect(out).toContain('⊘');
+  });
+});
+
+// ─── Collapsed mode ──────────────────────────────────────────────────────────
+
+describe('toolCard – collapsed mode', () => {
+  it('collapsed=true yields a single line even when body fields are provided', () => {
+    const out = toolCard({
+      toolName: 'bash',
+      status: 'done',
+      elapsed: 3000,
+      inputSummary: 'ls -la /tmp',
+      outputPreview: 'total 128',
+      diff: { added: 2, removed: 0, file: '/tmp/file.txt' },
+      collapsed: true,
+    });
+    expect(lines(out)).toHaveLength(1);
+  });
+
+  it('collapsed=true header still contains tool name and elapsed', () => {
+    const out = stripAnsi(
+      toolCard({
+        toolName: 'edit_file',
+        status: 'done',
+        elapsed: 1500,
+        collapsed: true,
+      }),
+    );
+    expect(out).toContain('edit_file');
+    expect(out).toContain('1s');
+  });
+
+  it('collapsed=false (default) renders body when content is provided', () => {
+    const out = toolCard({
+      toolName: 'bash',
+      status: 'done',
+      inputSummary: 'pnpm test',
+      outputPreview: 'All tests passed',
+    });
+    expect(lines(out).length).toBeGreaterThan(1);
+  });
+});
+
+// ─── Elapsed time ────────────────────────────────────────────────────────────
+
+describe('toolCard – elapsed time', () => {
+  it('shows elapsed when provided', () => {
+    const out = stripAnsi(toolCard({ toolName: 'bash', status: 'done', elapsed: 5000 }));
+    expect(out).toContain('5s');
+  });
+
+  it('shows <1s for sub-second elapsed', () => {
+    const out = stripAnsi(toolCard({ toolName: 'bash', status: 'running', elapsed: 500 }));
+    expect(out).toContain('<1s');
+  });
+
+  it('omits elapsed when not provided', () => {
+    const out = stripAnsi(toolCard({ toolName: 'bash', status: 'running' }));
+    // Should only have the badge + tool name on the single line
+    expect(lines(out)).toHaveLength(1);
+    expect(out.trim()).toBe('● bash');
+  });
+});
+
+// ─── Diff stat line ──────────────────────────────────────────────────────────
+
+describe('toolCard – diff stat', () => {
+  it('renders +N and -M when diff is provided', () => {
+    const out = stripAnsi(
+      toolCard({
+        toolName: 'edit_file',
+        status: 'done',
+        diff: { added: 5, removed: 3, file: 'src/index.ts' },
+      }),
+    );
+    expect(out).toContain('+5');
+    expect(out).toContain('-3');
+    expect(out).toContain('src/index.ts');
+  });
+
+  it('diff stat appears on its own line', () => {
+    const ls = lines(
+      toolCard({
+        toolName: 'edit_file',
+        status: 'done',
+        diff: { added: 1, removed: 0, file: 'a.ts' },
+      }),
+    );
+    const diffLine = ls.find((l) => l.includes('+1'));
+    expect(diffLine).toBeDefined();
+    // Header is always the first line; diff should be on a later line
+    expect(ls.indexOf(diffLine!)).toBeGreaterThan(0);
+  });
+
+  it('omits diff stat when diff is not provided', () => {
+    const out = stripAnsi(toolCard({ toolName: 'bash', status: 'done' }));
+    expect(out).not.toContain('+');
+    expect(out).not.toContain('-0');
+  });
+});
+
+// ─── Input summary and output preview ────────────────────────────────────────
+
+describe('toolCard – input summary and output preview', () => {
+  it('renders inputSummary when provided', () => {
+    const out = stripAnsi(
+      toolCard({ toolName: 'bash', status: 'done', inputSummary: 'ls -la /tmp' }),
+    );
+    expect(out).toContain('ls -la /tmp');
+  });
+
+  it('renders outputPreview when provided', () => {
+    const out = stripAnsi(
+      toolCard({ toolName: 'bash', status: 'done', outputPreview: 'total 42' }),
+    );
+    expect(out).toContain('total 42');
+  });
+
+  it('renders both on separate lines', () => {
+    const ls = lines(
+      toolCard({
+        toolName: 'bash',
+        status: 'done',
+        inputSummary: 'echo hello',
+        outputPreview: 'hello',
+      }),
+    );
+    expect(ls.some((l) => l.includes('echo hello'))).toBe(true);
+    expect(ls.some((l) => l.includes('hello'))).toBe(true);
+    // There should be at least 3 lines: header + input + output
+    expect(ls.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('omits body lines when inputs are empty strings', () => {
+    const out = toolCard({
+      toolName: 'bash',
+      status: 'done',
+      inputSummary: '',
+      outputPreview: '',
+    });
+    expect(lines(out)).toHaveLength(1);
+  });
+});
+
+// ─── Width truncation ─────────────────────────────────────────────────────────
+
+describe('toolCard – width truncation', () => {
+  it('truncates a very long tool name to fit width', () => {
+    const longName = 'a'.repeat(200);
+    const out = lines(toolCard({ toolName: longName, status: 'done', width: 40 }))[0]!;
+    // Strip ANSI before measuring
+    const plain = stripAnsi(out);
+    // Should not exceed width significantly (badge + name + possible elapsed)
+    expect(plain.length).toBeLessThanOrEqual(42); // allow 2 cols of slack
+  });
+
+  it('truncates inputSummary to fit within width', () => {
+    const longInput = 'x'.repeat(300);
+    const ls = lines(
+      toolCard({ toolName: 'bash', status: 'done', inputSummary: longInput, width: 50 }),
+    );
+    const bodyLine = stripAnsi(ls[1] ?? '');
+    // The body line should be shorter than the original (300 chars) due to truncation
+    expect(bodyLine.trimEnd().length).toBeLessThanOrEqual(52);
+  });
+
+  it('truncates diff file path to fit width', () => {
+    const longFile = '/very/long/path/'.repeat(10) + 'file.ts';
+    const ls = lines(
+      toolCard({
+        toolName: 'edit_file',
+        status: 'done',
+        diff: { added: 1, removed: 1, file: longFile },
+        width: 60,
+      }),
+    );
+    const diffLine = stripAnsi(ls.find((l) => l.includes('+1')) ?? '');
+    expect(diffLine.trimEnd().length).toBeLessThanOrEqual(62);
+  });
+});
+
+// ─── Minimal spec ────────────────────────────────────────────────────────────
+
+describe('toolCard – minimal spec', () => {
+  it('renders with only toolName and status', () => {
+    const out = toolCard({ toolName: 'bash', status: 'done' });
+    expect(lines(out)).toHaveLength(1);
+    expect(stripAnsi(out)).toContain('bash');
+    expect(stripAnsi(out)).toContain('✓');
+  });
+
+  it('returns a non-empty string', () => {
+    expect(toolCard({ toolName: '', status: 'running' }).length).toBeGreaterThan(0);
+  });
+
+  it('handles very small width without crashing', () => {
+    expect(() =>
+      toolCard({ toolName: 'bash', status: 'done', width: 1 }),
+    ).not.toThrow();
+  });
+});

--- a/src/cli/render/tool-card.test.ts
+++ b/src/cli/render/tool-card.test.ts
@@ -232,3 +232,58 @@ describe('toolCard – minimal spec', () => {
     ).not.toThrow();
   });
 });
+
+// ─── Sanitization (P1) ───────────────────────────────────────────────────────
+
+describe('toolCard – sanitization of untrusted input', () => {
+  it('strips ANSI escape sequences from outputPreview', () => {
+    const malicious = '\x1b[2J\x1b[Hinjected';
+    const out = stripAnsi(
+      toolCard({ toolName: 'bash', status: 'done', outputPreview: malicious }),
+    );
+    // The injected payload text may survive but the raw escape sequences must not
+    expect(out).not.toContain('\x1b[2J');
+    expect(out).not.toContain('\x1b[H');
+  });
+
+  it('strips ANSI escape sequences from inputSummary', () => {
+    const malicious = '\x1b]0;evil title\x07normal';
+    const out = stripAnsi(
+      toolCard({ toolName: 'bash', status: 'done', inputSummary: malicious }),
+    );
+    expect(out).not.toContain('\x1b]');
+    expect(out).toContain('normal');
+  });
+
+  it('strips ANSI escape sequences from toolName', () => {
+    const malicious = '\x1b[1mbold\x1b[0m';
+    const out = stripAnsi(toolCard({ toolName: malicious, status: 'done' }));
+    expect(out).not.toContain('\x1b[');
+    expect(out).toContain('bold');
+  });
+});
+
+// ─── Narrow width (P2) ───────────────────────────────────────────────────────
+
+describe('toolCard – narrow terminal width', () => {
+  it('does not widen output beyond a narrow caller budget (width=10)', () => {
+    const out = lines(
+      toolCard({ toolName: 'bash', status: 'done', width: 10 }),
+    )[0]!;
+    // stripAnsi first, then measure visible width
+    expect(stripAnsi(out).length).toBeLessThanOrEqual(12); // 2 col slack for badge+space
+  });
+
+  it('does not widen output beyond a very narrow budget (width=5)', () => {
+    const out = lines(
+      toolCard({ toolName: 'read_file', status: 'done', width: 5 }),
+    )[0]!;
+    expect(stripAnsi(out).length).toBeLessThanOrEqual(7);
+  });
+
+  it('renders without crashing at width=1', () => {
+    expect(() =>
+      toolCard({ toolName: 'bash', status: 'done', inputSummary: 'x', outputPreview: 'y', width: 1 }),
+    ).not.toThrow();
+  });
+});

--- a/src/cli/render/tool-card.ts
+++ b/src/cli/render/tool-card.ts
@@ -1,0 +1,153 @@
+import { displayWidth, truncateDisplayWidth } from '../display.js';
+import { palette } from '../palette.js';
+import { statusBadge } from './status-badge.js';
+import { formatElapsed } from './utils.js';
+
+// ─── ToolCard ─────────────────────────────────────────────────────────────────
+
+/**
+ * Configuration for {@link toolCard}.
+ *
+ * Models a single completed or in-flight tool call.  The `collapsed` flag
+ * gates whether the body lines (input summary, output preview, diff stat)
+ * are rendered — a collapsed card shows only the header, which is useful
+ * for long scrollback regions that want to conserve vertical space.
+ */
+export interface ToolCardSpec {
+  /** Display name of the tool being called. */
+  toolName: string;
+  /** Current lifecycle state of the tool call. */
+  status: 'running' | 'done' | 'error' | 'blocked';
+  /** Elapsed wall-clock time in milliseconds. */
+  elapsed?: number;
+  /** Truncated first argument — file path, shell command, URL, etc. */
+  inputSummary?: string;
+  /** Truncated tool output — first meaningful line of the result. */
+  outputPreview?: string;
+  /** Diff statistics for edit_file / write_file results. */
+  diff?: { added: number; removed: number; file: string };
+  /**
+   * When `true`, only the header line is rendered.
+   *
+   * Callers that manage scrollback regions can collapse cards for tools that
+   * have already been acknowledged, reducing vertical noise.
+   */
+  collapsed?: boolean;
+  /**
+   * Terminal column width used for truncation.
+   *
+   * Defaults to 80.  The component never reads `process.stdout.columns`
+   * directly so it remains a pure spec → string transform.
+   */
+  width?: number;
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** Left indent applied to body lines (keeps them visually below the badge). */
+const INDENT = '  ';
+
+/** Minimum width guard — prevents arithmetic from going negative. */
+const MIN_WIDTH = 20;
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Render a collapsible tool-call display with a status badge.
+ *
+ * Visual output (expanded, done):
+ *   ✓ bash  3s
+ *     ls -la /tmp
+ *     drwxr-xr-x  8 root  wheel  256 Jan  1 00:00 .
+ *     +2 -0  /tmp/newfile.txt
+ *
+ * Visual output (collapsed or no body):
+ *   ✓ bash  3s
+ *
+ * Visual output (running, no elapsed):
+ *   ● read_file
+ *
+ * Pure function — no side effects.  All ANSI styling is applied via the
+ * project palette so the card follows the active theme (dark / light / umber).
+ *
+ * @param spec - Tool card configuration.
+ * @returns Multi-line ANSI string (or single-line when collapsed / no body).
+ */
+export function toolCard(spec: ToolCardSpec): string {
+  const width = Math.max(MIN_WIDTH, spec.width ?? 80);
+  const collapsed = spec.collapsed ?? false;
+
+  // ── Header ──────────────────────────────────────────────────────────────────
+  const header = buildHeader(spec, width);
+
+  if (collapsed) return header;
+
+  // ── Body lines (optional) ────────────────────────────────────────────────────
+  const body: string[] = [];
+  const bodyWidth = Math.max(1, width - displayWidth(INDENT));
+
+  if (spec.inputSummary != null && spec.inputSummary.length > 0) {
+    const truncated = truncateDisplayWidth(spec.inputSummary, bodyWidth);
+    body.push(INDENT + palette.dim(truncated));
+  }
+
+  if (spec.outputPreview != null && spec.outputPreview.length > 0) {
+    const truncated = truncateDisplayWidth(spec.outputPreview, bodyWidth);
+    body.push(INDENT + palette.dim(truncated));
+  }
+
+  if (spec.diff != null) {
+    body.push(INDENT + buildDiffStat(spec.diff, bodyWidth));
+  }
+
+  if (body.length === 0) return header;
+  return [header, ...body].join('\n');
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Build the single-line header: `<badge> <toolName>  <elapsed?>`.
+ *
+ * The tool name is truncated so the assembled header never exceeds `width`.
+ */
+function buildHeader(spec: ToolCardSpec, width: number): string {
+  const badge = statusBadge(spec.status);
+  // badge renders as 1 display column; add 1 for the trailing space.
+  const badgeReserved = 2;
+
+  const elapsedStr =
+    spec.elapsed != null ? '  ' + palette.dim(formatElapsed(spec.elapsed)) : '';
+  // Measure plain-text width of elapsed (ANSI stripped by formatElapsed,
+  // but the leading two spaces are unstyled so we measure the raw string).
+  const elapsedPlain = spec.elapsed != null ? '  ' + formatElapsed(spec.elapsed) : '';
+  const elapsedReserved = displayWidth(elapsedPlain);
+
+  const nameMax = Math.max(1, width - badgeReserved - elapsedReserved);
+  const nameTruncated = truncateDisplayWidth(spec.toolName, nameMax);
+  const nameStyled = palette.tool(nameTruncated);
+
+  return `${badge} ${nameStyled}${elapsedStr}`;
+}
+
+/**
+ * Build the diff-stat line: `+N -M  file`.
+ *
+ * Added columns are green, removed are red, the separator and file path are dim.
+ */
+function buildDiffStat(
+  diff: { added: number; removed: number; file: string },
+  maxWidth: number,
+): string {
+  const addedStr = palette.diffAdd(`+${diff.added}`);
+  const removedStr = palette.diffRemove(`-${diff.removed}`);
+  // Two spaces between stat and file path.
+  const statPlain = `+${diff.added} -${diff.removed}  `;
+  const statWidth = displayWidth(statPlain);
+
+  const fileMax = Math.max(1, maxWidth - statWidth);
+  const fileTruncated = truncateDisplayWidth(diff.file, fileMax);
+  const fileStyled = palette.dim(fileTruncated);
+
+  return `${addedStr} ${removedStr}  ${fileStyled}`;
+}

--- a/src/cli/render/tool-card.ts
+++ b/src/cli/render/tool-card.ts
@@ -148,7 +148,7 @@ function buildDiffStat(
   const statWidth = displayWidth(statPlain);
 
   const fileMax = Math.max(1, maxWidth - statWidth);
-  const fileTruncated = truncateDisplayWidth(diff.file, fileMax);
+  const fileTruncated = truncateDisplayWidth(sanitizeForDisplay(diff.file), fileMax);
   const fileStyled = palette.dim(fileTruncated);
 
   return `${addedStr} ${removedStr}  ${fileStyled}`;

--- a/src/cli/render/tool-card.ts
+++ b/src/cli/render/tool-card.ts
@@ -1,3 +1,4 @@
+import { sanitizeForDisplay } from '../../utils/terminal-sanitize.js';
 import { displayWidth, truncateDisplayWidth } from '../display.js';
 import { palette } from '../palette.js';
 import { statusBadge } from './status-badge.js';
@@ -47,8 +48,6 @@ export interface ToolCardSpec {
 /** Left indent applied to body lines (keeps them visually below the badge). */
 const INDENT = '  ';
 
-/** Minimum width guard — prevents arithmetic from going negative. */
-const MIN_WIDTH = 20;
 
 // ─── Public API ───────────────────────────────────────────────────────────────
 
@@ -74,7 +73,7 @@ const MIN_WIDTH = 20;
  * @returns Multi-line ANSI string (or single-line when collapsed / no body).
  */
 export function toolCard(spec: ToolCardSpec): string {
-  const width = Math.max(MIN_WIDTH, spec.width ?? 80);
+  const width = Math.max(1, spec.width ?? 80);
   const collapsed = spec.collapsed ?? false;
 
   // ── Header ──────────────────────────────────────────────────────────────────
@@ -87,12 +86,14 @@ export function toolCard(spec: ToolCardSpec): string {
   const bodyWidth = Math.max(1, width - displayWidth(INDENT));
 
   if (spec.inputSummary != null && spec.inputSummary.length > 0) {
-    const truncated = truncateDisplayWidth(spec.inputSummary, bodyWidth);
+    const sanitized = sanitizeForDisplay(spec.inputSummary);
+    const truncated = truncateDisplayWidth(sanitized, bodyWidth);
     body.push(INDENT + palette.dim(truncated));
   }
 
   if (spec.outputPreview != null && spec.outputPreview.length > 0) {
-    const truncated = truncateDisplayWidth(spec.outputPreview, bodyWidth);
+    const sanitized = sanitizeForDisplay(spec.outputPreview);
+    const truncated = truncateDisplayWidth(sanitized, bodyWidth);
     body.push(INDENT + palette.dim(truncated));
   }
 
@@ -124,7 +125,8 @@ function buildHeader(spec: ToolCardSpec, width: number): string {
   const elapsedReserved = displayWidth(elapsedPlain);
 
   const nameMax = Math.max(1, width - badgeReserved - elapsedReserved);
-  const nameTruncated = truncateDisplayWidth(spec.toolName, nameMax);
+  const nameSanitized = sanitizeForDisplay(spec.toolName);
+  const nameTruncated = truncateDisplayWidth(nameSanitized, nameMax);
   const nameStyled = palette.tool(nameTruncated);
 
   return `${badge} ${nameStyled}${elapsedStr}`;


### PR DESCRIPTION
## Summary

Adds the `ToolCard` component — a collapsible tool-call display with status badge — as part of the render primitive library. Closes #1323.

**Stacks on**: `feat/render-primitives` (PR with `statusBadge`, `drawBox`, `streamProgress`, `subagentStatusBar` primitives). Base branch is `feat/render-primitives`, not `main`.

## Component API

```typescript
export interface ToolCardSpec {
  toolName: string;
  status: 'running' | 'done' | 'error' | 'blocked';
  elapsed?: number;        // ms
  inputSummary?: string;   // truncated first arg (file path, command, etc.)
  outputPreview?: string;  // truncated result
  diff?: { added: number; removed: number; file: string };
  collapsed?: boolean;     // header-only mode
  width?: number;          // terminal width, default 80
}

export function toolCard(spec: ToolCardSpec): string;
```

## Visual output

```
✓ bash  3s
  ls -la /tmp
  drwxr-xr-x  8 root  wheel  256 Jan  1 00:00 .
  +2 -0  /tmp/newfile.txt

● read_file          ← running, no elapsed

✗ write_file  12s   ← error, collapsed=true (single line)
```

## Design

- Header: `statusBadge()` glyph + `palette.tool` name + `palette.dim` elapsed via `formatElapsed`
- Input summary / output preview: `palette.dim`, width-truncated
- Diff stat: `palette.diffAdd` (+N) + `palette.diffRemove` (-M) + `palette.dim` file path
- Collapsed mode: header line only
- Pure function — no side effects, no terminal reads; `width` param for truncation
- Palette-only: never raw chalk

## Files

| File | LOC |
|---|---|
| `src/cli/render/tool-card.ts` | 153 |
| `src/cli/render/tool-card.test.ts` | 234 |
| `src/cli/render/index.ts` | +1 (barrel export) |

## Tests (23 passing)

- All 4 status variants (running/done/error/blocked)
- Collapsed mode — single line even with full body fields
- Elapsed formatting (<1s, Ns, Nm Ns)
- Diff stat line appearance and placement
- Input summary and output preview rendering
- Width truncation (tool name, input, diff file path)
- Minimal/empty spec — no crash

## Wiring

Wiring into `tool-lane-render.ts` is **deferred**. The scrollback flush path spans 5+ coupled files (`tool-lane.ts`, `tool-lane-render.ts`, `tool-lane-render-agent.ts`, `tool-lane-render-grouping.ts`, `tool-lane-format.ts`). The component ships as an exported API that live-render callers can adopt incrementally — the exported `toolCard()` function is immediately usable by any future wiring PR.

## Pre-existing filesize failures

`audit:filesize:check` reports pre-existing baseline overflows in `openai-compatible/query.ts` (+9 LOC) and `stream-consumer.ts` (+1 LOC). Neither file was touched in this PR.
