### PR TITLE
fix(render): formatTokenCount boundary shows '100.0k' at 99999 (#1328)

### DIFF
--- a/src/cli/render/stream-progress.test.ts
+++ b/src/cli/render/stream-progress.test.ts
@@ -59,6 +59,36 @@ describe('streamProgress', () => {
     expect(result).toContain('42 tokens');
   });
 
+  it('uses .toFixed(1) just below the 10k boundary', () => {
+    const result = stripAnsi(
+      streamProgress({ label: 'test', spinnerFrame: 0, elapsedMs: 1000, tokenCount: 9999 }),
+    );
+    expect(result).toContain('10.0k tokens');
+  });
+
+  it('uses Math.round at exactly the 10k boundary', () => {
+    const result = stripAnsi(
+      streamProgress({ label: 'test', spinnerFrame: 0, elapsedMs: 1000, tokenCount: 10000 }),
+    );
+    expect(result).toContain('10k tokens');
+    expect(result).not.toContain('10.0k');
+  });
+
+  it('renders 99999 as "100k tokens" not "100.0k tokens"', () => {
+    const result = stripAnsi(
+      streamProgress({ label: 'test', spinnerFrame: 0, elapsedMs: 1000, tokenCount: 99999 }),
+    );
+    expect(result).toContain('100k tokens');
+    expect(result).not.toContain('100.0k');
+  });
+
+  it('renders 100000 as "100k tokens"', () => {
+    const result = stripAnsi(
+      streamProgress({ label: 'test', spinnerFrame: 0, elapsedMs: 1000, tokenCount: 100000 }),
+    );
+    expect(result).toContain('100k tokens');
+  });
+
   it('renders M suffix for large counts', () => {
     const result = stripAnsi(
       streamProgress({

--- a/src/cli/render/stream-progress.ts
+++ b/src/cli/render/stream-progress.ts
@@ -63,7 +63,7 @@ export interface StreamProgressSpec {
 /** Format token count with k/M suffixes. */
 function formatTokenCount(tokens: number): string {
   if (tokens < 1000) return `${tokens} tokens`;
-  if (tokens < 100_000) return `${(tokens / 1000).toFixed(1)}k tokens`;
+  if (tokens < 10_000) return `${(tokens / 1000).toFixed(1)}k tokens`;
   if (tokens < 1_000_000) return `${Math.round(tokens / 1000)}k tokens`;
   return `${(tokens / 1_000_000).toFixed(1)}M tokens`;
 }


### PR DESCRIPTION
Fixes #1328.

`formatTokenCount(99999)` yielded `"100.0k tokens"` because the `.toFixed(1)` boundary was at 100,000. Lowered it to 10,000 so values >= 10k use `Math.round` (no trailing decimal).

### Changes
- `src/cli/render/stream-progress.ts` -- boundary from `100_000` to `10_000`
- `src/cli/render/stream-progress.test.ts` -- 4 boundary test cases added

### Verification
- 15/15 tests pass
- `pnpm lint` clean
