### PR TITLE
fix(subagent): sanitize id_prefix to prevent assertSafeJobId rejection (#1319)

### DIFF
--- a/src/agent/subagent/fork-resolution.test.ts
+++ b/src/agent/subagent/fork-resolution.test.ts
@@ -329,6 +329,37 @@ describe('id and resume', () => {
     expect(resolveForkInputs(args).id).toMatch(/^my-prefix-/);
   });
 
+  it('sanitizes idPrefix by replacing disallowed characters with hyphens (#1319)', () => {
+    // A model-supplied id_prefix containing dots, spaces, or other chars outside
+    // [A-Za-z0-9_-] would cause assertSafeJobId to throw in SubagentLogWriter.
+    // Verify they are replaced with '-' before the id is assembled.
+    const args = makeArgs({
+      options: {
+        parent: { sessionId: 'sid' },
+        config: { model: 'sonnet' },
+        agentType: 'a',
+        idPrefix: 'research.agent',
+      },
+      counter: 1,
+    });
+
+    expect(resolveForkInputs(args).id).toMatch(/^research-agent-/);
+  });
+
+  it('sanitizes idPrefix with spaces', () => {
+    const args = makeArgs({
+      options: {
+        parent: { sessionId: 'sid' },
+        config: { model: 'sonnet' },
+        agentType: 'a',
+        idPrefix: 'my agent',
+      },
+      counter: 1,
+    });
+
+    expect(resolveForkInputs(args).id).toMatch(/^my-agent-/);
+  });
+
   it('defaults to "subagent" when idPrefix is omitted', () => {
     const args = makeArgs({
       options: {

--- a/src/agent/subagent/fork-resolution.ts
+++ b/src/agent/subagent/fork-resolution.ts
@@ -92,7 +92,8 @@ export interface ForkResolved {
 export function resolveForkInputs(args: ResolveForkInputsArgs): ForkResolved {
   const { options, counter, managerHookRegistry, parentTraceWriter, parentModel } = args;
 
-  const id = `${options.idPrefix ?? 'subagent'}-${Date.now()}-${counter}`;
+  const safePrefix = (options.idPrefix ?? 'subagent').replace(/[^A-Za-z0-9_-]/g, '-');
+  const id = `${safePrefix}-${Date.now()}-${counter}`;
   const resume = options.parent.sessionId;
 
   const registry =


### PR DESCRIPTION
Fixes #1319.

Model-supplied `id_prefix` values containing characters outside `[A-Za-z0-9_-]` (dots, spaces, etc.) caused `assertSafeJobId` to throw from the log writer, aborting the entire fork. Now sanitized at the source.

### Changes
- `src/agent/subagent/fork-resolution.ts` -- sanitize `idPrefix` via `.replace(/[^A-Za-z0-9_-]/g, '-')` before interpolating into fork id
- `src/agent/subagent/fork-resolution.test.ts` -- 2 test cases for dot and space sanitization

### Verification
- 21/21 tests pass
- `pnpm lint` clean
