### PR TITLE
fix(subagent-log): document one-line overshoot contract and tighten cap test (#1316)

### DIFF
--- a/src/agent/subagent/log.test.ts
+++ b/src/agent/subagent/log.test.ts
@@ -174,19 +174,26 @@ describe('SubagentLogWriter.close flushes pending lines', () => {
 // ---------------------------------------------------------------------------
 
 describe('MAX_LOG_BYTES cap', () => {
-  it('file does not exceed 1 MiB even when many large events are written', async () => {
+  it('file does not exceed MAX_LOG_BYTES + one line (one-line overshoot contract)', async () => {
     const subId = 'sub-overflow';
     const w = new SubagentLogWriter(SESSION, subId);
 
     // Write ~2MB worth of events (each ~2KB) to exceed the 1MB cap
     const payload = 'x'.repeat(2000);
+    // Compute the exact serialized byte length of one event line so the
+    // assertion reflects the documented one-line-overshoot invariant precisely.
+    const oneLineBytes = Buffer.byteLength(
+      JSON.stringify(makeChunkEvent(payload)) + '\n',
+      'utf8',
+    );
     for (let i = 0; i < 1200; i++) {
       w.write(makeChunkEvent(payload));
     }
     await w.close();
 
     const stat = fs.statSync(w.logPath);
-    // File must be ≤ 1 MiB (with some tolerance for the final incomplete line)
-    expect(stat.size).toBeLessThanOrEqual(1_048_576 + 2100);
+    // The cap guard fires before serialization, so the last admitted line may
+    // push the file to MAX_LOG_BYTES + oneLineBytes. Assert the exact bound.
+    expect(stat.size).toBeLessThanOrEqual(1_048_576 + oneLineBytes);
   });
 });

--- a/src/agent/subagent/log.ts
+++ b/src/agent/subagent/log.ts
@@ -65,6 +65,13 @@ export class SubagentLogWriter {
   /**
    * Append an OutputEvent as a JSONL line.
    * Silently no-ops on error, after close, or when the file exceeds MAX_LOG_BYTES.
+   *
+   * Invariant: the cap allows a one-line overshoot. The guard fires before
+   * serialization, so the last admitted event may push the file up to
+   * MAX_LOG_BYTES + <size of that serialized line>. writeLine() applies the
+   * same guard, so the overshoot is bounded by the byte length of a single
+   * serialized event (in practice, ≤ a few KB). This is intentional — a
+   * strict hard cap would require a costly split across the line boundary.
    */
   write(event: OutputEvent): void {
     if (this.errored || this.closed || this.bytesWritten >= MAX_LOG_BYTES) return;


### PR DESCRIPTION
Fixes #1316.

Documents the one-line overshoot contract in the `write()` method (the cap guard fires before serialization, so the last admitted line can push the file past `MAX_LOG_BYTES` by one event) and tightens the test to compute the exact bound from the serialized event size rather than using a magic `+ 2100` tolerance.

### Changes
- `src/agent/subagent/log.ts` -- `Invariant:` comment on the overshoot contract
- `src/agent/subagent/log.test.ts` -- computed `oneLineBytes` replaces hardcoded tolerance

### Verification
- 10/10 tests pass
- `pnpm lint` clean
