### PR TITLE
fix(subagent-log): default AFK_SUBAGENT_LOG to off — raw tool args written without redaction (#1318)

### DIFF
--- a/docs/env-registry.json
+++ b/docs/env-registry.json
@@ -754,10 +754,10 @@
     },
     {
       "name": "AFK_SUBAGENT_LOG",
-      "description": "Always-on per-subagent conversation log. Writes OutputEvent JSONL to state/subagent-logs/<sessionLabel>/<subagentId>.jsonl for both foreground and background subagents. Powers /tasks:view replay. ON by default; set to 0 to disable.",
+      "description": "Opt-in per-subagent conversation log. Writes OutputEvent JSONL to state/subagent-logs/<sessionLabel>/<subagentId>.jsonl for both foreground and background subagents. Powers /tasks:view replay. OFF by default (raw tool arguments are written without redaction — consistent with AFK_CAPTURE_SUBAGENT_PROMPTS / AFK_CAPTURE_SUBAGENT_OUTPUT). Set to 1 to enable.",
       "type": "boolean",
       "required": false,
-      "default": "1",
+      "example": "1",
       "category": "debug"
     },
     {

--- a/docs/env-registry.md
+++ b/docs/env-registry.md
@@ -173,7 +173,7 @@ To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV
 | `AFK_SESSION_MAX_COUNT` | number |  | `1000` |  | Count-based safety valve: evict oldest session sidecars first once the total exceeds this number. Default 1000. |
 | `AFK_SESSION_RETENTION_DISABLE` | boolean |  |  | `1` | Disable the session sidecar retention sweep entirely, so no state/sessions/*.json file is ever evicted. |
 | `AFK_SKILL_STREAM_VERBOSE` | boolean |  |  |  | Verbose streaming output when a skill is dispatched. Logs sub-agent setup, intermediate events, and final result. |
-| `AFK_SUBAGENT_LOG` | boolean |  | `1` |  | Always-on per-subagent conversation log. Writes OutputEvent JSONL to state/subagent-logs/<sessionLabel>/<subagentId>.jsonl for both foreground and background subagents. Powers /tasks:view replay. ON by default; set to 0 to disable. |
+| `AFK_SUBAGENT_LOG` | boolean |  |  | `1` | Opt-in per-subagent conversation log. Writes OutputEvent JSONL to state/subagent-logs/<sessionLabel>/<subagentId>.jsonl for both foreground and background subagents. Powers /tasks:view replay. OFF by default (raw tool arguments are written without redaction — consistent with AFK_CAPTURE_SUBAGENT_PROMPTS / AFK_CAPTURE_SUBAGENT_OUTPUT). Set to 1 to enable. |
 | `AFK_TELEGRAM_TRACE` | boolean |  |  | `1` | Set to 1 to dump raw bridge traffic between the agent and the Telegram bot — debugging only. |
 | `AFK_TRACE_DISABLED` | boolean |  |  | `1` | Disable the agent trace subsystem entirely. Set to 1 to skip trace file writes. |
 | `AFK_WITNESS_MAX_AGE_DAYS` | number |  | `30` |  | Evict a witness session directory once its newest content is older than this many days. Default 30. |

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -437,7 +437,7 @@ export class SubagentManager {
       effectiveAgentType = options.agentType?.trim() || undefined;
       effectiveResolvedAgentType = options.resolvedAgentType?.trim() || undefined;
       const effectiveParentId = options.parentId?.trim() || undefined;
-      // Per-subagent conversation log — always on unless AFK_SUBAGENT_LOG=0.
+      // Per-subagent conversation log — opt-in via AFK_SUBAGENT_LOG=1 (off by default).
       // Use sessionLabel (the directory key for /tasks) rather than
       // options.parent.sessionId (the SDK runtime ID): writer and reader must
       // agree on the same key so logs are found after the handle is evicted.

--- a/src/agent/subagent/log.test.ts
+++ b/src/agent/subagent/log.test.ts
@@ -48,7 +48,7 @@ function makeMessageEvent(): OutputEvent {
 }
 
 // ---------------------------------------------------------------------------
-// isEnabled opt-out
+// isEnabled opt-in (#1318: default changed from on to off)
 // ---------------------------------------------------------------------------
 
 describe('SubagentLogWriter.isEnabled', () => {
@@ -57,9 +57,9 @@ describe('SubagentLogWriter.isEnabled', () => {
     vi.restoreAllMocks();
   });
 
-  it('returns true when AFK_SUBAGENT_LOG is unset', () => {
+  it('returns false when AFK_SUBAGENT_LOG is unset (off by default)', () => {
     delete process.env['AFK_SUBAGENT_LOG'];
-    expect(SubagentLogWriter.isEnabled()).toBe(true);
+    expect(SubagentLogWriter.isEnabled()).toBe(false);
   });
 
   it('returns false when AFK_SUBAGENT_LOG=0', () => {

--- a/src/agent/subagent/log.ts
+++ b/src/agent/subagent/log.ts
@@ -1,14 +1,17 @@
 /**
- * Always-on per-subagent conversation JSONL logger.
+ * Opt-in per-subagent conversation JSONL logger.
  *
  * `SubagentLogWriter` records every `OutputEvent` from a subagent's
  * `sendMessageStream` into a JSONL file at
  * `~/.afk/state/subagent-logs/<sessionLabel>/<subagentId>.jsonl`.
  * This powers the `/tasks:view` replay command.
  *
- * Unlike `BgJobLogWriter` (background-job-only), this fires for ALL
- * subagents (foreground and background) unless opted out via
- * `AFK_SUBAGENT_LOG=0`.
+ * OFF by default. Raw tool arguments (bash commands, file paths, API keys)
+ * are serialised without redaction — consistent with the opt-in posture of
+ * `AFK_CAPTURE_SUBAGENT_PROMPTS` / `AFK_CAPTURE_SUBAGENT_OUTPUT`.
+ * Enable by setting `AFK_SUBAGENT_LOG=1`.
+ *
+ * When enabled, fires for ALL subagents (foreground and background).
  *
  * Design mirrors `BgJobLogWriter` — lazy stream open, pending-line queue,
  * silent error suppression (subagent must never fail due to log IO).
@@ -57,9 +60,9 @@ export class SubagentLogWriter {
     }
   }
 
-  /** Whether subagent logging is enabled (not opted out). */
+  /** Whether subagent logging is enabled (opt-in via AFK_SUBAGENT_LOG=1). */
   static isEnabled(): boolean {
-    return env.AFK_SUBAGENT_LOG !== '0';
+    return env.AFK_SUBAGENT_LOG === '1';
   }
 
   /**

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1441,12 +1441,14 @@ export const ENV_REGISTRY: readonly EnvVarMeta[] = [
   {
     name: 'AFK_SUBAGENT_LOG',
     description:
-      'Always-on per-subagent conversation log. Writes OutputEvent JSONL to ' +
+      'Opt-in per-subagent conversation log. Writes OutputEvent JSONL to ' +
       'state/subagent-logs/<sessionLabel>/<subagentId>.jsonl for both foreground and ' +
-      'background subagents. Powers /tasks:view replay. ON by default; set to 0 to disable.',
+      'background subagents. Powers /tasks:view replay. OFF by default (raw tool arguments ' +
+      'are written without redaction — consistent with AFK_CAPTURE_SUBAGENT_PROMPTS / ' +
+      'AFK_CAPTURE_SUBAGENT_OUTPUT). Set to 1 to enable.',
     type: 'boolean',
     required: false,
-    default: '1',
+    example: '1',
     category: 'debug',
   },
   {


### PR DESCRIPTION
Fixes #1318.

**P1 security fix.** `SubagentLogWriter` serialized full `OutputEvent` objects including raw tool argument payloads (bash commands, file paths, potentially API keys) to disk. This was always-on by default (`AFK_SUBAGENT_LOG=1`), circumventing the trace subsystem's deliberate privacy posture of storing only `inputBytes`.

Changed the default to off (`AFK_SUBAGENT_LOG=0`), consistent with the opt-in posture of `AFK_CAPTURE_SUBAGENT_PROMPTS` and `AFK_CAPTURE_SUBAGENT_OUTPUT`.

### Changes
- `src/config/env.ts` -- removed `default: '1'`, added `example: '1'`
- `src/agent/subagent/log.ts` -- `isEnabled()` from `!== '0'` to `=== '1'`
- `src/agent/subagent.ts` -- updated inline comment
- `src/agent/subagent/log.test.ts` -- updated unset-case expectation
- `docs/env-registry.json` + `docs/env-registry.md` -- synced

### Verification
- 10/10 tests pass
- `pnpm lint` clean
