### PR TITLE
feat(render): reorder model name leftward in status line for visibility (#1343)

### DIFF
--- a/src/cli/status-line.test.ts
+++ b/src/cli/status-line.test.ts
@@ -613,7 +613,7 @@ describe('StatusLine with cwd field', () => {
     status.stop();
   });
 
-  it('places cwd before model so right-edge truncation preserves it', () => {
+  it('places model before cwd so it is the leftmost informational chip (#1343)', () => {
     const status = new StatusLine({
       stream: stream as unknown as NodeJS.WriteStream,
       throttleMs: 0,
@@ -625,7 +625,8 @@ describe('StatusLine with cwd field', () => {
     const cwdIdx = out.indexOf('/tmp/foo');
     const modelIdx = out.indexOf('sonnet');
     expect(cwdIdx).toBeGreaterThanOrEqual(0);
-    expect(modelIdx).toBeGreaterThan(cwdIdx);
+    expect(modelIdx).toBeGreaterThanOrEqual(0);
+    expect(modelIdx).toBeLessThan(cwdIdx); // model is leftmost — appears before cwd (#1343)
     status.stop();
   });
 });
@@ -683,7 +684,7 @@ describe('StatusLine with git branch + PR field', () => {
     status.stop();
   });
 
-  it('places the branch after cwd and before the model', () => {
+  it('places model before cwd and branch so it is the leftmost informational chip (#1343)', () => {
     const status = new StatusLine({ stream: stream as unknown as NodeJS.WriteStream, throttleMs: 0 });
     status.start();
     stream.writes.length = 0;
@@ -693,8 +694,8 @@ describe('StatusLine with git branch + PR field', () => {
     const branchIdx = out.indexOf('feat/x');
     const modelIdx = out.indexOf('sonnet');
     expect(cwdIdx).toBeGreaterThanOrEqual(0);
-    expect(branchIdx).toBeGreaterThan(cwdIdx);
-    expect(modelIdx).toBeGreaterThan(branchIdx);
+    expect(branchIdx).toBeGreaterThan(cwdIdx); // branch still follows cwd
+    expect(modelIdx).toBeLessThan(cwdIdx); // model now precedes cwd and branch (#1343)
     status.stop();
   });
 

--- a/src/cli/status-line.ts
+++ b/src/cli/status-line.ts
@@ -428,14 +428,16 @@ export class StatusLine {
   }
 
   private formatLine(f: StatusLineFields): string {
-    // Invariant: parts are built in semantic order (cwd/branch, model, plan,
+    // Invariant: parts are built in semantic order (model, cwd/branch, plan,
     // context, cost, tokens), tagged with droppability priority so narrow
     // terminals can shed lower-priority fields before resorting to right-edge
     // truncation that arbitrarily loses model info. Drop order (drop-first →
     // drop-last): tokens → cost → context bar → branch. The branch drops LAST
     // among droppables because it is identity ("which branch am I on?"), like
-    // cwd. Never drop: cwd, model, plan. When cwd and branch are deduped into
-    // one merged segment (see worktreeDedupe below), that segment inherits the
+    // cwd. Never drop: model, cwd, plan. Model is pushed FIRST (#1343) so it
+    // occupies the leftmost slot — the position the eye reaches first when
+    // scanning a narrow tmux pane. When cwd and branch are deduped into one
+    // merged segment (see worktreeDedupe below), that segment inherits the
     // branch's droppablePriority 1 (drop-last among droppables), NOT never-drop:
     // a never-drop location there would stack with the never-drop model and
     // force right-edge truncation to lose model info on a narrow terminal, so
@@ -457,6 +459,14 @@ export class StatusLine {
     // so none of the drop/truncate math below is affected.
     let parts: Part[] = [];
     const maxW = Math.max(4, (this.stream.columns ?? 80) - 2);
+
+    // Model chip is pushed FIRST so it appears at the leftmost informational
+    // position. It is never-drop, so the shed loop never removes it; placing it
+    // first also protects it from right-edge truncation — any right-edge shear
+    // always hits the rightmost fields (tokens, cost, context) first. This moves
+    // the most glanceable identity field to the position the eye hits earliest
+    // when scanning a narrow tmux pane (#1343).
+    parts.push({ text: palette.brand(f.model) }); // never drop
 
     // Invariant: afk-worktree cwd/branch dedupe. `.afk-worktrees/<slug>`
     // directories are named by replacing `/` with `-` in the branch that
@@ -528,8 +538,6 @@ export class StatusLine {
 
     // Trusted-skill in-flight indicator no longer renders on the status line;
     // it is emitted inline via completionWriter (see bootstrap.ts).
-    parts.push({ text: palette.brand(f.model) }); // never drop
-
     if (f.permissionMode === 'plan') {
       parts.push({ text: palette.warning('● plan') }); // never drop
     } else if (f.permissionMode === 'autonomous') {


### PR DESCRIPTION
Fixes #1343.

Moved the model name chip to the leftmost position in the status line `parts[]` array, making it the first thing visible at a glance. The model chip was already `never-drop` (survives terminal width truncation), and being leftmost now also protects it from right-edge shearing.

### Changes
- `src/cli/status-line.ts` -- moved model push to top of `formatLine()`
- `src/cli/status-line.test.ts` -- updated 2 ordering assertions

### Verification
- 68/68 tests pass
- `pnpm lint` clean
