### PR TITLE
feat(render): wire toolCard into task-view + fix duplicate barrel export

### DIFF
--- a/src/cli/commands/interactive/task-view.ts
+++ b/src/cli/commands/interactive/task-view.ts
@@ -15,6 +15,7 @@
 import { palette } from '../../palette.js';
 import { renderMarkdownToTerminal } from '../../formatter.js';
 import { getTerminalWidth } from '../../terminal-size.js';
+import { toolCard } from '../../render/tool-card.js';
 import type { Message } from '../../../agent/types/message-types.js';
 
 // ---------------------------------------------------------------------------
@@ -127,15 +128,16 @@ function renderContentBlock(block: unknown): string {
   if (b['type'] === 'tool_use') {
     const name  = typeof b['name'] === 'string' ? b['name'] : '?';
     const input = b['input'] !== undefined ? JSON.stringify(b['input']) : '';
-    return [
-      palette.tool(`  ▶ tool_use: ${name}`),
-      input ? palette.dim(`    ${truncate(input, CONTENT_PREVIEW_CHARS)}`) : '',
-    ].filter(Boolean).join('\n');
+    return toolCard({
+      toolName: name,
+      status: 'running',
+      inputSummary: input ? truncate(input, CONTENT_PREVIEW_CHARS) : undefined,
+      width: Math.min(getTerminalWidth(), 100),
+    });
   }
 
   if (b['type'] === 'tool_result') {
     const isError = b['is_error'] === true;
-    const label   = isError ? palette.error('✗ tool_result') : palette.success('✓ tool_result');
     const content = b['content'];
     let preview   = '';
     if (typeof content === 'string') {
@@ -145,10 +147,14 @@ function renderContentBlock(block: unknown): string {
       const text  = first && typeof first['text'] === 'string' ? first['text'] : '';
       preview     = truncate(text, CONTENT_PREVIEW_CHARS);
     }
-    return [
-      `  ${label}`,
-      preview ? palette.dim(`    ${preview}`) : '',
-    ].filter(Boolean).join('\n');
+    // tool_result blocks don't carry the tool name (it's on the preceding
+    // tool_use block), so use a generic label.
+    return toolCard({
+      toolName: 'result',
+      status: isError ? 'error' : 'done',
+      outputPreview: preview || undefined,
+      width: Math.min(getTerminalWidth(), 100),
+    });
   }
 
   // Fallback: emit the block type as a dim badge.

--- a/src/cli/render/index.ts
+++ b/src/cli/render/index.ts
@@ -24,4 +24,3 @@ export * from './utils.js';
 export * from './tool-card.js';
 export * from './interrupt-peek.js';
 export * from './compact-diff-view.js';
-export * from './interrupt-peek.js';


### PR DESCRIPTION
## What

Wire the `toolCard()` component from the component library into its first live consumer, and fix a minor barrel export duplicate.

### 1. task-view.ts: toolCard integration

The `/task` history viewer previously hand-rendered `tool_use` and `tool_result` content blocks with ad-hoc `palette.tool()` / `palette.success()` / `palette.error()` calls and divergent glyph choices (`▶` for tool_use, `✓`/`✗` for tool_result). Now uses `toolCard()` from `src/cli/render/tool-card.ts`, which provides:

- Consistent status badges via `statusBadge()` (same glyphs as the live overlay)
- Sanitized input/output via `sanitizeForDisplay()`
- Width-aware truncation via `truncateDisplayWidth()`
- Collapsed/expanded support for future use

This is the first live consumer of `toolCard()` outside its unit tests. The component was built in sprint 0 (#1341) but had zero non-test call sites until now.

### 2. render/index.ts: remove duplicate export

`interrupt-peek.js` was re-exported twice (lines 25 and 27). Harmless but noisy.

## Why now

The component library initiative (started 2026-08-27) built 6 components, but shadow-verify confirmed only 2 of 6 were wired into live paths. This PR begins the integration sprint -- wiring existing components into their natural consumers rather than building new ones.

## Investigation findings

During this session, a full audit of the component library revealed:
- **SubagentStatusBar, InterruptPeek**: already live in the overlay (wired in sprint 0)
- **ErrorCard**: live in scrollback (wired in sprint 0)
- **ToolCard**: now live via this PR (task-view)
- **StreamProgress, CompactDiffView**: remain unintegrated -- their production counterparts (`formatProgressBanner`, `formatDiffBlock`) are more specialized (multi-line banner with thinking clauses/stopping state/parallel counts vs. single-line spinner; tree-embedded indented diff with WeakMap memoization/env toggles vs. boxed standalone diff). Forcing integration would regress the UX.
- **Loading-state feedback plan (2026-07-02)**: all 3 items already implemented (sanitizeLabel, semantic progress descriptions, lastProgressByTask cleared on finalize)

## Tests

- `task-view.test.ts`: 17/17 pass
- `tool-card.test.ts`: 30/30 pass
- `pnpm lint`: clean
- `fix:pins:check`: clean
