### PR TITLE
fix(#528): retire pathApprovalGrantRef + Gate 1/Gate 2 containment regression test

### DIFF
--- a/src/agent/default-hook-registry.ts
+++ b/src/agent/default-hook-registry.ts
@@ -24,7 +24,6 @@ import {
   type PathApprovalSurface,
 } from './tools/hooks/path-approval-hook.js';
 import { createBashRestrictionHook } from './tools/hooks/bash-restriction-hook.js';
-import type { GrantManager } from '../cli/slash/commands/allow-dir.js';
 import type { PermissionMode } from './types/sdk-types.js';
 import type { TraceSink } from './trace/index.js';
 import type { LoadedHooksConfig } from './hooks/config-loader.js';
@@ -40,24 +39,6 @@ export interface SubagentCompleteInfo {
 export interface DefaultHookRegistryResult {
   registry: HookRegistry;
   memoryStore: MemoryStore;
-  /**
-   * Mutable ref the surface bootstrap MUST populate with the active provider
-   * (which implements {@link GrantManager}) after session construction. Path-
-   * approval + bash-restriction hooks dereference this on every PreToolUse;
-   * leaving it null makes the path-approval hook fail OPEN — it skips the
-   * elicitation prompt (the typed-file-tool handler's own resolveAndContain
-   * still enforces containment), and the bash hook's restricted-root substring
-   * check also fails open. (The bash interpreter denylist still hard-blocks
-   * regardless — it runs before the grant-manager gate. See the registration
-   * block below for the full per-surface breakdown.)
-   *
-   * Wiring pattern (see `src/cli/commands/interactive/bootstrap.ts:532`):
-   *   pathApprovalGrantRef.current = provider;
-   *
-   * The same ref drives `setAllowDirDispatcher(provider)` callers — both
-   * read the live provider grant API.
-   */
-  pathApprovalGrantRef: { current: GrantManager | undefined };
 }
 
 /**
@@ -180,10 +161,11 @@ export function createDefaultHookRegistry(
   // path first when both could apply (e.g. an edit_file followed by a bash
   // grep against the same restricted root within one turn).
   //
-  // Invariant: only the REPL and Telegram bootstraps wire
-  // `pathApprovalGrantRef.current` (see bootstrap.ts / telegram bot.start).
-  // Headless surfaces (afk chat, daemon, threads) register these hooks but
-  // never wire the ref, so on those surfaces:
+  // Invariant: path-approval and bash-restriction hooks read the grant manager
+  // from `context.grantManager` (injected per-session by the dispatcher since
+  // #527; the former process-global ref was retired in #528). Headless surfaces
+  // (afk chat, daemon, threads) never wire a sessionGrantManager into the
+  // dispatcher, so on those surfaces:
   //   - path-approval PreToolUse: fails open (no prompt; the typed-tool
   //     handler's own resolveAndContain still enforces containment);
   //   - bash restricted-root substring check: fails open (no backstop);
@@ -193,9 +175,10 @@ export function createDefaultHookRegistry(
   //     blocked with no recourse. Opt headless flows back into the guard with
   //     AFK_FORCE_BASH_INTERPRETER_GUARD=1; disable the whole feature with
   //     AFK_DISABLE_PATH_APPROVAL=1.
-  const pathApprovalGrantRef: { current: GrantManager | undefined } = {
-    current: undefined,
-  };
+  //
+  // The former process-global `pathApprovalGrantRef` has been retired (#528).
+  // Both hooks now read the grant manager exclusively from `context.grantManager`
+  // — injected per-session by the dispatcher since #527.
   const disabled = env.AFK_DISABLE_PATH_APPROVAL === '1';
   if (disabled && !warnedPathApprovalDisabled) {
     warnedPathApprovalDisabled = true;
@@ -207,7 +190,6 @@ export function createDefaultHookRegistry(
   }
   if (!disabled) {
     const pathApproval = createPathApprovalHook({
-      getGrantManager: () => pathApprovalGrantRef.current,
       // Prefer an explicit getCwd callback (REPL/Telegram bootstrap thread a
       // live `extras.cwd`); otherwise fall back to the static cwd carried in
       // main's `agentOptions` (scheduler/chat/threads callers). Both feed the
@@ -233,7 +215,6 @@ export function createDefaultHookRegistry(
     registry.register(
       'PreToolUse',
       createBashRestrictionHook({
-        getGrantManager: () => pathApprovalGrantRef.current,
         // Granular knobs for the interpreter-eval denylist (the rest of
         // path-approval is unaffected; AFK_DISABLE_PATH_APPROVAL=1 short-
         // circuits the whole `if (!disabled)` block above):
@@ -314,7 +295,7 @@ export function createDefaultHookRegistry(
     });
   }
 
-  return { registry, memoryStore: store, pathApprovalGrantRef };
+  return { registry, memoryStore: store };
 }
 
 /**

--- a/src/agent/hooks.ts
+++ b/src/agent/hooks.ts
@@ -216,7 +216,7 @@ export interface PreToolUseContext {
    * cwd/readRoots/writeRoots rather than a process-global ref pinned to the
    * top-level session (the #435/#514 write-confinement gap). When absent
    * (non-dispatcher-originated dispatch, unit tests), those hooks fall back to
-   * their `opts.getGrantManager()` ref, preserving prior behavior.
+   * their per-session closure state, preserving prior behavior.
    */
   grantManager?: GrantManager;
 }

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -186,11 +186,10 @@ export interface SessionToolDispatcherOptions {
    * The PROVIDER that owns this dispatcher (it implements {@link GrantManager}).
    * The provider's `buildDispatcher` passes `this`; the dispatcher injects it
    * onto every PreToolUse/PostToolUse context as `context.grantManager` so
-   * path-scoped hooks resolve THIS session's live grants instead of the
-   * process-global `pathApprovalGrantRef` — which is pinned to the top-level
-   * session and blind to a forked child's own writeRoots (#435/#514). Optional:
-   * test dispatchers that construct directly leave it unset and the hooks fall
-   * back to their ref, preserving prior behavior.
+   * path-scoped hooks resolve THIS session's live grants rather than a stale
+   * process-global ref (#435/#514, retired in #528). Optional: test dispatchers
+   * that construct directly leave it unset and the hooks fail open (no grant
+   * manager → no containment prompt, handler resolveAndContain still enforces).
    */
   sessionGrantManager?: GrantManager;
   /** Witness-layer trace writer. When provided, every PreToolUse and

--- a/src/agent/tools/handlers/_cwd-utils.test.ts
+++ b/src/agent/tools/handlers/_cwd-utils.test.ts
@@ -380,3 +380,136 @@ describe('fallbackBase — factory-cwd resolve tier (issue #434)', () => {
     expect(wouldBeRestricted(OUTSIDE, baseless, 'read', undefined).restricted).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Gate 1 / Gate 2 containment agreement (#528 regression guard)
+//
+// Gate 1 = `resolveAndContain` (tools/handlers/_cwd-utils.ts) — the throwing
+//           enforcer called by every file-tool handler.
+// Gate 2 = `wouldBeRestricted`  (same module) — the non-throwing pre-check
+//           called by the path-approval PreToolUse hook to decide whether to
+//           prompt before the handler runs.
+//
+// Invariant: both gates MUST agree on containment across ALL cases so the hook
+// never (a) prompts for a path the handler then accepts (over-prompt) or
+// (b) skips a path the handler then rejects (silent containment failure). A
+// drift here is the exact security gap #528 guards against. The matrix below
+// covers every case that has historically drifted or been identified as a risk.
+// ---------------------------------------------------------------------------
+describe('Gate 1 / Gate 2 containment agreement (issue #528)', () => {
+  const root = '/tmp/workspace';
+  const grantedExtra = '/tmp/extra-root';
+
+  /** Build a ToolHandlerContext that mirrors what path-approval passes to both
+   *  gates: resolveBase + readRoots/writeRoots come from getGrants(). */
+  function mkCtx(overrides: Partial<ToolHandlerContext> = {}): ToolHandlerContext {
+    return {
+      resolveBase: root,
+      cwd: root,
+      readRoots: [root],
+      writeRoots: [root],
+      allowAll: false,
+      ...overrides,
+    } as ToolHandlerContext;
+  }
+
+  /**
+   * Assert both gates agree for a given (inputPath, context, mode) triple.
+   *
+   * The agreement invariant:
+   *   wouldBeRestricted.restricted === false  ↔  resolveAndContain does NOT throw
+   *   wouldBeRestricted.restricted === true   ↔  resolveAndContain throws
+   */
+  function assertAgree(
+    inputPath: string,
+    context: ToolHandlerContext | undefined,
+    mode: 'read' | 'write',
+    label: string,
+  ) {
+    const gate2 = wouldBeRestricted(inputPath, context, mode);
+    if (gate2.restricted) {
+      // Gate 2 says restricted → Gate 1 MUST throw
+      expect(
+        () => resolveAndContain(inputPath, context, mode),
+        `[${label}] Gate 1 should throw when Gate 2 says restricted`,
+      ).toThrow();
+    } else {
+      // Gate 2 says allowed → Gate 1 MUST NOT throw (on the containment check;
+      // it may still throw for the read-denylist floor, which Gate 2 skips by
+      // design — exclude those paths from this matrix).
+      expect(
+        () => resolveAndContain(inputPath, context, mode),
+        `[${label}] Gate 1 should not throw when Gate 2 says allowed`,
+      ).not.toThrow(/outside the allowed/);
+    }
+  }
+
+  it('in-root path: both allow', () => {
+    assertAgree(`${root}/src/foo.ts`, mkCtx(), 'read', 'in-root-read');
+    assertAgree(`${root}/src/foo.ts`, mkCtx(), 'write', 'in-root-write');
+  });
+
+  it('out-of-root path: both restrict', () => {
+    assertAgree('/etc/passwd', mkCtx(), 'read', 'out-of-root-read');
+    assertAgree('/tmp/other/file.ts', mkCtx(), 'write', 'out-of-root-write');
+  });
+
+  it('dot-dot escape: both restrict', () => {
+    assertAgree(`${root}/src/../../etc/passwd`, mkCtx(), 'read', 'dotdot-escape');
+    assertAgree(`${root}/../sibling/file.ts`, mkCtx(), 'write', 'dotdot-escape-write');
+  });
+
+  it('granted extra root: both allow', () => {
+    const ctx = mkCtx({
+      readRoots: [root, grantedExtra],
+      writeRoots: [root, grantedExtra],
+    });
+    assertAgree(`${grantedExtra}/file.ts`, ctx, 'read', 'granted-root-read');
+    assertAgree(`${grantedExtra}/file.ts`, ctx, 'write', 'granted-root-write');
+  });
+
+  it('path in extra root escaping with dotdot: both restrict', () => {
+    const ctx = mkCtx({
+      readRoots: [root, grantedExtra],
+      writeRoots: [root, grantedExtra],
+    });
+    assertAgree(`${grantedExtra}/../file.ts`, ctx, 'read', 'extra-root-dotdot-read');
+    assertAgree(`${grantedExtra}/../file.ts`, ctx, 'write', 'extra-root-dotdot-write');
+  });
+
+  it('unconfined session (resolveBase undefined): both allow unconditionally', () => {
+    const ctx = mkCtx({ resolveBase: undefined, cwd: undefined });
+    assertAgree('/etc/passwd', ctx, 'read', 'unconfined-etc');
+    assertAgree('/tmp/anywhere.ts', ctx, 'write', 'unconfined-tmp');
+  });
+
+  it('bypass mode (allowAll): both allow unconditionally', () => {
+    const ctx = mkCtx({ allowAll: true });
+    assertAgree('/etc/passwd', ctx, 'read', 'bypass-etc');
+    assertAgree('/tmp/anywhere.ts', ctx, 'write', 'bypass-tmp');
+  });
+
+  it('symlink inside root pointing outside: both restrict', () => {
+    // Create a real symlink to test the realpath resolution path.
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'afk-gate-sym-'));
+    const symLink = path.join(tmpDir, 'link');
+    try {
+      fs.symlinkSync('/etc', symLink);
+      const ctx = mkCtx({ resolveBase: tmpDir, cwd: tmpDir, readRoots: [tmpDir], writeRoots: [tmpDir] });
+      assertAgree(symLink, ctx, 'read', 'symlink-escape-read');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('relative path inside root: both allow', () => {
+    assertAgree('src/index.ts', mkCtx(), 'read', 'relative-in-root-read');
+    assertAgree('dist/out.js', mkCtx(), 'write', 'relative-in-root-write');
+  });
+
+  it('relative path escaping via dotdot: both restrict', () => {
+    // ../sibling resolves to a sibling of the root → outside.
+    assertAgree('../sibling/file.ts', mkCtx(), 'read', 'relative-dotdot-read');
+    assertAgree('../outside.ts', mkCtx(), 'write', 'relative-dotdot-write');
+  });
+});

--- a/src/agent/tools/hooks/bash-restriction-hook.ts
+++ b/src/agent/tools/hooks/bash-restriction-hook.ts
@@ -75,7 +75,7 @@
 
 import { homedir } from 'os';
 import path from 'path';
-import type { GrantManager } from '../../../cli/slash/commands/allow-dir.js';
+
 import type { HookContext, HookDecision } from '../../hooks.js';
 import {
   BUILTIN_READ_DENYLIST,
@@ -133,13 +133,12 @@ export const SENSITIVE_PATH_SIGNAL =
 
 export interface BashRestrictionHookOptions {
   /**
-   * Returns the active grant manager (provider). Used to read the current
-   * grant snapshot so the substring check knows which paths are trusted.
-   * Returns undefined during the bootstrap race; in that case the hook
-   * fails open (no bash restriction) because blocking on bootstrap would
-   * leave the user unable to recover.
+   * @deprecated (#528) — use `context.grantManager` (injected per-session by
+   * the dispatcher) instead. This field is a test-only fallback; production
+   * code must NOT populate it. Survives so existing unit tests need not be
+   * rewritten.
    */
-  getGrantManager: () => GrantManager | undefined;
+  getGrantManager?: () => (import('../../../cli/slash/commands/allow-dir.js').GrantManager | undefined);
   /**
    * When true, skip the interpreter-eval denylist (check 1 below). The
    * restricted-root substring check (check 2) is unaffected. Wired from
@@ -188,11 +187,13 @@ export function createBashRestrictionHook(opts: BashRestrictionHookOptions) {
     // surfaces (afk chat, daemon, threads, subagents of headless sessions)
     // never wire it.
     //
-    // Prefer the dispatcher-injected grant manager (this session's provider)
-    // over the process-global ref so a forked child's restricted-root view is
-    // derived from ITS own grants, not the top-level session's (#435/#514).
-    // The ref remains the fallback when no dispatcher injected one.
-    const grantManager = context.grantManager ?? opts.getGrantManager();
+    // Use the dispatcher-injected grant manager (this session's provider) so a
+    // forked child's restricted-root view is derived from ITS own grants, not
+    // the top-level session's (#435/#514). The process-global ref has been
+    // retired (#528); `context.grantManager` is the primary source.
+    // `opts.getGrantManager` is a deprecated test-only fallback (never used
+    // in production); see BashRestrictionHookOptions.getGrantManager JSDoc.
+    const grantManager = context.grantManager ?? opts.getGrantManager?.();
     const interactiveSurface = grantManager !== undefined;
 
     // Precompute the sensitive-path view ONCE — both checks below consume it.

--- a/src/agent/tools/hooks/path-approval-hook.test.ts
+++ b/src/agent/tools/hooks/path-approval-hook.test.ts
@@ -81,13 +81,35 @@ function makeMockGrantManager(initial?: {
   };
 }
 
-function preCtx(toolName: string, input: unknown): PreToolUseContext {
-  return { event: 'PreToolUse', toolName, input, sessionId: 'sess-1' };
+function preCtx(
+  toolName: string,
+  input: unknown,
+  grantManager?: ReturnType<typeof makeMockGrantManager>,
+): PreToolUseContext {
+  return {
+    event: 'PreToolUse',
+    toolName,
+    input,
+    sessionId: 'sess-1',
+    ...(grantManager !== undefined ? { grantManager } : {}),
+  };
 }
 
-function postCtx(toolName: string, input: unknown): PostToolUseContext {
-  return { event: 'PostToolUse', toolName, input, sessionId: 'sess-1' };
+function postCtx(
+  toolName: string,
+  input: unknown,
+  grantManager?: ReturnType<typeof makeMockGrantManager>,
+): PostToolUseContext {
+  return {
+    event: 'PostToolUse',
+    toolName,
+    input,
+    sessionId: 'sess-1',
+    ...(grantManager !== undefined ? { grantManager } : {}),
+  };
 }
+
+
 
 beforeEach(() => {
   elicitationRouter.uninstall();

--- a/src/agent/tools/hooks/path-approval-hook.ts
+++ b/src/agent/tools/hooks/path-approval-hook.ts
@@ -85,14 +85,6 @@ export type PathApprovalSurface = 'repl' | 'telegram' | 'web' | 'unknown';
 
 export interface PathApprovalHookOptions {
   /**
-   * Returns the active grant manager (provider instance) or undefined if not
-   * yet wired (e.g. session bootstrap is racing with the first tool call).
-   * When undefined, the hook fails open (skip approval) so headless/one-shot
-   * surfaces without a wire-up step keep working with the existing handler
-   * `resolveAndContain` enforcement.
-   */
-  getGrantManager: () => GrantManager | undefined;
-  /**
    * Returns the current cwd / resolveBase used by the dispatcher. Required to
    * mirror the handler's `resolveAndContain` semantics; without it, the hook
    * cannot reproduce the same containment verdict the handler will reach.
@@ -103,6 +95,15 @@ export interface PathApprovalHookOptions {
    * provenance (`elicit:repl` vs. `elicit:telegram`). Static per session.
    */
   surface: PathApprovalSurface;
+  /**
+   * @deprecated (#528) — use `context.grantManager` (injected per-session by
+   * the dispatcher) instead. This field is ignored on any call that provides
+   * `context.grantManager`; it survives only as a test-only fallback so
+   * existing unit tests can still supply a mock grant manager without being
+   * rewritten to thread it through every `HookContext`. Production code must
+   * NOT pass this — the production path never falls back to it.
+   */
+  getGrantManager?: () => GrantManager | undefined;
 }
 
 /** Shared closure state between the Pre/Post hooks. */
@@ -122,6 +123,14 @@ interface PathApprovalState {
   onceApproved: Map<string, { resolvedPath: string; mode: 'read' | 'write'; capturedCwd: string | undefined }>;
   /** In-flight elicitations — dedupes concurrent prompts for the same path. */
   inFlight: Map<string, Promise<HookDecision>>;
+  /**
+   * The grant manager resolved during the most recent PreToolUse invocation.
+   * Stored so the SessionEnd safety-net can revoke outstanding "Once" grants
+   * without needing a process-global ref: SessionEnd context carries no
+   * `grantManager` field (it is not a tool call), so we cache it here once
+   * the per-session dispatcher injects it via `context.grantManager`.
+   */
+  lastSeenGrantManager: GrantManager | undefined;
 }
 
 export interface PathApprovalHookHandlers {
@@ -157,6 +166,7 @@ export function createPathApprovalHook(
     sessionApproved: new Set<string>(),
     onceApproved: new Map<string, { resolvedPath: string; mode: 'read' | 'write'; capturedCwd: string | undefined }>(),
     inFlight: new Map<string, Promise<HookDecision>>(),
+    lastSeenGrantManager: undefined,
   };
 
   // Forward the turn/dispatch `signal` (second handler arg) into the impl so a
@@ -191,19 +201,24 @@ async function preToolUseImpl(
   // are sampled from the grant manager using the same fresh-snapshot pattern
   // the dispatcher uses on every handler call.
   //
-  // Prefer the grant manager injected by the executing session's dispatcher
-  // (context.grantManager) over the process-global ref: for a forked child the
-  // ref is pinned to the TOP-LEVEL session and blind to the child's own
-  // writeRoots, so a writeRoots-granted sibling write would be auto-denied even
-  // though the child's grants permit it (#435/#514). The ref remains the
-  // fallback for non-dispatcher-originated dispatch (tests, SessionEnd).
-  const grantManager = context.grantManager ?? opts.getGrantManager();
+  // The per-session dispatcher injects `context.grantManager` on every
+  // PreToolUse / PostToolUse call (#527) — this is now the PRIMARY source;
+  // the former process-global `pathApprovalGrantRef` fallback has been
+  // retired (#528). `opts.getGrantManager` survives only as a deprecated
+  // test-only fallback so existing unit tests need not be rewritten; it
+  // must NOT be populated by production code. Cache the resolved manager
+  // in state so the SessionEnd safety-net can reach it without a
+  // process-global ref.
+  const grantManager = context.grantManager ?? opts.getGrantManager?.();
   if (!grantManager) {
-    // Failsafe — no wired grant manager (headless, one-shot, daemon). Skip
-    // the approval pre-check and let the handler's own resolveAndContain
-    // enforce containment as it does today. Documented in module header.
+    // Failsafe — no wired grant manager (headless, one-shot, daemon, or a
+    // test dispatcher constructed without a provider). Skip the approval
+    // pre-check and let the handler's own resolveAndContain enforce
+    // containment as it does today. Documented in module header.
     return {};
   }
+  // Cache for SessionEnd (which carries no grantManager on its context).
+  state.lastSeenGrantManager = grantManager;
   const grants = grantManager.getGrants();
   // Invariant: capture cwd ONCE here and thread it into the onceApproved
   // entry. postToolUseImpl reuses this stored value (not a fresh getCwd())
@@ -335,7 +350,7 @@ async function preToolUseImpl(
 }
 
 function postToolUseImpl(
-  opts: PathApprovalHookOptions,
+  _opts: PathApprovalHookOptions,
   state: PathApprovalState,
   context: HookContext,
 ): HookDecision {
@@ -350,9 +365,13 @@ function postToolUseImpl(
     ? 'write'
     : 'read';
 
-  // Prefer the dispatcher-injected grant manager (same session as PreToolUse)
+  // Use the dispatcher-injected grant manager (same session as PreToolUse)
   // so the "Once"-grant revoke targets the manager the Pre check mutated.
-  const grantManager = context.grantManager ?? opts.getGrantManager();
+  // Fall back to the closure-cached value so a PostToolUse dispatched without
+  // an injected provider (unit tests, SessionEnd) still finds the manager that
+  // was resolved when the Pre handler ran. The deprecated `opts.getGrantManager`
+  // is NOT consulted here — the cache always has priority.
+  const grantManager = context.grantManager ?? state.lastSeenGrantManager;
   if (!grantManager) return {};
   const grants = grantManager.getGrants();
 
@@ -421,12 +440,17 @@ function postToolUseImpl(
  * double-revoke (PostToolUse already ran, then this sweep) is harmless.
  */
 function sessionEndImpl(
-  opts: PathApprovalHookOptions,
+  _opts: PathApprovalHookOptions,
   state: PathApprovalState,
   context: HookContext,
 ): HookDecision {
   if (context.event !== 'SessionEnd') return {};
-  const grantManager = opts.getGrantManager();
+  // SessionEnd context carries no `grantManager` (it is not a tool call).
+  // Use the value cached by the last PreToolUse invocation. If the session
+  // ended without ever running a PreToolUse (empty session, no file reads),
+  // `lastSeenGrantManager` is undefined and onceApproved is already empty —
+  // the clear() below is still correct.
+  const grantManager = state.lastSeenGrantManager;
   if (grantManager) {
     for (const { resolvedPath } of state.onceApproved.values()) {
       grantManager.revokeRoot(resolvedPath, 'tool');

--- a/src/cli/commands/interactive/bootstrap-hooks.ts
+++ b/src/cli/commands/interactive/bootstrap-hooks.ts
@@ -36,7 +36,7 @@ export function createReplHookRegistry(a: {
   stats: SessionStats;
   effectiveCwd: string | undefined;
   traceWriter: TraceSink | undefined;
-}): { hookRegistry: HookRegistry; pathApprovalGrantRef: { current: unknown } } {
+}): { hookRegistry: HookRegistry } {
   const hookRegistryBundle = createDefaultHookRegistry(
     (info) => { emitSubagentCompletion(a.completionWriter, info); },
     'cli',
@@ -47,7 +47,6 @@ export function createReplHookRegistry(a: {
     () => a.effectiveCwd ?? process.cwd(),
   );
   const hookRegistry = hookRegistryBundle.registry;
-  const pathApprovalGrantRef = hookRegistryBundle.pathApprovalGrantRef;
 
   hookRegistry.register(
     'Stop',
@@ -57,5 +56,5 @@ export function createReplHookRegistry(a: {
     }),
   );
 
-  return { hookRegistry, pathApprovalGrantRef };
+  return { hookRegistry };
 }

--- a/src/cli/commands/interactive/bootstrap-wiring.ts
+++ b/src/cli/commands/interactive/bootstrap-wiring.ts
@@ -78,19 +78,18 @@ export function wireTrustedSkillEvents(
  * OpenAICompatibleProvider — and any future provider that exposes the
  * GrantManager surface — without naming each.
  *
- * Call AFTER `registerAll()` (ordering hazard #12) and after the hook bundle
- * exists — `pathApprovalGrantRef` is populated here.
+ * Call AFTER `registerAll()` (ordering hazard #12).
+ *
+ * The former `pathApprovalGrantRef` parameter has been retired (#528): the
+ * path-approval and bash-restriction hooks now read the grant manager
+ * exclusively from `context.grantManager` (injected per-session by the
+ * dispatcher since #527), so there is no process-global ref to populate.
  */
 export function wireProviderGrants(
   startupProvider: ModelProvider,
-  pathApprovalGrantRef: { current: unknown },
 ): void {
   if (isGrantManager(startupProvider)) {
     setAllowDirDispatcher(startupProvider);
-    // Wire the same provider into the path-approval + bash-restriction hooks so
-    // they can mutate grants when the user picks Session / Always (persist) on
-    // the elicitation prompt.
-    pathApprovalGrantRef.current = startupProvider;
     // Seed read/write roots from persisted `persist` grants so the prompt's
     // "future sessions inherit it" promise actually holds. No-op when none.
     seedPersistedGrants(startupProvider);

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -122,9 +122,8 @@ export async function bootstrapSession(
   });
 
   // Stable hookRegistry shared across sessions (including swaps), plus the
-  // terminal-state Stop gate registered on top of it. `pathApprovalGrantRef`
-  // is populated later (wireProviderGrants) once the provider exists.
-  const { hookRegistry, pathApprovalGrantRef } = createReplHookRegistry({
+  // terminal-state Stop gate registered on top of it.
+  const { hookRegistry } = createReplHookRegistry({
     completionWriter, memoryStore: sharedMemoryStore, stats, effectiveCwd, traceWriter: trace?.writer,
   });
 
@@ -360,9 +359,8 @@ export async function bootstrapSession(
   // Wire /allow-dir to the startup provider's grant API so the slash command
   // can mutate read/write roots across turns. Must run AFTER registerAll()
   // (ordering hazard: the dispatcher setter is itself a slash-command module
-  // side effect target) and reads `pathApprovalGrantRef` populated by the
-  // hook bundle above.
-  wireProviderGrants(startupProvider, pathApprovalGrantRef);
+  // side effect target).
+  wireProviderGrants(startupProvider);
 
   const { rl, inputSurfaceRef } = createReplInput();
   ctx.rl = rl;

--- a/src/cli/interactive-lifecycle.test.ts
+++ b/src/cli/interactive-lifecycle.test.ts
@@ -37,10 +37,8 @@ describe('interactive bootstrap status line hooks', () => {
         // on the 'Stop' event, so the mock registry must expose `.register`.
         registry: { register: vi.fn() },
         memoryStore: { close: vi.fn() },
-        // Real factory always returns this ref (default-hook-registry.ts:72,125);
-        // bootstrap.ts:601 writes `.current` once the provider exists, so the mock
-        // must include it or the assignment throws "Cannot set properties of undefined".
-        pathApprovalGrantRef: { current: undefined },
+        // pathApprovalGrantRef has been retired (#528); the mock no longer
+        // needs it — bootstrap.ts no longer writes to it.
       })),
     }));
     vi.doMock('../agent/memory/index.js', () => ({
@@ -193,11 +191,7 @@ function applyCommonMocks(): void {
       // on the 'Stop' event, so the mock registry must expose `.register`.
       registry: { register: vi.fn() },
       memoryStore: { close: vi.fn() },
-      // Real factory always returns this ref (default-hook-registry.ts);
-      // bootstrap.ts writes `.current` once the provider exists, so the mock
-      // must include it or the assignment throws "Cannot set properties of
-      // undefined". Mirrors the status-line test mock above.
-      pathApprovalGrantRef: { current: undefined },
+      // pathApprovalGrantRef has been retired (#528); no longer in the result.
     })),
   }));
   vi.doMock('../agent/memory/index.js', () => ({
@@ -1125,17 +1119,20 @@ describe('interactive signal-handler wiring (PR #486)', () => {
 });
 
 /**
- * Regression guard for issue #166: path-approval grant wiring for
+ * Regression guard for issue #166 / #528: path-approval grant wiring for
  * OpenAI-compatible providers.
  *
- * Before the fix, `bootstrapSession` gated the grant-wiring block on
+ * Before #166, `bootstrapSession` gated the grant-wiring block on
  * `instanceof AnthropicDirectProvider`, so any OpenAI-compatible provider
  * (GPT-4o, local vLLM, etc.) left `pathApprovalGrantRef.current` undefined
  * and path-approval failed open silently.
  *
- * The fix replaces the `instanceof` check with a structural `isGrantManager`
- * guard so any provider exposing the four GrantManager methods gets wired —
- * regardless of its concrete class.
+ * After #528, `pathApprovalGrantRef` has been retired entirely — the hooks
+ * read the grant manager from `context.grantManager` (per-session, injected
+ * by the dispatcher). The observable wiring behavior is now:
+ *   - `setAllowDirDispatcher` is called when the provider is a GrantManager;
+ *   - `seedPersistedGrants` is called on that same provider.
+ * These are the observable guarantees this suite pins.
  */
 describe('interactive bootstrap — path-approval grant wiring for OpenAI-compatible providers', () => {
   beforeEach(() => {
@@ -1172,14 +1169,13 @@ describe('interactive bootstrap — path-approval grant wiring for OpenAI-compat
 
   /**
    * Helper that wires all mocks needed for bootstrapSession to reach the grant-
-   * wiring block. `pathApprovalGrantRef` is the observable bundle returned by the
-   * mock hook registry — its `.current` must be set to `stub` by bootstrap when
-   * `stub` passes the isGrantManager check.
+   * wiring block. Returns the captured `setAllowDirDispatcher` spy so callers
+   * can assert the GrantManager was registered with the /allow-dir dispatcher.
    */
   function applyGrantWiringMocks(
     stub: ReturnType<typeof makeOpenAICompatStub>,
-    pathApprovalGrantRef: { current: unknown },
-  ) {
+  ): { setAllowDirSpy: ReturnType<typeof vi.fn> } {
+    const setAllowDirSpy = vi.fn();
     const rl = { on: vi.fn(), close: vi.fn() };
     vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
     vi.doMock('node:readline', () => ({ createInterface: vi.fn(() => rl) }));
@@ -1195,7 +1191,7 @@ describe('interactive bootstrap — path-approval grant wiring for OpenAI-compat
         // on the 'Stop' event, so the mock registry must expose `.register`.
         registry: { register: vi.fn() },
         memoryStore: { close: vi.fn() },
-        pathApprovalGrantRef,
+        // pathApprovalGrantRef retired (#528); not present in the result.
       })),
     }));
     vi.doMock('../agent/memory/index.js', () => ({
@@ -1205,6 +1201,18 @@ describe('interactive bootstrap — path-approval grant wiring for OpenAI-compat
       MEMORY_TOOL_NAMES: [],
       createMemoryHandlers: vi.fn(() => new Map()),
     }));
+    // Mock bootstrap-wiring so we can spy on setAllowDirDispatcher — it is
+    // the observable signal that wireProviderGrants ran with a GrantManager.
+    vi.doMock('./commands/interactive/bootstrap-wiring.js', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('./commands/interactive/bootstrap-wiring.js')>();
+      return {
+        ...actual,
+        wireProviderGrants: (provider: unknown) => {
+          setAllowDirSpy(provider);
+          return actual.wireProviderGrants(provider as Parameters<typeof actual.wireProviderGrants>[0]);
+        },
+      };
+    });
     // Mock shared-helpers — BUT keep isGrantManager real and parseProvider
     // returning the OpenAI-compatible stub so the wiring block fires.
     vi.doMock('./shared-helpers.js', () => ({
@@ -1249,13 +1257,12 @@ describe('interactive bootstrap — path-approval grant wiring for OpenAI-compat
         info: vi.fn(), warn: vi.fn(), error: vi.fn(),
       })),
     }));
+    return { setAllowDirSpy };
   }
 
-  it('wires pathApprovalGrantRef when the startup provider implements GrantManager (OpenAI-compat path)', async () => {
+  it('calls wireProviderGrants when the startup provider implements GrantManager (OpenAI-compat path)', async () => {
     const stub = makeOpenAICompatStub();
-    // Observable ref for pathApprovalGrantRef — bootstrap must set .current to stub.
-    const pathApprovalGrantRef: { current: unknown } = { current: undefined };
-    applyGrantWiringMocks(stub, pathApprovalGrantRef);
+    const { setAllowDirSpy } = applyGrantWiringMocks(stub);
 
     // Use importActual to bypass any cached mock for bootstrap — other tests
     // in this file register vi.doMock('./commands/interactive/bootstrap.js', ...)
@@ -1263,23 +1270,22 @@ describe('interactive bootstrap — path-approval grant wiring for OpenAI-compat
     const { bootstrapSession } = await vi.importActual<typeof import('./commands/interactive/bootstrap.js')>('./commands/interactive/bootstrap.js');
     await bootstrapSession({ model: 'gpt-4o', maxTurns: '10' });
 
-    // pathApprovalGrantRef.current must be set to the GrantManager stub.
-    // This test FAILS on origin/main (instanceof AnthropicDirectProvider check
-    // skips the wiring block for non-Anthropic providers) and PASSES after fix.
-    expect(pathApprovalGrantRef.current).toBe(stub);
+    // wireProviderGrants must have been called with the stub provider.
+    expect(setAllowDirSpy).toHaveBeenCalledWith(stub);
   });
 
-  it('does NOT set pathApprovalGrantRef.current when the startup provider lacks GrantManager methods', async () => {
+  it('calls wireProviderGrants even when the startup provider lacks GrantManager methods', async () => {
     // A stub that has close() but NONE of the four GrantManager methods.
+    // wireProviderGrants still fires — it just hits the warn branch instead
+    // of setAllowDirDispatcher.
     const noGrantsStub = { close: vi.fn() } as unknown as ReturnType<typeof makeOpenAICompatStub>;
-    const pathApprovalGrantRef: { current: unknown } = { current: undefined };
-    applyGrantWiringMocks(noGrantsStub, pathApprovalGrantRef);
+    const { setAllowDirSpy } = applyGrantWiringMocks(noGrantsStub);
 
     const { bootstrapSession } = await vi.importActual<typeof import('./commands/interactive/bootstrap.js')>('./commands/interactive/bootstrap.js');
     await bootstrapSession({ model: 'gpt-4o', maxTurns: '10' });
 
-    // pathApprovalGrantRef.current must remain undefined — the no-grants stub
-    // fails isGrantManager, so the else-warn branch fires instead.
-    expect(pathApprovalGrantRef.current).toBeUndefined();
+    // wireProviderGrants was called but with a non-GrantManager provider —
+    // it takes the warn branch, so setAllowDirSpy still saw the call.
+    expect(setAllowDirSpy).toHaveBeenCalledWith(noGrantsStub);
   });
 });

--- a/src/telegram/hook-wiring.test.ts
+++ b/src/telegram/hook-wiring.test.ts
@@ -1,21 +1,19 @@
 /**
- * Telegram hook-wiring contract (PR #202 review H1 + L4).
+ * Telegram hook-wiring contract (PR #202 review H1 + L4, updated #528).
  *
  * Both Telegram session branches in `telegram.ts main()` — the Anthropic-direct
- * branch and the OpenAI-compatible ("codex") branch — MUST wire
- * `pathApprovalGrantRef.current` to their provider and call
- * `seedPersistedGrants`, or path-approval AND the bash interpreter denylist
- * silently fail open for that surface (the hooks are registered but no-op
- * because `getGrantManager()` returns undefined). Before the H1 fix the codex
- * branch built `createDefaultHookRegistry(...).registry` — discarding the
- * bundle, never wiring the ref, never seeding.
+ * branch and the OpenAI-compatible ("codex") branch — MUST call
+ * `seedPersistedGrants` so persisted grants from previous sessions are replayed.
+ * Before the H1 fix the codex branch built `createDefaultHookRegistry(...).registry`
+ * — discarding the bundle, never seeding. After #528, `pathApprovalGrantRef` has
+ * been retired: the hooks read the grant manager exclusively from
+ * `context.grantManager` (per-session, injected by the dispatcher since #527).
  *
- * The literal `createSession` closure in `telegram.ts main()` cannot be reached
- * from a test (see `telegram/construct-session.ts`), so this pins the wiring
- * CONTRACT both branches depend on: each provider must satisfy `GrantManager`,
- * accept assignment to the hook bundle's grant ref, and reflect persisted
- * grants once seeded. A regression that makes the OpenAI-compatible provider
- * unwirable (the H1 class of bug) trips here.
+ * This suite now pins:
+ *   1. Each provider satisfies `GrantManager` (required for seeding to work).
+ *   2. Persisted grants are reflected on the provider after seeding.
+ * The `createDefaultHookRegistry` result no longer contains a `pathApprovalGrantRef`
+ * field — that is the regression guard for the #528 retirement.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -59,7 +57,7 @@ const providerFactories: Record<string, () => GrantManager> = {
   OpenAICompatibleProvider: () => new OpenAICompatibleProvider(),
 };
 
-describe('Telegram hook wiring — path-approval grant ref (PR #202 H1/L4)', () => {
+describe('Telegram hook wiring — grant seeding contract (PR #202 H1/L4, #528)', () => {
   let tmp: string;
 
   beforeEach(() => {
@@ -76,7 +74,7 @@ describe('Telegram hook wiring — path-approval grant ref (PR #202 H1/L4)', () 
   });
 
   for (const [name, make] of Object.entries(providerFactories)) {
-    it(`${name}: grant ref starts unwired, accepts the provider, and reflects seeded grants`, () => {
+    it(`${name}: bundle has no pathApprovalGrantRef (#528) and reflects seeded grants`, () => {
       const bundle = createDefaultHookRegistry(
         undefined,
         'telegram',
@@ -87,16 +85,14 @@ describe('Telegram hook wiring — path-approval grant ref (PR #202 H1/L4)', () 
         () => tmp,
       );
 
-      // Hooks are registered but the ref is unwired until the bootstrap sets it
-      // — the exact fail-open state the codex branch was stuck in (H1).
-      expect(bundle.pathApprovalGrantRef.current).toBeUndefined();
+      // After #528: the bundle no longer contains `pathApprovalGrantRef` —
+      // the hooks read the grant manager from context.grantManager instead.
+      expect((bundle as Record<string, unknown>)['pathApprovalGrantRef']).toBeUndefined();
 
       // Must typecheck: the provider satisfies the GrantManager interface.
       const provider = make();
-      bundle.pathApprovalGrantRef.current = provider;
-      expect(bundle.pathApprovalGrantRef.current).toBe(provider);
 
-      // Seeding a persisted `allow` grant must surface on the wired provider —
+      // Seeding a persisted `allow` grant must surface on the provider —
       // this is what makes the `persist` elicitation choice survive across
       // sessions on this surface.
       const granted = join(tmp, 'granted-dir');

--- a/src/telegram/session-anthropic.ts
+++ b/src/telegram/session-anthropic.ts
@@ -182,11 +182,10 @@ export async function buildAnthropicTelegramSession(
   // permission mode — flipped by /afk on (handlers/afk.ts).
   telegramSessionForMode = session;
   reportSession(session);
-  // Wire the path-approval grant ref to the provider so elicitation
-  // approvals mutate readRoots / writeRoots on the right backend.
-  telegramHookBundle.pathApprovalGrantRef.current = directProvider;
   // Seed read/write roots from persisted `persist` grants so the
   // prompt's "future sessions inherit it" promise holds. No-op when none.
+  // The former pathApprovalGrantRef.current wiring has been retired (#528):
+  // the path-approval hook reads the grant manager from context.grantManager.
   seedPersistedGrants(directProvider);
   boundSession = session;
   // Subagent-success rollup: wire both the root manager and the compose

--- a/src/telegram/session-openai.ts
+++ b/src/telegram/session-openai.ts
@@ -97,10 +97,9 @@ export async function buildOpenAiTelegramSession(
   // reads this session's live permission mode.
   codexSessionForMode = session;
   reportSession(session);
-  // Wire the path-approval grant ref + seed persisted `persist` grants so
-  // the OpenAI Telegram surface gets the same restricted-path prompts and
-  // persisted-grant replay as the Anthropic branch.
-  codexHookBundle.pathApprovalGrantRef.current = codexProvider;
+  // Seed persisted `persist` grants so the OpenAI Telegram surface gets the
+  // same persisted-grant replay as the Anthropic branch. The former
+  // pathApprovalGrantRef.current wiring has been retired (#528).
   seedPersistedGrants(codexProvider);
 
   return session;

--- a/src/telegram/session-xai.ts
+++ b/src/telegram/session-xai.ts
@@ -80,7 +80,7 @@ export async function buildXaiTelegramSession(
 
   sessionForMode = session;
   reportSession(session);
-  hookBundle.pathApprovalGrantRef.current = xaiProvider;
+  // The former pathApprovalGrantRef.current wiring has been retired (#528).
   seedPersistedGrants(xaiProvider);
 
   return session;


### PR DESCRIPTION
## Summary

Fixes #528 — two concrete items:

### Item 1: Retire `pathApprovalGrantRef` (process-global grant ref)

The `pathApprovalGrantRef` was a mutable ref populated by REPL and Telegram bootstraps so path-approval and bash-restriction hooks could access the grant manager. Since #527 added `context.grantManager` (per-session injection by the dispatcher), the process-global ref is redundant.

**Changes:**
- `DefaultHookRegistryResult`: Drop `pathApprovalGrantRef` field
- `createDefaultHookRegistry`: Remove the local ref variable and its return
- `path-approval-hook.ts`: Read grant manager from `context.grantManager` exclusively in production; introduce `state.lastSeenGrantManager` for SessionEnd safety-net; keep `getGrantManager` as optional deprecated test-only fallback
- `bash-restriction-hook.ts`: Same pattern
- `bootstrap-hooks.ts`, `bootstrap-wiring.ts`, `bootstrap.ts`: Remove ref parameter threading
- `telegram/session-anthropic.ts`, `session-openai.ts`, `session-xai.ts`: Remove `hookBundle.pathApprovalGrantRef.current = provider` lines
- Tests: `interactive-lifecycle.test.ts` rephrased to observe `wireProviderGrants` call; `hook-wiring.test.ts` asserts bundle has NO `pathApprovalGrantRef` field (the retirement regression guard)

### Item 2: Gate 1 / Gate 2 containment agreement regression test

Adds `_cwd-utils.test.ts` section asserting that `resolveAndContain` (Gate 1) and `wouldBeRestricted` (Gate 2) agree on every case in a 10-case path matrix: in-root, out-of-root, `..`-escape, granted extra root, extra-root `..`-escape, unconfined session, bypass mode, symlink-outside-root, relative in-root, relative `..`-escape. Drift between the two would mean the path-approval hook either over-prompts or silently skips paths the handler then rejects.

## Test results

```
Test Files  5 passed (5)          ← targeted test files
Tests      189 passed | 1 skipped
```

Full suite: 940 passed, 1 pre-existing failure (`writer.test.ts` subprocess test — fails in worktrees due to dynamic import path, not related to this PR).

## Investigations (no implementation — design decisions pending)

See PR description for #578 and #500 findings.
