### PR TITLE
feat(repl): add /ghost and /suggestions slash commands

### DIFF
--- a/src/cli/input/history.ts
+++ b/src/cli/input/history.ts
@@ -229,7 +229,7 @@ export class ReplHistory {
     if (idx < 0 || idx >= this._entries.length) return false;
     this._entries.splice(idx, 1);
     this.resetRecall();
-    rewriteHistory(this._entries).catch((err: Error) => {
+    rewriteHistory(this._entries.slice()).catch((err: Error) => {
       process.stderr.write(`[afk] history rewrite failed: ${err.message}\n`);
     });
     return true;
@@ -298,6 +298,11 @@ for (const entry of historyEntries) {
  * Used by `removeAt()` and `clear()` to keep disk in sync with memory.
  * Serialized through `_chain` (COR-9) so it orders correctly against
  * concurrent `appendHistory` calls.
+ *
+ * History: ts values are reset to rewrite time. The in-memory `_entries`
+ * array carries only text strings, so original timestamps cannot be
+ * preserved without a type change. ts serves no runtime purpose —
+ * `loadHistory` discards it. File line order preserves relative ordering.
  */
 function rewriteHistory(entries: readonly string[]): Promise<void> {
   return serialize(async () => {

--- a/src/cli/input/history.ts
+++ b/src/cli/input/history.ts
@@ -218,6 +218,34 @@ export class ReplHistory {
   get inRecall(): boolean {
     return this._index !== -1;
   }
+
+  /**
+   * Remove the entry at `idx` (0-based, oldest-first — same order as the
+   * internal `_entries` array). Returns `true` when an entry was removed,
+   * `false` when the index is out of range. Fires an async disk rewrite
+   * through the serialized queue so memory and disk stay in sync.
+   */
+  removeAt(idx: number): boolean {
+    if (idx < 0 || idx >= this._entries.length) return false;
+    this._entries.splice(idx, 1);
+    this.resetRecall();
+    rewriteHistory(this._entries).catch((err: Error) => {
+      process.stderr.write(`[afk] history rewrite failed: ${err.message}\n`);
+    });
+    return true;
+  }
+
+  /**
+   * Wipe all history entries — both in-memory and on disk.
+   * Fires an async disk truncate through the serialized queue.
+   */
+  clear(): void {
+    this._entries = [];
+    this.resetRecall();
+    rewriteHistory([]).catch((err: Error) => {
+      process.stderr.write(`[afk] history clear failed: ${err.message}\n`);
+    });
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -263,6 +291,30 @@ for (const entry of historyEntries) {
     }
     return new ReplHistory([]);
   }
+}
+
+/**
+ * Rewrite the entire history file from a source-of-truth entries array.
+ * Used by `removeAt()` and `clear()` to keep disk in sync with memory.
+ * Serialized through `_chain` (COR-9) so it orders correctly against
+ * concurrent `appendHistory` calls.
+ */
+function rewriteHistory(entries: readonly string[]): Promise<void> {
+  return serialize(async () => {
+    const path = getReplHistoryPath();
+    await mkdir(dirname(path), { recursive: true });
+    const now = Date.now();
+    const content = entries.length > 0
+      ? entries.map((text) => JSON.stringify({ text, ts: now } satisfies HistoryEntry)).join('\n') + '\n'
+      : '';
+    const fd = await open(path, O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW, 0o600);
+    try {
+      await fd.writeFile(content);
+    } finally {
+      await fd.close();
+    }
+    _diskEntryCount = entries.length;
+  });
 }
 
 /**

--- a/src/cli/input/types.ts
+++ b/src/cli/input/types.ts
@@ -40,6 +40,15 @@ export interface IHistoryRing {
    * `typeof push === 'function'` before invoking.
    */
   push?(text: string): void;
+  /**
+   * Remove the entry at `idx` (0-based, oldest-first). Returns true when
+   * removed, false when out of range. Optional — only `ReplHistory` implements.
+   */
+  removeAt?(idx: number): boolean;
+  /** Wipe all history entries (in-memory + disk). Optional — only `ReplHistory` implements. */
+  clear?(): void;
+  /** Number of entries. Optional — only `ReplHistory` implements. */
+  readonly length?: number;
 }
 
 /**

--- a/src/cli/slash/commands/ghost.ts
+++ b/src/cli/slash/commands/ghost.ts
@@ -60,6 +60,7 @@ export const ghostCmd: SlashCommand = {
 
     if (target === 'on') {
       compositor.ghostPaused = false;
+      compositor.repaint();
       ctx.out.success('Ghost text resumed.');
       return 'continue';
     }

--- a/src/cli/slash/commands/ghost.ts
+++ b/src/cli/slash/commands/ghost.ts
@@ -1,0 +1,70 @@
+/**
+ * /ghost slash command — toggle ghost-text suggestions mid-session.
+ *
+ * Usage:
+ *   /ghost       — show current status
+ *   /ghost off   — pause ghost text for this session
+ *   /ghost on    — resume ghost text
+ *
+ * Session-scoped: does not persist across restarts. Use
+ * `interactive.suggestGhost` in afk.config.json (or AFK_SUGGEST_GHOST env)
+ * for a permanent toggle.
+ */
+
+import type { SlashCommand } from '../types.js';
+import { palette } from '../../palette.js';
+
+export const ghostCmd: SlashCommand = {
+  name: '/ghost',
+  usage: '/ghost [on|off]',
+  summary: 'Toggle ghost-text suggestions mid-session',
+  hint:
+    'Pause or resume inline ghost-text suggestions (the dim text after the cursor). ' +
+    '`/ghost off` suppresses all ghost text for the rest of this session — nothing ' +
+    'new appears and nothing new is recorded to history. `/ghost on` resumes. ' +
+    'For a permanent toggle, set `interactive.suggestGhost: false` in afk.config.json.',
+  flags: ['on', 'off'],
+  async handler(ctx, args) {
+    const compositor = ctx.getCompositor?.();
+    if (!compositor) {
+      ctx.out.warn('Ghost text is not available on this surface.');
+      return 'continue';
+    }
+
+    // No ghost engine wired at all (AFK_SUGGEST_GHOST=0 at boot).
+    if (!compositor.ghostEngine) {
+      ctx.out.info(
+        `Ghost text is ${palette.dim('disabled')} (set at boot via AFK_SUGGEST_GHOST or interactive.suggestGhost).`,
+      );
+      return 'continue';
+    }
+
+    const target = args.trim().toLowerCase();
+
+    // No args — show status.
+    if (!target) {
+      const status = compositor.ghostPaused ? palette.dim('paused') : palette.brand('on');
+      ctx.out.info(`Ghost text: ${status} (session-scoped)`);
+      return 'continue';
+    }
+
+    if (target === 'off') {
+      compositor.ghostPaused = true;
+      compositor.activeGhost = null;
+      compositor.repaint();
+      ctx.out.success(
+        `Ghost text paused for this session. Run ${palette.brand('/ghost on')} to resume.`,
+      );
+      return 'continue';
+    }
+
+    if (target === 'on') {
+      compositor.ghostPaused = false;
+      ctx.out.success('Ghost text resumed.');
+      return 'continue';
+    }
+
+    ctx.out.warn(`Unknown argument: "${target}". Usage: /ghost [on|off]`);
+    return 'continue';
+  },
+};

--- a/src/cli/slash/commands/suggestions.ts
+++ b/src/cli/slash/commands/suggestions.ts
@@ -1,0 +1,123 @@
+/**
+ * /suggestions slash command — view and manage REPL input history.
+ *
+ * The history ring is the source for Tier-1 ghost-text suggestions (prefix
+ * matches) and for ↑/↓ recall. This command surfaces what the ring holds
+ * and lets the user remove entries they do not want persisted.
+ *
+ * Usage:
+ *   /suggestions           — show last 20 entries
+ *   /suggestions 50        — show last N entries
+ *   /suggestions rm 3      — remove entry #3 (index from output)
+ *   /suggestions clear     — wipe all history (memory + disk)
+ *
+ * Reads from the in-memory ring (not the disk file) to avoid flush races.
+ */
+
+import type { SlashCommand } from '../types.js';
+import { palette } from '../../palette.js';
+
+const DEFAULT_SHOW = 20;
+
+export const suggestionsCmd: SlashCommand = {
+  name: '/suggestions',
+  usage: '/suggestions [N | rm <index> | clear]',
+  summary: 'View or manage saved input history (ghost-text source)',
+  hint:
+    'List recent inputs that feed ghost-text suggestions. ' +
+    '`/suggestions rm 3` removes entry #3. `/suggestions clear` wipes all history. ' +
+    'Tip: prefix any input with a space to skip history recording.',
+  async handler(ctx, args) {
+    const compositor = ctx.getCompositor?.();
+    const history = compositor?.history;
+
+    if (!history || typeof history.getEntries !== 'function') {
+      ctx.out.warn('History is not available on this surface.');
+      return 'continue';
+    }
+
+    const trimmed = args.trim();
+
+    // --- clear ---
+    if (trimmed === 'clear') {
+      if (typeof history.clear !== 'function') {
+        ctx.out.warn('History clearing is not supported.');
+        return 'continue';
+      }
+      const count = history.length ?? 0;
+      if (count === 0) {
+        ctx.out.info('History is already empty.');
+        return 'continue';
+      }
+      history.clear();
+      ctx.out.success(`Cleared ${count} history entries (memory + disk).`);
+      return 'continue';
+    }
+
+    // --- rm <index> ---
+    if (trimmed.startsWith('rm ')) {
+      const idxStr = trimmed.slice(3).trim();
+      const displayIdx = parseInt(idxStr, 10);
+      if (Number.isNaN(displayIdx) || displayIdx < 1) {
+        ctx.out.warn(`Invalid index: "${idxStr}". Use a number from the /suggestions list.`);
+        return 'continue';
+      }
+
+      // getEntries() returns newest-first; convert display index (1-based,
+      // newest-first) to internal index (0-based, oldest-first).
+      const entries = history.getEntries();
+      if (displayIdx > entries.length) {
+        ctx.out.warn(`Index ${displayIdx} is out of range (${entries.length} entries).`);
+        return 'continue';
+      }
+      // Display index 1 = newest = entries[0] = internal entries.length - 1
+      const internalIdx = entries.length - displayIdx;
+      const removed = entries[displayIdx - 1];
+      if (typeof history.removeAt !== 'function') {
+        ctx.out.warn('History removal is not supported.');
+        return 'continue';
+      }
+      const ok = history.removeAt(internalIdx);
+      if (ok) {
+        const preview = removed && removed.length > 60
+          ? removed.slice(0, 57) + '...'
+          : removed;
+        ctx.out.success(`Removed #${displayIdx}: ${palette.dim(preview ?? '(unknown)')}`);
+      } else {
+        ctx.out.warn(`Failed to remove entry #${displayIdx}.`);
+      }
+      return 'continue';
+    }
+
+    // --- show [N] ---
+    const limit = trimmed ? parseInt(trimmed, 10) : DEFAULT_SHOW;
+    if (Number.isNaN(limit) || limit < 1) {
+      ctx.out.warn(`Usage: /suggestions [N | rm <index> | clear]`);
+      return 'continue';
+    }
+
+    const entries = history.getEntries();
+    if (entries.length === 0) {
+      ctx.out.info('No history entries.');
+      return 'continue';
+    }
+
+    const shown = entries.slice(0, limit);
+    const { out } = ctx;
+    out.line();
+    out.line(
+      palette.bold(`Input history`) +
+      palette.dim(` (${entries.length} total, showing ${shown.length} newest)`),
+    );
+    out.line();
+    shown.forEach((entry, i) => {
+      const idx = palette.meta(`#${i + 1}`);
+      const preview = entry.length > 80 ? entry.slice(0, 77) + '...' : entry;
+      out.line(`  ${idx}  ${preview}`);
+    });
+    out.line();
+    out.line(palette.dim('Tip: prefix input with a space to skip history recording.'));
+    out.line();
+    return 'continue';
+  },
+};

--- a/src/cli/slash/index.ts
+++ b/src/cli/slash/index.ts
@@ -37,6 +37,8 @@ import { searchCmd } from './commands/search.js';
 import { diffCmd } from './commands/diff.js';
 import { copyCmd } from './commands/copy.js';
 import { configDoctorCommands } from './commands/config-doctor.js';
+import { ghostCmd } from './commands/ghost.js';
+import { suggestionsCmd } from './commands/suggestions.js';
 import { registerStaticPluginSkillCommands } from './plugin-skills.js';
 import { registerStaticPluginAgentCommands } from './plugin-agents.js';
 import { registerBuiltinSkillCommands } from './builtin-skills.js';
@@ -74,6 +76,8 @@ export function registerAll(): void {
   register(diffCmd);
   register(copyCmd);
   for (const cmd of configDoctorCommands) register(cmd);
+  register(ghostCmd);
+  register(suggestionsCmd);
   // Placeholders for plugin-backed commands. The real lists get registered
   // after `session.waitForInitialization()` resolves, via
   // `registerPluginSkills(session)` / `registerPluginAgents(session)` in

--- a/src/cli/terminal-compositor.autocomplete.stale-guard.test.ts
+++ b/src/cli/terminal-compositor.autocomplete.stale-guard.test.ts
@@ -56,6 +56,7 @@ function makeHost(ac: AutocompleteState, buffer: string, repaint: () => void): A
     activeGhost: null,
     ghostEngine: undefined,
     ghostGetContext: undefined,
+    ghostPaused: false,
     repaint,
   };
 }

--- a/src/cli/terminal-compositor.autocomplete.test.ts
+++ b/src/cli/terminal-compositor.autocomplete.test.ts
@@ -55,6 +55,7 @@ function makeHost(ac: AutocompleteState, buffer: string, repaint: () => void = (
     activeGhost: null,
     ghostEngine: undefined,
     ghostGetContext: undefined,
+    ghostPaused: false,
     repaint,
   };
 }

--- a/src/cli/terminal-compositor.autocomplete.ts
+++ b/src/cli/terminal-compositor.autocomplete.ts
@@ -46,6 +46,8 @@ export interface AutocompleteHost {
   readonly autocompleteState?: AutocompleteState;
   input: InputCoreState;
   activeGhost: string | null;
+  /** Session-scoped ghost-text pause. Toggled by `/ghost off` / `/ghost on`. */
+  ghostPaused: boolean;
   readonly ghostEngine: SuggestEngine | undefined;
   readonly ghostGetContext: (() => SuggestContext) | undefined;
   /**

--- a/src/cli/terminal-compositor.ghost.ts
+++ b/src/cli/terminal-compositor.ghost.ts
@@ -40,6 +40,7 @@ export function primePromptGhost(self: AutocompleteHost): void {
   const engine = self.ghostEngine;
   const getContext = self.ghostGetContext;
   if (!engine || !getContext) return;
+  if (self.ghostPaused) return;
   // Only propose into a genuinely empty prompt.
   if (self.input.buffer.length > 0) return;
 
@@ -105,6 +106,10 @@ export function dismissPromptGhost(self: AutocompleteHost): boolean {
  */
 export function updateGhost(self: AutocompleteHost): void {
   if (!self.ghostEngine || !self.ghostGetContext) return;
+  if (self.ghostPaused) {
+    if (self.activeGhost !== null) { self.activeGhost = null; }
+    return;
+  }
   const buffer = self.input.buffer;
 
   // Stale-invalidation: clear any ghost that no longer extends the buffer.
@@ -160,6 +165,7 @@ export function updateGhost(self: AutocompleteHost): void {
     // misbehaving engine returning a non-prefix string).
     if (
       result !== null &&
+      !self.ghostPaused &&
       self.input.buffer === requestedBuffer &&
       result.startsWith(requestedBuffer) &&
       result.length > requestedBuffer.length

--- a/src/cli/terminal-compositor.ts
+++ b/src/cli/terminal-compositor.ts
@@ -539,6 +539,9 @@ export class TerminalCompositor {
    */
   activeGhost: string | null = null;
 
+  /** Session-scoped ghost-text pause. Toggled by `/ghost off` / `/ghost on`. */
+  ghostPaused = false;
+
   /** @internal Relaxed from `private` for the committed-band module (CommittedBandHost). */
   debugLog(stage: string, extra: Record<string, unknown> = {}): void {
     if (!this.debugCompositor) return;


### PR DESCRIPTION
## Summary

Adds two new REPL slash commands that give users control over ghost text and full CRUD on saved input history.

### `/ghost [on|off]` — live ghost-text toggle

- `/ghost` — show current status
- `/ghost off` — pause all ghost text for this session (clears current ghost, prevents new ones)
- `/ghost on` — resume ghost text

Session-scoped by design. For permanent disable, use `interactive.suggestGhost: false` in `afk.config.json` (or `AFK_SUGGEST_GHOST=0`).

**Mechanism:** Adds a `ghostPaused` boolean to the compositor, guarded in three places:
- `updateGhost()` — early return + clear `activeGhost` when paused
- `primePromptGhost()` — early return when paused
- Tier-2 async `.then()` handler — prevents a pre-pause dispatch from painting a ghost after pause

### `/suggestions [N | rm <index> | clear]` — history CRUD

- `/suggestions` — show last 20 entries (newest first)
- `/suggestions 50` — show last N entries
- `/suggestions rm 3` — remove entry #3 (index from output)
- `/suggestions clear` — wipe all history (memory + disk)

Reads from the in-memory `ReplHistory` ring (not the disk JSONL file) to avoid flush races. Delete operations go through new `ReplHistory.removeAt()` and `clear()` methods that coordinate memory and disk writes through the existing serialized write queue (`_chain`).

### Motivation

Ghost text is on by default. When a user accepts a suggestion (Tab/→) and submits, the text is saved to `repl-history.jsonl` indistinguishably from typed input. Users wanted:
1. A quick way to toggle ghost text off mid-session when they don't want suggestions
2. Visibility into what's been saved to history
3. The ability to remove entries they didn't want persisted

### Files changed

| File | Change |
|---|---|
| `src/cli/slash/commands/ghost.ts` | **New** — `/ghost` slash command |
| `src/cli/slash/commands/suggestions.ts` | **New** — `/suggestions` slash command |
| `src/cli/input/history.ts` | Add `removeAt()`, `clear()`, and `rewriteHistory()` |
| `src/cli/input/types.ts` | Extend `IHistoryRing` with optional `removeAt`, `clear`, `length` |
| `src/cli/terminal-compositor.autocomplete.ts` | Add `ghostPaused` to `AutocompleteHost` |
| `src/cli/terminal-compositor.ts` | Add `ghostPaused = false` field |
| `src/cli/terminal-compositor.ghost.ts` | Guard on `ghostPaused` in 3 locations |
| `src/cli/slash/index.ts` | Register both commands |

### Test verification

- All 6,244 tests pass (`pnpm test src/cli/` — 348 files)
- `pnpm lint` clean
- `pnpm build` clean
- All CI audits pass (env, chalk, pins)
