### PR TITLE
refactor(web): unify duplicate $() helpers with consistent null-safety (#1347)

### DIFF
--- a/src/web-server/frontend/app-chrome.ts
+++ b/src/web-server/frontend/app-chrome.ts
@@ -7,9 +7,7 @@
  * wired once at startup by the main module.
  */
 
-function $(id: string): HTMLElement | null {
-  return document.getElementById(id);
-}
+import { $ } from './dom-utils.js';
 
 /**
  * Show a transient toast notification in the #toast element.

--- a/src/web-server/frontend/app.ts
+++ b/src/web-server/frontend/app.ts
@@ -12,6 +12,7 @@ import { readAndScrubToken } from './web-token.js';
 import { SessionStream } from './sse-client.js';
 import { wireComposerAffordances } from './composer-wiring.js';
 import { showToast, wireSidebarClose, toggleNewSessionForm } from './app-chrome.js';
+import { $required as $ } from './dom-utils.js';
 import type { CommandEntry } from '../../cli/input/slash-match.js';
 import {
   renderApprovals,
@@ -52,12 +53,6 @@ let turnActive = false;
 
 /** True while the SSE transport is in a reconnecting state. */
 let sseReconnecting = false;
-
-function $(id: string): HTMLElement {
-  const node = document.getElementById(id);
-  if (!node) throw new Error(`missing #${id}`);
-  return node;
-}
 
 /**
  * Contract: constructed lazily on first use so this module can be imported

--- a/src/web-server/frontend/dom-utils.ts
+++ b/src/web-server/frontend/dom-utils.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared DOM query helpers.
+ *
+ * Two variants with distinct null-safety contracts:
+ *
+ *  • `$(id)` — null-safe: returns `HTMLElement | null`.  Use wherever the
+ *    element may legitimately be absent (e.g. optional chrome, feature-flagged
+ *    regions).  Mirrors `document.getElementById`.
+ *
+ *  • `$required(id)` — asserting: returns `HTMLElement` and throws a
+ *    `ReferenceError` if the element is missing.  Use when the markup is
+ *    required by the page contract and its absence is a hard bug.
+ */
+
+/**
+ * Null-safe element lookup.
+ *
+ * @param id - The HTML element `id` to look up.
+ * @returns The matching element, or `null` if absent.
+ */
+export function $(id: string): HTMLElement | null {
+  return document.getElementById(id);
+}
+
+/**
+ * Asserting element lookup.  Throws a `ReferenceError` when the element
+ * is missing, making the invariant violation explicit at the call site.
+ *
+ * @param id - The HTML element `id` to look up.
+ * @returns The matching element.
+ * @throws {ReferenceError} If no element with the given `id` exists.
+ */
+export function $required(id: string): HTMLElement {
+  const node = document.getElementById(id);
+  if (!node) throw new ReferenceError(`missing required element #${id}`);
+  return node;
+}


### PR DESCRIPTION
## Summary

Closes #1347

Extracts the duplicate module-private `$()` helpers from `app.ts` and `app-chrome.ts` into a shared `dom-utils.ts` utility with a single, documented null-safety contract.

## Changes

**New file: `src/web-server/frontend/dom-utils.ts`**
- `$(id): HTMLElement | null` — null-safe lookup (mirrors `document.getElementById`)
- `$required(id): HTMLElement` — asserting lookup, throws `ReferenceError` on missing element
- Both have JSDoc documenting the contract

**`app-chrome.ts`** — imports `$` from shared utility (null-safe, same contract as before)

**`app.ts`** — imports `$required as $` from shared utility (asserting, same contract as before)

## Verification

- `tsc --noEmit` clean
- 210/210 frontend tests pass
- No other files had similar duplicate helpers
