### PR TITLE
feat: skill when-to-use frontmatter + routing hints (Claude Code compat)

### DIFF
--- a/src/agent/plugins/tool-injector.ts
+++ b/src/agent/plugins/tool-injector.ts
@@ -42,6 +42,12 @@ export interface PluginSkillMetadata {
   description?: string;
   argumentHint?: string;
   /**
+   * When the model should reach for this skill. Parsed from `when-to-use`
+   * (or `whenToUse`) in SKILL.md frontmatter — matches the Claude Code
+   * `when_to_use` field. Surfaced as `When to use:` in the skill manifest.
+   */
+  whenToUse?: string;
+  /**
    * Which plugin directory this artifact came from. `'command'` marks a
    * Claude Code `commands/*.md` file (see `command-files.ts`); absent means
    * the default `skills/**\/SKILL.md` form. Read by `buildSkillManifest` to
@@ -354,6 +360,8 @@ export function parseSkillMetadata(
         // files were silently dropped while `user-skills.ts` (which reads both)
         // handled the identical file correctly.
         metadata.argumentHint = value.replace(/^["']|["']$/g, '');
+      } else if (key === 'when-to-use' || key === 'whenToUse' || key === 'when_to_use') {
+        metadata.whenToUse = value.replace(/^["']|["']$/g, '');
       } else if (key === 'tools') {
         // Collect the lines after this one to handle YAML list form
         const remainingLines = lines.slice(i + 1);

--- a/src/agent/routing-directive.ts
+++ b/src/agent/routing-directive.ts
@@ -51,6 +51,8 @@ Reach for context-isolated investigators when the task is exploratory:
 
 Or dispatch a raw \`agent\` call when no skill matches but the work is parallelizable, verification-heavy, or would otherwise consume substantial inline context.
 
+After local work is ready to push and PR → \`/ship\`; to fix PR review feedback or red CI → \`/fix-pr\`; to clean up complexity or dead code → \`/simplify\`; large-scope structural refactors → \`/refactor\`.
+
 Skip orchestration for: single-line edits, trivial Q&A, and direct tool calls the user explicitly requested. The goal is leverage, not ceremony. If a skill would add overhead without adding value, don't invoke it.
 
 Default to acting autonomously. \`ask_question\` is a last resort, not a first move — every question blocks on the operator, who is often away from keyboard.

--- a/src/agent/tools/skill-bridge.test.ts
+++ b/src/agent/tools/skill-bridge.test.ts
@@ -229,7 +229,14 @@ describe('buildSkillManifest', () => {
     const manifest = buildSkillManifest();
 
     expect(manifest).toContain('minimal-skill: Minimal skill');
-    expect(manifest).not.toMatch(/When to use:/);
+    // The minimal-skill entry itself must not have a When to use: line.
+    // Other bundled skills in the manifest may legitimately have one.
+    const lines = manifest.split('\n');
+    const idx = lines.findIndex((l) => l.includes('minimal-skill: Minimal skill'));
+    expect(idx).toBeGreaterThan(-1);
+    // The next line after the entry should NOT be a When to use: line
+    const nextLine = lines[idx + 1] ?? '';
+    expect(nextLine).not.toMatch(/^\s+When to use:/);
   });
 
   it('handles mixed skills with and without optional fields', () => {

--- a/src/agent/tools/skill-bridge.ts
+++ b/src/agent/tools/skill-bridge.ts
@@ -276,6 +276,7 @@ export function collectSkillEntries(
         description: skill.description ?? `Skill from plugin at ${plugin.path}`,
         source: skill.origin === 'command' ? 'command' : 'plugin',
         argumentHint: skill.argumentHint,
+        whenToUse: skill.whenToUse,
       });
       seen.add(skill.name);
     }

--- a/src/bundled-plugins/awa-bundled/bundled.test.ts
+++ b/src/bundled-plugins/awa-bundled/bundled.test.ts
@@ -70,7 +70,7 @@ const PINNED_HASHES = {
   'false-completion-gate':
     '9b0d90e150a9a4690c713d1063dd1901ce5b659d33b6c9f12b74e44b3d0163ce',
   'fix-pr':
-    '07ae5b92882c42a94426b182ee3226a7d0271388478874e87b76816ac59aec02',
+    'c89030fd9ab9200d9676ee503ae3db7e06fcb862d52a55eb67cb85786e585ff9',
   // gather + parallelize carry a bundled-only `context: load` frontmatter line
   // (2026-06 skill-execution-mode work). `context` is an agent-afk-specific
   // field; Claude Code upstream skills are natively inline/progressive-disclosure,
@@ -101,7 +101,7 @@ const PINNED_HASHES = {
   // (`pnpm test <file>` / `pnpm test -t "AuthService"`) plus a note to never emit
   // the `--` form. Bundled-only — mirror into the user-scope /refactor at
   // ~/.afk/skills/ if it drifts back.
-  refactor: '3adf801b9a61eba80afd34fef1e8c78a892ec07256dabb073370622a62d1b40f',
+  refactor: '816bcc71c185cf0fe511c67424986ae08b45364d00bb790c1b972c3d562d099e',
   research: 'abe79d75a5f3c74696ef002293dbe8714e446f8955de97089d1005f1e70bc269',
   // History: /review Wave 1 no longer mandates a `git show` re-read (#726,
   // #777); severity and disposition split into separate axes with an explicit
@@ -127,10 +127,10 @@ const PINNED_HASHES = {
   // git/gh ran, failing the call or recording a mangled/truncated body. The
   // file-based form matches the safe convention already used in src/agent/gh.ts.
   // BACK-PORT GAP: the same fix should still land in the upstream /ship skill.
-  ship: '4b082cdcbfe51453a20edd03231b473812775a7cc452b661bb786ff9735f0066',
+  ship: 'c74ef9e83e115ac34e32b188b909f39f87abb41933abc7e5c88fa9a0a35af102',
   // simplify is bundled-only (no upstream counterpart).
   simplify:
-    'ce720df16e81eff5e6022db38067d376f2177e08a9783fc377e04cf520c7bf3c',
+    'a984a507872949e17c87ab72979cb089524ba1da899f38af80fd0e725ebff667',
   spec: '167e7cbb84de5b716efa11bb9f20a6e4b940f6f9a6d1812a7fbd735dae4f67dd',
 } as const;
 

--- a/src/bundled-plugins/awa-bundled/skills/fix-pr/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/fix-pr/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: fix-pr
 description: "One-verb pipeline for the operator's highest-frequency manual loop: fetch a PR's unresolved reviewer feedback (inline review comments, review-summary bodies, and issue-level conversation comments) and failing CI checks, fix them in an isolated managed worktree via a budget-bounded subagent, verify with the project's test gates, and push the fix back to the PR branch. Replaces the retyped recipe 'send a subagent in a worktree to fix <PR feedback>, then push.' Use when a PR has review comments or red CI that needs addressing — e.g. 'fix pr 286', 'address the review on #215', 'CI is red on the worktree-sweep PR'. Never force-pushes, never touches main, fails closed on missing gh auth or un-pushable fork PRs."
+when-to-use: "A PR has review feedback or red CI that needs fixing."
 argument-hint: "<PR-number-or-URL> [--repo <path>] [--no-push] [--re-review]"
 surface: "afk"
 failure_modes:

--- a/src/bundled-plugins/awa-bundled/skills/refactor/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/refactor/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: refactor
 description: "Orchestrates safe, large-scale structural changes across a codebase — symbol renames, API migrations, pattern standardizations, layer restructurings. Enumerates all affected sites, groups them into dependency layers via the DAG executor, applies changes in parallel per layer with worktree isolation, and verifies behavioral preservation at each layer boundary before proceeding. Exits immediately on first regression, surfacing the exact site, diff, and behavioral delta before any commit."
+when-to-use: "Large-scope structural refactors across multiple files or layers."
 argument-hint: "<refactor goal> [--scope <glob-or-path>]"
 failure_modes:
   - bad decomposition

--- a/src/bundled-plugins/awa-bundled/skills/ship/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/ship/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ship
 description: "Release pipeline for already-done local work. Dispatches /ground-state pre-flight, runs the project test suite, drafts a commit message, pushes, and opens a PR with a structured verification summary. Use when local changes are ready to hand off to review — e.g. 'ship this', 'push and open a PR', 'release this work'. Add --verify to trigger an adversarial verifier wave on the diff before a human reads the PR."
+when-to-use: "Local changes are ready to push and open a PR."
 context: fork
 ---
 

--- a/src/bundled-plugins/awa-bundled/skills/simplify/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/simplify/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: simplify
 description: "Discovers incidental complexity, duplication, and dead code in a codebase and produces a ranked, behavior-preserving reduction plan — optionally applying safe changes. Dispatches four parallel read-only discovery lenses (clone detection, dead code, complexity hotspots, wrong abstraction), synthesizes into a prioritized reduction plan, and gates apply mode behind /refactor and a hard test check."
+when-to-use: "Reduce complexity, find duplicates, or remove dead code."
 argument-hint: "[target] [--apply] [--all]"
 context: load
 ---

--- a/src/skills/user-skills.ts
+++ b/src/skills/user-skills.ts
@@ -49,6 +49,7 @@ interface ParsedSkillMd {
   name: string;
   description: string;
   argumentHint?: string;
+  whenToUse?: string;
   flags?: readonly string[];
   body: string;
   /** Absolute path of the skill's root directory (e.g. `~/.afk/skills/<name>/`). */
@@ -129,10 +130,12 @@ function parseUserSkillMd(content: string, dirname: string): ParsedSkillMd | nul
   }
 
   const argumentHint = parsed.frontmatter['argument-hint'] ?? parsed.frontmatter['argumentHint'];
+  const whenToUse = parsed.frontmatter['when-to-use'] ?? parsed.frontmatter['whenToUse'] ?? parsed.frontmatter['when_to_use'];
   const flags = harvestFlagsFromSkillMd(content);
 
   const out: ParsedSkillMd = { name, description, body, dir: '' };
   if (argumentHint && argumentHint.length > 0) out.argumentHint = argumentHint;
+  if (whenToUse && whenToUse.length > 0) out.whenToUse = whenToUse;
   if (flags.length > 0) out.flags = flags;
   // Only accept the three well-known modes; an unknown value (typo) falls
   // through to the default (load) rather than silently mis-routing.
@@ -333,6 +336,7 @@ export function scanSkillsFromDir(
       origin,
     };
     if (parsed.argumentHint) meta.argumentHint = parsed.argumentHint;
+    if (parsed.whenToUse) meta.whenToUse = parsed.whenToUse;
     if (parsed.flags && parsed.flags.length > 0) meta.flags = parsed.flags;
     // Narrow the raw frontmatter string to the SkillCategory union. OOV values
     // are dropped (undefined) — the listing's F1 clamping only helps at render


### PR DESCRIPTION
## What

Two changes to close the skill adoption gap discovered by a facet opportunity sweep (65% of bundled skills had zero invocations across 3,422 sessions).

### Commit 1: One-liner routing hint in ROUTING_DIRECTIVE + `when-to-use` frontmatter

Adds a single compact sentence to the existing routing directive mentioning `/ship`, `/fix-pr`, `/simplify`, `/refactor` — four bundled skills with zero or low adoption despite matching common task shapes.

Adds `when-to-use` frontmatter to those 4 skills — matching Claude Code's `when_to_use` field and the Agent Skills spec convention of putting routing signals in `description`.

Deliberately omits `/polish` — "polish this" is extremely common user phrasing that would false-positive into multi-iteration evaluator loops.

### Commit 2: Parse `when-to-use` from SKILL.md frontmatter

Closes the gap where `whenToUse` was only available to TypeScript-registered skills (via `registerSkill()`). Plugin and user-authored SKILL.md files can now declare:

```yaml
when-to-use: "Trigger phrase or task shape description."
```

Parsed through both pipelines:
- `tool-injector.ts` (plugin SKILL.md files)
- `user-skills.ts` (user/project `~/.afk/skills/` files)

Surfaced as the existing `When to use:` line in the skill manifest — same rendering path as TS-registered skills, no new field needed.

Accepted frontmatter keys: `when-to-use` (kebab-case, preferred), `whenToUse` (camelCase), `when_to_use` (snake_case for Claude Code compat).

**Reworked from the original `routing-hint` approach** to match Claude Code's `when_to_use` field instead of inventing a non-standard field. The Agent Skills spec (agentskills.io) has no separate routing field — routing is done via `description`. Claude Code extends this with `when_to_use`. We now match that convention.

### Testing

- `pnpm lint` ✅
- `pnpm test src/bundled-plugins/awa-bundled/bundled.test.ts` ✅ (22 tests, pins regenerated)
- `pnpm test src/agent/plugins/tool-injector.test.ts src/agent/tools/skill-bridge.test.ts` ✅ (114 tests)
- `pnpm test src/skills/` ✅ (356 tests)

### Context

Opportunity gap report: `~/.afk/agent-framework/opportunity-gap-2026-08.md`
Key finding: 37/57 skills (65%) had zero invocations. 85% of sessions used zero skills. The constraint isn't idea generation — it's that most of what's already built is invisible to the agent.
