### PR TITLE
fix(test): add missing setPlanExitQueueCheck to repl-loop-wiring mock

### DIFF
--- a/src/cli/commands/interactive/repl-loop-wiring.test.ts
+++ b/src/cli/commands/interactive/repl-loop-wiring.test.ts
@@ -123,6 +123,7 @@ function makeMinimalCtx(backgroundRegistry: BackgroundAgentRegistry): Interactiv
         sessionId: 'mock',
         waitForInitialization: vi.fn(async () => ({})),
         takePendingPlanExitSeed: vi.fn(async () => undefined),
+        setPlanExitQueueCheck: vi.fn(),
       },
     },
     memoryStore: {} as never,


### PR DESCRIPTION
## Problem

CI is red on `main` (all 3 OS runners). All 12 tests in
`repl-loop-wiring.test.ts` fail with:

```
TypeError: ctx.session.current?.setPlanExitQueueCheck is not a function
```

## Root cause

Commit 4767128a (`fix(plan-mode): skip exit_plan_mode picker when user
has a queued message`) added a `setPlanExitQueueCheck()` call in
`surface-setup.ts:209`, but did not update the minimal session mock in
`repl-loop-wiring.test.ts`. The mock's `current` object existed (so
optional chaining `?.` did not short-circuit to `undefined`), but
lacked the method -- causing every test that reaches `setupSurface()`
to throw.

## Fix

One-line addition: `setPlanExitQueueCheck: vi.fn()` on the mock's
`current` object.

## Verification

- `pnpm lint` clean
- `pnpm test:coverage` -- 945 files, 18180 tests, 0 failures
