### PR TITLE
fix(workspace): restore BM25 normalization and add FTS5 DELETE/UPDATE triggers

### DIFF
--- a/src/agent/workspace/workspace-store.test.ts
+++ b/src/agent/workspace/workspace-store.test.ts
@@ -3,7 +3,12 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
+import type BetterSqlite3 from 'better-sqlite3';
 import { WorkspaceStore, buildFtsQuery } from './workspace-store.js';
+
+function rawDatabase(store: WorkspaceStore): BetterSqlite3.Database {
+  return Reflect.get(store, 'db') as BetterSqlite3.Database;
+}
 
 describe('WorkspaceStore', () => {
   let store: WorkspaceStore;
@@ -201,6 +206,51 @@ describe('WorkspaceStore', () => {
       expect(() => store.queryRelevant('s', 'NOT this AND that')).not.toThrow();
       expect(() => store.queryRelevant('s', 'prefix* wildcard')).not.toThrow();
       expect(() => store.queryRelevant('s', 'term -excluded')).not.toThrow();
+    });
+  });
+
+  // ── FTS5 synchronization triggers ────────────────────────────────────────
+
+  describe('FTS5 synchronization triggers', () => {
+    it('removes deleted entries from the FTS5 index', () => {
+      const id = store.publish({
+        session_id: 's',
+        type: 'finding',
+        subject: 'obsolete authentication',
+        content: 'Remove this stale token',
+      });
+      const db = rawDatabase(store);
+
+      db.prepare('DELETE FROM workspace_entries WHERE id = ?').run(id);
+
+      const matches = db
+        .prepare('SELECT rowid FROM workspace_fts WHERE workspace_fts MATCH ?')
+        .all('obsolete');
+      expect(matches).toEqual([]);
+    });
+
+    it('replaces old terms with new terms after an entry update', () => {
+      const id = store.publish({
+        session_id: 's',
+        type: 'finding',
+        subject: 'legacy authentication',
+        content: 'The old token flow',
+      });
+      const db = rawDatabase(store);
+
+      db.prepare('UPDATE workspace_entries SET subject = ?, content = ? WHERE id = ?').run(
+        'modern authorization',
+        'The replacement credential flow',
+        id,
+      );
+
+      const findRowIds = (term: string): number[] =>
+        db
+          .prepare('SELECT rowid FROM workspace_fts WHERE workspace_fts MATCH ?')
+          .all(term)
+          .map((row) => Number((row as { rowid: number }).rowid));
+      expect(findRowIds('legacy')).toEqual([]);
+      expect(findRowIds('modern')).toEqual([id]);
     });
   });
 

--- a/src/agent/workspace/workspace-store.ts
+++ b/src/agent/workspace/workspace-store.ts
@@ -66,6 +66,13 @@ export interface WorkspacePublishInput {
 
 // ── Schema ───────────────────────────────────────────────────────────────────
 
+// Invariant: workspace_entries is append-only. The FTS5 external-content table
+// (workspace_fts) has only synchronization triggers — AFTER INSERT, DELETE, and
+// UPDATE. If the append-only contract ever changes (e.g. adding a DELETE or
+// UPDATE query path on workspace_entries), the FTS triggers below already handle
+// it per SQLite FTS5 docs section 4.4.2. The triggers exist defensively; the
+// absence of mutation methods on WorkspaceStore is the primary guard.
+
 const SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS workspace_entries (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -95,10 +102,25 @@ CREATE VIRTUAL TABLE IF NOT EXISTS workspace_fts USING fts5(
 CREATE TRIGGER IF NOT EXISTS ws_fts_ai AFTER INSERT ON workspace_entries BEGIN
   INSERT INTO workspace_fts(rowid, subject, content) VALUES (new.id, new.subject, new.content);
 END;
+
+CREATE TRIGGER IF NOT EXISTS ws_fts_ad AFTER DELETE ON workspace_entries BEGIN
+  INSERT INTO workspace_fts(workspace_fts, rowid, subject, content)
+    VALUES ('delete', old.id, old.subject, old.content);
+END;
+
+CREATE TRIGGER IF NOT EXISTS ws_fts_au AFTER UPDATE ON workspace_entries BEGIN
+  INSERT INTO workspace_fts(workspace_fts, rowid, subject, content)
+    VALUES ('delete', old.id, old.subject, old.content);
+  INSERT INTO workspace_fts(rowid, subject, content)
+    VALUES (new.id, new.subject, new.content);
+END;
 `;
 
 // ── Store class ───────────────────────────────────────────────────────────────
 
+// Invariant: WorkspaceStore deliberately exposes no update() or delete() method.
+// workspace_entries is append-only by design. The FTS5 DELETE/UPDATE triggers
+// above exist as a defensive safety net, not because mutations are expected.
 export class WorkspaceStore {
   private readonly db: BetterSqlite3.Database;
 

--- a/src/agent/workspace/workspace-store.ts
+++ b/src/agent/workspace/workspace-store.ts
@@ -89,8 +89,7 @@ CREATE VIRTUAL TABLE IF NOT EXISTS workspace_fts USING fts5(
   content,
   content=workspace_entries,
   content_rowid=id,
-  tokenize='porter',
-  columnsize=0
+  tokenize='porter'
 );
 
 CREATE TRIGGER IF NOT EXISTS ws_fts_ai AFTER INSERT ON workspace_entries BEGIN

--- a/src/agent/workspace/workspace-store.ts
+++ b/src/agent/workspace/workspace-store.ts
@@ -91,6 +91,9 @@ CREATE TABLE IF NOT EXISTS workspace_entries (
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_ws_session_seq ON workspace_entries(session_id, seq);
 
+-- FTS5 options are fixed when the virtual table is created. If WorkspaceStore
+-- gains persistent-database callers, option changes require a migration that
+-- drops and recreates workspace_fts rather than relying on IF NOT EXISTS.
 CREATE VIRTUAL TABLE IF NOT EXISTS workspace_fts USING fts5(
   subject,
   content,


### PR DESCRIPTION
## Summary

Two related improvements to the workspace FTS5 virtual table:

### 1. Remove `columnsize=0` to restore BM25 length normalization (#1371)

`columnsize=0` disabled per-column token-count storage that FTS5 uses for BM25 length normalization. With it set, `bm25()` degrades to raw term-frequency scoring without a document-length penalty -- long entries get undeserved boosts over short ones. The workspace store is `:memory:`, so the column-size storage overhead is negligible.

### 2. Document append-only invariant and add FTS5 DELETE/UPDATE triggers (#1372)

The FTS5 external-content table had only an AFTER INSERT trigger. Per SQLite FTS5 docs section 4.4.2, external-content tables require DELETE and UPDATE triggers to stay consistent with the backing table. Today `workspace_entries` is append-only so the missing triggers were safe, but the contract was implicit.

Changes:
- Add `// Invariant:` comment above `SCHEMA_SQL` documenting the append-only contract
- Add `// Invariant:` comment on `WorkspaceStore` class explaining the deliberate absence of mutation methods
- Add `ws_fts_ad` (AFTER DELETE) and `ws_fts_au` (AFTER UPDATE) triggers with the FTS5 external-content sync protocol

Fixes #1371, fixes #1372
