### PR TITLE
fix(skills): wire pluginSkill.whenToUse into /skills detail card

### DIFF
--- a/src/agent/provider.ts
+++ b/src/agent/provider.ts
@@ -476,6 +476,7 @@ export interface ProviderCommandInfo {
   name: string;
   description?: string;
   argumentHint?: string;
+  whenToUse?: string;
   /**
    * Origin of the underlying skill/command. Inlined literal union (rather
    * than importing `SkillManifestEntry['source']` from

--- a/src/agent/providers/shared/supported-commands.ts
+++ b/src/agent/providers/shared/supported-commands.ts
@@ -38,6 +38,7 @@ export function collectSupportedCommands(): Promise<ProviderCommandInfo[]> {
           description: e.description,
         };
         if (e.argumentHint) info.argumentHint = e.argumentHint;
+        if (e.whenToUse) info.whenToUse = e.whenToUse;
         if (e.source) info.source = e.source;
         return info;
       }),

--- a/src/cli/slash/plugin-skills-hint.test.ts
+++ b/src/cli/slash/plugin-skills-hint.test.ts
@@ -2,10 +2,11 @@
  * Tests for `extractHintFromDescription` — the "Use when..." sentence parser
  * that powers tooltip hints on plugin-skill passthrough commands.
  *
- * Plugin SKILL.md descriptions don't carry a structured `whenToUse` field, so
- * the dropdown leans on the convention of embedding a "Use when..." sentence
- * in the description body. These cases lock the heuristic against shipped
- * plugin examples and a few adversarial shapes.
+ * `whenToUse` is now a structured field on `DiscoveredSkill` when available
+ * from SKILL.md frontmatter; `extractHintFromDescription` is the fallback for
+ * older plugins that embed a "Use when..." sentence in the description body.
+ * These cases lock the heuristic against shipped plugin examples and a few
+ * adversarial shapes.
  */
 
 import { describe, it, expect } from 'vitest';

--- a/src/cli/slash/plugin-skills-listing.test.ts
+++ b/src/cli/slash/plugin-skills-listing.test.ts
@@ -221,4 +221,25 @@ describe('/skills listing UX (Phase 1)', () => {
     const { ctx } = makeCtx();
     await expect(initialSkillsCmd.handler(ctx, '')).resolves.toBe('continue');
   });
+
+  it('detail card uses pluginSkill.whenToUse when registrySkill.whenToUse is absent', async () => {
+    // A plugin-only skill (not in the registry) whose whenToUse comes from
+    // SKILL.md frontmatter — verifies the pluginSkill?.whenToUse fallback
+    // added in listing-detail.ts (issue #1373).
+    const cmd = makeDynamicSkillsCmd([
+      {
+        name: 'fix-pr',
+        description: 'Fix pull-request review comments automatically.',
+        whenToUse: 'Use when a PR has blocking review comments you want resolved.',
+        source: 'plugin',
+      },
+    ]);
+
+    const { ctx, lines } = makeCtx();
+    await cmd.handler(ctx, 'fix-pr');
+    const out = stripAnsi(lines.join('\n'));
+
+    expect(out).toContain('When to use');
+    expect(out).toContain('blocking review comments');
+  });
 });

--- a/src/cli/slash/plugin-skills/dispatch.ts
+++ b/src/cli/slash/plugin-skills/dispatch.ts
@@ -8,6 +8,7 @@
  */
 
 import type { AgentSession } from '../../../agent/session.js';
+import type { ProviderCommandInfo } from '../../../agent/provider.js';
 import { listSkills, getSkill, isSkillVisible, type SkillMetadata } from '../../../skills/index.js';
 import { palette } from '../../palette.js';
 import { registerPluginAgents } from '../plugin-agents.js';
@@ -236,13 +237,18 @@ export async function registerPluginSkills(
     if (!harvestedCategories.has(name)) harvestedCategories.set(name, cat);
   }
 
-  const discovered: DiscoveredSkill[] = commands.map((c) => {
+  // Cast to ProviderCommandInfo[] — session.supportedCommands() returns
+  // SlashCommand[] for the REPL registry, but the underlying objects are
+  // ProviderCommandInfo-shaped (produced by collectSupportedCommands) and
+  // carry fields like `whenToUse` that are not on SlashCommand.
+  const discovered: DiscoveredSkill[] = (commands as unknown as ProviderCommandInfo[]).map((c) => {
     const bare = bareName(c.name);
     const cat = harvestedCategories.get(bare);
     return {
       name: c.name,
-      description: c.description,
+      description: c.description ?? '',
       ...(c.argumentHint ? { argumentHint: c.argumentHint } : {}),
+      ...(c.whenToUse ? { whenToUse: c.whenToUse } : {}),
       ...(c.source ? { source: c.source } : {}),
       ...(cat ? { category: cat } : {}),
     };

--- a/src/cli/slash/plugin-skills/flags.ts
+++ b/src/cli/slash/plugin-skills/flags.ts
@@ -149,11 +149,11 @@ export function harvestAllPluginSkillFlags(): Map<string, string[]> {
 /**
  * Best-effort "when to use" extraction from a plugin SKILL.md description.
  *
- * Plugin skills don't carry a structured `whenToUse` field — the convention
- * encoded in nearly every shipped SKILL.md is to embed a "Use when …" /
- * "When to use …" sentence inside the description. Pluck it out so the
- * dropdown tooltip can surface real guidance instead of repeating the
- * one-liner the dropdown summary already shows.
+ * `whenToUse` is now a structured field on `DiscoveredSkill` when available
+ * from SKILL.md frontmatter; `extractHintFromDescription` serves as the
+ * fallback for older plugins that embed the hint in the description body.
+ * Pluck it out so the dropdown tooltip can surface real guidance instead of
+ * repeating the one-liner the dropdown summary already shows.
  *
  * Falls back to `undefined` when no such sentence is detectable. The tooltip
  * row collapses cleanly in that case.

--- a/src/cli/slash/plugin-skills/listing-detail.ts
+++ b/src/cli/slash/plugin-skills/listing-detail.ts
@@ -108,7 +108,7 @@ export function renderSkillDetail(
     ctx.out.line(`  ${line}`);
   }
 
-  const whenToUse = registrySkill?.whenToUse ?? extractHintFromDescription(description);
+  const whenToUse = registrySkill?.whenToUse ?? pluginSkill?.whenToUse ?? extractHintFromDescription(description);
   if (whenToUse && whenToUse !== description.trim()) {
     ctx.out.line();
     ctx.out.line(`  ${palette.bold('When to use')}`);

--- a/src/cli/slash/plugin-skills/state.ts
+++ b/src/cli/slash/plugin-skills/state.ts
@@ -18,6 +18,8 @@ export interface DiscoveredSkill {
   source?: SkillManifestEntry['source'];
   /** Job-to-be-done category authored in SKILL.md frontmatter. */
   category?: string;
+  /** Job-to-be-done hint authored in SKILL.md frontmatter `when-to-use` field. */
+  whenToUse?: string;
 }
 
 /** Track collisions detected at registration time so /skills can render alts and boot can notify. */


### PR DESCRIPTION
## Summary

Wire `pluginSkill?.whenToUse` into the `/skills <name>` detail card fallback chain.

## Problem

`listing-detail.ts:111` resolves `whenToUse` from `registrySkill?.whenToUse ?? extractHintFromDescription(description)` but never reads `pluginSkill?.whenToUse`. Plugin skills whose `when-to-use` is parsed from SKILL.md frontmatter by `tool-injector.ts` will **not** appear in the operator's interactive `/skills fix-pr` detail view.

## Fix

- Insert `pluginSkill?.whenToUse` as the second fallback in the resolution chain
- Add `whenToUse` to the `DiscoveredSkill` interface in `state.ts` so the field is available
- Add a test verifying plugin skill `whenToUse` renders in the detail card

Fixes #1373
