### PR TITLE
test: add disk-scan coverage for whenToUse frontmatter parsing

### DIFF
--- a/src/agent/plugins/tool-injector.test.ts
+++ b/src/agent/plugins/tool-injector.test.ts
@@ -67,6 +67,35 @@ This is a test skill.
     });
   });
 
+  it('should extract whenToUse from a SKILL.md with when-to-use frontmatter', () => {
+    const skillDir = join(tmpDir, 'skills');
+    const fs = require('fs');
+    fs.mkdirSync(skillDir, { recursive: true });
+
+    const skillPath = join(skillDir, 'SKILL.md');
+    writeFileSync(
+      skillPath,
+      `---
+name: wtu-skill
+description: A skill with when-to-use
+when-to-use: "When something important happens"
+---
+# WTU Skill
+
+Body text.
+`
+    );
+
+    const skills = extractPluginSkills(tmpDir);
+    expect(skills).toHaveLength(1);
+    expect(skills[0]).toEqual({
+      name: 'wtu-skill',
+      description: 'A skill with when-to-use',
+      whenToUse: 'When something important happens',
+      body: '# WTU Skill\n\nBody text.',
+    });
+  });
+
   it('should handle SKILL.md without frontmatter', () => {
     const skillDir = join(tmpDir, 'skills');
     const fs = require('fs');

--- a/src/agent/tools/skill-bridge.test.ts
+++ b/src/agent/tools/skill-bridge.test.ts
@@ -1162,6 +1162,15 @@ describe('collectSkillEntries — disk-scan regression (user + project skills)',
     expect(entry?.argumentHint).toBe('<plan>');
   });
 
+  it('preserves whenToUse from a disk-scanned user skill', () => {
+    writeUserSkill('wtu-skill', 'Skill with wtu', 'when-to-use: "When something happens"\n');
+
+    const entries = collectSkillEntries([]);
+    const entry = entries.find((e) => e.name === 'wtu-skill');
+
+    expect(entry?.whenToUse).toBe('When something happens');
+  });
+
   it('includes user skill in buildSkillManifest() output', () => {
     writeUserSkill('manifest-user-skill', 'Appears in manifest');
 


### PR DESCRIPTION
## Summary

Add disk-scan test coverage for the `when-to-use` / `whenToUse` frontmatter parsing added in #1368.

## Problem

The `whenToUse` frontmatter had test coverage through the registry path (`registerSkill()`) but not through the two disk-scan paths that actually parse SKILL.md files:

1. **`tool-injector.ts` parser** (`parseSkillMetadata` via `extractPluginSkills`)
2. **`user-skills.ts` disk-scan** (`collectSkillEntries`)

## Tests Added

- `tool-injector.test.ts`: writes a SKILL.md with `when-to-use:` frontmatter and asserts `metadata.whenToUse` is populated via `extractPluginSkills()`
- `skill-bridge.test.ts`: uses `writeUserSkill()` with `when-to-use:` frontmatter and asserts `entry.whenToUse` survives `collectSkillEntries()` round-trip

Both tests mirror the existing `argumentHint` coverage pattern.

Fixes #1374
