### PR TITLE
fix(skills): add missing category annotations to audit-fit and diagnose (#12)

### DIFF
--- a/src/bundled-plugins/awa-bundled/bundled.test.ts
+++ b/src/bundled-plugins/awa-bundled/bundled.test.ts
@@ -64,7 +64,7 @@ const PINNED_HASHES = {
   // subagent-executor.isolation.test.ts + input-parse.ts confirm it is honored
   // at any depth, incl. nested inside a forked skill). Behavior-preserving prose
   // correction; frontmatter (context: fork) unchanged.
-  diagnose: '9a54f97470dce8adec5f1456f881aebe1bb550ee6f201ab9d63cccfd8a316096',
+  diagnose: '9d9751315bbae5a5411b034f6b311f9e9d7e8069a71e46384fa683da5915a090',
   // false-completion-gate, fix-pr, polish: high-usage user-scope skills bundled
   // in #943. No upstream counterpart — bundled-only.
   'false-completion-gate':

--- a/src/bundled-plugins/awa-bundled/skills/diagnose/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/diagnose/SKILL.md
@@ -2,6 +2,7 @@
 name: diagnose
 description: "Parallel root-cause analysis for bugs and failing tests. Use when a test fails, a bug is reported, or behavior is unexplained — dispatches sub-agents to form and validate hypotheses in isolated worktrees."
 context: fork
+category: Debug & fix
 ---
 
 Gather context: read the failing test or bug description, relevant error output, and recent git changes. If no failing test exists yet, write a minimal reproducer test (or identify a concrete verification command) before proceeding — hypotheses need a pass/fail signal to validate against. Dispatch two sub-agents in parallel — one to search the codebase for code paths involved in the failure (`subagent_type: research-agent`, read-only), and one to check recent commits and diffs that could have introduced the regression (`subagent_type: general-purpose` — requires Bash for `git log`/`git diff`/`git show`). When both return, synthesize findings into 2–4 ranked hypotheses, each with a specific code location and proposed cause.

--- a/src/skills/audit-fit/index.ts
+++ b/src/skills/audit-fit/index.ts
@@ -587,6 +587,7 @@ export const auditFitSkill: SkillMetadata = {
   // End users have no use for the brief output, so the skill is hidden unless
   // `AFK_INTERNAL=1` unlocks it.
   audience: 'internal',
+  category: 'Review & verify',
 };
 
 registerSkill(auditFitSkill);


### PR DESCRIPTION
## Summary

Adds the two missing `category` annotations to complete Phase 2 of the `/skills` job-to-be-done grouping (#12).

## Changes

- **`src/skills/audit-fit/index.ts`** — Added `category: 'Review & verify'` to the `auditFitSkill` metadata
- **`src/bundled-plugins/awa-bundled/skills/diagnose/SKILL.md`** — Added `category: Debug & fix` to frontmatter
- **`src/bundled-plugins/awa-bundled/bundled.test.ts`** — SHA pin for `diagnose` updated via `pnpm fix:pins`

## Context

Phase 2 infrastructure (the `SkillMetadata.category` field, frontmatter harvesting, grouped rendering in `/skills`) was already fully implemented. These were the only two skills missing annotations:
- `audit-fit` — vendored TS skill, `audience: 'internal'`
- `diagnose` — bundled plugin SKILL.md

## Verification

- `pnpm fix:pins:check` ✅
- `pnpm lint` ✅
- `pnpm test plugin-skills-category.test.ts` — 11/11 ✅
- `pnpm test bundled.test.ts` — 22/22 ✅

Closes #12
