### PR TITLE
fix(tasks): surface durationMs via public handle API and route stdin through compositor (#1346)

### DIFF
--- a/src/agent/subagent/handle.ts
+++ b/src/agent/subagent/handle.ts
@@ -81,6 +81,8 @@ export interface SubagentHandle<T = unknown> {
    * resolves; the caller owns delivery of the returned string.
    */
   getLastStopInjectContext(): string | undefined;
+  /** Wall-clock duration of the most recent completed run in ms; `undefined` before any run finishes. */
+  readonly durationMs: number | undefined;
 }
 
 /**
@@ -204,6 +206,10 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
 
   get status(): SubagentStatus {
     return this._currentStatus;
+  }
+
+  get durationMs(): number | undefined {
+    return this._lastDurationMs;
   }
 
   async run(prompt: string | ContentBlockParam[], sinkOverride?: SubagentProgressSink): Promise<Message> {

--- a/src/cli/slash/commands/tasks.ts
+++ b/src/cli/slash/commands/tasks.ts
@@ -248,8 +248,6 @@ export const tasksCmd: SlashCommand = {
     }
 
     // ── Interactive mode ──────────────────────────────────────────────────────
-    renderList();
-
     const compositor = ctx.getCompositor?.() ?? null;
 
     if (compositor) {
@@ -316,6 +314,10 @@ export const tasksCmd: SlashCommand = {
       });
     } else {
       // ── Stdin fallback: attach directly when no compositor is available ──────
+      // Render the initial list here — the compositor path uses its own
+      // renderRows() inside enterPickerMode, so renderList() is only needed
+      // for the raw-stdin branch.
+      renderList();
       await new Promise<void>((resolve) => {
         const onKeypress = (chunk: Buffer | string): void => {
           const str = typeof chunk === 'string' ? chunk : chunk.toString();

--- a/src/cli/slash/commands/tasks.ts
+++ b/src/cli/slash/commands/tasks.ts
@@ -26,6 +26,7 @@
 import { palette } from '../../palette.js';
 import { formatDuration } from '../../format-utils.js';
 import type { SlashCommand } from '../types.js';
+import type { PickerController } from '../../terminal-compositor.js';
 import type { SubagentManager } from '../../../agent/subagent.js';
 import type { SubagentStatus } from '../../../agent/subagent/result.js';
 import { SubagentLogReader } from '../../../agent/subagent/log.js';
@@ -180,13 +181,12 @@ async function collectAllTasks(
     const impl = entry.handle as unknown as {
       _agentType?: string;
       _currentTrace?: { toolCalls: unknown[] };
-      _lastDurationMs?: number;
     };
     entries.push({
       id: entry.handle.id,
       status: entry.handle.status,
       agentType: impl._agentType,
-      durationMs: impl._lastDurationMs,
+      durationMs: entry.handle.durationMs,
       toolCount: impl._currentTrace?.toolCalls.length ?? 0,
     });
   }
@@ -250,60 +250,122 @@ export const tasksCmd: SlashCommand = {
     // ── Interactive mode ──────────────────────────────────────────────────────
     renderList();
 
-    await new Promise<void>((resolve) => {
-      const onKeypress = (chunk: Buffer | string): void => {
-        const str = typeof chunk === 'string' ? chunk : chunk.toString();
-        if (str === '\x1b[A' || str === '\x1bOA') {
-          // Up arrow
-          cursor = Math.max(0, cursor - 1);
-          renderList();
-        } else if (str === '\x1b[B' || str === '\x1bOB') {
-          // Down arrow
-          cursor = Math.min(tasks.length - 1, cursor + 1);
-          renderList();
-        } else if (str === '\r' || str === '\n') {
-          // Enter — open the selected task in view mode.
-          const selected = tasks[cursor];
-          if (selected) {
-            // Wire Esc to resolve this promise (return to main prompt).
-            ctx.setSoftStopHandler?.(null);
-            process.stdin.off('data', onKeypress);
-            const entry: TaskViewEntry = {
-              id: selected.id,
-              manager,
-              sessionLabel,
-              ctx,
-              ictx: ictxRef,
-            };
-            void enterTaskViewMode(entry).then(resolve).catch((e) => {
+    const compositor = ctx.getCompositor?.() ?? null;
+
+    if (compositor) {
+      // ── Compositor path: route all input through enterPickerMode ────────────
+      // The compositor owns stdin routing in picker mode; `renderRows` is called
+      // by the compositor on every repaint, so mutating `cursor` and calling
+      // `repaintPicker()` is all that's needed to update the display.
+      await new Promise<void>((resolve) => {
+        let settled = false;
+
+        const finish = (openView?: TaskViewEntry): void => {
+          if (settled) return;
+          settled = true;
+          ctx.setSoftStopHandler?.(null);
+          compositor.exitPickerMode();
+          if (openView) {
+            void enterTaskViewMode(openView).then(resolve).catch((e) => {
               ctx.out.error?.(`task view error: ${String(e)}`);
               resolve();
             });
+          } else {
+            ctx.ui.clearScreen();
+            ctx.ui.repaintStatusLine();
+            resolve();
           }
-        } else if (str === '\x1b' || str === '\x03') {
-          // Esc or Ctrl-C — exit to main prompt.
+        };
+
+        const controller: PickerController = {
+          renderRows: (): readonly string[] => {
+            const rows: string[] = [];
+            rows.push(palette.dim(`  Subagent list — ↑/↓ navigate  Enter view  Esc return`));
+            rows.push('');
+            for (let i = 0; i < tasks.length; i++) {
+              const t = tasks[i]!;
+              rows.push(formatHandleLine(t.id, t.status, t.agentType, t.durationMs, t.toolCount, i === cursor));
+            }
+            rows.push('');
+            return rows;
+          },
+          onKey: (
+            _char: string | undefined,
+            key: { name?: string; ctrl?: boolean; shift?: boolean },
+          ): void => {
+            if (settled) return;
+            if (key.name === 'up') {
+              cursor = Math.max(0, cursor - 1);
+              compositor.repaintPicker();
+            } else if (key.name === 'down') {
+              cursor = Math.min(tasks.length - 1, cursor + 1);
+              compositor.repaintPicker();
+            } else if (key.name === 'return') {
+              const selected = tasks[cursor];
+              if (selected) {
+                finish({ id: selected.id, manager, sessionLabel, ctx, ictx: ictxRef });
+              }
+            } else if (key.name === 'escape' || (key.ctrl && key.name === 'c')) {
+              finish();
+            }
+          },
+        };
+
+        ctx.setSoftStopHandler?.(() => { finish(); });
+        compositor.enterPickerMode(controller);
+      });
+    } else {
+      // ── Stdin fallback: attach directly when no compositor is available ──────
+      await new Promise<void>((resolve) => {
+        const onKeypress = (chunk: Buffer | string): void => {
+          const str = typeof chunk === 'string' ? chunk : chunk.toString();
+          if (str === '\x1b[A' || str === '\x1bOA') {
+            // Up arrow
+            cursor = Math.max(0, cursor - 1);
+            renderList();
+          } else if (str === '\x1b[B' || str === '\x1bOB') {
+            // Down arrow
+            cursor = Math.min(tasks.length - 1, cursor + 1);
+            renderList();
+          } else if (str === '\r' || str === '\n') {
+            // Enter — open the selected task in view mode.
+            const selected = tasks[cursor];
+            if (selected) {
+              ctx.setSoftStopHandler?.(null);
+              process.stdin.off('data', onKeypress);
+              const entry: TaskViewEntry = {
+                id: selected.id,
+                manager,
+                sessionLabel,
+                ctx,
+                ictx: ictxRef,
+              };
+              void enterTaskViewMode(entry).then(resolve).catch((e) => {
+                ctx.out.error?.(`task view error: ${String(e)}`);
+                resolve();
+              });
+            }
+          } else if (str === '\x1b' || str === '\x03') {
+            // Esc or Ctrl-C — exit to main prompt.
+            ctx.setSoftStopHandler?.(null);
+            process.stdin.off('data', onKeypress);
+            ctx.ui.clearScreen();
+            ctx.ui.repaintStatusLine();
+            resolve();
+          }
+        };
+
+        ctx.setSoftStopHandler?.(() => {
           ctx.setSoftStopHandler?.(null);
           process.stdin.off('data', onKeypress);
           ctx.ui.clearScreen();
           ctx.ui.repaintStatusLine();
           resolve();
-        }
-      };
+        });
 
-      // Wire Esc handler via the surface-level soft-stop.
-      ctx.setSoftStopHandler?.(() => {
-        ctx.setSoftStopHandler?.(null);
-        process.stdin.off('data', onKeypress);
-        ctx.ui.clearScreen();
-        ctx.ui.repaintStatusLine();
-        resolve();
+        process.stdin.on('data', onKeypress);
       });
-
-      // TODO: route through compositor.enterPickerMode() instead of attaching
-      // directly to process.stdin — direct stdin listeners bypass the
-      // compositor's routing and can conflict with other input consumers.
-      process.stdin.on('data', onKeypress);
-    });
+    }
 
     return 'continue';
   },


### PR DESCRIPTION
## Summary

Surfaces `_lastDurationMs` via a proper public `SubagentHandle` API and routes the `/tasks` interactive picker through the compositor instead of direct `process.stdin` listeners (#1346).

## Changes

### Part 1: Route stdin through compositor

**`src/cli/slash/commands/tasks.ts`**:
- Interactive picker now uses `compositor.enterPickerMode(controller)` with a `PickerController` when a compositor is available
- `renderRows()` closure reads the live cursor position; arrow keys trigger `compositor.repaintPicker()`
- `exitPickerMode()` called on Esc/Enter/soft-stop
- Falls back to the original raw `process.stdin.on('data')` for non-compositor surfaces (Telegram, daemon, tests)

This eliminates the race condition between direct stdin listeners and the compositor's own keypress dispatch, matching the prior art in `/resume`.

### Part 2: Surface `durationMs` via public API

**`src/agent/subagent/handle.ts`** (+6 lines):
- Added `readonly durationMs: number | undefined` to the `SubagentHandle<T>` interface
- Added getter on `SubagentHandleImpl<T>` returning `this._lastDurationMs`

**`src/cli/slash/commands/tasks.ts`**:
- Replaced `impl._lastDurationMs` (accessed via `as unknown as` cast) with `entry.handle.durationMs`
- Removed `_lastDurationMs` from the unsafe cast type (retains `_agentType`/`_currentTrace` which are still internal)

## Verification

- `pnpm lint` ✅
- `pnpm test handle.test.ts` — 11/11 ✅
- `pnpm test tasks.test.ts` — 14/14 ✅

Closes #1346
