### PR TITLE
fix(provider): handle chatgpt-oauth in standalone oneshot auth path (#555)

### DIFF
--- a/src/agent/providers/openai-compatible/oneshot.test.ts
+++ b/src/agent/providers/openai-compatible/oneshot.test.ts
@@ -30,7 +30,7 @@ import type { OpenAIAuthResolution } from './auth.js';
 import type { ResponsesStreamEvent } from './responses-translate.js';
 
 // ── Auth mock ───────────────────────────────────────────────────────────────
-// `oneShotChatCompletion` calls `resolveOpenAIAuth(apiKey)` without deps, so we
+// `oneShotChatCompletion` calls `resolveOpenAIAuth(apiKey, {}, forceChatgptOAuth)`,
 // mock the module to control the resolution outcome deterministically.
 const { mockResolveAuth } = vi.hoisted(() => ({ mockResolveAuth: vi.fn() }));
 vi.mock('./auth.js', () => ({ resolveOpenAIAuth: mockResolveAuth }));
@@ -292,7 +292,19 @@ describe('oneShotChatCompletion', () => {
       user: 'msg',
       clientFactory: () => makeClient(async () => ({ choices: [{ message: { content: 'ok' } }] })),
     });
-    expect(mockResolveAuth).toHaveBeenCalledWith('sk-explicit');
+    expect(mockResolveAuth).toHaveBeenCalledWith('sk-explicit', {}, false);
+  });
+
+  it('forwards forceChatgptOAuth=true to resolveOpenAIAuth as third arg', async () => {
+    mockResolveAuth.mockReturnValueOnce({ apiKey: 'oauth-token', source: 'chatgpt-oauth' });
+    await oneShotChatCompletion({
+      model: 'gpt-4o',
+      system: 'sys',
+      user: 'msg',
+      forceChatgptOAuth: true,
+      clientFactory: () => makeClient(async () => ({ choices: [{ message: { content: 'ok' } }] })),
+    });
+    expect(mockResolveAuth).toHaveBeenCalledWith(undefined, {}, true);
   });
 
   // ── factory precedence ──────────────────────────────────────────────────────

--- a/src/agent/providers/openai-compatible/oneshot.ts
+++ b/src/agent/providers/openai-compatible/oneshot.ts
@@ -96,6 +96,14 @@ export interface OpenAIOneShotInput {
    * `apiKey` / `baseURL` / `clientFactory`.
    */
   client?: OpenAI;
+  /**
+   * When true, resolve the ChatGPT-subscription OAuth token from
+   * `~/.codex/auth.json` ahead of every other auth tier and WITHOUT the global
+   * `AFK_OPENAI_CHATGPT_OAUTH` flag — mirrors the `provider: 'chatgpt-oauth'`
+   * slot semantics in `resolveOpenAIAuth`. Ignored when `client` is provided
+   * (the pre-built client already carries the correct credentials).
+   */
+  forceChatgptOAuth?: boolean;
 }
 
 /**
@@ -135,7 +143,7 @@ export async function oneShotChatCompletion(input: OpenAIOneShotInput): Promise<
   if (input.client !== undefined) {
     client = input.client;
   } else {
-    const auth = resolveOpenAIAuth(apiKey);
+    const auth = resolveOpenAIAuth(apiKey, {}, input.forceChatgptOAuth ?? false);
     if (auth.apiKey === null) {
       throw new Error('oneShotChatCompletion: no usable OpenAI auth (set OPENAI_API_KEY or pass apiKey)');
     }


### PR DESCRIPTION
## Problem

`oneShotChatCompletion` called `resolveOpenAIAuth(apiKey)` with only one argument, silently ignoring a `forceChatgptOAuth: true` flag set on a `provider: 'chatgpt-oauth'` slot. A standalone one-shot invocation on such a slot would fall through the standard precedence chain and yield `no-usable-auth-codex-oauth` (or null) instead of the ChatGPT subscription token.

The practical impact is narrow — real in-session one-shots (history compaction) always supply a pre-built `client` and skip auth resolution entirely, so only a truly standalone one-shot without `OPENAI_API_KEY` would degrade — but the code was still wrong.

Fixes issue #555, item 3 (LOW: "Standalone one-shot path ignores the forced flag").

## Fix

Thread `forceChatgptOAuth?: boolean` through `OpenAIOneShotInput` and pass it as the third argument to `resolveOpenAIAuth(apiKey, {}, force)`, matching the established pattern in `query.ts`.

**Changes:**
- `src/agent/providers/openai-compatible/oneshot.ts`: add `forceChatgptOAuth?` field to `OpenAIOneShotInput`; update `resolveOpenAIAuth` call from 1-arg to 3-arg form
- `src/agent/providers/openai-compatible/oneshot.test.ts`: add test verifying the flag is forwarded as the third arg; update the existing apiKey-forwarding assertion to the full 3-arg signature

## Verification

```
pnpm lint   ✓ (tsc --noEmit clean)
vitest run src/agent/providers/openai-compatible/oneshot.test.ts  ✓ 29/29 tests pass
```
