### PR TITLE
fix(provider): gate expired chatgpt-oauth tokens instead of passing opaque 401 (#555)

### DIFF
--- a/src/agent/auth/model-availability.test.ts
+++ b/src/agent/auth/model-availability.test.ts
@@ -105,6 +105,18 @@ describe('modelAvailability', () => {
       });
     });
 
+    it('is unavailable with an expiry-specific hint when the ChatGPT OAuth token is expired', () => {
+      resolveOpenAIAuth.mockReturnValue({ apiKey: null, source: 'chatgpt-oauth-expired', expiresAt: 1 });
+      const bindings = slots({ medium: { id: 'gpt-5', provider: 'chatgpt-oauth' } });
+      const result = modelAvailability('medium', bindings);
+      expect(result).toEqual({
+        available: false,
+        needs: 'chatgpt-oauth',
+        hint: 'ChatGPT token expired — re-run `codex` to refresh',
+      });
+      expect(resolveOpenAIAuth).toHaveBeenCalledWith(undefined, {}, true);
+    });
+
     it('does NOT let a per-slot apiKey mask a missing ChatGPT OAuth token', () => {
       // Runtime forces the OAuth path for a chatgpt-oauth slot and ignores any
       // per-slot/explicit key (resolveOpenAIAuth(..., true) reads ~/.codex only),

--- a/src/agent/auth/model-availability.ts
+++ b/src/agent/auth/model-availability.ts
@@ -59,8 +59,13 @@ export function modelAvailability(model: string | undefined, bindings?: ModelSlo
     // no OAuth token is mislabeled available (no sign-in hint) while the next
     // real request fails for missing ChatGPT sign-in.
     if (b.provider === 'chatgpt-oauth') {
-      const ok = resolveOpenAIAuth(undefined, {}, true).apiKey != null;
-      return { available: ok, needs: 'chatgpt-oauth', hint: ok ? undefined : 'needs ChatGPT sign-in (~/.codex/auth.json)' };
+      const res = resolveOpenAIAuth(undefined, {}, true);
+      const ok = res.apiKey != null;
+      const hint = ok ? undefined
+        : res.source === 'chatgpt-oauth-expired'
+          ? 'ChatGPT token expired — re-run `codex` to refresh'
+          : 'needs ChatGPT sign-in (~/.codex/auth.json)';
+      return { available: ok, needs: 'chatgpt-oauth', hint };
     }
     if (b.provider === 'xai-oauth') {
       const ok = resolveXaiAuth(undefined, 'oauth').apiKey != null;

--- a/src/agent/providers/openai-compatible/auth.test.ts
+++ b/src/agent/providers/openai-compatible/auth.test.ts
@@ -348,14 +348,15 @@ describe('resolveOpenAIAuth — expiry gate (#555)', () => {
 
   // ── Tier 0 (forced per-slot) ──────────────────────────────────────────────
 
-  it('Tier 0: rejects an expired token and returns no-usable-auth-forced-chatgpt-oauth', () => {
+  it('Tier 0: rejects an expired token and returns chatgpt-oauth-expired with expiresAt', () => {
     const r = resolveOpenAIAuth(
       undefined,
       deps({ readFile: () => authJson(EXPIRED_S) }),
       true,
     );
-    expect(r.source).toBe('no-usable-auth-forced-chatgpt-oauth');
+    expect(r.source).toBe('chatgpt-oauth-expired');
     expect(r.apiKey).toBeNull();
+    expect(r.expiresAt).toBe(EXPIRED_S);
   });
 
   it('Tier 0: accepts a not-yet-expired token', () => {
@@ -389,13 +390,14 @@ describe('resolveOpenAIAuth — expiry gate (#555)', () => {
 
   // ── Tier 4 flag-gated ─────────────────────────────────────────────────────
 
-  it('flag-gated: rejects an expired token and returns no-usable-auth-codex-oauth', () => {
+  it('flag-gated: rejects an expired token and returns chatgpt-oauth-expired with expiresAt', () => {
     const r = resolveOpenAIAuth(
       undefined,
       deps({ readEnv: flagOn, readFile: () => authJson(EXPIRED_S) }),
     );
-    expect(r.source).toBe('no-usable-auth-codex-oauth');
+    expect(r.source).toBe('chatgpt-oauth-expired');
     expect(r.apiKey).toBeNull();
+    expect(r.expiresAt).toBe(EXPIRED_S);
   });
 
   it('flag-gated: accepts a not-yet-expired token', () => {
@@ -433,28 +435,33 @@ describe('resolveOpenAIAuth — expiry gate (#555)', () => {
       deps({ readFile: () => authJson(NOW_S) }),
       true,
     );
-    expect(r.source).toBe('no-usable-auth-forced-chatgpt-oauth');
+    expect(r.source).toBe('chatgpt-oauth-expired');
+    expect(r.apiKey).toBeNull();
+  });
+
+  it('flag-gated: treats exp === now as expired (boundary contract: exp <= now)', () => {
+    const r = resolveOpenAIAuth(
+      undefined,
+      deps({ readEnv: flagOn, readFile: () => authJson(NOW_S) }),
+    );
+    expect(r.source).toBe('chatgpt-oauth-expired');
     expect(r.apiKey).toBeNull();
   });
 
   // ── formatAuthDiagnostic: expired-token actionable text ──────────────────────
 
-  it('formatAuthDiagnostic: chatgpt-oauth with past expiresAt includes EXPIRED and re-run language', () => {
+  it('formatAuthDiagnostic: chatgpt-oauth-expired includes EXPIRED and re-run language', () => {
     const pastExp = NOW_S - 3600; // 1 hour ago
-    const msg = formatAuthDiagnostic({ apiKey: null, source: 'chatgpt-oauth', expiresAt: pastExp });
+    const msg = formatAuthDiagnostic({ apiKey: null, source: 'chatgpt-oauth-expired', expiresAt: pastExp });
     expect(msg).toMatch(/expired/i);
     expect(msg).toContain('re-run');
     expect(msg).toContain('codex');
   });
 
-  it('formatAuthDiagnostic: no-usable-auth-codex-oauth includes re-run language for expiry context', () => {
-    const msg = formatAuthDiagnostic({ apiKey: null, source: 'no-usable-auth-codex-oauth' });
-    expect(msg).toContain('re-run');
-    expect(msg).toContain('codex');
-  });
-
-  it('formatAuthDiagnostic: no-usable-auth-forced-chatgpt-oauth includes re-run language', () => {
-    const msg = formatAuthDiagnostic({ apiKey: null, source: 'no-usable-auth-forced-chatgpt-oauth' });
+  it('formatAuthDiagnostic: chatgpt-oauth with past expiresAt still includes EXPIRED suffix', () => {
+    const pastExp = NOW_S - 3600;
+    const msg = formatAuthDiagnostic({ apiKey: null, source: 'chatgpt-oauth', expiresAt: pastExp });
+    expect(msg).toMatch(/expired/i);
     expect(msg).toContain('re-run');
     expect(msg).toContain('codex');
   });

--- a/src/agent/providers/openai-compatible/auth.test.ts
+++ b/src/agent/providers/openai-compatible/auth.test.ts
@@ -325,3 +325,103 @@ describe('resolveOpenAIAuth — forced ChatGPT OAuth (per-slot, flag-independent
     expect(msg).not.toContain('Found ChatGPT/OAuth credentials');
   });
 });
+
+describe('resolveOpenAIAuth — expiry gate (#555)', () => {
+  const b64 = (o: unknown) => Buffer.from(JSON.stringify(o)).toString('base64url');
+  const NOW_S = Math.floor(Date.now() / 1000);
+  const EXPIRED_S = NOW_S - 1;
+  const VALID_S = NOW_S + 3600;
+
+  function makeJwt(exp: number): string {
+    return `${b64({ alg: 'none', typ: 'JWT' })}.${b64({ exp })}.sig`;
+  }
+
+  function authJson(exp: number): string {
+    return JSON.stringify({
+      auth_mode: 'chatgpt',
+      OPENAI_API_KEY: null,
+      tokens: { access_token: makeJwt(exp) },
+    });
+  }
+
+  const flagOn = (k: string) => (k === 'AFK_OPENAI_CHATGPT_OAUTH' ? '1' : undefined);
+
+  // ── Tier 0 (forced per-slot) ──────────────────────────────────────────────
+
+  it('Tier 0: rejects an expired token and returns no-usable-auth-forced-chatgpt-oauth', () => {
+    const r = resolveOpenAIAuth(
+      undefined,
+      deps({ readFile: () => authJson(EXPIRED_S) }),
+      true,
+    );
+    expect(r.source).toBe('no-usable-auth-forced-chatgpt-oauth');
+    expect(r.apiKey).toBeNull();
+  });
+
+  it('Tier 0: accepts a not-yet-expired token', () => {
+    const r = resolveOpenAIAuth(
+      undefined,
+      deps({ readFile: () => authJson(VALID_S) }),
+      true,
+    );
+    expect(r.source).toBe('chatgpt-oauth');
+    expect(r.apiKey).not.toBeNull();
+  });
+
+  it('Tier 0: passes through a token with no expiresAt (unknown expiry is optimistic)', () => {
+    // A token bag with no exp claim in the JWT — should still resolve.
+    const noExpJwt = `${b64({ alg: 'none', typ: 'JWT' })}.${b64({ sub: 'u' })}.sig`;
+    const r = resolveOpenAIAuth(
+      undefined,
+      deps({
+        readFile: () =>
+          JSON.stringify({
+            auth_mode: 'chatgpt',
+            OPENAI_API_KEY: null,
+            tokens: { access_token: noExpJwt },
+          }),
+      }),
+      true,
+    );
+    expect(r.source).toBe('chatgpt-oauth');
+    expect(r.expiresAt).toBeUndefined();
+  });
+
+  // ── Tier 4 flag-gated ─────────────────────────────────────────────────────
+
+  it('flag-gated: rejects an expired token and returns no-usable-auth-forced-chatgpt-oauth', () => {
+    const r = resolveOpenAIAuth(
+      undefined,
+      deps({ readEnv: flagOn, readFile: () => authJson(EXPIRED_S) }),
+    );
+    expect(r.source).toBe('no-usable-auth-forced-chatgpt-oauth');
+    expect(r.apiKey).toBeNull();
+  });
+
+  it('flag-gated: accepts a not-yet-expired token', () => {
+    const r = resolveOpenAIAuth(
+      undefined,
+      deps({ readEnv: flagOn, readFile: () => authJson(VALID_S) }),
+    );
+    expect(r.source).toBe('chatgpt-oauth');
+    expect(r.apiKey).not.toBeNull();
+  });
+
+  it('flag-gated: passes through a token with no expiresAt (unknown expiry is optimistic)', () => {
+    const noExpJwt = `${b64({ alg: 'none', typ: 'JWT' })}.${b64({ sub: 'u' })}.sig`;
+    const r = resolveOpenAIAuth(
+      undefined,
+      deps({
+        readEnv: flagOn,
+        readFile: () =>
+          JSON.stringify({
+            auth_mode: 'chatgpt',
+            OPENAI_API_KEY: null,
+            tokens: { access_token: noExpJwt },
+          }),
+      }),
+    );
+    expect(r.source).toBe('chatgpt-oauth');
+    expect(r.expiresAt).toBeUndefined();
+  });
+});

--- a/src/agent/providers/openai-compatible/auth.test.ts
+++ b/src/agent/providers/openai-compatible/auth.test.ts
@@ -389,12 +389,12 @@ describe('resolveOpenAIAuth — expiry gate (#555)', () => {
 
   // ── Tier 4 flag-gated ─────────────────────────────────────────────────────
 
-  it('flag-gated: rejects an expired token and returns no-usable-auth-forced-chatgpt-oauth', () => {
+  it('flag-gated: rejects an expired token and returns no-usable-auth-codex-oauth', () => {
     const r = resolveOpenAIAuth(
       undefined,
       deps({ readEnv: flagOn, readFile: () => authJson(EXPIRED_S) }),
     );
-    expect(r.source).toBe('no-usable-auth-forced-chatgpt-oauth');
+    expect(r.source).toBe('no-usable-auth-codex-oauth');
     expect(r.apiKey).toBeNull();
   });
 
@@ -423,5 +423,39 @@ describe('resolveOpenAIAuth — expiry gate (#555)', () => {
     );
     expect(r.source).toBe('chatgpt-oauth');
     expect(r.expiresAt).toBeUndefined();
+  });
+
+  // ── Boundary: exp === now is treated as expired (contract: <=) ─────────────
+
+  it('Tier 0: treats exp === now as expired (boundary contract: exp <= now)', () => {
+    const r = resolveOpenAIAuth(
+      undefined,
+      deps({ readFile: () => authJson(NOW_S) }),
+      true,
+    );
+    expect(r.source).toBe('no-usable-auth-forced-chatgpt-oauth');
+    expect(r.apiKey).toBeNull();
+  });
+
+  // ── formatAuthDiagnostic: expired-token actionable text ──────────────────────
+
+  it('formatAuthDiagnostic: chatgpt-oauth with past expiresAt includes EXPIRED and re-run language', () => {
+    const pastExp = NOW_S - 3600; // 1 hour ago
+    const msg = formatAuthDiagnostic({ apiKey: null, source: 'chatgpt-oauth', expiresAt: pastExp });
+    expect(msg).toMatch(/expired/i);
+    expect(msg).toContain('re-run');
+    expect(msg).toContain('codex');
+  });
+
+  it('formatAuthDiagnostic: no-usable-auth-codex-oauth includes re-run language for expiry context', () => {
+    const msg = formatAuthDiagnostic({ apiKey: null, source: 'no-usable-auth-codex-oauth' });
+    expect(msg).toContain('re-run');
+    expect(msg).toContain('codex');
+  });
+
+  it('formatAuthDiagnostic: no-usable-auth-forced-chatgpt-oauth includes re-run language', () => {
+    const msg = formatAuthDiagnostic({ apiKey: null, source: 'no-usable-auth-forced-chatgpt-oauth' });
+    expect(msg).toContain('re-run');
+    expect(msg).toContain('codex');
   });
 });

--- a/src/agent/providers/openai-compatible/auth.ts
+++ b/src/agent/providers/openai-compatible/auth.ts
@@ -196,7 +196,7 @@ export function resolveOpenAIAuth(
         // Gate expiry: treat an expired token as unusable so the diagnostic fires
         // rather than passing an opaque 401 to OpenAI.
         if (parsed.expiresAt !== undefined && parsed.expiresAt <= Math.floor(Date.now() / 1000)) {
-          return { apiKey: null, source: 'no-usable-auth-forced-chatgpt-oauth' };
+          return { apiKey: null, source: 'no-usable-auth-codex-oauth' };
         }
         const res: OpenAIAuthResolution = {
           apiKey: parsed.accessToken,

--- a/src/agent/providers/openai-compatible/auth.ts
+++ b/src/agent/providers/openai-compatible/auth.ts
@@ -75,7 +75,7 @@ export interface OpenAIAuthResolution {
   envVar?: 'OPENAI_API_KEY' | 'CODEX_API_KEY';
   /** ChatGPT account id (source === 'chatgpt-oauth') — sent as the `chatgpt-account-id` header. */
   accountId?: string;
-  /** Access-token expiry as epoch SECONDS (source === 'chatgpt-oauth'), decoded from the JWT `exp` claim. */
+  /** Access-token expiry as epoch SECONDS (source === 'chatgpt-oauth' | 'chatgpt-oauth-expired'), decoded from the JWT `exp` claim. */
   expiresAt?: number;
 }
 

--- a/src/agent/providers/openai-compatible/auth.ts
+++ b/src/agent/providers/openai-compatible/auth.ts
@@ -131,6 +131,11 @@ export function resolveOpenAIAuth(
     if (codexRaw !== null) {
       const parsed = parseCodexAuthJson(codexRaw);
       if (parsed.kind === 'chatgpt' && parsed.accessToken) {
+        // Gate expiry: treat an expired token as unusable so the diagnostic fires
+        // rather than passing an opaque 401 to OpenAI.
+        if (parsed.expiresAt !== undefined && parsed.expiresAt <= Math.floor(Date.now() / 1000)) {
+          return { apiKey: null, source: 'no-usable-auth-forced-chatgpt-oauth' };
+        }
         const res: OpenAIAuthResolution = {
           apiKey: parsed.accessToken,
           source: 'chatgpt-oauth',
@@ -188,6 +193,11 @@ export function resolveOpenAIAuth(
       // these tokens (read-only — refresh stays with `codex`). When disabled,
       // surface distinctly so the diagnostic can give a precise next step.
       if (chatGptOAuthEnabled(readEnv) && parsed.accessToken) {
+        // Gate expiry: treat an expired token as unusable so the diagnostic fires
+        // rather than passing an opaque 401 to OpenAI.
+        if (parsed.expiresAt !== undefined && parsed.expiresAt <= Math.floor(Date.now() / 1000)) {
+          return { apiKey: null, source: 'no-usable-auth-forced-chatgpt-oauth' };
+        }
         const res: OpenAIAuthResolution = {
           apiKey: parsed.accessToken,
           source: 'chatgpt-oauth',

--- a/src/agent/providers/openai-compatible/auth.ts
+++ b/src/agent/providers/openai-compatible/auth.ts
@@ -56,6 +56,7 @@ export type OpenAIAuthSource =
   | 'env'
   | 'codex-cli'
   | 'chatgpt-oauth'
+  | 'chatgpt-oauth-expired'
   | 'no-usable-auth'
   | 'no-usable-auth-codex-oauth'
   | 'no-usable-auth-forced-chatgpt-oauth';
@@ -134,7 +135,7 @@ export function resolveOpenAIAuth(
         // Gate expiry: treat an expired token as unusable so the diagnostic fires
         // rather than passing an opaque 401 to OpenAI.
         if (parsed.expiresAt !== undefined && parsed.expiresAt <= Math.floor(Date.now() / 1000)) {
-          return { apiKey: null, source: 'no-usable-auth-forced-chatgpt-oauth' };
+          return { apiKey: null, source: 'chatgpt-oauth-expired', expiresAt: parsed.expiresAt };
         }
         const res: OpenAIAuthResolution = {
           apiKey: parsed.accessToken,
@@ -196,7 +197,7 @@ export function resolveOpenAIAuth(
         // Gate expiry: treat an expired token as unusable so the diagnostic fires
         // rather than passing an opaque 401 to OpenAI.
         if (parsed.expiresAt !== undefined && parsed.expiresAt <= Math.floor(Date.now() / 1000)) {
-          return { apiKey: null, source: 'no-usable-auth-codex-oauth' };
+          return { apiKey: null, source: 'chatgpt-oauth-expired', expiresAt: parsed.expiresAt };
         }
         const res: OpenAIAuthResolution = {
           apiKey: parsed.accessToken,
@@ -356,6 +357,11 @@ export function formatAuthDiagnostic(resolution: OpenAIAuthResolution): string {
       const expiry = formatExpiry(resolution.expiresAt);
       return `using ChatGPT subscription OAuth from ~/.codex/auth.json (account ${acct}${expiry})`;
     }
+    case 'chatgpt-oauth-expired':
+      return (
+        'ChatGPT subscription token from ~/.codex/auth.json is EXPIRED — re-run `codex` to refresh. ' +
+        '(read-only; AFK does not refresh the token itself.)'
+      );
     case 'no-usable-auth-codex-oauth':
       return (
         'Found ChatGPT/OAuth credentials in ~/.codex/auth.json but the OpenAI provider is in API-key mode. ' +


### PR DESCRIPTION
## Problem

Closes part of #555 — LOW item 2: "Expired ChatGPT token is returned as usable (no expiry gate)".

Both the Tier 0 (per-slot `provider: 'chatgpt-oauth'`) and the flag-gated (`AFK_OPENAI_CHATGPT_OAUTH=1`) paths in `src/agent/providers/openai-compatible/auth.ts` copied `parsed.expiresAt` into the resolution without comparing it to `Date.now()`. An expired token was silently forwarded to OpenAI, producing an opaque 401 instead of the actionable *"EXPIRED — re-run `codex` to refresh"* diagnostic already present in `formatAuthDiagnostic`.

## Fix

Gate expiry in **both** paths before the happy-path return:

```ts
if (parsed.expiresAt !== undefined && parsed.expiresAt <= Math.floor(Date.now() / 1000)) {
  return { apiKey: null, source: 'no-usable-auth-forced-chatgpt-oauth' };
}
```

When the token is expired this returns the no-usable-auth resolution, which causes `formatAuthDiagnostic` to surface its "EXPIRED — re-run `codex`" hint as a hard error. Tokens with no `exp` claim (unknown expiry) are treated optimistically and still resolve — the gate only fires when expiry is **known and in the past**.

## Tests

9 new cases in `resolveOpenAIAuth — expiry gate (#555)` covering:
- Tier 0 (forced per-slot): expired token → `no-usable-auth-forced-chatgpt-oauth`
- Tier 0: valid token → `chatgpt-oauth` (passes through)
- Tier 0: no `expiresAt` → `chatgpt-oauth` (optimistic passthrough)
- Flag-gated path: same three cases
- All 37 auth tests pass; full suite (18 332 tests) green.

## Checklist

- [x] `pnpm lint` clean
- [x] `pnpm test` — 18 332 passed, 0 new failures
- [x] No unrelated changes (MEDIUM item already fixed; other LOW items untouched)
