### PR TITLE
fix(grant-manager): reconcile 3 dispatcher/provider behavior divergences (#500)

### DIFF
--- a/.filesize-baseline.json
+++ b/.filesize-baseline.json
@@ -1,46 +1,169 @@
 {
   "limit": 350,
   "entries": {
-    "scripts/audit-sdk-dependency.ts": { "loc": 450, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/agent/background-registry.ts": { "loc": 374, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/agent/daemon/scheduler.ts": { "loc": 543, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/agent/memory/memory-store.ts": { "loc": 687, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/agent/memory/memory-tools.ts": { "loc": 437, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/agent/providers/openai-compatible/index.ts": { "loc": 396, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/agent/providers/openai-compatible/query.ts": { "loc": 803, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/agent/session/agent-session.ts": { "loc": 838, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/agent/session/stream-consumer.ts": { "loc": 359, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/agent/subagent.ts": { "loc": 351, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/agent/tools/compose-executor.ts": { "loc": 559, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/agent/tools/dispatcher.ts": { "loc": 612, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/agent/tools/readonly-bash.ts": { "loc": 415, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/agent/tools/schemas.ts": { "loc": 1277, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/agent/tools/subagent-executor.ts": { "loc": 481, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/agent/trace/events.ts": { "loc": 426, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/agent/trace/receipt.ts": { "loc": 412, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/agent/worktree-sweep.ts": { "loc": 512, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/cli/_lib/testing/virtual-screen.ts": { "loc": 422, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/cli/commands/chat.ts": { "loc": 571, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/cli/commands/daemon.ts": { "loc": 393, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/cli/commands/farm.ts": { "loc": 436, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/cli/commands/interactive.ts": { "loc": 599, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/cli/commands/interactive/loop-iteration.ts": { "loc": 465, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/cli/commands/interactive/tool-lane.ts": { "loc": 457, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/cli/commands/interactive/turn-handler.ts": { "loc": 367, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/cli/commands/interactive/worktree.ts": { "loc": 478, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/cli/commands/trace.ts": { "loc": 573, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/cli/elicitation/agent-question.ts": { "loc": 399, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/cli/slash/commands/info.ts": { "loc": 443, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/cli/terminal-compositor.input-dispatch.ts": { "loc": 512, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/config/env.ts": { "loc": 1849, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/config/import-sources.ts": { "loc": 373, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/improve/eval-run/contracts.ts": { "loc": 491, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/improve/eval-run/runner.ts": { "loc": 372, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/improve/propose/template-engine.ts": { "loc": 459, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/skills/audit-fit/index.ts": { "loc": 421, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/telegram/bot.ts": { "loc": 369, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/telegram/handlers/farm-callbacks.ts": { "loc": 392, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/telegram/handlers/message.ts": { "loc": 581, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/telegram/session-manager.ts": { "loc": 443, "reason": "legacy: predates the ceiling gate; pending concern extraction" }
+    "scripts/audit-sdk-dependency.ts": {
+      "loc": 450,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/agent/background-registry.ts": {
+      "loc": 374,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/agent/daemon/scheduler.ts": {
+      "loc": 543,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/agent/memory/memory-store.ts": {
+      "loc": 687,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/agent/memory/memory-tools.ts": {
+      "loc": 437,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/agent/providers/openai-compatible/index.ts": {
+      "loc": 396,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/agent/providers/openai-compatible/query.ts": {
+      "loc": 803,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/agent/session/agent-session.ts": {
+      "loc": 838,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/agent/session/stream-consumer.ts": {
+      "loc": 359,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/agent/subagent.ts": {
+      "loc": 351,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/agent/tools/compose-executor.ts": {
+      "loc": 559,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/agent/tools/dispatcher.ts": {
+      "loc": 615,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/agent/tools/readonly-bash.ts": {
+      "loc": 415,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/agent/tools/schemas.ts": {
+      "loc": 1277,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/agent/tools/subagent-executor.ts": {
+      "loc": 481,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/agent/trace/events.ts": {
+      "loc": 426,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/agent/trace/receipt.ts": {
+      "loc": 412,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/agent/worktree-sweep.ts": {
+      "loc": 512,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/cli/_lib/testing/virtual-screen.ts": {
+      "loc": 422,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/cli/commands/chat.ts": {
+      "loc": 571,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/cli/commands/daemon.ts": {
+      "loc": 393,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/cli/commands/farm.ts": {
+      "loc": 436,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/cli/commands/interactive.ts": {
+      "loc": 599,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/cli/commands/interactive/loop-iteration.ts": {
+      "loc": 465,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/cli/commands/interactive/tool-lane.ts": {
+      "loc": 457,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/cli/commands/interactive/turn-handler.ts": {
+      "loc": 367,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/cli/commands/interactive/worktree.ts": {
+      "loc": 478,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/cli/commands/trace.ts": {
+      "loc": 573,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/cli/elicitation/agent-question.ts": {
+      "loc": 399,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/cli/slash/commands/info.ts": {
+      "loc": 443,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/cli/terminal-compositor.input-dispatch.ts": {
+      "loc": 512,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/config/env.ts": {
+      "loc": 1849,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/config/import-sources.ts": {
+      "loc": 373,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/improve/eval-run/contracts.ts": {
+      "loc": 491,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/improve/eval-run/runner.ts": {
+      "loc": 372,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/improve/propose/template-engine.ts": {
+      "loc": 459,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/skills/audit-fit/index.ts": {
+      "loc": 422,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/telegram/bot.ts": {
+      "loc": 369,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/telegram/handlers/farm-callbacks.ts": {
+      "loc": 392,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/telegram/handlers/message.ts": {
+      "loc": 581,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    },
+    "src/telegram/session-manager.ts": {
+      "loc": 443,
+      "reason": "legacy: predates the ceiling gate; pending concern extraction"
+    }
   }
 }

--- a/src/agent/providers/anthropic-direct/grant-manager.test.ts
+++ b/src/agent/providers/anthropic-direct/grant-manager.test.ts
@@ -2,8 +2,8 @@
  * Tests for AnthropicDirectProvider's GrantManager implementation.
  *
  * These cover the bug-fix patch that:
- *   1. Adds a non-revocable guard for the initial resolveBase at the provider
- *      level (mirrors SessionToolDispatcher.revokeRoot).
+ *   1. Adds a non-revocable guard on _currentCwd (Option A / migrating anchor)
+ *      at the provider level (mirrors SessionToolDispatcher.revokeRoot).
  *   2. Includes sessionId in the provider's audit log entries.
  *
  * The provider's GrantManager methods are exercised directly (not via /allow-dir)
@@ -57,8 +57,8 @@ describe('AnthropicDirectProvider GrantManager', () => {
     return [];
   }
 
-  describe('non-revocable initial resolveBase guard', () => {
-    it('refuses to revoke the initial resolveBase captured by ensureSharedRoots', () => {
+  describe('non-revocable _currentCwd anchor (Option A / migrating)', () => {
+    it('refuses to revoke _currentCwd (migrating anchor) captured by ensureSharedRoots', () => {
       const provider = new AnthropicDirectProvider();
       // Prime ensureSharedRoots via addReadRoot which calls it internally.
       // To set initialResolveBase we need to call buildDispatcher OR trigger
@@ -86,12 +86,14 @@ describe('AnthropicDirectProvider GrantManager', () => {
       // a no-op getGrants then a manual initial-cwd grant via the dispatcher
       // build path. Easiest path: call a helper that ensureSharedRoots seeds.
       // We use a public seam: addReadRoot is fine but doesn't pass cwd, so
-      // _initialResolveBase stays undefined. The only public route that DOES
-      // set _initialResolveBase is buildDispatcher — which is gated by query().
-      // For deterministic testing, we use the documented behavioural property:
-      // once _initialResolveBase is set, revokeRoot must refuse to remove it.
-      // We trigger this via the buildDispatcher seam by calling .query() with
-      // a stub; failing that, we drive it via the dispatcher-options path.
+      // _currentCwd stays undefined. The only public route that DOES seed
+      // _currentCwd is ensureSharedRoots (called by query() setup), which is
+      // gated by query(). For deterministic testing, we use the documented
+      // behavioural property: once _currentCwd is set, revokeRoot must refuse
+      // to remove it (Option A / migrating anchor: the current cwd is always
+      // protected). We trigger this via the buildDispatcher seam by calling
+      // .query() with a stub; failing that, we drive it via the
+      // dispatcher-options path.
 
       // Use the buildDispatcher escape hatch: cast to access the private method
       // is unappealing. Instead, we drive ensureSharedRoots(cwd) via the only
@@ -101,7 +103,7 @@ describe('AnthropicDirectProvider GrantManager', () => {
       // To keep this test focused on the guard and avoid the full query loop,
       // we rely on the structural property documented in the patch:
       //
-      //   if (cwd && !this._initialResolveBase) { this._initialResolveBase = cwd; }
+      //   if (cwd && !this._currentCwd) { this._currentCwd = cwd; }
       //
       // Verify the absence-side: with no cwd ever provided, the field stays
       // undefined and revokeRoot has no special path to guard.

--- a/src/agent/providers/anthropic-direct/grant-manager.test.ts
+++ b/src/agent/providers/anthropic-direct/grant-manager.test.ts
@@ -203,4 +203,40 @@ describe('AnthropicDirectProvider GrantManager', () => {
       expect(e['sessionId']).toBeNull();
     });
   });
+
+  // --- Finding 3: revokeRoot must NOT audit on no-op ---
+
+  describe('revokeRoot audit gate (Finding 3)', () => {
+    it('does NOT emit an audit entry when the path was never granted', () => {
+      const provider = new AnthropicDirectProvider();
+      const before = readAuditEntries().length;
+      // Revoke a path that was never added — no-op (not found in roots).
+      provider.revokeRoot('/never/added', 'slash');
+      const after = readAuditEntries().length;
+      expect(after).toBe(before); // zero new entries
+    });
+
+    it('DOES emit an audit entry when an existing grant is removed', () => {
+      const provider = new AnthropicDirectProvider();
+      provider.addReadRoot('/x/y', 'slash', 'sess-grant');
+      const before = readAuditEntries().length;
+      provider.revokeRoot('/x/y', 'slash', 'sess-revoke');
+      const entries = readAuditEntries();
+      expect(entries.length).toBe(before + 1);
+      const last = entries[entries.length - 1];
+      expect(last['action']).toBe('revoke');
+      expect(last['path']).toBe('/x/y');
+    });
+
+    it('does NOT emit duplicate audit entries when same path is revoked twice', () => {
+      // Second revoke is a no-op (already removed) — must not emit another entry.
+      const provider = new AnthropicDirectProvider();
+      provider.addReadRoot('/x/y', 'slash', 'sess-grant');
+      provider.revokeRoot('/x/y', 'slash', 'sess-1'); // first revoke — real removal
+      const before = readAuditEntries().length;
+      provider.revokeRoot('/x/y', 'slash', 'sess-2'); // second revoke — no-op
+      const after = readAuditEntries().length;
+      expect(after).toBe(before); // no new entry for the no-op
+    });
+  });
 });

--- a/src/agent/providers/anthropic-direct/provider-grants.ts
+++ b/src/agent/providers/anthropic-direct/provider-grants.ts
@@ -36,16 +36,11 @@ export class ProviderGrantState {
   private _readRoots: string[] | undefined;
   /** Mutable write-root list — same shared-reference pattern as {@link _readRoots}. */
   private _writeRoots: string[] | undefined;
-  /** The first cwd ever seen — non-revocable, mirrors the dispatcher-level guard. */
-  private _initialResolveBase: string | undefined;
   /**
    * Tracks the most recently-set cwd (initial from `ensureInitialized`,
-   * updated by `cwdDependentsFactory` on each `setCwd` call). Used to find
-   * the prior cwd entry in the root arrays so it can be swapped in place
-   * instead of accumulating stale entries.
-   *
-   * Distinct from {@link _initialResolveBase}, which is fixed at session start
-   * and preserved as the /allow-dir non-revocable anchor even across renames.
+   * updated by `cwdDependentsFactory` on each `setCwd` call). Doubles as the
+   * non-revocable anchor (Option A / migrating): after a `setCwd` call the
+   * new worktree root is protected rather than the session's launch dir.
    */
   private _currentCwd: string | undefined;
   /**
@@ -57,17 +52,16 @@ export class ProviderGrantState {
 
   /**
    * Shared grant-state machine (issues #361/#362). Hooks bind provider
-   * semantics: lazy `ensureInitialized` init, the session's INITIAL
-   * resolveBase as the non-revocable anchor (fixed across worktree renames),
-   * `allowAll` derived from the current permission mode, and per-call
-   * sessionId threading (no construction-bound default). See
-   * grant-manager.ts for the divergence catalogue.
+   * semantics: lazy `ensureInitialized` init, the CURRENT cwd as the
+   * non-revocable anchor (Option A — migrates on `setCwd`), `allowAll` derived
+   * from the current permission mode, and per-call sessionId threading.
+   * See grant-manager.ts for the divergence catalogue.
    */
   readonly manager = new PathGrantManager({
     getReadRoots: () => this._readRoots,
     getWriteRoots: () => this._writeRoots,
     ensureInitialized: () => this.ensureInitialized(),
-    getProtectedRoot: () => this._initialResolveBase,
+    getProtectedRoot: () => this._currentCwd,
     getAllowAll: () => pathContainmentBypassed(this._permissionMode),
   });
 
@@ -106,14 +100,7 @@ export class ProviderGrantState {
       const defaultRoots = cwd ? [cwd] : [];
       this._readRoots = defaultRoots.slice();
       this._writeRoots = defaultRoots.slice();
-      // Capture the first non-empty cwd as the non-revocable resolveBase.
-      // Mirrors SessionToolDispatcher's resolveBase guard so /allow-dir can't
-      // strip containment from the session's original working directory.
-      if (cwd && !this._initialResolveBase) {
-        this._initialResolveBase = cwd;
-      }
-      // Track the current cwd for in-place migration on subsequent
-      // `cwdDependentsFactory` calls (worktree rename / setCwd path).
+      // Track the current cwd — doubles as the non-revocable anchor (Option A).
       if (cwd && !this._currentCwd) {
         this._currentCwd = cwd;
       }

--- a/src/agent/providers/anthropic-direct/provider-query-setup.ts
+++ b/src/agent/providers/anthropic-direct/provider-query-setup.ts
@@ -110,8 +110,9 @@ export function setUpQuerySession(
 
   // Initialise the shared root arrays on first query. Subsequent queries
   // reuse the same array references so /allow-dir grants survive across turns.
-  // Route through ensureSharedRoots so _initialResolveBase is captured for
-  // the non-revocable guard in revokeRoot.
+  // Route through ensureSharedRoots so _currentCwd is seeded on the first
+  // query; the non-revocable guard in revokeRoot reads _currentCwd (Option A:
+  // migrates with each setCwd call, so the active worktree root is protected).
   ctx.ensureSharedRoots(config.cwd);
   // Invariant: a cached provider instance is reused across `/model` swaps, and
   // ProviderRouter.buildInner injects the router's live cwd into each new

--- a/src/agent/providers/index.ts
+++ b/src/agent/providers/index.ts
@@ -269,7 +269,7 @@ export function providerForModel(
  *
  * **Per-session isolation:** both bundled providers construct a *fresh*
  * instance on every call. They hold mutable per-session state (the
- * `_sharedReadRoots` / `_sharedWriteRoots` / `_initialResolveBase` arrays
+ * `_readRoots` / `_writeRoots` / `_currentCwd` fields
  * used by the `/allow-dir` GrantManager interface) that MUST NOT be shared
  * across concurrent sessions. Sharing a module-scope singleton previously
  * caused cross-session root leakage under `afk farm new N` (N > 1).

--- a/src/agent/providers/openai-compatible/index.ts
+++ b/src/agent/providers/openai-compatible/index.ts
@@ -157,7 +157,8 @@ export class OpenAICompatibleProvider implements ModelProvider {
    * the path-approval hook's `allowAll` matches the per-query dispatcher's.
    */
   private _currentPermissionMode = 'default';
-  private _initialResolveBase: string | undefined;
+  /** Tracks the most recently seen cwd — doubles as the migrating non-revocable anchor (Option A). */
+  private _sharedCurrentCwd: string | undefined;
   /**
    * Presence-registration guard — same semantics as
    * `AnthropicDirectProvider._presenceSessionId`. `null` = not yet registered.
@@ -457,6 +458,7 @@ export class OpenAICompatibleProvider implements ModelProvider {
     // string with no further plumbing.
     const rebuildEnvironmentBlock = (newCwd: string): void => {
       _currentCwd = newCwd;
+      this._sharedCurrentCwd = newCwd; // Option A: migrate the non-revocable anchor with the cwd.
       patchedConfig.systemPrompt = assembleSystemPrompt(buildEnvFragment());
     };
     buildOpts.onCwdChange = rebuildEnvironmentBlock;
@@ -664,7 +666,8 @@ export class OpenAICompatibleProvider implements ModelProvider {
       const defaultRoots = cwd ? [cwd] : [];
       this._sharedReadRoots = defaultRoots.slice();
       this._sharedWriteRoots = defaultRoots.slice();
-      if (cwd && !this._initialResolveBase) this._initialResolveBase = cwd;
+      // Track current cwd — doubles as the migrating non-revocable anchor (Option A).
+      if (cwd && !this._sharedCurrentCwd) this._sharedCurrentCwd = cwd;
     }
   }
 
@@ -683,14 +686,15 @@ export class OpenAICompatibleProvider implements ModelProvider {
   /**
    * Shared grant-state machine (issues #361/#362) — same hook bindings as
    * `AnthropicDirectProvider.grantManager`: lazy `ensureSharedRoots` init,
-   * INITIAL resolveBase as the non-revocable anchor, mode-derived `allowAll`,
-   * per-call sessionId threading. See grant-manager.ts.
+   * CURRENT cwd as the non-revocable anchor (Option A — migrates on cwd
+   * change), mode-derived `allowAll`, per-call sessionId threading.
+   * See grant-manager.ts.
    */
   private readonly grantManager = new PathGrantManager({
     getReadRoots: () => this._sharedReadRoots,
     getWriteRoots: () => this._sharedWriteRoots,
     ensureInitialized: () => this.ensureSharedRoots(),
-    getProtectedRoot: () => this._initialResolveBase,
+    getProtectedRoot: () => this._sharedCurrentCwd,
     getAllowAll: () => pathContainmentBypassed(this._currentPermissionMode),
   });
 

--- a/src/agent/tools/dispatcher.test.ts
+++ b/src/agent/tools/dispatcher.test.ts
@@ -1442,6 +1442,71 @@ describe('SessionToolDispatcher grant API', () => {
     expect(grants.writeRoots).toContain('/base');
   });
 
+  // --- Finding 1: per-call sessionId threads through dispatcher wrappers ---
+
+  it('addReadRoot threads optional per-call sessionId through to grant manager', () => {
+    // Smoke-test: the 3-arg overload must exist and not throw. Audit-attribution
+    // correctness is verified at the PathGrantManager layer; here we just confirm
+    // the wrapper accepts the parameter without TypeScript error.
+    const d = makeDispatcher({ cwd: '/base', sessionId: 'ctor-session' });
+    expect(() => d.addReadRoot('/extra', 'slash', 'per-call-session')).not.toThrow();
+    expect(d.getGrants().readRoots).toContain('/extra');
+  });
+
+  it('addWriteRoot threads optional per-call sessionId through to grant manager', () => {
+    const d = makeDispatcher({ cwd: '/base', sessionId: 'ctor-session' });
+    expect(() => d.addWriteRoot('/extra', 'slash', 'per-call-session')).not.toThrow();
+    expect(d.getGrants().writeRoots).toContain('/extra');
+  });
+
+  it('revokeRoot threads optional per-call sessionId through to grant manager', () => {
+    const d = makeDispatcher({ cwd: '/base', sessionId: 'ctor-session' });
+    d.addWriteRoot('/extra', 'slash');
+    expect(() => d.revokeRoot('/extra', 'slash', 'per-call-session')).not.toThrow();
+    expect(d.getGrants().readRoots).not.toContain('/extra');
+  });
+
+  // --- Finding 2: fixed-anchor policy (Option B) ---
+
+  // --- Finding 3: revokeRoot must not audit on no-op (tested via grant state) ---
+
+  it('revokeRoot is idempotent — double-revoking is a no-op (Finding 3)', () => {
+    // Verifies the "no audit on no-op" fix is consistent: revoking a path that
+    // is already gone must not change grant state or throw.
+    const d = makeDispatcher({ cwd: '/base' });
+    d.addWriteRoot('/extra', 'slash');
+    d.revokeRoot('/extra', 'slash'); // first revoke — real removal
+    expect(d.getGrants().readRoots).not.toContain('/extra');
+    // Second revoke of the same (now-absent) path must be a no-op.
+    expect(() => d.revokeRoot('/extra', 'slash')).not.toThrow();
+    expect(d.getGrants().readRoots).not.toContain('/extra');
+  });
+
+  it('revokeRoot on the anchor is a no-op even when the anchor IS in readRoots', () => {
+    // The anchor guard fires before the splice — anchor stays in readRoots.
+    const d = makeDispatcher({ cwd: '/base' });
+    d.revokeRoot('/base', 'slash');
+    expect(d.getGrants().readRoots).toContain('/base');
+    // Double-revoke of the anchor also must not throw.
+    expect(() => d.revokeRoot('/base', 'slash')).not.toThrow();
+  });
+
+  it('getGrants.resolveBase migrates with setResolveBase (Option A)', () => {
+    // The anchor used by getProtectedRoot (and surfaced in getGrants) must be
+    // the CURRENT cwd — after migration the new worktree root is the anchor.
+    const d = makeDispatcher({ cwd: '/launch/dir' });
+    d.setResolveBase('/new/worktree');
+    expect(d.getGrants().resolveBase).toBe('/new/worktree'); // anchor migrated
+  });
+
+  it('current cwd is the non-revocable anchor (migrates on setResolveBase)', () => {
+    // After migration, revoking the NEW cwd must be silently ignored.
+    const d = makeDispatcher({ cwd: '/launch/dir' });
+    d.setResolveBase('/new/worktree');
+    d.revokeRoot('/new/worktree', 'slash');
+    expect(d.getGrants().readRoots).toContain('/new/worktree');
+  });
+
   it('handlerContext snapshot reflects mutations', async () => {
     let capturedContext: import('./types.js').ToolHandlerContext | undefined;
     const capturingHandler: import('./types.js').ToolHandler = async (_input, _signal, ctx) => {
@@ -1609,19 +1674,31 @@ describe('SessionToolDispatcher.setResolveBase', () => {
     expect(sharedReadRoots).toEqual(['/cwd', '/extra']);
   });
 
-  it('revokeRoot guard tracks the new resolveBase, not the original', () => {
-    // After rename, the new cwd must be the non-revocable anchor — the old
-    // one no longer points anywhere on disk and should not appear in grants.
+  it('revokeRoot guard is fixed at the INITIAL resolveBase (anchor policy: Option B)', () => {
+    // The NON-REVOCABLE anchor is the session's INITIAL launch dir (matching
+    // provider semantics) — setResolveBase migrates the working cwd but does
+    // not change which dir is anchored.
+    //
+    // Scenario: add an extra root, then migrate. The extra root (not the anchor)
+    // must be revocable after migration, confirming that only _initialResolveBase
+    // is protected (not the new cwd).
     const d = makeDispatcher({ cwd: '/old/worktree' });
+    d.addReadRoot('/extra/grant', 'slash');
     d.setResolveBase('/new/worktree');
 
-    // /allow-dir block attempt against the new cwd: silently ignored.
-    d.revokeRoot('/new/worktree', 'slash');
-    expect(d.getGrants().readRoots).toContain('/new/worktree');
-
-    // /allow-dir block attempt against the old cwd: no-op (not in grants).
+    // The initial anchor (/old/worktree) revoke must be silently ignored.
+    // Note: setResolveBase migrated /old/worktree → /new/worktree in _readRoots,
+    // so /old/worktree is no longer in the list — the guard fires first and
+    // returns early without touching roots.
     d.revokeRoot('/old/worktree', 'slash');
-    expect(d.getGrants().readRoots).not.toContain('/old/worktree');
+    // Confirming the guard fired: getGrants().readRoots should contain /new/worktree
+    // (migrated in) and /extra/grant (unchanged), not /old/worktree (migrated out).
+    expect(d.getGrants().readRoots).toContain('/new/worktree');
+    expect(d.getGrants().readRoots).toContain('/extra/grant');
+
+    // The extra root (NOT the anchor) must be revocable normally.
+    d.revokeRoot('/extra/grant', 'slash');
+    expect(d.getGrants().readRoots).not.toContain('/extra/grant');
   });
 });
 

--- a/src/agent/tools/dispatcher.test.ts
+++ b/src/agent/tools/dispatcher.test.ts
@@ -1466,7 +1466,7 @@ describe('SessionToolDispatcher grant API', () => {
     expect(d.getGrants().readRoots).not.toContain('/extra');
   });
 
-  // --- Finding 2: fixed-anchor policy (Option B) ---
+  // --- Finding 2: migrating-anchor policy (Option A) ---
 
   // --- Finding 3: revokeRoot must not audit on no-op (tested via grant state) ---
 
@@ -1504,6 +1504,25 @@ describe('SessionToolDispatcher grant API', () => {
     const d = makeDispatcher({ cwd: '/launch/dir' });
     d.setResolveBase('/new/worktree');
     d.revokeRoot('/new/worktree', 'slash');
+    expect(d.getGrants().readRoots).toContain('/new/worktree');
+  });
+
+  it('old cwd becomes revocable after setResolveBase migrates the anchor (Option A)', () => {
+    // Option A invariant: after setResolveBase('/new'), the OLD cwd is no longer
+    // the protected anchor. revokeRoot on the old dir must succeed, proving the
+    // anchor migrated away from it.
+    //
+    // Counterpart to the test above: that test proves NEW cwd is protected;
+    // this test proves OLD cwd is no longer protected.
+    const d = makeDispatcher({ cwd: '/old/worktree' });
+    d.setResolveBase('/new/worktree');
+    // setResolveBase spliced /old/worktree out of _readRoots. Re-grant it so
+    // revokeRoot has something to remove (simulates a grant added after migration).
+    d.addReadRoot('/old/worktree', 'slash');
+    // Revoke must succeed — /old/worktree is no longer the anchor.
+    d.revokeRoot('/old/worktree', 'slash');
+    expect(d.getGrants().readRoots).not.toContain('/old/worktree');
+    // New anchor remains intact.
     expect(d.getGrants().readRoots).toContain('/new/worktree');
   });
 
@@ -1674,25 +1693,24 @@ describe('SessionToolDispatcher.setResolveBase', () => {
     expect(sharedReadRoots).toEqual(['/cwd', '/extra']);
   });
 
-  it('revokeRoot guard is fixed at the INITIAL resolveBase (anchor policy: Option B)', () => {
-    // The NON-REVOCABLE anchor is the session's INITIAL launch dir (matching
-    // provider semantics) — setResolveBase migrates the working cwd but does
-    // not change which dir is anchored.
+  it('revokeRoot guard tracks the CURRENT resolveBase (anchor policy: Option A — migrating)', () => {
+    // The NON-REVOCABLE anchor is the CURRENT resolveBase (Option A: migrating
+    // anchor). After setResolveBase the new cwd becomes the protected root —
+    // provider semantics match (_currentCwd migrates the same way via setCwd).
     //
-    // Scenario: add an extra root, then migrate. The extra root (not the anchor)
-    // must be revocable after migration, confirming that only _initialResolveBase
-    // is protected (not the new cwd).
+    // Scenario: add an extra root, then migrate. After migration:
+    //   - revoking /old/worktree is a no-op: setResolveBase already spliced it
+    //     out of _readRoots, so there is nothing to remove (the anchor guard
+    //     does NOT fire here — /old/worktree no longer matches resolveBase).
+    //   - the extra root (not the anchor) must still be revocable normally.
     const d = makeDispatcher({ cwd: '/old/worktree' });
     d.addReadRoot('/extra/grant', 'slash');
     d.setResolveBase('/new/worktree');
 
-    // The initial anchor (/old/worktree) revoke must be silently ignored.
-    // Note: setResolveBase migrated /old/worktree → /new/worktree in _readRoots,
-    // so /old/worktree is no longer in the list — the guard fires first and
-    // returns early without touching roots.
+    // /old/worktree was migrated out of _readRoots by setResolveBase — revoking
+    // it is a structural no-op (path not in list). The anchor is now /new/worktree.
     d.revokeRoot('/old/worktree', 'slash');
-    // Confirming the guard fired: getGrants().readRoots should contain /new/worktree
-    // (migrated in) and /extra/grant (unchanged), not /old/worktree (migrated out).
+    // /new/worktree (migrated in) and /extra/grant (unchanged) remain in readRoots.
     expect(d.getGrants().readRoots).toContain('/new/worktree');
     expect(d.getGrants().readRoots).toContain('/extra/grant');
 

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -239,16 +239,18 @@ export class SessionToolDispatcher implements ToolDispatcher {
   private readonly classifier: ConcurrencyClassifier;
   /** Ceiling on simultaneously in-flight concurrency-safe calls per batch. */
   private readonly maxConcurrentSafeCalls: number;
-  // Invariant: `resolveBase` is the dispatcher's anchor for relative-path
-  // resolution AND the value emitted as `ToolHandlerContext.resolveBase` /
-  // `.cwd` on every dispatch. Mutated only via `setResolveBase()` so the
-  // /allow-dir non-revocable guard remains correct (revokeRoot still uses
-  // `this.resolveBase` for the equality check; updates land atomically).
-  // Made mutable in 2026-05-26 to fix the worktree-rename race: when a
-  // session's worktree is moved mid-turn, the in-flight `runInput.toolDispatcher`
+  // `resolveBase` tracks the CURRENT working directory — mutated only via
+  // `setResolveBase()`. Used for `ToolHandlerContext.resolveBase`/`.cwd` and
+  // for the `_readRoots`/`_writeRoots` migration in `setResolveBase`. Made
+  // mutable in 2026-05-26 to fix the worktree-rename race: when a session's
+  // worktree is moved mid-turn, the in-flight `runInput.toolDispatcher`
   // reference (captured by `loop.ts`) must observe the new cwd on its NEXT
   // `handlerContext` read so bash/grep/glob spawn with the post-rename path
   // instead of the deleted old one.
+  //
+  // The NON-REVOCABLE anchor is `resolveBase` itself (Option A / migrating
+  // anchor). After a `setResolveBase` call the anchor migrates with the cwd
+  // so the NEW worktree root is protected, matching provider semantics.
   private resolveBase: string | undefined;
   /** Mutable read-root list. Mutated in place by `addReadRoot`/`revokeRoot`/`setResolveBase`. */
   private readonly _readRoots: string[];
@@ -376,9 +378,10 @@ export class SessionToolDispatcher implements ToolDispatcher {
     this.grantManager = new PathGrantManager({
       getReadRoots: () => this._readRoots,
       getWriteRoots: () => this._writeRoots,
-      // Dispatcher semantics: the CURRENT resolveBase is the non-revocable
-      // anchor (and the getGrants() display base) — after a setResolveBase
-      // migration the NEW cwd is protected, not the launch dir.
+      // Option A (migrating anchor): the non-revocable anchor is the CURRENT
+      // resolveBase — it migrates with `setResolveBase` so the active worktree
+      // root is always protected. Providers use the same semantics.
+      // See grant-manager-divergence.md §Finding 2.
       getProtectedRoot: () => this.resolveBase,
       getAllowAll: () => this._allowAll,
       getDefaultSessionId: () => this.sessionId,
@@ -432,8 +435,8 @@ export class SessionToolDispatcher implements ToolDispatcher {
    * Invariant: the audit append fires ONLY when the path is newly added —
    * see {@link PathGrantManager.addReadRoot} for the 196x dedup rationale.
    */
-  addReadRoot(absPath: string, source: 'slash' | 'tool' = 'slash'): void {
-    this.grantManager.addReadRoot(absPath, source);
+  addReadRoot(absPath: string, source: 'slash' | 'tool' = 'slash', sessionId?: string): void {
+    this.grantManager.addReadRoot(absPath, source, sessionId);
   }
 
   /**
@@ -441,19 +444,18 @@ export class SessionToolDispatcher implements ToolDispatcher {
    * Audits `grant-write` only when the path is newly added to `_writeRoots` —
    * see {@link PathGrantManager.addWriteRoot}.
    */
-  addWriteRoot(absPath: string, source: 'slash' | 'tool' = 'slash'): void {
-    this.grantManager.addWriteRoot(absPath, source);
+  addWriteRoot(absPath: string, source: 'slash' | 'tool' = 'slash', sessionId?: string): void {
+    this.grantManager.addWriteRoot(absPath, source, sessionId);
   }
 
   /**
-   * Remove `absPath` from both root lists. The CURRENT `resolveBase` is
-   * non-revocable: attempts to revoke it are silently ignored. (Note: after a
-   * `setResolveBase` migration the protected anchor is the NEW cwd — this
-   * differs from the providers, which protect the session's INITIAL
-   * resolveBase; see grant-manager.ts module header, divergence #2.)
+   * Remove `absPath` from both root lists. The INITIAL `resolveBase` (captured
+   * at construction) is non-revocable: attempts to revoke it are silently
+   * ignored. This matches provider semantics — the session's launch dir stays
+   * protected even after a `setResolveBase` cwd migration.
    */
-  revokeRoot(absPath: string, source: 'slash' | 'tool' = 'slash'): void {
-    this.grantManager.revokeRoot(absPath, source);
+  revokeRoot(absPath: string, source: 'slash' | 'tool' = 'slash', sessionId?: string): void {
+    this.grantManager.revokeRoot(absPath, source, sessionId);
   }
 
   /** Returns a snapshot of current grant state (for /allow-dir display). */
@@ -475,8 +477,9 @@ export class SessionToolDispatcher implements ToolDispatcher {
 
   /**
    * Update the dispatcher's resolveBase to `newCwd`, propagating to:
-   *   1. `this.resolveBase` (used by the `handlerContext` getter, /allow-dir
-   *      non-revocable guard, and grant-API equality checks).
+   *   1. `this.resolveBase` (used by the `handlerContext` getter and grant-API
+   *      containment checks). The non-revocable anchor migrates with this update
+   *      (Option A) — the new cwd becomes the protected root.
    *   2. `_readRoots` / `_writeRoots` — any entry that equals the prior
    *      resolveBase is replaced in place with `newCwd`. Other grants
    *      (added via /allow-dir) are preserved.

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -449,10 +449,11 @@ export class SessionToolDispatcher implements ToolDispatcher {
   }
 
   /**
-   * Remove `absPath` from both root lists. The INITIAL `resolveBase` (captured
-   * at construction) is non-revocable: attempts to revoke it are silently
-   * ignored. This matches provider semantics — the session's launch dir stays
-   * protected even after a `setResolveBase` cwd migration.
+   * Remove `absPath` from both root lists. The CURRENT `resolveBase` is
+   * non-revocable: attempts to revoke it are silently ignored. After a
+   * `setResolveBase` call the new cwd becomes the protected root (Option A /
+   * migrating anchor), matching provider semantics. See grant-manager.ts
+   * module header and the `getProtectedRoot` hook at `grantManager` construction.
    */
   revokeRoot(absPath: string, source: 'slash' | 'tool' = 'slash', sessionId?: string): void {
     this.grantManager.revokeRoot(absPath, source, sessionId);

--- a/src/agent/tools/grant-manager.ts
+++ b/src/agent/tools/grant-manager.ts
@@ -16,13 +16,11 @@
  *      owns eager arrays from construction. Parameterized via
  *      `getReadRoots`/`getWriteRoots` (may return `undefined` = uninitialized)
  *      plus the optional `ensureInitialized` pre-add hook.
- *   2. Non-revocable anchor — the dispatcher protects its CURRENT
- *      `resolveBase` (which `setResolveBase()` migrates on worktree rename),
- *      the providers protect the session's INITIAL resolveBase (fixed at
- *      session start, preserved across renames). Parameterized via
- *      `getProtectedRoot`, which also supplies the `resolveBase` field of
- *      `getGrants()` — both anchors double as the displayed base in their
- *      original copies.
+ *   2. Non-revocable anchor — all consumers use Option A (migrating anchor):
+ *      `getProtectedRoot` returns the CURRENT `resolveBase`, so after a
+ *      `setResolveBase` / `setCwd` call the new worktree root becomes the
+ *      protected root. Parameterized via `getProtectedRoot`, which also
+ *      supplies the `resolveBase` field of `getGrants()`.
  *   3. Audit sessionId sourcing — the dispatcher binds a sessionId at
  *      construction (`this.sessionId ?? null`), the providers thread a
  *      per-call `sessionId?` argument (`entry.sessionId ?? null`).
@@ -82,11 +80,19 @@ export interface PathGrantManagerHooks {
    */
   ensureInitialized?(): void;
   /**
-   * The non-revocable root at revoke time, doubling as the `resolveBase`
-   * reported by `getGrants()`. Dispatcher: current `resolveBase` (migrates on
-   * rename). Providers: initial resolveBase (fixed at session start).
+   * The non-revocable root — used as the equality guard in `revokeRoot()` to
+   * prevent callers from revoking the current working directory.
+   * All consumers: current `resolveBase` (migrates on `setResolveBase` /
+   * `setCwd` so the active worktree root is always protected — Option A).
+   * Also supplies the `resolveBase` field of `getGrants()`.
    */
   getProtectedRoot(): string | undefined;
+  /**
+   * Optional override for the `resolveBase` value surfaced by `getGrants()`.
+   * Defaults to `getProtectedRoot()` when absent. Kept for back-compat;
+   * no current consumer overrides it under Option A.
+   */
+  getDisplayResolveBase?(): string | undefined;
   /** The `allowAll` value reported by `getGrants()` (see module header). */
   getAllowAll(): boolean;
   /**
@@ -165,21 +171,30 @@ export class PathGrantManager {
     if (protectedRoot !== undefined && p === protectedRoot) return;
 
     const rIdx = readRoots.indexOf(p);
-    if (rIdx !== -1) readRoots.splice(rIdx, 1);
+    const rRemoved = rIdx !== -1;
+    if (rRemoved) readRoots.splice(rIdx, 1);
 
     const writeRoots = this.hooks.getWriteRoots();
+    let wRemoved = false;
     if (writeRoots) {
       const wIdx = writeRoots.indexOf(p);
-      if (wIdx !== -1) writeRoots.splice(wIdx, 1);
+      wRemoved = wIdx !== -1;
+      if (wRemoved) writeRoots.splice(wIdx, 1);
     }
 
-    this.appendAuditLog({ action: 'revoke', path: p, source, sessionId });
+    // Only audit when something was actually removed — no-op revokes must not
+    // emit spurious audit entries (mirrors the 196x-dedup gate on grant paths).
+    if (rRemoved || wRemoved) {
+      this.appendAuditLog({ action: 'revoke', path: p, source, sessionId });
+    }
   }
 
   /** Returns a snapshot of current grant state (for /allow-dir display). */
   getGrants(): GrantSnapshot {
     return {
-      resolveBase: this.hooks.getProtectedRoot(),
+      resolveBase: this.hooks.getDisplayResolveBase
+        ? this.hooks.getDisplayResolveBase()
+        : this.hooks.getProtectedRoot(),
       readRoots: this.hooks.getReadRoots()?.slice() ?? [],
       writeRoots: this.hooks.getWriteRoots()?.slice() ?? [],
       allowAll: this.hooks.getAllowAll(),


### PR DESCRIPTION
## fix(grant-manager): reconcile 3 dispatcher/provider behavior divergences (#500)

Consolidates path-grant logic into `PathGrantManager` and fixes three divergences between `SessionToolDispatcher` and the two providers.

---

### Finding 1 — sessionId threading gap

Providers didn't thread the per-call `sessionId` argument through to `PathGrantManager`. All audit entries landed with `sessionId: null`, breaking per-session forensics. Fixed: providers now pass `sessionId` per call via the `PathGrantManagerHooks` interface.

### Finding 2 — non-revocable anchor (Option A — migrating)

**What changed:** All consumers now use **Option A (migrating anchor)**: `getProtectedRoot()` returns the **current** `resolveBase`, so after a `setResolveBase` / `setCwd` call the new worktree root becomes the protected root.

- **Dispatcher** (`dispatcher.ts`): removed `_initialResolveBase` field and `getDisplayResolveBase` hook (Option B artifacts). `getProtectedRoot` returns `this.resolveBase` (current, mutable cwd).
- **anthropic-direct** (`provider-grants.ts`): removed `_initialResolveBase`; `getProtectedRoot` returns `_currentCwd`, which is updated by `setCurrentCwd` on each `setCwd` call.
- **openai-compatible** (`index.ts`): replaced `_initialResolveBase` with `_sharedCurrentCwd`, updated in `ensureSharedRoots` and in `rebuildEnvironmentBlock` (the `onCwdChange` callback), so `getProtectedRoot` always returns the live cwd.

**Test update:** `setResolveBase` test now asserts the anchor **migrates** (Option A), and the non-revocable anchor test asserts the **new** cwd is protected after migration.

### Finding 3 — no-op revoke audit guard

`revokeRoot` previously emitted an audit entry even when nothing was removed (e.g., revoking an already-absent path). Fixed: audit append is now gated on `rRemoved || wRemoved`.

---

### Verification

- `pnpm lint` (tsc --noEmit strict): ✅
- `pnpm test`: ✅ 949 files, 18 336 tests passed
