### PR TITLE
fix(witness): add SCOPE paragraphs to tool descriptions to prevent misuse

### DIFF
--- a/src/agent/tools/schemas.witness.ts
+++ b/src/agent/tools/schemas.witness.ts
@@ -18,7 +18,13 @@ export const readWitnessTool: AnthropicToolDef = {
     'Read and filter events from a session\'s witness trace (the durable record of ' +
     'everything the agent did). Returns structured trace events in chronological order. ' +
     'Use to inspect tool calls, errors, subagent lifecycles, costs, and session phases ' +
-    'from a specific session. Defaults to the most recent session.',
+    'from a specific session. Defaults to the most recent session.\n\n' +
+    'SCOPE: trace events contain operational metadata only — which tools fired, ' +
+    'timing, byte counts, error/success, session phases. They do NOT contain ' +
+    'conversation text, user messages, assistant replies, tool arguments, or tool ' +
+    'output. To find a session by what was *discussed*, search transcripts ' +
+    '(~/.afk/state/transcripts/) or session events (~/.afk/state/sessions/) via bash. ' +
+    'To recall cross-session context by topic, use memory_search.',
   input_schema: {
     type: 'object',
     properties: {
@@ -63,7 +69,13 @@ export const searchWitnessTool: AnthropicToolDef = {
     'trace events grouped by session. Use to find patterns across sessions — recurring errors, ' +
     'specific tool usage, cost spikes, or any text that appears in trace event payloads. ' +
     'Scans the N most recent sessions (default 20). Results are capped at 200 total matches ' +
-    'across all scanned sessions.',
+    'across all scanned sessions.\n\n' +
+    'SCOPE: searches trace event METADATA only — tool names, session phases, subagent IDs, ' +
+    'error classes, timing. Does NOT search conversation content, user/assistant messages, ' +
+    'tool arguments, or tool output (those are not stored in the trace). ' +
+    'To find a prior session by topic or what was said, search transcripts ' +
+    '(~/.afk/state/transcripts/) or session events (~/.afk/state/sessions/) via bash, ' +
+    'or use memory_search for cross-session topic recall.',
   input_schema: {
     type: 'object',
     properties: {

--- a/src/agent/tools/schemas.witness.ts
+++ b/src/agent/tools/schemas.witness.ts
@@ -19,11 +19,12 @@ export const readWitnessTool: AnthropicToolDef = {
     'everything the agent did). Returns structured trace events in chronological order. ' +
     'Use to inspect tool calls, errors, subagent lifecycles, costs, and session phases ' +
     'from a specific session. Defaults to the most recent session.\n\n' +
-    'SCOPE: trace events contain operational metadata only — which tools fired, ' +
-    'timing, byte counts, error/success, session phases. They do NOT contain ' +
-    'conversation text, user messages, assistant replies, tool arguments, or tool ' +
-    'output. To find a session by what was *discussed*, search transcripts ' +
-    '(~/.afk/state/transcripts/) or session events (~/.afk/state/sessions/) via bash. ' +
+    'SCOPE: trace events record which tools fired, timing, byte counts, ' +
+    'error/success, session phases, and some semantic snippets (e.g. subagent ' +
+    'promptHead, compaction summaries, claims). They do NOT contain full ' +
+    'conversation text, user/assistant messages, complete tool arguments, or ' +
+    'tool output. To find a session by what was *discussed*, search transcripts ' +
+    'or session events via bash (paths vary with AFK_STATE_DIR). ' +
     'To recall cross-session context by topic, use memory_search.',
   input_schema: {
     type: 'object',
@@ -70,11 +71,12 @@ export const searchWitnessTool: AnthropicToolDef = {
     'specific tool usage, cost spikes, or any text that appears in trace event payloads. ' +
     'Scans the N most recent sessions (default 20). Results are capped at 200 total matches ' +
     'across all scanned sessions.\n\n' +
-    'SCOPE: searches trace event METADATA only — tool names, session phases, subagent IDs, ' +
-    'error classes, timing. Does NOT search conversation content, user/assistant messages, ' +
-    'tool arguments, or tool output (those are not stored in the trace). ' +
+    'SCOPE: searches trace event payloads — tool names, session phases, subagent IDs, ' +
+    'error classes, timing, and semantic snippets like subagent promptHead (first 80 ' +
+    'chars), compaction summaries, and claims. Does NOT contain full conversation ' +
+    'text, user/assistant messages, complete tool arguments, or tool output. ' +
     'To find a prior session by topic or what was said, search transcripts ' +
-    '(~/.afk/state/transcripts/) or session events (~/.afk/state/sessions/) via bash, ' +
+    'or session events via bash (paths vary with AFK_STATE_DIR), ' +
     'or use memory_search for cross-session topic recall.',
   input_schema: {
     type: 'object',


### PR DESCRIPTION
## Problem

`read_witness` and `search_witness` tool descriptions say "the durable record of everything the agent did" without clarifying that traces contain **operational metadata only** -- not conversation text, tool arguments, or tool output.

Agents reading the description reasonably assume they can search for prior session content by topic. They fire queries like `"TUI UX claude code surpass"`, get empty results (~120 bytes), then fall back to bash on transcripts/session-events. Observed concretely in session `d3641f64` and confirmed across 50 recent sessions: **every session that used `search_witness` also used bash as fallback**.

![witness-fallback-pattern](https://github.com/user-attachments/assets/placeholder)

## Fix

Add explicit `SCOPE` paragraphs to both tool descriptions:
- State what traces **do** contain: tool names, timing, byte counts, error/success, session phases
- State what they **don't**: conversation text, user/assistant messages, tool arguments, tool output
- Direct agents to the right alternatives: transcripts via bash, `memory_search` for topic recall

This is a description-only change -- no handler or query logic modified.

## Expected impact

Agents should stop burning 2-3 empty `search_witness` calls before falling back to bash when looking for "what did we discuss in session X." The tool remains useful for its actual purpose (trace-level debugging: which tools fired, error patterns, cost spikes).
