### PR TITLE
fix(repl): deduplicate terminal-state rendering -- verdict card only

### DIFF
--- a/src/cli/_lib/stream-renderer.ts
+++ b/src/cli/_lib/stream-renderer.ts
@@ -457,6 +457,37 @@ export class StreamRenderer {
     }
   }
 
+  /**
+   * Strip the terminal-state prose block (Done/Blocked/Asking/Interrupted)
+   * from the markdown renderer's pending buffer so the verdict card is the
+   * sole visible rendering. Call BEFORE dispose — dispose flushes the pending
+   * buffer to scrollback.
+   *
+   * `headingOffset` is the character offset within the pending buffer where
+   * the terminal-state heading starts (from `findTerminalStateHeadingOffset`
+   * applied to the buffer, NOT to `responseText`).
+   *
+   * Returns `true` if the strip succeeded. No-op when the markdown renderer
+   * is not alive or the offset is out of bounds.
+   */
+  stripPendingTerminalState(headingOffset: number): boolean {
+    if (this.disposed) return false;
+    const md = this.streamingMarkdownRef.current;
+    if (!md) return false;
+    return md.stripPendingFrom(headingOffset);
+  }
+
+  /**
+   * Read the raw pending (uncommitted) buffer from the orchestrator's
+   * markdown renderer. Returns '' when disposed or no renderer is alive.
+   * Used by the turn handler to locate the terminal-state heading within
+   * the buffer rather than the full responseText.
+   */
+  getPendingBuffer(): string {
+    if (this.disposed) return '';
+    return this.streamingMarkdownRef.current?.getPendingBuffer() ?? '';
+  }
+
   /** Signal first streaming content — clears the TTFB waiting indicator. Idempotent. */
   notifyFirstContent(): void {
     if (this.disposed) return;

--- a/src/cli/commands/interactive/terminal-state.test.ts
+++ b/src/cli/commands/interactive/terminal-state.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { parseTerminalState } from './terminal-state.js';
+import { parseTerminalState, findTerminalStateHeadingOffset } from './terminal-state.js';
 
 describe('parseTerminalState — recognition', () => {
   it('returns null on empty input', () => {
@@ -228,5 +228,66 @@ describe('parseTerminalState — tail-anchored window', () => {
     const text = `Done\n- What was done: built it\n${filler}`;
     // Buried 10 lines deep, still within the 40-line tail.
     expect(parseTerminalState(text)?.kind).toBe('done');
+  });
+});
+
+describe('findTerminalStateHeadingOffset', () => {
+  it('returns -1 on empty input', () => {
+    expect(findTerminalStateHeadingOffset('')).toBe(-1);
+  });
+
+  it('returns -1 when no terminal heading is present', () => {
+    expect(findTerminalStateHeadingOffset('just some prose\nand more')).toBe(-1);
+  });
+
+  it('returns the character offset of a plain Done heading', () => {
+    const text = 'I fixed the bug.\n\nDone\n- What was done: fixed it';
+    const offset = findTerminalStateHeadingOffset(text);
+    expect(offset).toBe(text.indexOf('Done'));
+    expect(text.slice(offset)).toMatch(/^Done\n/);
+  });
+
+  it('returns the character offset of a bold **Done** heading', () => {
+    const text = 'prose here\n\n**Done**\n- What was done: shipped';
+    const offset = findTerminalStateHeadingOffset(text);
+    expect(offset).toBe(text.indexOf('**Done**'));
+  });
+
+  it('returns the character offset of a markdown ### Done heading', () => {
+    const text = 'prose\n\n### Done\n- What was done: shipped';
+    const offset = findTerminalStateHeadingOffset(text);
+    expect(offset).toBe(text.indexOf('### Done'));
+  });
+
+  it('returns the offset of a Blocked heading', () => {
+    const text = 'tried stuff\n\n**Blocked**\n- What blocks: no key';
+    const offset = findTerminalStateHeadingOffset(text);
+    expect(offset).toBe(text.indexOf('**Blocked**'));
+  });
+
+  it('returns the offset of an Asking heading', () => {
+    const text = 'looked around\n\nAsking\n- Question: which branch?';
+    const offset = findTerminalStateHeadingOffset(text);
+    expect(offset).toBe(text.indexOf('Asking'));
+  });
+
+  it('returns the offset of an Interrupted heading', () => {
+    const text = 'mid-work\n\nInterrupted\n- What you were doing: building';
+    const offset = findTerminalStateHeadingOffset(text);
+    expect(offset).toBe(text.indexOf('Interrupted'));
+  });
+
+  it('handles text with no preceding prose (heading is the first line)', () => {
+    const text = '**Done**\n- What was done: quick fix';
+    const offset = findTerminalStateHeadingOffset(text);
+    expect(offset).toBe(0);
+  });
+
+  it('slicing at the offset gives the terminal state block', () => {
+    const prose = 'I investigated the issue and found the root cause.\n\n';
+    const heading = '**Done**\n- What was done: patched auth.ts\n- Evidence: tests pass';
+    const text = prose + heading;
+    const offset = findTerminalStateHeadingOffset(text);
+    expect(text.slice(offset)).toBe(heading);
   });
 });

--- a/src/cli/commands/interactive/terminal-state.ts
+++ b/src/cli/commands/interactive/terminal-state.ts
@@ -76,6 +76,41 @@ export interface TerminalState {
 const TAIL_LINES = 40;
 
 /**
+ * Find the character offset in `text` where the terminal-state heading
+ * starts (the `**Done**`, `### Blocked`, etc. line). Returns -1 when no
+ * terminal state heading is found in the tail region.
+ *
+ * Used by the markdown stream to strip the terminal-state prose block
+ * from the pending buffer before flush, so the verdict card is the sole
+ * visible rendering (eliminating the double-render).
+ *
+ * The search is tail-anchored like `parseTerminalState` — it scans the
+ * last `TAIL_LINES` lines and walks backward for the heading.
+ */
+export function findTerminalStateHeadingOffset(text: string): number {
+  if (!text) return -1;
+
+  const lines = text.split('\n');
+  const tailStart = Math.max(0, lines.length - TAIL_LINES);
+  const tail = lines.slice(tailStart);
+
+  for (let i = tail.length - 1; i >= 0; i--) {
+    const line = tail[i] ?? '';
+    if (lineToKind(line)) {
+      // Compute the character offset in the original text. Sum lengths of
+      // all lines before `tailStart + i`, plus `tailStart + i` newlines.
+      const absoluteIdx = tailStart + i;
+      let offset = 0;
+      for (let j = 0; j < absoluteIdx; j++) {
+        offset += (lines[j]?.length ?? 0) + 1; // +1 for the '\n'
+      }
+      return offset;
+    }
+  }
+  return -1;
+}
+
+/**
  * Attempt to parse a terminal-state declaration from the assistant's final
  * text. Returns `null` when the trailing region does not look like a verdict.
  *

--- a/src/cli/commands/interactive/turn-handler.ts
+++ b/src/cli/commands/interactive/turn-handler.ts
@@ -18,7 +18,7 @@ import {
   formatTerminalTitle,
 } from '../../_lib/capture-mode.js';
 import { runWithSink } from '../../../agent/_lib/skill-sink-channel.js';
-import { parseTerminalState, type TerminalState } from './terminal-state.js';
+import { parseTerminalState, findTerminalStateHeadingOffset, type TerminalState } from './terminal-state.js';
 import { joinAtRoundSeam } from './turn-text-seam.js';
 import { renderVerdictCard } from './verdict-card.js';
 import { pushTerminalStateToTelegram, doneHasCorroboratingEvidence, classifyDoneEvidence } from './afk-push.js';
@@ -580,6 +580,13 @@ export async function runTurn(
       }
     });
 
+    // Invariant: strip the terminal-state prose from the pending buffer
+    // BEFORE dispose flushes it — the verdict card is the sole rendering.
+    if (doneFired && !softStopRequested && !pauseInterruptRequested) {
+      const off = findTerminalStateHeadingOffset(renderer.getPendingBuffer());
+      if (off >= 0) renderer.stripPendingTerminalState(off);
+    }
+
     // Stage 3e — mid-stream queued buffer is now handled natively by the
     // persistent compositor: dispose() flips to idle mode, which (per
     // the widened setInputMode flush invariant) fires the surface's
@@ -614,8 +621,10 @@ export async function runTurn(
     // here; doing so sent users down a dead-end. See the onSoftStop doc in
     // terminal-compositor.types.ts: "next Enter starts a new turn in the
     // same session.")
+    // Shared writer for soft-stop and pause-interrupt notices below.
+    const writeNotice = completionWriter ? completionWriter.fn : console.log;
+
     if (softStopRequested) {
-      const write = completionWriter ? completionWriter.fn : console.log;
       // Surface how many type-ahead messages are still queued (Enter-committed
       // pendingSubmissions preserved across the soft-stop per the ESC contract).
       // The authoritative count is the persistent compositor's getPendingCount()
@@ -630,27 +639,24 @@ export async function runTurn(
       // trailing blank line. The predecessor (last committed paragraph
       // or tool block) already emitted its own trailing blank, so a
       // leading blank here would double-up. See docs/tui-rhythm.md.
-      write(palette.warning(`⏸ Stopped${queuedSuffix} — work so far kept.`) +
+      writeNotice(palette.warning(`⏸ Stopped${queuedSuffix} — work so far kept.`) +
         palette.dim('  Send a message to continue.'));
-      write('');
+      writeNotice('');
     }
 
     // Pause-interrupt: the user submitted a line during a usage-limit pause to
     // end the wait. The queued buffer flushes as the next turn at the next
     // readLine (idle-transition flush). Gentle note, distinct from ESC's stop.
     if (pauseInterruptRequested) {
-      const write = completionWriter ? completionWriter.fn : console.log;
       // Owns one trailing blank (TUI rhythm contract — see docs/tui-rhythm.md).
-      write(palette.dim('▶ Ending wait — running your next command…'));
-      write('');
+      writeNotice(palette.dim('▶ Ending wait — running your next command…'));
+      writeNotice('');
     }
 
     if (doneFired && !softStopRequested && !pauseInterruptRequested) {
       recordTurn(stats, historyText, responseText, doneMeta, toolEvents);
 
-      if (h.onTurnComplete) {
-        await h.onTurnComplete(historyText, responseText).catch(() => { /* best-effort */ });
-      }
+      await h.onTurnComplete?.(historyText, responseText).catch(() => { /* best-effort */ });
 
       // Ring the terminal bell on turn completion when enabled (AFK_BELL=1,
       // TTY-only) — an away-from-keyboard completion cue. No-op otherwise.

--- a/src/cli/markdown-stream.test.ts
+++ b/src/cli/markdown-stream.test.ts
@@ -1166,4 +1166,69 @@ describe('StreamingMarkdownRenderer', () => {
       expect(output).toContain('other: val');
     });
   });
+
+  describe('stripPendingFrom', () => {
+    it('strips content from offset to end of pending buffer', () => {
+      renderer = new StreamingMarkdownRenderer({ out: stream });
+      renderer.push('prose here\n\n**Done**\n- What was done: fixed it');
+      // After push, 'prose here\n\n' was committed as a block.
+      // The pending buffer should contain the Done block.
+      const pending = renderer.getPendingBuffer();
+      expect(pending).toContain('**Done**');
+
+      const offset = pending.indexOf('**Done**');
+      expect(renderer.stripPendingFrom(offset)).toBe(true);
+      expect(renderer.getPendingBuffer()).not.toContain('Done');
+    });
+
+    it('returns false when offset is out of bounds', () => {
+      renderer = new StreamingMarkdownRenderer({ out: stream });
+      renderer.push('some text');
+      expect(renderer.stripPendingFrom(999)).toBe(false);
+      expect(renderer.stripPendingFrom(-1)).toBe(false);
+    });
+
+    it('stripped content does not appear in committed output after flush', async () => {
+      renderer = new StreamingMarkdownRenderer({ out: stream });
+      // Push prose + terminal state in one go. The \n\n commits prose; Done stays pending.
+      renderer.push('I fixed the bug.\n\n**Done**\n- What was done: fixed it');
+
+      const pending = renderer.getPendingBuffer();
+      const offset = pending.indexOf('**Done**');
+      renderer.stripPendingFrom(offset);
+
+      await renderer.flush();
+
+      const output = renderer.getCommittedOutput();
+      expect(output).toContain('I fixed the bug');
+      expect(output).not.toContain('**Done**');
+      expect(output).not.toContain('What was done');
+    });
+
+    it('preserves content before the terminal state heading', async () => {
+      renderer = new StreamingMarkdownRenderer({ out: stream });
+      renderer.push('Some important context.\n\n**Done**\n- What was done: shipped');
+
+      const pending = renderer.getPendingBuffer();
+      const offset = pending.indexOf('**Done**');
+      renderer.stripPendingFrom(offset);
+
+      await renderer.flush();
+
+      const output = renderer.getCommittedOutput();
+      expect(output).toContain('Some important context');
+    });
+
+    it('handles Done block as the only content (offset 0)', () => {
+      renderer = new StreamingMarkdownRenderer({ out: stream });
+      renderer.push('**Done**\n- What was done: quick fix');
+
+      const pending = renderer.getPendingBuffer();
+      expect(pending).toContain('**Done**');
+
+      const offset = pending.indexOf('**Done**');
+      expect(renderer.stripPendingFrom(offset)).toBe(true);
+      expect(renderer.getPendingBuffer().trim()).toBe('');
+    });
+  });
 });

--- a/src/cli/markdown-stream.ts
+++ b/src/cli/markdown-stream.ts
@@ -371,6 +371,29 @@ export class StreamingMarkdownRenderer {
   }
 
   /**
+   * Strip a suffix from the pending buffer, starting at `offset`.
+   * Content from `buffer[offset]` onward is dropped without committing.
+   * Leading/trailing whitespace around the truncation point is trimmed
+   * so no orphan blank lines remain.
+   *
+   * Returns `true` if anything was stripped, `false` otherwise.
+   *
+   * Used to remove the terminal-state prose block (Done/Blocked/…) from
+   * the pending buffer before flush commits it to scrollback — so the
+   * verdict card is the sole visible rendering.
+   *
+   * Contract: this ONLY operates on the pending buffer. Content already
+   * committed to scrollback (past a `\n\n` boundary during streaming) is
+   * unreachable — the terminal-state block is expected to be the last
+   * block in the response, with no trailing `\n\n`, so it stays pending.
+   */
+  stripPendingFrom(offset: number): boolean {
+    if (offset < 0 || offset >= this.buffer.length) return false;
+    this.buffer = this.buffer.slice(0, offset).trimEnd();
+    return true;
+  }
+
+  /**
    * Discard the pending (uncommitted) buffer WITHOUT committing it to
    * scrollback, and clear the live overlay. Counterpart to {@link
    * commitPending} (which COMMITS the buffer) and distinct from {@link


### PR DESCRIPTION
## Problem

The Done/Blocked/Asking/Interrupted terminal state renders **twice** in the REPL:

1. As prose in the markdown stream (the bullet list the model emits)
2. As the structured verdict card (`╭─ ✓ Done ─╮` box) parsed from that same prose

The card was documented as "additive," but on short turns the duplication is pure noise -- the same four fields appear verbatim in both renderings.

## Fix

Strip the terminal-state prose block from the markdown renderer's pending buffer **before** `dispose()` flushes it to scrollback. The verdict card becomes the sole visible rendering.

### Why this works

- The terminal-state block is always the last thing the model emits, with no trailing `\n\n`, so it stays in the markdown renderer's **pending buffer** (never committed during streaming).
- `responseText` -- which `parseTerminalState()` reads to build the verdict card -- accumulates independently from stream deltas and is unaffected by the strip.
- **Fallback safety**: if the heading is not found in the pending buffer (e.g., it was already committed during streaming due to an unusual `\n\n` placement, or format mismatch), no strip occurs and the prose renders as before.

### Changes

| File | What |
|------|------|
| `terminal-state.ts` | New `findTerminalStateHeadingOffset()` -- locates the character offset of the terminal-state heading in a text block. Reuses the existing `lineToKind()` parser. |
| `markdown-stream.ts` | New `stripPendingFrom(offset)` -- removes content from offset onward in the pending buffer without committing it. |
| `stream-renderer.ts` | New `stripPendingTerminalState()` and `getPendingBuffer()` -- public API that delegates to the markdown renderer. |
| `turn-handler.ts` | 4-line strip call between stream completion and `disposeRendererOnce()`. Budget-neutral: hoisted a duplicate `const write` and inlined an `if` guard to offset the addition. |

### Tests

- 10 new tests for `findTerminalStateHeadingOffset()` (offset correctness, all four terminal kinds, edge cases)
- 5 new tests for `stripPendingFrom()` (strip behavior, out-of-bounds, flush-after-strip, content preservation)
- All 6,384 existing tests pass
