### PR TITLE
feat(render): extract costTokenParts into shared component (#1401)

### DIFF
--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -14,7 +14,8 @@ import { env } from '../../config/env.js';
 import { injectCompanionPrimer } from '../../agent/companion/index.js';
 import type { AgentModelInput, ThinkingConfig, EffortLevel } from '../../agent/types.js';
 import { unconfiguredSlotError } from '../../agent/session/model-slots.js';
-import { formatDuration, formatCost, formatTokens } from '../format-utils.js';
+import { formatDuration } from '../format-utils.js';
+import { costTokenParts } from '../render/session-summary.js';
 import { parseThinking, parseEffort, parseBudget, parseMaxOutputTokens, parseProvider, getApiKeyForModel, getModel, getThinking, getEffort, getMaxBudgetUsd, getTaskBudget, getMaxOutputTokens, getMaxToolUseIterations, getDefaultSubagentModel, resolveBaseSystemPrompt, explicitProviderHints } from '../shared-helpers.js';
 import { topLevelSurfaceAllowedTools } from '../../agent/tools/top-level-allowlist.js';
 import { loadConfig } from '../config.js';
@@ -757,10 +758,13 @@ export function registerChatCommand(program: Command): void {
           if (responseMeta) {
             const chatParts: string[] = [];
             if (responseMeta.durationMs) chatParts.push(formatDuration(responseMeta.durationMs));
-            if (responseMeta.totalCostUsd !== undefined) chatParts.push(formatCost(responseMeta.totalCostUsd));
             const chatInputTokens = Number(responseMeta.usage?.['input_tokens'] ?? 0);
             const chatOutputTokens = Number(responseMeta.usage?.['output_tokens'] ?? 0);
-            if (chatInputTokens + chatOutputTokens > 0) chatParts.push(formatTokens(chatInputTokens + chatOutputTokens) + ' tokens');
+            chatParts.push(...costTokenParts({
+              costUsd: responseMeta.totalCostUsd,
+              tokens: chatInputTokens + chatOutputTokens,
+              includeZeroCost: responseMeta.totalCostUsd !== undefined,
+            }));
             if (chatParts.length > 0) {
               console.log(palette.dim('  · ' + chatParts.join(' · ')));
             }

--- a/src/cli/commands/interactive.ts
+++ b/src/cli/commands/interactive.ts
@@ -5,7 +5,8 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { welcomeBanner, divider } from '../render.js';
-import { formatDuration, formatCost, formatTokens } from '../format-utils.js';
+import { formatDuration } from '../format-utils.js';
+import { costTokenParts } from '../render/session-summary.js';
 import { registerCleanup, runCleanupFunctions } from '../../utils/cleanupRegistry.js';
 import { getModel } from '../shared-helpers.js';
 import { palette } from '../palette.js';
@@ -1006,8 +1007,7 @@ function printExitSummary(
     `${ctx.stats.totalTurns} turn${ctx.stats.totalTurns === 1 ? '' : 's'}`,
     formatDuration(Date.now() - ctx.stats.sessionStartTime),
   ];
-  if (ctx.stats.totalCostUsd > 0) parts.push(formatCost(ctx.stats.totalCostUsd));
-  if (ctx.stats.totalTokens > 0) parts.push(formatTokens(ctx.stats.totalTokens) + ' tokens');
+  parts.push(...costTokenParts({ costUsd: ctx.stats.totalCostUsd, tokens: ctx.stats.totalTokens }));
   console.log(palette.dim('  ' + parts.join(' · ')));
 
   // Line 2: model · worktree name (or 'none')

--- a/src/cli/commands/interactive/resume-swap.ts
+++ b/src/cli/commands/interactive/resume-swap.ts
@@ -1,6 +1,6 @@
 import { resumeConfigFor, type ResolvedResumeTarget } from '../../resume-session.js';
 import { autoRegisterPluginPassthroughs } from '../../slash/plugin-skills.js';
-import { formatCost, formatTokens } from '../../format-utils.js';
+import { costTokenParts } from '../../render/session-summary.js';
 import { palette } from '../../palette.js';
 import { formatStatusFields, printResumeBanner, reseedStatsFromStored, type ResumeSwapResult, type CompletionWriter } from './shared.js';
 import type { SessionRef } from '../../../agent/session-ref.js';
@@ -225,8 +225,7 @@ export async function performResumeSwap(
   // Step 11 — Print a "Resuming…" line.
   const resumingParts: string[] = [`↪ Resumed ${target.id}`];
   if (deps.stats.totalTurns > 0) resumingParts.push(`${deps.stats.totalTurns} prior turn${deps.stats.totalTurns === 1 ? '' : 's'}`);
-  if (deps.stats.totalCostUsd > 0) resumingParts.push(formatCost(deps.stats.totalCostUsd));
-  if (deps.stats.totalTokens > 0) resumingParts.push(formatTokens(deps.stats.totalTokens) + ' tokens');
+  resumingParts.push(...costTokenParts({ costUsd: deps.stats.totalCostUsd, tokens: deps.stats.totalTokens }));
   deps.completionWriter.fn(palette.brand(resumingParts.join('  ·  ')));
 
   // Step 11b — Surface a brief "where was I" cue under the resume line

--- a/src/cli/commands/interactive/turn-handler.footer.ts
+++ b/src/cli/commands/interactive/turn-handler.footer.ts
@@ -12,7 +12,8 @@
 
 import type { SessionStats } from '../../slash/types.js';
 import { palette } from '../../palette.js';
-import { formatDuration, formatCost, formatTokens } from '../../format-utils.js';
+import { formatDuration, formatTokens } from '../../format-utils.js';
+import { costTokenParts } from '../../render/session-summary.js';
 import { contextLimitFor } from '../../model-limits.js';
 import { getQuotaSnapshot } from '../../../agent/quota-cache.js';
 import { quotaWindowsFromSnapshot } from '../../quota-indicator.js';
@@ -73,10 +74,13 @@ export function printTurnFooter(
   if (!meta) return;
   const parts: string[] = [];
   if (meta.durationMs) parts.push(formatDuration(meta.durationMs));
-  if (meta.totalCostUsd !== undefined) parts.push(formatCost(meta.totalCostUsd));
   const inTok = Number(meta.usage?.['input_tokens'] ?? 0);
   const outTok = Number(meta.usage?.['output_tokens'] ?? 0);
-  if (inTok + outTok > 0) parts.push(formatTokens(inTok + outTok) + ' tokens');
+  parts.push(...costTokenParts({
+    costUsd: meta.totalCostUsd,
+    tokens: inTok + outTok,
+    includeZeroCost: meta.totalCostUsd !== undefined,
+  }));
   if (parts.length > 0) {
     write(palette.dim('  ◦ ' + parts.join('  ·  ')));
   }

--- a/src/cli/render/index.ts
+++ b/src/cli/render/index.ts
@@ -27,3 +27,4 @@ export * from './compact-diff-view.js';
 export * from './preview-diff.js';
 export * from './context-bar.js';
 export * from './context-sparkline.js';
+export * from './session-summary.js';

--- a/src/cli/render/session-summary.test.ts
+++ b/src/cli/render/session-summary.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for src/cli/render/session-summary.ts
+ */
+
+import { describe, it, expect } from 'vitest';
+import { costTokenParts } from './session-summary.js';
+
+describe('costTokenParts', () => {
+  // ── both absent / zero ──────────────────────────────────────────────────────
+
+  it('returns [] when both costUsd and tokens are undefined', () => {
+    expect(costTokenParts({})).toEqual([]);
+  });
+
+  it('returns [] when costUsd is 0 and includeZeroCost is false (default)', () => {
+    expect(costTokenParts({ costUsd: 0 })).toEqual([]);
+  });
+
+  it('returns [] when tokens is 0', () => {
+    expect(costTokenParts({ tokens: 0 })).toEqual([]);
+  });
+
+  it('returns [] when both costUsd is 0 and tokens is 0', () => {
+    expect(costTokenParts({ costUsd: 0, tokens: 0 })).toEqual([]);
+  });
+
+  // ── cost only ───────────────────────────────────────────────────────────────
+
+  it('returns cost fragment when costUsd > 0', () => {
+    const result = costTokenParts({ costUsd: 1.23 });
+    expect(result).toEqual(['$1.23']);
+  });
+
+  it('returns cost fragment for a sub-cent cost', () => {
+    const result = costTokenParts({ costUsd: 0.0012 });
+    expect(result).toEqual(['$0.0012']);
+  });
+
+  it('returns zero-cost fragment when includeZeroCost is true', () => {
+    const result = costTokenParts({ costUsd: 0, includeZeroCost: true });
+    expect(result).toEqual(['$0.00']);
+  });
+
+  it('omits cost when costUsd is undefined even with includeZeroCost true', () => {
+    const result = costTokenParts({ includeZeroCost: true });
+    expect(result).toEqual([]);
+  });
+
+  // ── tokens only ─────────────────────────────────────────────────────────────
+
+  it('returns token fragment when tokens > 0', () => {
+    const result = costTokenParts({ tokens: 500 });
+    expect(result).toEqual(['500 tokens']);
+  });
+
+  it('returns formatted k-suffix for large token counts', () => {
+    const result = costTokenParts({ tokens: 1500 });
+    expect(result).toEqual(['1.5k tokens']);
+  });
+
+  it('returns formatted m-suffix for million-scale token counts', () => {
+    const result = costTokenParts({ tokens: 2_000_000 });
+    expect(result).toEqual(['2m tokens']);
+  });
+
+  it('skips token fragment when tokens is undefined', () => {
+    const result = costTokenParts({ costUsd: 0.5 });
+    expect(result).toEqual(['$0.50']);
+  });
+
+  // ── both present ────────────────────────────────────────────────────────────
+
+  it('returns [cost, tokens] in that order when both are positive', () => {
+    const result = costTokenParts({ costUsd: 0.05, tokens: 1200 });
+    expect(result).toEqual(['$0.05', '1.2k tokens']);
+  });
+
+  it('returns [cost, tokens] with includeZeroCost when cost is zero', () => {
+    const result = costTokenParts({ costUsd: 0, tokens: 42, includeZeroCost: true });
+    expect(result).toEqual(['$0.00', '42 tokens']);
+  });
+
+  it('returns [tokens] only when costUsd is 0 and includeZeroCost is false', () => {
+    const result = costTokenParts({ costUsd: 0, tokens: 42 });
+    expect(result).toEqual(['42 tokens']);
+  });
+
+  // ── edge / defensive ────────────────────────────────────────────────────────
+
+  it('handles NaN tokens gracefully — skips token fragment', () => {
+    // formatTokens('NaN') returns '0'; tokenCount 0 is skipped.
+    const result = costTokenParts({ tokens: NaN });
+    expect(result).toEqual([]);
+  });
+
+  it('handles non-finite costUsd (Infinity) — skips cost fragment', () => {
+    const result = costTokenParts({ costUsd: Infinity, includeZeroCost: true });
+    expect(result).toEqual([]);
+  });
+
+  it('returns exactly two elements for typical session-end stats', () => {
+    const result = costTokenParts({ costUsd: 0.1234, tokens: 50_000 });
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatch(/^\$/);
+    expect(result[1]).toMatch(/tokens$/);
+  });
+});

--- a/src/cli/render/session-summary.ts
+++ b/src/cli/render/session-summary.ts
@@ -1,0 +1,85 @@
+/**
+ * Session summary render helpers — shared cost/token line fragments.
+ *
+ * Extracted from the duplicated hand-rolled session-end summaries in:
+ *   - src/cli/commands/interactive.ts          (printExitSummary)
+ *   - src/cli/commands/interactive/turn-handler.footer.ts (printTurnFooter)
+ *   - src/cli/commands/interactive/resume-swap.ts          (resume line)
+ *   - src/cli/commands/chat.ts                             (turn summary)
+ *
+ * Design principles:
+ *   - Pure: no color, no separator — callers own those concerns.
+ *   - Returns `string[]` so callers can spread into their own parts arrays
+ *     and join with their own separator string.
+ */
+
+import { formatCost, formatTokens } from '../format-utils.js';
+
+// ─── CostTokenSpec ────────────────────────────────────────────────────────────
+
+/**
+ * Input spec for {@link costTokenParts}.
+ */
+export interface CostTokenSpec {
+  /** Cost in USD. Omitted or `undefined` → cost fragment is skipped. */
+  costUsd?: number;
+  /**
+   * Total token count (typically input + output tokens combined).
+   * Omitted, `undefined`, or `0` → token fragment is skipped.
+   */
+  tokens?: number;
+  /**
+   * When `true`, include the cost fragment even when `costUsd` is exactly
+   * zero (matching the `!== undefined` guard used by per-turn footers and
+   * the chat command). When `false` (default), a zero cost is omitted,
+   * matching the `> 0` guard used by session-end summaries and resume lines.
+   */
+  includeZeroCost?: boolean;
+}
+
+// ─── costTokenParts ───────────────────────────────────────────────────────────
+
+/**
+ * Return formatted string fragments for cost and token statistics.
+ *
+ * Pure — produces no color, no separator, and no surrounding whitespace.
+ * Callers spread the result into their own `parts` array and join with
+ * their preferred separator (e.g. `' · '` or `'  ·  '`).
+ *
+ * Fragment ordering:
+ *   1. cost  (`$0.00`, `$0.0012`, `$1.23`) — when present
+ *   2. tokens (`42 tokens`, `1.2k tokens`) — when present
+ *
+ * @example
+ * // Session-end summary (zero cost omitted):
+ * parts.push(...costTokenParts({ costUsd: ctx.stats.totalCostUsd, tokens: ctx.stats.totalTokens }));
+ *
+ * @example
+ * // Per-turn footer (zero cost included when the field was present):
+ * parts.push(...costTokenParts({ costUsd: meta.totalCostUsd, tokens: inTok + outTok, includeZeroCost: meta.totalCostUsd !== undefined }));
+ *
+ * @param spec - Cost/token values and rendering options.
+ * @returns Array of zero, one, or two formatted strings.
+ */
+export function costTokenParts(spec: CostTokenSpec): string[] {
+  const parts: string[] = [];
+
+  const { costUsd, tokens, includeZeroCost = false } = spec;
+
+  // Cost fragment — include when:
+  //   • costUsd is a finite number, AND
+  //   • either costUsd > 0 OR the caller explicitly allows zero
+  if (costUsd !== undefined && Number.isFinite(costUsd)) {
+    if (costUsd > 0 || includeZeroCost) {
+      parts.push(formatCost(costUsd));
+    }
+  }
+
+  // Token fragment — include when token count is a positive finite number
+  const tokenCount = tokens ?? 0;
+  if (Number.isFinite(tokenCount) && tokenCount > 0) {
+    parts.push(formatTokens(tokenCount) + ' tokens');
+  }
+
+  return parts;
+}


### PR DESCRIPTION
## What

Extract the duplicated `formatCost(cost)` + `formatTokens(tokens) + ' tokens'` inline pattern into a shared `costTokenParts()` helper in `src/cli/render/session-summary.ts`.

Closes #1401 (the `costTokenLine` portion — the full `sessionSummary` component is deferred to a follow-up since the three session-end sites have more formatting variation than a single component can cleanly absorb).

## Migration sites

| File | Before | After |
|------|--------|-------|
| `interactive.ts` | `if (cost > 0) parts.push(formatCost(...))` + `if (tokens > 0) parts.push(formatTokens(...) + ' tokens')` | `parts.push(...costTokenParts({ costUsd, tokens }))` |
| `turn-handler.footer.ts` | Same inline pattern with `!== undefined` guard | `parts.push(...costTokenParts({ costUsd, tokens, includeZeroCost: true }))` |
| `resume-swap.ts` | Same inline pattern | `parts.push(...costTokenParts({ costUsd, tokens }))` |
| `chat.ts` | Same inline pattern with `!== undefined` guard | `parts.push(...costTokenParts({ costUsd, tokens, includeZeroCost: true }))` |

## Design

- **Returns `string[]`**, not a joined string — callers spread into their own parts arrays and join with their own separator (`' · '`, `'  ·  '`, etc.)
- **Pure — no color** — callers apply `palette.dim` / `palette.brand` at their level
- **`includeZeroCost`** flag preserves the behavioral split: session-end summaries skip `$0.00`, per-turn footers show it when the field was defined

## Tests

18 tests in `session-summary.test.ts` covering:
- Both absent / zero (4 cases)
- Cost only (4 cases including sub-cent, zero with flag)
- Tokens only (4 cases including k/m suffix)
- Both present (3 cases)
- Edge / defensive (3 cases: NaN, Infinity, typical stats)
