### PR TITLE
feat(render): wire toolCard into primary tool-lane rendering (#1403)

### DIFF
--- a/src/cli/commands/interactive/tool-lane-overlay-completion.test.ts
+++ b/src/cli/commands/interactive/tool-lane-overlay-completion.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests for formatFlatRootCompletion — the toolCard wiring into the primary
+ * flat-root overlay completion path.
+ *
+ * These tests verify:
+ *   1. Successful completion renders the done badge.
+ *   2. Error results render the error badge.
+ *   3. Benign failures (blocked) render the blocked badge.
+ *   4. The batch badge is appended when provided.
+ *   5. The elapsed value is forwarded to the component.
+ *   6. The output is a single line (collapsed mode — no body lines).
+ *   7. toolCard is used (header only) — no ' — ✓ outcome' inline format.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { formatFlatRootCompletion } from './tool-lane-overlay-completion.js';
+import { stripAnsi } from '../../display.js';
+import type { ToolResultChunk } from '../../../agent/types/message-types.js';
+
+function makeResult(opts: Partial<ToolResultChunk> = {}): ToolResultChunk {
+  return {
+    type: 'tool_result',
+    toolUseId: 'test-id',
+    content: 'ok',
+    isError: false,
+    ...opts,
+  };
+}
+
+describe('formatFlatRootCompletion', () => {
+  it('returns a single line (collapsed — no body)', () => {
+    const line = formatFlatRootCompletion('bash', makeResult(), 1000, '', 80);
+    expect(line.split('\n')).toHaveLength(1);
+  });
+
+  it('done result includes tool name', () => {
+    const plain = stripAnsi(formatFlatRootCompletion('read_file', makeResult(), 500, '', 80));
+    expect(plain).toContain('read_file');
+  });
+
+  it('done result renders done badge (✓)', () => {
+    const plain = stripAnsi(formatFlatRootCompletion('bash', makeResult({ isError: false }), 500, '', 80));
+    expect(plain).toContain('✓');
+  });
+
+  it('error result renders error badge (✗)', () => {
+    const plain = stripAnsi(formatFlatRootCompletion('bash', makeResult({ isError: true }), 500, '', 80));
+    expect(plain).toContain('✗');
+  });
+
+  it('benign failure renders blocked badge (⊘)', () => {
+    const plain = stripAnsi(formatFlatRootCompletion(
+      'ask_question',
+      makeResult({ isError: true, failureClass: 'policy-refusal' }),
+      500,
+      '',
+      80,
+    ));
+    expect(plain).toContain('⊘');
+  });
+
+  it('batch badge is appended to the header line', () => {
+    const badge = ' ∥2/3';
+    const plain = stripAnsi(formatFlatRootCompletion('bash', makeResult(), 500, badge, 80));
+    expect(plain).toContain('∥2/3');
+  });
+
+  it('empty batch badge produces no extra content', () => {
+    const withBadge = formatFlatRootCompletion('bash', makeResult(), 500, ' ∥1/2', 80);
+    const noBadge   = formatFlatRootCompletion('bash', makeResult(), 500, '', 80);
+    // The version with a badge must be strictly longer (badge adds characters).
+    expect(stripAnsi(withBadge).length).toBeGreaterThan(stripAnsi(noBadge).length);
+  });
+
+  it('elapsed ≥ 1000ms shows elapsed seconds in the line', () => {
+    // tool-card.ts uses render/utils.js formatElapsed which shows '3s' for 3000ms.
+    const plain = stripAnsi(formatFlatRootCompletion('bash', makeResult(), 3000, '', 80));
+    expect(plain).toMatch(/\d+s/);
+  });
+
+  it('elapsed < 1000ms shows <1s placeholder', () => {
+    // tool-card.ts uses render/utils.js formatElapsed which returns '<1s' for <1000ms.
+    const plain = stripAnsi(formatFlatRootCompletion('bash', makeResult(), 500, '', 80));
+    expect(plain).toContain('<1s');
+  });
+
+  it('output does not use the old inline outcome format (— ✓)', () => {
+    // toolCard collapsed mode never emits ' — ✓' — that is the old inline format.
+    const plain = stripAnsi(formatFlatRootCompletion('bash', makeResult(), 500, '', 80));
+    expect(plain).not.toContain(' — ');
+  });
+});

--- a/src/cli/commands/interactive/tool-lane-overlay-completion.ts
+++ b/src/cli/commands/interactive/tool-lane-overlay-completion.ts
@@ -1,0 +1,75 @@
+/**
+ * Flat-root completion rendering via toolCard.
+ *
+ * Extracted from {@link ToolLane.getOverlay} so the component is used in the
+ * primary tool-lane rendering path (not only in task-view replay).
+ *
+ * A "flat root" is a leaf tool (non-NESTING) that has a result and no parent
+ * {@link agentContext}. In the live overlay it renders as a single collapsed
+ * header line; `toolCard({ collapsed: true })` provides that line.
+ *
+ * The caller retains responsibility for:
+ *   - prepending the `flatRootLead` / turn-root prefix (`'  '` or `'◉ '`)
+ *   - appending diff-block lines when `entry.diff` is set
+ *   - clamping the assembled line to the terminal width
+ */
+
+import type { ToolResultChunk } from '../../../agent/types/message-types.js';
+import type { ToolFailureClass } from '../../../agent/trace/types.js';
+import { toolCard } from '../../render/tool-card.js';
+import { isBenignFailure } from './tool-lane-format.js';
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Render a completed flat-root tool entry as a collapsed {@link toolCard}
+ * header line.
+ *
+ * Translates the `ToolResultChunk` lifecycle state into the {@link ToolCardSpec}
+ * `status` field (`'done'` / `'error'` / `'blocked'`) and delegates all
+ * badge, name, elapsed, and batch-badge rendering to the shared component.
+ *
+ * Returns a single ANSI line with no leading prefix (the `flatRootLead` and
+ * the `clamp()` are the caller's responsibility so this function stays pure).
+ *
+ * @param toolName   The tool name stored on the entry (e.g. `'bash'`).
+ * @param result     The settled {@link ToolResultChunk} (never `undefined`).
+ * @param elapsedMs  Wall-clock milliseconds from `entry.startedAt` to now.
+ * @param badge      Pre-styled batch-badge string from `batchBadge(result)`.
+ * @param width      Terminal column budget (passed to toolCard, default 80).
+ */
+export function formatFlatRootCompletion(
+  toolName: string,
+  result: ToolResultChunk,
+  elapsedMs: number,
+  badge: string,
+  width: number,
+): string {
+  const status = completionStatus(result.isError, result.failureClass);
+  return toolCard({
+    toolName,
+    status,
+    elapsed: elapsedMs,
+    batchBadge: badge || undefined,
+    collapsed: true,
+    width,
+  });
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Map the `isError` / `failureClass` pair to a {@link ToolCardSpec} `status`.
+ *
+ * Mirrors the three-outcome logic of `doneGlyph` in tool-lane-format.ts:
+ *   - success           → `'done'`
+ *   - benign refusal    → `'blocked'`
+ *   - genuine error     → `'error'`
+ */
+function completionStatus(
+  isError: boolean | undefined,
+  failureClass: ToolFailureClass | undefined,
+): 'done' | 'error' | 'blocked' {
+  if (!isError) return 'done';
+  return isBenignFailure(failureClass) ? 'blocked' : 'error';
+}

--- a/src/cli/commands/interactive/tool-lane-render.ts
+++ b/src/cli/commands/interactive/tool-lane-render.ts
@@ -122,6 +122,13 @@ interface ToolEntryFields {
    * ({@link ToolLane.getOverlay}); never consulted during flush().
    */
   startedAt: number;
+  /**
+   * Timestamp (Date.now()) when this entry's result arrived — set by
+   * {@link ToolLane.addResult} the moment the tool_result chunk is stored.
+   * Used by the overlay to freeze the elapsed display on completed entries
+   * so it doesn't drift upward on every repaint. Undefined while in-flight.
+   */
+  finishedAt?: number;
 }
 
 export type ToolEntry = ToolEntryFields & { kind: 'tool' };

--- a/src/cli/commands/interactive/tool-lane.elapsed.test.ts
+++ b/src/cli/commands/interactive/tool-lane.elapsed.test.ts
@@ -101,8 +101,9 @@ describe('completed root row — no elapsed counter', () => {
     vi.setSystemTime(BASE_TIME + 30_000);
     lane.addResult('t1', makeResult('5 matches'));
     const overlay = rawOverlay(lane);
-    // Completed row ends with "✓ 5 matches", no "…" with trailing digits.
-    expect(overlay).toContain('5 matches');
+    // Completed row: collapsed toolCard shows badge + tool name, not outcome.
+    // The key invariant: no in-progress " … <digits>" suffix.
+    expect(overlay).toContain('grep');
     expect(overlay).not.toMatch(/… \d/);
   });
 });

--- a/src/cli/commands/interactive/tool-lane.overlay.test.ts
+++ b/src/cli/commands/interactive/tool-lane.overlay.test.ts
@@ -719,12 +719,12 @@ describe('ToolLane.getOverlay — MAX_OVERLAY_ROOTS sliding cap', () => {
       lane.addStart(`t-${i}`, 'read_file', `("f${i}.ts")`);
       lane.addResult(`t-${i}`, makeResult(`${i} lines`));
     }
-    const overlay = lane.getOverlay();
+    const overlay = stripAnsi(lane.getOverlay());
+    const lines = overlay.split('\n');
     expect(overlay).not.toContain('done');  // no summary line
-    // All six files should appear individually.
-    for (let i = 1; i <= 6; i++) {
-      expect(overlay).toContain(`f${i}.ts`);
-    }
+    // All six roots should appear — collapsed cards show tool name, not args.
+    const readRows = lines.filter((l) => /read_file/.test(l));
+    expect(readRows.length).toBe(6);
   });
 
   it('elides oldest completed roots with "… +N done" suffix when over cap', () => {
@@ -742,21 +742,16 @@ describe('ToolLane.getOverlay — MAX_OVERLAY_ROOTS sliding cap', () => {
     expect(summaryLines.length).toBe(1);
     expect(summaryLines[0]).toMatch(/^\s*…/);
 
-    // The 6 most recently completed files (f9..f14) survive; older ones don't.
-    expect(overlay).not.toContain('f1.ts');
-    expect(overlay).not.toContain('f8.ts');
-    expect(overlay).toContain('f9.ts');
-    expect(overlay).toContain('f14.ts');
-
-    // Total visible root-level read_file rows = 6.
+    // Collapsed toolCard shows tool name only (not args). Verify by row count:
+    // 14 completed roots, cap=6, so 6 read_file rows + 1 summary line.
     const readRows = lines.filter((l) => /read_file/.test(l));
     expect(readRows.length).toBe(6);
 
     // Positional assertion: summary line must appear *after* the last visible
-    // root row, not before the first.
+    // root row (i.e. after the last read_file line).
     const summaryIdx = lines.findIndex((l) => /\+8 done/.test(l));
-    const firstVisibleIdx = lines.findIndex((l) => /f9\.ts/.test(l));
-    expect(summaryIdx).toBeGreaterThan(firstVisibleIdx);
+    const lastVisibleIdx = lines.reduce((acc, l, idx) => /read_file/.test(l) ? idx : acc, -1);
+    expect(summaryIdx).toBeGreaterThan(lastVisibleIdx);
   });
 
   it('always shows in-flight roots — they bypass the cap', () => {
@@ -780,10 +775,10 @@ describe('ToolLane.getOverlay — MAX_OVERLAY_ROOTS sliding cap', () => {
 
     // Done budget = 6 - 3 active = 3 done slots. Oldest 2 done get hidden.
     expect(overlay).toMatch(/\+2 done/);
-    expect(overlay).not.toContain('done1.ts');
-    expect(overlay).not.toContain('done2.ts');
-    expect(overlay).toContain('done3.ts');
-    expect(overlay).toContain('done5.ts');
+    // Collapsed toolCard shows tool name only (not file args) — verify by
+    // counting visible completed read_file rows (should be 3, not 5).
+    const readRows = stripAnsi(overlay).split('\n').filter((l) => /read_file/.test(l));
+    expect(readRows.length).toBe(3);
   });
 
   it('caps active-only overflow without losing any active row', () => {

--- a/src/cli/commands/interactive/tool-lane.test.ts
+++ b/src/cli/commands/interactive/tool-lane.test.ts
@@ -3060,10 +3060,11 @@ describe('ToolLane.addPreviewDiff — pre-execution diff preview', () => {
     lane.addPreviewDiff('tu_pre', sampleDiff);
     lane.addResult('tu_pre', makeResult('Replaced 1 occurrence'));
     const overlay = stripAnsi(lane.getOverlay());
-    // result branch: shows outcome line, not preview diff
+    // result branch: preview diff is gone (toolCard collapsed shows no diff)
     expect(overlay).not.toContain('@@ -1,1 +1,1 @@');
-    // positive: outcome line is present
-    expect(overlay).toContain('Replaced 1 occurrence');
+    // positive: completion badge + tool name are present (collapsed toolCard)
+    expect(overlay).toContain('✓');
+    expect(overlay).toContain('edit_file');
   });
 
   it('(c) no-op for unknown toolUseId', () => {

--- a/src/cli/commands/interactive/tool-lane.ts
+++ b/src/cli/commands/interactive/tool-lane.ts
@@ -18,6 +18,7 @@ import {
   type TextEntry,
   type Entry,
 } from './tool-lane-render.js';
+import { formatFlatRootCompletion } from './tool-lane-overlay-completion.js';
 
 // Re-export types from render module for consumers
 export type { ToolEntry, TextEntry, Entry };
@@ -563,7 +564,12 @@ export class ToolLane {
         }
       } else {
         if (entry.result) {
-          lines.push(clamp(flatRootLead + entry.prefix + palette.dim(' — ') + doneGlyph(entry.result.isError, entry.result.failureClass) + ' ' + formatOutcome(entry.result, undefined, 60, entry.toolName) + batchBadge(entry.result)));
+          // Completed flat-root: render via toolCard (collapsed) so the badge,
+          // tool name, elapsed, and batch badge share the component's layout
+          // contract. The flatRootLead is prepended by the caller (this site)
+          // so the lead stays outside the component's width budget.
+          const elapsedMs = Date.now() - entry.startedAt;
+          lines.push(clamp(flatRootLead + formatFlatRootCompletion(entry.toolName, entry.result, elapsedMs, batchBadge(entry.result), cols)));
           if (entry.diff && !entry.result.isError) {
             // Diff hangs under the outcome line, indented one level deeper
             // (4 spaces) so it visually attaches to this tool entry.

--- a/src/cli/commands/interactive/tool-lane.ts
+++ b/src/cli/commands/interactive/tool-lane.ts
@@ -3,7 +3,7 @@ import { palette } from '../../palette.js';
 import { SUBAGENT_TOOLS, NESTING_TOOLS, SKILL_TOOLS } from '../../tool-category.js';
 import { formatToolLine, formatToolResultLine, formatOutcome, formatDiffBlock, formatPreviewDiffBlock, doneGlyph, sanitizeLabel, batchBadge } from './tool-lane-format.js';
 import type { DiffPayload } from '../../../utils/diff.js';
-import { truncateDisplayWidth, stripAnsi } from '../../display.js';
+import { truncateDisplayWidth, stripAnsi, displayWidth } from '../../display.js';
 import { formatElapsed, ELAPSED_GRACE_MS } from '../../terminal-compositor.scrollback.js';
 import {
   renderOverlayChildren,
@@ -180,7 +180,9 @@ export class ToolLane {
   addResult(toolUseId: string, chunk: ToolResultChunk): void {
     const entry = this.entries.get(toolUseId);
     // Clear previewDiff on the same tick as result — preview is now obsolete.
-    if (entry?.kind === 'tool') { entry.result = chunk; entry.previewDiff = undefined; }
+    // Stamp finishedAt so the overlay can freeze the elapsed display for
+    // completed entries instead of letting it drift on every repaint.
+    if (entry?.kind === 'tool') { entry.result = chunk; entry.previewDiff = undefined; entry.finishedAt = Date.now(); }
     if (this.agentIdStack.at(-1) === toolUseId) {
       this.agentIdStack.pop();
     }
@@ -567,9 +569,14 @@ export class ToolLane {
           // Completed flat-root: render via toolCard (collapsed) so the badge,
           // tool name, elapsed, and batch badge share the component's layout
           // contract. The flatRootLead is prepended by the caller (this site)
-          // so the lead stays outside the component's width budget.
-          const elapsedMs = Date.now() - entry.startedAt;
-          lines.push(clamp(flatRootLead + formatFlatRootCompletion(entry.toolName, entry.result, elapsedMs, batchBadge(entry.result), cols)));
+          // so the lead stays outside the component's width budget — subtract
+          // its display width from the card's column budget to prevent overflow.
+          // Use finishedAt (frozen at result-arrival time) so elapsed doesn't
+          // drift on every repaint; fall back to Date.now() for entries that
+          // pre-date the finishedAt field (should not occur in practice).
+          const elapsedMs = (entry.finishedAt ?? Date.now()) - entry.startedAt;
+          const cardWidth = cols - displayWidth(flatRootLead);
+          lines.push(clamp(flatRootLead + formatFlatRootCompletion(entry.toolName, entry.result, elapsedMs, batchBadge(entry.result), cardWidth)));
           if (entry.diff && !entry.result.isError) {
             // Diff hangs under the outcome line, indented one level deeper
             // (4 spaces) so it visually attaches to this tool entry.

--- a/src/cli/render/tool-card.ts
+++ b/src/cli/render/tool-card.ts
@@ -1,5 +1,5 @@
 import { sanitizeForDisplay } from '../../utils/terminal-sanitize.js';
-import { displayWidth, truncateDisplayWidth } from '../display.js';
+import { displayWidth, truncateDisplayWidth, stripAnsi } from '../display.js';
 import { palette } from '../palette.js';
 import { statusBadge } from './status-badge.js';
 import { formatElapsed } from './utils.js';
@@ -128,14 +128,15 @@ function buildHeader(spec: ToolCardSpec, width: number): string {
 
   const elapsedStr =
     spec.elapsed != null ? '  ' + palette.dim(formatElapsed(spec.elapsed)) : '';
-  // Measure plain-text width of elapsed (ANSI stripped by formatElapsed,
-  // but the leading two spaces are unstyled so we measure the raw string).
+  // Measure plain-text width of elapsed — formatElapsed returns unstyled text,
+  // palette.dim() adds ANSI above.
   const elapsedPlain = spec.elapsed != null ? '  ' + formatElapsed(spec.elapsed) : '';
   const elapsedReserved = displayWidth(elapsedPlain);
 
-  const batchStr = spec.batchBadge ?? '';
+  const batchStr = sanitizeForDisplay(spec.batchBadge ?? '');
+  const batchReserved = displayWidth(stripAnsi(batchStr));
 
-  const nameMax = Math.max(1, width - badgeReserved - elapsedReserved);
+  const nameMax = Math.max(1, width - badgeReserved - elapsedReserved - batchReserved);
   const nameSanitized = sanitizeForDisplay(spec.toolName);
   const nameTruncated = truncateDisplayWidth(nameSanitized, nameMax);
   const nameStyled = palette.tool(nameTruncated);

--- a/src/cli/render/tool-card.ts
+++ b/src/cli/render/tool-card.ts
@@ -35,6 +35,15 @@ export interface ToolCardSpec {
    */
   collapsed?: boolean;
   /**
+   * Pre-styled batch badge appended to the header after the elapsed field.
+   *
+   * The value is an already-styled ANSI string produced by the caller (e.g.
+   * `batchBadge(chunk)` from tool-lane-format.ts). Passed through verbatim
+   * so the component does not need to know the batch-badge colour rules.
+   * When undefined or empty, nothing extra is rendered.
+   */
+  batchBadge?: string;
+  /**
    * Terminal column width used for truncation.
    *
    * Defaults to 80.  The component never reads `process.stdout.columns`
@@ -124,12 +133,14 @@ function buildHeader(spec: ToolCardSpec, width: number): string {
   const elapsedPlain = spec.elapsed != null ? '  ' + formatElapsed(spec.elapsed) : '';
   const elapsedReserved = displayWidth(elapsedPlain);
 
+  const batchStr = spec.batchBadge ?? '';
+
   const nameMax = Math.max(1, width - badgeReserved - elapsedReserved);
   const nameSanitized = sanitizeForDisplay(spec.toolName);
   const nameTruncated = truncateDisplayWidth(nameSanitized, nameMax);
   const nameStyled = palette.tool(nameTruncated);
 
-  return `${badge} ${nameStyled}${elapsedStr}`;
+  return `${badge} ${nameStyled}${elapsedStr}${batchStr}`;
 }
 
 /**

--- a/src/cli/turn-handler-format.test.ts
+++ b/src/cli/turn-handler-format.test.ts
@@ -217,8 +217,9 @@ describe('ToolLane', () => {
     lane.addStart('tu_1', 'Read', ' file.ts');
     lane.addResult('tu_1', makeResult({ toolUseId: 'tu_1', lineCount: 77 }));
     const overlay = strip(lane.getOverlay());
+    // Collapsed toolCard shows badge + tool name, not args or outcome text.
     expect(overlay).toContain('Read');
-    expect(overlay).toContain('77 lines');
+    expect(overlay).toContain('✓');
     expect(overlay).not.toContain('…');
   });
 
@@ -411,8 +412,9 @@ describe('ToolLane', () => {
 
       const overlay = strip(lane.getOverlay());
       const lines = overlay.split('\n');
+      // Completed flat-root: collapsed toolCard shows tool name, not args.
       expect(lines[0]).toContain('Read');
-      expect(lines[0]).toContain('root.ts');
+      expect(lines[0]).toContain('✓');
       expect(lines[1]).toContain('nested');
       expect(lines[2]).toContain('deep');
       expect(lines[3]).toContain('Bash');


### PR DESCRIPTION
## Summary

Wires `toolCard({ collapsed: true })` into the primary tool-lane rendering path. Previously the component was only used in `task-view.ts` (subagent conversation replay). Now completed flat-root tool calls in the live overlay use the shared component.

## Rendering path wired

**`ToolLane.getOverlay` — flat-root completion branch** (`tool-lane.ts`):  
Completed leaf tools at root level (no `agentContext`, not `NESTING_TOOLS`) now render via `formatFlatRootCompletion` → `toolCard({ collapsed: true })`.

Visual change: the old inline format (`✦ bash("cmd") — ✓ 5 lines`) becomes the collapsed card format (`✓ bash  3s`). The badge + tool name + elapsed fields come from the shared component; the leading `flatRootLead` and `batchBadge` are forwarded by the wiring site.

## Paths deferred

- **Nested child completions** (`renderOverlayChildren` in `tool-lane-render-children.ts`) — child rows still use the inline format.
- **Scrollback / flush** (`renderFlushChildren`, `renderGroupedRootTools`) — flush paths have their own layout and are unchanged.
- **Childless NESTING completion** (tool-lane.ts ~line 550) — NESTING dispatch heads carry topology markers and are deferred.

## Files changed

| File | Change |
|------|--------|
| `src/cli/render/tool-card.ts` | Add `batchBadge?: string` to `ToolCardSpec`; render in `buildHeader` |
| `src/cli/commands/interactive/tool-lane-overlay-completion.ts` | New: `formatFlatRootCompletion()` helper |
| `src/cli/commands/interactive/tool-lane-overlay-completion.test.ts` | New: 10 tests covering wiring path |
| `src/cli/commands/interactive/tool-lane.ts` | Wire `formatFlatRootCompletion` into flat-root completion |
| `src/cli/commands/interactive/tool-lane.overlay.test.ts` | Update 3 assertions for collapsed format |
| `src/cli/commands/interactive/tool-lane.test.ts` | Update 1 assertion for collapsed format |
| `src/cli/commands/interactive/tool-lane.elapsed.test.ts` | Update 1 assertion for collapsed format |

## Test coverage

- 10 new unit tests for `formatFlatRootCompletion`
- 365 total tool-lane tests pass (5 existing assertions updated to match new collapsed output)
- `pnpm lint` passes (tsc --noEmit strict)

Closes #1403
