### PR TITLE
feat(tools): wait_for tool with poll-based condition waiting

### DIFF
--- a/src/agent/risk-classifier.ts
+++ b/src/agent/risk-classifier.ts
@@ -415,6 +415,36 @@ export function classifyRisk(
     return 'medium';
   }
 
+  // ---- wait_for ------------------------------------------------------------
+  // wait_for condition types differ significantly in risk:
+  //
+  //   url     — issues outbound HTTP; same risk profile as web_scrape ('medium').
+  //   file    — read-only fs.stat / readFile; 'safe'.
+  //   process — read-only process.kill(pid, 0); 'safe'.
+  //   command — runs a shell command via execSync. The command string is
+  //             classified using the same bash rule table (classifyBash) as the
+  //             bash tool, but that logic lives inside evaluateCommand so we
+  //             cannot call it here without the command string. We therefore
+  //             use the bash classifier directly when the type is 'command'.
+  //             For other types fall through to the type-specific rules above.
+  //
+  // A missing or unknown `type` field is treated conservatively as 'medium'.
+  if (tool === 'wait_for') {
+    const obj =
+      typeof input === 'object' && input !== null
+        ? (input as Record<string, unknown>)
+        : {};
+    const condType = typeof obj['type'] === 'string' ? obj['type'] : '';
+    if (condType === 'command') {
+      const cmd =
+        typeof obj['command'] === 'string' ? obj['command'] : '';
+      return classifyBash(cmd);
+    }
+    if (condType === 'file' || condType === 'process') return 'safe';
+    // url or unknown: treat as medium (outbound network).
+    return 'medium';
+  }
+
   // ---- unknown tool -------------------------------------------------------
   // Don't gate things we haven't classified — default to safe so the
   // classifier never blocks novel tools without an explicit rule.

--- a/src/agent/tool-category.ts
+++ b/src/agent/tool-category.ts
@@ -63,6 +63,8 @@ const READ_TOOLS = new Set([
 const WRITE_TOOLS = new Set([
   'Write', 'Edit', 'NotebookEdit', 'MultiEdit',
   'write_file', 'edit_file',
+  // patch_apply applies unified diffs to files on disk — a write operation.
+  'patch_apply',
   // memory-tools.ts — both mutate persistent state on disk (the fact
   // archive / HOT.md and ~/.afk/procedures/<name>.md respectively), so
   // they belong in the write bucket alongside file edits.
@@ -86,6 +88,8 @@ const WRITE_TOOLS = new Set([
 const SHELL_TOOLS = new Set([
   'Bash', 'BashOutput', 'KillBash',
   'bash',
+  'test_run',
+  'wait_for',
 ]);
 export const SUBAGENT_TOOLS = new Set([
   'Agent', 'Task',

--- a/src/agent/tools/handlers/index.test.ts
+++ b/src/agent/tools/handlers/index.test.ts
@@ -3,9 +3,9 @@ import { createBuiltinHandlers } from './index.js';
 import { BUILTIN_TOOL_NAMES } from '../schemas.js';
 
 describe('createBuiltinHandlers', () => {
-  it('returns a Map with all 22 built-in tools', () => {
+  it('returns a Map with all built-in tools', () => {
     const handlers = createBuiltinHandlers();
-    expect(handlers.size).toBe(26);
+    expect(handlers.size).toBe(27);
   });
 
   it('has an entry for every tool in BUILTIN_TOOL_NAMES', () => {
@@ -27,7 +27,7 @@ describe('createBuiltinHandlers', () => {
     // when permissionMode is undefined but cwd is set. Ensure we get a
     // valid map back and bash is still callable.
     const handlers = createBuiltinHandlers(undefined, '/tmp');
-    expect(handlers.size).toBe(26);
+    expect(handlers.size).toBe(27);
     expect(typeof handlers.get('bash')).toBe('function');
     expect(typeof handlers.get('grep')).toBe('function');
     expect(typeof handlers.get('glob')).toBe('function');
@@ -35,7 +35,7 @@ describe('createBuiltinHandlers', () => {
 
   it('cwd parameter: builds handler set with both permissionMode and cwd', () => {
     const handlers = createBuiltinHandlers('default', '/tmp');
-    expect(handlers.size).toBe(26);
+    expect(handlers.size).toBe(27);
     expect(typeof handlers.get('bash')).toBe('function');
   });
 

--- a/src/agent/tools/handlers/index.ts
+++ b/src/agent/tools/handlers/index.ts
@@ -38,6 +38,7 @@ import { browserObserveHandler } from './browser-observe.js';
 import { browserActHandler } from './browser-act.js';
 import { browserScreenshotHandler } from './browser-screenshot.js';
 import { browserCloseHandler } from './browser-close.js';
+import { waitForHandler } from './wait-for.js';
 
 /**
  * Build the built-in tool handler map for a session.
@@ -98,6 +99,7 @@ export function createBuiltinHandlers(
     ['config_get', configGetHandler],
     ['config_set', configSetHandler],
     ['ask_question', askQuestionHandler],
+    ['wait_for', waitForHandler],
     ['browser_open', browserOpenHandler],
     ['browser_observe', browserObserveHandler],
     ['browser_act', browserActHandler],
@@ -126,6 +128,7 @@ export {
   configGetHandler,
   configSetHandler,
   askQuestionHandler,
+  waitForHandler,
   browserOpenHandler,
   browserObserveHandler,
   browserActHandler,

--- a/src/agent/tools/handlers/wait-for-conditions.test.ts
+++ b/src/agent/tools/handlers/wait-for-conditions.test.ts
@@ -10,11 +10,22 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // ---------------------------------------------------------------------------
-// Mock the egress guard so tests don't hit DNS.
+// Mock guardedFetch so tests don't hit DNS or real HTTP.
 // ---------------------------------------------------------------------------
 vi.mock('../../../web/egress-guard.js', () => ({
+  guardedFetch: vi.fn(),
   checkEgressTarget: vi.fn().mockResolvedValue({ allowed: true }),
   assertEgressAllowed: vi.fn().mockResolvedValue(undefined),
+  EgressBlockedError: class EgressBlockedError extends Error {
+    constructor(msg: string) { super(msg); this.name = 'EgressBlockedError'; }
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Mock the risk classifier so command-gate tests are deterministic.
+// ---------------------------------------------------------------------------
+vi.mock('../../risk-classifier.js', () => ({
+  classifyRisk: vi.fn().mockReturnValue('safe'),
 }));
 
 // ---------------------------------------------------------------------------
@@ -33,11 +44,13 @@ vi.mock('node:child_process', () => ({
 }));
 
 import { evaluateUrl, evaluateFile, evaluateProcess, evaluateCommand } from './wait-for-conditions.js';
-import { checkEgressTarget } from '../../../web/egress-guard.js';
+import { guardedFetch, EgressBlockedError } from '../../../web/egress-guard.js';
+import { classifyRisk } from '../../risk-classifier.js';
 import * as fsPromises from 'node:fs/promises';
 import { execSync } from 'node:child_process';
 
-const mockCheckEgress = vi.mocked(checkEgressTarget);
+const mockGuardedFetch = vi.mocked(guardedFetch);
+const mockClassifyRisk = vi.mocked(classifyRisk);
 const mockStat = vi.mocked(fsPromises.stat);
 const mockReadFile = vi.mocked(fsPromises.readFile);
 const mockExecSync = vi.mocked(execSync);
@@ -51,75 +64,82 @@ const neverSignal = new AbortController().signal;
 
 describe('evaluateUrl', () => {
   beforeEach(() => {
-    mockCheckEgress.mockResolvedValue({ allowed: true });
+    vi.clearAllMocks();
+    mockClassifyRisk.mockReturnValue('safe');
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it('returns met:true on HTTP 200', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+  it('returns met:true on HTTP 200 using guardedFetch', async () => {
+    mockGuardedFetch.mockResolvedValue({
       status: 200,
       body: { cancel: vi.fn().mockResolvedValue(undefined) },
-    }));
+    } as unknown as Response);
     const result = await evaluateUrl({ type: 'url', url: 'https://example.com' }, neverSignal);
     expect(result.met).toBe(true);
     expect(result.detail).toContain('200');
-    vi.unstubAllGlobals();
+    expect(mockGuardedFetch).toHaveBeenCalledWith(
+      globalThis.fetch,
+      'https://example.com',
+      expect.objectContaining({ method: 'HEAD' }),
+    );
   });
 
   it('returns met:false on HTTP 503', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    mockGuardedFetch.mockResolvedValue({
       status: 503,
       body: { cancel: vi.fn().mockResolvedValue(undefined) },
-    }));
+    } as unknown as Response);
     const result = await evaluateUrl({ type: 'url', url: 'https://example.com' }, neverSignal);
     expect(result.met).toBe(false);
     expect(result.data?.status).toBe(503);
-    vi.unstubAllGlobals();
   });
 
   it('respects expected_status', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    mockGuardedFetch.mockResolvedValue({
       status: 201,
       body: { cancel: vi.fn().mockResolvedValue(undefined) },
-    }));
+    } as unknown as Response);
     const result = await evaluateUrl(
       { type: 'url', url: 'https://example.com', expected_status: 200 },
       neverSignal,
     );
     expect(result.met).toBe(false);
-    vi.unstubAllGlobals();
   });
 
   it('checks body_contains when present', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    mockGuardedFetch.mockResolvedValue({
       status: 200,
       text: vi.fn().mockResolvedValue('Hello world'),
       body: { cancel: vi.fn() },
-    }));
+    } as unknown as Response);
     const hit = await evaluateUrl(
       { type: 'url', url: 'https://example.com', method: 'GET', body_contains: 'world' },
       neverSignal,
     );
     expect(hit.met).toBe(true);
 
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    mockGuardedFetch.mockResolvedValue({
       status: 200,
       text: vi.fn().mockResolvedValue('Hello world'),
       body: { cancel: vi.fn() },
-    }));
+    } as unknown as Response);
     const miss = await evaluateUrl(
       { type: 'url', url: 'https://example.com', method: 'GET', body_contains: 'goodbye' },
       neverSignal,
     );
     expect(miss.met).toBe(false);
-    vi.unstubAllGlobals();
   });
 
-  it('returns met:false and blocked detail when SSRF guard blocks', async () => {
-    mockCheckEgress.mockResolvedValueOnce({ allowed: false, reason: 'private IP' });
+  it('returns met:false and blocked detail when SSRF guard blocks via guardedFetch', async () => {
+    // guardedFetch throws EgressBlockedError when a private target is detected
+    // on any hop (including redirect chains). The evaluator converts this to a
+    // structured "SSRF blocked:" detail so callers can pattern-match on it.
+    mockGuardedFetch.mockRejectedValue(
+      new EgressBlockedError('refusing to fetch — internal/private address 127.0.0.1'),
+    );
     const result = await evaluateUrl({ type: 'url', url: 'http://127.0.0.1' }, neverSignal);
     expect(result.met).toBe(false);
     expect(result.detail).toContain('SSRF blocked');
@@ -127,11 +147,24 @@ describe('evaluateUrl', () => {
   });
 
   it('returns met:false on network error', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
+    mockGuardedFetch.mockRejectedValue(new Error('ECONNREFUSED'));
     const result = await evaluateUrl({ type: 'url', url: 'https://example.com' }, neverSignal);
     expect(result.met).toBe(false);
     expect(result.detail).toContain('fetch error');
-    vi.unstubAllGlobals();
+  });
+
+  it('passes signal through to guardedFetch', async () => {
+    mockGuardedFetch.mockResolvedValue({
+      status: 200,
+      body: { cancel: vi.fn().mockResolvedValue(undefined) },
+    } as unknown as Response);
+    const ac = new AbortController();
+    await evaluateUrl({ type: 'url', url: 'https://example.com' }, ac.signal);
+    expect(mockGuardedFetch).toHaveBeenCalledWith(
+      globalThis.fetch,
+      'https://example.com',
+      expect.objectContaining({ signal: ac.signal }),
+    );
   });
 });
 
@@ -213,6 +246,10 @@ describe('evaluateProcess', () => {
 // ---------------------------------------------------------------------------
 
 describe('evaluateCommand', () => {
+  beforeEach(() => {
+    mockClassifyRisk.mockReturnValue('safe');
+  });
+
   afterEach(() => vi.restoreAllMocks());
 
   it('returns met:true when command exits 0', () => {
@@ -229,5 +266,34 @@ describe('evaluateCommand', () => {
     const result = evaluateCommand({ type: 'command', command: 'false' });
     expect(result.met).toBe(false);
     expect(result.detail).toContain('exited 1');
+  });
+
+  it('blocks high-risk commands before execSync is called', () => {
+    // Simulate the classifier flagging a dangerous command (rm -rf, sudo, etc.)
+    mockClassifyRisk.mockReturnValue('high');
+    const result = evaluateCommand({ type: 'command', command: 'rm -rf /' });
+    expect(result.met).toBe(false);
+    expect(result.detail).toContain('blocked by risk classifier');
+    expect(result.data?.blocked).toBe(true);
+    // execSync must NOT have been called
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it('classifies using the bash tool name so the same bash rule table applies', () => {
+    mockExecSync.mockReturnValue(Buffer.from(''));
+    evaluateCommand({ type: 'command', command: 'echo hello', cwd: '/tmp' });
+    expect(mockClassifyRisk).toHaveBeenCalledWith(
+      'bash',
+      { command: 'echo hello' },
+      expect.objectContaining({ cwd: '/tmp' }),
+    );
+  });
+
+  it('passes medium-risk commands through to execSync', () => {
+    mockClassifyRisk.mockReturnValue('medium');
+    mockExecSync.mockReturnValue(Buffer.from(''));
+    const result = evaluateCommand({ type: 'command', command: 'git status' });
+    expect(mockExecSync).toHaveBeenCalledOnce();
+    expect(result.met).toBe(true);
   });
 });

--- a/src/agent/tools/handlers/wait-for-conditions.test.ts
+++ b/src/agent/tools/handlers/wait-for-conditions.test.ts
@@ -43,17 +43,27 @@ vi.mock('node:child_process', () => ({
   execSync: vi.fn(),
 }));
 
+// ---------------------------------------------------------------------------
+// Mock _cwd-utils so evaluateFile containment tests are deterministic.
+// Default: resolveAndContain is a pass-through (returns the path unchanged).
+// ---------------------------------------------------------------------------
+vi.mock('./_cwd-utils.js', () => ({
+  resolveAndContain: vi.fn((p: string) => p),
+}));
+
 import { evaluateUrl, evaluateFile, evaluateProcess, evaluateCommand } from './wait-for-conditions.js';
 import { guardedFetch, EgressBlockedError } from '../../../web/egress-guard.js';
 import { classifyRisk } from '../../risk-classifier.js';
 import * as fsPromises from 'node:fs/promises';
 import { execSync } from 'node:child_process';
+import { resolveAndContain } from './_cwd-utils.js';
 
 const mockGuardedFetch = vi.mocked(guardedFetch);
 const mockClassifyRisk = vi.mocked(classifyRisk);
 const mockStat = vi.mocked(fsPromises.stat);
 const mockReadFile = vi.mocked(fsPromises.readFile);
 const mockExecSync = vi.mocked(execSync);
+const mockResolveAndContain = vi.mocked(resolveAndContain);
 
 // A never-aborting signal for tests that don't test cancellation.
 const neverSignal = new AbortController().signal;
@@ -173,6 +183,12 @@ describe('evaluateUrl', () => {
 // ---------------------------------------------------------------------------
 
 describe('evaluateFile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: pass-through (path allowed)
+    mockResolveAndContain.mockImplementation((p: string) => p);
+  });
+
   afterEach(() => vi.restoreAllMocks());
 
   it('returns met:true when file exists', async () => {
@@ -208,6 +224,63 @@ describe('evaluateFile', () => {
     expect(miss.met).toBe(false);
     expect(miss.detail).toContain('does not contain');
   });
+
+  // H-2: denylist and containment enforcement
+  it('H-2: returns met:false when resolveAndContain rejects the path (denylist hit)', async () => {
+    mockResolveAndContain.mockImplementation(() => {
+      throw new Error('is a protected credential/secret path (read-denylist entry: ~/.ssh)');
+    });
+    const result = await evaluateFile({ type: 'file', path: '/home/user/.ssh/id_rsa' });
+    expect(result.met).toBe(false);
+    expect(result.detail).toContain('path rejected');
+    expect(result.data?.blocked).toBe(true);
+    // fs.stat must NOT have been called after a denylist hit
+    expect(mockStat).not.toHaveBeenCalled();
+  });
+
+  it('H-2: returns met:false when path is outside workspace root (containment failure)', async () => {
+    mockResolveAndContain.mockImplementation(() => {
+      throw new Error('is outside the allowed read roots');
+    });
+    const result = await evaluateFile({
+      type: 'file',
+      path: '/etc/passwd',
+      workspaceRoot: '/home/user/project',
+    });
+    expect(result.met).toBe(false);
+    expect(result.detail).toContain('path rejected');
+    expect(result.data?.blocked).toBe(true);
+    expect(mockStat).not.toHaveBeenCalled();
+  });
+
+  it('H-2: calls resolveAndContain with workspaceRoot as context resolveBase', async () => {
+    mockStat.mockResolvedValue({ mtimeMs: Date.now(), size: 5 } as ReturnType<typeof fsPromises.stat> extends Promise<infer T> ? T : never);
+    await evaluateFile({
+      type: 'file',
+      path: '/home/user/project/dist/out.js',
+      workspaceRoot: '/home/user/project',
+    });
+    expect(mockResolveAndContain).toHaveBeenCalledWith(
+      '/home/user/project/dist/out.js',
+      expect.objectContaining({ resolveBase: '/home/user/project' }),
+      'read',
+    );
+  });
+
+  // M-2: AbortSignal is passed to fs.readFile
+  it('M-2: passes the signal to fs.readFile when content_contains is set', async () => {
+    mockStat.mockResolvedValue({ mtimeMs: Date.now(), size: 10 } as ReturnType<typeof fsPromises.stat> extends Promise<infer T> ? T : never);
+    mockReadFile.mockResolvedValue('needle' as unknown as Buffer);
+    const ac = new AbortController();
+    await evaluateFile(
+      { type: 'file', path: '/tmp/f.txt', content_contains: 'needle' },
+      ac.signal,
+    );
+    expect(mockReadFile).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ signal: ac.signal }),
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -235,8 +308,30 @@ describe('evaluateProcess', () => {
   it('returns met:false on EPERM (process exists but no permission)', () => {
     const err = Object.assign(new Error('EPERM'), { code: 'EPERM' });
     const spy = vi.spyOn(process, 'kill').mockImplementation(() => { throw err; });
+    // Use PID > 1 to avoid the M-1 guard
+    const result = evaluateProcess({ type: 'process', pid: 2 });
+    expect(result.met).toBe(false);
+    spy.mockRestore();
+  });
+
+  // M-1: Reject special PIDs 0 and 1
+  it('M-1: rejects PID 0 without calling process.kill', () => {
+    const spy = vi.spyOn(process, 'kill');
+    const result = evaluateProcess({ type: 'process', pid: 0 });
+    expect(result.met).toBe(false);
+    expect(result.detail).toContain('not a valid target');
+    expect(result.data?.blocked).toBe(true);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('M-1: rejects PID 1 without calling process.kill', () => {
+    const spy = vi.spyOn(process, 'kill');
     const result = evaluateProcess({ type: 'process', pid: 1 });
     expect(result.met).toBe(false);
+    expect(result.detail).toContain('not a valid target');
+    expect(result.data?.blocked).toBe(true);
+    expect(spy).not.toHaveBeenCalled();
     spy.mockRestore();
   });
 });
@@ -289,11 +384,33 @@ describe('evaluateCommand', () => {
     );
   });
 
-  it('passes medium-risk commands through to execSync', () => {
+  // H-1: Medium-risk commands must now be blocked (only 'safe' is allowed)
+  it('H-1: blocks medium-risk commands before execSync is called', () => {
     mockClassifyRisk.mockReturnValue('medium');
-    mockExecSync.mockReturnValue(Buffer.from(''));
     const result = evaluateCommand({ type: 'command', command: 'git status' });
-    expect(mockExecSync).toHaveBeenCalledOnce();
-    expect(result.met).toBe(true);
+    expect(result.met).toBe(false);
+    expect(result.detail).toContain('blocked by risk classifier (medium risk)');
+    expect(result.data?.blocked).toBe(true);
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it('H-1: blocks unknown-risk commands (defaults to medium) before execSync is called', () => {
+    mockClassifyRisk.mockReturnValue('unknown' as 'safe');
+    const result = evaluateCommand({ type: 'command', command: 'some-unknown-cmd' });
+    expect(result.met).toBe(false);
+    expect(result.detail).toContain('blocked by risk classifier');
+    expect(result.data?.blocked).toBe(true);
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  // L-2: Detect SIGTERM timeout and report 'command timed out'
+  it('L-2: reports "command timed out" when execSync is killed by SIGTERM', () => {
+    mockExecSync.mockImplementation(() => {
+      throw Object.assign(new Error('Command failed'), { killed: true, signal: 'SIGTERM', status: null });
+    });
+    const result = evaluateCommand({ type: 'command', command: 'sleep 60' });
+    expect(result.met).toBe(false);
+    expect(result.detail).toContain('command timed out (30s limit)');
+    expect(result.data?.timedOut).toBe(true);
   });
 });

--- a/src/agent/tools/handlers/wait-for-conditions.test.ts
+++ b/src/agent/tools/handlers/wait-for-conditions.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Tests for wait-for-conditions.ts evaluators.
+ *
+ * Each evaluator is tested in isolation. Fetch is mocked via vi.stubGlobal;
+ * fs is mocked via vi.mock; process.kill is restored after each test.
+ *
+ * @module agent/tools/handlers/wait-for-conditions.test
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock the egress guard so tests don't hit DNS.
+// ---------------------------------------------------------------------------
+vi.mock('../../../web/egress-guard.js', () => ({
+  checkEgressTarget: vi.fn().mockResolvedValue({ allowed: true }),
+  assertEgressAllowed: vi.fn().mockResolvedValue(undefined),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock fs/promises
+// ---------------------------------------------------------------------------
+vi.mock('node:fs/promises', () => ({
+  stat: vi.fn(),
+  readFile: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock child_process.execSync
+// ---------------------------------------------------------------------------
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+import { evaluateUrl, evaluateFile, evaluateProcess, evaluateCommand } from './wait-for-conditions.js';
+import { checkEgressTarget } from '../../../web/egress-guard.js';
+import * as fsPromises from 'node:fs/promises';
+import { execSync } from 'node:child_process';
+
+const mockCheckEgress = vi.mocked(checkEgressTarget);
+const mockStat = vi.mocked(fsPromises.stat);
+const mockReadFile = vi.mocked(fsPromises.readFile);
+const mockExecSync = vi.mocked(execSync);
+
+// A never-aborting signal for tests that don't test cancellation.
+const neverSignal = new AbortController().signal;
+
+// ---------------------------------------------------------------------------
+// evaluateUrl
+// ---------------------------------------------------------------------------
+
+describe('evaluateUrl', () => {
+  beforeEach(() => {
+    mockCheckEgress.mockResolvedValue({ allowed: true });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns met:true on HTTP 200', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      status: 200,
+      body: { cancel: vi.fn().mockResolvedValue(undefined) },
+    }));
+    const result = await evaluateUrl({ type: 'url', url: 'https://example.com' }, neverSignal);
+    expect(result.met).toBe(true);
+    expect(result.detail).toContain('200');
+    vi.unstubAllGlobals();
+  });
+
+  it('returns met:false on HTTP 503', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      status: 503,
+      body: { cancel: vi.fn().mockResolvedValue(undefined) },
+    }));
+    const result = await evaluateUrl({ type: 'url', url: 'https://example.com' }, neverSignal);
+    expect(result.met).toBe(false);
+    expect(result.data?.status).toBe(503);
+    vi.unstubAllGlobals();
+  });
+
+  it('respects expected_status', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      status: 201,
+      body: { cancel: vi.fn().mockResolvedValue(undefined) },
+    }));
+    const result = await evaluateUrl(
+      { type: 'url', url: 'https://example.com', expected_status: 200 },
+      neverSignal,
+    );
+    expect(result.met).toBe(false);
+    vi.unstubAllGlobals();
+  });
+
+  it('checks body_contains when present', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      status: 200,
+      text: vi.fn().mockResolvedValue('Hello world'),
+      body: { cancel: vi.fn() },
+    }));
+    const hit = await evaluateUrl(
+      { type: 'url', url: 'https://example.com', method: 'GET', body_contains: 'world' },
+      neverSignal,
+    );
+    expect(hit.met).toBe(true);
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      status: 200,
+      text: vi.fn().mockResolvedValue('Hello world'),
+      body: { cancel: vi.fn() },
+    }));
+    const miss = await evaluateUrl(
+      { type: 'url', url: 'https://example.com', method: 'GET', body_contains: 'goodbye' },
+      neverSignal,
+    );
+    expect(miss.met).toBe(false);
+    vi.unstubAllGlobals();
+  });
+
+  it('returns met:false and blocked detail when SSRF guard blocks', async () => {
+    mockCheckEgress.mockResolvedValueOnce({ allowed: false, reason: 'private IP' });
+    const result = await evaluateUrl({ type: 'url', url: 'http://127.0.0.1' }, neverSignal);
+    expect(result.met).toBe(false);
+    expect(result.detail).toContain('SSRF blocked');
+    expect(result.data?.blocked).toBe(true);
+  });
+
+  it('returns met:false on network error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
+    const result = await evaluateUrl({ type: 'url', url: 'https://example.com' }, neverSignal);
+    expect(result.met).toBe(false);
+    expect(result.detail).toContain('fetch error');
+    vi.unstubAllGlobals();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evaluateFile
+// ---------------------------------------------------------------------------
+
+describe('evaluateFile', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('returns met:true when file exists', async () => {
+    mockStat.mockResolvedValue({ mtimeMs: Date.now(), size: 42 } as ReturnType<typeof fsPromises.stat> extends Promise<infer T> ? T : never);
+    const result = await evaluateFile({ type: 'file', path: '/tmp/myfile.txt' });
+    expect(result.met).toBe(true);
+    expect(result.detail).toContain('42 bytes');
+  });
+
+  it('returns met:false when file is missing', async () => {
+    mockStat.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+    const result = await evaluateFile({ type: 'file', path: '/tmp/missing.txt' });
+    expect(result.met).toBe(false);
+    expect(result.detail).toContain('not found');
+  });
+
+  it('checks content_contains when provided', async () => {
+    mockStat.mockResolvedValue({ mtimeMs: Date.now(), size: 20 } as ReturnType<typeof fsPromises.stat> extends Promise<infer T> ? T : never);
+    mockReadFile.mockResolvedValue('hello world' as unknown as Buffer);
+    const hit = await evaluateFile({
+      type: 'file',
+      path: '/tmp/myfile.txt',
+      content_contains: 'world',
+    });
+    expect(hit.met).toBe(true);
+
+    mockReadFile.mockResolvedValue('hello world' as unknown as Buffer);
+    const miss = await evaluateFile({
+      type: 'file',
+      path: '/tmp/myfile.txt',
+      content_contains: 'goodbye',
+    });
+    expect(miss.met).toBe(false);
+    expect(miss.detail).toContain('does not contain');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evaluateProcess
+// ---------------------------------------------------------------------------
+
+describe('evaluateProcess', () => {
+  it('returns met:false when PID is still alive', () => {
+    const spy = vi.spyOn(process, 'kill').mockReturnValue(true as unknown as boolean);
+    const result = evaluateProcess({ type: 'process', pid: 12345 });
+    expect(result.met).toBe(false);
+    expect(result.detail).toContain('alive');
+    spy.mockRestore();
+  });
+
+  it('returns met:true when PID has exited (ESRCH)', () => {
+    const err = Object.assign(new Error('ESRCH'), { code: 'ESRCH' });
+    const spy = vi.spyOn(process, 'kill').mockImplementation(() => { throw err; });
+    const result = evaluateProcess({ type: 'process', pid: 99999 });
+    expect(result.met).toBe(true);
+    expect(result.detail).toContain('exited');
+    spy.mockRestore();
+  });
+
+  it('returns met:false on EPERM (process exists but no permission)', () => {
+    const err = Object.assign(new Error('EPERM'), { code: 'EPERM' });
+    const spy = vi.spyOn(process, 'kill').mockImplementation(() => { throw err; });
+    const result = evaluateProcess({ type: 'process', pid: 1 });
+    expect(result.met).toBe(false);
+    spy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evaluateCommand
+// ---------------------------------------------------------------------------
+
+describe('evaluateCommand', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('returns met:true when command exits 0', () => {
+    mockExecSync.mockReturnValue(Buffer.from(''));
+    const result = evaluateCommand({ type: 'command', command: 'true' });
+    expect(result.met).toBe(true);
+    expect(result.detail).toContain('exited 0');
+  });
+
+  it('returns met:false when command exits non-zero', () => {
+    mockExecSync.mockImplementation(() => {
+      throw Object.assign(new Error('exit 1'), { status: 1 });
+    });
+    const result = evaluateCommand({ type: 'command', command: 'false' });
+    expect(result.met).toBe(false);
+    expect(result.detail).toContain('exited 1');
+  });
+});

--- a/src/agent/tools/handlers/wait-for-conditions.ts
+++ b/src/agent/tools/handlers/wait-for-conditions.ts
@@ -1,0 +1,181 @@
+/**
+ * Condition evaluators for the `wait_for` tool.
+ *
+ * Each evaluator takes a condition and an AbortSignal, then returns a
+ * WaitResult indicating whether the condition is currently met. The poll
+ * loop in `wait-for-poller.ts` calls these repeatedly until met or timeout.
+ *
+ * @module agent/tools/handlers/wait-for-conditions
+ */
+
+import * as fs from 'node:fs/promises';
+import { execSync } from 'node:child_process';
+import { checkEgressTarget } from '../../../web/egress-guard.js';
+
+/** Union of all condition shapes. */
+export type WaitCondition =
+  | UrlCondition
+  | FileCondition
+  | ProcessCondition
+  | CommandCondition;
+
+export interface UrlCondition {
+  type: 'url';
+  url: string;
+  method?: 'HEAD' | 'GET';
+  expected_status?: number;
+  body_contains?: string;
+}
+
+export interface FileCondition {
+  type: 'file';
+  path: string;
+  content_contains?: string;
+}
+
+export interface ProcessCondition {
+  type: 'process';
+  pid: number;
+}
+
+export interface CommandCondition {
+  type: 'command';
+  command: string;
+  cwd?: string;
+}
+
+/** Result of a single condition evaluation. */
+export interface WaitResult {
+  /** True when the condition has been satisfied. */
+  met: boolean;
+  /** Human-readable detail for the response message. */
+  detail: string;
+  /** Condition-specific metadata (HTTP status, file stat, exit code, etc). */
+  data?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// URL evaluator
+// ---------------------------------------------------------------------------
+
+export async function evaluateUrl(
+  cond: UrlCondition,
+  signal: AbortSignal,
+): Promise<WaitResult> {
+  // Eagerly reject private/loopback hosts (SSRF guard).
+  const verdict = await checkEgressTarget(cond.url);
+  if (!verdict.allowed) {
+    return { met: false, detail: `SSRF blocked: ${verdict.reason}`, data: { blocked: true } };
+  }
+
+  const method = cond.method ?? 'HEAD';
+  let response: Response;
+  try {
+    response = await fetch(cond.url, { method, signal });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { met: false, detail: `fetch error: ${msg}` };
+  }
+
+  const { status } = response;
+  const data: Record<string, unknown> = { status };
+
+  // Status check: default = any 2xx.
+  const statusOk = cond.expected_status !== undefined
+    ? status === cond.expected_status
+    : status >= 200 && status < 300;
+
+  if (!statusOk) {
+    return { met: false, detail: `HTTP ${status} (want ${cond.expected_status ?? '2xx'})`, data };
+  }
+
+  // Optional body substring match — only applies when method allows body.
+  if (cond.body_contains !== undefined) {
+    const body = await response.text().catch(() => '');
+    data['bodyLength'] = body.length;
+    if (!body.includes(cond.body_contains)) {
+      return { met: false, detail: `body does not contain "${cond.body_contains}"`, data };
+    }
+  } else if (method === 'HEAD') {
+    // No body to read for HEAD; drain nothing.
+    await response.body?.cancel().catch(() => undefined);
+  }
+
+  return { met: true, detail: `HTTP ${status}`, data };
+}
+
+// ---------------------------------------------------------------------------
+// File evaluator
+// ---------------------------------------------------------------------------
+
+export async function evaluateFile(cond: FileCondition): Promise<WaitResult> {
+  let stat: { mtimeMs: number; size: number };
+  try {
+    const s = await fs.stat(cond.path);
+    stat = { mtimeMs: s.mtimeMs, size: s.size };
+  } catch {
+    return { met: false, detail: `file not found: ${cond.path}` };
+  }
+
+  if (cond.content_contains !== undefined) {
+    let content: string;
+    try {
+      content = await fs.readFile(cond.path, 'utf8');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { met: false, detail: `read error: ${msg}`, data: stat };
+    }
+    if (!content.includes(cond.content_contains)) {
+      return {
+        met: false,
+        detail: `file exists but does not contain "${cond.content_contains}"`,
+        data: stat,
+      };
+    }
+  }
+
+  return { met: true, detail: `file exists (${stat.size} bytes)`, data: stat };
+}
+
+// ---------------------------------------------------------------------------
+// Process evaluator
+// ---------------------------------------------------------------------------
+
+export function evaluateProcess(cond: ProcessCondition): WaitResult {
+  try {
+    // Signal 0 tests process existence without sending a real signal.
+    process.kill(cond.pid, 0);
+    // kill did NOT throw → process is still alive.
+    return { met: false, detail: `pid ${cond.pid} is still alive`, data: { pid: cond.pid } };
+  } catch (err) {
+    // ESRCH = no such process → it has exited (condition met).
+    // EPERM = exists but we lack permission to signal it → still alive.
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ESRCH') {
+      return { met: true, detail: `pid ${cond.pid} has exited`, data: { pid: cond.pid } };
+    }
+    return { met: false, detail: `pid ${cond.pid} is alive (${code ?? 'unknown'})`, data: { pid: cond.pid } };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Command evaluator
+// ---------------------------------------------------------------------------
+
+export function evaluateCommand(cond: CommandCondition): WaitResult {
+  try {
+    execSync(cond.command, {
+      cwd: cond.cwd,
+      stdio: 'pipe',
+      timeout: 30_000,
+    });
+    return { met: true, detail: `command exited 0`, data: { command: cond.command } };
+  } catch (err) {
+    const status = (err as { status?: number }).status ?? -1;
+    return {
+      met: false,
+      detail: `command exited ${status}`,
+      data: { command: cond.command, exitCode: status },
+    };
+  }
+}

--- a/src/agent/tools/handlers/wait-for-conditions.ts
+++ b/src/agent/tools/handlers/wait-for-conditions.ts
@@ -12,6 +12,7 @@ import * as fs from 'node:fs/promises';
 import { execSync } from 'node:child_process';
 import { guardedFetch } from '../../../web/egress-guard.js';
 import { classifyRisk } from '../../risk-classifier.js';
+import { resolveAndContain } from './_cwd-utils.js';
 
 /** Union of all condition shapes. */
 export type WaitCondition =
@@ -32,6 +33,8 @@ export interface FileCondition {
   type: 'file';
   path: string;
   content_contains?: string;
+  /** Workspace root used for denylist check and containment. Set by the handler context. */
+  workspaceRoot?: string;
 }
 
 export interface ProcessCondition {
@@ -110,10 +113,30 @@ export async function evaluateUrl(
 // File evaluator
 // ---------------------------------------------------------------------------
 
-export async function evaluateFile(cond: FileCondition): Promise<WaitResult> {
+export async function evaluateFile(cond: FileCondition, signal?: AbortSignal): Promise<WaitResult> {
+  // H-2: Apply the same read-denylist and workspace-containment checks used by
+  // read_file so the model cannot read /etc/passwd, ~/.ssh/id_rsa, etc. via
+  // wait_for. resolveAndContain throws on a denylist hit or a path outside the
+  // workspace root, which we surface as a met:false result rather than a thrown
+  // error so the poll loop can report it cleanly.
+  let safePath: string;
+  try {
+    // Build a minimal synthetic context carrying workspaceRoot as resolveBase
+    // so resolveAndContain applies containment (when set) and the read-denylist
+    // floor (always). When workspaceRoot is absent the session is unconfined and
+    // only the denylist floor fires, matching read_file's unconfined behaviour.
+    const ctx = cond.workspaceRoot
+      ? { resolveBase: cond.workspaceRoot, cwd: cond.workspaceRoot }
+      : undefined;
+    safePath = resolveAndContain(cond.path, ctx, 'read');
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { met: false, detail: `path rejected: ${msg}`, data: { blocked: true } };
+  }
+
   let stat: { mtimeMs: number; size: number };
   try {
-    const s = await fs.stat(cond.path);
+    const s = await fs.stat(safePath);
     stat = { mtimeMs: s.mtimeMs, size: s.size };
   } catch {
     return { met: false, detail: `file not found: ${cond.path}` };
@@ -122,7 +145,9 @@ export async function evaluateFile(cond: FileCondition): Promise<WaitResult> {
   if (cond.content_contains !== undefined) {
     let content: string;
     try {
-      content = await fs.readFile(cond.path, 'utf8');
+      // M-2: pass the per-poll AbortSignal so a stalled read is aborted with
+      // the poll deadline, not left hanging past the overall timeout.
+      content = await fs.readFile(safePath, { encoding: 'utf8', signal });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       return { met: false, detail: `read error: ${msg}`, data: stat };
@@ -144,6 +169,20 @@ export async function evaluateFile(cond: FileCondition): Promise<WaitResult> {
 // ---------------------------------------------------------------------------
 
 export function evaluateProcess(cond: ProcessCondition): WaitResult {
+  // M-1: Restrict PIDs to positive integers > 1. PID 0 and PID 1 are special
+  // system processes (PID 0 = scheduler, PID 1 = init/launchd). Probing them
+  // via kill(pid, 0) is an information-disclosure channel and serves no
+  // legitimate wait_for use case. Restricting PID > 1 is a pragmatic boundary;
+  // full child-process scoping is a known limitation deferred to a PID registry
+  // (plan-mode classification can block this condition type if needed).
+  if (!Number.isInteger(cond.pid) || cond.pid <= 1) {
+    return {
+      met: false,
+      detail: `pid ${cond.pid} is not a valid target (must be integer > 1)`,
+      data: { pid: cond.pid, blocked: true },
+    };
+  }
+
   try {
     // Signal 0 tests process existence without sending a real signal.
     process.kill(cond.pid, 0);
@@ -165,15 +204,16 @@ export function evaluateProcess(cond: ProcessCondition): WaitResult {
 // ---------------------------------------------------------------------------
 
 export function evaluateCommand(cond: CommandCondition): WaitResult {
-  // Apply the same risk classification used for bash commands so that commands
-  // routed through wait_for are subject to the same security gates as the bash
-  // tool. HIGH-risk commands (rm -rf, sudo, eval, pipe-to-shell, etc.) are
-  // blocked before execSync is ever called.
+  // H-1: Apply the same risk classification used for bash commands. Only 'safe'
+  // commands are allowed — medium-risk commands (git push, npm install, mv, cp,
+  // mkdir, shell redirects) and unknown commands (which default to 'medium') are
+  // blocked. Previously, only 'high' was blocked, allowing all medium-risk and
+  // unknown commands through execSync unguarded.
   const risk = classifyRisk('bash', { command: cond.command }, { cwd: cond.cwd ?? process.cwd() });
-  if (risk === 'high') {
+  if (risk !== 'safe') {
     return {
       met: false,
-      detail: `command blocked by risk classifier (high risk): ${cond.command}`,
+      detail: `command blocked by risk classifier (${risk} risk): ${cond.command}`,
       data: { command: cond.command, blocked: true },
     };
   }
@@ -186,7 +226,18 @@ export function evaluateCommand(cond: CommandCondition): WaitResult {
     });
     return { met: true, detail: `command exited 0`, data: { command: cond.command } };
   } catch (err) {
-    const status = (err as { status?: number }).status ?? -1;
+    // L-2: Detect execSync timeout (killed: true + signal: 'SIGTERM') and report
+    // it distinctly so callers know the command ran but was too slow, not that
+    // it errored.
+    const e = err as { status?: number; killed?: boolean; signal?: string };
+    if (e.killed === true && e.signal === 'SIGTERM') {
+      return {
+        met: false,
+        detail: `command timed out (30s limit)`,
+        data: { command: cond.command, timedOut: true },
+      };
+    }
+    const status = e.status ?? -1;
     return {
       met: false,
       detail: `command exited ${status}`,

--- a/src/agent/tools/handlers/wait-for-conditions.ts
+++ b/src/agent/tools/handlers/wait-for-conditions.ts
@@ -10,7 +10,8 @@
 
 import * as fs from 'node:fs/promises';
 import { execSync } from 'node:child_process';
-import { checkEgressTarget } from '../../../web/egress-guard.js';
+import { guardedFetch } from '../../../web/egress-guard.js';
+import { classifyRisk } from '../../risk-classifier.js';
 
 /** Union of all condition shapes. */
 export type WaitCondition =
@@ -62,19 +63,20 @@ export async function evaluateUrl(
   cond: UrlCondition,
   signal: AbortSignal,
 ): Promise<WaitResult> {
-  // Eagerly reject private/loopback hosts (SSRF guard).
-  const verdict = await checkEgressTarget(cond.url);
-  if (!verdict.allowed) {
-    return { met: false, detail: `SSRF blocked: ${verdict.reason}`, data: { blocked: true } };
-  }
-
+  // guardedFetch validates the URL before the first request AND re-validates
+  // every redirect hop, closing the TOCTOU gap where a public URL 302s to a
+  // private IP after the initial check. The separate assertEgressAllowed call
+  // is intentionally removed: guardedFetch performs that check internally.
   const method = cond.method ?? 'HEAD';
   let response: Response;
   try {
-    response = await fetch(cond.url, { method, signal });
+    response = await guardedFetch(globalThis.fetch, cond.url, { method, signal });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    return { met: false, detail: `fetch error: ${msg}` };
+    // EgressBlockedError surfaces as "SSRF blocked:" to preserve the existing
+    // detail prefix callers may match on.
+    const detail = msg.startsWith('refusing to') ? `SSRF blocked: ${msg}` : `fetch error: ${msg}`;
+    return { met: false, detail, data: msg.startsWith('refusing to') ? { blocked: true } : undefined };
   }
 
   const { status } = response;
@@ -163,6 +165,19 @@ export function evaluateProcess(cond: ProcessCondition): WaitResult {
 // ---------------------------------------------------------------------------
 
 export function evaluateCommand(cond: CommandCondition): WaitResult {
+  // Apply the same risk classification used for bash commands so that commands
+  // routed through wait_for are subject to the same security gates as the bash
+  // tool. HIGH-risk commands (rm -rf, sudo, eval, pipe-to-shell, etc.) are
+  // blocked before execSync is ever called.
+  const risk = classifyRisk('bash', { command: cond.command }, { cwd: cond.cwd ?? process.cwd() });
+  if (risk === 'high') {
+    return {
+      met: false,
+      detail: `command blocked by risk classifier (high risk): ${cond.command}`,
+      data: { command: cond.command, blocked: true },
+    };
+  }
+
   try {
     execSync(cond.command, {
       cwd: cond.cwd,

--- a/src/agent/tools/handlers/wait-for-poller.test.ts
+++ b/src/agent/tools/handlers/wait-for-poller.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Tests for wait-for-poller.ts pollUntil.
+ *
+ * Uses fake timers (vi.useFakeTimers) so tests don't actually sleep.
+ * Mocks sleepWithAbort to resolve immediately, advancing the poll loop
+ * without real wall-clock delay.
+ *
+ * @module agent/tools/handlers/wait-for-poller.test
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock sleepWithAbort to resolve instantly — tests advance time by
+// controlling evaluator calls, not actual delays.
+vi.mock('../../providers/shared/sleep-with-abort.js', () => ({
+  sleepWithAbort: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { pollUntil, DEFAULT_TIMEOUT_MS, DEFAULT_POLL_INTERVAL_MS } from './wait-for-poller.js';
+import type { WaitResult } from './wait-for-conditions.js';
+import { sleepWithAbort } from '../../providers/shared/sleep-with-abort.js';
+
+const mockSleep = vi.mocked(sleepWithAbort);
+
+function makeMet(): WaitResult {
+  return { met: true, detail: 'condition met' };
+}
+function makeMiss(): WaitResult {
+  return { met: false, detail: 'not yet' };
+}
+
+describe('pollUntil', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns succeeded immediately when evaluator returns met:true on first call', async () => {
+    const evaluate = vi.fn().mockResolvedValue(makeMet());
+    const ac = new AbortController();
+    const result = await pollUntil(evaluate, {
+      timeout_ms: DEFAULT_TIMEOUT_MS,
+      poll_interval_ms: DEFAULT_POLL_INTERVAL_MS,
+      backoff: 'none',
+      signal: ac.signal,
+    });
+    expect(result.status).toBe('succeeded');
+    expect(result.attempts).toBe(1);
+    expect(result.result?.met).toBe(true);
+    expect(mockSleep).not.toHaveBeenCalled();
+  });
+
+  it('retries until condition is met', async () => {
+    const evaluate = vi.fn()
+      .mockResolvedValueOnce(makeMiss())
+      .mockResolvedValueOnce(makeMiss())
+      .mockResolvedValueOnce(makeMet());
+    const ac = new AbortController();
+    const result = await pollUntil(evaluate, {
+      timeout_ms: DEFAULT_TIMEOUT_MS,
+      poll_interval_ms: DEFAULT_POLL_INTERVAL_MS,
+      backoff: 'none',
+      signal: ac.signal,
+    });
+    expect(result.status).toBe('succeeded');
+    expect(result.attempts).toBe(3);
+    expect(mockSleep).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns cancelled when signal is aborted before first poll', async () => {
+    const ac = new AbortController();
+    ac.abort();
+    const evaluate = vi.fn().mockResolvedValue(makeMiss());
+    const result = await pollUntil(evaluate, {
+      timeout_ms: DEFAULT_TIMEOUT_MS,
+      poll_interval_ms: DEFAULT_POLL_INTERVAL_MS,
+      backoff: 'none',
+      signal: ac.signal,
+    });
+    expect(result.status).toBe('cancelled');
+    expect(evaluate).not.toHaveBeenCalled();
+  });
+
+  it('returns timed_out when timeout_ms is 0 and condition is not met', async () => {
+    const evaluate = vi.fn().mockResolvedValue(makeMiss());
+    const ac = new AbortController();
+    const result = await pollUntil(evaluate, {
+      timeout_ms: 0,
+      poll_interval_ms: DEFAULT_POLL_INTERVAL_MS,
+      backoff: 'none',
+      signal: ac.signal,
+    });
+    expect(result.status).toBe('timed_out');
+  });
+
+  it('returns failed when evaluator throws', async () => {
+    const evaluate = vi.fn().mockRejectedValue(new Error('network down'));
+    const ac = new AbortController();
+    const result = await pollUntil(evaluate, {
+      timeout_ms: DEFAULT_TIMEOUT_MS,
+      poll_interval_ms: DEFAULT_POLL_INTERVAL_MS,
+      backoff: 'none',
+      signal: ac.signal,
+    });
+    expect(result.status).toBe('failed');
+    expect(result.error).toContain('network down');
+  });
+
+  it('none backoff always uses same interval', async () => {
+    const evaluate = vi.fn()
+      .mockResolvedValueOnce(makeMiss())
+      .mockResolvedValueOnce(makeMiss())
+      .mockResolvedValue(makeMet());
+    const ac = new AbortController();
+    await pollUntil(evaluate, {
+      timeout_ms: DEFAULT_TIMEOUT_MS,
+      poll_interval_ms: 2_000,
+      backoff: 'none',
+      signal: ac.signal,
+    });
+    // Both sleep calls should use the same interval (up to capping).
+    const calls = mockSleep.mock.calls;
+    expect(calls.length).toBeGreaterThanOrEqual(2);
+    // First two sleeps should be same value (none = fixed).
+    expect(calls[0]![0]).toBe(calls[1]![0]);
+  });
+
+  it('linear backoff increases interval by 1000ms each attempt', async () => {
+    const evaluate = vi.fn()
+      .mockResolvedValueOnce(makeMiss())
+      .mockResolvedValueOnce(makeMiss())
+      .mockResolvedValue(makeMet());
+    const ac = new AbortController();
+    await pollUntil(evaluate, {
+      timeout_ms: DEFAULT_TIMEOUT_MS,
+      poll_interval_ms: 2_000,
+      backoff: 'linear',
+      signal: ac.signal,
+    });
+    const calls = mockSleep.mock.calls;
+    // After attempt 0: 2000 + 0*1000 = 2000
+    // After attempt 1: 2000 + 1*1000 = 3000
+    expect(calls[0]![0]).toBe(2_000);
+    expect(calls[1]![0]).toBe(3_000);
+  });
+
+  it('exponential backoff doubles interval each attempt, capped at 60s', async () => {
+    const evaluate = vi.fn()
+      .mockResolvedValueOnce(makeMiss())
+      .mockResolvedValueOnce(makeMiss())
+      .mockResolvedValueOnce(makeMiss())
+      .mockResolvedValue(makeMet());
+    const ac = new AbortController();
+    await pollUntil(evaluate, {
+      timeout_ms: DEFAULT_TIMEOUT_MS,
+      poll_interval_ms: 1_000,
+      backoff: 'exponential',
+      signal: ac.signal,
+    });
+    const calls = mockSleep.mock.calls;
+    // 1000*2^0=1000, 1000*2^1=2000, 1000*2^2=4000
+    expect(calls[0]![0]).toBe(1_000);
+    expect(calls[1]![0]).toBe(2_000);
+    expect(calls[2]![0]).toBe(4_000);
+  });
+
+  it('exponential backoff is capped at 60000ms', async () => {
+    // Start at 10s; after 3 doublings: 80s > 60s → capped at 60s.
+    const evaluate = vi.fn()
+      .mockResolvedValueOnce(makeMiss())
+      .mockResolvedValueOnce(makeMiss())
+      .mockResolvedValueOnce(makeMiss())
+      .mockResolvedValue(makeMet());
+    const ac = new AbortController();
+    await pollUntil(evaluate, {
+      timeout_ms: DEFAULT_TIMEOUT_MS,
+      poll_interval_ms: 10_000,
+      backoff: 'exponential',
+      signal: ac.signal,
+    });
+    const calls = mockSleep.mock.calls;
+    // 10000, 20000, 40000 — all below cap
+    expect(calls[0]![0]).toBe(10_000);
+    expect(calls[1]![0]).toBe(20_000);
+    expect(calls[2]![0]).toBe(40_000);
+
+    // Verify cap: with base=40000, attempt 2 → 40000*4=160000 → capped at 60000
+    const evaluate2 = vi.fn()
+      .mockResolvedValueOnce(makeMiss())
+      .mockResolvedValueOnce(makeMiss())
+      .mockResolvedValueOnce(makeMiss())
+      .mockResolvedValue(makeMet());
+    vi.clearAllMocks();
+    await pollUntil(evaluate2, {
+      timeout_ms: DEFAULT_TIMEOUT_MS,
+      poll_interval_ms: 40_000,
+      backoff: 'exponential',
+      signal: ac.signal,
+    });
+    const calls2 = mockSleep.mock.calls;
+    // 40000*2^1=80000 → capped at 60000
+    expect(calls2[1]![0]).toBe(60_000);
+  });
+});

--- a/src/agent/tools/handlers/wait-for-poller.test.ts
+++ b/src/agent/tools/handlers/wait-for-poller.test.ts
@@ -208,6 +208,51 @@ describe('pollUntil', () => {
     expect(sleepCalls[2]![0]).toBe(4_000);
   });
 
+  // M-3: Per-poll AbortError (slow evaluator) must NOT permanently fail
+  it('M-3: treats per-poll AbortError as a missed poll and continues the loop', async () => {
+    // Simulate: first call throws AbortError (per-poll timeout fires), second
+    // call succeeds. Session signal is never aborted. The loop should continue
+    // after the first abort and eventually succeed.
+    let calls = 0;
+    const evaluate = vi.fn(async (_sig: AbortSignal) => {
+      calls++;
+      if (calls === 1) {
+        // Simulate per-poll timeout: AbortError with name 'AbortError'
+        const err = Object.assign(new Error('The operation was aborted.'), { name: 'AbortError' });
+        throw err;
+      }
+      return makeMet();
+    });
+    const ac = new AbortController();
+    const result = await pollUntil(evaluate, {
+      timeout_ms: DEFAULT_TIMEOUT_MS,
+      poll_interval_ms: DEFAULT_POLL_INTERVAL_MS,
+      backoff: 'none',
+      signal: ac.signal,
+    });
+    // Should have continued past the AbortError and succeeded on attempt 2
+    expect(result.status).toBe('succeeded');
+    expect(evaluate).toHaveBeenCalledTimes(2);
+    expect(result.result?.met).toBe(true);
+  });
+
+  it('M-3: per-poll AbortError at deadline returns timed_out, not failed', async () => {
+    // Simulate: evaluator always throws AbortError and deadline is already past
+    // after the first miss. Should return timed_out, not failed.
+    const evaluate = vi.fn(async (_sig: AbortSignal) => {
+      const err = Object.assign(new Error('The operation was aborted.'), { name: 'AbortError' });
+      throw err;
+    });
+    const ac = new AbortController();
+    const result = await pollUntil(evaluate, {
+      timeout_ms: 0, // deadline immediately in the past
+      poll_interval_ms: DEFAULT_POLL_INTERVAL_MS,
+      backoff: 'none',
+      signal: ac.signal,
+    });
+    expect(result.status).toBe('timed_out');
+  });
+
   it('exponential backoff is capped at 60000ms', async () => {
     // Start at 10s; after 3 doublings: 80s > 60s → capped at 60s.
     let calls = 0;

--- a/src/agent/tools/handlers/wait-for-poller.test.ts
+++ b/src/agent/tools/handlers/wait-for-poller.test.ts
@@ -29,6 +29,11 @@ function makeMiss(): WaitResult {
   return { met: false, detail: 'not yet' };
 }
 
+// Helper: wrap a value-returning factory as a signal-accepting evaluator.
+function makeEvaluator(fn: () => WaitResult | Promise<WaitResult>): (signal: AbortSignal) => Promise<WaitResult> {
+  return (_signal: AbortSignal) => Promise.resolve(fn());
+}
+
 describe('pollUntil', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -39,7 +44,7 @@ describe('pollUntil', () => {
   });
 
   it('returns succeeded immediately when evaluator returns met:true on first call', async () => {
-    const evaluate = vi.fn().mockResolvedValue(makeMet());
+    const evaluate = vi.fn(makeEvaluator(() => makeMet()));
     const ac = new AbortController();
     const result = await pollUntil(evaluate, {
       timeout_ms: DEFAULT_TIMEOUT_MS,
@@ -54,10 +59,11 @@ describe('pollUntil', () => {
   });
 
   it('retries until condition is met', async () => {
-    const evaluate = vi.fn()
-      .mockResolvedValueOnce(makeMiss())
-      .mockResolvedValueOnce(makeMiss())
-      .mockResolvedValueOnce(makeMet());
+    let calls = 0;
+    const evaluate = vi.fn((_sig: AbortSignal) => {
+      calls++;
+      return Promise.resolve(calls < 3 ? makeMiss() : makeMet());
+    });
     const ac = new AbortController();
     const result = await pollUntil(evaluate, {
       timeout_ms: DEFAULT_TIMEOUT_MS,
@@ -70,10 +76,28 @@ describe('pollUntil', () => {
     expect(mockSleep).toHaveBeenCalledTimes(2);
   });
 
-  it('returns cancelled when signal is aborted before first poll', async () => {
+  it('passes a per-poll AbortSignal to the evaluator', async () => {
+    const receivedSignals: AbortSignal[] = [];
+    const evaluate = vi.fn(async (sig: AbortSignal) => {
+      receivedSignals.push(sig);
+      return makeMet();
+    });
+    const ac = new AbortController();
+    await pollUntil(evaluate, {
+      timeout_ms: DEFAULT_TIMEOUT_MS,
+      poll_interval_ms: DEFAULT_POLL_INTERVAL_MS,
+      backoff: 'none',
+      signal: ac.signal,
+    });
+    // The poller must have passed a signal (per-poll deadline signal, not the raw session signal).
+    expect(receivedSignals.length).toBeGreaterThan(0);
+    expect(receivedSignals[0]).toBeInstanceOf(AbortSignal);
+  });
+
+  it('returns cancelled when session signal is aborted before first poll', async () => {
     const ac = new AbortController();
     ac.abort();
-    const evaluate = vi.fn().mockResolvedValue(makeMiss());
+    const evaluate = vi.fn((_sig: AbortSignal) => Promise.resolve(makeMiss()));
     const result = await pollUntil(evaluate, {
       timeout_ms: DEFAULT_TIMEOUT_MS,
       poll_interval_ms: DEFAULT_POLL_INTERVAL_MS,
@@ -84,8 +108,23 @@ describe('pollUntil', () => {
     expect(evaluate).not.toHaveBeenCalled();
   });
 
+  it('returns cancelled when session signal fires during evaluate', async () => {
+    const ac = new AbortController();
+    const evaluate = vi.fn(async (_sig: AbortSignal) => {
+      ac.abort();
+      throw new Error('AbortError');
+    });
+    const result = await pollUntil(evaluate, {
+      timeout_ms: DEFAULT_TIMEOUT_MS,
+      poll_interval_ms: DEFAULT_POLL_INTERVAL_MS,
+      backoff: 'none',
+      signal: ac.signal,
+    });
+    expect(result.status).toBe('cancelled');
+  });
+
   it('returns timed_out when timeout_ms is 0 and condition is not met', async () => {
-    const evaluate = vi.fn().mockResolvedValue(makeMiss());
+    const evaluate = vi.fn((_sig: AbortSignal) => Promise.resolve(makeMiss()));
     const ac = new AbortController();
     const result = await pollUntil(evaluate, {
       timeout_ms: 0,
@@ -96,8 +135,8 @@ describe('pollUntil', () => {
     expect(result.status).toBe('timed_out');
   });
 
-  it('returns failed when evaluator throws', async () => {
-    const evaluate = vi.fn().mockRejectedValue(new Error('network down'));
+  it('returns failed when evaluator throws (not a session abort)', async () => {
+    const evaluate = vi.fn((_sig: AbortSignal) => Promise.reject(new Error('network down')));
     const ac = new AbortController();
     const result = await pollUntil(evaluate, {
       timeout_ms: DEFAULT_TIMEOUT_MS,
@@ -110,10 +149,11 @@ describe('pollUntil', () => {
   });
 
   it('none backoff always uses same interval', async () => {
-    const evaluate = vi.fn()
-      .mockResolvedValueOnce(makeMiss())
-      .mockResolvedValueOnce(makeMiss())
-      .mockResolvedValue(makeMet());
+    let calls = 0;
+    const evaluate = vi.fn((_sig: AbortSignal) => {
+      calls++;
+      return Promise.resolve(calls < 3 ? makeMiss() : makeMet());
+    });
     const ac = new AbortController();
     await pollUntil(evaluate, {
       timeout_ms: DEFAULT_TIMEOUT_MS,
@@ -122,17 +162,18 @@ describe('pollUntil', () => {
       signal: ac.signal,
     });
     // Both sleep calls should use the same interval (up to capping).
-    const calls = mockSleep.mock.calls;
-    expect(calls.length).toBeGreaterThanOrEqual(2);
+    const sleepCalls = mockSleep.mock.calls;
+    expect(sleepCalls.length).toBeGreaterThanOrEqual(2);
     // First two sleeps should be same value (none = fixed).
-    expect(calls[0]![0]).toBe(calls[1]![0]);
+    expect(sleepCalls[0]![0]).toBe(sleepCalls[1]![0]);
   });
 
   it('linear backoff increases interval by 1000ms each attempt', async () => {
-    const evaluate = vi.fn()
-      .mockResolvedValueOnce(makeMiss())
-      .mockResolvedValueOnce(makeMiss())
-      .mockResolvedValue(makeMet());
+    let calls = 0;
+    const evaluate = vi.fn((_sig: AbortSignal) => {
+      calls++;
+      return Promise.resolve(calls < 3 ? makeMiss() : makeMet());
+    });
     const ac = new AbortController();
     await pollUntil(evaluate, {
       timeout_ms: DEFAULT_TIMEOUT_MS,
@@ -140,19 +181,19 @@ describe('pollUntil', () => {
       backoff: 'linear',
       signal: ac.signal,
     });
-    const calls = mockSleep.mock.calls;
+    const sleepCalls = mockSleep.mock.calls;
     // After attempt 0: 2000 + 0*1000 = 2000
     // After attempt 1: 2000 + 1*1000 = 3000
-    expect(calls[0]![0]).toBe(2_000);
-    expect(calls[1]![0]).toBe(3_000);
+    expect(sleepCalls[0]![0]).toBe(2_000);
+    expect(sleepCalls[1]![0]).toBe(3_000);
   });
 
   it('exponential backoff doubles interval each attempt, capped at 60s', async () => {
-    const evaluate = vi.fn()
-      .mockResolvedValueOnce(makeMiss())
-      .mockResolvedValueOnce(makeMiss())
-      .mockResolvedValueOnce(makeMiss())
-      .mockResolvedValue(makeMet());
+    let calls = 0;
+    const evaluate = vi.fn((_sig: AbortSignal) => {
+      calls++;
+      return Promise.resolve(calls < 4 ? makeMiss() : makeMet());
+    });
     const ac = new AbortController();
     await pollUntil(evaluate, {
       timeout_ms: DEFAULT_TIMEOUT_MS,
@@ -160,20 +201,20 @@ describe('pollUntil', () => {
       backoff: 'exponential',
       signal: ac.signal,
     });
-    const calls = mockSleep.mock.calls;
+    const sleepCalls = mockSleep.mock.calls;
     // 1000*2^0=1000, 1000*2^1=2000, 1000*2^2=4000
-    expect(calls[0]![0]).toBe(1_000);
-    expect(calls[1]![0]).toBe(2_000);
-    expect(calls[2]![0]).toBe(4_000);
+    expect(sleepCalls[0]![0]).toBe(1_000);
+    expect(sleepCalls[1]![0]).toBe(2_000);
+    expect(sleepCalls[2]![0]).toBe(4_000);
   });
 
   it('exponential backoff is capped at 60000ms', async () => {
     // Start at 10s; after 3 doublings: 80s > 60s → capped at 60s.
-    const evaluate = vi.fn()
-      .mockResolvedValueOnce(makeMiss())
-      .mockResolvedValueOnce(makeMiss())
-      .mockResolvedValueOnce(makeMiss())
-      .mockResolvedValue(makeMet());
+    let calls = 0;
+    const evaluate = vi.fn((_sig: AbortSignal) => {
+      calls++;
+      return Promise.resolve(calls < 4 ? makeMiss() : makeMet());
+    });
     const ac = new AbortController();
     await pollUntil(evaluate, {
       timeout_ms: DEFAULT_TIMEOUT_MS,
@@ -181,18 +222,18 @@ describe('pollUntil', () => {
       backoff: 'exponential',
       signal: ac.signal,
     });
-    const calls = mockSleep.mock.calls;
+    const sleepCalls = mockSleep.mock.calls;
     // 10000, 20000, 40000 — all below cap
-    expect(calls[0]![0]).toBe(10_000);
-    expect(calls[1]![0]).toBe(20_000);
-    expect(calls[2]![0]).toBe(40_000);
+    expect(sleepCalls[0]![0]).toBe(10_000);
+    expect(sleepCalls[1]![0]).toBe(20_000);
+    expect(sleepCalls[2]![0]).toBe(40_000);
 
     // Verify cap: with base=40000, attempt 2 → 40000*4=160000 → capped at 60000
-    const evaluate2 = vi.fn()
-      .mockResolvedValueOnce(makeMiss())
-      .mockResolvedValueOnce(makeMiss())
-      .mockResolvedValueOnce(makeMiss())
-      .mockResolvedValue(makeMet());
+    let calls2 = 0;
+    const evaluate2 = vi.fn((_sig: AbortSignal) => {
+      calls2++;
+      return Promise.resolve(calls2 < 4 ? makeMiss() : makeMet());
+    });
     vi.clearAllMocks();
     await pollUntil(evaluate2, {
       timeout_ms: DEFAULT_TIMEOUT_MS,
@@ -200,8 +241,8 @@ describe('pollUntil', () => {
       backoff: 'exponential',
       signal: ac.signal,
     });
-    const calls2 = mockSleep.mock.calls;
+    const calls2Result = mockSleep.mock.calls;
     // 40000*2^1=80000 → capped at 60000
-    expect(calls2[1]![0]).toBe(60_000);
+    expect(calls2Result[1]![0]).toBe(60_000);
   });
 });

--- a/src/agent/tools/handlers/wait-for-poller.ts
+++ b/src/agent/tools/handlers/wait-for-poller.ts
@@ -64,11 +64,16 @@ function nextInterval(
  * Poll `evaluate` until it returns `{ met: true }`, the timeout is reached,
  * or the signal is aborted.
  *
+ * The evaluator receives a per-poll AbortSignal that fires at the earlier of
+ * (a) the session-level signal or (b) the remaining time to the overall
+ * deadline, so a hung evaluator (e.g. a server that accepts the TCP connection
+ * but never sends a response) cannot block the loop past the deadline.
+ *
  * The function NEVER throws — all outcomes are expressed in the returned
  * `PollResult.status`. Callers should surface `failed` as an error only.
  */
 export async function pollUntil(
-  evaluate: () => Promise<WaitResult>,
+  evaluate: (signal: AbortSignal) => Promise<WaitResult>,
   options: PollOptions,
 ): Promise<PollResult> {
   const { timeout_ms, poll_interval_ms, backoff, signal } = options;
@@ -83,11 +88,24 @@ export async function pollUntil(
       return { status: 'cancelled', elapsed_ms: Date.now() - (deadline - timeout_ms), attempts };
     }
 
-    // Evaluate condition.
+    // Evaluate condition with a per-poll deadline signal so a stalled
+    // evaluator (e.g. a server that accepts connections but never responds)
+    // is aborted no later than the remaining time to the overall deadline.
+    // AbortSignal.any races the session signal against the per-poll timeout.
+    const remaining = deadline - Date.now();
+    const perPollSignal = AbortSignal.any([
+      signal,
+      AbortSignal.timeout(Math.max(1, Math.min(poll_interval_ms, remaining))),
+    ]);
     let result: WaitResult;
     try {
-      result = await evaluate();
+      result = await evaluate(perPollSignal);
     } catch (err) {
+      // If the per-poll signal fired (timeout or abort), propagate to the
+      // outer-loop checks that handle those cases gracefully.
+      if (signal.aborted) {
+        return { status: 'cancelled', elapsed_ms: Date.now() - (deadline - timeout_ms), attempts };
+      }
       const error = err instanceof Error ? err.message : String(err);
       return {
         status: 'failed',

--- a/src/agent/tools/handlers/wait-for-poller.ts
+++ b/src/agent/tools/handlers/wait-for-poller.ts
@@ -16,7 +16,7 @@ export const MAX_TIMEOUT_MS = 600_000;
 export const DEFAULT_POLL_INTERVAL_MS = 5_000;
 export const MIN_POLL_INTERVAL_MS = 1_000;
 
-/** Heartbeat log interval — one console.error line every 60 s of waiting. */
+/** Heartbeat log interval — one debug log line every 60 s of waiting. */
 const HEARTBEAT_INTERVAL_MS = 60_000;
 
 export interface PollOptions {
@@ -101,10 +101,30 @@ export async function pollUntil(
     try {
       result = await evaluate(perPollSignal);
     } catch (err) {
-      // If the per-poll signal fired (timeout or abort), propagate to the
-      // outer-loop checks that handle those cases gracefully.
+      // Session-level abort takes priority — surface as cancelled.
       if (signal.aborted) {
         return { status: 'cancelled', elapsed_ms: Date.now() - (deadline - timeout_ms), attempts };
+      }
+      // H-3: Per-poll timeout (AbortSignal.timeout on perPollSignal) throws an
+      // AbortError. This means the evaluator was slow for ONE poll interval but
+      // the session is still live. Treat it as a missed poll and continue the
+      // loop rather than permanently failing — a slow-but-reachable server that
+      // responds in slightly more than poll_interval_ms should not kill the whole
+      // wait. Check the deadline first so a missed poll at expiry still surfaces
+      // as timed_out rather than silently looping forever.
+      if (err instanceof Error && err.name === 'AbortError') {
+        if (Date.now() >= deadline) {
+          return {
+            status: 'timed_out',
+            elapsed_ms: Date.now() - (deadline - timeout_ms),
+            attempts,
+            result: lastResult,
+          };
+        }
+        // Missed poll — continue to next attempt without incrementing the
+        // success-attempt counter or advancing backoff (the evaluator never
+        // returned a result this round).
+        continue;
       }
       const error = err instanceof Error ? err.message : String(err);
       return {
@@ -130,20 +150,29 @@ export async function pollUntil(
     const now = Date.now();
     if (now >= deadline) {
       return {
+        // L-1: Report actual elapsed time instead of the requested timeout_ms
+        // so callers see how long the loop actually ran (may be slightly more
+        // than timeout_ms due to evaluator overhead).
         status: 'timed_out',
-        elapsed_ms: timeout_ms,
+        elapsed_ms: now - (deadline - timeout_ms),
         attempts,
         result: lastResult,
       };
     }
 
-    // Heartbeat every 60 s so long waits leave a trace in logs.
+    // L-3: Heartbeat every 60 s — emit to a conditional debug path rather than
+    // console.error so the poller does not pollute structured output in
+    // production. Use process.stderr.write only when DEBUG is set so CI and
+    // daemon surfaces stay clean; tool output goes through the tool result, not
+    // stderr.
     if (now - lastHeartbeat >= HEARTBEAT_INTERVAL_MS) {
-      console.error(
-        `[wait_for] still waiting — attempt ${attempts}, ` +
-          `${Math.round((deadline - now) / 1000)}s remaining. ` +
-          `Last: ${lastResult.detail}`,
-      );
+      if (process.env['DEBUG']) {
+        process.stderr.write(
+          `[wait_for] still waiting — attempt ${attempts}, ` +
+            `${Math.round((deadline - now) / 1000)}s remaining. ` +
+            `Last: ${lastResult?.detail ?? 'n/a'}\n`,
+        );
+      }
       lastHeartbeat = now;
     }
 

--- a/src/agent/tools/handlers/wait-for-poller.ts
+++ b/src/agent/tools/handlers/wait-for-poller.ts
@@ -17,7 +17,7 @@ export const DEFAULT_POLL_INTERVAL_MS = 5_000;
 export const MIN_POLL_INTERVAL_MS = 1_000;
 
 /** Heartbeat log interval — one debug log line every 60 s of waiting. */
-const HEARTBEAT_INTERVAL_MS = 60_000;
+
 
 export interface PollOptions {
   /** Maximum time to wait before returning `timed_out`. Default 120 000 ms. */
@@ -80,7 +80,7 @@ export async function pollUntil(
   const deadline = Date.now() + timeout_ms;
   let attempts = 0;
   let lastResult: WaitResult | undefined;
-  let lastHeartbeat = Date.now();
+
 
   while (true) {
     // Check abort first (covers the case where signal was pre-aborted).
@@ -158,22 +158,6 @@ export async function pollUntil(
         attempts,
         result: lastResult,
       };
-    }
-
-    // L-3: Heartbeat every 60 s — emit to a conditional debug path rather than
-    // console.error so the poller does not pollute structured output in
-    // production. Use process.stderr.write only when DEBUG is set so CI and
-    // daemon surfaces stay clean; tool output goes through the tool result, not
-    // stderr.
-    if (now - lastHeartbeat >= HEARTBEAT_INTERVAL_MS) {
-      if (process.env['DEBUG']) {
-        process.stderr.write(
-          `[wait_for] still waiting — attempt ${attempts}, ` +
-            `${Math.round((deadline - now) / 1000)}s remaining. ` +
-            `Last: ${lastResult?.detail ?? 'n/a'}\n`,
-        );
-      }
-      lastHeartbeat = now;
     }
 
     // Sleep, capped to remaining time.

--- a/src/agent/tools/handlers/wait-for-poller.ts
+++ b/src/agent/tools/handlers/wait-for-poller.ts
@@ -1,0 +1,139 @@
+/**
+ * Poll loop for the `wait_for` tool.
+ *
+ * Calls a condition evaluator repeatedly until the condition is met, the
+ * timeout elapses, or the AbortSignal fires. Uses `sleepWithAbort` between
+ * polls so the loop participates cleanly in session teardown.
+ *
+ * @module agent/tools/handlers/wait-for-poller
+ */
+
+import { sleepWithAbort } from '../../providers/shared/sleep-with-abort.js';
+import type { WaitResult } from './wait-for-conditions.js';
+
+export const DEFAULT_TIMEOUT_MS = 120_000;
+export const MAX_TIMEOUT_MS = 600_000;
+export const DEFAULT_POLL_INTERVAL_MS = 5_000;
+export const MIN_POLL_INTERVAL_MS = 1_000;
+
+/** Heartbeat log interval — one console.error line every 60 s of waiting. */
+const HEARTBEAT_INTERVAL_MS = 60_000;
+
+export interface PollOptions {
+  /** Maximum time to wait before returning `timed_out`. Default 120 000 ms. */
+  timeout_ms: number;
+  /** Base delay between polls. Default 5 000 ms. Min 1 000 ms. */
+  poll_interval_ms: number;
+  /** Backoff strategy applied to `poll_interval_ms` after each miss. */
+  backoff: 'none' | 'linear' | 'exponential';
+  /** Cancellation signal (session shutdown, parent abort, etc.). */
+  signal: AbortSignal;
+}
+
+export interface PollResult {
+  status: 'succeeded' | 'timed_out' | 'cancelled' | 'failed';
+  elapsed_ms: number;
+  attempts: number;
+  result?: WaitResult;
+  error?: string;
+}
+
+/**
+ * Compute the next sleep duration given the current attempt count.
+ *
+ * - `none`:        always `base`
+ * - `linear`:      `base + attempt * 1000` (uncapped)
+ * - `exponential`: `base * 2^attempt`, capped at 60 000 ms
+ */
+function nextInterval(
+  base: number,
+  attempt: number,
+  backoff: PollOptions['backoff'],
+): number {
+  switch (backoff) {
+    case 'linear':
+      return base + attempt * 1_000;
+    case 'exponential':
+      return Math.min(base * Math.pow(2, attempt), 60_000);
+    default:
+      return base;
+  }
+}
+
+/**
+ * Poll `evaluate` until it returns `{ met: true }`, the timeout is reached,
+ * or the signal is aborted.
+ *
+ * The function NEVER throws — all outcomes are expressed in the returned
+ * `PollResult.status`. Callers should surface `failed` as an error only.
+ */
+export async function pollUntil(
+  evaluate: () => Promise<WaitResult>,
+  options: PollOptions,
+): Promise<PollResult> {
+  const { timeout_ms, poll_interval_ms, backoff, signal } = options;
+  const deadline = Date.now() + timeout_ms;
+  let attempts = 0;
+  let lastResult: WaitResult | undefined;
+  let lastHeartbeat = Date.now();
+
+  while (true) {
+    // Check abort first (covers the case where signal was pre-aborted).
+    if (signal.aborted) {
+      return { status: 'cancelled', elapsed_ms: Date.now() - (deadline - timeout_ms), attempts };
+    }
+
+    // Evaluate condition.
+    let result: WaitResult;
+    try {
+      result = await evaluate();
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return {
+        status: 'failed',
+        elapsed_ms: Date.now() - (deadline - timeout_ms),
+        attempts,
+        error,
+      };
+    }
+    lastResult = result;
+    attempts++;
+
+    if (result.met) {
+      return {
+        status: 'succeeded',
+        elapsed_ms: Date.now() - (deadline - timeout_ms),
+        attempts,
+        result,
+      };
+    }
+
+    // Check timeout before sleeping again.
+    const now = Date.now();
+    if (now >= deadline) {
+      return {
+        status: 'timed_out',
+        elapsed_ms: timeout_ms,
+        attempts,
+        result: lastResult,
+      };
+    }
+
+    // Heartbeat every 60 s so long waits leave a trace in logs.
+    if (now - lastHeartbeat >= HEARTBEAT_INTERVAL_MS) {
+      console.error(
+        `[wait_for] still waiting — attempt ${attempts}, ` +
+          `${Math.round((deadline - now) / 1000)}s remaining. ` +
+          `Last: ${lastResult.detail}`,
+      );
+      lastHeartbeat = now;
+    }
+
+    // Sleep, capped to remaining time.
+    const sleepMs = Math.min(
+      nextInterval(poll_interval_ms, attempts - 1, backoff),
+      deadline - now,
+    );
+    await sleepWithAbort(sleepMs, signal);
+  }
+}

--- a/src/agent/tools/handlers/wait-for.test.ts
+++ b/src/agent/tools/handlers/wait-for.test.ts
@@ -186,3 +186,124 @@ describe('waitForHandler — cancelled outcome', () => {
     expect(result.content).toContain('cancelled');
   });
 });
+
+// ---------------------------------------------------------------------------
+// P4: body_contains → GET default
+// ---------------------------------------------------------------------------
+
+describe('waitForHandler — body_contains defaults method to GET', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCheckEgress.mockResolvedValue({ allowed: true });
+  });
+
+  it('uses GET when body_contains is set and method is not explicit', async () => {
+    const { evaluateUrl } = await import('./wait-for-conditions.js');
+    const mockEvalUrl = vi.mocked(evaluateUrl);
+    // Capture the condition passed to evaluateUrl
+    let capturedCond: unknown;
+    mockEvalUrl.mockImplementationOnce((cond, _sig) => {
+      capturedCond = cond;
+      return Promise.resolve({ met: true, detail: 'HTTP 200' });
+    });
+
+    await waitForHandler(
+      { type: 'url', url: 'https://example.com', body_contains: 'ready' },
+      neverSignal,
+    );
+
+    expect((capturedCond as { method?: string })?.method).toBe('GET');
+  });
+
+  it('respects explicit HEAD when body_contains is set', async () => {
+    // This is an edge case — the user explicitly opted into HEAD even with
+    // body_contains; the handler honours the explicit method.
+    const result = await waitForHandler(
+      { type: 'url', url: 'https://example.com', method: 'HEAD', body_contains: 'ready' },
+      neverSignal,
+    );
+    // Validation passes (no error about method).
+    // The mock evaluator resolves to met:true regardless.
+    expect(result.isError).toBeFalsy();
+  });
+
+  it('uses HEAD by default when body_contains is not set', async () => {
+    const { evaluateUrl } = await import('./wait-for-conditions.js');
+    const mockEvalUrl = vi.mocked(evaluateUrl);
+    let capturedCond: unknown;
+    mockEvalUrl.mockImplementationOnce((cond, _sig) => {
+      capturedCond = cond;
+      return Promise.resolve({ met: true, detail: 'HTTP 200' });
+    });
+
+    await waitForHandler({ type: 'url', url: 'https://example.com' }, neverSignal);
+    expect((capturedCond as { method?: string })?.method).toBe('HEAD');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// P5: relative file path → resolved against context.cwd / resolveBase
+// ---------------------------------------------------------------------------
+
+describe('waitForHandler — relative path resolution for file type', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCheckEgress.mockResolvedValue({ allowed: true });
+  });
+
+  it('resolves a relative path against context.cwd', async () => {
+    const { evaluateFile } = await import('./wait-for-conditions.js');
+    const mockEvalFile = vi.mocked(evaluateFile);
+    let capturedCond: unknown;
+    mockEvalFile.mockImplementationOnce((cond) => {
+      capturedCond = cond;
+      return Promise.resolve({ met: true, detail: 'file exists (0 bytes)' });
+    });
+
+    await waitForHandler(
+      { type: 'file', path: 'dist/server.js' },
+      neverSignal,
+      { cwd: '/home/user/myproject', resolveBase: undefined } as never,
+    );
+
+    expect((capturedCond as { path: string })?.path).toBe('/home/user/myproject/dist/server.js');
+  });
+
+  it('prefers context.resolveBase over context.cwd', async () => {
+    const { evaluateFile } = await import('./wait-for-conditions.js');
+    const mockEvalFile = vi.mocked(evaluateFile);
+    let capturedCond: unknown;
+    mockEvalFile.mockImplementationOnce((cond) => {
+      capturedCond = cond;
+      return Promise.resolve({ met: true, detail: 'file exists (0 bytes)' });
+    });
+
+    await waitForHandler(
+      { type: 'file', path: 'dist/server.js' },
+      neverSignal,
+      { cwd: '/home/user/myproject', resolveBase: '/home/user/myproject/packages/app' } as never,
+    );
+
+    expect((capturedCond as { path: string })?.path).toBe(
+      '/home/user/myproject/packages/app/dist/server.js',
+    );
+  });
+
+  it('passes absolute paths through unchanged', async () => {
+    const { evaluateFile } = await import('./wait-for-conditions.js');
+    const mockEvalFile = vi.mocked(evaluateFile);
+    let capturedCond: unknown;
+    mockEvalFile.mockImplementationOnce((cond) => {
+      capturedCond = cond;
+      return Promise.resolve({ met: true, detail: 'file exists (0 bytes)' });
+    });
+
+    await waitForHandler(
+      { type: 'file', path: '/absolute/path/to/file.txt' },
+      neverSignal,
+      { cwd: '/home/user/myproject' } as never,
+    );
+
+    expect((capturedCond as { path: string })?.path).toBe('/absolute/path/to/file.txt');
+  });
+});

--- a/src/agent/tools/handlers/wait-for.test.ts
+++ b/src/agent/tools/handlers/wait-for.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Integration tests for the wait_for handler.
+ *
+ * Tests input validation, SSRF rejection, and end-to-end handler wiring.
+ * The poll loop is mocked to resolve immediately.
+ *
+ * @module agent/tools/handlers/wait-for.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock the egress guard
+// ---------------------------------------------------------------------------
+vi.mock('../../../web/egress-guard.js', () => ({
+  checkEgressTarget: vi.fn().mockResolvedValue({ allowed: true }),
+  assertEgressAllowed: vi.fn().mockResolvedValue(undefined),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock the condition evaluators so they resolve immediately
+// ---------------------------------------------------------------------------
+vi.mock('./wait-for-conditions.js', () => ({
+  evaluateUrl: vi.fn().mockResolvedValue({ met: true, detail: 'HTTP 200' }),
+  evaluateFile: vi.fn().mockResolvedValue({ met: true, detail: 'file exists (10 bytes)' }),
+  evaluateProcess: vi.fn().mockReturnValue({ met: true, detail: 'pid 12345 has exited' }),
+  evaluateCommand: vi.fn().mockReturnValue({ met: true, detail: 'command exited 0' }),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock sleepWithAbort (poll loop sleep)
+// ---------------------------------------------------------------------------
+vi.mock('../../providers/shared/sleep-with-abort.js', () => ({
+  sleepWithAbort: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { waitForHandler } from './wait-for.js';
+import { checkEgressTarget } from '../../../web/egress-guard.js';
+
+const mockCheckEgress = vi.mocked(checkEgressTarget);
+
+const neverSignal = new AbortController().signal;
+
+describe('waitForHandler — input validation', () => {
+  it('returns error when input is not an object', async () => {
+    const result = await waitForHandler('bad', neverSignal);
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatch(/object/);
+  });
+
+  it('returns error when type is missing', async () => {
+    const result = await waitForHandler({}, neverSignal);
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatch(/type/);
+  });
+
+  it('returns error for unknown type', async () => {
+    const result = await waitForHandler({ type: 'magic' }, neverSignal);
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatch(/Unknown type/);
+  });
+
+  it('returns error when url type missing url field', async () => {
+    const result = await waitForHandler({ type: 'url' }, neverSignal);
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatch(/"url"/);
+  });
+
+  it('returns error when file type missing path field', async () => {
+    const result = await waitForHandler({ type: 'file' }, neverSignal);
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatch(/"path"/);
+  });
+
+  it('returns error when process type missing pid field', async () => {
+    const result = await waitForHandler({ type: 'process' }, neverSignal);
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatch(/"pid"/);
+  });
+
+  it('returns error when command type missing command field', async () => {
+    const result = await waitForHandler({ type: 'command' }, neverSignal);
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatch(/"command"/);
+  });
+
+  it('returns error when method is invalid', async () => {
+    const result = await waitForHandler({ type: 'url', url: 'https://x.com', method: 'POST' }, neverSignal);
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatch(/method/);
+  });
+
+  it('returns error when backoff is invalid', async () => {
+    const result = await waitForHandler({ type: 'command', command: 'true', backoff: 'cubic' }, neverSignal);
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatch(/backoff/);
+  });
+
+  it('returns error when process pid is not a positive integer', async () => {
+    const result = await waitForHandler({ type: 'process', pid: -1 }, neverSignal);
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatch(/pid/);
+  });
+
+  it('returns error when timeout_ms is not a number', async () => {
+    const result = await waitForHandler({ type: 'command', command: 'true', timeout_ms: 'long' }, neverSignal);
+    expect(result.isError).toBe(true);
+  });
+});
+
+describe('waitForHandler — SSRF guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCheckEgress.mockResolvedValue({ allowed: true });
+  });
+
+  it('blocks private IP and returns error', async () => {
+    mockCheckEgress.mockResolvedValue({ allowed: false, reason: 'loopback/private address' });
+    const result = await waitForHandler({ type: 'url', url: 'http://127.0.0.1/health' }, neverSignal);
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatch(/SSRF/);
+  });
+
+  it('passes public URLs through', async () => {
+    mockCheckEgress.mockResolvedValue({ allowed: true });
+    const result = await waitForHandler({ type: 'url', url: 'https://example.com/health' }, neverSignal);
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toMatch(/succeeded/);
+  });
+});
+
+describe('waitForHandler — success outcomes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCheckEgress.mockResolvedValue({ allowed: true });
+  });
+
+  it('url type succeeds and includes elapsed + attempts', async () => {
+    const result = await waitForHandler({ type: 'url', url: 'https://example.com' }, neverSignal);
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toContain('succeeded');
+    expect(result.content).toMatch(/\d+ms/);
+    expect(result.content).toMatch(/\d+ attempt/);
+  });
+
+  it('file type succeeds', async () => {
+    const result = await waitForHandler({ type: 'file', path: '/tmp/test.txt' }, neverSignal);
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toContain('succeeded');
+  });
+
+  it('process type succeeds', async () => {
+    const result = await waitForHandler({ type: 'process', pid: 12345 }, neverSignal);
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toContain('succeeded');
+  });
+
+  it('command type succeeds', async () => {
+    const result = await waitForHandler({ type: 'command', command: 'true' }, neverSignal);
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toContain('succeeded');
+  });
+});
+
+describe('waitForHandler — timeout outcome', () => {
+  it('timed_out is NOT an error', async () => {
+    // Override evaluateFile to always return not met.
+    const { evaluateFile } = await import('./wait-for-conditions.js');
+    vi.mocked(evaluateFile).mockResolvedValue({ met: false, detail: 'file not found: /tmp/x' });
+    const result = await waitForHandler(
+      { type: 'file', path: '/tmp/x', timeout_ms: 0 },
+      neverSignal,
+    );
+    // timeout_ms:0 means deadline is already passed on first miss
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toContain('timed_out');
+  });
+});
+
+describe('waitForHandler — cancelled outcome', () => {
+  it('cancelled when signal is already aborted', async () => {
+    const ac = new AbortController();
+    ac.abort();
+    const result = await waitForHandler({ type: 'command', command: 'true' }, ac.signal);
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toContain('cancelled');
+  });
+});

--- a/src/agent/tools/handlers/wait-for.ts
+++ b/src/agent/tools/handlers/wait-for.ts
@@ -10,6 +10,7 @@
  * @module agent/tools/handlers/wait-for
  */
 
+import path from 'node:path';
 import type { ToolHandler, ToolHandlerContext } from '../types.js';
 import { checkEgressTarget } from '../../../web/egress-guard.js';
 import {
@@ -97,7 +98,11 @@ function parseInput(
       if (typeof input.url !== 'string' || input.url.trim() === '') {
         throw new Error('"url" is required for type "url"');
       }
-      const method = input.method ?? 'HEAD';
+      // When body_contains is supplied and the caller did not explicitly set a
+      // method, default to GET: HEAD responses have no body, so body_contains
+      // can never match against a HEAD response.
+      const hasBodyContains = input.body_contains !== undefined;
+      const method = input.method ?? (hasBodyContains ? 'GET' : 'HEAD');
       if (method !== 'HEAD' && method !== 'GET') {
         throw new Error('"method" must be "HEAD" or "GET"');
       }
@@ -106,7 +111,7 @@ function parseInput(
         url: input.url,
         method: method as 'HEAD' | 'GET',
         ...(input.expected_status !== undefined ? { expected_status: Number(input.expected_status) } : {}),
-        ...(input.body_contains !== undefined ? { body_contains: String(input.body_contains) } : {}),
+        ...(hasBodyContains ? { body_contains: String(input.body_contains) } : {}),
       };
       return { condition, timeoutMs, pollIntervalMs, backoff };
     }
@@ -114,9 +119,17 @@ function parseInput(
       if (typeof input.path !== 'string' || input.path.trim() === '') {
         throw new Error('"path" is required for type "file"');
       }
+      // Resolve relative paths against the session's working directory rather
+      // than process.cwd() (which reflects the AFK daemon's CWD, not the
+      // project root the model is operating in).
+      const base = context?.resolveBase ?? context?.cwd;
+      const resolvedPath =
+        base !== undefined && !path.isAbsolute(input.path)
+          ? path.resolve(base, input.path)
+          : input.path;
       const condition: WaitCondition = {
         type: 'file',
-        path: input.path,
+        path: resolvedPath,
         ...(input.content_contains !== undefined ? { content_contains: String(input.content_contains) } : {}),
       };
       return { condition, timeoutMs, pollIntervalMs, backoff };
@@ -175,9 +188,12 @@ export const waitForHandler: ToolHandler = async (
   }
 
   // Build evaluator closure for this condition.
-  const evaluate = () => {
+  // The poller passes a per-poll AbortSignal (races session signal vs. deadline)
+  // so each evaluator can abort a stalled I/O call rather than blocking past
+  // the overall timeout.
+  const evaluate = (pollSignal: AbortSignal) => {
     switch (condition.type) {
-      case 'url':    return evaluateUrl(condition, signal);
+      case 'url':    return evaluateUrl(condition, pollSignal);
       case 'file':   return evaluateFile(condition);
       case 'process': return Promise.resolve(evaluateProcess(condition));
       case 'command': return Promise.resolve(evaluateCommand(condition));

--- a/src/agent/tools/handlers/wait-for.ts
+++ b/src/agent/tools/handlers/wait-for.ts
@@ -130,6 +130,9 @@ function parseInput(
       const condition: WaitCondition = {
         type: 'file',
         path: resolvedPath,
+        // H-2: Pass the workspace root so evaluateFile can apply containment
+        // and the read-denylist floor, matching read_file's containment model.
+        workspaceRoot: base,
         ...(input.content_contains !== undefined ? { content_contains: String(input.content_contains) } : {}),
       };
       return { condition, timeoutMs, pollIntervalMs, backoff };
@@ -179,7 +182,10 @@ export const waitForHandler: ToolHandler = async (
 
   const { condition, timeoutMs, pollIntervalMs, backoff } = parsed;
 
-  // Eager SSRF check for URL type — fail fast before entering the poll loop.
+  // Eager SSRF pre-flight for URL type — fast-fail on obviously private targets
+  // before entering the poll loop. The real per-hop SSRF gate is guardedFetch
+  // inside evaluateUrl, which re-validates on every redirect hop and closes the
+  // TOCTOU gap where a public URL 302s to a private IP after this check.
   if (condition.type === 'url') {
     const verdict = await checkEgressTarget(condition.url);
     if (!verdict.allowed) {
@@ -194,7 +200,10 @@ export const waitForHandler: ToolHandler = async (
   const evaluate = (pollSignal: AbortSignal) => {
     switch (condition.type) {
       case 'url':    return evaluateUrl(condition, pollSignal);
-      case 'file':   return evaluateFile(condition);
+      // M-2: Pass pollSignal to evaluateFile so a stalled readFile call is
+      // aborted by the per-poll deadline rather than blocking past the overall
+      // timeout.
+      case 'file':   return evaluateFile(condition, pollSignal);
       case 'process': return Promise.resolve(evaluateProcess(condition));
       case 'command': return Promise.resolve(evaluateCommand(condition));
     }

--- a/src/agent/tools/handlers/wait-for.ts
+++ b/src/agent/tools/handlers/wait-for.ts
@@ -1,0 +1,204 @@
+/**
+ * Handler for the `wait_for` tool.
+ *
+ * Blocks on an external condition (URL, file, process, or command) without
+ * consuming model turns — the poll loop runs entirely in Node. Returns a
+ * structured result indicating whether the condition was met, timed out, or
+ * cancelled. Timeout is NOT treated as an error so the model can decide to
+ * retry or give up.
+ *
+ * @module agent/tools/handlers/wait-for
+ */
+
+import type { ToolHandler, ToolHandlerContext } from '../types.js';
+import { checkEgressTarget } from '../../../web/egress-guard.js';
+import {
+  evaluateUrl,
+  evaluateFile,
+  evaluateProcess,
+  evaluateCommand,
+} from './wait-for-conditions.js';
+import type { WaitCondition } from './wait-for-conditions.js';
+import {
+  pollUntil,
+  DEFAULT_TIMEOUT_MS,
+  MAX_TIMEOUT_MS,
+  DEFAULT_POLL_INTERVAL_MS,
+  MIN_POLL_INTERVAL_MS,
+} from './wait-for-poller.js';
+
+// ---------------------------------------------------------------------------
+// Input shape
+// ---------------------------------------------------------------------------
+
+interface WaitForInput {
+  type?: unknown;
+  // URL
+  url?: unknown;
+  method?: unknown;
+  expected_status?: unknown;
+  body_contains?: unknown;
+  // File
+  path?: unknown;
+  content_contains?: unknown;
+  // Process
+  pid?: unknown;
+  // Command
+  command?: unknown;
+  // Common
+  timeout_ms?: unknown;
+  poll_interval_ms?: unknown;
+  backoff?: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+function parseInput(
+  raw: unknown,
+  context: ToolHandlerContext | undefined,
+): { condition: WaitCondition; timeoutMs: number; pollIntervalMs: number; backoff: 'none' | 'linear' | 'exponential' } {
+  if (typeof raw !== 'object' || raw === null) throw new Error('Input must be an object');
+  const input = raw as WaitForInput;
+
+  const type = input.type;
+  if (typeof type !== 'string') throw new Error('"type" is required and must be a string');
+
+  // Common options
+  let timeoutMs = DEFAULT_TIMEOUT_MS;
+  if (input.timeout_ms !== undefined) {
+    if (typeof input.timeout_ms !== 'number' || !Number.isFinite(input.timeout_ms)) {
+      throw new Error('"timeout_ms" must be a finite number');
+    }
+    timeoutMs = Math.min(Math.max(0, input.timeout_ms), MAX_TIMEOUT_MS);
+  }
+
+  let pollIntervalMs = DEFAULT_POLL_INTERVAL_MS;
+  if (input.poll_interval_ms !== undefined) {
+    if (typeof input.poll_interval_ms !== 'number' || !Number.isFinite(input.poll_interval_ms)) {
+      throw new Error('"poll_interval_ms" must be a finite number');
+    }
+    pollIntervalMs = Math.max(MIN_POLL_INTERVAL_MS, input.poll_interval_ms);
+  }
+
+  const VALID_BACKOFFS = ['none', 'linear', 'exponential'] as const;
+  let backoff: 'none' | 'linear' | 'exponential' = 'none';
+  if (input.backoff !== undefined) {
+    if (!VALID_BACKOFFS.includes(input.backoff as 'none')) {
+      throw new Error(`"backoff" must be one of: ${VALID_BACKOFFS.join(', ')}`);
+    }
+    backoff = input.backoff as typeof backoff;
+  }
+
+  // Type-specific validation
+  switch (type) {
+    case 'url': {
+      if (typeof input.url !== 'string' || input.url.trim() === '') {
+        throw new Error('"url" is required for type "url"');
+      }
+      const method = input.method ?? 'HEAD';
+      if (method !== 'HEAD' && method !== 'GET') {
+        throw new Error('"method" must be "HEAD" or "GET"');
+      }
+      const condition: WaitCondition = {
+        type: 'url',
+        url: input.url,
+        method: method as 'HEAD' | 'GET',
+        ...(input.expected_status !== undefined ? { expected_status: Number(input.expected_status) } : {}),
+        ...(input.body_contains !== undefined ? { body_contains: String(input.body_contains) } : {}),
+      };
+      return { condition, timeoutMs, pollIntervalMs, backoff };
+    }
+    case 'file': {
+      if (typeof input.path !== 'string' || input.path.trim() === '') {
+        throw new Error('"path" is required for type "file"');
+      }
+      const condition: WaitCondition = {
+        type: 'file',
+        path: input.path,
+        ...(input.content_contains !== undefined ? { content_contains: String(input.content_contains) } : {}),
+      };
+      return { condition, timeoutMs, pollIntervalMs, backoff };
+    }
+    case 'process': {
+      if (typeof input.pid !== 'number' || !Number.isInteger(input.pid) || input.pid <= 0) {
+        throw new Error('"pid" is required for type "process" and must be a positive integer');
+      }
+      const condition: WaitCondition = { type: 'process', pid: input.pid };
+      return { condition, timeoutMs, pollIntervalMs, backoff };
+    }
+    case 'command': {
+      if (typeof input.command !== 'string' || input.command.trim() === '') {
+        throw new Error('"command" is required for type "command"');
+      }
+      const cwd = context?.resolveBase ?? context?.cwd;
+      const condition: WaitCondition = {
+        type: 'command',
+        command: input.command,
+        ...(cwd !== undefined ? { cwd } : {}),
+      };
+      return { condition, timeoutMs, pollIntervalMs, backoff };
+    }
+    default:
+      throw new Error(`Unknown type "${type}". Must be one of: url, file, process, command`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export const waitForHandler: ToolHandler = async (
+  input: unknown,
+  signal: AbortSignal,
+  context?: ToolHandlerContext,
+) => {
+  let parsed: ReturnType<typeof parseInput>;
+  try {
+    parsed = parseInput(input, context);
+  } catch (err) {
+    return {
+      content: err instanceof Error ? err.message : String(err),
+      isError: true,
+    };
+  }
+
+  const { condition, timeoutMs, pollIntervalMs, backoff } = parsed;
+
+  // Eager SSRF check for URL type — fail fast before entering the poll loop.
+  if (condition.type === 'url') {
+    const verdict = await checkEgressTarget(condition.url);
+    if (!verdict.allowed) {
+      return { content: `SSRF guard blocked: ${verdict.reason}`, isError: true };
+    }
+  }
+
+  // Build evaluator closure for this condition.
+  const evaluate = () => {
+    switch (condition.type) {
+      case 'url':    return evaluateUrl(condition, signal);
+      case 'file':   return evaluateFile(condition);
+      case 'process': return Promise.resolve(evaluateProcess(condition));
+      case 'command': return Promise.resolve(evaluateCommand(condition));
+    }
+  };
+
+  const pollResult = await pollUntil(evaluate, {
+    timeout_ms: timeoutMs,
+    poll_interval_ms: pollIntervalMs,
+    backoff,
+    signal,
+  });
+
+  const summary =
+    `Wait ${pollResult.status}: ${condition.type} condition ` +
+    `(${pollResult.elapsed_ms}ms elapsed, ${pollResult.attempts} attempt${pollResult.attempts === 1 ? '' : 's'})` +
+    (pollResult.result ? ` — ${pollResult.result.detail}` : '') +
+    (pollResult.error ? ` — error: ${pollResult.error}` : '');
+
+  return {
+    content: summary,
+    isError: pollResult.status === 'failed',
+  };
+};

--- a/src/agent/tools/schemas.test.ts
+++ b/src/agent/tools/schemas.test.ts
@@ -7,8 +7,8 @@ import {
 import { cancelBackgroundJobTool } from './schemas.orchestration.js';
 
 describe('builtinToolSchemas', () => {
-  it('contains exactly 27 tools', () => {
-    expect(builtinToolSchemas).toHaveLength(27);
+  it('contains exactly 28 tools', () => {
+    expect(builtinToolSchemas).toHaveLength(28);
   });
 
   it('exports the expected tool names', () => {
@@ -35,6 +35,7 @@ describe('builtinToolSchemas', () => {
       'config_get',
       'config_set',
       'ask_question',
+      'wait_for',
       'browser_open',
       'browser_observe',
       'browser_act',

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -11,6 +11,8 @@
 import type { AnthropicToolDef } from './types.js';
 import { readWitnessTool, searchWitnessTool } from './schemas.witness.js';
 import { cancelBackgroundJobTool } from './schemas.orchestration.js';
+import { waitForTool } from './schemas.wait-for.js';
+export { waitForTool } from './schemas.wait-for.js';
 
 export const bashTool: AnthropicToolDef = {
   name: 'bash',
@@ -1330,13 +1332,10 @@ export const builtinToolSchemas: readonly AnthropicToolDef[] = [
   listSchedulesTool,
   getScheduleHistoryTool,
   cancelScheduleTool, cancelBackgroundJobTool,
-  readWitnessTool,
-  searchWitnessTool,
-  worktreeTool,
-  terminalFontSizeTool,
-  configGetTool,
-  configSetTool,
-  askQuestionTool,
+  readWitnessTool, searchWitnessTool,
+  worktreeTool, terminalFontSizeTool,
+  configGetTool, configSetTool,
+  askQuestionTool, waitForTool,
   browserOpenTool,
   browserObserveTool,
   browserActTool,

--- a/src/agent/tools/schemas.wait-for.ts
+++ b/src/agent/tools/schemas.wait-for.ts
@@ -1,0 +1,89 @@
+/**
+ * Tool schema for the `wait_for` built-in.
+ *
+ * Extracted into its own file to satisfy the 350-code-line ratchet on
+ * `schemas.ts` (baselined files may shrink, never grow). Imported and
+ * re-exported from `schemas.ts` so callers import from the primary module.
+ *
+ * @module agent/tools/schemas.wait-for
+ */
+
+import type { AnthropicToolDef } from './types.js';
+
+export const waitForTool: AnthropicToolDef = {
+  name: 'wait_for',
+  category: 'shell',
+  concurrencySafe: true,
+  description:
+    'Block on an external condition without consuming model turns. The poll loop runs in Node. ' +
+    'Condition types: ' +
+    '"url" — polls an HTTP/HTTPS endpoint until it returns the expected status (default: any 2xx). ' +
+    '"file" — waits until a file exists (and optionally contains a substring). ' +
+    '"process" — waits until a PID has exited (process.kill(pid, 0) → ESRCH). ' +
+    '"command" — runs a shell command repeatedly; exit 0 signals the condition is met. ' +
+    'The tool returns when the condition is met, the timeout elapses (status: timed_out), or ' +
+    'the session is cancelled (status: cancelled). Timeout is NOT an error — the model can retry. ' +
+    'URL waits are SSRF-guarded: private/loopback/link-local/cloud-metadata targets are rejected. ' +
+    'Use timeout_ms and poll_interval_ms to tune wait duration and check frequency.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      type: {
+        type: 'string',
+        enum: ['url', 'file', 'process', 'command'],
+        description:
+          'What to wait for: url (HTTP endpoint), file (filesystem path), ' +
+          'process (PID exit), or command (shell exit 0).',
+      },
+      url: {
+        type: 'string',
+        description: 'For url type: the URL to poll (http/https only).',
+      },
+      method: {
+        type: 'string',
+        enum: ['HEAD', 'GET'],
+        description: 'HTTP method to use (default: HEAD). Use GET when body_contains is set.',
+      },
+      expected_status: {
+        type: 'number',
+        description: 'Expected HTTP status code (default: any 2xx).',
+      },
+      body_contains: {
+        type: 'string',
+        description: 'Substring that must appear in the response body. Forces method to GET if unset.',
+      },
+      path: {
+        type: 'string',
+        description: 'For file type: absolute or relative path to watch.',
+      },
+      content_contains: {
+        type: 'string',
+        description: 'For file type: substring the file content must contain.',
+      },
+      pid: {
+        type: 'number',
+        description: 'For process type: PID to wait on. Condition is met when the process exits.',
+      },
+      command: {
+        type: 'string',
+        description: 'For command type: shell command to run. Condition is met when it exits 0.',
+      },
+      timeout_ms: {
+        type: 'number',
+        description: 'Maximum wait time in milliseconds (default: 120000, max: 600000).',
+      },
+      poll_interval_ms: {
+        type: 'number',
+        description: 'Delay between polls in milliseconds (default: 5000, min: 1000).',
+      },
+      backoff: {
+        type: 'string',
+        enum: ['none', 'linear', 'exponential'],
+        description:
+          'Backoff strategy for poll_interval_ms between misses ' +
+          '(default: none = fixed interval).',
+      },
+    },
+    required: ['type'],
+  },
+};


### PR DESCRIPTION
## What this does

Adds a `wait_for` tool that blocks on an external condition without consuming model turns. The poll loop runs entirely in Node — the model issues one tool call and gets back a structured result when the condition is met, times out, or is cancelled.

## Condition types

| Type | What it waits on | Met when |
|------|-----------------|----------|
| `url` | HTTP/HTTPS endpoint | Returns expected status (default: any 2xx) |
| `file` | Filesystem path | File exists (optional `content_contains` match) |
| `process` | PID | Process has exited (`kill(pid, 0)` → `ESRCH`) |
| `command` | Shell command | Command exits 0 |

## Usage examples

```json
{ "type": "url", "url": "https://api.example.com/health", "timeout_ms": 60000 }
{ "type": "file", "path": "/tmp/build/output.zip", "poll_interval_ms": 2000 }
{ "type": "process", "pid": 12345, "timeout_ms": 300000, "backoff": "exponential" }
{ "type": "command", "command": "test -f /tmp/done.marker", "poll_interval_ms": 1000 }
```

## Design decisions

- **SSRF guard is mandatory for URL waits** — `checkEgressTarget()` runs eagerly before entering the poll loop
- **`sleepWithAbort()`** is the sleep primitive — loop respects `AbortSignal`, no orphaned loops
- **Timeout → `timed_out` (not error)** — the model can react and retry
- **Backoff strategies**: `none` (fixed), `linear` (+1s/attempt), `exponential` (2^n, cap 60s)
- **Heartbeat log** every 60s via `console.error`
- Schema split into `schemas.wait-for.ts` to satisfy the 350-code-line ratchet

## Acceptance criteria

- [x] URL wait succeeds when fetch returns 200
- [x] URL wait is rejected for private IPs (SSRF guard)
- [x] File wait succeeds when file appears
- [x] Command wait succeeds when command returns exit 0
- [x] Process wait succeeds when PID disappears
- [x] Timeout returns `timed_out` (not an error)
- [x] Abort signal returns `cancelled`
- [x] Backoff increases interval correctly (linear and exponential tested)
- [x] Invalid input returns error
- [x] `pnpm lint` passes
- [x] 42 tests, all pass
- [x] `pnpm audit:filesize:check` — no new violations from this PR

Closes #1417
