### PR TITLE
feat(tools): patch_apply tool with atomic multi-file changes

### DIFF
--- a/src/agent/risk-classifier.ts
+++ b/src/agent/risk-classifier.ts
@@ -322,6 +322,27 @@ export function classifyRisk(
     return classifyFilePath(filePath, ctx);
   }
 
+  // ---- patch_apply ---------------------------------------------------------
+  // patch_apply atomically writes multiple files; classify by the highest-risk
+  // path across the entire changes array. An empty changes array is safe.
+  if (tool === 'patch_apply') {
+    const obj =
+      typeof input === 'object' && input !== null
+        ? (input as Record<string, unknown>)
+        : {};
+    const changes = Array.isArray(obj['changes']) ? obj['changes'] : [];
+    let highest: RiskLevel = 'safe';
+    for (const change of changes) {
+      if (typeof change !== 'object' || change === null) continue;
+      const p = (change as Record<string, unknown>)['path'];
+      const filePath = typeof p === 'string' ? p : '';
+      const level = classifyFilePath(filePath, ctx);
+      if (level === 'high') return 'high';
+      if (level === 'medium') highest = 'medium';
+    }
+    return highest;
+  }
+
   // ---- read-class tools ---------------------------------------------------
   // Derive from tool-category taxonomy rather than a local hand-maintained list.
   // Previously this was a 5-entry if-chain that diverged from tool-category.ts

--- a/src/agent/tool-category.ts
+++ b/src/agent/tool-category.ts
@@ -63,7 +63,7 @@ const READ_TOOLS = new Set([
 const WRITE_TOOLS = new Set([
   'Write', 'Edit', 'NotebookEdit', 'MultiEdit',
   'write_file', 'edit_file',
-  // patch_apply applies unified diffs to files on disk — a write operation.
+  // patch_apply atomically writes structured multi-file changes to disk.
   'patch_apply',
   // memory-tools.ts — both mutate persistent state on disk (the fact
   // archive / HOT.md and ~/.afk/procedures/<name>.md respectively), so

--- a/src/agent/tools/handlers/index.ts
+++ b/src/agent/tools/handlers/index.ts
@@ -39,6 +39,7 @@ import { browserActHandler } from './browser-act.js';
 import { browserScreenshotHandler } from './browser-screenshot.js';
 import { browserCloseHandler } from './browser-close.js';
 import { waitForHandler } from './wait-for.js';
+import { patchApplyHandler, createPatchApplyHandler } from './patch-apply.js';
 
 /**
  * Build the built-in tool handler map for a session.
@@ -77,6 +78,7 @@ export function createBuiltinHandlers(
   const listDirectory = cwd !== undefined ? createListDirectoryHandler(cwd) : listDirectoryHandler;
   const terminalFontSize = createTerminalFontSizeHandler();
   const worktree = createWorktreeHandler(cwd);
+  const patchApply = cwd !== undefined ? createPatchApplyHandler(cwd) : patchApplyHandler;
   return new Map<string, ToolHandler>([
     ['bash', bash],
     ['read_file', readFile],
@@ -105,6 +107,7 @@ export function createBuiltinHandlers(
     ['browser_act', browserActHandler],
     ['browser_screenshot', browserScreenshotHandler],
     ['browser_close', browserCloseHandler],
+    ['patch_apply', patchApply],
   ]);
 }
 
@@ -129,6 +132,7 @@ export {
   configSetHandler,
   askQuestionHandler,
   waitForHandler,
+  patchApplyHandler,
   browserOpenHandler,
   browserObserveHandler,
   browserActHandler,

--- a/src/agent/tools/handlers/patch-apply-engine.test.ts
+++ b/src/agent/tools/handlers/patch-apply-engine.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for patch-apply-engine.ts
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { writeFile, readFile, mkdir, rm } from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { randomBytes, createHash } from 'crypto';
+import { applyPatch } from './patch-apply-engine.js';
+import type { PatchFileChange } from './patch-validate.js';
+
+const tempDir = path.join(
+  os.tmpdir(),
+  `afk-patch-engine-test-${process.pid}-${randomBytes(4).toString('hex')}`,
+);
+
+async function writeTemp(filename: string, content: string): Promise<string> {
+  await mkdir(tempDir, { recursive: true });
+  const p = path.join(tempDir, filename);
+  await writeFile(p, content, 'utf-8');
+  return p;
+}
+
+function sha256(content: string): string {
+  return createHash('sha256').update(content, 'utf8').digest('hex');
+}
+
+afterEach(async () => {
+  try {
+    await rm(tempDir, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+  vi.restoreAllMocks();
+});
+
+describe('applyPatch (dry-run)', () => {
+  it('returns diff without modifying the file', async () => {
+    const filePath = await writeTemp('dry.txt', 'before\n');
+    const changes: PatchFileChange[] = [{ path: filePath, content: 'after\n' }];
+    const fileContents = new Map([[filePath, 'before\n']]);
+
+    const result = await applyPatch(changes, fileContents, tempDir, /* dryRun */ true);
+
+    expect(result.status).toBe('dry_run');
+    expect(result.diff).toContain('-before');
+    expect(result.diff).toContain('+after');
+    expect(result.errors).toHaveLength(0);
+
+    // File must NOT have been modified.
+    const actual = await readFile(filePath, 'utf-8');
+    expect(actual).toBe('before\n');
+  });
+
+  it('dry-run diff for sequential edits', async () => {
+    const filePath = await writeTemp('dry-edits.txt', 'foo bar baz\n');
+    const changes: PatchFileChange[] = [
+      {
+        path: filePath,
+        edits: [
+          { old: 'foo', new: 'FOO' },
+          { old: 'bar', new: 'BAR' },
+        ],
+      },
+    ];
+    const fileContents = new Map([[filePath, 'foo bar baz\n']]);
+
+    const result = await applyPatch(changes, fileContents, tempDir, true);
+
+    expect(result.status).toBe('dry_run');
+    expect(result.diff).toContain('+FOO BAR baz');
+    const actual = await readFile(filePath, 'utf-8');
+    expect(actual).toBe('foo bar baz\n'); // unchanged
+  });
+
+  it('dry-run returns correct before/after hashes', async () => {
+    const filePath = await writeTemp('hash-check.txt', 'original\n');
+    const changes: PatchFileChange[] = [{ path: filePath, content: 'replaced\n' }];
+    const fileContents = new Map([[filePath, 'original\n']]);
+
+    const result = await applyPatch(changes, fileContents, tempDir, true);
+
+    expect(result.files_changed).toHaveLength(1);
+    const fc = result.files_changed[0]!;
+    expect(fc.before_hash).toBe(`sha256:${sha256('original\n')}`);
+    expect(fc.after_hash).toBe(`sha256:${sha256('replaced\n')}`);
+  });
+});
+
+describe('applyPatch (live write)', () => {
+  it('writes correct content for full-file replacement', async () => {
+    const filePath = await writeTemp('write.txt', 'old content\n');
+    const changes: PatchFileChange[] = [{ path: filePath, content: 'new content\n' }];
+    const fileContents = new Map([[filePath, 'old content\n']]);
+
+    const result = await applyPatch(changes, fileContents, tempDir, false);
+
+    expect(result.status).toBe('applied');
+    expect(result.errors).toHaveLength(0);
+    const actual = await readFile(filePath, 'utf-8');
+    expect(actual).toBe('new content\n');
+  });
+
+  it('applies sequential edits in order', async () => {
+    const filePath = await writeTemp('seq.txt', 'step1 step2 step3\n');
+    const changes: PatchFileChange[] = [
+      {
+        path: filePath,
+        edits: [
+          { old: 'step1', new: 'STEP1' },
+          { old: 'STEP1 step2', new: 'STEP1+STEP2' },
+        ],
+      },
+    ];
+    const fileContents = new Map([[filePath, 'step1 step2 step3\n']]);
+
+    const result = await applyPatch(changes, fileContents, tempDir, false);
+
+    expect(result.status).toBe('applied');
+    const actual = await readFile(filePath, 'utf-8');
+    expect(actual).toBe('STEP1+STEP2 step3\n');
+  });
+
+  it('includes diff in successful result', async () => {
+    const filePath = await writeTemp('diff-check.txt', 'hello\n');
+    const changes: PatchFileChange[] = [{ path: filePath, content: 'world\n' }];
+    const fileContents = new Map([[filePath, 'hello\n']]);
+
+    const result = await applyPatch(changes, fileContents, tempDir, false);
+
+    expect(result.status).toBe('applied');
+    expect(result.diff).toContain('-hello');
+    expect(result.diff).toContain('+world');
+  });
+
+  it('handles new-file creation (empty originalContent)', async () => {
+    const newFilePath = path.join(tempDir, 'newfile.txt');
+    await mkdir(tempDir, { recursive: true });
+    const changes: PatchFileChange[] = [{ path: newFilePath, content: 'brand new\n' }];
+    const fileContents = new Map([[newFilePath, '']]);
+
+    const result = await applyPatch(changes, fileContents, tempDir, false);
+
+    expect(result.status).toBe('applied');
+    const actual = await readFile(newFilePath, 'utf-8');
+    expect(actual).toBe('brand new\n');
+  });
+
+  it('reports partial_failure when rename cannot succeed', async () => {
+    // Make the target path a directory so rename fails with EISDIR.
+    const targetPath = path.join(tempDir, 'is-a-dir');
+    await mkdir(targetPath, { recursive: true });
+    // The fileContents map stores '' so the engine doesn't fail on the temp write.
+    const fileContents = new Map([[targetPath, '']]);
+    const changes: PatchFileChange[] = [{ path: targetPath, content: 'new content\n' }];
+
+    const result = await applyPatch(changes, fileContents, tempDir, false);
+
+    // rename(tmpFile, directory) → EISDIR on POSIX.
+    expect(result.status).toBe('partial_failure');
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+});

--- a/src/agent/tools/handlers/patch-apply-engine.test.ts
+++ b/src/agent/tools/handlers/patch-apply-engine.test.ts
@@ -2,7 +2,7 @@
  * Tests for patch-apply-engine.ts
  */
 
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { writeFile, readFile, mkdir, rm } from 'fs/promises';
 import os from 'os';
 import path from 'path';
@@ -134,11 +134,12 @@ describe('applyPatch (live write)', () => {
     expect(result.diff).toContain('+world');
   });
 
-  it('handles new-file creation (empty originalContent)', async () => {
+  it('handles new-file creation (null sentinel in fileContents)', async () => {
     const newFilePath = path.join(tempDir, 'newfile.txt');
     await mkdir(tempDir, { recursive: true });
     const changes: PatchFileChange[] = [{ path: newFilePath, content: 'brand new\n' }];
-    const fileContents = new Map([[newFilePath, '']]);
+    // null = new file (did not exist before); '' = existing empty file.
+    const fileContents = new Map<string, string | null>([[newFilePath, null]]);
 
     const result = await applyPatch(changes, fileContents, tempDir, false);
 
@@ -147,12 +148,35 @@ describe('applyPatch (live write)', () => {
     expect(actual).toBe('brand new\n');
   });
 
-  it('reports partial_failure when rename cannot succeed', async () => {
+  it('rollback unlinks new file on rename failure (null sentinel)', async () => {
+    // Two changes: a new file (null sentinel) and an existing dir that will fail rename.
+    const newFilePath = path.join(tempDir, 'will-be-unlinked.txt');
+    const targetPath = path.join(tempDir, 'is-a-dir');
+    await mkdir(tempDir, { recursive: true });
+    await mkdir(targetPath, { recursive: true });
+
+    const changes: PatchFileChange[] = [
+      { path: newFilePath, content: 'new\n' },
+      { path: targetPath, content: 'new content\n' },
+    ];
+    const fileContents = new Map<string, string | null>([
+      [newFilePath, null],       // new file — rollback should UNLINK, not write ''
+      [targetPath, 'original\n'], // existing file
+    ]);
+
+    const result = await applyPatch(changes, fileContents, tempDir, false);
+
+    // rename(tmpFile, directory) → EISDIR on POSIX.
+    expect(result.status).toBe('partial_failure');
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it('reports partial_failure when rename cannot succeed (existing file)', async () => {
     // Make the target path a directory so rename fails with EISDIR.
     const targetPath = path.join(tempDir, 'is-a-dir');
     await mkdir(targetPath, { recursive: true });
-    // The fileContents map stores '' so the engine doesn't fail on the temp write.
-    const fileContents = new Map([[targetPath, '']]);
+    // '' = existing empty file (not a new file — no null sentinel).
+    const fileContents = new Map<string, string | null>([[targetPath, '']]);
     const changes: PatchFileChange[] = [{ path: targetPath, content: 'new content\n' }];
 
     const result = await applyPatch(changes, fileContents, tempDir, false);

--- a/src/agent/tools/handlers/patch-apply-engine.ts
+++ b/src/agent/tools/handlers/patch-apply-engine.ts
@@ -115,7 +115,7 @@ function tempPath(targetPath: string): string {
  */
 export async function applyPatch(
   changes: PatchFileChange[],
-  fileContents: Map<string, string>,
+  fileContents: Map<string, string | null>,
   resolveBase: string,
   dryRun: boolean,
 ): Promise<PatchApplyResult> {
@@ -125,7 +125,7 @@ export async function applyPatch(
     originalContent: string;
     newContent: string;
     diffBlock: string;
-    /** True when the file did not exist before the patch (originalContent is ''). */
+    /** True when the file did not exist before the patch (null sentinel in fileContents). */
     isNewFile: boolean;
   }> = [];
 
@@ -137,11 +137,11 @@ export async function applyPatch(
       ? change.path
       : resolve(resolveBase, change.path);
 
-    const originalContent = fileContents.get(resolvedPath) ?? '';
-    // A file is "new" when the validator stored an empty string because the
-    // file didn't exist on disk. Use has() to distinguish missing key (new
-    // file) from an existing empty file (the validator always sets the key).
-    const isNewFile = !fileContents.has(resolvedPath);
+    // null sentinel = new file (did not exist before the patch).
+    // '' = existing empty file. Both come from the validator.
+    const storedContent = fileContents.get(resolvedPath);
+    const isNewFile = storedContent === null;
+    const originalContent = storedContent ?? '';
 
     let newContent: string;
     if (change.content !== undefined) {
@@ -276,6 +276,7 @@ export async function applyPatch(
       }
     }
     // Also clean up remaining temp files.
+    // ENOENT expected for temp paths already renamed; catch {} is intentional.
     for (const tf of tempFiles) {
       try {
         await unlink(tf.tempPath);

--- a/src/agent/tools/handlers/patch-apply-engine.ts
+++ b/src/agent/tools/handlers/patch-apply-engine.ts
@@ -9,7 +9,7 @@
  */
 
 import { createHash, randomBytes } from 'crypto';
-import { writeFile, rename, mkdir, unlink } from 'fs/promises';
+import { writeFile, rename, mkdir, unlink, chmod, stat } from 'fs/promises';
 import { dirname, join, isAbsolute, resolve } from 'path';
 import { computeLineDiff } from '../../../utils/diff.js';
 import type { PatchFileChange, ValidationError } from './patch-validate.js';
@@ -125,26 +125,23 @@ export async function applyPatch(
     originalContent: string;
     newContent: string;
     diffBlock: string;
+    /** True when the file did not exist before the patch (originalContent is ''). */
+    isNewFile: boolean;
   }> = [];
 
   for (const change of changes) {
-    // Derive the resolved path. fileContents is keyed by resolved path, so we
-    // need to find the matching key. The validator stored entries by resolved
-    // path; changes.path may be relative. We reconstruct the resolved path the
-    // same way the validator did: normalise via the resolveBase.
-    const resolvedPath = (() => {
-      // fileContents keys ARE the resolved paths set by the validator.
-      // Find the key matching this change's path.
-      for (const key of fileContents.keys()) {
-        if (key === change.path || key.endsWith(`/${change.path}`)) return key;
-      }
-      // Fallback: reconstruct from resolveBase (same logic as validator).
-      return isAbsolute(change.path)
-        ? change.path
-        : resolve(resolveBase, change.path);
-    })();
+    // Derive the resolved path using the same logic as the validator:
+    // path.resolve(resolveBase, changePath) handles both absolute and relative
+    // paths without suffix-collision ambiguity (e.g. "dir/foo.ts" vs "foo.ts").
+    const resolvedPath = isAbsolute(change.path)
+      ? change.path
+      : resolve(resolveBase, change.path);
 
     const originalContent = fileContents.get(resolvedPath) ?? '';
+    // A file is "new" when the validator stored an empty string because the
+    // file didn't exist on disk. Use has() to distinguish missing key (new
+    // file) from an existing empty file (the validator always sets the key).
+    const isNewFile = !fileContents.has(resolvedPath);
 
     let newContent: string;
     if (change.content !== undefined) {
@@ -158,7 +155,7 @@ export async function applyPatch(
 
     const diffBlock = formatUnifiedDiff(change.path, originalContent, newContent);
 
-    planned.push({ resolvedPath, originalContent, newContent, diffBlock });
+    planned.push({ resolvedPath, originalContent, newContent, diffBlock, isNewFile });
   }
 
   // Build combined diff string.
@@ -184,16 +181,32 @@ export async function applyPatch(
   // Phase 2: atomic apply via temp files.
   // Write each new content to a temp file (same directory — ensures same mount
   // point for an atomic rename). Collect temp paths for rollback.
-  const tempFiles: Array<{ tempPath: string; targetPath: string }> = [];
+  const tempFiles: Array<{ tempPath: string; targetPath: string; originalMode: number | undefined }> = [];
   const writeErrors: ValidationError[] = [];
 
   for (const plan of planned) {
     const tmp = tempPath(plan.resolvedPath);
     try {
+      // Preserve original file permissions for existing files. Capture the
+      // mode BEFORE writing the temp so the original is still on disk.
+      let originalMode: number | undefined;
+      if (!plan.isNewFile) {
+        try {
+          const s = await stat(plan.resolvedPath);
+          originalMode = s.mode;
+        } catch {
+          // If we can't stat (e.g. race condition), proceed without chmod.
+        }
+      }
       // Ensure the parent directory exists (for new files).
       await mkdir(dirname(plan.resolvedPath), { recursive: true });
       await writeFile(tmp, plan.newContent, 'utf-8');
-      tempFiles.push({ tempPath: tmp, targetPath: plan.resolvedPath });
+      // Restore original permissions on the temp file before rename so the
+      // final file inherits the correct mode, not the process umask.
+      if (originalMode !== undefined) {
+        await chmod(tmp, originalMode);
+      }
+      tempFiles.push({ tempPath: tmp, targetPath: plan.resolvedPath, originalMode });
     } catch (err) {
       writeErrors.push({
         path: plan.resolvedPath,
@@ -222,7 +235,11 @@ export async function applyPatch(
 
   // Commit point: rename all temp files to their targets atomically.
   const renameErrors: ValidationError[] = [];
-  const completedRenames: Array<{ targetPath: string; originalContent: string }> = [];
+  const completedRenames: Array<{
+    targetPath: string;
+    originalContent: string;
+    isNewFile: boolean;
+  }> = [];
 
   for (let i = 0; i < tempFiles.length; i++) {
     const tf = tempFiles[i]!;
@@ -231,6 +248,7 @@ export async function applyPatch(
       completedRenames.push({
         targetPath: tf.targetPath,
         originalContent: planned[i]!.originalContent,
+        isNewFile: planned[i]!.isNewFile,
       });
     } catch (err) {
       renameErrors.push({
@@ -243,9 +261,16 @@ export async function applyPatch(
 
   if (renameErrors.length > 0) {
     // Partial failure: roll back successfully-renamed files.
+    // For files that didn't exist before the patch, unlink the newly created
+    // file (there is no original content to restore). For existing files,
+    // overwrite with the original content.
     for (const completed of completedRenames) {
       try {
-        await writeFile(completed.targetPath, completed.originalContent, 'utf-8');
+        if (completed.isNewFile) {
+          await unlink(completed.targetPath);
+        } else {
+          await writeFile(completed.targetPath, completed.originalContent, 'utf-8');
+        }
       } catch {
         // Best-effort rollback — log but continue.
       }

--- a/src/agent/tools/handlers/patch-apply-engine.ts
+++ b/src/agent/tools/handlers/patch-apply-engine.ts
@@ -1,0 +1,275 @@
+/**
+ * Atomic patch-apply engine for the patch_apply tool.
+ *
+ * Applies a validated set of file changes atomically using temp-file + rename.
+ * Supports dry-run mode (returns diff without touching the filesystem) and
+ * best-effort rollback on partial failure.
+ *
+ * @module agent/tools/handlers/patch-apply-engine
+ */
+
+import { createHash, randomBytes } from 'crypto';
+import { writeFile, rename, mkdir, unlink } from 'fs/promises';
+import { dirname, join, isAbsolute, resolve } from 'path';
+import { computeLineDiff } from '../../../utils/diff.js';
+import type { PatchFileChange, ValidationError } from './patch-validate.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Result of applying (or dry-running) a patch. */
+export interface PatchApplyResult {
+  status: 'applied' | 'dry_run' | 'validation_failed' | 'partial_failure';
+  /** Unified diff of all changes (empty string if no changes). */
+  diff: string;
+  files_changed: Array<{
+    path: string;
+    before_hash: string;
+    after_hash: string;
+  }>;
+  errors: ValidationError[];
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Compute SHA-256 hex digest of UTF-8 content. */
+function sha256Hex(content: string): string {
+  return createHash('sha256').update(content, 'utf8').digest('hex');
+}
+
+/**
+ * Format a structured {@link DiffPayload} as a unified-diff string for a
+ * given file pair. Returns an empty string when the payload is null (identical
+ * content).
+ */
+function formatUnifiedDiff(
+  filePath: string,
+  before: string,
+  after: string,
+): string {
+  const payload = computeLineDiff(before, after);
+  if (!payload) return '';
+
+  const lines: string[] = [
+    `--- a/${filePath}`,
+    `+++ b/${filePath}`,
+  ];
+
+  for (const hunk of payload.hunks) {
+    lines.push(
+      `@@ -${hunk.oldStart},${hunk.oldLines} +${hunk.newStart},${hunk.newLines} @@`,
+    );
+    for (const line of hunk.lines) {
+      lines.push(`${line.kind}${line.text}`);
+    }
+  }
+
+  return lines.join('\n') + '\n';
+}
+
+/**
+ * Apply edits sequentially. Each edit replaces the FIRST (and only validated)
+ * occurrence of `old` with `new`. Returns the modified content.
+ */
+function applyEdits(
+  content: string,
+  edits: Array<{ old: string; new: string }>,
+): string {
+  let result = content;
+  for (const edit of edits) {
+    const idx = result.indexOf(edit.old);
+    if (idx === -1) {
+      // Should not happen after validation, but guard defensively.
+      throw new Error(
+        `patch_apply engine: edit old-string not found at apply time (validation may have passed a stale snapshot).`,
+      );
+    }
+    result = result.slice(0, idx) + edit.new + result.slice(idx + edit.old.length);
+  }
+  return result;
+}
+
+/** Generate a stable temp-file name in the same directory as the target. */
+function tempPath(targetPath: string): string {
+  const suffix = randomBytes(8).toString('hex');
+  return join(dirname(targetPath), `.patch-tmp-${suffix}`);
+}
+
+// ---------------------------------------------------------------------------
+// Exported engine
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply a validated set of file changes, optionally as a dry run.
+ *
+ * Pre-condition: `fileContents` was produced by {@link validatePatchChanges}
+ * for the same `changes` array.
+ *
+ * @param changes      - Validated file changes.
+ * @param fileContents - Current file contents keyed by RESOLVED path.
+ * @param resolveBase  - Used to form relative paths in diff headers.
+ * @param dryRun       - When true, compute diffs but do not write.
+ */
+export async function applyPatch(
+  changes: PatchFileChange[],
+  fileContents: Map<string, string>,
+  resolveBase: string,
+  dryRun: boolean,
+): Promise<PatchApplyResult> {
+  // Phase 1: compute new content and diffs for every file.
+  const planned: Array<{
+    resolvedPath: string;
+    originalContent: string;
+    newContent: string;
+    diffBlock: string;
+  }> = [];
+
+  for (const change of changes) {
+    // Derive the resolved path. fileContents is keyed by resolved path, so we
+    // need to find the matching key. The validator stored entries by resolved
+    // path; changes.path may be relative. We reconstruct the resolved path the
+    // same way the validator did: normalise via the resolveBase.
+    const resolvedPath = (() => {
+      // fileContents keys ARE the resolved paths set by the validator.
+      // Find the key matching this change's path.
+      for (const key of fileContents.keys()) {
+        if (key === change.path || key.endsWith(`/${change.path}`)) return key;
+      }
+      // Fallback: reconstruct from resolveBase (same logic as validator).
+      return isAbsolute(change.path)
+        ? change.path
+        : resolve(resolveBase, change.path);
+    })();
+
+    const originalContent = fileContents.get(resolvedPath) ?? '';
+
+    let newContent: string;
+    if (change.content !== undefined) {
+      newContent = change.content;
+    } else if (change.edits !== undefined) {
+      newContent = applyEdits(originalContent, change.edits);
+    } else {
+      // Should not happen post-validation, but guard.
+      throw new Error(`patch_apply engine: change for ${change.path} has neither content nor edits.`);
+    }
+
+    const diffBlock = formatUnifiedDiff(change.path, originalContent, newContent);
+
+    planned.push({ resolvedPath, originalContent, newContent, diffBlock });
+  }
+
+  // Build combined diff string.
+  const combinedDiff = planned.map((p) => p.diffBlock).filter(Boolean).join('\n');
+
+  // Compute result metadata (before/after hashes).
+  const filesChanged = planned.map((p) => ({
+    path: p.resolvedPath,
+    before_hash: `sha256:${sha256Hex(p.originalContent)}`,
+    after_hash: `sha256:${sha256Hex(p.newContent)}`,
+  }));
+
+  // Dry-run: return without touching the filesystem.
+  if (dryRun) {
+    return {
+      status: 'dry_run',
+      diff: combinedDiff,
+      files_changed: filesChanged,
+      errors: [],
+    };
+  }
+
+  // Phase 2: atomic apply via temp files.
+  // Write each new content to a temp file (same directory — ensures same mount
+  // point for an atomic rename). Collect temp paths for rollback.
+  const tempFiles: Array<{ tempPath: string; targetPath: string }> = [];
+  const writeErrors: ValidationError[] = [];
+
+  for (const plan of planned) {
+    const tmp = tempPath(plan.resolvedPath);
+    try {
+      // Ensure the parent directory exists (for new files).
+      await mkdir(dirname(plan.resolvedPath), { recursive: true });
+      await writeFile(tmp, plan.newContent, 'utf-8');
+      tempFiles.push({ tempPath: tmp, targetPath: plan.resolvedPath });
+    } catch (err) {
+      writeErrors.push({
+        path: plan.resolvedPath,
+        error: 'temp_write_failed',
+        detail: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  if (writeErrors.length > 0) {
+    // Clean up any temp files already written.
+    for (const tf of tempFiles) {
+      try {
+        await unlink(tf.tempPath);
+      } catch {
+        // Best-effort cleanup.
+      }
+    }
+    return {
+      status: 'partial_failure',
+      diff: combinedDiff,
+      files_changed: filesChanged,
+      errors: writeErrors,
+    };
+  }
+
+  // Commit point: rename all temp files to their targets atomically.
+  const renameErrors: ValidationError[] = [];
+  const completedRenames: Array<{ targetPath: string; originalContent: string }> = [];
+
+  for (let i = 0; i < tempFiles.length; i++) {
+    const tf = tempFiles[i]!;
+    try {
+      await rename(tf.tempPath, tf.targetPath);
+      completedRenames.push({
+        targetPath: tf.targetPath,
+        originalContent: planned[i]!.originalContent,
+      });
+    } catch (err) {
+      renameErrors.push({
+        path: tf.targetPath,
+        error: 'rename_failed',
+        detail: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  if (renameErrors.length > 0) {
+    // Partial failure: roll back successfully-renamed files.
+    for (const completed of completedRenames) {
+      try {
+        await writeFile(completed.targetPath, completed.originalContent, 'utf-8');
+      } catch {
+        // Best-effort rollback — log but continue.
+      }
+    }
+    // Also clean up remaining temp files.
+    for (const tf of tempFiles) {
+      try {
+        await unlink(tf.tempPath);
+      } catch {
+        // Best-effort cleanup.
+      }
+    }
+    return {
+      status: 'partial_failure',
+      diff: combinedDiff,
+      files_changed: filesChanged,
+      errors: renameErrors,
+    };
+  }
+
+  return {
+    status: 'applied',
+    diff: combinedDiff,
+    files_changed: filesChanged,
+    errors: [],
+  };
+}

--- a/src/agent/tools/handlers/patch-apply.test.ts
+++ b/src/agent/tools/handlers/patch-apply.test.ts
@@ -1,0 +1,203 @@
+/**
+ * End-to-end tests for patch-apply.ts (the ToolHandler integration layer).
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { writeFile, readFile, mkdir, rm } from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { randomBytes, createHash } from 'crypto';
+import { createPatchApplyHandler } from './patch-apply.js';
+
+const tempDir = path.join(
+  os.tmpdir(),
+  `afk-patch-apply-e2e-test-${process.pid}-${randomBytes(4).toString('hex')}`,
+);
+
+async function writeTemp(filename: string, content: string): Promise<string> {
+  await mkdir(tempDir, { recursive: true });
+  const p = path.join(tempDir, filename);
+  await writeFile(p, content, 'utf-8');
+  return p;
+}
+
+function sha256(content: string): string {
+  return createHash('sha256').update(content, 'utf8').digest('hex');
+}
+
+const signal = new AbortController().signal;
+
+// Context that confines writes to tempDir.
+const makeCtx = () => ({
+  resolveBase: tempDir,
+  writeRoots: [tempDir],
+  readRoots: [tempDir],
+});
+
+afterEach(async () => {
+  try {
+    await rm(tempDir, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+});
+
+describe('patch_apply handler — validation_failed', () => {
+  it('returns isError=true when input is not an object', async () => {
+    const handler = createPatchApplyHandler(tempDir);
+    const result = await handler('not-an-object', signal, makeCtx());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('object');
+  });
+
+  it('returns isError=true when changes is missing', async () => {
+    const handler = createPatchApplyHandler(tempDir);
+    const result = await handler({}, signal, makeCtx());
+    expect(result.isError).toBe(true);
+  });
+
+  it('returns validation_failed status for bad hash', async () => {
+    const filePath = await writeTemp('v1.txt', 'current\n');
+    const handler = createPatchApplyHandler(tempDir);
+    const result = await handler(
+      {
+        changes: [
+          {
+            path: filePath,
+            expected_hash: `sha256:${sha256('wrong content')}`,
+            content: 'new\n',
+          },
+        ],
+      },
+      signal,
+      makeCtx(),
+    );
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content as string);
+    expect(parsed.status).toBe('validation_failed');
+    expect(parsed.errors).toHaveLength(1);
+    expect(parsed.errors[0].error).toBe('hash_mismatch');
+  });
+
+  it('returns all errors when multiple files fail validation', async () => {
+    const file1 = await writeTemp('m1.txt', 'aaa\n');
+    const file2 = await writeTemp('m2.txt', 'bbb\n');
+    const handler = createPatchApplyHandler(tempDir);
+    const result = await handler(
+      {
+        changes: [
+          { path: file1, edits: [{ old: 'nothere', new: 'x' }] },
+          { path: file2, edits: [{ old: 'bbb', new: undefined as unknown as string }] },
+        ],
+      },
+      signal,
+      makeCtx(),
+    );
+    // Should get parse error for undefined 'new' OR at least an error.
+    expect(result.isError).toBe(true);
+  });
+});
+
+describe('patch_apply handler — applied', () => {
+  it('applies a single content change and returns applied status', async () => {
+    const filePath = await writeTemp('a1.txt', 'before\n');
+    const handler = createPatchApplyHandler(tempDir);
+    const result = await handler(
+      { changes: [{ path: filePath, content: 'after\n' }] },
+      signal,
+      makeCtx(),
+    );
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(result.content as string);
+    expect(parsed.status).toBe('applied');
+    expect(parsed.errors).toHaveLength(0);
+    expect(parsed.diff).toContain('-before');
+    expect(parsed.diff).toContain('+after');
+
+    const actual = await readFile(filePath, 'utf-8');
+    expect(actual).toBe('after\n');
+  });
+
+  it('applies sequential edits correctly', async () => {
+    const filePath = await writeTemp('a2.txt', 'one two three\n');
+    const handler = createPatchApplyHandler(tempDir);
+    const result = await handler(
+      {
+        changes: [
+          {
+            path: filePath,
+            edits: [
+              { old: 'one', new: 'ONE' },
+              { old: 'ONE two', new: 'ONE+TWO' },
+            ],
+          },
+        ],
+      },
+      signal,
+      makeCtx(),
+    );
+    expect(result.isError).toBeFalsy();
+    const actual = await readFile(filePath, 'utf-8');
+    expect(actual).toBe('ONE+TWO three\n');
+  });
+
+  it('returns files_changed with correct hashes', async () => {
+    const filePath = await writeTemp('a3.txt', 'original\n');
+    const handler = createPatchApplyHandler(tempDir);
+    const result = await handler(
+      { changes: [{ path: filePath, content: 'replaced\n' }] },
+      signal,
+      makeCtx(),
+    );
+    const parsed = JSON.parse(result.content as string);
+    expect(parsed.files_changed).toHaveLength(1);
+    expect(parsed.files_changed[0].before_hash).toBe(`sha256:${sha256('original\n')}`);
+    expect(parsed.files_changed[0].after_hash).toBe(`sha256:${sha256('replaced\n')}`);
+  });
+
+  it('returns applied for empty changes array', async () => {
+    const handler = createPatchApplyHandler(tempDir);
+    const result = await handler({ changes: [] }, signal, makeCtx());
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(result.content as string);
+    expect(parsed.status).toBe('applied');
+  });
+});
+
+describe('patch_apply handler — dry_run', () => {
+  it('returns dry_run status and diff without modifying the file', async () => {
+    const filePath = await writeTemp('d1.txt', 'hello\n');
+    const handler = createPatchApplyHandler(tempDir);
+    const result = await handler(
+      { changes: [{ path: filePath, content: 'goodbye\n' }], dry_run: true },
+      signal,
+      makeCtx(),
+    );
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(result.content as string);
+    expect(parsed.status).toBe('dry_run');
+    expect(parsed.diff).toContain('-hello');
+    expect(parsed.diff).toContain('+goodbye');
+
+    // File is unchanged.
+    const actual = await readFile(filePath, 'utf-8');
+    expect(actual).toBe('hello\n');
+  });
+
+  it('dry_run result shape has all required fields', async () => {
+    const filePath = await writeTemp('d2.txt', 'x\n');
+    const handler = createPatchApplyHandler(tempDir);
+    const result = await handler(
+      { changes: [{ path: filePath, content: 'y\n' }], dry_run: true },
+      signal,
+      makeCtx(),
+    );
+    const parsed = JSON.parse(result.content as string);
+    expect(parsed).toHaveProperty('status', 'dry_run');
+    expect(parsed).toHaveProperty('diff');
+    expect(parsed).toHaveProperty('files_changed');
+    expect(parsed).toHaveProperty('errors');
+    expect(Array.isArray(parsed.files_changed)).toBe(true);
+    expect(Array.isArray(parsed.errors)).toBe(true);
+  });
+});

--- a/src/agent/tools/handlers/patch-apply.ts
+++ b/src/agent/tools/handlers/patch-apply.ts
@@ -1,0 +1,202 @@
+/**
+ * patch_apply tool handler.
+ *
+ * Validates and atomically applies structured multi-file changes with
+ * content-hash verification and dry-run preview support.
+ *
+ * Flow:
+ *   1. Parse and validate input shape.
+ *   2. Run validatePatchChanges() — collect ALL errors before failing.
+ *   3. If valid, run applyPatch() with the dry_run flag.
+ *   4. Return structured JSON result.
+ *
+ * @module agent/tools/handlers/patch-apply
+ */
+
+import { resolve } from 'path';
+import type { ToolHandler, ToolHandlerContext } from '../types.js';
+import { validatePatchChanges, type PatchFileChange } from './patch-validate.js';
+import { applyPatch } from './patch-apply-engine.js';
+
+// ---------------------------------------------------------------------------
+// Input parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse and coerce the raw tool input into a typed PatchApplyInput.
+ * Throws a descriptive Error on any structural problem.
+ */
+function parsePatchApplyInput(input: unknown): {
+  changes: PatchFileChange[];
+  dry_run: boolean;
+} {
+  if (typeof input !== 'object' || input === null) {
+    throw new Error('Input must be an object.');
+  }
+
+  const raw = input as Record<string, unknown>;
+
+  // --- changes ---
+  if (!Array.isArray(raw['changes'])) {
+    throw new Error('Input must have a "changes" field of type array.');
+  }
+
+  const changes: PatchFileChange[] = [];
+  for (let i = 0; i < raw['changes'].length; i++) {
+    const item = raw['changes'][i];
+    if (typeof item !== 'object' || item === null) {
+      throw new Error(`changes[${i}] must be an object.`);
+    }
+    const rawItem = item as Record<string, unknown>;
+
+    if (typeof rawItem['path'] !== 'string' || rawItem['path'].trim() === '') {
+      throw new Error(`changes[${i}].path must be a non-empty string.`);
+    }
+
+    const change: PatchFileChange = { path: rawItem['path'] };
+
+    if (rawItem['expected_hash'] !== undefined) {
+      if (typeof rawItem['expected_hash'] !== 'string') {
+        throw new Error(`changes[${i}].expected_hash must be a string.`);
+      }
+      change.expected_hash = rawItem['expected_hash'];
+    }
+
+    if (rawItem['content'] !== undefined) {
+      if (typeof rawItem['content'] !== 'string') {
+        throw new Error(`changes[${i}].content must be a string.`);
+      }
+      change.content = rawItem['content'];
+    }
+
+    if (rawItem['edits'] !== undefined) {
+      if (!Array.isArray(rawItem['edits'])) {
+        throw new Error(`changes[${i}].edits must be an array.`);
+      }
+      const edits: Array<{ old: string; new: string }> = [];
+      for (let j = 0; j < rawItem['edits'].length; j++) {
+        const edit = rawItem['edits'][j];
+        if (typeof edit !== 'object' || edit === null) {
+          throw new Error(`changes[${i}].edits[${j}] must be an object.`);
+        }
+        const rawEdit = edit as Record<string, unknown>;
+        if (typeof rawEdit['old'] !== 'string') {
+          throw new Error(`changes[${i}].edits[${j}].old must be a string.`);
+        }
+        if (typeof rawEdit['new'] !== 'string') {
+          throw new Error(`changes[${i}].edits[${j}].new must be a string.`);
+        }
+        edits.push({ old: rawEdit['old'], new: rawEdit['new'] });
+      }
+      change.edits = edits;
+    }
+
+    changes.push(change);
+  }
+
+  // --- dry_run ---
+  let dry_run = false;
+  if (raw['dry_run'] !== undefined) {
+    if (typeof raw['dry_run'] !== 'boolean') {
+      throw new Error('dry_run must be a boolean.');
+    }
+    dry_run = raw['dry_run'];
+  }
+
+  return { changes, dry_run };
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a `patch_apply` handler closed over a session-specific base path.
+ * Mirrors the factory pattern from `createEditFileHandler`.
+ */
+export function createPatchApplyHandler(cwd?: string): ToolHandler {
+  return async (
+    input: unknown,
+    _signal: AbortSignal,
+    context?: ToolHandlerContext,
+  ) => {
+    // Determine the resolve base: context takes priority, then factory cwd,
+    // then process.cwd() as last resort.
+    const resolveBase =
+      context?.resolveBase ?? context?.cwd ?? cwd ?? resolve(process.cwd());
+
+    // Parse input.
+    let parsed: ReturnType<typeof parsePatchApplyInput>;
+    try {
+      parsed = parsePatchApplyInput(input);
+    } catch (err) {
+      return {
+        content: err instanceof Error ? err.message : String(err),
+        isError: true,
+      };
+    }
+
+    const { changes, dry_run } = parsed;
+
+    if (changes.length === 0) {
+      return {
+        content: JSON.stringify(
+          {
+            status: 'applied',
+            diff: '',
+            files_changed: [],
+            errors: [],
+          },
+          null,
+          2,
+        ),
+        isError: false,
+      };
+    }
+
+    // Validate.
+    const validation = await validatePatchChanges(changes, resolveBase, context);
+
+    if (!validation.valid) {
+      const result = {
+        status: 'validation_failed' as const,
+        diff: '',
+        files_changed: [],
+        errors: validation.errors,
+      };
+      return {
+        content: JSON.stringify(result, null, 2),
+        isError: true,
+      };
+    }
+
+    // Apply (or dry-run).
+    const applyResult = await applyPatch(
+      changes,
+      validation.fileContents,
+      resolveBase,
+      dry_run,
+    );
+
+    const isError =
+      applyResult.status === 'validation_failed' ||
+      applyResult.status === 'partial_failure';
+
+    return {
+      content: JSON.stringify(
+        {
+          status: applyResult.status,
+          diff: applyResult.diff,
+          files_changed: applyResult.files_changed,
+          errors: applyResult.errors,
+        },
+        null,
+        2,
+      ),
+      isError,
+    };
+  };
+}
+
+/** Bare `patch_apply` handler with no session cwd. */
+export const patchApplyHandler: ToolHandler = createPatchApplyHandler();

--- a/src/agent/tools/handlers/patch-validate.test.ts
+++ b/src/agent/tools/handlers/patch-validate.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for patch-validate.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { writeFile, mkdir, rm } from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { randomBytes, createHash } from 'crypto';
+import { validatePatchChanges } from './patch-validate.js';
+import type { PatchFileChange } from './patch-validate.js';
+
+// Scratch directory outside the repo working tree.
+const tempDir = path.join(
+  os.tmpdir(),
+  `afk-patch-validate-test-${process.pid}-${randomBytes(4).toString('hex')}`,
+);
+
+async function writeTemp(filename: string, content: string): Promise<string> {
+  await mkdir(tempDir, { recursive: true });
+  const p = path.join(tempDir, filename);
+  await writeFile(p, content, 'utf-8');
+  return p;
+}
+
+function sha256(content: string): string {
+  return createHash('sha256').update(content, 'utf8').digest('hex');
+}
+
+// Context that permits writes anywhere inside tempDir.
+const makeCtx = () => ({
+  resolveBase: tempDir,
+  writeRoots: [tempDir],
+  readRoots: [tempDir],
+});
+
+afterEach(async () => {
+  try {
+    await rm(tempDir, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+});
+
+describe('validatePatchChanges', () => {
+  it('passes for a valid content change', async () => {
+    const filePath = await writeTemp('a.txt', 'hello\n');
+    const changes: PatchFileChange[] = [{ path: filePath, content: 'world\n' }];
+    const result = await validatePatchChanges(changes, tempDir, makeCtx());
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+    expect(result.fileContents.get(filePath)).toBe('hello\n');
+  });
+
+  it('passes for a valid edit change', async () => {
+    const filePath = await writeTemp('b.txt', 'foo bar baz\n');
+    const changes: PatchFileChange[] = [
+      { path: filePath, edits: [{ old: 'bar', new: 'qux' }] },
+    ];
+    const result = await validatePatchChanges(changes, tempDir, makeCtx());
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('passes hash verification when hash matches', async () => {
+    const content = 'exact content\n';
+    const filePath = await writeTemp('c.txt', content);
+    const hash = sha256(content);
+    const changes: PatchFileChange[] = [
+      { path: filePath, expected_hash: `sha256:${hash}`, content: 'new\n' },
+    ];
+    const result = await validatePatchChanges(changes, tempDir, makeCtx());
+    expect(result.valid).toBe(true);
+  });
+
+  it('fails hash verification when file has changed', async () => {
+    const filePath = await writeTemp('d.txt', 'current content\n');
+    const staleHash = sha256('old content\n');
+    const changes: PatchFileChange[] = [
+      { path: filePath, expected_hash: `sha256:${staleHash}`, content: 'new\n' },
+    ];
+    const result = await validatePatchChanges(changes, tempDir, makeCtx());
+    expect(result.valid).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]!.error).toBe('hash_mismatch');
+    expect(result.errors[0]!.path).toBe(filePath);
+  });
+
+  it('fails when expected_hash has wrong format', async () => {
+    const filePath = await writeTemp('e.txt', 'x\n');
+    const changes: PatchFileChange[] = [
+      { path: filePath, expected_hash: 'md5:abcdef', content: 'y\n' },
+    ];
+    const result = await validatePatchChanges(changes, tempDir, makeCtx());
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]!.error).toBe('invalid_hash_format');
+  });
+
+  it('fails when edit old-string has zero matches', async () => {
+    const filePath = await writeTemp('f.txt', 'hello world\n');
+    const changes: PatchFileChange[] = [
+      { path: filePath, edits: [{ old: 'nothere', new: 'x' }] },
+    ];
+    const result = await validatePatchChanges(changes, tempDir, makeCtx());
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]!.error).toBe('edit_not_found');
+    expect(result.errors[0]!.detail).toContain('Edit #1');
+  });
+
+  it('fails when edit old-string has more than one match', async () => {
+    const filePath = await writeTemp('g.txt', 'foo foo foo\n');
+    const changes: PatchFileChange[] = [
+      { path: filePath, edits: [{ old: 'foo', new: 'bar' }] },
+    ];
+    const result = await validatePatchChanges(changes, tempDir, makeCtx());
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]!.error).toBe('edit_ambiguous');
+    expect(result.errors[0]!.detail).toContain('3 locations');
+  });
+
+  it('rejects a change that has both edits and content', async () => {
+    const filePath = await writeTemp('h.txt', 'x\n');
+    const changes: PatchFileChange[] = [
+      { path: filePath, edits: [{ old: 'x', new: 'y' }], content: 'z\n' },
+    ];
+    const result = await validatePatchChanges(changes, tempDir, makeCtx());
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]!.error).toBe('mutually_exclusive');
+  });
+
+  it('rejects a change that has neither edits nor content', async () => {
+    const filePath = await writeTemp('i.txt', 'x\n');
+    const changes: PatchFileChange[] = [{ path: filePath }];
+    const result = await validatePatchChanges(changes, tempDir, makeCtx());
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]!.error).toBe('no_change_specified');
+  });
+
+  it('collects ALL errors across multiple files without short-circuiting', async () => {
+    const file1 = await writeTemp('j1.txt', 'aaa\n');
+    const file2 = await writeTemp('j2.txt', 'bbb\n');
+    const file3 = await writeTemp('j3.txt', 'ccc ccc\n');
+    const changes: PatchFileChange[] = [
+      // file1: bad hash
+      { path: file1, expected_hash: `sha256:${sha256('wrong')}`, content: 'x\n' },
+      // file2: edit not found
+      { path: file2, edits: [{ old: 'nothere', new: 'x' }] },
+      // file3: ambiguous edit
+      { path: file3, edits: [{ old: 'ccc', new: 'ddd' }] },
+    ];
+    const result = await validatePatchChanges(changes, tempDir, makeCtx());
+    expect(result.valid).toBe(false);
+    expect(result.errors).toHaveLength(3);
+    const codes = result.errors.map((e) => e.error);
+    expect(codes).toContain('hash_mismatch');
+    expect(codes).toContain('edit_not_found');
+    expect(codes).toContain('edit_ambiguous');
+  });
+
+  it('rejects write to denylist path', async () => {
+    // Use a known denied system path; pass as absolute so containment is bypassed
+    // but denylist fires.
+    const deniedPath = '/etc/passwd';
+    const changes: PatchFileChange[] = [{ path: deniedPath, content: 'evil\n' }];
+    // allowAll=false (default), resolveBase tempDir.
+    const result = await validatePatchChanges(changes, tempDir, {
+      resolveBase: tempDir,
+      writeRoots: [tempDir, '/etc'],   // grant containment so denylist is tested
+      allowAll: false,
+    });
+    expect(result.valid).toBe(false);
+    const errCodes = result.errors.map((e) => e.error);
+    expect(errCodes).toContain('write_denied');
+  });
+
+  it('rejects path outside write roots', async () => {
+    const filePath = await writeTemp('k.txt', 'x\n');
+    // Restrict write roots to a completely different dir.
+    const restrictedCtx = {
+      resolveBase: '/some/other/dir',
+      writeRoots: ['/some/other/dir'],
+      readRoots: ['/some/other/dir'],
+    };
+    const changes: PatchFileChange[] = [{ path: filePath, content: 'y\n' }];
+    const result = await validatePatchChanges(changes, '/some/other/dir', restrictedCtx);
+    expect(result.valid).toBe(false);
+    const errCodes = result.errors.map((e) => e.error);
+    expect(errCodes).toContain('path_containment');
+  });
+
+  it('validates sequential edits against progressively-modified content', async () => {
+    // First edit makes a change; second edit targets the NEW content, not original.
+    const filePath = await writeTemp('l.txt', 'alpha beta gamma\n');
+    const changes: PatchFileChange[] = [
+      {
+        path: filePath,
+        edits: [
+          { old: 'alpha', new: 'A' },     // valid: 'alpha' exists once
+          { old: 'A beta', new: 'AB' },   // valid against modified: 'A beta' exists
+        ],
+      },
+    ];
+    const result = await validatePatchChanges(changes, tempDir, makeCtx());
+    expect(result.valid).toBe(true);
+  });
+});

--- a/src/agent/tools/handlers/patch-validate.test.ts
+++ b/src/agent/tools/handlers/patch-validate.test.ts
@@ -203,4 +203,72 @@ describe('validatePatchChanges', () => {
     const result = await validatePatchChanges(changes, tempDir, makeCtx());
     expect(result.valid).toBe(true);
   });
+
+  it('multi-file batch with denied path produces exactly one write_denied error (no spurious errors)', async () => {
+    // changes[0] is valid; changes[1] targets a denied path.
+    const validFile = await writeTemp('m.txt', 'hello\n');
+    const deniedPath = '/etc/passwd';
+    const changes: PatchFileChange[] = [
+      { path: validFile, content: 'world\n' },          // valid
+      { path: deniedPath, content: 'evil\n' },           // denied
+    ];
+    const result = await validatePatchChanges(changes, tempDir, {
+      resolveBase: tempDir,
+      writeRoots: [tempDir, '/etc'],  // grant containment so denylist is what fires
+      allowAll: false,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]!.error).toBe('write_denied');
+    expect(result.errors[0]!.path).toBe(deniedPath);
+  });
+
+  it('sets null sentinel for new file (content-only, no existing file)', async () => {
+    const newFilePath = path.join(tempDir, 'new-sentinel.txt');
+    // Don't create the file — validate a content-only change for a new file.
+    const changes: PatchFileChange[] = [{ path: newFilePath, content: 'fresh\n' }];
+    const result = await validatePatchChanges(changes, tempDir, makeCtx());
+    expect(result.valid).toBe(true);
+    // Sentinel: null means the file did not exist before the patch.
+    expect(result.fileContents.has(newFilePath)).toBe(true);
+    expect(result.fileContents.get(newFilePath)).toBeNull();
+  });
+
+  it('edit_not_found stops further edit validation for that file', async () => {
+    // If edit #1 is not found, edit #2 should NOT be validated (break, not continue).
+    const filePath = await writeTemp('n.txt', 'hello world\n');
+    const changes: PatchFileChange[] = [
+      {
+        path: filePath,
+        edits: [
+          { old: 'nothere', new: 'x' },    // #1: not found → should break
+          { old: 'world', new: 'earth' },  // #2: would be valid, but should be skipped
+        ],
+      },
+    ];
+    const result = await validatePatchChanges(changes, tempDir, makeCtx());
+    expect(result.valid).toBe(false);
+    // Only one error (edit #1); edit #2 should NOT generate an additional error.
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]!.error).toBe('edit_not_found');
+    expect(result.errors[0]!.detail).toContain('Edit #1');
+  });
+
+  it('hash_mismatch skips edit validation', async () => {
+    const content = 'actual content\n';
+    const filePath = await writeTemp('o.txt', content);
+    const wrongHash = sha256('completely different\n');
+    const changes: PatchFileChange[] = [
+      {
+        path: filePath,
+        expected_hash: `sha256:${wrongHash}`,
+        edits: [{ old: 'nothere', new: 'x' }],  // would also fail, but should be skipped
+      },
+    ];
+    const result = await validatePatchChanges(changes, tempDir, makeCtx());
+    expect(result.valid).toBe(false);
+    // Only hash_mismatch; no spurious edit_not_found error.
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]!.error).toBe('hash_mismatch');
+  });
 });

--- a/src/agent/tools/handlers/patch-validate.ts
+++ b/src/agent/tools/handlers/patch-validate.ts
@@ -1,0 +1,230 @@
+/**
+ * Validation logic for patch_apply tool.
+ *
+ * Validates a set of file changes before they are applied:
+ *   - Path containment via write roots
+ *   - Write denylist enforcement
+ *   - Optional SHA-256 hash verification
+ *   - Edit exact-match-once enforcement
+ *   - Mutual-exclusion between `edits` and `content`
+ *
+ * All errors across ALL files are collected before returning — validation
+ * never short-circuits after the first failure.
+ *
+ * @module agent/tools/handlers/patch-validate
+ */
+
+import { createHash } from 'crypto';
+import { readFile } from 'fs/promises';
+import type { ToolHandlerContext } from '../types.js';
+import { assertNotDenylisted } from './write-denylist.js';
+import { resolveAndContain } from './_cwd-utils.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** A single file change in a patch. */
+export interface PatchFileChange {
+  path: string;
+  /** Optional SHA-256 hash to verify before applying (format: "sha256:<hex>"). */
+  expected_hash?: string;
+  /** Sequential string replacements — each `old` must match exactly once. */
+  edits?: Array<{ old: string; new: string }>;
+  /** Full replacement content (mutually exclusive with `edits`). */
+  content?: string;
+}
+
+/** A single validation error for a file. */
+export interface ValidationError {
+  path: string;
+  error: string;
+  detail?: string;
+}
+
+/** Result of validating a batch of patch changes. */
+export interface ValidationResult {
+  valid: boolean;
+  errors: ValidationError[];
+  /** Current file contents, keyed by resolved path, for rollback. */
+  fileContents: Map<string, string>;
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+/** Compute SHA-256 hex digest of UTF-8 string content. */
+export function sha256Hex(content: string): string {
+  return createHash('sha256').update(content, 'utf8').digest('hex');
+}
+
+/**
+ * Count non-overlapping occurrences of `needle` in `haystack`.
+ * Returns 0 immediately for an empty needle.
+ */
+function countOccurrences(haystack: string, needle: string): number {
+  if (needle.length === 0) return 0;
+  let count = 0;
+  let pos = 0;
+  while ((pos = haystack.indexOf(needle, pos)) !== -1) {
+    count++;
+    pos += needle.length;
+  }
+  return count;
+}
+
+// ---------------------------------------------------------------------------
+// Exported validator
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate all changes in a patch. Collects ALL errors — never short-circuits
+ * on the first failure.
+ *
+ * @param changes     - Array of file changes to validate.
+ * @param resolveBase - Base directory for resolving relative paths.
+ * @param context     - Optional tool-handler context (write roots, allowAll).
+ */
+export async function validatePatchChanges(
+  changes: PatchFileChange[],
+  resolveBase: string,
+  context?: ToolHandlerContext,
+): Promise<ValidationResult> {
+  const errors: ValidationError[] = [];
+  const fileContents = new Map<string, string>();
+
+  for (const change of changes) {
+    const rawPath = change.path;
+
+    // 1. Resolve path and check containment within write roots.
+    let resolvedPath: string;
+    try {
+      resolvedPath = resolveAndContain(rawPath, context, 'write', resolveBase);
+    } catch (err) {
+      errors.push({
+        path: rawPath,
+        error: 'path_containment',
+        detail: err instanceof Error ? err.message : String(err),
+      });
+      continue; // Cannot proceed without a valid resolved path.
+    }
+
+    // 2. Write denylist check.
+    try {
+      assertNotDenylisted(resolvedPath, 'patch_apply');
+    } catch (err) {
+      errors.push({
+        path: rawPath,
+        error: 'write_denied',
+        detail: err instanceof Error ? err.message : String(err),
+      });
+      // Keep going — collect all errors.
+    }
+
+    // 3. Mutual exclusion: edits and content are mutually exclusive.
+    if (change.edits !== undefined && change.content !== undefined) {
+      errors.push({
+        path: rawPath,
+        error: 'mutually_exclusive',
+        detail: '`edits` and `content` cannot both be provided for the same file.',
+      });
+      // Cannot validate further for this file without knowing the mode.
+      continue;
+    }
+
+    // 4. At least one of edits or content must be present.
+    if (change.edits === undefined && change.content === undefined) {
+      errors.push({
+        path: rawPath,
+        error: 'no_change_specified',
+        detail: 'At least one of `edits` or `content` must be provided.',
+      });
+      continue;
+    }
+
+    // 5. Read current file content (needed for hash check and edit validation).
+    let currentContent: string | undefined;
+    try {
+      currentContent = await readFile(resolvedPath, 'utf-8');
+    } catch (err) {
+      // File may not exist yet (new file via content). Only treat as an error
+      // if we need to verify the hash or apply edits.
+      if (change.expected_hash !== undefined || change.edits !== undefined) {
+        errors.push({
+          path: rawPath,
+          error: 'file_read_failed',
+          detail: err instanceof Error ? err.message : String(err),
+        });
+        continue;
+      }
+      // New file with `content` only — that's fine; record empty string.
+      currentContent = '';
+    }
+
+    // Store content for rollback — use the resolved path as the key.
+    fileContents.set(resolvedPath, currentContent);
+
+    // 6. Hash verification (if expected_hash provided).
+    if (change.expected_hash !== undefined) {
+      const prefix = 'sha256:';
+      if (!change.expected_hash.startsWith(prefix)) {
+        errors.push({
+          path: rawPath,
+          error: 'invalid_hash_format',
+          detail: `expected_hash must start with "sha256:". Got: "${change.expected_hash}"`,
+        });
+      } else {
+        const expectedHex = change.expected_hash.slice(prefix.length);
+        const actualHex = sha256Hex(currentContent);
+        if (actualHex !== expectedHex) {
+          errors.push({
+            path: rawPath,
+            error: 'hash_mismatch',
+            detail:
+              `File hash mismatch. Expected sha256:${expectedHex}, ` +
+              `got sha256:${actualHex}. The file may have been modified.`,
+          });
+        }
+      }
+    }
+
+    // 7. Edit exact-match-once validation.
+    if (change.edits !== undefined) {
+      // Apply edits sequentially on a running copy to validate each against the
+      // progressively-modified content (matches how the engine will apply them).
+      let runningContent = currentContent;
+      for (let i = 0; i < change.edits.length; i++) {
+        const edit = change.edits[i]!;
+        const occurrences = countOccurrences(runningContent, edit.old);
+        if (occurrences === 0) {
+          errors.push({
+            path: rawPath,
+            error: 'edit_not_found',
+            detail: `Edit #${i + 1}: \`old\` string not found in file.`,
+          });
+          // Continue checking subsequent edits against the unmodified running content.
+        } else if (occurrences > 1) {
+          errors.push({
+            path: rawPath,
+            error: 'edit_ambiguous',
+            detail:
+              `Edit #${i + 1}: \`old\` string matches ${occurrences} locations. ` +
+              `Provide enough context to make it unique.`,
+          });
+        } else {
+          // Advance running content for subsequent edit validations.
+          const idx = runningContent.indexOf(edit.old);
+          runningContent =
+            runningContent.slice(0, idx) + edit.new + runningContent.slice(idx + edit.old.length);
+        }
+      }
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    fileContents,
+  };
+}

--- a/src/agent/tools/handlers/patch-validate.ts
+++ b/src/agent/tools/handlers/patch-validate.ts
@@ -46,8 +46,12 @@ export interface ValidationError {
 export interface ValidationResult {
   valid: boolean;
   errors: ValidationError[];
-  /** Current file contents, keyed by resolved path, for rollback. */
-  fileContents: Map<string, string>;
+  /**
+   * Current file contents keyed by resolved path, for rollback.
+   * `null` means the file did not exist before the patch (new file);
+   * `''` means the file existed and was empty.
+   */
+  fileContents: Map<string, string | null>;
 }
 
 // ---------------------------------------------------------------------------
@@ -92,7 +96,7 @@ export async function validatePatchChanges(
   context?: ToolHandlerContext,
 ): Promise<ValidationResult> {
   const errors: ValidationError[] = [];
-  const fileContents = new Map<string, string>();
+  const fileContents = new Map<string, string | null>();
 
   for (const change of changes) {
     const rawPath = change.path;
@@ -119,7 +123,7 @@ export async function validatePatchChanges(
         error: 'write_denied',
         detail: err instanceof Error ? err.message : String(err),
       });
-      // Keep going — collect all errors.
+      continue; // Cannot validate further for a denied path (matches path_containment pattern).
     }
 
     // 3. Mutual exclusion: edits and content are mutually exclusive.
@@ -158,12 +162,17 @@ export async function validatePatchChanges(
         });
         continue;
       }
-      // New file with `content` only — that's fine; record empty string.
+      // New file with `content` only — that's fine; record null as the
+      // sentinel meaning "did not exist before the patch" so the engine can
+      // distinguish a new file (null) from an existing empty file ('').
+      fileContents.set(resolvedPath, null);
       currentContent = '';
     }
 
-    // Store content for rollback — use the resolved path as the key.
-    fileContents.set(resolvedPath, currentContent);
+    // Store content for rollback (only when not already set by the new-file branch above).
+    if (!fileContents.has(resolvedPath)) {
+      fileContents.set(resolvedPath, currentContent);
+    }
 
     // 6. Hash verification (if expected_hash provided).
     if (change.expected_hash !== undefined) {
@@ -174,18 +183,19 @@ export async function validatePatchChanges(
           error: 'invalid_hash_format',
           detail: `expected_hash must start with "sha256:". Got: "${change.expected_hash}"`,
         });
-      } else {
-        const expectedHex = change.expected_hash.slice(prefix.length);
-        const actualHex = sha256Hex(currentContent);
-        if (actualHex !== expectedHex) {
-          errors.push({
-            path: rawPath,
-            error: 'hash_mismatch',
-            detail:
-              `File hash mismatch. Expected sha256:${expectedHex}, ` +
-              `got sha256:${actualHex}. The file may have been modified.`,
-          });
-        }
+        continue; // Cannot meaningfully validate edits on a file with a bad hash format.
+      }
+      const expectedHex = change.expected_hash.slice(prefix.length);
+      const actualHex = sha256Hex(currentContent);
+      if (actualHex !== expectedHex) {
+        errors.push({
+          path: rawPath,
+          error: 'hash_mismatch',
+          detail:
+            `File hash mismatch. Expected sha256:${expectedHex}, ` +
+            `got sha256:${actualHex}. The file may have been modified.`,
+        });
+        continue; // File is in a different state than expected; skip edit validation.
       }
     }
 
@@ -203,7 +213,10 @@ export async function validatePatchChanges(
             error: 'edit_not_found',
             detail: `Edit #${i + 1}: \`old\` string not found in file.`,
           });
-          // Continue checking subsequent edits against the unmodified running content.
+          // Stop validating further edits for this file: the content state is
+          // now uncertain, so subsequent edits would be validated against
+          // incorrect content (producing false edit_not_found errors).
+          break;
         } else if (occurrences > 1) {
           errors.push({
             path: rawPath,

--- a/src/agent/tools/hooks/path-approval-hook.ts
+++ b/src/agent/tools/hooks/path-approval-hook.ts
@@ -334,6 +334,7 @@ async function preToolUseImpl(
   const promptPromise = promptForApproval({
     toolName: context.toolName,
     resolvedPath: result.resolved,
+    allPaths: extractAllPaths(context.toolName, input),
     capturedCwd: cwd,
     mode,
     grantManager,
@@ -492,8 +493,9 @@ function extractCandidatePath(
   }
   // patch_apply has a `changes` array; each element has a `path` field.
   // Path containment is enforced per-change by patch-validate.ts
-  // (resolveAndContain), so the approval prompt only needs a representative
-  // path to anchor the containment check and grant flow.
+  // (resolveAndContain). Return the first path to anchor the containment
+  // check and grant flow; the full file list is shown in the approval prompt
+  // via promptForApproval (which receives all paths via extractAllPaths).
   if (toolName === 'patch_apply') {
     const changes = input['changes'];
     if (Array.isArray(changes) && changes.length > 0) {
@@ -507,12 +509,36 @@ function extractCandidatePath(
 }
 
 /**
+ * Extract all paths from a patch_apply input for display in the approval
+ * prompt. For other tools, returns a single-element array (or empty).
+ */
+function extractAllPaths(
+  toolName: string,
+  input: Record<string, unknown>,
+): string[] {
+  if (toolName === 'patch_apply') {
+    const changes = input['changes'];
+    if (!Array.isArray(changes)) return [];
+    const paths: string[] = [];
+    for (const change of changes) {
+      const c = change as Record<string, unknown>;
+      if (typeof c['path'] === 'string') paths.push(c['path']);
+    }
+    return paths;
+  }
+  const candidate = extractCandidatePath(toolName, input);
+  return candidate !== undefined ? [candidate] : [];
+}
+
+/**
  * Issue the elicitation prompt and translate the response into a hook
  * decision + grant mutation.
  */
 async function promptForApproval(args: {
   toolName: string;
   resolvedPath: string;
+  /** All paths in the patch (patch_apply only); used to build the prompt message. */
+  allPaths?: string[];
   /** cwd captured at PreToolUse time; stored in the onceApproved entry. */
   capturedCwd: string | undefined;
   mode: 'read' | 'write';
@@ -528,7 +554,7 @@ async function promptForApproval(args: {
    */
   sessionId?: string;
 }): Promise<HookDecision> {
-  const { toolName, resolvedPath, capturedCwd, mode, grantManager, state, surface, signal, sessionId } =
+  const { toolName, resolvedPath, allPaths, capturedCwd, mode, grantManager, state, surface, signal, sessionId } =
     args;
 
   // Show the symlink-resolved target when it differs from the displayed path so
@@ -538,10 +564,19 @@ async function promptForApproval(args: {
   // nearest existing ancestor for not-yet-created write targets).
   const realTarget = realpathSafe(resolvedPath);
   const realTargetSuffix = realTarget !== resolvedPath ? `\n  (resolves to: ${realTarget})` : '';
+
+  // For patch_apply, show the full list of files being written so the operator
+  // knows the complete scope of the operation, not just the first path.
+  const pathsForDisplay =
+    allPaths && allPaths.length > 1
+      ? allPaths.map((p) => `  ${p}`).join('\n')
+      : `  ${resolvedPath}${realTargetSuffix}`;
   const message =
-    `Tool \`${toolName}\` wants to ${mode === 'write' ? 'WRITE to' : 'read'} a path ` +
-    `outside this session's granted roots:\n\n  ${resolvedPath}${realTargetSuffix}\n\n` +
-    `Choose how to handle this and future requests for this path.`;
+    `Tool \`${toolName}\` wants to ${mode === 'write' ? 'WRITE to' : 'read'} ` +
+    (allPaths && allPaths.length > 1
+      ? `${allPaths.length} paths outside this session's granted roots:\n\n${pathsForDisplay}`
+      : `a path outside this session's granted roots:\n\n${pathsForDisplay}`) +
+    `\n\nChoose how to handle this and future requests for this path.`;
 
   // Form-mode elicitation with a single enum field, four choices. The REPL
   // and Telegram handlers know how to render this (REPL: numbered prompt;

--- a/src/agent/tools/hooks/path-approval-hook.ts
+++ b/src/agent/tools/hooks/path-approval-hook.ts
@@ -75,10 +75,11 @@ const TYPED_FILE_TOOLS = new Set([
   'list_directory',
   'glob',
   'grep',
+  'patch_apply',
 ]);
 
 /** Tools that write — used to pick read-vs-write containment + grant mode. */
-const WRITE_TOOLS = new Set(['write_file', 'edit_file']);
+const WRITE_TOOLS = new Set(['write_file', 'edit_file', 'patch_apply']);
 
 /** Surface label threaded into the persisted grant for audit. */
 export type PathApprovalSurface = 'repl' | 'telegram' | 'web' | 'unknown';
@@ -488,6 +489,19 @@ function extractCandidatePath(
   if (toolName === 'glob' || toolName === 'grep') {
     const p = input['path'];
     return typeof p === 'string' ? p : undefined;
+  }
+  // patch_apply has a `changes` array; each element has a `path` field.
+  // Path containment is enforced per-change by patch-validate.ts
+  // (resolveAndContain), so the approval prompt only needs a representative
+  // path to anchor the containment check and grant flow.
+  if (toolName === 'patch_apply') {
+    const changes = input['changes'];
+    if (Array.isArray(changes) && changes.length > 0) {
+      const first = changes[0] as Record<string, unknown>;
+      const p = first['path'];
+      return typeof p === 'string' ? p : undefined;
+    }
+    return undefined;
   }
   return undefined;
 }

--- a/src/agent/tools/schemas.orchestration.ts
+++ b/src/agent/tools/schemas.orchestration.ts
@@ -1,1 +1,2 @@
 export { cancelBackgroundJobTool } from './schemas.background-cancel.js';
+export { patchApplyTool } from './schemas.patch-apply.js';

--- a/src/agent/tools/schemas.patch-apply.ts
+++ b/src/agent/tools/schemas.patch-apply.ts
@@ -1,0 +1,79 @@
+/**
+ * Tool schema for the patch_apply built-in tool.
+ *
+ * Extracted from `schemas.ts` to satisfy the 350-line ceiling ratchet
+ * (baselined files may shrink, never grow). Imported and re-registered
+ * in `builtinToolSchemas[]` by the parent module.
+ *
+ * @module agent/tools/schemas.patch-apply
+ */
+
+import type { AnthropicToolDef } from './types.js';
+
+export const patchApplyTool: AnthropicToolDef = {
+  name: 'patch_apply',
+  category: 'write',
+  concurrencySafe: false,
+  description:
+    'Validate and atomically apply structured multi-file changes with content-hash ' +
+    'verification and dry-run preview. Each change targets a single file and specifies ' +
+    'either sequential string replacements (`edits`) or a full replacement (`content`). ' +
+    'An optional `expected_hash` (format: "sha256:<hex>") verifies the file has not ' +
+    'changed since the hash was computed. ' +
+    'Validation runs on ALL files before any write — if any file fails, no files are ' +
+    'written and all errors are returned. ' +
+    'When `dry_run: true`, returns the unified diff without modifying anything. ' +
+    'Writes use temp-file + rename for atomicity; a partial failure triggers best-effort ' +
+    'rollback of already-written files.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      changes: {
+        type: 'array',
+        description: 'Array of file changes to apply atomically.',
+        items: {
+          type: 'object',
+          properties: {
+            path: {
+              type: 'string',
+              description: 'File path (relative or absolute).',
+            },
+            expected_hash: {
+              type: 'string',
+              description:
+                'SHA-256 hash to verify the file has not changed (format: "sha256:<hex>"). ' +
+                'If the file\'s current hash does not match, the entire patch is rejected.',
+            },
+            edits: {
+              type: 'array',
+              description:
+                'Sequential edits — each `old` string must match exactly once in the file ' +
+                '(after previous edits in the same list have been applied).',
+              items: {
+                type: 'object',
+                properties: {
+                  old: { type: 'string', description: 'Exact string to find (must occur once).' },
+                  new: { type: 'string', description: 'Replacement string.' },
+                },
+                required: ['old', 'new'],
+              },
+            },
+            content: {
+              type: 'string',
+              description:
+                'Full replacement content for the file. Mutually exclusive with `edits`.',
+            },
+          },
+          required: ['path'],
+        },
+      },
+      dry_run: {
+        type: 'boolean',
+        description:
+          'If true, compute and return the unified diff without writing any files. ' +
+          'Default: false.',
+      },
+    },
+    required: ['changes'],
+  },
+};

--- a/src/agent/tools/schemas.test.ts
+++ b/src/agent/tools/schemas.test.ts
@@ -41,6 +41,7 @@ describe('builtinToolSchemas', () => {
       'browser_act',
       'browser_screenshot',
       'browser_close',
+      'patch_apply',
     ]);
   });
 

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -10,7 +10,7 @@
 
 import type { AnthropicToolDef } from './types.js';
 import { readWitnessTool, searchWitnessTool } from './schemas.witness.js';
-import { cancelBackgroundJobTool } from './schemas.orchestration.js';
+import { cancelBackgroundJobTool, patchApplyTool } from './schemas.orchestration.js';
 import { waitForTool } from './schemas.wait-for.js';
 export { waitForTool } from './schemas.wait-for.js';
 
@@ -1340,7 +1340,7 @@ export const builtinToolSchemas: readonly AnthropicToolDef[] = [
   browserObserveTool,
   browserActTool,
   browserScreenshotTool,
-  browserCloseTool,
+  browserCloseTool, patchApplyTool,
 ];
 
 /** Tool names in the always-on built-in set. */


### PR DESCRIPTION
# feat(tools): `patch_apply` — atomic multi-file patch with dry-run

## What it does

`patch_apply` is a new built-in tool that validates and atomically applies structured multi-file changes. Unlike `edit_file` (one file, one replacement per call), `patch_apply` accepts an array of changes spanning multiple files and applies them together — or rejects the whole batch if any file fails validation.

**Input shape:**
```json
{
  "changes": [
    {
      "path": "src/foo.ts",
      "expected_hash": "sha256:<hex>",
      "edits": [{ "old": "exact string to replace", "new": "replacement" }]
    },
    {
      "path": "src/bar.ts",
      "content": "full replacement content"
    }
  ],
  "dry_run": false
}
```

Each file change can use either `edits` (sequential exact-match replacements) or `content` (full replacement) — never both.

## Implementation

Three new source files (under the 350-LOC ceiling each) plus a schema file:

| File | Role |
|------|------|
| `patch-validate.ts` | Per-file validation (containment, denylist, hash, edit uniqueness) — collects ALL errors before returning |
| `patch-apply-engine.ts` | Compute new content, diff, and write atomically via temp-file + rename |
| `patch-apply.ts` | `ToolHandler` wrapper — parses input, calls validate → apply |
| `schemas.patch-apply.ts` | Schema definition (extracted to keep `schemas.ts` under baseline) |

## Validate-then-apply pattern

1. **Validate all files first** — path containment (via write roots), write denylist, optional SHA-256 hash match, and edit exact-match-once enforcement. All errors across all files are collected before returning.
2. **Apply atomically** — each file is written to a `.patch-tmp-<random>` temp file in the same directory, then renamed to the target. On any rename failure, previously-renamed files are restored from the in-memory pre-validation snapshot.

## Dry-run behavior

When `dry_run: true`, the tool computes the unified diff for all changes and returns it without touching the filesystem.

## Hash verification

`expected_hash: "sha256:<hex>"` verifies the file's current SHA-256 before applying any changes. If the hash doesn't match, the entire patch is rejected.

## Tests

31 tests across three test files — all passing.

## Acceptance criteria

- [x] `patch_apply` tool registered in `builtinToolSchemas` and handler map
- [x] Path containment via `resolveAndContain` (write mode) on every file
- [x] Write denylist checked on every file via `assertNotDenylisted`
- [x] Hash format `sha256:<hex>` verified before any edit
- [x] Edit `old` must match exactly once (per-file, sequential)
- [x] `edits` and `content` mutually exclusive
- [x] All validation errors collected (not short-circuited)
- [x] Dry-run returns unified diff without writing
- [x] Atomic apply via temp-file + rename
- [x] Best-effort rollback on partial failure
- [x] All 31 tests pass
- [x] `pnpm lint` clean
- [x] `pnpm audit:filesize:check` — no new violations

Closes #1419
