### PR TITLE
fix: lazy-load playwright to fix Next.js standalone import

### DIFF
--- a/src/browser/playwright/launcher.ts
+++ b/src/browser/playwright/launcher.ts
@@ -15,8 +15,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { randomBytes } from 'node:crypto';
-import { chromium } from 'playwright';
 import type { Browser, BrowserContext, Dialog, Page, Request, Response } from 'playwright';
+import type { BrowserType } from 'playwright';
 import type { BrowserConfig } from '../types.js';
 import { decoratePlaywrightLaunchError } from '../playwright-missing.js';
 import { getBrowserStorageStatePath } from '../../paths.js';
@@ -213,20 +213,38 @@ export class BrowserLauncher {
       return this.launchPromise;
     }
 
-    this.launchPromise = chromium
-      .launch({ headless: this.config.headless })
-      .then((b) => {
-        this.browser = b;
+    // Invariant: load playwright LAZILY, not at module top-level. The package
+    // loads `browsers.json` via a dynamic filesystem read at init time, which
+    // Next.js standalone file tracers (@vercel/nft) miss — producing an
+    // incomplete copy that throws MODULE_NOT_FOUND on import (issue #1428). A
+    // top-level `import { chromium } from 'playwright'` would force every
+    // `import('agent-afk')` consumer to pay that init cost even when browser
+    // tools are never used. Importing here confines the resolution to the
+    // first browser launch and lets a missing package flow through the same
+    // decoratePlaywrightLaunchError + latch path as a missing binary.
+    this.launchPromise = (async (): Promise<Browser> => {
+      let chromium: BrowserType;
+      try {
+        ({ chromium } = await import('playwright'));
+      } catch (err: unknown) {
+        // Import failure (package absent) — decorate + latch the same way a
+        // launch failure would, so the fast-fail path carries the install hint.
+        const decorated = decoratePlaywrightLaunchError(err, this.config.headless, true);
+        this.latchLaunchFailure(decorated);
         this.launchPromise = undefined;
+        throw decorated;
+      }
+
+      try {
+        const b = await chromium.launch({ headless: this.config.headless });
+        this.browser = b;
         // A success must never leave a latch behind. Nothing can set one while
         // this launch is in flight (the latch short-circuits before we get
         // here), but clearing unconditionally keeps "browser live ⇒ no latch"
         // true by construction rather than by argument.
         this.clearLaunchFailure();
         return b;
-      })
-      .catch((err: unknown) => {
-        this.launchPromise = undefined;
+      } catch (err: unknown) {
         // Headed and headless need DIFFERENT chromium downloads, and only this
         // frame knows which one was requested — a handler catch sees just a
         // string. Passing it through lets the hint name the missing artifact.
@@ -239,7 +257,10 @@ export class BrowserLauncher {
         // carry the same install remediation as this first failure.
         this.latchLaunchFailure(decorated);
         throw decorated;
-      });
+      } finally {
+        this.launchPromise = undefined;
+      }
+    })();
 
     return this.launchPromise;
   }


### PR DESCRIPTION
## Summary

Fixes #1428 — `agent-afk` fails to import in Next.js standalone builds (`output: "standalone"`) because `playwright-core` loads `browsers.json` via a dynamic filesystem read that the standalone file tracer (`@vercel/nft`) misses.

## Root cause

The static `import { chromium } from 'playwright'` at the top of `src/browser/playwright/launcher.ts` forced `playwright-core` to initialize at module parse time, reading `browsers.json` via `fs.readFileSync`. Next.js standalone tracing copies only statically-referenced files, so `browsers.json` was missing from the standalone output, causing `MODULE_NOT_FOUND` on import.

## Fix

Replace the static import with a dynamic `await import('playwright')` inside `ensureBrowser()` — the method that actually launches chromium. This matches the lazy-import pattern already used by `registry.ts` and `scrape.ts` for the same module.

Key properties preserved:
- **Latch invariant intact.** Import failures (package absent) flow through the same `decoratePlaywrightLaunchError` + latch path as chromium-binary-missing failures. The fast-fail path still carries the decorated install hint.
- **Type imports unchanged.** `import type { Browser, ... }` stays static — erased at compile time, zero runtime cost.
- **No dependency category change.** `playwright` stays in `dependencies`. Moving to `optionalDependencies` is a separate contract decision with a wider blast radius (tracked separately).

## What this doesn't change

- `package.json` — `playwright` remains a hard dependency. A future PR may move it to `optionalDependencies` with proper migration guidance.
- Consumer-side config — Next.js consumers who also want to exclude `playwright` from tracing entirely can still add it to `serverExternalPackages`, but this fix makes that unnecessary.

## Verification

- `pnpm lint` — clean
- `pnpm test:file src/browser/` — 330/330 tests pass (11 test files across the entire browser subsystem)
- `pnpm audit:filesize:check` — `launcher.ts` under ceiling
- `pnpm audit:module-state:check` — no duplicated module state
