### PR TITLE
feat: wave 1 parallel issues — #1402, #1404, #1407, #1431, #1433

### DIFF
--- a/src/agent/daemon/lease-store.test.ts
+++ b/src/agent/daemon/lease-store.test.ts
@@ -377,8 +377,8 @@ describe('leaseTask — retry state carry-through (P2 fix)', () => {
   });
 });
 
-describe('leaseTask — unlinkSync error propagates (P2 fix)', () => {
-  it('throws when srcPath does not exist (no silent swallow)', () => {
+describe('leaseTask — multi-process safety (rename-as-claim)', () => {
+  it('throws when srcPath does not exist (atomic claim via rename guards double-dequeue)', () => {
     const queueDir = tmpQueueDir();
     const task: import('./queue-store.js').QueuedTask = {
       id: 'ghost-id',
@@ -386,8 +386,59 @@ describe('leaseTask — unlinkSync error propagates (P2 fix)', () => {
       enqueuedAt: new Date().toISOString(),
       sequence: 1,
     };
-    // srcPath does not exist — unlinkSync will throw ENOENT.
+    // srcPath does not exist — renameSync(srcPath → dest) throws ENOENT,
+    // which is the signal that another process already claimed this task.
     const ghostPath = require('node:path').join(queueDir, '0001-ghost-id.json');
     expect(() => leaseTask(task, ghostPath, undefined, queueDir)).toThrow();
+  });
+
+  it('second leaseTask on same srcPath throws (rename is single-winner)', () => {
+    // Simulate two processes racing to lease the same queue file.
+    // The first call succeeds; the second gets ENOENT from renameSync.
+    const queueDir = tmpQueueDir();
+    const { task, srcPath } = makeTask(queueDir);
+
+    // First caller wins — succeeds.
+    expect(() => leaseTask(task, srcPath, undefined, queueDir)).not.toThrow();
+
+    // Second caller loses — srcPath is gone; must throw, not silently skip.
+    expect(() => leaseTask(task, srcPath, undefined, queueDir)).toThrow();
+  });
+});
+
+describe('recoverExpiredLeases — multi-process safety (claim-rename)', () => {
+  it('concurrent recoverExpiredLeases on the same expired lease produces exactly one re-enqueue', () => {
+    // This test verifies that the rename-based claim prevents double-enqueue
+    // when two daemon processes run recoverExpiredLeases concurrently.
+    // We simulate concurrency by running two sequential calls on a queue
+    // where the first call has already claimed the lease file (the file is
+    // gone from leased/ after the first call).
+    const queueDir = tmpQueueDir();
+    const { task, srcPath } = makeTask(queueDir);
+    leaseTask(task, srcPath, undefined, queueDir);
+
+    // Expire the lease and set maxAttempts=2 so recovery re-enqueues.
+    const leasedPath = join(queueDir, 'leased', `${task.id}.json`);
+    const record = JSON.parse(readFileSync(leasedPath, 'utf-8'));
+    record.leaseExpiry = Date.now() - 1;
+    record.maxAttempts = 2;
+    writeFileSync(leasedPath, JSON.stringify(record));
+
+    // First call: claims and re-enqueues.
+    const first = recoverExpiredLeases(queueDir);
+    expect(first).toHaveLength(1);
+    expect(first[0]!.state).toBe('retrying');
+
+    // Second call: lease file is gone (claimed by first call); should produce
+    // zero recoveries — NOT a second re-enqueue for the same task.
+    const second = recoverExpiredLeases(queueDir);
+    expect(second).toHaveLength(0);
+
+    // Exactly one queue file must exist.
+    const fs = require('node:fs');
+    const queueFiles = fs.readdirSync(queueDir).filter(
+      (f: string) => f.endsWith('.json') && !f.startsWith('.tmp-'),
+    );
+    expect(queueFiles).toHaveLength(1);
   });
 });

--- a/src/agent/daemon/lease-store.test.ts
+++ b/src/agent/daemon/lease-store.test.ts
@@ -406,6 +406,95 @@ describe('leaseTask — multi-process safety (rename-as-claim)', () => {
   });
 });
 
+describe('recoverExpiredLeases — stale .claim-* file recovery (second pass)', () => {
+  it('recovers a stale .claim-* file left by an interrupted prior recovery', () => {
+    const queueDir = tmpQueueDir();
+    const leasedDir = join(queueDir, 'leased');
+    mkdirSync(leasedDir, { recursive: true });
+
+    // Simulate a crash-interrupted recovery: a .claim-<hex>.json file sits in
+    // leased/ with a valid expired TaskRecord — left behind because the prior
+    // recovery process crashed after renaming but before re-enqueueing.
+    const record = {
+      id: 'q-stale-claim-test',
+      command: '/stale-cmd',
+      state: 'leased',
+      attempts: 1,
+      maxAttempts: 2,
+      leaseExpiry: Date.now() - 60_000,
+      createdAt: Date.now() - 120_000,
+      updatedAt: Date.now() - 60_000,
+    };
+    const claimFile = join(leasedDir, '.claim-deadbeef.json');
+    writeFileSync(claimFile, JSON.stringify(record));
+
+    const recovered = recoverExpiredLeases(queueDir);
+    expect(recovered).toHaveLength(1);
+    expect(recovered[0]!.id).toBe('q-stale-claim-test');
+    expect(recovered[0]!.state).toBe('retrying');
+
+    // The claim file must be gone.
+    expect(existsSync(claimFile)).toBe(false);
+
+    // Exactly one re-enqueued file in the queue dir.
+    const fs = require('node:fs');
+    const queueFiles = fs.readdirSync(queueDir).filter(
+      (f: string) => f.endsWith('.json') && !f.startsWith('.tmp-'),
+    );
+    expect(queueFiles).toHaveLength(1);
+  });
+
+  it('removes a corrupt .claim-* file without crashing', () => {
+    const queueDir = tmpQueueDir();
+    const leasedDir = join(queueDir, 'leased');
+    mkdirSync(leasedDir, { recursive: true });
+
+    const claimFile = join(leasedDir, '.claim-corrupt01.json');
+    writeFileSync(claimFile, 'NOT VALID JSON!!!');
+
+    // Must not throw and must produce zero recoveries.
+    const recovered = recoverExpiredLeases(queueDir);
+    expect(recovered).toHaveLength(0);
+
+    // The corrupt file should be cleaned up.
+    expect(existsSync(claimFile)).toBe(false);
+  });
+
+  it('concurrent second-pass recovery on the same .claim-* file produces exactly one re-enqueue', () => {
+    // Simulates the race: two sequential calls where the first claims the
+    // .claim-* file via rename; the second should find it gone and skip.
+    const queueDir = tmpQueueDir();
+    const leasedDir = join(queueDir, 'leased');
+    mkdirSync(leasedDir, { recursive: true });
+
+    const record = {
+      id: 'q-race-claim-test',
+      command: '/race-cmd',
+      state: 'leased',
+      attempts: 1,
+      maxAttempts: 2,
+      leaseExpiry: Date.now() - 60_000,
+      createdAt: Date.now() - 120_000,
+      updatedAt: Date.now() - 60_000,
+    };
+    writeFileSync(join(leasedDir, '.claim-racetest1.json'), JSON.stringify(record));
+
+    const first = recoverExpiredLeases(queueDir);
+    expect(first).toHaveLength(1);
+
+    // Second call: .claim-* file is gone (renamed by first call).
+    const second = recoverExpiredLeases(queueDir);
+    expect(second).toHaveLength(0);
+
+    // Exactly one queue file.
+    const fs = require('node:fs');
+    const queueFiles = fs.readdirSync(queueDir).filter(
+      (f: string) => f.endsWith('.json') && !f.startsWith('.tmp-'),
+    );
+    expect(queueFiles).toHaveLength(1);
+  });
+});
+
 describe('recoverExpiredLeases — multi-process safety (claim-rename)', () => {
   it('concurrent recoverExpiredLeases on the same expired lease produces exactly one re-enqueue', () => {
     // This test verifies that the rename-based claim prevents double-enqueue

--- a/src/agent/daemon/lease-store.ts
+++ b/src/agent/daemon/lease-store.ts
@@ -169,8 +169,10 @@ export function leaseTask(
 
   // We are now the sole owner of leased/<id>.json.  Overwrite it with the
   // proper TaskRecord content.  A crash between the rename and this write
-  // leaves the file with stale QueuedTask JSON, which recoverExpiredLeases
-  // will parse successfully (all fields it needs are present) and recover.
+  // leaves the file with raw QueuedTask JSON (no leaseExpiry/attempts/
+  // maxAttempts).  recoverExpiredLeases detects this case (undefined fields)
+  // and reconstructs a valid TaskRecord so the task is re-enqueued rather
+  // than dead-lettered.
   atomicWriteJson(dest, record);
 
   return record;
@@ -311,34 +313,55 @@ export function recoverExpiredLeases(queueDir: string = getQueueDir()): TaskReco
   for (const filename of files) {
     const filePath = join(dir, filename);
 
-    // Invariant: claim the lease file via atomic rename BEFORE reading its
-    // content or acting on it.  If two processes race to recover the same
-    // expired lease, only the winner's rename succeeds; the loser gets ENOENT
-    // and skips.  This is the same single-winner primitive used in leaseTask.
-    // The claim file is a scratch name in the same directory so the rename is
-    // guaranteed to be on the same filesystem (no EXDEV).
+    // Read-before-claim: read the record first to check expiry before we
+    // rename.  This eliminates the TOCTOU window where a live lease gets
+    // claimed and then the rename-back fails silently, permanently removing
+    // the lease file from under the running task.
+    //   - If the read fails (corrupt / concurrent removal): skip this file.
+    //   - If leaseExpiry > now: not expired — leave it in place, no rename.
+    //   - If expired (or crash-window artifact): claim via atomic rename, then
+    //     recover.  Two processes racing on the same expired lease: only the
+    //     winner's rename succeeds; the loser gets ENOENT and skips — same
+    //     single-winner primitive used in leaseTask.
+    let record: TaskRecord;
+    try {
+      record = JSON.parse(readFileSync(filePath, 'utf-8')) as TaskRecord;
+    } catch {
+      // Unreadable (corrupt or concurrently removed) — skip.
+      continue;
+    }
+
+    // Crash-window artifact: if the process crashed between the rename (line
+    // ~168) and the atomicWriteJson overwrite (~174), the file contains raw
+    // QueuedTask JSON with no leaseExpiry, attempts, or maxAttempts.
+    // Without this guard: leaseExpiry ?? 0 → 0 (expired); attempts <
+    // maxAttempts → undefined < undefined → false → dead-lettered silently.
+    // Fix: reconstruct a minimal valid TaskRecord so the task is re-enqueued.
+    if (record.attempts === undefined || record.maxAttempts === undefined) {
+      record = {
+        ...record,
+        state: 'leased',
+        attempts: 0,
+        maxAttempts: 1,
+        leaseExpiry: 0, // treat as expired so recovery proceeds below
+        createdAt: record.createdAt ?? now,
+        updatedAt: now,
+      } as TaskRecord;
+    }
+
+    const expiry = record.leaseExpiry ?? 0;
+    if (expiry > now) {
+      // Lease is not expired — leave the file in place for the running task.
+      continue;
+    }
+
+    // Lease is expired (or crash-window artifact with leaseExpiry:0): claim
+    // it via atomic rename so concurrent recovery processes skip it.
     const claimPath = join(dir, `.claim-${randomBytes(4).toString('hex')}.json`);
     try {
       renameSync(filePath, claimPath);
     } catch {
       continue; // ENOENT: another process already claimed this file — skip.
-    }
-
-    let record: TaskRecord;
-    try {
-      record = JSON.parse(readFileSync(claimPath, 'utf-8')) as TaskRecord;
-    } catch {
-      // Claim file is unreadable (corrupt) — remove the scratch file and skip.
-      try { unlinkSync(claimPath); } catch { /* ignore */ }
-      continue;
-    }
-
-    const expiry = record.leaseExpiry ?? 0;
-    if (expiry > now) {
-      // Lease is not actually expired — rename it back so the running task
-      // keeps its lease file in the expected location.
-      try { renameSync(claimPath, filePath); } catch { /* ignore */ }
-      continue;
     }
 
     // Lease expired — recover.
@@ -360,6 +383,56 @@ export function recoverExpiredLeases(queueDir: string = getQueueDir()): TaskReco
     // Remove the claim scratch file now that recovery is complete.
     try { unlinkSync(claimPath); } catch { /* ignore */ }
     recovered.push(record);
+  }
+
+  // Second pass: recover stale .claim-* files left by an interrupted recovery
+  // run.  If recovery crashed after renaming a lease to .claim-*.json but
+  // before re-enqueueing or dead-lettering, the claim file is the only copy
+  // of the task.  Future recovery silently skips it (the main loop filters
+  // !f.startsWith('.claim-')), causing permanent task loss.  We handle them
+  // here so no task is ever permanently orphaned.
+  const claimFiles = readdirSync(dir).filter(
+    (f) => f.endsWith('.json') && f.startsWith('.claim-'),
+  );
+  for (const claimFilename of claimFiles) {
+    const claimFilePath = join(dir, claimFilename);
+    let claimRecord: TaskRecord;
+    try {
+      claimRecord = JSON.parse(readFileSync(claimFilePath, 'utf-8')) as TaskRecord;
+    } catch {
+      // Unreadable — remove and skip.
+      try { unlinkSync(claimFilePath); } catch { /* ignore */ }
+      continue;
+    }
+
+    // Apply same crash-window reconstruction as above.
+    if (claimRecord.attempts === undefined || claimRecord.maxAttempts === undefined) {
+      claimRecord = {
+        ...claimRecord,
+        state: 'leased',
+        attempts: 0,
+        maxAttempts: 1,
+        leaseExpiry: 0,
+        createdAt: claimRecord.createdAt ?? now,
+        updatedAt: now,
+      } as TaskRecord;
+    }
+
+    claimRecord.updatedAt = now;
+
+    if (claimRecord.attempts < claimRecord.maxAttempts) {
+      claimRecord.state = 'retrying';
+      reEnqueue(claimRecord, queueDir);
+    } else {
+      claimRecord.state = 'dead-letter';
+      claimRecord.lastError = claimRecord.lastError ?? 'lease expired';
+      delete claimRecord.leaseExpiry;
+      mkdirSync(deadLetterDir(queueDir), { recursive: true });
+      atomicWriteJson(deadLetterPath(queueDir, claimRecord.id), claimRecord);
+    }
+
+    try { unlinkSync(claimFilePath); } catch { /* ignore */ }
+    recovered.push(claimRecord);
   }
 
   return recovered;

--- a/src/agent/daemon/lease-store.ts
+++ b/src/agent/daemon/lease-store.ts
@@ -104,12 +104,26 @@ function atomicWriteJson(dest: string, data: unknown): void {
 /**
  * Create a TaskRecord from a QueuedTask and move the queue file to leased/.
  *
+ * Multi-process safety: the queue file is atomically claimed via
+ * `renameSync(srcPath → leased/<id>.json)` as the FIRST write operation.
+ * POSIX rename(2) is atomic on the same filesystem — when two processes race
+ * to lease the same task, the rename is the single-winner gate:
+ *   - The winner's rename succeeds; the queue file is gone from the FIFO.
+ *   - The loser's rename throws ENOENT (src is already gone); leaseTask
+ *     propagates that error so the caller knows it did NOT win the race.
+ * The lease record (TaskRecord JSON) is written AFTER the atomic claim so the
+ * file content reflects the winner's process ID / timestamp. This is safe:
+ * after the rename, the winner is the sole owner of leased/<id>.json and can
+ * overwrite it without a further race.
+ *
  * @param task       - The QueuedTask dequeued from queue-store.
  * @param srcPath    - Absolute path to the queue file (before deletion).
  *                     Caller must NOT have deleted it yet.
  * @param leaseTtlMs - Override the lease TTL (defaults to AFK_LEASE_TTL_MS or 10 min).
  * @param queueDir   - Queue root directory.
  * @returns The newly created TaskRecord in state 'leased'.
+ * @throws If srcPath does not exist (ENOENT) — signals that another process
+ *         already claimed this task and the caller must not proceed.
  */
 export function leaseTask(
   task: QueuedTask,
@@ -145,15 +159,19 @@ export function leaseTask(
 
   mkdirSync(leasedDir(queueDir), { recursive: true });
   const dest = leasedPath(queueDir, task.id);
-  atomicWriteJson(dest, record);
 
-  // Remove the source queue file now that the lease record is written.
-  // NOT best-effort: if unlink fails, the caller must know leasing did not
-  // complete cleanly — the original queue entry would remain intact and
-  // dequeueNext could process the same task again (double-fire).  The
-  // caller (dequeueNext) catches this error and falls back to a direct
-  // unlinkSync so the file is always removed before the task is returned.
-  unlinkSync(srcPath);
+  // Invariant: renameSync is the single-winner atomic claim for multi-process
+  // safety. It MUST execute before atomicWriteJson so that a concurrent
+  // process racing to lease the same task gets ENOENT here and aborts,
+  // rather than overwriting the winner's lease record after the fact.
+  // Do NOT reorder: write-then-rename loses the atomicity guarantee.
+  renameSync(srcPath, dest);
+
+  // We are now the sole owner of leased/<id>.json.  Overwrite it with the
+  // proper TaskRecord content.  A crash between the rename and this write
+  // leaves the file with stale QueuedTask JSON, which recoverExpiredLeases
+  // will parse successfully (all fields it needs are present) and recover.
+  atomicWriteJson(dest, record);
 
   return record;
 }
@@ -269,6 +287,14 @@ export function completeTask(
  *
  * Returns the list of recovered TaskRecords for logging.
  *
+ * Multi-process safety: before re-enqueueing or dead-lettering, the lease
+ * file is atomically claimed by renaming it to a `.claim-<random>.json`
+ * scratch file.  If two daemon processes run recoverExpiredLeases
+ * concurrently, both may enumerate the same expired file; but only the one
+ * whose `renameSync` succeeds actually owns the recovery — the loser gets
+ * ENOENT and skips that entry.  This prevents the double-enqueue that would
+ * otherwise occur when both processes call `reEnqueue` for the same task.
+ *
  * @param queueDir - Queue root directory.
  * @returns Array of TaskRecords that were processed (re-enqueued or dead-lettered).
  */
@@ -280,19 +306,40 @@ export function recoverExpiredLeases(queueDir: string = getQueueDir()): TaskReco
   const recovered: TaskRecord[] = [];
 
   const files = readdirSync(dir)
-    .filter((f) => f.endsWith('.json') && !f.startsWith('.tmp-'));
+    .filter((f) => f.endsWith('.json') && !f.startsWith('.tmp-') && !f.startsWith('.claim-'));
 
   for (const filename of files) {
     const filePath = join(dir, filename);
+
+    // Invariant: claim the lease file via atomic rename BEFORE reading its
+    // content or acting on it.  If two processes race to recover the same
+    // expired lease, only the winner's rename succeeds; the loser gets ENOENT
+    // and skips.  This is the same single-winner primitive used in leaseTask.
+    // The claim file is a scratch name in the same directory so the rename is
+    // guaranteed to be on the same filesystem (no EXDEV).
+    const claimPath = join(dir, `.claim-${randomBytes(4).toString('hex')}.json`);
+    try {
+      renameSync(filePath, claimPath);
+    } catch {
+      continue; // ENOENT: another process already claimed this file — skip.
+    }
+
     let record: TaskRecord;
     try {
-      record = JSON.parse(readFileSync(filePath, 'utf-8')) as TaskRecord;
+      record = JSON.parse(readFileSync(claimPath, 'utf-8')) as TaskRecord;
     } catch {
-      continue; // Unreadable — skip.
+      // Claim file is unreadable (corrupt) — remove the scratch file and skip.
+      try { unlinkSync(claimPath); } catch { /* ignore */ }
+      continue;
     }
 
     const expiry = record.leaseExpiry ?? 0;
-    if (expiry > now) continue; // Lease still valid.
+    if (expiry > now) {
+      // Lease is not actually expired — rename it back so the running task
+      // keeps its lease file in the expected location.
+      try { renameSync(claimPath, filePath); } catch { /* ignore */ }
+      continue;
+    }
 
     // Lease expired — recover.
     record.updatedAt = now;
@@ -310,8 +357,8 @@ export function recoverExpiredLeases(queueDir: string = getQueueDir()): TaskReco
       atomicWriteJson(deadLetterPath(queueDir, record.id), record);
     }
 
-    // Remove from leased/ regardless of outcome.
-    try { unlinkSync(filePath); } catch { /* ignore */ }
+    // Remove the claim scratch file now that recovery is complete.
+    try { unlinkSync(claimPath); } catch { /* ignore */ }
     recovered.push(record);
   }
 

--- a/src/agent/daemon/lease-store.ts
+++ b/src/agent/daemon/lease-store.ts
@@ -391,17 +391,34 @@ export function recoverExpiredLeases(queueDir: string = getQueueDir()): TaskReco
   // of the task.  Future recovery silently skips it (the main loop filters
   // !f.startsWith('.claim-')), causing permanent task loss.  We handle them
   // here so no task is ever permanently orphaned.
+  //
+  // Invariant: each .claim-* file is atomically claimed via renameSync to a
+  // .process-<random>.json scratch name before processing.  If two daemon
+  // processes run this loop concurrently, only the winner's rename succeeds;
+  // the loser gets ENOENT and skips — same single-winner primitive used in
+  // the first pass and in leaseTask.  Without this gate, both processes
+  // would read, re-enqueue, and produce a double-fire.
   const claimFiles = readdirSync(dir).filter(
     (f) => f.endsWith('.json') && f.startsWith('.claim-'),
   );
   for (const claimFilename of claimFiles) {
     const claimFilePath = join(dir, claimFilename);
+
+    // Atomic claim: rename to a process-private scratch name so concurrent
+    // recovery skips this file.  Same pattern as the first-pass claim.
+    const processPath = join(dir, `.process-${randomBytes(4).toString('hex')}.json`);
+    try {
+      renameSync(claimFilePath, processPath);
+    } catch {
+      continue; // ENOENT: another process already claimed this file — skip.
+    }
+
     let claimRecord: TaskRecord;
     try {
-      claimRecord = JSON.parse(readFileSync(claimFilePath, 'utf-8')) as TaskRecord;
+      claimRecord = JSON.parse(readFileSync(processPath, 'utf-8')) as TaskRecord;
     } catch {
-      // Unreadable — remove and skip.
-      try { unlinkSync(claimFilePath); } catch { /* ignore */ }
+      // Unreadable — remove the scratch file and skip.
+      try { unlinkSync(processPath); } catch { /* ignore */ }
       continue;
     }
 
@@ -431,7 +448,7 @@ export function recoverExpiredLeases(queueDir: string = getQueueDir()): TaskReco
       atomicWriteJson(deadLetterPath(queueDir, claimRecord.id), claimRecord);
     }
 
-    try { unlinkSync(claimFilePath); } catch { /* ignore */ }
+    try { unlinkSync(processPath); } catch { /* ignore */ }
     recovered.push(claimRecord);
   }
 
@@ -474,7 +491,7 @@ export function listActiveTasks(queueDir: string = getQueueDir()): TaskRecord[] 
   const dir = leasedDir(queueDir);
   if (!existsSync(dir)) return [];
   const result: TaskRecord[] = [];
-  for (const f of readdirSync(dir).filter((f) => f.endsWith('.json') && !f.startsWith('.tmp-'))) {
+  for (const f of readdirSync(dir).filter((f) => f.endsWith('.json') && !f.startsWith('.tmp-') && !f.startsWith('.claim-') && !f.startsWith('.process-'))) {
     try {
       result.push(JSON.parse(readFileSync(join(dir, f), 'utf-8')) as TaskRecord);
     } catch { /* skip corrupt */ }

--- a/src/agent/daemon/queue-store-poison-fallback.test.ts
+++ b/src/agent/daemon/queue-store-poison-fallback.test.ts
@@ -88,7 +88,7 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe('quarantinePoisonEntry — outer-catch fallback (branch 1: both renames fail)', () => {
-  it('unlinks the entry and unblocks the queue when both renameSync calls throw', () => {
+  it('unlinks the poison entry and does not return an unleased task', () => {
     // Arm: all renameSync calls throw EPERM (simulating a permission error that
     // blocks every rename attempt, including the timestamp-suffixed retry).
     renameSyncShouldThrow = true;
@@ -102,21 +102,57 @@ describe('quarantinePoisonEntry — outer-catch fallback (branch 1: both renames
       sequence: 2,
     }));
 
-    // dequeueNext must not throw even though rename fails.
-    // quarantinePoisonEntry falls back to unlinkSync (which succeeds — only
-    // renameSync is mocked to throw), removes the poison entry, then continues
-    // the loop and returns the valid task — all in a single call.
+    // With rename globally broken, dequeueNext quarantines the poison entry
+    // (via unlinkSync fallback) but cannot lease the valid task either —
+    // leaseTask also uses renameSync and will throw EPERM.  The H1 fix
+    // ensures dequeueNext does NOT return a task it failed to lease; it
+    // cleans up the queue file and continues.  Returns null because no task
+    // could be successfully leased.
     const result = dequeueNext(tmpDir);
+    expect(result).toBeNull();
 
-    // The valid task behind the poison entry was reached — queue unblocked.
-    expect(result).not.toBeNull();
-    expect(result!.command).toBe('echo hi');
-
-    // The FIFO path is now clear: both entries were consumed on the single call.
+    // Both entries were cleaned up: the poison entry by quarantine fallback,
+    // the valid entry by the lease-failure cleanup (non-ENOENT errors unlink
+    // the queue file to prevent deadlock).  The queue is empty.
     const remaining = realFs.readdirSync(tmpDir).filter(
       (f) => f.endsWith('.json') && !f.startsWith('.tmp-'),
     );
     expect(remaining).toHaveLength(0);
+  });
+
+  it('dequeues the valid task when only the poison entry rename fails', () => {
+    // Write a malformed entry followed by a valid task.
+    realFs.writeFileSync(join(tmpDir, '0001-q-poison.json'), 'not-json');
+    realFs.writeFileSync(join(tmpDir, '0002-q-valid.json'), JSON.stringify({
+      id: 'q-1-valid',
+      command: 'echo hi',
+      enqueuedAt: new Date().toISOString(),
+      sequence: 2,
+    }));
+
+    // Arm rename to fail only for the first call (poison quarantine attempt),
+    // then restore so leaseTask succeeds on the valid entry.
+    renameSyncShouldThrow = true;
+
+    // quarantinePoisonEntry falls back to unlinkSync for the poison entry,
+    // then the loop reaches the valid task.  leaseTask calls renameSync —
+    // it will also throw, so both entries are consumed this call.
+    // Re-enqueue the valid task and retry with rename working.
+    const result1 = dequeueNext(tmpDir);
+    expect(result1).toBeNull();
+
+    // Restore rename.  Re-enqueue the valid task for a clean dequeue.
+    renameSyncShouldThrow = false;
+    realFs.writeFileSync(join(tmpDir, '0002-q-valid.json'), JSON.stringify({
+      id: 'q-1-valid',
+      command: 'echo hi',
+      enqueuedAt: new Date().toISOString(),
+      sequence: 2,
+    }));
+
+    const result2 = dequeueNext(tmpDir);
+    expect(result2).not.toBeNull();
+    expect(result2!.command).toBe('echo hi');
   });
 
   it('does not throw even when both renames fail (outer-catch is never-throw)', () => {

--- a/src/agent/daemon/queue-store.ts
+++ b/src/agent/daemon/queue-store.ts
@@ -174,23 +174,28 @@ export function dequeueNext(queueDir: string = getQueueDir()): QueuedTask | null
       continue;
     }
     // ORDERING INVARIANT: acquire a durable lease BEFORE returning task.
-    // leaseTask moves the queue file to leased/ and writes a TaskRecord —
-    // the file is no longer in the queue dir after this call. On daemon
-    // restart, recoverExpiredLeases re-enqueues any orphaned lease files.
-    // See JSDoc above — do NOT move this after the return.
+    // leaseTask atomically claims the queue file via rename(filePath →
+    // leased/<id>.json) and then writes a TaskRecord over it — the file is
+    // no longer in the queue dir after this call.  The rename is the
+    // single-winner gate: if two daemon processes race, only the winner's
+    // rename succeeds; the loser gets ENOENT and leaseTask throws, so
+    // dequeueNext skips that task and moves to the next entry in `sorted`.
+    // On daemon restart, recoverExpiredLeases re-enqueues any orphaned
+    // lease files.  See JSDoc above — do NOT move this after the return.
     //
-    // FALLBACK: if leaseTask fails (e.g. renameSync unavailable in a
-    // permission-restricted environment), fall back to unlinkSync so the
-    // file is still removed from the queue and the task is returned.
-    // This preserves the pre-lease atomicity invariant: queue file is
-    // gone before the task is handed to the caller.
+    // FALLBACK: if leaseTask fails before the rename completes (e.g. the
+    // leased/ directory cannot be created due to a permission error), the
+    // queue file is still present at filePath and the fallback unlinkSync
+    // removes it.  If the rename succeeded but the TaskRecord overwrite
+    // failed, filePath is already gone (the rename moved it) so the
+    // fallback unlinkSync gets ENOENT and is silently ignored — the file is
+    // correctly claimed in leased/ and recoverExpiredLeases will recover it.
     try {
       _leaseTask(task, filePath, undefined, queueDir);
     } catch {
-      // Best-effort unlink so the queue file is cleared even when the
-      // lease record cannot be written.  A missing lease file means this
-      // task will NOT appear in recoverExpiredLeases, which is acceptable:
-      // the caller already has the task in hand and can process it.
+      // Best-effort unlink covers the case where leaseTask failed before
+      // or during the rename.  If the rename already completed (file moved
+      // to leased/), this unlink gets ENOENT — silently ignored.
       try { unlinkSync(filePath); } catch { /* ignore */ }
     }
     return task;

--- a/src/agent/daemon/queue-store.ts
+++ b/src/agent/daemon/queue-store.ts
@@ -24,6 +24,15 @@ import { leaseTask as _leaseTask, recoverExpiredLeases } from './lease-store.js'
 
 export { recoverExpiredLeases };
 
+/** Returns true if err is a Node.js ENOENT filesystem error. */
+function isEnoent(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    (err as NodeJS.ErrnoException).code === 'ENOENT'
+  );
+}
+
 export interface QueuedTask {
   /** Unique task identifier, e.g. `q-1716000000000-abc123`. */
   id: string;
@@ -183,20 +192,22 @@ export function dequeueNext(queueDir: string = getQueueDir()): QueuedTask | null
     // On daemon restart, recoverExpiredLeases re-enqueues any orphaned
     // lease files.  See JSDoc above — do NOT move this after the return.
     //
-    // FALLBACK: if leaseTask fails before the rename completes (e.g. the
-    // leased/ directory cannot be created due to a permission error), the
-    // queue file is still present at filePath and the fallback unlinkSync
-    // removes it.  If the rename succeeded but the TaskRecord overwrite
-    // failed, filePath is already gone (the rename moved it) so the
-    // fallback unlinkSync gets ENOENT and is silently ignored — the file is
-    // correctly claimed in leased/ and recoverExpiredLeases will recover it.
+    // ERROR HANDLING: on any leaseTask error the lease was NOT successfully
+    // acquired, so we must NOT return the task.  Two sub-cases:
+    //   ENOENT (race-loss): another process already claimed this file — skip.
+    //   Other errors: the queue file may still be present; best-effort
+    //   unlinkSync removes it so it does not block FIFO ordering.  Either
+    //   way, continue to the next entry instead of returning the task.
     try {
       _leaseTask(task, filePath, undefined, queueDir);
-    } catch {
-      // Best-effort unlink covers the case where leaseTask failed before
-      // or during the rename.  If the rename already completed (file moved
-      // to leased/), this unlink gets ENOENT — silently ignored.
-      try { unlinkSync(filePath); } catch { /* ignore */ }
+    } catch (err: unknown) {
+      // Race-loss (ENOENT): another process already claimed this file — skip.
+      // Other errors: the lease was not acquired; clean up the queue file
+      // (if it still exists) and skip to the next entry.
+      if (!isEnoent(err)) {
+        try { unlinkSync(filePath); } catch { /* ignore */ }
+      }
+      continue;
     }
     return task;
   }

--- a/src/agent/plan-mode-gate.test.ts
+++ b/src/agent/plan-mode-gate.test.ts
@@ -159,4 +159,46 @@ describe('createPlanModeGate', () => {
     const result = gate({ event: 'PreToolUse', toolName: 'write_file', input: {} });
     expect(result.decision).toBe('block');
   });
+
+  // test_run coverage guard (issue #1431)
+  it('blocks test_run with coverage=true in plan mode (writes artifact files)', () => {
+    const { gate } = makeGate('plan');
+    const result = gate({
+      event: 'PreToolUse',
+      toolName: 'test_run',
+      input: { coverage: true },
+    });
+    expect(result.decision).toBe('block');
+    expect(result.reason).toContain('coverage');
+  });
+
+  it('allows test_run without coverage in plan mode (read-only spawn)', () => {
+    const { gate } = makeGate('plan');
+    const result = gate({
+      event: 'PreToolUse',
+      toolName: 'test_run',
+      input: { file: 'src/foo.test.ts' },
+    });
+    expect(result.decision).toBeUndefined();
+  });
+
+  it('allows test_run with coverage=false in plan mode', () => {
+    const { gate } = makeGate('plan');
+    const result = gate({
+      event: 'PreToolUse',
+      toolName: 'test_run',
+      input: { coverage: false },
+    });
+    expect(result.decision).toBeUndefined();
+  });
+
+  it('allows test_run with coverage=true in default mode', () => {
+    const { gate } = makeGate('default');
+    const result = gate({
+      event: 'PreToolUse',
+      toolName: 'test_run',
+      input: { coverage: true },
+    });
+    expect(result.decision).toBeUndefined();
+  });
 });

--- a/src/agent/plan-mode-gate.ts
+++ b/src/agent/plan-mode-gate.ts
@@ -18,6 +18,11 @@
  *     the SAME best-effort classifier that gates read-only skill phases (the
  *     dispatcher's `readOnlyBash` path), so the mutation rules live in one place
  *     and the two consumers cannot drift apart.
+ *   - `test_run` — blocked when `coverage: true` is set; coverage writes artifact
+ *     files to disk (`coverage.out`, `lcov.info`, `/coverage/` directories) which
+ *     are a state mutation indistinguishable from a write_file call. Without
+ *     coverage, test_run is read-only: it spawns a child process and returns
+ *     structured results, with no filesystem side-effects.
  *
  * The bash check is an honesty guardrail, NOT a security boundary. Because bash
  * is Turing-complete, no classifier is exhaustive — obfuscated writes
@@ -74,6 +79,25 @@ export function createPlanModeGate(
           reason:
             `plan mode: worktree "${action}" is refused (mutates the worktree ` +
             `registry). Only action "list" is allowed in plan mode. Use /plan off to act.`,
+        };
+      }
+    }
+
+    // `test_run` is input-gated on the `coverage` flag: running tests without
+    // coverage is read-only (spawn + return structured output); with coverage,
+    // the runner writes artifact files to disk (coverage.out, lcov.info,
+    // /coverage/ directories). Block the disk-write path; allow plain test runs.
+    if (toolName === 'test_run') {
+      const hasCoverage =
+        typeof context.input === 'object' && context.input !== null
+          ? (context.input as Record<string, unknown>)['coverage'] === true
+          : false;
+      if (hasCoverage) {
+        return {
+          decision: 'block',
+          reason:
+            'plan mode: test_run with coverage=true is refused — coverage writes ' +
+            'artifact files to disk. Run without coverage, or use /plan off to act.',
         };
       }
     }

--- a/src/agent/tools/handlers/index.test.ts
+++ b/src/agent/tools/handlers/index.test.ts
@@ -5,7 +5,7 @@ import { BUILTIN_TOOL_NAMES } from '../schemas.js';
 describe('createBuiltinHandlers', () => {
   it('returns a Map with all built-in tools', () => {
     const handlers = createBuiltinHandlers();
-    expect(handlers.size).toBe(27);
+    expect(handlers.size).toBe(29);
   });
 
   it('has an entry for every tool in BUILTIN_TOOL_NAMES', () => {
@@ -27,7 +27,7 @@ describe('createBuiltinHandlers', () => {
     // when permissionMode is undefined but cwd is set. Ensure we get a
     // valid map back and bash is still callable.
     const handlers = createBuiltinHandlers(undefined, '/tmp');
-    expect(handlers.size).toBe(27);
+    expect(handlers.size).toBe(29);
     expect(typeof handlers.get('bash')).toBe('function');
     expect(typeof handlers.get('grep')).toBe('function');
     expect(typeof handlers.get('glob')).toBe('function');
@@ -35,7 +35,7 @@ describe('createBuiltinHandlers', () => {
 
   it('cwd parameter: builds handler set with both permissionMode and cwd', () => {
     const handlers = createBuiltinHandlers('default', '/tmp');
-    expect(handlers.size).toBe(27);
+    expect(handlers.size).toBe(29);
     expect(typeof handlers.get('bash')).toBe('function');
   });
 

--- a/src/agent/tools/schemas.test.ts
+++ b/src/agent/tools/schemas.test.ts
@@ -7,8 +7,8 @@ import {
 import { cancelBackgroundJobTool } from './schemas.orchestration.js';
 
 describe('builtinToolSchemas', () => {
-  it('contains exactly 28 tools', () => {
-    expect(builtinToolSchemas).toHaveLength(28);
+  it('contains exactly 30 tools', () => {
+    expect(builtinToolSchemas).toHaveLength(30);
   });
 
   it('exports the expected tool names', () => {
@@ -42,6 +42,7 @@ describe('builtinToolSchemas', () => {
       'browser_screenshot',
       'browser_close',
       'patch_apply',
+      'test_run',
     ]);
   });
 
@@ -63,6 +64,8 @@ describe('builtinToolSchemas', () => {
     //   `browser_observe`   — all 3 fields are optional knobs.
     //   `browser_screenshot`— `target` and `full_page` are both optional.
     //   `browser_close`     — no inputs at all.
+    //   `test_run`          — all 4 fields (file, name, timeout_ms, coverage)
+    //                         are optional; required is [].
     // All other built-ins have non-empty required arrays.
     const noRequired = new Set([
       'web_scrape',
@@ -71,6 +74,7 @@ describe('builtinToolSchemas', () => {
       'browser_observe',
       'browser_screenshot',
       'browser_close',
+      'test_run',
     ]);
     for (const tool of builtinToolSchemas) {
       expect(tool.input_schema.required).toBeDefined();

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -1341,7 +1341,6 @@ export const builtinToolSchemas: readonly AnthropicToolDef[] = [
   browserObserveTool,
   browserActTool,
   browserScreenshotTool,
-<<<<<<< HEAD
   browserCloseTool, patchApplyTool,
   testRunTool,
 ];

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { palette } from '../palette.js';
+import { healthCheckRows, healthCheckSummary } from '../render/status-panel.js';
 import { runDoctorChecks } from './doctor-checks.js';
 
 export function registerDoctorCommand(program: Command): void {
@@ -19,30 +19,12 @@ export function registerDoctorCommand(program: Command): void {
       if (options.format === 'json') {
         console.log(JSON.stringify({ checks, summary }, null, 2));
       } else {
-        checks.forEach((check) => {
-          let icon: string;
-          if (check.state === 'pass') {
-            icon = palette.success('✓');
-          } else if (check.state === 'warn') {
-            icon = palette.warning('⚠');
-          } else {
-            icon = palette.error('✗');
+        for (const check of checks) {
+          for (const line of healthCheckRows(check)) {
+            console.log(line);
           }
-
-          let line = `${icon} ${check.name}`;
-          if (check.detail) {
-            line += ` — ${check.detail}`;
-          }
-          console.log(line);
-
-          if (check.state === 'fail' && check.fix) {
-            console.log(`  Fix: ${check.fix}`);
-          }
-        });
-
-        console.log(
-          `\nSummary: ${summary.passed} passed, ${summary.warned} warned, ${summary.failed} failed`,
-        );
+        }
+        console.log('\n' + healthCheckSummary(checks));
       }
 
       process.exit(summary.failed > 0 ? 1 : 0);

--- a/src/cli/render/file-op-summary.test.ts
+++ b/src/cli/render/file-op-summary.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Tests for src/cli/render/file-op-summary.ts
+ */
+
+import { describe, it, expect } from 'vitest';
+import { stripAnsi } from '../display.js';
+import { fileOpSummary } from './file-op-summary.js';
+
+// ─── Empty spec ───────────────────────────────────────────────────────────────
+
+describe('fileOpSummary – empty spec', () => {
+  it('returns empty string when no counts are provided', () => {
+    expect(fileOpSummary({})).toBe('');
+  });
+
+  it('returns empty string when all counts are zero', () => {
+    expect(fileOpSummary({ filesRead: 0, filesWritten: 0, filesEdited: 0, filesDeleted: 0 })).toBe('');
+  });
+
+  it('returns empty string when all counts are explicitly zero', () => {
+    expect(fileOpSummary({ filesRead: 0 })).toBe('');
+  });
+});
+
+// ─── Read-only (analyzed) ─────────────────────────────────────────────────────
+
+describe('fileOpSummary – read-only operations', () => {
+  it('uses "analyzed" verb for a single file read', () => {
+    const out = stripAnsi(fileOpSummary({ filesRead: 1 }));
+    expect(out).toContain('analyzed');
+    expect(out).toContain('1 file');
+  });
+
+  it('uses "analyzed" verb for multiple files read', () => {
+    const out = stripAnsi(fileOpSummary({ filesRead: 7 }));
+    expect(out).toContain('analyzed');
+    expect(out).toContain('7 files');
+  });
+
+  it('uses singular "file" for exactly 1 read', () => {
+    const out = stripAnsi(fileOpSummary({ filesRead: 1 }));
+    // Should say "1 file" not "1 files"
+    expect(out).toMatch(/1 file(?!s)/);
+  });
+
+  it('uses plural "files" for >1 reads', () => {
+    const out = stripAnsi(fileOpSummary({ filesRead: 3 }));
+    expect(out).toContain('3 files');
+  });
+});
+
+// ─── Edits ────────────────────────────────────────────────────────────────────
+
+describe('fileOpSummary – edit operations', () => {
+  it('renders "1 edit" for a single edit', () => {
+    const out = stripAnsi(fileOpSummary({ filesEdited: 1 }));
+    expect(out).toMatch(/1 edit(?!s)/);
+  });
+
+  it('renders "N edits" for multiple edits', () => {
+    const out = stripAnsi(fileOpSummary({ filesEdited: 4 }));
+    expect(out).toContain('4 edits');
+  });
+
+  it('does not include "analyzed" when no reads occurred', () => {
+    const out = stripAnsi(fileOpSummary({ filesEdited: 2 }));
+    expect(out).not.toContain('analyzed');
+  });
+});
+
+// ─── Writes (created) ────────────────────────────────────────────────────────
+
+describe('fileOpSummary – write operations', () => {
+  it('renders "1 file created" for a single write', () => {
+    const out = stripAnsi(fileOpSummary({ filesWritten: 1 }));
+    expect(out).toContain('1 file created');
+  });
+
+  it('renders "N files created" for multiple writes', () => {
+    const out = stripAnsi(fileOpSummary({ filesWritten: 3 }));
+    expect(out).toContain('3 files created');
+  });
+});
+
+// ─── Deletes ─────────────────────────────────────────────────────────────────
+
+describe('fileOpSummary – delete operations', () => {
+  it('renders "1 file deleted" for a single delete', () => {
+    const out = stripAnsi(fileOpSummary({ filesDeleted: 1 }));
+    expect(out).toContain('1 file deleted');
+  });
+
+  it('renders "N files deleted" for multiple deletes', () => {
+    const out = stripAnsi(fileOpSummary({ filesDeleted: 5 }));
+    expect(out).toContain('5 files deleted');
+  });
+});
+
+// ─── Mixed operations ────────────────────────────────────────────────────────
+
+describe('fileOpSummary – mixed operations', () => {
+  it('includes "analyzed" prefix for reads when mutations also present', () => {
+    const out = stripAnsi(fileOpSummary({ filesRead: 4, filesEdited: 2 }));
+    expect(out).toContain('analyzed 4 files');
+    expect(out).toContain('2 edits');
+  });
+
+  it('joins segments with ", "', () => {
+    const out = stripAnsi(fileOpSummary({ filesRead: 3, filesEdited: 1, filesWritten: 2 }));
+    expect(out).toContain(', ');
+  });
+
+  it('combines all four operation types', () => {
+    const out = stripAnsi(
+      fileOpSummary({ filesRead: 6, filesEdited: 3, filesWritten: 1, filesDeleted: 2 }),
+    );
+    expect(out).toContain('analyzed 6 files');
+    expect(out).toContain('3 edits');
+    expect(out).toContain('1 file created');
+    expect(out).toContain('2 files deleted');
+  });
+
+  it('skips zero-count segments in a mixed spec', () => {
+    const out = stripAnsi(fileOpSummary({ filesRead: 0, filesEdited: 2, filesWritten: 0 }));
+    expect(out).not.toContain('analyzed');
+    expect(out).not.toContain('created');
+    expect(out).toContain('2 edits');
+  });
+
+  it('edits and creates with no reads — no "analyzed" prefix', () => {
+    const out = stripAnsi(fileOpSummary({ filesEdited: 1, filesWritten: 1 }));
+    expect(out).not.toContain('analyzed');
+    expect(out).toContain('1 edit');
+    expect(out).toContain('1 file created');
+  });
+
+  it('segment order: reads before edits before writes before deletes', () => {
+    const out = stripAnsi(
+      fileOpSummary({ filesDeleted: 1, filesWritten: 1, filesEdited: 1, filesRead: 1 }),
+    );
+    const readIdx    = out.indexOf('analyzed');
+    const editIdx    = out.indexOf('edit');
+    const createIdx  = out.indexOf('created');
+    const deleteIdx  = out.indexOf('deleted');
+    expect(readIdx).toBeLessThan(editIdx);
+    expect(editIdx).toBeLessThan(createIdx);
+    expect(createIdx).toBeLessThan(deleteIdx);
+  });
+});
+
+// ─── Styling ─────────────────────────────────────────────────────────────────
+
+describe('fileOpSummary – styling', () => {
+  it('returns an ANSI-styled string (non-empty) for a non-empty spec', () => {
+    const raw = fileOpSummary({ filesRead: 1 });
+    // The raw string contains ANSI codes (dim), so it is longer than the stripped version.
+    const stripped = stripAnsi(raw);
+    expect(stripped.length).toBeGreaterThan(0);
+    // In a real terminal ANSI codes would be present; we confirm the function
+    // wraps with palette (raw !== stripped when chalk is active, but chalk
+    // may be disabled in CI — we just check the content is correct).
+    expect(stripped).toContain('analyzed');
+  });
+
+  it('raw output is a string', () => {
+    expect(typeof fileOpSummary({ filesWritten: 2 })).toBe('string');
+  });
+});
+
+// ─── Width truncation ────────────────────────────────────────────────────────
+
+describe('fileOpSummary – width truncation', () => {
+  it('truncates output to fit a narrow width', () => {
+    const wide = fileOpSummary({ filesRead: 100, filesEdited: 50, filesWritten: 25, filesDeleted: 10 });
+    const narrow = fileOpSummary(
+      { filesRead: 100, filesEdited: 50, filesWritten: 25, filesDeleted: 10, width: 30 },
+    );
+    // Both should be non-empty strings
+    expect(narrow.length).toBeGreaterThan(0);
+    // The narrow output (stripped) should be shorter than the wide output
+    expect(stripAnsi(narrow).length).toBeLessThanOrEqual(stripAnsi(wide).length);
+  });
+
+  it('does not crash at width=1', () => {
+    expect(() =>
+      fileOpSummary({ filesRead: 5, filesEdited: 3, width: 1 }),
+    ).not.toThrow();
+  });
+
+  it('does not crash at width=0', () => {
+    expect(() =>
+      fileOpSummary({ filesRead: 2, width: 0 }),
+    ).not.toThrow();
+  });
+});
+
+// ─── Defensive / edge cases ──────────────────────────────────────────────────
+
+describe('fileOpSummary – edge cases', () => {
+  it('handles very large counts without crashing', () => {
+    expect(() =>
+      fileOpSummary({ filesRead: 1_000_000, filesEdited: 999_999 }),
+    ).not.toThrow();
+  });
+
+  it('returns non-empty for exactly 1 of each operation', () => {
+    const out = stripAnsi(
+      fileOpSummary({ filesRead: 1, filesEdited: 1, filesWritten: 1, filesDeleted: 1 }),
+    );
+    expect(out.length).toBeGreaterThan(0);
+  });
+
+  it('returns empty string for a spec with all undefined', () => {
+    expect(fileOpSummary({ width: 80 })).toBe('');
+  });
+});

--- a/src/cli/render/file-op-summary.ts
+++ b/src/cli/render/file-op-summary.ts
@@ -1,0 +1,148 @@
+/**
+ * FileOpSummary — compact aggregate file-operation summary line.
+ *
+ * Renders a single collapsed summary of file operations that completed in
+ * a turn, mirroring Claude Code's "Analyzed N files, edited M files" style.
+ * Used as a compact substitute for per-call tool cards when multiple file
+ * operations complete together and vertical space is at a premium.
+ *
+ * Design:
+ *   - Pure function (spec → string), no I/O, no side effects.
+ *   - Palette-only coloring (never raw chalk).
+ *   - Width-aware: truncates gracefully at narrow terminal budgets.
+ *   - Returns `''` when the spec is empty (all counts zero/absent) so callers
+ *     can safely drop the output without a visibility check.
+ */
+
+import { palette } from '../palette.js';
+import { displayWidth, truncateDisplayWidth } from '../display.js';
+
+// ─── Public types ─────────────────────────────────────────────────────────────
+
+/**
+ * Input spec for {@link fileOpSummary}.
+ *
+ * All count fields are optional; absent or `0` values are silently omitted
+ * from the rendered line. A spec with all counts absent/zero returns `''`.
+ */
+export interface FileOpSummarySpec {
+  /**
+   * Number of files read (via `read_file`, `list_directory`, `glob`, `grep`).
+   * Omitted or `0` → read segment skipped.
+   */
+  filesRead?: number;
+  /**
+   * Number of files written (via `write_file`).
+   * Omitted or `0` → write segment skipped.
+   */
+  filesWritten?: number;
+  /**
+   * Number of files edited (via `edit_file`).
+   * Omitted or `0` → edit segment skipped.
+   */
+  filesEdited?: number;
+  /**
+   * Number of files deleted (via destructive shell ops or explicit deletes).
+   * Omitted or `0` → delete segment skipped.
+   */
+  filesDeleted?: number;
+  /**
+   * Terminal column width used for truncation.
+   * Defaults to 80. The component never reads `process.stdout.columns` so it
+   * stays a pure spec → string transform.
+   */
+  width?: number;
+}
+
+// ─── Segment builders ────────────────────────────────────────────────────────
+
+/**
+ * Format a count + noun segment, pluralizing the noun when count > 1.
+ *
+ * Invariant: callers guard count > 0 before calling so count is always ≥ 1.
+ */
+function segment(count: number, singular: string, plural: string): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Render a compact single-line aggregate file-operation summary.
+ *
+ * Visual output examples:
+ *   analyzed 4 files, edited 2 files, created 1 file
+ *   analyzed 12 files
+ *   edited 3 files, created 1 file, deleted 1 file
+ *
+ * The output is dim-styled (low visual weight) so it recedes relative to the
+ * assistant's prose and the result is self-describing without dominating the
+ * scrollback region.
+ *
+ * Returns `''` when the spec is empty so callers can omit the line cleanly:
+ * ```ts
+ * const summary = fileOpSummary({ filesRead: 0 });
+ * // summary === '' — nothing to write
+ * ```
+ *
+ * Pure function — no side effects.
+ *
+ * @param spec - File operation counts and rendering options.
+ * @returns Single-line ANSI string, or `''` when all counts are absent/zero.
+ */
+export function fileOpSummary(spec: FileOpSummarySpec): string {
+  const width = Math.max(1, spec.width ?? 80);
+
+  const read    = spec.filesRead    ?? 0;
+  const written = spec.filesWritten ?? 0;
+  const edited  = spec.filesEdited  ?? 0;
+  const deleted = spec.filesDeleted ?? 0;
+
+  // Early exit when nothing to summarize.
+  if (read === 0 && edited === 0 && written === 0 && deleted === 0) return '';
+
+  // Build the full label with operation verbs.
+  // "analyzed N files" for reads; plain counts for mutations so the line
+  // reads naturally ("3 edits, 2 files created" not "created 2 files").
+  const label = buildLabel(read, edited, written, deleted);
+
+  return palette.dim(truncateDisplayWidth(label, Math.max(1, width - displayWidth('  '))));
+}
+
+// ─── Label builder ────────────────────────────────────────────────────────────
+
+/**
+ * Compose the natural-language summary from the operation counts.
+ *
+ * Reads use an "analyzed" verb prefix to match Claude Code phrasing;
+ * mutations use plain noun phrases joined by commas.
+ *
+ * Contract: at least one count > 0; the return is always a non-empty string.
+ */
+function buildLabel(
+  read: number,
+  edited: number,
+  written: number,
+  deleted: number,
+): string {
+  // When only reads occurred, use the "analyzed" verb form ("analyzed 4 files").
+  // When mutations are present, use a flat join ("3 edits, 2 files created").
+  // When both reads and mutations are present, prefix the read count with
+  // "analyzed" and append the mutations: "analyzed 4 files, 2 edits".
+  const hasMutation = edited > 0 || written > 0 || deleted > 0;
+
+  if (!hasMutation) {
+    // Pure-read case: "analyzed N file(s)"
+    return `analyzed ${segment(read, 'file', 'files')}`;
+  }
+
+  // Mutation case: rebuild with verb prefix on the read segment.
+  const segments: string[] = [];
+
+  if (read    > 0) segments.push(`analyzed ${segment(read, 'file', 'files')}`);
+  if (edited  > 0) segments.push(segment(edited,  'edit',          'edits'));
+  if (written > 0) segments.push(segment(written, 'file created',  'files created'));
+  if (deleted > 0) segments.push(segment(deleted, 'file deleted',  'files deleted'));
+
+  return segments.join(', ');
+}

--- a/src/cli/render/index.ts
+++ b/src/cli/render/index.ts
@@ -28,3 +28,4 @@ export * from './preview-diff.js';
 export * from './context-bar.js';
 export * from './context-sparkline.js';
 export * from './session-summary.js';
+export * from './file-op-summary.js';

--- a/src/cli/render/status-panel.ts
+++ b/src/cli/render/status-panel.ts
@@ -9,6 +9,72 @@ import { maxInnerBoxWidth, truncateDisplay } from './utils.js';
 /** Indicator kind controls the coloured dot shown next to a value. */
 export type StatusKind = 'ok' | 'warn' | 'error' | 'info';
 
+// ─── Health Check Rows ────────────────────────────────────────────────────────
+
+/**
+ * Structural interface for a health check result.
+ *
+ * Invariant: intentionally structurally compatible with the `Check` type in
+ * `src/cli/commands/doctor-checks.ts` — both doctor surfaces (CLI command and
+ * slash command) share this renderer without a hard dependency on that module.
+ */
+export interface HealthCheck {
+  name: string;
+  state: 'pass' | 'warn' | 'fail';
+  detail?: string;
+  fix?: string;
+}
+
+/**
+ * Render a single health-check result as 1–2 formatted lines.
+ *
+ * Line 1: `  <icon> <name>  — <detail>` (detail omitted when absent)
+ * Line 2: `      Fix: <fix>` (only when state is not pass AND fix is set)
+ *
+ * Invariant: palette calls are deferred to call time (not captured at import)
+ * for the same reason as `dot()` above — a `light` theme swap must not leave
+ * stale dark-theme colours on screen.
+ */
+export function healthCheckRows(check: HealthCheck): string[] {
+  let icon: string;
+  if (check.state === 'pass') {
+    icon = palette.success('✓');
+  } else if (check.state === 'warn') {
+    icon = palette.warning('⚠');
+  } else {
+    icon = palette.error('✗');
+  }
+
+  let line = `  ${icon} ${check.name}`;
+  if (check.detail) {
+    line += `  — ${palette.dim(check.detail)}`;
+  }
+
+  const lines = [line];
+  if (check.state !== 'pass' && check.fix) {
+    lines.push(palette.dim(`      Fix: ${check.fix}`));
+  }
+  return lines;
+}
+
+/**
+ * Render the passed / warned / failed tally for a set of health checks.
+ *
+ * Example: `  Summary: 5 passed  ·  1 warned  ·  2 failed`
+ */
+export function healthCheckSummary(checks: HealthCheck[]): string {
+  const passed = checks.filter((c) => c.state === 'pass').length;
+  const warned = checks.filter((c) => c.state === 'warn').length;
+  const failed = checks.filter((c) => c.state === 'fail').length;
+
+  const parts: string[] = [
+    palette.success(`${passed} passed`),
+    warned > 0 ? palette.warning(`${warned} warned`) : palette.dim(`${warned} warned`),
+    failed > 0 ? palette.error(`${failed} failed`) : palette.dim(`${failed} failed`),
+  ];
+  return `  Summary: ${parts.join(palette.dim('  ·  '))}`;
+}
+
 /**
  * Render the coloured indicator glyph for a status kind.
  *

--- a/src/cli/slash/commands/config-doctor.ts
+++ b/src/cli/slash/commands/config-doctor.ts
@@ -15,7 +15,7 @@
 
 import { env } from '../../../config/env.js';
 import { palette } from '../../palette.js';
-import { divider } from '../../render.js';
+import { divider, healthCheckRows, healthCheckSummary } from '../../render.js';
 import { providerForModel } from '../../../agent/providers/index.js';
 import { resolveCliPermissionMode, loadConfig } from '../../config.js';
 import { runDoctorChecks } from '../../commands/doctor-checks.js';
@@ -290,37 +290,13 @@ const doctorCmd: SlashCommand = {
     }
 
     for (const check of checks) {
-      let icon: string;
-      if (check.state === 'pass') {
-        icon = palette.success('✓');
-      } else if (check.state === 'warn') {
-        icon = palette.warning('⚠');
-      } else {
-        icon = palette.error('✗');
-      }
-
-      let line = `  ${icon} ${check.name}`;
-      if (check.detail) {
-        line += `  — ${palette.dim(check.detail)}`;
-      }
-      out.line(line);
-
-      if (check.state !== 'pass' && check.fix) {
-        out.line(palette.dim(`      Fix: ${check.fix}`));
+      for (const line of healthCheckRows(check)) {
+        out.line(line);
       }
     }
 
-    const passed = checks.filter((c) => c.state === 'pass').length;
-    const warned = checks.filter((c) => c.state === 'warn').length;
-    const failed = checks.filter((c) => c.state === 'fail').length;
-
     out.line();
-    const summaryParts: string[] = [
-      palette.success(`${passed} passed`),
-      warned > 0 ? palette.warning(`${warned} warned`) : palette.dim(`${warned} warned`),
-      failed > 0 ? palette.error(`${failed} failed`) : palette.dim(`${failed} failed`),
-    ];
-    out.line(`  Summary: ${summaryParts.join(palette.dim('  ·  '))}`);
+    out.line(healthCheckSummary(checks));
     out.line();
 
     return 'continue';


### PR DESCRIPTION
Wave 1 of the parallel issue triage -- five independent issues tackled simultaneously in isolated worktrees.

## Changes

### fix: remove stray conflict marker in schemas.ts
A `<<<<<<< HEAD` marker was accidentally committed in the v5.173.0 merge (`c9ce0d33`). No `=======`/`>>>>>>>` counterpart -- the content after it was already correct. One-line deletion.

### feat(tools): test_run plan-mode guard for coverage writes (#1431)
Adds a `test_run` case to `createPlanModeGate`. When `coverage: true` is set, the gate blocks (coverage writes artifact files to disk). Without coverage, test_run passes through as read-only. 4 new test cases.

### feat(render): add fileOpSummary component (#1402)
New `fileOpSummary(spec)` component in `src/cli/render/file-op-summary.ts` -- renders compact aggregate lines like "analyzed 4 files, 3 edits, 2 files created" in the Claude Code style. Pure function, palette-only coloring, width-aware truncation. 28 test cases.

### refactor(render): consolidate doctor/health-check with statusPanel (#1404)
Extracts `healthCheckRows()` and `healthCheckSummary()` into `status-panel.ts` so both doctor surfaces (CLI command and `/doctor` slash command) share the same rendering logic instead of duplicating ~40 lines of icon/tally code each.

### fix(daemon): address multi-process safety in lease-based dequeue (#1433)
Two concrete race conditions fixed in the lease-based task lifecycle:

1. **leaseTask double-dequeue**: Replaced write-then-unlink with atomic `renameSync` as the first operation. POSIX `rename(2)` is the single-winner gate -- loser gets ENOENT and skips.
2. **recoverExpiredLeases double-enqueue**: Claim expired lease files via rename to `.claim-<random>.json` before acting. Prevents two processes from both re-enqueueing the same expired task.

## Closes
- Closes #1402
- Closes #1404
- Closes #1407 (already fixed in 1d0894cb; closed as duplicate)
- Closes #1431
- Closes #1433

## Verification
- 114 tests across all changed files pass
- `pnpm lint` clean
- `pnpm audit:filesize:check` clean
