### PR TITLE
feat(daemon): wire computeBackoffMs into re-enqueue path (#1432)

### DIFF
--- a/src/agent/daemon/lease-store.test.ts
+++ b/src/agent/daemon/lease-store.test.ts
@@ -531,3 +531,143 @@ describe('recoverExpiredLeases — multi-process safety (claim-rename)', () => {
     expect(queueFiles).toHaveLength(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Backoff wiring tests (#1432)
+// ---------------------------------------------------------------------------
+
+describe('reEnqueue — backoff wiring via computeBackoffMs (#1432)', () => {
+  it('re-enqueued task from completeTask carries eligibleAfter > now (fixed backoff)', () => {
+    const queueDir = tmpQueueDir();
+    const { task, srcPath } = makeTask(queueDir);
+    leaseTask(task, srcPath, undefined, queueDir);
+
+    // Patch lease to allow retry and set a 30s fixed backoff.
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const leasedFilePath = path.join(queueDir, 'leased', `${task.id}.json`);
+    const record = JSON.parse(fs.readFileSync(leasedFilePath, 'utf-8'));
+    record.maxAttempts = 3;
+    record.backoffStrategy = 'fixed';
+    record.backoffBaseMs = 30_000;
+    fs.writeFileSync(leasedFilePath, JSON.stringify(record));
+
+    const before = Date.now();
+    completeTask(task.id, 'failed', 'transient', queueDir);
+
+    // Find the re-enqueued queue file.
+    const queueFiles = fs.readdirSync(queueDir).filter(
+      (f: string) => f.endsWith('.json') && !f.startsWith('.tmp-'),
+    );
+    expect(queueFiles.length).toBeGreaterThan(0);
+    const requeued = JSON.parse(fs.readFileSync(path.join(queueDir, queueFiles[0]), 'utf-8'));
+
+    // eligibleAfter must be set and >= before + 30_000ms.
+    expect(requeued.eligibleAfter).toBeDefined();
+    expect(requeued.eligibleAfter).toBeGreaterThanOrEqual(before + 30_000);
+  });
+
+  it('re-enqueued task from completeTask carries eligibleAfter using exponential backoff', () => {
+    const queueDir = tmpQueueDir();
+    const { task, srcPath } = makeTask(queueDir);
+    leaseTask(task, srcPath, undefined, queueDir);
+
+    // Patch lease to simulate second attempt (attempts=2) with exponential backoff.
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const leasedFilePath = path.join(queueDir, 'leased', `${task.id}.json`);
+    const record = JSON.parse(fs.readFileSync(leasedFilePath, 'utf-8'));
+    record.attempts = 2;  // second attempt already made
+    record.maxAttempts = 5;
+    record.backoffStrategy = 'exponential';
+    record.backoffBaseMs = 1_000;
+    fs.writeFileSync(leasedFilePath, JSON.stringify(record));
+
+    const before = Date.now();
+    completeTask(task.id, 'failed', 'transient', queueDir);
+
+    const queueFiles = fs.readdirSync(queueDir).filter(
+      (f: string) => f.endsWith('.json') && !f.startsWith('.tmp-'),
+    );
+    const requeued = JSON.parse(fs.readFileSync(path.join(queueDir, queueFiles[0]), 'utf-8'));
+
+    // For attempts=2, exponential: 1000 * 2^(2-1) = 2000ms
+    expect(requeued.eligibleAfter).toBeGreaterThanOrEqual(before + 2_000);
+  });
+
+  it('re-enqueued task from recoverExpiredLeases carries eligibleAfter', () => {
+    const queueDir = tmpQueueDir();
+    const { task, srcPath } = makeTask(queueDir);
+    leaseTask(task, srcPath, undefined, queueDir);
+
+    // Expire the lease and configure retry with 5s fixed backoff.
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const leasedFilePath = path.join(queueDir, 'leased', `${task.id}.json`);
+    const record = JSON.parse(fs.readFileSync(leasedFilePath, 'utf-8'));
+    record.leaseExpiry = Date.now() - 1;
+    record.maxAttempts = 3;
+    record.backoffStrategy = 'fixed';
+    record.backoffBaseMs = 5_000;
+    fs.writeFileSync(leasedFilePath, JSON.stringify(record));
+
+    const before = Date.now();
+    recoverExpiredLeases(queueDir);
+
+    // Find the re-enqueued queue file.
+    const queueFiles = fs.readdirSync(queueDir).filter(
+      (f: string) => f.endsWith('.json') && !f.startsWith('.tmp-'),
+    );
+    expect(queueFiles.length).toBeGreaterThan(0);
+    const requeued = JSON.parse(fs.readFileSync(path.join(queueDir, queueFiles[0]), 'utf-8'));
+
+    expect(requeued.eligibleAfter).toBeDefined();
+    expect(requeued.eligibleAfter).toBeGreaterThanOrEqual(before + 5_000);
+  });
+
+  it('dequeueNext skips a re-enqueued task during its backoff window', () => {
+    const queueDir = tmpQueueDir();
+    const { task, srcPath } = makeTask(queueDir);
+    leaseTask(task, srcPath, undefined, queueDir);
+
+    // Re-enqueue with a far-future eligibleAfter (simulating a long backoff).
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const leasedFilePath = path.join(queueDir, 'leased', `${task.id}.json`);
+    const record = JSON.parse(fs.readFileSync(leasedFilePath, 'utf-8'));
+    record.maxAttempts = 3;
+    record.backoffStrategy = 'fixed';
+    record.backoffBaseMs = 60_000; // 60s — will not elapse during this test
+    fs.writeFileSync(leasedFilePath, JSON.stringify(record));
+
+    completeTask(task.id, 'failed', 'transient', queueDir);
+
+    // The re-enqueued task must NOT be returned by dequeueNext (backoff active).
+    const dequeued = dequeueNext(queueDir);
+    expect(dequeued).toBeNull();
+  });
+
+  it('dequeueNext returns a re-enqueued task once its eligibleAfter has passed', () => {
+    const queueDir = tmpQueueDir();
+
+    // Write a queue file directly with an eligibleAfter already in the past.
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const pastTask = {
+      id: 'q-backoff-past-test',
+      command: '/past-test',
+      enqueuedAt: new Date().toISOString(),
+      sequence: 1,
+      attempts: 1,
+      maxAttempts: 3,
+      backoffStrategy: 'fixed',
+      backoffBaseMs: 30_000,
+      eligibleAfter: Date.now() - 1, // already past — immediately dequeue-able
+    };
+    fs.writeFileSync(path.join(queueDir, '0001-q-backoff-past-test.json'), JSON.stringify(pastTask));
+
+    const dequeued = dequeueNext(queueDir);
+    expect(dequeued).not.toBeNull();
+    expect(dequeued?.id).toBe('q-backoff-past-test');
+  });
+});

--- a/src/agent/daemon/lease-store.ts
+++ b/src/agent/daemon/lease-store.ts
@@ -35,6 +35,7 @@ import {
   type TaskRecord,
   type TaskState,
   DEFAULT_LEASE_TTL_MS,
+  computeBackoffMs,
 } from './task-lifecycle.js';
 
 // ---------------------------------------------------------------------------
@@ -519,6 +520,10 @@ function buildFallbackRecord(taskId: string, status: 'succeeded' | 'failed'): Ta
 /**
  * Write a new queue file for a recovered task so it re-enters the FIFO.
  * The new queue file carries the same id so downstream telemetry can correlate.
+ *
+ * Backoff: computes an eligibleAfter timestamp using computeBackoffMs so the
+ * task is not immediately dequeued on the next poll tick, preventing retry
+ * storms when many tasks fail concurrently.
  */
 function reEnqueue(record: TaskRecord, queueDir: string): void {
   mkdirSync(queueDir, { recursive: true });
@@ -527,6 +532,19 @@ function reEnqueue(record: TaskRecord, queueDir: string): void {
   const seq = String(sequence).padStart(4, '0');
   // Re-use the same id so audit can correlate attempts.
   const filename = `${seq}-${record.id}.json`;
+
+  // Compute backoff delay from the record's retry policy.  record.attempts is
+  // the count of attempts already made (1-based after the first failure), so
+  // computeBackoffMs(record.attempts, policy) gives the correct delay for this
+  // retry interval.  The result is epoch ms — dequeueNext skips the task until
+  // Date.now() >= eligibleAfter, preventing immediate re-dequeue after failure.
+  const backoffMs = computeBackoffMs(record.attempts, {
+    maxAttempts: record.maxAttempts,
+    backoffStrategy: record.backoffStrategy ?? 'fixed',
+    backoffBaseMs: record.backoffBaseMs ?? 30_000,
+  });
+  const eligibleAfter = Date.now() + backoffMs;
+
   const queuedTask: QueuedTask = {
     id: record.id,
     command: record.command,
@@ -543,6 +561,7 @@ function reEnqueue(record: TaskRecord, queueDir: string): void {
     maxAttempts: record.maxAttempts,
     ...(record.backoffStrategy !== undefined ? { backoffStrategy: record.backoffStrategy } : {}),
     ...(record.backoffBaseMs !== undefined ? { backoffBaseMs: record.backoffBaseMs } : {}),
+    eligibleAfter,
   };
   atomicWriteJson(join(queueDir, filename), queuedTask);
 }

--- a/src/agent/daemon/queue-store.ts
+++ b/src/agent/daemon/queue-store.ts
@@ -57,6 +57,12 @@ export interface QueuedTask {
   maxAttempts?: number;
   backoffStrategy?: 'fixed' | 'exponential';
   backoffBaseMs?: number;
+  /**
+   * Epoch ms before which this task must NOT be dequeued.
+   * Set by reEnqueue when a backoff delay applies to a retried task.
+   * dequeueNext skips tasks where eligibleAfter > Date.now().
+   */
+  eligibleAfter?: number;
 }
 
 export interface EnqueueOptions {
@@ -180,6 +186,13 @@ export function dequeueNext(queueDir: string = getQueueDir()): QueuedTask | null
       task = JSON.parse(raw) as QueuedTask;
     } catch (err) {
       quarantinePoisonEntry(queueDir, filename, err);
+      continue;
+    }
+    // BACKOFF GATE: skip tasks that are not yet eligible for dequeue.
+    // Re-enqueued tasks carry an eligibleAfter timestamp set by reEnqueue
+    // (via computeBackoffMs) to prevent retry storms.  A task is skipped
+    // (not quarantined) — it remains in the queue for the next poll tick.
+    if (task.eligibleAfter !== undefined && task.eligibleAfter > Date.now()) {
       continue;
     }
     // ORDERING INVARIANT: acquire a durable lease BEFORE returning task.


### PR DESCRIPTION
## Summary

Wire `computeBackoffMs` into the re-enqueue path so retried tasks respect backoff delays before becoming eligible for dequeue.

Closes #1432

## Changes

- **`queue-store.ts`**: Added `eligibleAfter?: number` to `QueuedTask`; `dequeueNext` skips tasks where `eligibleAfter > Date.now()`
- **`lease-store.ts`**: `reEnqueue` calls `computeBackoffMs(record.attempts, policy)` and sets `eligibleAfter` on every re-enqueued task (both `completeTask` failure and `recoverExpiredLeases` paths)
- **`lease-store.test.ts`**: 5 new tests covering fixed/exponential backoff on re-enqueue, dequeue gating during backoff window, and dequeue after backoff expires

## Verification

- `pnpm test src/agent/daemon/task-lifecycle.test.ts` -- 7/7 passed
- `pnpm test src/agent/daemon/lease-store.test.ts` -- 34/34 passed (29 existing + 5 new)
- `pnpm lint` -- clean
