### PR TITLE
feat(security): restrict evaluateProcess PID probing to session-owned PIDs (#1430)

### DIFF
--- a/src/agent/providers/anthropic-direct/build-dispatcher.ts
+++ b/src/agent/providers/anthropic-direct/build-dispatcher.ts
@@ -33,6 +33,7 @@ import type { AnthropicToolDef, ToolHandler } from '../../tools/types.js';
 import type { CustomToolDef } from '../../tools/custom-tool.js';
 import type { GrantManager } from '../../../cli/slash/commands/allow-dir.js';
 import type { RuntimeStateSource } from '../../awareness/index.js';
+import type { SpawnedPidRegistry } from '../../tools/handlers/pid-registry.js';
 import { SessionToolDispatcher } from '../../tools/dispatcher.js';
 import { createBuiltinHandlers } from '../../tools/handlers/index.js';
 import {
@@ -97,6 +98,14 @@ export interface BuildDispatcherOptions {
    * `permissionMode === 'plan'`, the handler + schema are registered.
    */
   planExitControls?: PlanExitControls;
+  /**
+   * Session-scoped PID registry. When present, the `wait_for` process
+   * condition restricts PID probing to session-owned child processes (#1430).
+   * Top-level sessions always supply one (created once per session in
+   * `AnthropicDirectProvider`). Forked children inherit their parent's
+   * restrictions via their own dispatcher and do not share the registry.
+   */
+  spawnedPidRegistry?: SpawnedPidRegistry;
 }
 
 /**
@@ -293,5 +302,7 @@ export function buildDispatcher(
     // (set by createChildProviderFactory / buildReadOnlyReconProvider) so a
     // read-only skill's forked child can't run mutating shell commands.
     readOnlyBash: deps.readOnlyBash,
+    // #1430: PID registry — gates wait_for process condition to session-owned PIDs.
+    ...(opts?.spawnedPidRegistry !== undefined ? { spawnedPidRegistry: opts.spawnedPidRegistry } : {}),
   });
 }

--- a/src/agent/providers/anthropic-direct/provider-runtime.ts
+++ b/src/agent/providers/anthropic-direct/provider-runtime.ts
@@ -59,6 +59,7 @@ import type { ToolPermissionConfig } from '../../tools/permissions.js';
 import type { SkillExecutor } from '../../tools/skill-executor.js';
 import { MemoryStore } from '../../memory/index.js';
 import { WorkspaceStore } from '../../workspace/workspace-store.js';
+import { SpawnedPidRegistry } from '../../tools/handlers/pid-registry.js';
 import { env } from '../../../config/env.js';
 import { buildProviderSchemas } from './provider-schemas.js';
 import type { ProviderQueryContext } from './provider-context.js';
@@ -152,6 +153,14 @@ export class AnthropicDirectProvider implements ModelProvider {
    */
   private _mintedSessionId: string | null = null;
 
+  /**
+   * Session-scoped registry of child process PIDs spawned by the bash tool.
+   * Created once on construction and threaded into every per-query dispatcher
+   * via {@link buildDispatcher} so the `wait_for` process condition can restrict
+   * probing to session-owned PIDs (#1430).
+   */
+  private readonly _spawnedPidRegistry = new SpawnedPidRegistry();
+
   constructor(opts: AnthropicDirectProviderOptions = {}) {
     this.memoryStore = opts.memoryStore ?? new MemoryStore();
     this.workspaceStore = opts.workspaceStore;
@@ -229,7 +238,9 @@ export class AnthropicDirectProvider implements ModelProvider {
         setMcpHandlersCache: (v) => { this._mcpHandlersCache = v; },
       },
       permissionMode,
-      opts,
+      // Inject the session-scoped PID registry into every per-query dispatcher
+      // so bash can register spawned PIDs and wait_for can gate on them (#1430).
+      { ...opts, spawnedPidRegistry: this._spawnedPidRegistry },
     );
   }
 

--- a/src/agent/providers/openai-compatible/index.ts
+++ b/src/agent/providers/openai-compatible/index.ts
@@ -30,6 +30,7 @@ import { SessionToolDispatcher } from '../../tools/dispatcher.js';
 import { PathGrantManager } from '../../tools/grant-manager.js';
 import { pathContainmentBypassed } from '../../permission-policy.js';
 import { createBuiltinHandlers } from '../../tools/handlers/index.js';
+import { SpawnedPidRegistry } from '../../tools/handlers/pid-registry.js';
 import {
   exitPlanModeTool,
   createExitPlanModeHandler,
@@ -172,6 +173,13 @@ export class OpenAICompatibleProvider implements ModelProvider {
    * under the presence file the Telegram watcher is following.
    */
   private _mintedSessionId: string | null = null;
+
+  /**
+   * Session-scoped PID registry — mirrors AnthropicDirectProvider._spawnedPidRegistry.
+   * Threaded into every per-query dispatcher so wait_for can gate on session-owned
+   * PIDs (#1430).
+   */
+  private readonly _spawnedPidRegistry = new SpawnedPidRegistry();
 
   constructor(opts: OpenAICompatibleProviderOptions = {}) {
     this.providerOpts = opts;
@@ -657,6 +665,10 @@ export class OpenAICompatibleProvider implements ModelProvider {
     // session's live grants (a forked child's own writeRoots), not the
     // process-global ref pinned to the top-level session (#435/#514).
     dispatcherOpts.sessionGrantManager = this;
+
+    // #1430: PID registry — gates wait_for process condition to session-owned PIDs.
+    // Parity with AnthropicDirectProvider.buildDispatcher.
+    dispatcherOpts.spawnedPidRegistry = this._spawnedPidRegistry;
 
     return new SessionToolDispatcher(dispatcherOpts);
   }

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -27,6 +27,7 @@ import type { SubagentExecutor } from './subagent-executor.js';
 import type { SkillExecutor } from './skill-executor.js';
 import type { ComposeExecutor } from './compose-executor.js';
 import type { ToolHandler, ToolHandlerContext, ConcurrencyClassifier } from './types.js';
+import type { SpawnedPidRegistry } from './handlers/pid-registry.js';
 import { checkToolPermission, type ToolPermissionConfig } from './permissions.js';
 import type { CanUseTool, PermissionResult } from '../types/sdk-types.js';
 import { classifyBashCommand } from './readonly-bash.js';
@@ -225,6 +226,13 @@ export interface SessionToolDispatcherOptions {
    * containing the class at the child dispatcher is the narrow, high-value fix.
    */
   maxOutputBytes?: number;
+  /**
+   * Session-scoped PID registry. When provided, the `wait_for` process
+   * condition restricts probing to PIDs registered here (i.e. child processes
+   * the bash tool actually spawned in this session). Optional for back-compat;
+   * new session construction paths should always supply one.
+   */
+  spawnedPidRegistry?: SpawnedPidRegistry;
 }
 
 export class SessionToolDispatcher implements ToolDispatcher {
@@ -283,6 +291,8 @@ export class SessionToolDispatcher implements ToolDispatcher {
    * children so the whole tool-output-overflow crash class is contained (#661).
    */
   private readonly maxOutputBytes: number | undefined;
+  /** Session-scoped PID registry for wait_for process condition gating (#1430). */
+  private readonly spawnedPidRegistry: SpawnedPidRegistry | undefined;
   /**
    * Repeat-loop circuit breaker state. The dispatcher is built per `query()`,
    * so this naturally tracks CONSECUTIVE byte-identical calls within a single
@@ -367,6 +377,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
         ? opts.maxOutputBytes
         : undefined;
     this._allowAll = opts.allowAll === true;
+    this.spawnedPidRegistry = opts.spawnedPidRegistry;
 
     // When caller passes arrays by reference (provider sharing pattern), use
     // them directly so mutations are visible without rebuilding. Otherwise
@@ -408,6 +419,8 @@ export class SessionToolDispatcher implements ToolDispatcher {
       // Lets human-blocking handlers tell the elicitation router WHICH session's
       // presence file to mark as waiting-on-a-human.
       ...(this.sessionId !== undefined ? { sessionId: this.sessionId } : {}),
+      // #1430: PID registry gates wait_for process condition to session-owned PIDs.
+      ...(this.spawnedPidRegistry !== undefined ? { spawnedPidRegistry: this.spawnedPidRegistry } : {}),
     };
   }
 

--- a/src/agent/tools/handlers/bash.ts
+++ b/src/agent/tools/handlers/bash.ts
@@ -249,6 +249,16 @@ export function createBashHandler(
     // detach — belt-and-suspenders alongside detached: true.
     proc.unref();
 
+    // #1430: Register the spawned PID in the session's PID registry so the
+    // wait_for handler can probe it later. Only runs when a registry is
+    // present in the context (new session paths always supply one). The
+    // pid guard inside SpawnedPidRegistry.register() silently drops
+    // undefined PIDs (spawn can omit pid on non-detached shells on some
+    // platforms, though in practice detached:true always provides one).
+    if (context?.spawnedPidRegistry !== undefined && proc.pid !== undefined) {
+      context.spawnedPidRegistry.register(proc.pid);
+    }
+
     // Set up timeout — resolve immediately, don't wait for streams.
     // External constraint: SIGTERM can be caught/ignored by user processes;
     // SIGKILL cannot. Use process.kill(-proc.pid, 'SIGKILL') to send SIGKILL

--- a/src/agent/tools/handlers/pid-registry.test.ts
+++ b/src/agent/tools/handlers/pid-registry.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for SpawnedPidRegistry.
+ *
+ * @module agent/tools/handlers/pid-registry.test
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SpawnedPidRegistry } from './pid-registry.js';
+
+describe('SpawnedPidRegistry', () => {
+  let registry: SpawnedPidRegistry;
+
+  beforeEach(() => {
+    registry = new SpawnedPidRegistry();
+  });
+
+  it('starts empty', () => {
+    expect(registry.size).toBe(0);
+  });
+
+  it('registers a PID and reports has() as true', () => {
+    registry.register(12345);
+    expect(registry.has(12345)).toBe(true);
+    expect(registry.size).toBe(1);
+  });
+
+  it('returns false for unregistered PIDs', () => {
+    registry.register(12345);
+    expect(registry.has(99999)).toBe(false);
+  });
+
+  it('silently ignores PID 0 (guard inside register)', () => {
+    registry.register(0);
+    expect(registry.has(0)).toBe(false);
+    expect(registry.size).toBe(0);
+  });
+
+  it('silently ignores PID 1 (special system process)', () => {
+    registry.register(1);
+    expect(registry.has(1)).toBe(false);
+    expect(registry.size).toBe(0);
+  });
+
+  it('silently ignores negative PIDs', () => {
+    registry.register(-1);
+    expect(registry.has(-1)).toBe(false);
+    expect(registry.size).toBe(0);
+  });
+
+  it('silently ignores non-integer values', () => {
+    registry.register(1.5);
+    expect(registry.has(1.5)).toBe(false);
+    expect(registry.size).toBe(0);
+  });
+
+  it('accepts multiple distinct PIDs', () => {
+    registry.register(100);
+    registry.register(200);
+    registry.register(300);
+    expect(registry.has(100)).toBe(true);
+    expect(registry.has(200)).toBe(true);
+    expect(registry.has(300)).toBe(true);
+    expect(registry.size).toBe(3);
+  });
+
+  it('is idempotent: registering the same PID twice keeps size at 1', () => {
+    registry.register(12345);
+    registry.register(12345);
+    expect(registry.size).toBe(1);
+  });
+
+  it('clear() removes all PIDs', () => {
+    registry.register(100);
+    registry.register(200);
+    expect(registry.size).toBe(2);
+    registry.clear();
+    expect(registry.size).toBe(0);
+    expect(registry.has(100)).toBe(false);
+    expect(registry.has(200)).toBe(false);
+  });
+
+  it('has() returns false after clear()', () => {
+    registry.register(42);
+    registry.clear();
+    expect(registry.has(42)).toBe(false);
+  });
+});

--- a/src/agent/tools/handlers/pid-registry.ts
+++ b/src/agent/tools/handlers/pid-registry.ts
@@ -1,0 +1,66 @@
+/**
+ * Session-scoped PID registry for the `wait_for` process condition.
+ *
+ * Records PIDs of child processes spawned by the agent's bash tool so that
+ * `evaluateProcess` can restrict probing to processes the current session
+ * actually owns. Any PID not in the registry is rejected, preventing the
+ * model from leaking process-liveness information for arbitrary host PIDs.
+ *
+ * The registry is intentionally simple — a Set<number> with a thin API —
+ * because its entire job is membership tracking. It has no eviction policy:
+ * PIDs persist for the session lifetime. This is safe because:
+ *   - Sessions are bounded in duration and typically spawn O(100s) of children.
+ *   - A PID that has already been waited on is harmless to re-probe; the kernel
+ *     reuses PIDs slowly enough that a stale entry rarely collides within a
+ *     session window.
+ *
+ * Thread-safety note: Node.js runs on a single thread, so all Set operations
+ * are atomic from our perspective. No mutex is needed.
+ *
+ * @module agent/tools/handlers/pid-registry
+ */
+
+/**
+ * Tracks PIDs of child processes spawned by the current session's bash tool.
+ *
+ * Create one instance per session and share it between the bash handler
+ * (which registers PIDs) and the wait_for handler (which checks membership).
+ */
+export class SpawnedPidRegistry {
+  private readonly _pids = new Set<number>();
+
+  /**
+   * Record a PID as session-owned.
+   * Called by the bash handler immediately after `spawn()` assigns a PID.
+   *
+   * @param pid - The child process PID. Must be a positive integer.
+   */
+  register(pid: number): void {
+    if (Number.isInteger(pid) && pid > 1) {
+      this._pids.add(pid);
+    }
+  }
+
+  /**
+   * Check whether a PID was spawned by this session.
+   *
+   * @param pid - PID to test.
+   * @returns `true` iff the PID was previously registered via `register()`.
+   */
+  has(pid: number): boolean {
+    return this._pids.has(pid);
+  }
+
+  /**
+   * Remove all registered PIDs.
+   * Useful in tests to reset state between cases.
+   */
+  clear(): void {
+    this._pids.clear();
+  }
+
+  /** Number of currently registered PIDs (for diagnostics/tests). */
+  get size(): number {
+    return this._pids.size;
+  }
+}

--- a/src/agent/tools/handlers/wait-for-conditions.test.ts
+++ b/src/agent/tools/handlers/wait-for-conditions.test.ts
@@ -57,6 +57,7 @@ import { classifyRisk } from '../../risk-classifier.js';
 import * as fsPromises from 'node:fs/promises';
 import { execSync } from 'node:child_process';
 import { resolveAndContain } from './_cwd-utils.js';
+import { SpawnedPidRegistry } from './pid-registry.js';
 
 const mockGuardedFetch = vi.mocked(guardedFetch);
 const mockClassifyRisk = vi.mocked(classifyRisk);
@@ -330,6 +331,67 @@ describe('evaluateProcess', () => {
     const result = evaluateProcess({ type: 'process', pid: 1 });
     expect(result.met).toBe(false);
     expect(result.detail).toContain('not a valid target');
+    expect(result.data?.blocked).toBe(true);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  // #1430: PID registry gate tests
+  it('#1430: rejects PID not in registry (blocked: true, no process.kill)', () => {
+    const registry = new SpawnedPidRegistry();
+    // Register a DIFFERENT pid — 12345 is NOT registered
+    registry.register(99999);
+    const spy = vi.spyOn(process, 'kill');
+    const result = evaluateProcess({ type: 'process', pid: 12345 }, registry);
+    expect(result.met).toBe(false);
+    expect(result.detail).toContain('not a session-owned process');
+    expect(result.data?.blocked).toBe(true);
+    // Must NOT call process.kill — no probing of unregistered PIDs
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('#1430: allows registered PID — probes liveness (alive case)', () => {
+    const registry = new SpawnedPidRegistry();
+    registry.register(12345);
+    // kill(pid, 0) returns without throwing → process alive
+    const spy = vi.spyOn(process, 'kill').mockReturnValue(true as unknown as boolean);
+    const result = evaluateProcess({ type: 'process', pid: 12345 }, registry);
+    expect(result.met).toBe(false);
+    expect(result.detail).toContain('still alive');
+    expect(result.data?.blocked).toBeUndefined();
+    expect(spy).toHaveBeenCalledWith(12345, 0);
+    spy.mockRestore();
+  });
+
+  it('#1430: allows registered PID — probes liveness (exited / ESRCH case)', () => {
+    const registry = new SpawnedPidRegistry();
+    registry.register(77777);
+    const err = Object.assign(new Error('ESRCH'), { code: 'ESRCH' });
+    const spy = vi.spyOn(process, 'kill').mockImplementation(() => { throw err; });
+    const result = evaluateProcess({ type: 'process', pid: 77777 }, registry);
+    expect(result.met).toBe(true);
+    expect(result.detail).toContain('exited');
+    spy.mockRestore();
+  });
+
+  it('#1430: back-compat — no registry supplied, PID > 1 is probed normally', () => {
+    // When no registry is provided (legacy callers), the pre-registry behaviour
+    // is preserved: any PID > 1 is probed via process.kill.
+    const spy = vi.spyOn(process, 'kill').mockReturnValue(true as unknown as boolean);
+    const result = evaluateProcess({ type: 'process', pid: 5000 }); // no registry
+    expect(result.met).toBe(false);
+    expect(result.detail).toContain('still alive');
+    expect(result.data?.blocked).toBeUndefined();
+    expect(spy).toHaveBeenCalledWith(5000, 0);
+    spy.mockRestore();
+  });
+
+  it('#1430: empty registry rejects any PID > 1', () => {
+    const registry = new SpawnedPidRegistry(); // no PIDs registered
+    const spy = vi.spyOn(process, 'kill');
+    const result = evaluateProcess({ type: 'process', pid: 12345 }, registry);
+    expect(result.met).toBe(false);
     expect(result.data?.blocked).toBe(true);
     expect(spy).not.toHaveBeenCalled();
     spy.mockRestore();

--- a/src/agent/tools/handlers/wait-for-conditions.ts
+++ b/src/agent/tools/handlers/wait-for-conditions.ts
@@ -13,6 +13,7 @@ import { execSync } from 'node:child_process';
 import { guardedFetch } from '../../../web/egress-guard.js';
 import { classifyRisk } from '../../risk-classifier.js';
 import { resolveAndContain } from './_cwd-utils.js';
+import type { SpawnedPidRegistry } from './pid-registry.js';
 
 /** Union of all condition shapes. */
 export type WaitCondition =
@@ -168,17 +169,42 @@ export async function evaluateFile(cond: FileCondition, signal?: AbortSignal): P
 // Process evaluator
 // ---------------------------------------------------------------------------
 
-export function evaluateProcess(cond: ProcessCondition): WaitResult {
+/**
+ * Evaluate whether a process condition is met (the target PID has exited).
+ *
+ * @param cond - The process condition, containing the PID to probe.
+ * @param registry - Optional session-scoped PID registry. When supplied,
+ *   only PIDs registered in it (i.e. processes spawned by this session's
+ *   bash tool) are probed. Any PID not in the registry is rejected with
+ *   `blocked: true` to prevent the model from leaking process-liveness
+ *   information for arbitrary host PIDs (#1430).
+ *   When absent (legacy / unconfined callers), any PID > 1 is probed —
+ *   the pre-registry behaviour is preserved for back-compat.
+ */
+export function evaluateProcess(
+  cond: ProcessCondition,
+  registry?: SpawnedPidRegistry,
+): WaitResult {
   // M-1: Restrict PIDs to positive integers > 1. PID 0 and PID 1 are special
   // system processes (PID 0 = scheduler, PID 1 = init/launchd). Probing them
   // via kill(pid, 0) is an information-disclosure channel and serves no
-  // legitimate wait_for use case. Restricting PID > 1 is a pragmatic boundary;
-  // full child-process scoping is a known limitation deferred to a PID registry
-  // (plan-mode classification can block this condition type if needed).
+  // legitimate wait_for use case.
   if (!Number.isInteger(cond.pid) || cond.pid <= 1) {
     return {
       met: false,
       detail: `pid ${cond.pid} is not a valid target (must be integer > 1)`,
+      data: { pid: cond.pid, blocked: true },
+    };
+  }
+
+  // #1430: Registry gate — reject PIDs the session did not spawn.
+  // When a registry is provided (all new session paths supply one), the PID
+  // must appear in it. An unregistered PID returns blocked:true so the model
+  // gets a clear, stable signal rather than silently receiving stale info.
+  if (registry !== undefined && !registry.has(cond.pid)) {
+    return {
+      met: false,
+      detail: `pid ${cond.pid} is not a session-owned process (not in spawned PID registry)`,
       data: { pid: cond.pid, blocked: true },
     };
   }

--- a/src/agent/tools/handlers/wait-for.test.ts
+++ b/src/agent/tools/handlers/wait-for.test.ts
@@ -242,6 +242,69 @@ describe('waitForHandler — body_contains defaults method to GET', () => {
 });
 
 // ---------------------------------------------------------------------------
+// #1430: PID registry wiring through the handler context
+// ---------------------------------------------------------------------------
+
+describe('waitForHandler — #1430 PID registry wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCheckEgress.mockResolvedValue({ allowed: true });
+  });
+
+  it('passes context.spawnedPidRegistry to evaluateProcess', async () => {
+    const { evaluateProcess } = await import('./wait-for-conditions.js');
+    const mockEvalProcess = vi.mocked(evaluateProcess);
+    let capturedRegistry: unknown;
+    mockEvalProcess.mockImplementationOnce((_cond, registry) => {
+      capturedRegistry = registry;
+      return { met: true, detail: 'pid 12345 has exited' };
+    });
+
+    const fakeRegistry = { has: () => true, register: () => undefined, clear: () => undefined, size: 1 };
+    await waitForHandler(
+      { type: 'process', pid: 12345 },
+      neverSignal,
+      { spawnedPidRegistry: fakeRegistry } as never,
+    );
+
+    expect(capturedRegistry).toBe(fakeRegistry);
+  });
+
+  it('passes undefined registry when context has none', async () => {
+    const { evaluateProcess } = await import('./wait-for-conditions.js');
+    const mockEvalProcess = vi.mocked(evaluateProcess);
+    let registryArg: unknown = 'NOT_SET';
+    mockEvalProcess.mockImplementationOnce((_cond, registry) => {
+      registryArg = registry;
+      return { met: true, detail: 'pid 12345 has exited' };
+    });
+
+    await waitForHandler({ type: 'process', pid: 12345 }, neverSignal); // no context
+    expect(registryArg).toBeUndefined();
+  });
+
+  it('registry-blocked result (met:false, blocked:true) still produces a non-error summary', async () => {
+    // The handler should NOT surface blocked:true as isError — it returns the
+    // poll summary (succeeded / timed_out). A registry rejection is a met:false
+    // on each poll, and the test lets it time out at timeout_ms:0.
+    const { evaluateProcess } = await import('./wait-for-conditions.js');
+    vi.mocked(evaluateProcess).mockReturnValue({
+      met: false,
+      detail: 'pid 12345 is not a session-owned process (not in spawned PID registry)',
+      data: { pid: 12345, blocked: true },
+    });
+
+    const result = await waitForHandler(
+      { type: 'process', pid: 12345, timeout_ms: 0 } as never,
+      neverSignal,
+    );
+    // timeout_ms:0 → timed_out verdict, which is NOT an error
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toContain('timed_out');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // P5: relative file path → resolved against context.cwd / resolveBase
 // ---------------------------------------------------------------------------
 

--- a/src/agent/tools/handlers/wait-for.ts
+++ b/src/agent/tools/handlers/wait-for.ts
@@ -204,7 +204,7 @@ export const waitForHandler: ToolHandler = async (
       // aborted by the per-poll deadline rather than blocking past the overall
       // timeout.
       case 'file':   return evaluateFile(condition, pollSignal);
-      case 'process': return Promise.resolve(evaluateProcess(condition));
+      case 'process': return Promise.resolve(evaluateProcess(condition, context?.spawnedPidRegistry));
       case 'command': return Promise.resolve(evaluateCommand(condition));
     }
   };

--- a/src/agent/tools/types.ts
+++ b/src/agent/tools/types.ts
@@ -15,6 +15,7 @@ export type { ToolDispatcher } from '../providers/anthropic-direct/tool-dispatch
 
 import type { ToolResult } from '../providers/shared/tool-result.js';
 import type { TraceSink } from '../trace/index.js';
+import type { SpawnedPidRegistry } from './handlers/pid-registry.js';
 
 /**
  * Per-invocation context forwarded to every tool handler.
@@ -107,6 +108,19 @@ export interface ToolHandlerContext {
    * without a session id, in which case the blocked marker is simply not written.
    */
   sessionId?: string;
+  /**
+   * Session-scoped registry of PIDs spawned by the bash tool.
+   *
+   * When present, `evaluateProcess` in the `wait_for` handler restricts PID
+   * probing to PIDs that appear in this registry — i.e. child processes that
+   * this session actually spawned. Any PID not in the registry is rejected
+   * with `blocked: true` so the model cannot probe arbitrary host processes.
+   *
+   * When absent (e.g. legacy call sites, subagents that do not carry a
+   * registry), the old behaviour is preserved: any PID > 1 is probed. New
+   * session construction paths should always supply this field.
+   */
+  spawnedPidRegistry?: SpawnedPidRegistry;
 }
 
 /**


### PR DESCRIPTION
## Summary

Restrict `evaluateProcess` PID probing to child processes spawned by the current session via a session-scoped PID registry, closing the information-leak surface where arbitrary model-supplied PIDs could probe host process liveness.

Closes #1430

## Changes

- **New: `pid-registry.ts`** -- `SpawnedPidRegistry` class (register/has/clear/size), drops PID <= 1
- **`wait-for-conditions.ts`** -- `evaluateProcess` rejects PIDs not in the registry when one is provided; back-compat when no registry supplied
- **`wait-for.ts`** -- threads `context.spawnedPidRegistry` into `evaluateProcess`
- **`bash.ts`** -- registers spawned PIDs via `context.spawnedPidRegistry.register(proc.pid)`
- **`dispatcher.ts`** + **`build-dispatcher.ts`** + **both providers** -- plumbs registry through tool context

## Verification

- 70 tests passed across 3 test files (11 new pid-registry + 5 new wait-for-conditions + 3 new wait-for)
- `pnpm lint` -- clean
