### PR TITLE
feat(render): wire streamProgress into live overlay spinner (#1399)

### DIFF
--- a/src/cli/_lib/stream-renderer-lifecycle.ts
+++ b/src/cli/_lib/stream-renderer-lifecycle.ts
@@ -15,7 +15,6 @@ import { createStageTracker } from '../commands/interactive/loop-stage.js';
 import { formatDuration } from '../format-utils.js';
 import { formatThinkingParagraph } from '../commands/interactive/thinking-paragraph.js';
 import { deriveProgressActivity, formatProgressBanner } from '../commands/interactive/progress-banner.js';
-import { palette } from '../palette.js';
 import { interruptPeek } from '../render/interrupt-peek.js';
 import { getTerminalWidth } from '../terminal-size.js';
 import { isDebugEnabled } from '../../utils/debug.js';
@@ -31,7 +30,7 @@ import type { ThinkingLane } from '../commands/interactive/thinking-lane.js';
 import type { StreamingMarkdownRenderer } from '../markdown-stream.js';
 import type { Writer } from '../slash/types.js';
 import type { ProgressEvent } from '../../agent/types.js';
-import { renderTtfbWaitingLine, checkTtfbAnnotation, type TtfbTickCtx } from './stream-renderer-ttfb.js';
+import { renderTtfbWaitingProgress, checkTtfbAnnotation, type TtfbTickCtx } from './stream-renderer-ttfb.js';
 import { subagentStatusStack, type SubagentStatusBarSpec } from '../render.js';
 
 const PAUSE_THRESHOLD_MS = 30_000;
@@ -105,6 +104,12 @@ export function registerOverlaySlots(
      */
     getTtfbStartedAt?: () => number | undefined;
     isTtfbDone?: () => boolean;
+    /**
+     * Current braille spinner frame for the TTFB waiting indicator. Incremented
+     * once per second by `checkTtfbAnnotation` so the glyph animates at ~1 Hz.
+     * Optional — when absent the frame defaults to 0 (static first glyph).
+     */
+    getTtfbSpinnerFrame?: () => number;
     /**
      * Live accessor for the active subagent status bar specs, keyed by subagentId.
      * Optional so existing non-TTY callers and tests register slots unchanged;
@@ -236,11 +241,16 @@ export function registerOverlaySlots(
           ),
         );
       }
-      // TTFB waiting line: no progress events yet and no content has arrived.
-      // Delegates to renderTtfbWaitingLine (stream-renderer-ttfb.ts) which
+      // TTFB waiting progress: no progress events yet and no content has arrived.
+      // Delegates to renderTtfbWaitingProgress (stream-renderer-ttfb.ts) which
       // returns '' when the timer is inactive, done, or inside the grace period.
+      // Uses streamProgress so the overlay spinner is driven uniformly.
       if (bannerLines.length === 0 && !stopping) {
-        const waiting = renderTtfbWaitingLine(ctx.getTtfbStartedAt, ctx.isTtfbDone, palette);
+        const waiting = renderTtfbWaitingProgress(
+          ctx.getTtfbStartedAt,
+          ctx.isTtfbDone,
+          ctx.getTtfbSpinnerFrame,
+        );
         if (waiting) bannerLines.push(waiting);
       }
       return bannerLines.length > 0 ? bannerLines.join('\n') : '';

--- a/src/cli/_lib/stream-renderer-ttfb.test.ts
+++ b/src/cli/_lib/stream-renderer-ttfb.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { StreamRenderer } from './stream-renderer.js';
-import { applyFirstContent } from './stream-renderer-ttfb.js';
+import {
+  applyFirstContent,
+  checkTtfbAnnotation,
+  renderTtfbWaitingProgress,
+  type TtfbTickCtx,
+} from './stream-renderer-ttfb.js';
+import { stripAnsi } from '../display.js';
 import type { OverlayComposer } from './overlay-composer.js';
 import type { Writer } from '../slash/types.js';
 
@@ -17,6 +23,8 @@ afterEach(() => {
   vi.useRealTimers();
   vi.restoreAllMocks();
 });
+
+// ─── applyFirstContent ───────────────────────────────────────────────────────
 
 describe('applyFirstContent', () => {
   it('marks the banner without flushing synchronously and is idempotent', () => {
@@ -36,6 +44,205 @@ describe('applyFirstContent', () => {
     expect(composer.markDirty).toHaveBeenCalledOnce();
   });
 });
+
+// ─── checkTtfbAnnotation — spinner frame tracking ────────────────────────────
+
+describe('checkTtfbAnnotation — spinner frame increments on each second advance', () => {
+  function makeCtx(overrides?: Partial<TtfbTickCtx>): TtfbTickCtx {
+    return {
+      ttfbStartedAt: Date.now() - 3_000, // 3s ago → past grace period
+      ttfbDone: false,
+      lastTtfbAnnotation: '',
+      ttfbSpinnerFrame: 0,
+      isTTY: true,
+      disposed: false,
+      overlayComposer: {
+        markDirty: vi.fn(),
+        flush: vi.fn(),
+      } as unknown as OverlayComposer,
+      ...overrides,
+    };
+  }
+
+  it('returns false and does not increment when inside grace period', () => {
+    const ctx = makeCtx({ ttfbStartedAt: Date.now() - 500 });
+    const fired = checkTtfbAnnotation(ctx, Date.now());
+    expect(fired).toBe(false);
+    expect(ctx.ttfbSpinnerFrame).toBe(0);
+  });
+
+  it('increments spinnerFrame on the first tick past the grace period', () => {
+    const ctx = makeCtx();
+    const fired = checkTtfbAnnotation(ctx, Date.now());
+    expect(fired).toBe(true);
+    expect(ctx.ttfbSpinnerFrame).toBe(1);
+  });
+
+  it('does NOT increment spinnerFrame on a repeat tick within the same second', () => {
+    const ctx = makeCtx();
+    checkTtfbAnnotation(ctx, Date.now());
+    const frameAfterFirst = ctx.ttfbSpinnerFrame;
+    // Second call with same timestamp → same second → no increment
+    checkTtfbAnnotation(ctx, Date.now());
+    expect(ctx.ttfbSpinnerFrame).toBe(frameAfterFirst);
+  });
+
+  it('increments spinnerFrame on each new second', () => {
+    const now = Date.now();
+    const ctx = makeCtx({ ttfbStartedAt: now - 3_000 });
+    checkTtfbAnnotation(ctx, now); // 3s → fires
+    expect(ctx.ttfbSpinnerFrame).toBe(1);
+    checkTtfbAnnotation(ctx, now + 1_000); // 4s → fires
+    expect(ctx.ttfbSpinnerFrame).toBe(2);
+    checkTtfbAnnotation(ctx, now + 2_000); // 5s → fires
+    expect(ctx.ttfbSpinnerFrame).toBe(3);
+  });
+
+  it('returns false when ttfbDone is true', () => {
+    const ctx = makeCtx({ ttfbDone: true });
+    expect(checkTtfbAnnotation(ctx, Date.now())).toBe(false);
+    expect(ctx.ttfbSpinnerFrame).toBe(0);
+  });
+
+  it('returns false when disposed', () => {
+    const ctx = makeCtx({ disposed: true });
+    expect(checkTtfbAnnotation(ctx, Date.now())).toBe(false);
+    expect(ctx.ttfbSpinnerFrame).toBe(0);
+  });
+});
+
+// ─── renderTtfbWaitingProgress — uses streamProgress component ───────────────
+
+describe('renderTtfbWaitingProgress', () => {
+  it('returns empty string when isTtfbDone is true', () => {
+    const result = renderTtfbWaitingProgress(
+      () => Date.now() - 5_000,
+      () => true,
+      () => 0,
+    );
+    expect(result).toBe('');
+  });
+
+  it('returns empty string when getTtfbStartedAt is undefined', () => {
+    const result = renderTtfbWaitingProgress(
+      () => undefined,
+      () => false,
+      () => 0,
+    );
+    expect(result).toBe('');
+  });
+
+  it('returns empty string inside the grace period (< 2s)', () => {
+    const result = renderTtfbWaitingProgress(
+      () => Date.now() - 1_000, // 1s → inside 2s grace
+      () => false,
+      () => 0,
+    );
+    expect(result).toBe('');
+  });
+
+  it('returns empty string when getTtfbStartedAt is not provided', () => {
+    const result = renderTtfbWaitingProgress(undefined, () => false, () => 0);
+    expect(result).toBe('');
+  });
+
+  it('returns empty string when isTtfbDone is not provided', () => {
+    const result = renderTtfbWaitingProgress(() => Date.now() - 5_000, undefined, () => 0);
+    expect(result).toBe('');
+  });
+
+  it('renders a non-empty line past the grace period', () => {
+    const result = renderTtfbWaitingProgress(
+      () => Date.now() - 5_000,
+      () => false,
+      () => 0,
+    );
+    expect(result).not.toBe('');
+  });
+
+  it('contains the "Generating…" label from streamProgress', () => {
+    const result = stripAnsi(
+      renderTtfbWaitingProgress(
+        () => Date.now() - 5_000,
+        () => false,
+        () => 0,
+      ),
+    );
+    expect(result).toContain('Generating…');
+  });
+
+  it('renders a braille spinner glyph (not the legacy ◦ glyph)', () => {
+    const result = stripAnsi(
+      renderTtfbWaitingProgress(
+        () => Date.now() - 5_000,
+        () => false,
+        () => 0,
+      ),
+    );
+    // The braille glyph at frame 0 is ⠋
+    expect(result).toContain('⠋');
+    expect(result).not.toContain('◦');
+  });
+
+  it('advances the spinner glyph with spinnerFrame', () => {
+    const at0 = stripAnsi(
+      renderTtfbWaitingProgress(
+        () => Date.now() - 5_000,
+        () => false,
+        () => 0,
+      ),
+    );
+    const at3 = stripAnsi(
+      renderTtfbWaitingProgress(
+        () => Date.now() - 5_000,
+        () => false,
+        () => 3,
+      ),
+    );
+    // frame 0 → ⠋, frame 3 → ⠸
+    expect(at0).toContain('⠋');
+    expect(at3).toContain('⠸');
+    expect(at0).not.toContain('⠸');
+    expect(at3).not.toContain('⠋');
+  });
+
+  it('contains the elapsed time', () => {
+    const result = stripAnsi(
+      renderTtfbWaitingProgress(
+        () => Date.now() - 5_000,
+        () => false,
+        () => 0,
+      ),
+    );
+    // formatElapsed for ~5000ms → '5s'
+    expect(result).toMatch(/\d+s/);
+  });
+
+  it('defaults spinnerFrame to 0 when getSpinnerFrame is not provided', () => {
+    const result = stripAnsi(
+      renderTtfbWaitingProgress(
+        () => Date.now() - 5_000,
+        () => false,
+        undefined,
+      ),
+    );
+    // frame 0 → ⠋
+    expect(result).toContain('⠋');
+  });
+
+  it('does NOT contain the old "waiting for response…" copy', () => {
+    const result = stripAnsi(
+      renderTtfbWaitingProgress(
+        () => Date.now() - 5_000,
+        () => false,
+        () => 0,
+      ),
+    );
+    expect(result).not.toContain('waiting for response');
+  });
+});
+
+// ─── StreamRenderer integration — ttfbSpinnerFrame write-back ────────────────
 
 describe('StreamRenderer.notifyFirstContent', () => {
   it('guarantees one post-notification flush in a later event-loop turn', () => {
@@ -66,5 +273,17 @@ describe('StreamRenderer.notifyFirstContent', () => {
     renderer.notifyFirstContent();
     vi.runOnlyPendingTimers();
     expect(composer.flush).toHaveBeenCalledOnce();
+  });
+});
+
+describe('StreamRenderer — ttfbSpinnerFrame lifecycle', () => {
+  it('initialises ttfbSpinnerFrame to 0', () => {
+    const renderer = new StreamRenderer({
+      out: writer,
+      forceNonTty: true,
+      turnStartedAt: Date.now(),
+    });
+    const priv = renderer as unknown as { ttfbSpinnerFrame: number };
+    expect(priv.ttfbSpinnerFrame).toBe(0);
   });
 });

--- a/src/cli/_lib/stream-renderer-ttfb.ts
+++ b/src/cli/_lib/stream-renderer-ttfb.ts
@@ -3,18 +3,20 @@
  *
  * Extracted from stream-renderer-lifecycle.ts to keep that file under the
  * 350-line ceiling. Contains the per-tick TTFB annotation checker that drives
- * the "waiting for response… Ns" progress-banner update at ~1 Hz, and the
+ * the live overlay spinner update at ~1 Hz via {@link streamProgress}, and the
  * shared TTFB_GRACE_MS constant.
  *
  * Invariant: this module has no side effects and no singleton state. All
  * functions are pure or take their mutable state as explicit arguments. The
- * lifecycle context carries the mutable `lastTtfbAnnotation` field; callers
- * write it back after each tick (stream-renderer.ts:checkPauseAnnotations).
+ * lifecycle context carries the mutable `lastTtfbAnnotation` and
+ * `ttfbSpinnerFrame` fields; callers write them back after each tick
+ * (stream-renderer.ts:checkPauseAnnotations).
  *
  * @module cli/_lib/stream-renderer-ttfb
  */
 
 import type { OverlayComposer } from './overlay-composer.js';
+import { streamProgress } from '../render/stream-progress.js';
 
 /**
  * Minimum elapsed time before showing the TTFB waiting line, in milliseconds.
@@ -49,23 +51,31 @@ export interface TtfbTickCtx {
    * only re-flushed when the displayed second value changes.
    */
   lastTtfbAnnotation: string;
+  /**
+   * Braille spinner frame index for the TTFB waiting indicator, incremented
+   * once per second by `checkTtfbAnnotation`. Passed directly to
+   * `streamProgress` so the braille glyph animates at ~1 Hz during the
+   * pre-first-byte wait — the same 1 Hz tick that advances the elapsed counter.
+   */
+  ttfbSpinnerFrame: number;
   isTTY: boolean;
   disposed: boolean;
   overlayComposer: OverlayComposer | null;
 }
 
 /**
- * Drive the TTFB waiting-line overlay update. Called on every 80ms
- * `checkPauseAnnotations` tick; fires a progress-banner flush at most once per
- * second (change-detection on the annotation string, same pattern as the stall
- * annotation in `checkPauseAnnotations`).
+ * Drive the TTFB overlay update. Called on every 80ms `checkPauseAnnotations`
+ * tick; fires a progress-banner flush at most once per second (change-detection
+ * on the annotation string, same pattern as the stall annotation in
+ * `checkPauseAnnotations`).
  *
- * Contract: mutates `ctx.lastTtfbAnnotation` when the displayed second
- * advances. The caller (stream-renderer.ts `checkPauseAnnotations`) writes the
- * updated value back to its own instance field so successive ticks see it.
- * This avoids the LifecycleContext snapshot becoming stale between the read
- * and the write-back — the snapshot is rebuilt from instance fields on every
- * tick, so writing to the snapshot's field propagates on write-back.
+ * Contract: mutates `ctx.lastTtfbAnnotation` and `ctx.ttfbSpinnerFrame` when
+ * the displayed second advances. The caller (stream-renderer.ts
+ * `checkPauseAnnotations`) writes the updated values back to its own instance
+ * fields so successive ticks see them. This avoids the LifecycleContext
+ * snapshot becoming stale between the read and the write-back — the snapshot
+ * is rebuilt from instance fields on every tick, so writing to the snapshot's
+ * fields propagates on write-back.
  *
  * Returns true when the progress-banner was marked dirty (caller must flush).
  */
@@ -87,6 +97,7 @@ export function checkTtfbAnnotation(ctx: TtfbTickCtx, now: number): boolean {
   if (ctx.lastTtfbAnnotation === annotation) return false;
 
   ctx.lastTtfbAnnotation = annotation;
+  ctx.ttfbSpinnerFrame += 1;
   ctx.overlayComposer.markDirty('progress-banner');
   // No flush() here — checkPauseAnnotations batches all dirty marks and
   // issues one flush per tick to prevent double-setOverlay compositor desyncs.
@@ -128,20 +139,31 @@ export function applyFirstContent(
 }
 
 /**
- * Render the TTFB waiting line for the progress-banner overlay slot, or
- * return `''` when the timer is not active, done, or inside the grace period.
- * Pure (no side effects).
+ * Render the TTFB waiting progress line for the progress-banner overlay slot
+ * using the {@link streamProgress} component, or return `''` when the timer
+ * is not active, done, or inside the grace period.
+ *
+ * Visual output (example at 4.7s elapsed, spinner frame 4):
+ *   ⠴ Generating…  4.7s
+ *
+ * Replaces the previous ad-hoc `  ◦ waiting for response… Ns` string with the
+ * shared component so the overlay spinner is driven uniformly. Pure — no side
+ * effects.
  */
-export function renderTtfbWaitingLine(
+export function renderTtfbWaitingProgress(
   getTtfbStartedAt: (() => number | undefined) | undefined,
   isTtfbDone: (() => boolean) | undefined,
-  palette: { dim: (s: string) => string },
+  getSpinnerFrame: (() => number) | undefined,
 ): string {
   if (!getTtfbStartedAt || !isTtfbDone || isTtfbDone()) return '';
   const startedAt = getTtfbStartedAt();
   if (startedAt === undefined) return '';
   const elapsedMs = Date.now() - startedAt;
   if (elapsedMs < TTFB_GRACE_MS) return '';
-  const secs = Math.floor(elapsedMs / 1000);
-  return palette.dim(`  ◦ waiting for response… ${secs}s`);
+  const spinnerFrame = getSpinnerFrame ? getSpinnerFrame() : 0;
+  return streamProgress({
+    label: 'Generating…',
+    spinnerFrame,
+    elapsedMs,
+  });
 }

--- a/src/cli/_lib/stream-renderer.ts
+++ b/src/cli/_lib/stream-renderer.ts
@@ -177,6 +177,12 @@ export class StreamRenderer {
   private ttfbDone: boolean;
   /** Last annotation string rendered for the TTFB line — drives 1 Hz change detection. */
   private lastTtfbAnnotation = '';
+  /**
+   * Braille spinner frame index for the TTFB waiting indicator. Incremented
+   * once per second by `checkTtfbAnnotation` (via the lifecycle context
+   * write-back in `checkPauseAnnotations`) so the glyph animates at ~1 Hz.
+   */
+  private ttfbSpinnerFrame = 0;
 
   /** Ref wired in arm() so the edit-preview hook can push diffs to the tool lane. */
   private readonly addPreviewDiffRef: PreviewDiffRef | undefined;
@@ -365,6 +371,7 @@ export class StreamRenderer {
       getSoftStopping: () => this.softStopping,
       getTtfbStartedAt: () => this.ttfbStartedAt,
       isTtfbDone: () => this.ttfbDone,
+      getTtfbSpinnerFrame: () => this.ttfbSpinnerFrame,
       getActiveSubagents: () => this.activeSubagents,
     });
 
@@ -646,10 +653,12 @@ export class StreamRenderer {
       ttfbStartedAt: this.ttfbStartedAt,
       ttfbDone: this.ttfbDone,
       lastTtfbAnnotation: this.lastTtfbAnnotation,
+      ttfbSpinnerFrame: this.ttfbSpinnerFrame,
     };
     checkProgressBannerStaleness(lifecycleCtx);
     checkPauseAnnotations(lifecycleCtx);
     this.lastTtfbAnnotation = lifecycleCtx.lastTtfbAnnotation;
+    this.ttfbSpinnerFrame = lifecycleCtx.ttfbSpinnerFrame;
   }
 
 }


### PR DESCRIPTION
## Summary

Wire `streamProgress` component into the live overlay spinner, replacing the ad-hoc TTFB waiting line with the component library's animated braille spinner.

Closes #1399

## Visual change

Before: `◦ waiting for response… 4s`
After: `⠴ Generating…  4.7s`

## Changes

- **`stream-renderer-ttfb.ts`** -- replaced `renderTtfbWaitingLine` with `renderTtfbWaitingProgress` delegating to `streamProgress`; added `ttfbSpinnerFrame` to tick context
- **`stream-renderer-lifecycle.ts`** -- updated imports and call site
- **`stream-renderer.ts`** -- threaded spinner frame state through lifecycle context
- **`stream-renderer-ttfb.test.ts`** -- expanded from 2 to 21 tests

## Verification

- stream-progress: 15/15, progress-banner: 56/56, stream-renderer-ttfb: 21/21, live-progress-no-timer: 7/7
- Full _lib/ suite: 463/463, render/ suite: 400/400, interactive/ suite: 1347/1347
- `pnpm lint` -- clean
