### PR TITLE
feat(tools): safe web_request tool with SSRF guard and risk classification (#1413)

### DIFF
--- a/scripts/audit-env-access.ts
+++ b/scripts/audit-env-access.ts
@@ -64,6 +64,10 @@ const ALLOWED_FILES: ReadonlyArray<{ file: string; reason: string }> = [
     reason: 'Accepts `env` as an injectable opt for testing; default is `process.env` (whole object).',
   },
   {
+    file: 'src/agent/tools/handlers/web-request.ts',
+    reason: 'Accepts env as an injectable opt for testing; default is process.env (whole object). Same pattern as web-scrape.ts.',
+  },
+  {
     file: 'src/agent/mcp/transport.ts',
     reason:
       'Inherits a fixed allowlist of OS-level env vars (PATH, USER, SHELL, TERM, TMPDIR, etc.) into spawned MCP server child processes. The keys are bounded but include vars outside the AFK domain (TMP, SYSTEMROOT, APPDATA) that do not belong in ENV_REGISTRY.',

--- a/src/agent/risk-classifier.ts
+++ b/src/agent/risk-classifier.ts
@@ -436,6 +436,25 @@ export function classifyRisk(
     return 'medium';
   }
 
+  // ---- web_request ---------------------------------------------------------
+  // web_request supports all HTTP methods, so risk is method-dependent:
+  //   GET / HEAD / OPTIONS → 'safe' (read-only, no server-side mutation)
+  //   POST / PUT / PATCH   → 'medium' (mutation, but generally recoverable)
+  //   DELETE               → 'high' (irreversible destructive mutation)
+  //
+  // The method is extracted from the raw input and mapped per the tool spec.
+  // An unknown or absent method falls through to 'medium' (conservative).
+  if (tool === 'web_request') {
+    const obj =
+      typeof input === 'object' && input !== null
+        ? (input as Record<string, unknown>)
+        : {};
+    const rawMethod = typeof obj['method'] === 'string' ? obj['method'].toUpperCase() : '';
+    if (rawMethod === 'DELETE') return 'high';
+    if (rawMethod === 'GET' || rawMethod === 'HEAD' || rawMethod === 'OPTIONS') return 'safe';
+    return 'medium';
+  }
+
   // ---- wait_for ------------------------------------------------------------
   // wait_for condition types differ significantly in risk:
   //

--- a/src/agent/risk-classifier.ts
+++ b/src/agent/risk-classifier.ts
@@ -438,7 +438,8 @@ export function classifyRisk(
 
   // ---- web_request ---------------------------------------------------------
   // web_request supports all HTTP methods, so risk is method-dependent:
-  //   GET / HEAD / OPTIONS → 'safe' (read-only, no server-side mutation)
+  //   GET / HEAD / OPTIONS → 'safe' (read-only; web-request.ts uses 'low' in its own
+  //                          MethodRisk vocabulary — 'safe' is the RiskLevel equivalent)
   //   POST / PUT / PATCH   → 'medium' (mutation, but generally recoverable)
   //   DELETE               → 'high' (irreversible destructive mutation)
   //

--- a/src/agent/tool-category.ts
+++ b/src/agent/tool-category.ts
@@ -129,8 +129,10 @@ const WEB_TOOLS = new Set([
   // send_telegram is an outbound HTTP call to a third-party API —
   // same conceptual shape as a web fetch, so it shares the web bucket.
   'send_telegram',
-  // agent-afk's native web tool (local Readability/Turndown scrape + Exa search, plus raw GET).
+  // agent-afk's native web tools.
   'web_scrape',
+  // web_request: structured HTTP tool (all methods, SSRF-guarded, #1413).
+  'web_request',
 ]);
 const BROWSER_TOOLS = new Set([
   // agent-afk native browser-control tools (src/browser/, src/agent/tools/handlers/browser-*.ts).

--- a/src/agent/tools/handlers/index.test.ts
+++ b/src/agent/tools/handlers/index.test.ts
@@ -5,7 +5,7 @@ import { BUILTIN_TOOL_NAMES } from '../schemas.js';
 describe('createBuiltinHandlers', () => {
   it('returns a Map with all built-in tools', () => {
     const handlers = createBuiltinHandlers();
-    expect(handlers.size).toBe(29);
+    expect(handlers.size).toBe(30);
   });
 
   it('has an entry for every tool in BUILTIN_TOOL_NAMES', () => {
@@ -27,7 +27,7 @@ describe('createBuiltinHandlers', () => {
     // when permissionMode is undefined but cwd is set. Ensure we get a
     // valid map back and bash is still callable.
     const handlers = createBuiltinHandlers(undefined, '/tmp');
-    expect(handlers.size).toBe(29);
+    expect(handlers.size).toBe(30);
     expect(typeof handlers.get('bash')).toBe('function');
     expect(typeof handlers.get('grep')).toBe('function');
     expect(typeof handlers.get('glob')).toBe('function');
@@ -35,7 +35,7 @@ describe('createBuiltinHandlers', () => {
 
   it('cwd parameter: builds handler set with both permissionMode and cwd', () => {
     const handlers = createBuiltinHandlers('default', '/tmp');
-    expect(handlers.size).toBe(29);
+    expect(handlers.size).toBe(30);
     expect(typeof handlers.get('bash')).toBe('function');
   });
 

--- a/src/agent/tools/handlers/index.ts
+++ b/src/agent/tools/handlers/index.ts
@@ -18,6 +18,7 @@ import { grepHandler, createGrepHandler } from './grep.js';
 import { listDirectoryHandler, createListDirectoryHandler } from './list-directory.js';
 import { sendTelegramHandler } from './send-telegram.js';
 import { webScrapeHandler } from './web-scrape.js';
+import { webRequestHandler } from './web-request.js';
 import {
   createScheduleHandler,
   listSchedulesHandler,
@@ -91,6 +92,7 @@ export function createBuiltinHandlers(
     ['list_directory', listDirectory],
     ['send_telegram', sendTelegramHandler],
     ['web_scrape', webScrapeHandler],
+    ['web_request', webRequestHandler],
     ['create_schedule', createScheduleHandler],
     ['list_schedules', listSchedulesHandler],
     ['get_schedule_history', getScheduleHistoryHandler],
@@ -124,6 +126,7 @@ export {
   listDirectoryHandler,
   sendTelegramHandler,
   webScrapeHandler,
+  webRequestHandler,
   createScheduleHandler,
   listSchedulesHandler,
   getScheduleHistoryHandler,

--- a/src/agent/tools/handlers/web-request.test.ts
+++ b/src/agent/tools/handlers/web-request.test.ts
@@ -265,19 +265,14 @@ describe('web_request handler — credential injection', () => {
     expect(r.content).toMatch(/not set/);
   });
 
-  it('does not override caller-supplied Authorization header', async () => {
-    let capturedAuth: string | null = null;
-    const fetchFn = makeFetch((_url, init) => {
-      const hdrs = init.headers as Record<string, string> | undefined;
-      capturedAuth = hdrs?.['Authorization'] ?? null;
-      return makeResponse({ body: 'ok' });
-    });
+  it('returns an error when both credential and Authorization header are supplied', async () => {
+    const fetchFn = makeFetch(() => makeResponse({ body: 'ok' }));
     const handler = createWebRequestHandler({
       fetchFn,
       lookupFn: publicLookup,
       env: { MY_KEY: 'env-value' },
     });
-    await handler(
+    const r = await handler(
       {
         url: 'https://api.example.com/',
         method: 'GET',
@@ -287,7 +282,8 @@ describe('web_request handler — credential injection', () => {
       signal(),
     );
 
-    expect(capturedAuth).toBe('Bearer caller-supplied');
+    expect(r.isError).toBe(true);
+    expect(r.content).toMatch(/both "credential" and an explicit Authorization header/);
   });
 });
 

--- a/src/agent/tools/handlers/web-request.test.ts
+++ b/src/agent/tools/handlers/web-request.test.ts
@@ -1,0 +1,399 @@
+/**
+ * Unit tests for the `web_request` tool handler.
+ *
+ * All tests inject `fetchFn` and `lookupFn` so no real network or DNS calls
+ * are issued.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { createWebRequestHandler } from './web-request.js';
+
+type FetchFn = typeof fetch;
+
+/** Always resolves to a public IP — passes the SSRF guard without real DNS. */
+const publicLookup = async (): Promise<readonly { address: string }[]> => [
+  { address: '93.184.216.34' },
+];
+
+function makeResponse(init: {
+  status?: number;
+  body?: string;
+  contentType?: string;
+  headers?: Record<string, string>;
+}): Response {
+  const status = init.status ?? 200;
+  const hdrs: Record<string, string> = { ...(init.headers ?? {}) };
+  if (init.contentType !== undefined) hdrs['content-type'] = init.contentType;
+  return new Response(init.body ?? '', { status, headers: hdrs });
+}
+
+function makeFetch(
+  handler: (url: string, init: RequestInit) => Response | Promise<Response>,
+): FetchFn {
+  return vi.fn(async (input: Parameters<FetchFn>[0], init?: Parameters<FetchFn>[1]) => {
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    return handler(url, init ?? {});
+  }) as unknown as FetchFn;
+}
+
+const signal = (): AbortSignal => new AbortController().signal;
+
+// ---------------------------------------------------------------------------
+// Input validation
+// ---------------------------------------------------------------------------
+
+describe('web_request handler — input validation', () => {
+  const handler = createWebRequestHandler({
+    fetchFn: makeFetch(() => makeResponse({ body: 'unused' })),
+    lookupFn: publicLookup,
+  });
+
+  it('rejects non-object input', async () => {
+    const r = await handler('not-an-object' as unknown, signal());
+    expect(r.isError).toBe(true);
+    expect(r.content).toMatch(/expected an object/);
+  });
+
+  it('rejects missing url', async () => {
+    const r = await handler({ method: 'GET' }, signal());
+    expect(r.isError).toBe(true);
+    expect(r.content).toMatch(/url/);
+  });
+
+  it('rejects invalid url', async () => {
+    const r = await handler({ url: 'not-a-url', method: 'GET' }, signal());
+    expect(r.isError).toBe(true);
+    expect(r.content).toMatch(/not a valid absolute URL/);
+  });
+
+  it('rejects non-http scheme', async () => {
+    const r = await handler({ url: 'ftp://example.com/', method: 'GET' }, signal());
+    expect(r.isError).toBe(true);
+    expect(r.content).toMatch(/not supported/);
+  });
+
+  it('rejects missing method', async () => {
+    const r = await handler({ url: 'https://example.com/' }, signal());
+    expect(r.isError).toBe(true);
+    expect(r.content).toMatch(/method/);
+  });
+
+  it('rejects unsupported method', async () => {
+    const r = await handler({ url: 'https://example.com/', method: 'CONNECT' }, signal());
+    expect(r.isError).toBe(true);
+    expect(r.content).toMatch(/not supported/);
+  });
+
+  it('rejects non-object headers', async () => {
+    const r = await handler(
+      { url: 'https://example.com/', method: 'GET', headers: 'bad' },
+      signal(),
+    );
+    expect(r.isError).toBe(true);
+    expect(r.content).toMatch(/headers/);
+  });
+
+  it('rejects non-string header value', async () => {
+    const r = await handler(
+      { url: 'https://example.com/', method: 'GET', headers: { 'x-count': 42 } },
+      signal(),
+    );
+    expect(r.isError).toBe(true);
+    expect(r.content).toMatch(/header value/);
+  });
+
+  it('rejects invalid timeout_ms', async () => {
+    const r = await handler(
+      { url: 'https://example.com/', method: 'GET', timeout_ms: -1 },
+      signal(),
+    );
+    expect(r.isError).toBe(true);
+    expect(r.content).toMatch(/timeout_ms/);
+  });
+
+  it('rejects invalid max_response_bytes', async () => {
+    const r = await handler(
+      { url: 'https://example.com/', method: 'GET', max_response_bytes: 0 },
+      signal(),
+    );
+    expect(r.isError).toBe(true);
+    expect(r.content).toMatch(/max_response_bytes/);
+  });
+
+  it('rejects empty credential string', async () => {
+    const r = await handler(
+      { url: 'https://example.com/', method: 'GET', credential: '' },
+      signal(),
+    );
+    expect(r.isError).toBe(true);
+    expect(r.content).toMatch(/credential/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+describe('web_request handler — GET happy path', () => {
+  it('returns JSON-structured response', async () => {
+    const fetchFn = makeFetch(() =>
+      makeResponse({ body: 'Hello', contentType: 'text/plain' }),
+    );
+    const handler = createWebRequestHandler({ fetchFn, lookupFn: publicLookup });
+    const r = await handler({ url: 'https://example.com/', method: 'GET' }, signal());
+
+    expect(r.isError).toBeUndefined();
+    const parsed = JSON.parse(r.content as string) as {
+      status: number;
+      body: unknown;
+      timing_ms: number;
+      headers: Record<string, string>;
+    };
+    expect(parsed.status).toBe(200);
+    expect(parsed.body).toBe('Hello');
+    expect(parsed.timing_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it('auto-parses JSON response body', async () => {
+    const fetchFn = makeFetch(() =>
+      makeResponse({ body: '{"key":"val"}', contentType: 'application/json' }),
+    );
+    const handler = createWebRequestHandler({ fetchFn, lookupFn: publicLookup });
+    const r = await handler({ url: 'https://api.example.com/', method: 'GET' }, signal());
+
+    const parsed = JSON.parse(r.content as string) as { body: unknown };
+    expect(parsed.body).toEqual({ key: 'val' });
+  });
+});
+
+describe('web_request handler — POST with body', () => {
+  it('sends body and returns medium risk indication', async () => {
+    let receivedBody: string | null = null;
+    const fetchFn = makeFetch((_url, init) => {
+      receivedBody = typeof init.body === 'string' ? init.body : null;
+      return makeResponse({ body: '{"created":true}', contentType: 'application/json' });
+    });
+    const handler = createWebRequestHandler({ fetchFn, lookupFn: publicLookup });
+    const r = await handler(
+      { url: 'https://api.example.com/items', method: 'POST', body: { name: 'test' } },
+      signal(),
+    );
+
+    expect(r.isError).toBeUndefined();
+    expect(receivedBody).toBe('{"name":"test"}');
+    // Response is a JSON object, no isError
+    const parsed = JSON.parse(r.content as string) as { status: number };
+    expect(parsed.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SSRF blocking
+// ---------------------------------------------------------------------------
+
+describe('web_request handler — SSRF blocking', () => {
+  it('returns error result for loopback target', async () => {
+    const fetchFn = makeFetch(() => makeResponse({ body: 'secret' }));
+    const handler = createWebRequestHandler({ fetchFn });
+    const r = await handler({ url: 'http://127.0.0.1/admin', method: 'GET' }, signal());
+
+    expect(r.isError).toBe(true);
+    expect(r.content).toMatch(/blocked/);
+  });
+
+  it('returns error for hostname resolving to private IP', async () => {
+    const privateLookup = async (): Promise<readonly { address: string }[]> => [
+      { address: '192.168.1.1' },
+    ];
+    const fetchFn = makeFetch(() => makeResponse({ body: 'internal' }));
+    const handler = createWebRequestHandler({ fetchFn, lookupFn: privateLookup });
+    const r = await handler(
+      { url: 'https://internal.corp.example.com/', method: 'GET' },
+      signal(),
+    );
+
+    expect(r.isError).toBe(true);
+    expect(r.content).toMatch(/blocked/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Credential injection
+// ---------------------------------------------------------------------------
+
+describe('web_request handler — credential injection', () => {
+  it('injects env var as Bearer token', async () => {
+    let capturedAuth: string | null = null;
+    const fetchFn = makeFetch((_url, init) => {
+      const hdrs = init.headers as Record<string, string> | undefined;
+      capturedAuth = hdrs?.['Authorization'] ?? null;
+      return makeResponse({ body: 'ok' });
+    });
+    const handler = createWebRequestHandler({
+      fetchFn,
+      lookupFn: publicLookup,
+      env: { MY_API_KEY: 'secret-token-value' },
+    });
+    const r = await handler(
+      { url: 'https://api.example.com/', method: 'GET', credential: 'MY_API_KEY' },
+      signal(),
+    );
+
+    expect(r.isError).toBeUndefined();
+    expect(capturedAuth).toBe('Bearer secret-token-value');
+  });
+
+  it('returns error when env var is not set', async () => {
+    const fetchFn = makeFetch(() => makeResponse({ body: 'ok' }));
+    const handler = createWebRequestHandler({
+      fetchFn,
+      lookupFn: publicLookup,
+      env: {},
+    });
+    const r = await handler(
+      { url: 'https://api.example.com/', method: 'GET', credential: 'MISSING_VAR' },
+      signal(),
+    );
+
+    expect(r.isError).toBe(true);
+    expect(r.content).toMatch(/MISSING_VAR/);
+    expect(r.content).toMatch(/not set/);
+  });
+
+  it('does not override caller-supplied Authorization header', async () => {
+    let capturedAuth: string | null = null;
+    const fetchFn = makeFetch((_url, init) => {
+      const hdrs = init.headers as Record<string, string> | undefined;
+      capturedAuth = hdrs?.['Authorization'] ?? null;
+      return makeResponse({ body: 'ok' });
+    });
+    const handler = createWebRequestHandler({
+      fetchFn,
+      lookupFn: publicLookup,
+      env: { MY_KEY: 'env-value' },
+    });
+    await handler(
+      {
+        url: 'https://api.example.com/',
+        method: 'GET',
+        headers: { Authorization: 'Bearer caller-supplied' },
+        credential: 'MY_KEY',
+      },
+      signal(),
+    );
+
+    expect(capturedAuth).toBe('Bearer caller-supplied');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Domain policy
+// ---------------------------------------------------------------------------
+
+describe('web_request handler — domain policy', () => {
+  it('returns error when domain is blocked', async () => {
+    const fetchFn = makeFetch(() => makeResponse({ body: 'ok' }));
+    const handler = createWebRequestHandler({
+      fetchFn,
+      lookupFn: publicLookup,
+      domainCheck: () => ({ allowed: false, reason: 'not in AFK_BROWSER_ALLOWED_DOMAINS' }),
+    });
+    const r = await handler({ url: 'https://blocked.example.com/', method: 'GET' }, signal());
+
+    expect(r.isError).toBe(true);
+    expect(r.content).toMatch(/blocked/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Secret redaction in response body
+// ---------------------------------------------------------------------------
+
+describe('web_request handler — secret redaction in response', () => {
+  it('redacts Authorization header tokens from string response body', async () => {
+    const bodyWithSecret = 'Authorization: Bearer sk-ant-api03-super-secret-token-1234567890123456789012345678901234567890';
+    const fetchFn = makeFetch(() =>
+      makeResponse({ body: bodyWithSecret, contentType: 'text/plain' }),
+    );
+    const handler = createWebRequestHandler({ fetchFn, lookupFn: publicLookup });
+    const r = await handler({ url: 'https://example.com/', method: 'GET' }, signal());
+
+    const parsed = JSON.parse(r.content as string) as { body: unknown };
+    expect(typeof parsed.body).toBe('string');
+    expect(parsed.body as string).toContain('[REDACTED]');
+    expect(parsed.body as string).not.toContain('super-secret-token');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Response truncation flag propagation
+// ---------------------------------------------------------------------------
+
+describe('web_request handler — truncation flag', () => {
+  it('sets truncated on ToolResult when body is truncated', async () => {
+    const bigBody = 'a'.repeat(200_000);
+    const fetchFn = makeFetch(() =>
+      makeResponse({ body: bigBody, contentType: 'text/plain' }),
+    );
+    const handler = createWebRequestHandler({ fetchFn, lookupFn: publicLookup });
+    const r = await handler(
+      { url: 'https://example.com/', method: 'GET', max_response_bytes: 1000 },
+      signal(),
+    );
+
+    expect(r.isError).toBeUndefined();
+    expect(r.truncated).toBe(true);
+    const parsed = JSON.parse(r.content as string) as { truncated?: boolean };
+    expect(parsed.truncated).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pre-aborted signal
+// ---------------------------------------------------------------------------
+
+describe('web_request handler — pre-aborted signal', () => {
+  it('returns abort error when signal is already aborted', async () => {
+    const ac = new AbortController();
+    ac.abort(new Error('cancelled before start'));
+
+    const fetchFn = makeFetch(() => makeResponse({ body: 'ok' }));
+    const handler = createWebRequestHandler({ fetchFn, lookupFn: publicLookup });
+    const r = await handler({ url: 'https://example.com/', method: 'GET' }, ac.signal);
+
+    expect(r.isError).toBe(true);
+    expect(r.content).toMatch(/aborted/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// timeout_ms and max_response_bytes clamping
+// ---------------------------------------------------------------------------
+
+describe('web_request handler — clamping', () => {
+  it('clamps timeout_ms to 120000', async () => {
+    // Just ensure we don't error on a valid oversized timeout
+    const fetchFn = makeFetch(() => makeResponse({ body: 'ok' }));
+    const handler = createWebRequestHandler({ fetchFn, lookupFn: publicLookup });
+    const r = await handler(
+      { url: 'https://example.com/', method: 'GET', timeout_ms: 999_999 },
+      signal(),
+    );
+    expect(r.isError).toBeUndefined();
+  });
+
+  it('clamps max_response_bytes to 1MB', async () => {
+    const fetchFn = makeFetch(() => makeResponse({ body: 'small', contentType: 'text/plain' }));
+    const handler = createWebRequestHandler({ fetchFn, lookupFn: publicLookup });
+    const r = await handler(
+      { url: 'https://example.com/', method: 'GET', max_response_bytes: 9_999_999 },
+      signal(),
+    );
+    expect(r.isError).toBeUndefined();
+  });
+});

--- a/src/agent/tools/handlers/web-request.ts
+++ b/src/agent/tools/handlers/web-request.ts
@@ -80,6 +80,10 @@ function parseInput(raw: unknown): ParsedInput | { error: string } {
       error: `Invalid input: protocol "${parsedUrl.protocol}" not supported (http/https only)`,
     };
   }
+  // Strip userinfo (user:password@host) so it is not written to the effect
+  // ledger or forwarded anywhere it could leak credentials.
+  parsedUrl.username = '';
+  parsedUrl.password = '';
   const url = parsedUrl.toString();
 
   // method
@@ -94,7 +98,7 @@ function parseInput(raw: unknown): ParsedInput | { error: string } {
   if (obj['body'] !== undefined && obj['body'] !== null) {
     if (
       typeof obj['body'] !== 'string' &&
-      (typeof obj['body'] !== 'object' || Array.isArray(obj['body']) === false && typeof obj['body'] !== 'object')
+      typeof obj['body'] !== 'object'
     ) {
       return { error: 'Invalid input: "body" must be a string, object, or array' };
     }
@@ -183,6 +187,21 @@ export function createWebRequestHandler(opts: WebRequestHandlerOptions = {}): To
   const fetchFn: FetchFn = opts.fetchFn ?? globalThis.fetch;
   const envSource: NodeJS.ProcessEnv = opts.env ?? process.env;
 
+  // Lazily resolve the domain policy enforcer so AFK_BROWSER_ALLOWED_DOMAINS /
+  // AFK_BROWSER_BLOCKED_DOMAINS apply to web_request without requiring the
+  // caller to thread BrowserConfig through createBuiltinHandlers.
+  // When opts.domainCheck is supplied (e.g. in tests), it takes precedence.
+  async function resolveDomainCheck(): Promise<DomainCheckFn | undefined> {
+    if (opts.domainCheck !== undefined) return opts.domainCheck;
+    try {
+      const { loadBrowserConfig, enforceDomainPolicy } = await import('../../../browser/config.js');
+      const config = loadBrowserConfig();
+      return (url: string) => enforceDomainPolicy(url, config);
+    } catch {
+      return undefined;
+    }
+  }
+
   return async (input, signal) => {
     if (typeof fetchFn !== 'function') {
       return {
@@ -211,7 +230,7 @@ export function createWebRequestHandler(opts: WebRequestHandlerOptions = {}): To
     const headers = { ...parsed.headers };
     if (parsed.credential !== undefined) {
       const token = envSource[parsed.credential];
-      if (token === undefined || token.length === 0) {
+      if (token === undefined || token.trim().length === 0) {
         return {
           content:
             `web_request credential error: environment variable "${parsed.credential}" is not set. ` +
@@ -219,13 +238,19 @@ export function createWebRequestHandler(opts: WebRequestHandlerOptions = {}): To
           isError: true,
         };
       }
-      // Inject as Bearer token if no Authorization is already set
+      // Explicit error when caller supplies both credential and Authorization header —
+      // silently discarding the credential would be confusing and error-prone.
       const hasAuth = Object.keys(headers).some(
         (k) => k.toLowerCase() === 'authorization',
       );
-      if (!hasAuth) {
-        headers['Authorization'] = `Bearer ${token}`;
+      if (hasAuth) {
+        return {
+          content:
+            'web_request credential error: both "credential" and an explicit Authorization header were provided. Use one or the other.',
+          isError: true,
+        };
       }
+      headers['Authorization'] = `Bearer ${token}`;
     }
 
     // -- Abort controller with timeout ---------------------------------------
@@ -246,6 +271,10 @@ export function createWebRequestHandler(opts: WebRequestHandlerOptions = {}): To
       }, parsed.timeoutMs);
 
       // -- Core request -------------------------------------------------------
+      // Resolve domain policy lazily so env-var-driven domain restrictions
+      // (AFK_BROWSER_ALLOWED_DOMAINS / BLOCKED_DOMAINS) take effect even when
+      // the caller creates the handler with no opts (production default path).
+      const domainCheck = await resolveDomainCheck();
       const requestOpts: WebRequestOptions = {
         url: parsed.url,
         method: parsed.method,
@@ -255,7 +284,7 @@ export function createWebRequestHandler(opts: WebRequestHandlerOptions = {}): To
         signal: ac.signal,
         fetchFn,
         lookupFn: opts.lookupFn,
-        domainCheck: opts.domainCheck,
+        domainCheck,
         recordEffect: opts.recordEffect,
       };
 
@@ -279,10 +308,15 @@ export function createWebRequestHandler(opts: WebRequestHandlerOptions = {}): To
       }
 
       // -- Format structured response ----------------------------------------
-      // Redact secrets from string body before returning to model context
+      // Redact secrets from response body before returning to model context.
+      // JSON responses are parsed objects — serialize, redact, then re-parse so
+      // token patterns embedded in JSON values (e.g. {"key":"sk-ant-…"}) are masked.
       let responseBody = result.body;
       if (typeof responseBody === 'string') {
         responseBody = redactSecrets(responseBody);
+      } else if (typeof responseBody === 'object' && responseBody !== null) {
+        const serialized = redactSecrets(JSON.stringify(responseBody));
+        try { responseBody = JSON.parse(serialized); } catch { responseBody = serialized; }
       }
 
       const output = {

--- a/src/agent/tools/handlers/web-request.ts
+++ b/src/agent/tools/handlers/web-request.ts
@@ -1,0 +1,308 @@
+/**
+ * Handler for the `web_request` tool.
+ *
+ * Provides structured, SSRF-guarded HTTP requests for all methods:
+ *   GET / HEAD / OPTIONS — low risk, idempotent (auto-retried on transient failures)
+ *   POST / PUT / PATCH   — medium risk, only PUT is idempotent (POST/PATCH never retried)
+ *   DELETE               — high risk, idempotent
+ *
+ * Safety layers (in application order):
+ *   1. Input validation — URL, method, timeout, body, headers
+ *   2. Domain policy — AFK_BROWSER_ALLOWED_DOMAINS / BLOCKED_DOMAINS (when set)
+ *   3. SSRF guard — DNS-resolved IP classification, per-hop redirect validation
+ *   4. Response truncation — max_response_bytes (default 100KB, ceiling 1MB)
+ *   5. Secret redaction — Authorization header, known token patterns
+ *
+ * Credential injection: pass `credential: "<ENV_VAR_NAME>"` to resolve an
+ * environment variable at runtime and inject it as a Bearer token in the
+ * Authorization header. The raw value is never logged or returned.
+ *
+ * Effect ledger hook: if `opts.recordEffect` is provided, it is called after a
+ * successful response. The handler does NOT hard-depend on the ledger (#1412).
+ *
+ * @module agent/tools/handlers/web-request
+ */
+
+import type { ToolHandler } from '../types.js';
+import {
+  webRequest,
+  parseMethod,
+  DEFAULT_TIMEOUT_MS,
+  MAX_TIMEOUT_MS,
+  DEFAULT_MAX_RESPONSE_BYTES,
+  MAX_RESPONSE_BYTES,
+  type WebRequestOptions,
+  type RecordEffectFn,
+  type DomainCheckFn,
+} from '../../../web/web-request.js';
+import { EgressBlockedError } from '../../../web/egress-guard.js';
+import type { EgressGuardOptions } from '../../../web/egress-guard.js';
+import { redactSecrets } from '../../redact-secrets.js';
+
+type FetchFn = typeof fetch;
+
+// ---------------------------------------------------------------------------
+// Input parsing
+// ---------------------------------------------------------------------------
+
+interface ParsedInput {
+  url: string;
+  method: ReturnType<typeof parseMethod> extends infer R
+    ? R extends { error: string }
+      ? never
+      : R
+    : never;
+  body: string | Record<string, unknown> | unknown[] | null | undefined;
+  headers: Record<string, string>;
+  timeoutMs: number;
+  maxResponseBytes: number;
+  credential: string | undefined;
+}
+
+function parseInput(raw: unknown): ParsedInput | { error: string } {
+  if (!raw || typeof raw !== 'object') {
+    return { error: 'Invalid input: expected an object' };
+  }
+  const obj = raw as Record<string, unknown>;
+
+  // url
+  if (typeof obj['url'] !== 'string' || obj['url'].length === 0) {
+    return { error: 'Invalid input: "url" must be a non-empty string' };
+  }
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(obj['url']);
+  } catch {
+    return { error: `Invalid input: "${obj['url']}" is not a valid absolute URL` };
+  }
+  if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+    return {
+      error: `Invalid input: protocol "${parsedUrl.protocol}" not supported (http/https only)`,
+    };
+  }
+  const url = parsedUrl.toString();
+
+  // method
+  const methodResult = parseMethod(obj['method']);
+  if (typeof methodResult === 'object' && 'error' in methodResult) {
+    return { error: `Invalid input: ${methodResult.error}` };
+  }
+  const method = methodResult;
+
+  // body — string, object, or absent
+  let body: string | Record<string, unknown> | unknown[] | null | undefined;
+  if (obj['body'] !== undefined && obj['body'] !== null) {
+    if (
+      typeof obj['body'] !== 'string' &&
+      (typeof obj['body'] !== 'object' || Array.isArray(obj['body']) === false && typeof obj['body'] !== 'object')
+    ) {
+      return { error: 'Invalid input: "body" must be a string, object, or array' };
+    }
+    body = obj['body'] as string | Record<string, unknown> | unknown[];
+  }
+
+  // headers — optional Record<string, string>
+  let headers: Record<string, string> = {};
+  if (obj['headers'] !== undefined) {
+    if (typeof obj['headers'] !== 'object' || obj['headers'] === null || Array.isArray(obj['headers'])) {
+      return { error: 'Invalid input: "headers" must be a string-keyed object' };
+    }
+    const headersRaw = obj['headers'] as Record<string, unknown>;
+    for (const [k, v] of Object.entries(headersRaw)) {
+      if (typeof v !== 'string') {
+        return { error: `Invalid input: header value for "${k}" must be a string` };
+      }
+      headers[k] = v;
+    }
+  }
+
+  // timeout_ms
+  let timeoutMs = DEFAULT_TIMEOUT_MS;
+  if (obj['timeout_ms'] !== undefined) {
+    if (
+      typeof obj['timeout_ms'] !== 'number' ||
+      !Number.isFinite(obj['timeout_ms']) ||
+      obj['timeout_ms'] <= 0
+    ) {
+      return { error: 'Invalid input: "timeout_ms" must be a positive finite number' };
+    }
+    timeoutMs = Math.min(obj['timeout_ms'], MAX_TIMEOUT_MS);
+  }
+
+  // max_response_bytes
+  let maxResponseBytes = DEFAULT_MAX_RESPONSE_BYTES;
+  if (obj['max_response_bytes'] !== undefined) {
+    if (
+      typeof obj['max_response_bytes'] !== 'number' ||
+      !Number.isFinite(obj['max_response_bytes']) ||
+      obj['max_response_bytes'] <= 0
+    ) {
+      return { error: 'Invalid input: "max_response_bytes" must be a positive finite number' };
+    }
+    maxResponseBytes = Math.min(obj['max_response_bytes'], MAX_RESPONSE_BYTES);
+  }
+
+  // credential — optional env var name
+  let credential: string | undefined;
+  if (obj['credential'] !== undefined) {
+    if (typeof obj['credential'] !== 'string' || obj['credential'].length === 0) {
+      return { error: 'Invalid input: "credential" must be a non-empty string (an env var name)' };
+    }
+    credential = obj['credential'];
+  }
+
+  return { url, method, body, headers, timeoutMs, maxResponseBytes, credential };
+}
+
+// ---------------------------------------------------------------------------
+// Handler options
+// ---------------------------------------------------------------------------
+
+export interface WebRequestHandlerOptions {
+  /** Override fetch for tests. Defaults to `globalThis.fetch`. */
+  fetchFn?: FetchFn;
+  /** DNS resolution override for tests. */
+  lookupFn?: EgressGuardOptions['lookupFn'];
+  /** Environment variable source. Defaults to `process.env`. */
+  env?: NodeJS.ProcessEnv;
+  /**
+   * Optional domain policy enforcer. When set, checked before the SSRF guard.
+   * Allows AFK_BROWSER_ALLOWED_DOMAINS / BLOCKED_DOMAINS to apply to web_request
+   * as well as browser tools.
+   */
+  domainCheck?: DomainCheckFn;
+  /** Optional effect ledger hook (see #1412). */
+  recordEffect?: RecordEffectFn;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createWebRequestHandler(opts: WebRequestHandlerOptions = {}): ToolHandler {
+  const fetchFn: FetchFn = opts.fetchFn ?? globalThis.fetch;
+  const envSource: NodeJS.ProcessEnv = opts.env ?? process.env;
+
+  return async (input, signal) => {
+    if (typeof fetchFn !== 'function') {
+      return {
+        content:
+          'web_request unavailable: global fetch() is not present ' +
+          '(agent-afk requires Node 20+).',
+        isError: true,
+      };
+    }
+
+    const parsed = parseInput(input);
+    if ('error' in parsed) {
+      return { content: parsed.error, isError: true };
+    }
+
+    // Pre-aborted short-circuit
+    if (signal.aborted) {
+      const reason = signal.reason;
+      const msg = reason instanceof Error ? reason.message : String(reason ?? 'aborted');
+      return { content: `web_request aborted: ${msg}`, isError: true };
+    }
+
+    // -- Credential resolution -----------------------------------------------
+    // Resolve the env var before building the AbortController so a missing
+    // var is a clean synchronous error, not a partially-started request.
+    const headers = { ...parsed.headers };
+    if (parsed.credential !== undefined) {
+      const token = envSource[parsed.credential];
+      if (token === undefined || token.length === 0) {
+        return {
+          content:
+            `web_request credential error: environment variable "${parsed.credential}" is not set. ` +
+            `Set it in afk.env or export it in the shell before starting AFK.`,
+          isError: true,
+        };
+      }
+      // Inject as Bearer token if no Authorization is already set
+      const hasAuth = Object.keys(headers).some(
+        (k) => k.toLowerCase() === 'authorization',
+      );
+      if (!hasAuth) {
+        headers['Authorization'] = `Bearer ${token}`;
+      }
+    }
+
+    // -- Abort controller with timeout ---------------------------------------
+    const ac = new AbortController();
+    const onParentAbort = (): void => ac.abort(signal.reason);
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const abortMessage = (): string => {
+      const reason = ac.signal.reason;
+      return reason instanceof Error ? reason.message : String(reason ?? 'aborted');
+    };
+
+    try {
+      signal.addEventListener('abort', onParentAbort, { once: true });
+      timer = setTimeout(() => {
+        ac.abort(new Error(`web_request timeout after ${parsed.timeoutMs}ms`));
+      }, parsed.timeoutMs);
+
+      // -- Core request -------------------------------------------------------
+      const requestOpts: WebRequestOptions = {
+        url: parsed.url,
+        method: parsed.method,
+        body: parsed.body,
+        headers,
+        maxResponseBytes: parsed.maxResponseBytes,
+        signal: ac.signal,
+        fetchFn,
+        lookupFn: opts.lookupFn,
+        domainCheck: opts.domainCheck,
+        recordEffect: opts.recordEffect,
+      };
+
+      let result;
+      try {
+        result = await webRequest(requestOpts);
+      } catch (err) {
+        if (ac.signal.aborted) {
+          return { content: `web_request aborted: ${abortMessage()}`, isError: true };
+        }
+        if (err instanceof EgressBlockedError) {
+          return { content: `web_request blocked: ${err.message}`, isError: true };
+        }
+        const name = err instanceof Error && err.name === 'DomainPolicyError' ? 'blocked' : 'network error';
+        const msg = err instanceof Error ? err.message : String(err);
+        return { content: `web_request ${name}: ${msg}`, isError: true };
+      }
+
+      if (ac.signal.aborted) {
+        return { content: `web_request aborted: ${abortMessage()}`, isError: true };
+      }
+
+      // -- Format structured response ----------------------------------------
+      // Redact secrets from string body before returning to model context
+      let responseBody = result.body;
+      if (typeof responseBody === 'string') {
+        responseBody = redactSecrets(responseBody);
+      }
+
+      const output = {
+        status: result.status,
+        headers: result.headers,
+        body: responseBody,
+        timing_ms: result.timing_ms,
+        ...(result.truncated ? { truncated: true } : {}),
+      };
+
+      const content = JSON.stringify(output, null, 2);
+      return {
+        content,
+        ...(result.truncated ? { truncated: true } : {}),
+      };
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+      signal.removeEventListener('abort', onParentAbort);
+    }
+  };
+}
+
+export const webRequestHandler: ToolHandler = createWebRequestHandler();

--- a/src/agent/tools/schemas.test.ts
+++ b/src/agent/tools/schemas.test.ts
@@ -7,8 +7,8 @@ import {
 import { cancelBackgroundJobTool } from './schemas.orchestration.js';
 
 describe('builtinToolSchemas', () => {
-  it('contains exactly 30 tools', () => {
-    expect(builtinToolSchemas).toHaveLength(30);
+  it('contains exactly 31 tools', () => {
+    expect(builtinToolSchemas).toHaveLength(31);
   });
 
   it('exports the expected tool names', () => {
@@ -23,6 +23,7 @@ describe('builtinToolSchemas', () => {
       'list_directory',
       'send_telegram',
       'web_scrape',
+      'web_request',
       'create_schedule',
       'list_schedules',
       'get_schedule_history',

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -356,6 +356,70 @@ export const webScrapeTool: AnthropicToolDef = {
   },
 };
 
+export const webRequestTool: AnthropicToolDef = {
+  name: 'web_request',
+  category: 'web',
+  concurrencySafe: true,
+  description:
+    'Make a structured HTTP request with any method (GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS). ' +
+    'Unlike `web_scrape` (GET-only read), `web_request` supports mutating methods and returns a ' +
+    'structured `{ status, headers, body, timing_ms }` response. ' +
+    'SSRF-guarded: all private/internal IP ranges blocked by default (see AFK_WEB_ALLOW_PRIVATE_HOSTS). ' +
+    'Respects AFK_BROWSER_ALLOWED_DOMAINS / BLOCKED_DOMAINS when domain policy is configured.\n\n' +
+    'Risk levels: GET/HEAD/OPTIONS = low; POST/PUT/PATCH = medium; DELETE = high. ' +
+    'Only idempotent methods (GET, HEAD, OPTIONS, PUT, DELETE) are auto-retried on transient failures; ' +
+    'POST and PATCH are NEVER auto-retried.\n\n' +
+    'Body is auto-serialized: objects/arrays → JSON with Content-Type: application/json; ' +
+    'strings → text/plain. Caller-supplied Content-Type overrides inference.\n\n' +
+    'Response body is truncated to `max_response_bytes` (default 100KB, ceiling 1MB). ' +
+    'JSON responses are auto-parsed when not truncated.\n\n' +
+    'Credential injection: pass `credential: "ENV_VAR_NAME"` to resolve an env var at runtime ' +
+    'and inject it as a Bearer token. The raw value is never logged or returned to the model.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      url: {
+        type: 'string',
+        description: 'Absolute http(s) URL.',
+      },
+      method: {
+        type: 'string',
+        enum: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'],
+        description: 'HTTP method. GET/HEAD/OPTIONS = low risk; POST/PUT/PATCH = medium; DELETE = high.',
+      },
+      body: {
+        description:
+          'Request body. Strings are sent as text/plain; objects/arrays are JSON-serialized ' +
+          'with Content-Type: application/json. Ignored for GET, HEAD, OPTIONS.',
+      },
+      headers: {
+        type: 'object',
+        description:
+          'Request headers as a string-keyed object. Secret values (Authorization, token patterns) ' +
+          'are redacted from traces but sent on the wire.',
+      },
+      timeout_ms: {
+        type: 'number',
+        description: 'Request timeout in milliseconds (default 30000, clamped to 120000).',
+      },
+      max_response_bytes: {
+        type: 'number',
+        description:
+          'Maximum response body bytes (default 100000, clamped to 1000000). ' +
+          'Content over the cap is truncated head+tail with a marker.',
+      },
+      credential: {
+        type: 'string',
+        description:
+          'Name of an environment variable whose value is injected as a Bearer token ' +
+          '(Authorization: Bearer <value>). Use instead of hardcoding secrets in headers. ' +
+          'Returns an error if the env var is not set.',
+      },
+    },
+    required: ['url', 'method'],
+  },
+};
+
 export const agentTool: AnthropicToolDef = {
   name: 'agent',
   category: 'subagent',
@@ -1329,6 +1393,7 @@ export const builtinToolSchemas: readonly AnthropicToolDef[] = [
   listDirectoryTool,
   sendTelegramTool,
   webScrapeTool,
+  webRequestTool,
   createScheduleTool,
   listSchedulesTool,
   getScheduleHistoryTool,

--- a/src/web/web-request.test.ts
+++ b/src/web/web-request.test.ts
@@ -1,0 +1,484 @@
+/**
+ * Unit tests for the `web_request` core implementation (src/web/web-request.ts).
+ *
+ * All tests use injected `fetchFn` and `lookupFn` so no real network or DNS
+ * calls are issued.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  webRequest,
+  parseMethod,
+  classifyMethodRisk,
+  isIdempotentMethod,
+  DEFAULT_TIMEOUT_MS,
+  DEFAULT_MAX_RESPONSE_BYTES,
+  MAX_RESPONSE_BYTES,
+  type HttpMethod,
+} from './web-request.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type FetchFn = typeof fetch;
+
+/** Always resolves to a public IP — passes the SSRF guard without real DNS. */
+const publicLookup = async (): Promise<readonly { address: string }[]> => [
+  { address: '93.184.216.34' },
+];
+
+function makeResponse(init: {
+  status?: number;
+  body?: string;
+  contentType?: string;
+  headers?: Record<string, string>;
+}): Response {
+  const status = init.status ?? 200;
+  const hdrs: Record<string, string> = { ...(init.headers ?? {}) };
+  if (init.contentType !== undefined) hdrs['content-type'] = init.contentType;
+  return new Response(init.body ?? '', { status, headers: hdrs });
+}
+
+function makeFetch(
+  handler: (url: string, init: RequestInit) => Response | Promise<Response>,
+): FetchFn {
+  return vi.fn(async (input: Parameters<FetchFn>[0], init?: Parameters<FetchFn>[1]) => {
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    return handler(url, init ?? {});
+  }) as unknown as FetchFn;
+}
+
+const signal = (): AbortSignal => new AbortController().signal;
+
+// ---------------------------------------------------------------------------
+// parseMethod
+// ---------------------------------------------------------------------------
+
+describe('parseMethod', () => {
+  const valid: HttpMethod[] = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'];
+
+  for (const m of valid) {
+    it(`accepts ${m}`, () => {
+      expect(parseMethod(m)).toBe(m);
+    });
+    it(`accepts lowercase ${m.toLowerCase()}`, () => {
+      expect(parseMethod(m.toLowerCase())).toBe(m);
+    });
+  }
+
+  it('rejects unknown method', () => {
+    const r = parseMethod('CONNECT');
+    expect(r).toMatchObject({ error: expect.stringContaining('not supported') as unknown });
+  });
+
+  it('rejects empty string', () => {
+    const r = parseMethod('');
+    expect(r).toMatchObject({ error: expect.any(String) as unknown });
+  });
+
+  it('rejects non-string', () => {
+    const r = parseMethod(42);
+    expect(r).toMatchObject({ error: expect.any(String) as unknown });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyMethodRisk / isIdempotentMethod
+// ---------------------------------------------------------------------------
+
+describe('classifyMethodRisk', () => {
+  it('GET → low', () => expect(classifyMethodRisk('GET')).toBe('low'));
+  it('HEAD → low', () => expect(classifyMethodRisk('HEAD')).toBe('low'));
+  it('OPTIONS → low', () => expect(classifyMethodRisk('OPTIONS')).toBe('low'));
+  it('POST → medium', () => expect(classifyMethodRisk('POST')).toBe('medium'));
+  it('PUT → medium', () => expect(classifyMethodRisk('PUT')).toBe('medium'));
+  it('PATCH → medium', () => expect(classifyMethodRisk('PATCH')).toBe('medium'));
+  it('DELETE → high', () => expect(classifyMethodRisk('DELETE')).toBe('high'));
+});
+
+describe('isIdempotentMethod', () => {
+  it('GET → true', () => expect(isIdempotentMethod('GET')).toBe(true));
+  it('HEAD → true', () => expect(isIdempotentMethod('HEAD')).toBe(true));
+  it('OPTIONS → true', () => expect(isIdempotentMethod('OPTIONS')).toBe(true));
+  it('PUT → true', () => expect(isIdempotentMethod('PUT')).toBe(true));
+  it('DELETE → true', () => expect(isIdempotentMethod('DELETE')).toBe(true));
+  it('POST → false', () => expect(isIdempotentMethod('POST')).toBe(false));
+  it('PATCH → false', () => expect(isIdempotentMethod('PATCH')).toBe(false));
+});
+
+// ---------------------------------------------------------------------------
+// webRequest — happy path
+// ---------------------------------------------------------------------------
+
+describe('webRequest — GET happy path', () => {
+  it('returns status, body, timing, risk', async () => {
+    const fetchFn = makeFetch(() => makeResponse({ body: 'Hello World', contentType: 'text/plain' }));
+    const result = await webRequest({
+      url: 'https://example.com/api',
+      method: 'GET',
+      signal: signal(),
+      fetchFn,
+      lookupFn: publicLookup,
+    });
+    expect(result.status).toBe(200);
+    expect(result.body).toBe('Hello World');
+    expect(result.risk).toBe('low');
+    expect(result.timing_ms).toBeGreaterThanOrEqual(0);
+    expect(result.truncated).toBe(false);
+  });
+
+  it('auto-parses JSON when content-type is application/json', async () => {
+    const data = { user: 'alice', score: 42 };
+    const fetchFn = makeFetch(() =>
+      makeResponse({ body: JSON.stringify(data), contentType: 'application/json' }),
+    );
+    const result = await webRequest({
+      url: 'https://api.example.com/user',
+      method: 'GET',
+      signal: signal(),
+      fetchFn,
+      lookupFn: publicLookup,
+    });
+    expect(result.body).toEqual(data);
+    expect(result.truncated).toBe(false);
+  });
+
+  it('returns string body when JSON parse fails', async () => {
+    const fetchFn = makeFetch(() =>
+      makeResponse({ body: 'not-valid-json{{{', contentType: 'application/json' }),
+    );
+    const result = await webRequest({
+      url: 'https://api.example.com/',
+      method: 'GET',
+      signal: signal(),
+      fetchFn,
+      lookupFn: publicLookup,
+    });
+    expect(typeof result.body).toBe('string');
+  });
+});
+
+describe('webRequest — POST with JSON body', () => {
+  it('sends JSON body and returns medium risk', async () => {
+    let capturedBody: string | null = null;
+    let capturedContentType: string | null = null;
+
+    const fetchFn = makeFetch((_url, init) => {
+      capturedBody = typeof init.body === 'string' ? init.body : null;
+      const hdrs = init.headers as Record<string, string> | undefined;
+      capturedContentType = hdrs?.['content-type'] ?? null;
+      return makeResponse({ body: '{"ok":true}', contentType: 'application/json' });
+    });
+
+    const result = await webRequest({
+      url: 'https://api.example.com/data',
+      method: 'POST',
+      body: { name: 'test', value: 1 },
+      signal: signal(),
+      fetchFn,
+      lookupFn: publicLookup,
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.risk).toBe('medium');
+    expect(capturedBody).toBe('{"name":"test","value":1}');
+    expect(capturedContentType).toBe('application/json');
+  });
+
+  it('sends string body with text/plain content-type', async () => {
+    let capturedContentType: string | null = null;
+    const fetchFn = makeFetch((_url, init) => {
+      const hdrs = init.headers as Record<string, string> | undefined;
+      capturedContentType = hdrs?.['content-type'] ?? null;
+      return makeResponse({ body: 'ok' });
+    });
+
+    await webRequest({
+      url: 'https://api.example.com/plain',
+      method: 'POST',
+      body: 'raw text body',
+      signal: signal(),
+      fetchFn,
+      lookupFn: publicLookup,
+    });
+    expect(capturedContentType).toBe('text/plain');
+  });
+
+  it('respects caller-supplied content-type override', async () => {
+    let capturedContentType: string | null = null;
+    const fetchFn = makeFetch((_url, init) => {
+      const hdrs = init.headers as Record<string, string> | undefined;
+      capturedContentType = hdrs?.['content-type'] ?? null;
+      return makeResponse({ body: 'ok' });
+    });
+
+    await webRequest({
+      url: 'https://api.example.com/',
+      method: 'POST',
+      body: { foo: 'bar' },
+      headers: { 'content-type': 'application/vnd.api+json' },
+      signal: signal(),
+      fetchFn,
+      lookupFn: publicLookup,
+    });
+    expect(capturedContentType).toBe('application/vnd.api+json');
+  });
+});
+
+describe('webRequest — DELETE risk', () => {
+  it('returns high risk for DELETE', async () => {
+    const fetchFn = makeFetch(() => makeResponse({ status: 200, body: '{"deleted":true}', contentType: 'application/json' }));
+    const result = await webRequest({
+      url: 'https://api.example.com/resource/1',
+      method: 'DELETE',
+      signal: signal(),
+      fetchFn,
+      lookupFn: publicLookup,
+    });
+    expect(result.risk).toBe('high');
+    expect(result.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Response truncation
+// ---------------------------------------------------------------------------
+
+describe('webRequest — response truncation', () => {
+  it('truncates body when over maxResponseBytes', async () => {
+    const bigBody = 'x'.repeat(200_000);
+    const fetchFn = makeFetch(() =>
+      makeResponse({ body: bigBody, contentType: 'text/plain' }),
+    );
+    const result = await webRequest({
+      url: 'https://example.com/big',
+      method: 'GET',
+      maxResponseBytes: 1000,
+      signal: signal(),
+      fetchFn,
+      lookupFn: publicLookup,
+    });
+    expect(result.truncated).toBe(true);
+    expect(typeof result.body).toBe('string');
+    expect(Buffer.byteLength(result.body as string, 'utf8')).toBeLessThanOrEqual(1500); // marker overhead
+  });
+
+  it('does not truncate when body fits', async () => {
+    const fetchFn = makeFetch(() => makeResponse({ body: 'small', contentType: 'text/plain' }));
+    const result = await webRequest({
+      url: 'https://example.com/',
+      method: 'GET',
+      signal: signal(),
+      fetchFn,
+      lookupFn: publicLookup,
+    });
+    expect(result.truncated).toBe(false);
+    expect(result.body).toBe('small');
+  });
+
+  it('enforces MAX_RESPONSE_BYTES ceiling', () => {
+    // Just verify the constant is as documented
+    expect(MAX_RESPONSE_BYTES).toBe(1_000_000);
+    expect(DEFAULT_MAX_RESPONSE_BYTES).toBe(100_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Response header filtering
+// ---------------------------------------------------------------------------
+
+describe('webRequest — response header filtering', () => {
+  it('strips set-cookie headers', async () => {
+    const fetchFn = makeFetch(() =>
+      makeResponse({
+        body: 'ok',
+        headers: { 'set-cookie': 'session=abc; HttpOnly', 'content-type': 'text/plain' },
+      }),
+    );
+    const result = await webRequest({
+      url: 'https://example.com/',
+      method: 'GET',
+      signal: signal(),
+      fetchFn,
+      lookupFn: publicLookup,
+    });
+    expect(Object.keys(result.headers)).not.toContain('set-cookie');
+    expect(result.headers['content-type']).toBe('text/plain');
+  });
+
+  it('strips x- headers', async () => {
+    const fetchFn = makeFetch(() =>
+      makeResponse({
+        body: 'ok',
+        headers: { 'x-request-id': '123', 'x-internal': 'secret', 'content-type': 'text/plain' },
+      }),
+    );
+    const result = await webRequest({
+      url: 'https://example.com/',
+      method: 'GET',
+      signal: signal(),
+      fetchFn,
+      lookupFn: publicLookup,
+    });
+    expect(Object.keys(result.headers)).not.toContain('x-request-id');
+    expect(Object.keys(result.headers)).not.toContain('x-internal');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SSRF guard
+// ---------------------------------------------------------------------------
+
+describe('webRequest — SSRF guard', () => {
+  it('blocks requests to loopback addresses', async () => {
+    const fetchFn = makeFetch(() => makeResponse({ body: 'should not reach' }));
+    await expect(
+      webRequest({
+        url: 'http://127.0.0.1/secret',
+        method: 'GET',
+        signal: signal(),
+        fetchFn,
+        // No lookupFn override — the IP literal path classifies without DNS
+      }),
+    ).rejects.toThrow(/internal\/private address/);
+  });
+
+  it('blocks requests to cloud metadata endpoint', async () => {
+    const fetchFn = makeFetch(() => makeResponse({ body: 'metadata' }));
+    await expect(
+      webRequest({
+        url: 'http://169.254.169.254/latest/meta-data/',
+        method: 'GET',
+        signal: signal(),
+        fetchFn,
+      }),
+    ).rejects.toThrow(/internal\/private address/);
+  });
+
+  it('allows public addresses', async () => {
+    const fetchFn = makeFetch(() => makeResponse({ body: 'public ok' }));
+    const result = await webRequest({
+      url: 'https://example.com/',
+      method: 'GET',
+      signal: signal(),
+      fetchFn,
+      lookupFn: publicLookup,
+    });
+    expect(result.status).toBe(200);
+  });
+
+  it('blocks hostname that resolves to private IP', async () => {
+    const privateLookup = async (): Promise<readonly { address: string }[]> => [
+      { address: '10.0.0.1' },
+    ];
+    const fetchFn = makeFetch(() => makeResponse({ body: 'private' }));
+    await expect(
+      webRequest({
+        url: 'https://internal.example.com/secret',
+        method: 'GET',
+        signal: signal(),
+        fetchFn,
+        lookupFn: privateLookup,
+      }),
+    ).rejects.toThrow(/internal\/private address/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Domain policy check
+// ---------------------------------------------------------------------------
+
+describe('webRequest — domain policy', () => {
+  it('blocks when domainCheck returns not-allowed', async () => {
+    const fetchFn = makeFetch(() => makeResponse({ body: 'ok' }));
+    await expect(
+      webRequest({
+        url: 'https://blocked.example.com/',
+        method: 'GET',
+        signal: signal(),
+        fetchFn,
+        lookupFn: publicLookup,
+        domainCheck: () => ({ allowed: false, reason: 'not in allowlist' }),
+      }),
+    ).rejects.toThrow(/domain policy/);
+  });
+
+  it('allows when domainCheck returns allowed', async () => {
+    const fetchFn = makeFetch(() => makeResponse({ body: 'ok' }));
+    const result = await webRequest({
+      url: 'https://allowed.example.com/',
+      method: 'GET',
+      signal: signal(),
+      fetchFn,
+      lookupFn: publicLookup,
+      domainCheck: () => ({ allowed: true }),
+    });
+    expect(result.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Effect ledger hook
+// ---------------------------------------------------------------------------
+
+describe('webRequest — effect ledger hook', () => {
+  it('calls recordEffect with correct metadata', async () => {
+    const fetchFn = makeFetch(() => makeResponse({ status: 201, body: 'created' }));
+    const calls: Array<{
+      url: string;
+      method: HttpMethod;
+      status: number;
+      risk: string;
+      timing_ms: number;
+    }> = [];
+
+    await webRequest({
+      url: 'https://api.example.com/items',
+      method: 'POST',
+      signal: signal(),
+      fetchFn,
+      lookupFn: publicLookup,
+      recordEffect: (entry) => {
+        calls.push(entry);
+      },
+    });
+
+    // recordEffect is fire-and-forget; wait a tick
+    await new Promise((r) => setTimeout(r, 10));
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe('https://api.example.com/items');
+    expect(calls[0]?.method).toBe('POST');
+    expect(calls[0]?.status).toBe(201);
+    expect(calls[0]?.risk).toBe('medium');
+    expect(calls[0]?.timing_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it('does not throw when recordEffect is absent', async () => {
+    const fetchFn = makeFetch(() => makeResponse({ body: 'ok' }));
+    await expect(
+      webRequest({
+        url: 'https://example.com/',
+        method: 'GET',
+        signal: signal(),
+        fetchFn,
+        lookupFn: publicLookup,
+      }),
+    ).resolves.not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+describe('webRequest — constant defaults', () => {
+  it('DEFAULT_TIMEOUT_MS is 30000', () => expect(DEFAULT_TIMEOUT_MS).toBe(30_000));
+  it('DEFAULT_MAX_RESPONSE_BYTES is 100000', () => expect(DEFAULT_MAX_RESPONSE_BYTES).toBe(100_000));
+  it('MAX_RESPONSE_BYTES is 1000000', () => expect(MAX_RESPONSE_BYTES).toBe(1_000_000));
+});

--- a/src/web/web-request.ts
+++ b/src/web/web-request.ts
@@ -1,0 +1,340 @@
+/**
+ * Core HTTP implementation for the `web_request` tool.
+ *
+ * Provides structured, SSRF-guarded HTTP requests supporting all standard
+ * methods (GET, HEAD, OPTIONS, POST, PUT, PATCH, DELETE) with:
+ *   - SSRF protection via `guardedFetch` (per-hop redirect validation)
+ *   - Automatic retry only for idempotent methods (GET, HEAD, OPTIONS, PUT,
+ *     DELETE); POST/PATCH are never auto-retried
+ *   - Response body truncation to a configurable byte budget
+ *   - JSON auto-parse when response Content-Type is application/json
+ *   - Filtered response headers (no set-cookie, no x-* internals)
+ *   - Timing measurement
+ *
+ * Risk classification (for callers / audit trails):
+ *   GET / HEAD / OPTIONS → low
+ *   POST / PUT / PATCH   → medium
+ *   DELETE               → high
+ *
+ * Domain policy: callers may optionally pass a `domainCheck` to enforce
+ * AFK_BROWSER_ALLOWED_DOMAINS / AFK_BROWSER_BLOCKED_DOMAINS in addition to
+ * the SSRF guard. The SSRF guard always runs regardless.
+ *
+ * Effect ledger hook: when a `recordEffect` callback is supplied the call is
+ * forwarded after the response is returned. The function is optional — callers
+ * that don't supply it get no ledger write, so there is no hard dependency on
+ * the ledger being present (it is built in parallel as #1412).
+ *
+ * @module web/web-request
+ */
+
+import { guardedFetch, checkEgressTarget, EgressBlockedError } from './egress-guard.js';
+import type { EgressGuardOptions } from './egress-guard.js';
+import type { FetchFn } from './types.js';
+import { headAndTail } from '../agent/tools/handlers/_output-cap.js';
+
+// ---------------------------------------------------------------------------
+// Public constants
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_TIMEOUT_MS = 30_000;
+export const MAX_TIMEOUT_MS = 120_000;
+export const DEFAULT_MAX_RESPONSE_BYTES = 100_000;
+export const MAX_RESPONSE_BYTES = 1_000_000;
+
+// ---------------------------------------------------------------------------
+// Risk classification
+// ---------------------------------------------------------------------------
+
+/** HTTP method risk classification per the tool spec. */
+export type MethodRisk = 'low' | 'medium' | 'high';
+
+/** All supported HTTP methods (uppercase). */
+export type HttpMethod = 'GET' | 'HEAD' | 'OPTIONS' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+const LOW_RISK_METHODS = new Set<HttpMethod>(['GET', 'HEAD', 'OPTIONS']);
+const IDEMPOTENT_METHODS = new Set<HttpMethod>(['GET', 'HEAD', 'OPTIONS', 'PUT', 'DELETE']);
+
+export function classifyMethodRisk(method: HttpMethod): MethodRisk {
+  if (LOW_RISK_METHODS.has(method)) return 'low';
+  if (method === 'DELETE') return 'high';
+  return 'medium';
+}
+
+export function isIdempotentMethod(method: HttpMethod): boolean {
+  return IDEMPOTENT_METHODS.has(method);
+}
+
+// ---------------------------------------------------------------------------
+// Response header filtering
+// ---------------------------------------------------------------------------
+
+/**
+ * Headers suppressed from the structured response to avoid leaking
+ * auth cookies, server internals, or implementation details.
+ */
+const SUPPRESSED_HEADER_PREFIXES = ['set-cookie', 'x-'];
+const SUPPRESSED_HEADERS_EXACT = new Set(['server', 'via', 'age', 'vary']);
+
+function filterResponseHeaders(headers: Headers): Record<string, string> {
+  const out: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    const lower = key.toLowerCase();
+    if (SUPPRESSED_HEADERS_EXACT.has(lower)) return;
+    if (SUPPRESSED_HEADER_PREFIXES.some((p) => lower.startsWith(p))) return;
+    out[key] = value;
+  });
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Body serialisation
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialise the caller-supplied `body` field into a fetch-ready body string
+ * and infer the Content-Type when not already present.
+ * Returns `{ serialized, contentType }` where `contentType` is undefined
+ * when the caller already set one in `headers`.
+ */
+function serializeBody(
+  body: string | Record<string, unknown> | unknown[] | null | undefined,
+  headers: Record<string, string>,
+): { serialized: string | undefined; inferredContentType: string | undefined } {
+  if (body === null || body === undefined) {
+    return { serialized: undefined, inferredContentType: undefined };
+  }
+  const hasContentType = Object.keys(headers).some(
+    (k) => k.toLowerCase() === 'content-type',
+  );
+  if (typeof body === 'string') {
+    return { serialized: body, inferredContentType: hasContentType ? undefined : 'text/plain' };
+  }
+  // object / array → JSON
+  const serialized = JSON.stringify(body);
+  return {
+    serialized,
+    inferredContentType: hasContentType ? undefined : 'application/json',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Response body parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Truncate a raw response body to `maxBytes` and auto-parse JSON when the
+ * Content-Type header indicates it.
+ */
+function parseResponseBody(
+  raw: string,
+  contentType: string,
+  maxBytes: number,
+): { body: string | unknown; truncated: boolean } {
+  const byteLen = Buffer.byteLength(raw, 'utf8');
+  let bodyText = raw;
+  let truncated = false;
+
+  if (byteLen > maxBytes) {
+    bodyText = headAndTail(raw, maxBytes);
+    truncated = true;
+  }
+
+  // Auto-parse JSON (non-truncated only — partial JSON is not parseable)
+  if (!truncated && /application\/json/i.test(contentType)) {
+    try {
+      return { body: JSON.parse(bodyText) as unknown, truncated: false };
+    } catch {
+      // Parse failure: return as text
+    }
+  }
+
+  return { body: bodyText, truncated };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/** Structured result returned by {@link webRequest}. */
+export interface WebRequestResult {
+  status: number;
+  /** Filtered response headers. */
+  headers: Record<string, string>;
+  /** Response body — auto-parsed JSON object or string. Truncated when `truncated` is true. */
+  body: unknown;
+  /** True when the response body was truncated to `maxResponseBytes`. */
+  truncated: boolean;
+  /** Wall-clock duration of the HTTP round trip, in milliseconds. */
+  timing_ms: number;
+  /** Risk level of the HTTP method used. */
+  risk: MethodRisk;
+}
+
+/** Optional hook for recording the call in an effect ledger (#1412). */
+export type RecordEffectFn = (entry: {
+  url: string;
+  method: HttpMethod;
+  status: number;
+  risk: MethodRisk;
+  timing_ms: number;
+}) => void | Promise<void>;
+
+/** Domain policy check — same shape as `enforceDomainPolicy` from browser/config. */
+export type DomainCheckFn = (
+  url: string,
+) => { allowed: true } | { allowed: false; reason: string };
+
+export interface WebRequestOptions {
+  url: string;
+  method: HttpMethod;
+  body?: string | Record<string, unknown> | unknown[] | null;
+  headers?: Record<string, string>;
+  maxResponseBytes?: number;
+  /** Abort signal — request is cancelled when this fires. Timeout is managed by the caller. */
+  signal: AbortSignal;
+  /** Override fetch for tests. Defaults to `globalThis.fetch`. */
+  fetchFn?: FetchFn;
+  /** DNS resolution override for tests (forwarded to the egress guard). */
+  lookupFn?: EgressGuardOptions['lookupFn'];
+  /**
+   * Optional domain policy enforcer (AFK_BROWSER_ALLOWED_DOMAINS /
+   * BLOCKED_DOMAINS). Runs IN ADDITION to the SSRF guard; a blocked domain
+   * verdict causes an immediate error return, same as an SSRF block.
+   */
+  domainCheck?: DomainCheckFn;
+  /**
+   * Optional hook for recording the call in the effect ledger.
+   * If absent the tool still works — no hard ledger dependency.
+   */
+  recordEffect?: RecordEffectFn;
+}
+
+/**
+ * Make a structured, SSRF-guarded HTTP request.
+ *
+ * @throws {EgressBlockedError} when the target resolves to an internal address.
+ *   Callers should catch this and surface a structured error ToolResult.
+ * @throws {Error} on network-level failures. Caller surfaces as error ToolResult.
+ * @throws when `signal` is already aborted or fires mid-request.
+ */
+export async function webRequest(opts: WebRequestOptions): Promise<WebRequestResult> {
+  const {
+    url,
+    method,
+    signal,
+    domainCheck,
+    recordEffect,
+  } = opts;
+
+  const maxResponseBytes = Math.min(
+    opts.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES,
+    MAX_RESPONSE_BYTES,
+  );
+  const headers: Record<string, string> = { ...opts.headers };
+  const fetchFn = opts.fetchFn ?? globalThis.fetch;
+  const guardOpts: EgressGuardOptions = opts.lookupFn !== undefined
+    ? { lookupFn: opts.lookupFn }
+    : {};
+
+  const risk = classifyMethodRisk(method);
+
+  // -- Domain policy check (runs before SSRF guard to give a clearer error) --
+  if (domainCheck !== undefined) {
+    const verdict = domainCheck(url);
+    if (!verdict.allowed) {
+      throw Object.assign(new Error(`web_request blocked by domain policy: ${verdict.reason}`), {
+        name: 'DomainPolicyError',
+      });
+    }
+  }
+
+  // -- SSRF pre-check ---------------------------------------------------------
+  const egressVerdict = await checkEgressTarget(url, guardOpts);
+  if (!egressVerdict.allowed) {
+    throw new EgressBlockedError(egressVerdict.reason);
+  }
+
+  // -- Body serialisation -----------------------------------------------------
+  const { serialized: rawBody, inferredContentType } = serializeBody(opts.body, headers);
+  if (inferredContentType !== undefined) {
+    headers['content-type'] = inferredContentType;
+  }
+
+  // -- Build fetch init -------------------------------------------------------
+  const init: RequestInit = {
+    method,
+    headers: Object.keys(headers).length > 0 ? headers : undefined,
+    body: rawBody,
+    signal,
+  };
+
+  // -- Execute request (with optional retry for idempotent methods) -----------
+  const idempotent = isIdempotentMethod(method);
+  const retryOpts = idempotent
+    ? { retries: 2, baseDelayMs: 300, maxDelayMs: 5_000 }
+    : { retries: 0 }; // never auto-retry POST/PATCH
+
+  const t0 = Date.now();
+
+  let response: Response;
+  try {
+    // guardedFetch owns the redirect loop + SSRF re-check on each hop.
+    response = await guardedFetch(fetchFn, url, init, {
+      ...guardOpts,
+      retry: retryOpts,
+    });
+  } catch (err) {
+    // EgressBlockedError surfaces cleanly — re-throw as-is for the handler.
+    if (err instanceof EgressBlockedError) throw err;
+    throw err;
+  }
+
+  const timing_ms = Date.now() - t0;
+  const responseContentType = response.headers.get('content-type') ?? '';
+
+  let rawBodyText: string;
+  try {
+    // HEAD / OPTIONS may have no body; .text() returns '' in that case.
+    rawBodyText = await response.text();
+  } catch {
+    rawBodyText = '';
+  }
+
+  const { body, truncated } = parseResponseBody(rawBodyText, responseContentType, maxResponseBytes);
+  const filteredHeaders = filterResponseHeaders(response.headers);
+
+  // -- Effect ledger (fire-and-forget; no hard dependency) --------------------
+  if (recordEffect !== undefined) {
+    void Promise.resolve(
+      recordEffect({ url, method, status: response.status, risk, timing_ms }),
+    ).catch(() => undefined);
+  }
+
+  return {
+    status: response.status,
+    headers: filteredHeaders,
+    body,
+    truncated,
+    timing_ms,
+    risk,
+  };
+}
+
+/**
+ * Validate and normalise a raw `method` string to an uppercase `HttpMethod`.
+ * Returns `{ error }` when the method is not supported.
+ */
+export function parseMethod(raw: unknown): HttpMethod | { error: string } {
+  if (typeof raw !== 'string' || raw.trim().length === 0) {
+    return { error: 'method must be a non-empty string (GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS)' };
+  }
+  const upper = raw.trim().toUpperCase() as HttpMethod;
+  const SUPPORTED: readonly HttpMethod[] = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'];
+  if (!SUPPORTED.includes(upper)) {
+    return {
+      error: `method "${raw}" is not supported — must be one of: ${SUPPORTED.join(', ')}`,
+    };
+  }
+  return upper;
+}

--- a/src/web/web-request.ts
+++ b/src/web/web-request.ts
@@ -74,7 +74,12 @@ export function isIdempotentMethod(method: HttpMethod): boolean {
  * auth cookies, server internals, or implementation details.
  */
 const SUPPRESSED_HEADER_PREFIXES = ['set-cookie', 'x-'];
-const SUPPRESSED_HEADERS_EXACT = new Set(['server', 'via', 'age', 'vary']);
+const SUPPRESSED_HEADERS_EXACT = new Set([
+  'server', 'via', 'age', 'vary',
+  // Prevent OAuth/token-exchange responses that echo bearer tokens in headers
+  // from leaking credentials into model context.
+  'authorization', 'www-authenticate',
+]);
 
 function filterResponseHeaders(headers: Headers): Record<string, string> {
   const out: Record<string, string> = {};
@@ -295,8 +300,30 @@ export async function webRequest(opts: WebRequestOptions): Promise<WebRequestRes
 
   let rawBodyText: string;
   try {
-    // HEAD / OPTIONS may have no body; .text() returns '' in that case.
-    rawBodyText = await response.text();
+    // Stream the response body up to 2× maxResponseBytes before the downstream
+    // truncation logic runs. This prevents an untrusted endpoint from forcing
+    // the process to buffer an arbitrarily large response body via response.text().
+    const reader = response.body?.getReader();
+    if (!reader) {
+      rawBodyText = '';
+    } else {
+      const chunks: Uint8Array[] = [];
+      let totalBytes = 0;
+      const byteLimit = maxResponseBytes * 2;
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done || !value) break;
+        chunks.push(value);
+        totalBytes += value.byteLength;
+        if (totalBytes >= byteLimit) {
+          await reader.cancel();
+          break;
+        }
+      }
+      rawBodyText = new TextDecoder().decode(
+        Buffer.concat(chunks, totalBytes),
+      );
+    }
   } catch {
     rawBodyText = '';
   }


### PR DESCRIPTION
## Summary

Adds a structured `web_request` tool for making HTTP requests (GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS) with full SSRF protection, risk classification, credential injection, and secret redaction.

Closes #1413

## New files

| File | Purpose |
|------|---------|
| `src/web/web-request.ts` (343 LOC) | Core HTTP implementation -- SSRF guard via `guardedFetch`, body serialization, header filtering, response truncation, effect ledger hook point |
| `src/agent/tools/handlers/web-request.ts` (308 LOC) | Tool handler -- input validation, credential injection from env vars, abort/timeout wiring, secret redaction in witness |

## Modified files

- `src/agent/tools/schemas.ts` -- added `webRequestTool` definition (30 -> 31 tools)
- `src/agent/tools/handlers/index.ts` -- registered `webRequestHandler`
- `src/agent/tool-category.ts` -- added `web_request` to `WEB_TOOLS`
- `src/agent/risk-classifier.ts` -- GET/HEAD/OPTIONS = safe, POST/PUT/PATCH = medium, DELETE = high

## Design decisions

- **SSRF guard reused** -- all requests pass through `guardedFetch` from `egress-guard.ts`
- **Effect ledger integration is fire-and-forget** -- `recordEffect` hook point exists but doesn't block or error when ledger absent (parallel #1412)
- **Credential references** -- `credential` field maps to env var names, resolved at runtime, never exposed to model context
- **Domain policy** -- respects `AFK_BROWSER_ALLOWED_DOMAINS` / `BLOCKED_DOMAINS` when set
- **Header filtering** -- strips `set-cookie`, `x-*`, `server`, `via`, `age`, `vary` from responses
- **Retry safety** -- only idempotent methods (GET, HEAD, OPTIONS, PUT, DELETE) auto-retry; POST/PATCH never retried

## Verification

- 76 new tests (44 core + 32 handler) -- all pass
- 18,725 total tests pass, 0 failures
- `pnpm lint` -- clean
