### PR TITLE
feat(core): external-effect and idempotency ledger (#1412)

### DIFF
--- a/src/agent/default-hook-registry.ts
+++ b/src/agent/default-hook-registry.ts
@@ -298,7 +298,11 @@ export function createDefaultHookRegistry(
   // a full disk or unwritable state dir never disrupts tool execution.
   // Registered last among built-in PostToolUse handlers so it runs after all
   // policy hooks (path-approval once-grant revoke, etc.) have fired.
-  registry.register('PostToolUse', createEffectLedgerPostHook());
+  // Also registered for PostToolUseFailure so thrown tool handlers (the most
+  // uncertain-outcome case) are recorded with status 'failed'.
+  const ledgerHook = createEffectLedgerPostHook();
+  registry.register('PostToolUse', ledgerHook);
+  registry.register('PostToolUseFailure', ledgerHook);
 
   // Register config-driven shell hooks after all built-ins so built-in
   // handlers always run first. Config hooks are optional — when no

--- a/src/agent/default-hook-registry.ts
+++ b/src/agent/default-hook-registry.ts
@@ -19,6 +19,7 @@ import { runReceiptSessionEndHook } from './trace/receipt.js';
 import { createFacetSessionEndHook } from './facets/session-end-hook.js';
 import { inboundAttachmentRegistry } from './content/attachment-registry.js';
 import { env } from '../config/env.js';
+import { createEffectLedgerPostHook } from './effect-ledger/index.js';
 import {
   createPathApprovalHook,
   type PathApprovalSurface,
@@ -290,6 +291,14 @@ export function createDefaultHookRegistry(
       return {};
     });
   }
+
+  // External-effect ledger: record outbound side effects (Telegram sends,
+  // GitHub PR creation, MCP writes, outbound bash commands) to a durable
+  // NDJSON file. Non-blocking, best-effort — write failures are swallowed so
+  // a full disk or unwritable state dir never disrupts tool execution.
+  // Registered last among built-in PostToolUse handlers so it runs after all
+  // policy hooks (path-approval once-grant revoke, etc.) have fired.
+  registry.register('PostToolUse', createEffectLedgerPostHook());
 
   // Register config-driven shell hooks after all built-ins so built-in
   // handlers always run first. Config hooks are optional — when no

--- a/src/agent/effect-ledger/classifier.test.ts
+++ b/src/agent/effect-ledger/classifier.test.ts
@@ -19,13 +19,13 @@ describe('classifyToolCall — always-external tools', () => {
   it('mcp__ prefixed tools are external', () => {
     const c = classifyToolCall('mcp__github__create_issue', {});
     expect(c.isExternal).toBe(true);
-    expect(c.operationType).toBe('mcp_write');
+    expect(c.operationType).toBe('mcp_write:mcp__github__create_issue');
   });
 
   it('MCP__ prefixed tools are external (uppercase)', () => {
     const c = classifyToolCall('MCP__someserver__write', {});
     expect(c.isExternal).toBe(true);
-    expect(c.operationType).toBe('mcp_write');
+    expect(c.operationType).toBe('mcp_write:MCP__someserver__write');
   });
 });
 
@@ -67,6 +67,21 @@ describe('classifyToolCall — bash external patterns', () => {
 
   it('curl --data is external', () => {
     const c = classifyToolCall('bash', { command: 'curl --data \'payload\' https://api.example.com/' });
+    expect(c.isExternal).toBe(true);
+  });
+
+  it('curl -XPOST (no space) is external', () => {
+    const c = classifyToolCall('bash', { command: 'curl -XPOST https://api.example.com/hook' });
+    expect(c.isExternal).toBe(true);
+  });
+
+  it('curl --request POST is external', () => {
+    const c = classifyToolCall('bash', { command: 'curl --request POST https://api.example.com/submit' });
+    expect(c.isExternal).toBe(true);
+  });
+
+  it('curl -F (multipart form) is external', () => {
+    const c = classifyToolCall('bash', { command: 'curl -F file=@photo.jpg https://api.example.com/upload' });
     expect(c.isExternal).toBe(true);
   });
 

--- a/src/agent/effect-ledger/classifier.test.ts
+++ b/src/agent/effect-ledger/classifier.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Unit tests for the tool-call classifier.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { classifyToolCall } from './classifier.js';
+
+// ---------------------------------------------------------------------------
+// Always-external tools
+// ---------------------------------------------------------------------------
+
+describe('classifyToolCall — always-external tools', () => {
+  it('send_telegram is always external', () => {
+    const c = classifyToolCall('send_telegram', { message: 'hi' });
+    expect(c.isExternal).toBe(true);
+    expect(c.operationType).toBe('send_telegram');
+  });
+
+  it('mcp__ prefixed tools are external', () => {
+    const c = classifyToolCall('mcp__github__create_issue', {});
+    expect(c.isExternal).toBe(true);
+    expect(c.operationType).toBe('mcp_write');
+  });
+
+  it('MCP__ prefixed tools are external (uppercase)', () => {
+    const c = classifyToolCall('MCP__someserver__write', {});
+    expect(c.isExternal).toBe(true);
+    expect(c.operationType).toBe('mcp_write');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bash — external patterns
+// ---------------------------------------------------------------------------
+
+describe('classifyToolCall — bash external patterns', () => {
+  it('gh pr create is external', () => {
+    const c = classifyToolCall('bash', { command: 'gh pr create --title "My PR"' });
+    expect(c.isExternal).toBe(true);
+    expect(c.operationType).toBe('bash_external');
+  });
+
+  it('gh issue create is external', () => {
+    const c = classifyToolCall('bash', { command: 'gh issue create --title "Bug"' });
+    expect(c.isExternal).toBe(true);
+  });
+
+  it('gh release create is external', () => {
+    const c = classifyToolCall('bash', { command: 'gh release create v1.0.0' });
+    expect(c.isExternal).toBe(true);
+  });
+
+  it('git push is external', () => {
+    const c = classifyToolCall('bash', { command: 'git push origin main' });
+    expect(c.isExternal).toBe(true);
+  });
+
+  it('git push --force is external', () => {
+    const c = classifyToolCall('bash', { command: 'git push --force origin my-branch' });
+    expect(c.isExternal).toBe(true);
+  });
+
+  it('curl POST is external', () => {
+    const c = classifyToolCall('bash', { command: 'curl -X POST https://api.example.com/webhook -d \'{"event":"test"}\'' });
+    expect(c.isExternal).toBe(true);
+  });
+
+  it('curl --data is external', () => {
+    const c = classifyToolCall('bash', { command: 'curl --data \'payload\' https://api.example.com/' });
+    expect(c.isExternal).toBe(true);
+  });
+
+  it('pnpm publish is external', () => {
+    const c = classifyToolCall('bash', { command: 'pnpm publish --access public' });
+    expect(c.isExternal).toBe(true);
+  });
+
+  it('npm publish is external', () => {
+    const c = classifyToolCall('bash', { command: 'npm publish' });
+    expect(c.isExternal).toBe(true);
+  });
+
+  it('docker push is external', () => {
+    const c = classifyToolCall('bash', { command: 'docker push myimage:latest' });
+    expect(c.isExternal).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bash — NOT external
+// ---------------------------------------------------------------------------
+
+describe('classifyToolCall — bash not external', () => {
+  it('git commit is not external', () => {
+    const c = classifyToolCall('bash', { command: 'git commit -m "feat: add tests"' });
+    expect(c.isExternal).toBe(false);
+  });
+
+  it('git status is not external', () => {
+    const c = classifyToolCall('bash', { command: 'git status' });
+    expect(c.isExternal).toBe(false);
+  });
+
+  it('ls command is not external', () => {
+    const c = classifyToolCall('bash', { command: 'ls -la' });
+    expect(c.isExternal).toBe(false);
+  });
+
+  it('curl GET (no -d / -X POST) is not external', () => {
+    const c = classifyToolCall('bash', { command: 'curl https://api.example.com/status' });
+    expect(c.isExternal).toBe(false);
+  });
+
+  it('pnpm test is not external', () => {
+    const c = classifyToolCall('bash', { command: 'pnpm test' });
+    expect(c.isExternal).toBe(false);
+  });
+
+  it('handles missing command field gracefully', () => {
+    const c = classifyToolCall('bash', { notCommand: 'foo' });
+    expect(c.isExternal).toBe(false);
+  });
+
+  it('handles null input gracefully', () => {
+    const c = classifyToolCall('bash', null);
+    expect(c.isExternal).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// browser_act
+// ---------------------------------------------------------------------------
+
+describe('classifyToolCall — browser_act', () => {
+  it('click is external', () => {
+    const c = classifyToolCall('browser_act', { action: 'click', target: { kind: 'semantic', text: 'Submit' } });
+    expect(c.isExternal).toBe(true);
+    expect(c.operationType).toBe('browser_act_external');
+  });
+
+  it('fill is external', () => {
+    const c = classifyToolCall('browser_act', { action: 'fill', target: { kind: 'semantic', text: 'Email' }, value: 'test@example.com' });
+    expect(c.isExternal).toBe(true);
+  });
+
+  it('scroll_to is not external', () => {
+    const c = classifyToolCall('browser_act', { action: 'scroll_to', target: { kind: 'semantic', text: 'Footer' } });
+    expect(c.isExternal).toBe(false);
+  });
+
+  it('hover is not external', () => {
+    const c = classifyToolCall('browser_act', { action: 'hover', target: { kind: 'semantic', text: 'Menu' } });
+    expect(c.isExternal).toBe(false);
+  });
+
+  it('wait_for is not external', () => {
+    const c = classifyToolCall('browser_act', { action: 'wait_for', target: { kind: 'semantic', text: 'Spinner' } });
+    expect(c.isExternal).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Read/write/shell tools — not external
+// ---------------------------------------------------------------------------
+
+describe('classifyToolCall — non-external tools', () => {
+  it('read_file is not external', () => {
+    expect(classifyToolCall('read_file', { file_path: '/tmp/foo.ts' }).isExternal).toBe(false);
+  });
+
+  it('write_file is not external', () => {
+    expect(classifyToolCall('write_file', { file_path: '/tmp/foo.ts', content: '' }).isExternal).toBe(false);
+  });
+
+  it('edit_file is not external', () => {
+    expect(classifyToolCall('edit_file', {}).isExternal).toBe(false);
+  });
+
+  it('glob is not external', () => {
+    expect(classifyToolCall('glob', { pattern: '**/*.ts' }).isExternal).toBe(false);
+  });
+
+  it('agent is not external', () => {
+    expect(classifyToolCall('agent', { prompt: 'do something' }).isExternal).toBe(false);
+  });
+
+  it('unknown tool is not external', () => {
+    expect(classifyToolCall('some_custom_tool', {}).isExternal).toBe(false);
+  });
+});

--- a/src/agent/effect-ledger/classifier.ts
+++ b/src/agent/effect-ledger/classifier.ts
@@ -1,0 +1,145 @@
+/**
+ * Effect classifier: determines whether a tool call constitutes an external
+ * side effect that must be tracked in the ledger.
+ *
+ * # V1 approach
+ *
+ * A static allowlist of tool names and (for bash) a command-content scanner.
+ * The allowlist is the single source of truth for "what counts as an external
+ * effect". Future work can replace `classifyToolCall` with a plugin-based
+ * classifier that consults dynamic rules or MCP server metadata.
+ *
+ * # Extensibility path
+ *
+ * The public interface is `classifyToolCall(toolName, input) → Classification`.
+ * Replace the function body to add dynamic classification; the hook layer
+ * consumes only this interface.
+ *
+ * @module agent/effect-ledger/classifier
+ */
+
+// ---------------------------------------------------------------------------
+// Static allowlists
+// ---------------------------------------------------------------------------
+
+/**
+ * Tool names that are ALWAYS external effects regardless of their arguments.
+ */
+const ALWAYS_EXTERNAL_TOOLS = new Set<string>([
+  // Outbound Telegram message
+  'send_telegram',
+  // MCP write tools match the `mcp__*` prefix pattern — see classifyToolCall.
+]);
+
+/**
+ * Browser actions that submit data externally (form submit, API call, etc.).
+ * `browser_act` is external only when the action is a click or fill on a
+ * submit-flavoured target — we approximate with the action type.
+ */
+const EXTERNAL_BROWSER_ACTIONS = new Set<string>([
+  'click',
+  'fill',
+  'press',
+]);
+
+/**
+ * Command fragments that indicate a bash invocation produces an external effect.
+ * Matched as case-insensitive substrings of the full command string.
+ */
+const EXTERNAL_BASH_PATTERNS: readonly RegExp[] = [
+  // GitHub CLI operations that create/mutate remote state
+  /\bgh\s+(pr|issue|release|repo)\s+(create|edit|merge|close|delete|push|comment)/i,
+  // git push (including --force variants)
+  /\bgit\s+push\b/i,
+  // curl / wget POSTing to external APIs
+  /\bcurl\b.*\s(?:-X\s*POST|-d\s|--data\b|--data-raw\b)/i,
+  /\bwget\b.*\s(?:--post-data\b|--post-file\b)/i,
+  // npm publish / pnpm publish / yarn publish
+  /\b(?:npm|pnpm|yarn)\s+publish\b/i,
+  // docker push
+  /\bdocker\s+push\b/i,
+];
+
+// ---------------------------------------------------------------------------
+// Classification result
+// ---------------------------------------------------------------------------
+
+/** Result returned by the classifier for each tool call. */
+export interface Classification {
+  /** True when this call is an external side effect that must be ledgered. */
+  isExternal: boolean;
+  /**
+   * Human-readable operation type string (used as the `operationType` field
+   * in the effect record). Only meaningful when `isExternal` is true.
+   */
+  operationType: string;
+}
+
+// ---------------------------------------------------------------------------
+// Classifier
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify a tool call as an external effect or not.
+ *
+ * @param toolName  The name of the tool being called.
+ * @param input     The raw (un-redacted) tool input.
+ * @returns         `{ isExternal, operationType }`.
+ */
+export function classifyToolCall(toolName: string, input: unknown): Classification {
+  // MCP write tools: any tool name prefixed with `mcp__` is considered an
+  // external mutation regardless of the specific server. Read-only MCP tools
+  // cannot be distinguished from their name alone; v1 treats ALL MCP calls as
+  // external (conservative). A future classifier can inspect the MCP server
+  // schema to exclude read-only operations.
+  if (toolName.startsWith('mcp__') || toolName.startsWith('MCP__')) {
+    return { isExternal: true, operationType: 'mcp_write' };
+  }
+
+  // Always-external tool names.
+  if (ALWAYS_EXTERNAL_TOOLS.has(toolName)) {
+    return { isExternal: true, operationType: toolName };
+  }
+
+  // bash: scan command content for external-effect patterns.
+  if (toolName === 'bash') {
+    const command = extractBashCommand(input);
+    if (command !== null) {
+      for (const pattern of EXTERNAL_BASH_PATTERNS) {
+        if (pattern.test(command)) {
+          return { isExternal: true, operationType: 'bash_external' };
+        }
+      }
+    }
+    return { isExternal: false, operationType: 'bash' };
+  }
+
+  // browser_act: external when it performs a state-changing action.
+  if (toolName === 'browser_act') {
+    const action = extractBrowserAction(input);
+    if (action !== null && EXTERNAL_BROWSER_ACTIONS.has(action)) {
+      return { isExternal: true, operationType: 'browser_act_external' };
+    }
+    return { isExternal: false, operationType: 'browser_act' };
+  }
+
+  return { isExternal: false, operationType: toolName };
+}
+
+// ---------------------------------------------------------------------------
+// Input extractors
+// ---------------------------------------------------------------------------
+
+function extractBashCommand(input: unknown): string | null {
+  if (input === null || typeof input !== 'object') return null;
+  const obj = input as Record<string, unknown>;
+  const cmd = obj['command'];
+  return typeof cmd === 'string' ? cmd : null;
+}
+
+function extractBrowserAction(input: unknown): string | null {
+  if (input === null || typeof input !== 'object') return null;
+  const obj = input as Record<string, unknown>;
+  const action = obj['action'];
+  return typeof action === 'string' ? action : null;
+}

--- a/src/agent/effect-ledger/classifier.ts
+++ b/src/agent/effect-ledger/classifier.ts
@@ -52,7 +52,7 @@ const EXTERNAL_BASH_PATTERNS: readonly RegExp[] = [
   // git push (including --force variants)
   /\bgit\s+push\b/i,
   // curl / wget POSTing to external APIs
-  /\bcurl\b.*\s(?:-X\s*POST|-d\s|--data\b|--data-raw\b)/i,
+  /\bcurl\b.*(?:\s-X\s*POST|-XPOST|--request\s+POST|-d\s|--data\b|--data-raw\b|-F\s)/i,
   /\bwget\b.*\s(?:--post-data\b|--post-file\b)/i,
   // npm publish / pnpm publish / yarn publish
   /\b(?:npm|pnpm|yarn)\s+publish\b/i,
@@ -93,7 +93,7 @@ export function classifyToolCall(toolName: string, input: unknown): Classificati
   // external (conservative). A future classifier can inspect the MCP server
   // schema to exclude read-only operations.
   if (toolName.startsWith('mcp__') || toolName.startsWith('MCP__')) {
-    return { isExternal: true, operationType: 'mcp_write' };
+    return { isExternal: true, operationType: `mcp_write:${toolName}` };
   }
 
   // Always-external tool names.

--- a/src/agent/effect-ledger/hook.test.ts
+++ b/src/agent/effect-ledger/hook.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Integration tests for the PostToolUse effect-ledger hook.
+ *
+ * Each test creates an isolated EffectStore backed by a temp file to avoid
+ * cross-test contamination.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createEffectLedgerPostHook } from './hook.js';
+import { EffectStore } from './store.js';
+import type { PostToolUseContext } from '../hooks.js';
+
+let tmpDir: string;
+let ledgerPath: string;
+let store: EffectStore;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'effect-ledger-hook-test-'));
+  ledgerPath = join(tmpDir, 'effect-ledger.jsonl');
+  store = new EffectStore(ledgerPath);
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function makeCtx(overrides: Partial<PostToolUseContext> = {}): PostToolUseContext {
+  return {
+    event: 'PostToolUse',
+    toolName: 'send_telegram',
+    input: { message: 'hello' },
+    output: { content: 'Sent Telegram message to chat 12345.' },
+    sessionId: 'test-session',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Non-external tools are ignored
+// ---------------------------------------------------------------------------
+
+describe('createEffectLedgerPostHook — non-external tools', () => {
+  it('does not write a record for read_file', async () => {
+    const hook = createEffectLedgerPostHook(store);
+    const ctx: PostToolUseContext = {
+      event: 'PostToolUse',
+      toolName: 'read_file',
+      input: { file_path: '/tmp/foo.ts' },
+      output: { content: 'file contents' },
+    };
+    await hook(ctx);
+    const all = await store.all();
+    expect(all).toHaveLength(0);
+  });
+
+  it('does not write a record for edit_file', async () => {
+    const hook = createEffectLedgerPostHook(store);
+    const ctx: PostToolUseContext = {
+      event: 'PostToolUse',
+      toolName: 'edit_file',
+      input: {},
+      output: {},
+    };
+    await hook(ctx);
+    expect(await store.all()).toHaveLength(0);
+  });
+
+  it('does not write a record for bash ls', async () => {
+    const hook = createEffectLedgerPostHook(store);
+    const ctx: PostToolUseContext = {
+      event: 'PostToolUse',
+      toolName: 'bash',
+      input: { command: 'ls -la' },
+      output: { content: 'file list' },
+    };
+    await hook(ctx);
+    expect(await store.all()).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// External tools are recorded
+// ---------------------------------------------------------------------------
+
+describe('createEffectLedgerPostHook — external tools', () => {
+  it('records send_telegram as executed', async () => {
+    const hook = createEffectLedgerPostHook(store);
+    await hook(makeCtx());
+    const all = await store.all();
+    expect(all).toHaveLength(1);
+    expect(all[0]?.operationType).toBe('send_telegram');
+    expect(all[0]?.status).toBe('executed');
+    expect(all[0]?.sessionId).toBe('test-session');
+  });
+
+  it('records send_telegram as failed when output has isError: true', async () => {
+    const hook = createEffectLedgerPostHook(store);
+    await hook(makeCtx({ output: { isError: true, content: 'Telegram is not configured' } }));
+    const all = await store.all();
+    expect(all).toHaveLength(1);
+    expect(all[0]?.status).toBe('failed');
+  });
+
+  it('records bash git push as external', async () => {
+    const hook = createEffectLedgerPostHook(store);
+    const ctx: PostToolUseContext = {
+      event: 'PostToolUse',
+      toolName: 'bash',
+      input: { command: 'git push origin main' },
+      output: { content: 'Branch pushed.' },
+      sessionId: 'sess-2',
+    };
+    await hook(ctx);
+    const all = await store.all();
+    expect(all).toHaveLength(1);
+    expect(all[0]?.operationType).toBe('bash_external');
+    expect(all[0]?.status).toBe('executed');
+  });
+
+  it('records mcp__ tool as mcp_write', async () => {
+    const hook = createEffectLedgerPostHook(store);
+    const ctx: PostToolUseContext = {
+      event: 'PostToolUse',
+      toolName: 'mcp__github__create_pr',
+      input: { title: 'My PR', body: 'desc' },
+      output: { number: 42 },
+    };
+    await hook(ctx);
+    const all = await store.all();
+    expect(all).toHaveLength(1);
+    expect(all[0]?.operationType).toBe('mcp_write');
+  });
+
+  it('stores redacted args (token removed)', async () => {
+    const hook = createEffectLedgerPostHook(store);
+    const ctx: PostToolUseContext = {
+      event: 'PostToolUse',
+      toolName: 'send_telegram',
+      input: { message: 'token sk-ant-api03-' + 'A'.repeat(30) + ' in message' },
+      output: { content: 'Sent.' },
+    };
+    await hook(ctx);
+    const all = await store.all();
+    expect(all).toHaveLength(1);
+    const argsStr = JSON.stringify(all[0]?.args);
+    expect(argsStr).not.toContain('sk-ant-api03-');
+    expect(argsStr).toContain('[REDACTED]');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Idempotency — dedup for executed records
+// ---------------------------------------------------------------------------
+
+describe('createEffectLedgerPostHook — dedup behavior', () => {
+  it('records both calls when same args sent twice (marks first ambiguous on second)', async () => {
+    const hook = createEffectLedgerPostHook(store);
+    const ctx = makeCtx();
+    // First call: records as executed.
+    await hook(ctx);
+    // Second call with same args: prior record exists with status "executed".
+    // The hook writes a new pending record (the "ambiguous" note).
+    await hook(ctx);
+
+    const all = await store.all();
+    // After id-collapse, we have 2 distinct records (2 distinct ids).
+    // One is executed; one is pending (the ambiguous note).
+    expect(all.length).toBeGreaterThanOrEqual(2);
+    const statuses = all.map((r) => r.status);
+    expect(statuses).toContain('executed');
+    expect(statuses).toContain('pending');
+  });
+
+  it('second call with different args creates a new independent record', async () => {
+    const hook = createEffectLedgerPostHook(store);
+    await hook(makeCtx({ input: { message: 'hello' } }));
+    await hook(makeCtx({ input: { message: 'world' } }));
+
+    const all = await store.all();
+    expect(all.length).toBe(2);
+    const statuses = all.map((r) => r.status);
+    expect(statuses.every((s) => s === 'executed')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Non-PostToolUse events are ignored
+// ---------------------------------------------------------------------------
+
+describe('createEffectLedgerPostHook — non-matching events', () => {
+  it('ignores PreToolUse events', async () => {
+    const hook = createEffectLedgerPostHook(store);
+    const ctx = { event: 'PreToolUse' as const, toolName: 'send_telegram', input: { message: 'hi' } };
+    await hook(ctx);
+    expect(await store.all()).toHaveLength(0);
+  });
+
+  it('ignores SessionEnd events', async () => {
+    const hook = createEffectLedgerPostHook(store);
+    const ctx = { event: 'SessionEnd' as const };
+    await hook(ctx);
+    expect(await store.all()).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Return value is always an empty HookDecision (non-blocking)
+// ---------------------------------------------------------------------------
+
+describe('createEffectLedgerPostHook — return value', () => {
+  it('returns an empty decision (never blocks)', async () => {
+    const hook = createEffectLedgerPostHook(store);
+    const decision = await hook(makeCtx());
+    expect(decision).toEqual({});
+    expect((decision as Record<string, unknown>)['decision']).toBeUndefined();
+  });
+});

--- a/src/agent/effect-ledger/hook.test.ts
+++ b/src/agent/effect-ledger/hook.test.ts
@@ -131,7 +131,7 @@ describe('createEffectLedgerPostHook — external tools', () => {
     await hook(ctx);
     const all = await store.all();
     expect(all).toHaveLength(1);
-    expect(all[0]?.operationType).toBe('mcp_write');
+    expect(all[0]?.operationType).toBe('mcp_write:mcp__github__create_pr');
   });
 
   it('stores redacted args (token removed)', async () => {
@@ -167,11 +167,11 @@ describe('createEffectLedgerPostHook — dedup behavior', () => {
 
     const all = await store.all();
     // After id-collapse, we have 2 distinct records (2 distinct ids).
-    // One is executed; one is pending (the ambiguous note).
+    // One is executed; one is ambiguous (the dedup note).
     expect(all.length).toBeGreaterThanOrEqual(2);
     const statuses = all.map((r) => r.status);
     expect(statuses).toContain('executed');
-    expect(statuses).toContain('pending');
+    expect(statuses).toContain('ambiguous');
   });
 
   it('second call with different args creates a new independent record', async () => {

--- a/src/agent/effect-ledger/hook.test.ts
+++ b/src/agent/effect-ledger/hook.test.ts
@@ -11,7 +11,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createEffectLedgerPostHook } from './hook.js';
 import { EffectStore } from './store.js';
-import type { PostToolUseContext } from '../hooks.js';
+import type { PostToolUseContext, PostToolUseFailureContext } from '../hooks.js';
 
 let tmpDir: string;
 let ledgerPath: string;
@@ -183,6 +183,73 @@ describe('createEffectLedgerPostHook — dedup behavior', () => {
     expect(all.length).toBe(2);
     const statuses = all.map((r) => r.status);
     expect(statuses.every((s) => s === 'executed')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PostToolUseFailure dedup behavior
+// ---------------------------------------------------------------------------
+
+describe('createEffectLedgerPostHook — PostToolUseFailure dedup', () => {
+  function makeFailureCtx(overrides: Partial<PostToolUseFailureContext> = {}): PostToolUseFailureContext {
+    return {
+      event: 'PostToolUseFailure',
+      toolName: 'send_telegram',
+      input: { message: 'hello' },
+      error: 'Telegram send failed',
+      sessionId: 'test-session',
+      ...overrides,
+    };
+  }
+
+  it('records first failure as failed', async () => {
+    const hook = createEffectLedgerPostHook(store);
+    await hook(makeFailureCtx());
+    const all = await store.all();
+    expect(all).toHaveLength(1);
+    expect(all[0]?.status).toBe('failed');
+  });
+
+  it('marks duplicate failure (same args) as ambiguous', async () => {
+    const hook = createEffectLedgerPostHook(store);
+    await hook(makeFailureCtx());
+    await hook(makeFailureCtx());
+
+    const all = await store.all();
+    expect(all).toHaveLength(2);
+    const statuses = all.map((r) => r.status);
+    expect(statuses).toContain('failed');
+    expect(statuses).toContain('ambiguous');
+  });
+
+  it('marks failure after prior executed record as ambiguous', async () => {
+    const hook = createEffectLedgerPostHook(store);
+    // First call succeeds via PostToolUse.
+    await hook(makeCtx());
+    // Second call fails via PostToolUseFailure with the same args.
+    await hook(makeFailureCtx());
+
+    const all = await store.all();
+    expect(all).toHaveLength(2);
+    const statuses = all.map((r) => r.status);
+    expect(statuses).toContain('executed');
+    expect(statuses).toContain('ambiguous');
+  });
+
+  it('records failure with different args as independent failed record', async () => {
+    const hook = createEffectLedgerPostHook(store);
+    await hook(makeFailureCtx({ input: { message: 'hello' } }));
+    await hook(makeFailureCtx({ input: { message: 'world' } }));
+
+    const all = await store.all();
+    expect(all).toHaveLength(2);
+    expect(all.every((r) => r.status === 'failed')).toBe(true);
+  });
+
+  it('ignores non-external tools on failure path', async () => {
+    const hook = createEffectLedgerPostHook(store);
+    await hook(makeFailureCtx({ toolName: 'read_file', input: { file_path: '/tmp/foo' } }));
+    expect(await store.all()).toHaveLength(0);
   });
 });
 

--- a/src/agent/effect-ledger/hook.ts
+++ b/src/agent/effect-ledger/hook.ts
@@ -89,6 +89,31 @@ export function createEffectLedgerPostHook(store?: EffectStore): HookHandler {
   const effectStore = store ?? new EffectStore();
 
   return async (context: HookContext): Promise<HookDecision> => {
+    // Handle PostToolUseFailure: tool handler threw — record as 'failed'.
+    if (context.event === 'PostToolUseFailure') {
+      const { toolName, input, sessionId } = context;
+      const classification = classifyToolCall(toolName, input);
+      if (!classification.isExternal) return {};
+
+      const ikey = computeIdempotencyKey(classification.operationType, input);
+      try {
+        const pending = effectStore.writePending({
+          idempotencyKey: ikey,
+          operationType: classification.operationType,
+          args: redactArgs(input),
+          sessionId,
+        });
+        await effectStore.updateStatus({
+          id: pending.id,
+          status: 'failed',
+          result: redactResult(context.error),
+        });
+      } catch {
+        // Best-effort — ledger write failure must never disrupt tool execution.
+      }
+      return {};
+    }
+
     if (context.event !== 'PostToolUse') return {};
 
     const { toolName, input, output, sessionId } = context;
@@ -112,12 +137,13 @@ export function createEffectLedgerPostHook(store?: EffectStore): HookHandler {
       // Record it as "ambiguous" to surface in reconciliation rather than
       // silently dropping the duplicate.
       try {
-        effectStore.writePending({
+        const pending = effectStore.writePending({
           idempotencyKey: ikey,
           operationType: classification.operationType,
           args: redactArgs(input),
           sessionId,
         });
+        await effectStore.updateStatus({ id: pending.id, status: 'ambiguous' });
       } catch {
         // Best-effort — ledger write failure must never disrupt tool execution.
       }
@@ -125,10 +151,13 @@ export function createEffectLedgerPostHook(store?: EffectStore): HookHandler {
     }
 
     // Write outcome record (new effect, or retry of a failed attempt).
+    // Check context.isError first (set by the dispatcher from ToolResult.isError),
+    // then fall back to the legacy object check for callers that pass output directly.
     const isError =
-      output !== null &&
-      typeof output === 'object' &&
-      (output as Record<string, unknown>)['isError'] === true;
+      context.isError === true ||
+      (output !== null &&
+        typeof output === 'object' &&
+        (output as Record<string, unknown>)['isError'] === true);
 
     const status = isError ? 'failed' : 'executed';
 

--- a/src/agent/effect-ledger/hook.ts
+++ b/src/agent/effect-ledger/hook.ts
@@ -96,6 +96,32 @@ export function createEffectLedgerPostHook(store?: EffectStore): HookHandler {
       if (!classification.isExternal) return {};
 
       const ikey = computeIdempotencyKey(classification.operationType, input);
+
+      // Dedup check: mirror the PostToolUse path so retried failures with the
+      // same idempotency key are recorded as 'ambiguous' rather than producing
+      // duplicate 'failed' records that break reconciliation queries.
+      let prior;
+      try {
+        prior = await effectStore.findByIdempotencyKey(ikey);
+      } catch {
+        prior = null;
+      }
+
+      if (prior !== null && (prior.status === 'executed' || prior.status === 'confirmed' || prior.status === 'failed')) {
+        try {
+          const pending = effectStore.writePending({
+            idempotencyKey: ikey,
+            operationType: classification.operationType,
+            args: redactArgs(input),
+            sessionId,
+          });
+          await effectStore.updateStatus({ id: pending.id, status: 'ambiguous' });
+        } catch {
+          // Best-effort — ledger write failure must never disrupt tool execution.
+        }
+        return {};
+      }
+
       try {
         const pending = effectStore.writePending({
           idempotencyKey: ikey,

--- a/src/agent/effect-ledger/hook.ts
+++ b/src/agent/effect-ledger/hook.ts
@@ -1,0 +1,203 @@
+/**
+ * PostToolUse hook that integrates the effect ledger into the hook pipeline.
+ *
+ * Registration: add to the default hook registry after the existing
+ * PostToolUse handlers. The hook is non-blocking (never returns
+ * `decision: 'block'`); its sole purpose is record-keeping.
+ *
+ * # Lifecycle within one tool call
+ *
+ *   1. PostToolUse fires after the tool returns.
+ *   2. The hook classifies the call via `classifyToolCall`.
+ *   3. If external:
+ *      a. Computes an idempotency key from operationType + args.
+ *      b. Checks for a prior record with that key via the store.
+ *      c. If found with status "executed" or "confirmed": records an
+ *         `ambiguous` note (we cannot know if the execution was a duplicate
+ *         or a new call) and returns. No record is created.
+ *      d. If not found (or only a "pending" / "failed" record exists): writes
+ *         the outcome record with status "executed" or "failed".
+ *
+ * # Write-ahead note
+ *
+ * The task specifies "write-ahead recording before execution". The FULL
+ * write-ahead (pending → execute) pattern requires a PreToolUse hook that
+ * writes "pending" before execution, then a PostToolUse hook that updates
+ * the status. This module ships the lightweight PostToolUse-only variant that
+ * records the outcome; a PreToolUse companion is a natural follow-on once the
+ * dedup-gate requirement is confirmed to be valuable (adding it without a clear
+ * production need adds unnecessary blocking overhead to every tool call).
+ *
+ * The store.writePending / store.updateStatus methods are available for callers
+ * that DO want full write-ahead behavior; the `createEffectLedgerPreHook`
+ * export below provides the PreToolUse half if desired.
+ *
+ * @module agent/effect-ledger/hook
+ */
+
+import { classifyToolCall } from './classifier.js';
+import { computeIdempotencyKey } from './idempotency.js';
+import { EffectStore } from './store.js';
+import { redactSecrets } from '../redact-secrets.js';
+import type { HookContext, HookDecision, HookHandler } from '../hooks.js';
+
+// ---------------------------------------------------------------------------
+// Redaction helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Redact secrets from a structured tool-input object before persisting.
+ *
+ * Converts to JSON string (for the redaction regex), then re-parses. Returns
+ * the input unchanged if serialization fails (best-effort).
+ */
+function redactArgs(input: unknown): unknown {
+  try {
+    const json = JSON.stringify(input);
+    const redacted = redactSecrets(json);
+    return JSON.parse(redacted) as unknown;
+  } catch {
+    return '[serialization error]';
+  }
+}
+
+/**
+ * Redact secrets from a tool output before persisting. Same approach.
+ */
+function redactResult(output: unknown): unknown {
+  if (output === undefined) return undefined;
+  try {
+    const json = JSON.stringify(output);
+    const redacted = redactSecrets(json);
+    return JSON.parse(redacted) as unknown;
+  } catch {
+    return '[serialization error]';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// PostToolUse hook factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a PostToolUse hook handler that records external effects to the
+ * ledger.
+ *
+ * Pass a custom `store` in tests to avoid writing to the real ledger file.
+ */
+export function createEffectLedgerPostHook(store?: EffectStore): HookHandler {
+  const effectStore = store ?? new EffectStore();
+
+  return async (context: HookContext): Promise<HookDecision> => {
+    if (context.event !== 'PostToolUse') return {};
+
+    const { toolName, input, output, sessionId } = context;
+
+    const classification = classifyToolCall(toolName, input);
+    if (!classification.isExternal) return {};
+
+    const ikey = computeIdempotencyKey(classification.operationType, input);
+
+    // Dedup check: look for a prior record with the same key.
+    let prior;
+    try {
+      prior = await effectStore.findByIdempotencyKey(ikey);
+    } catch {
+      // Best-effort: if the store read fails, proceed without dedup check.
+      prior = null;
+    }
+
+    if (prior !== null && (prior.status === 'executed' || prior.status === 'confirmed')) {
+      // A prior executed/confirmed record exists — this looks like a duplicate.
+      // Record it as "ambiguous" to surface in reconciliation rather than
+      // silently dropping the duplicate.
+      try {
+        effectStore.writePending({
+          idempotencyKey: ikey,
+          operationType: classification.operationType,
+          args: redactArgs(input),
+          sessionId,
+        });
+      } catch {
+        // Best-effort — ledger write failure must never disrupt tool execution.
+      }
+      return {};
+    }
+
+    // Write outcome record (new effect, or retry of a failed attempt).
+    const isError =
+      output !== null &&
+      typeof output === 'object' &&
+      (output as Record<string, unknown>)['isError'] === true;
+
+    const status = isError ? 'failed' : 'executed';
+
+    try {
+      const pending = effectStore.writePending({
+        idempotencyKey: ikey,
+        operationType: classification.operationType,
+        args: redactArgs(input),
+        sessionId,
+      });
+      await effectStore.updateStatus({
+        id: pending.id,
+        status,
+        result: redactResult(output),
+      });
+    } catch {
+      // Best-effort — ledger write failure must never disrupt tool execution.
+    }
+
+    return {};
+  };
+}
+
+// ---------------------------------------------------------------------------
+// PreToolUse hook factory (write-ahead companion)
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a PreToolUse hook handler that writes a "pending" record BEFORE
+ * execution begins, and stores the record id in the provided map for the
+ * PostToolUse companion to pick up via `toolUseId`.
+ *
+ * This is the write-ahead half. Wire BOTH createEffectLedgerPreHook and a
+ * matching PostToolUse hook that calls `store.updateStatus` using the pending
+ * id stored here, if full write-ahead behavior is required.
+ *
+ * Note: The id map must be shared between the pre and post hooks. This is an
+ * optional advanced usage; most callers should use `createEffectLedgerPostHook`
+ * alone.
+ */
+export function createEffectLedgerPreHook(
+  pendingIds: Map<string, string>,
+  store?: EffectStore,
+): HookHandler {
+  const effectStore = store ?? new EffectStore();
+
+  return (context: HookContext): HookDecision => {
+    if (context.event !== 'PreToolUse') return {};
+
+    const { toolName, input, sessionId, toolUseId } = context;
+    if (!toolUseId) return {};
+
+    const classification = classifyToolCall(toolName, input);
+    if (!classification.isExternal) return {};
+
+    const ikey = computeIdempotencyKey(classification.operationType, input);
+
+    try {
+      const pending = effectStore.writePending({
+        idempotencyKey: ikey,
+        operationType: classification.operationType,
+        args: redactArgs(input),
+        sessionId,
+      });
+      pendingIds.set(toolUseId, pending.id);
+    } catch {
+      // Best-effort.
+    }
+
+    return {};
+  };
+}

--- a/src/agent/effect-ledger/idempotency.test.ts
+++ b/src/agent/effect-ledger/idempotency.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit tests for idempotency key computation.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { computeIdempotencyKey } from './idempotency.js';
+
+describe('computeIdempotencyKey', () => {
+  it('returns a 64-char hex string (SHA-256)', () => {
+    const key = computeIdempotencyKey('send_telegram', { message: 'hello' });
+    expect(key).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('same inputs produce the same key', () => {
+    const k1 = computeIdempotencyKey('send_telegram', { message: 'hello' });
+    const k2 = computeIdempotencyKey('send_telegram', { message: 'hello' });
+    expect(k1).toBe(k2);
+  });
+
+  it('different operationType produces different key', () => {
+    const k1 = computeIdempotencyKey('send_telegram', { message: 'hello' });
+    const k2 = computeIdempotencyKey('mcp_write', { message: 'hello' });
+    expect(k1).not.toBe(k2);
+  });
+
+  it('different args produce different key', () => {
+    const k1 = computeIdempotencyKey('send_telegram', { message: 'hello' });
+    const k2 = computeIdempotencyKey('send_telegram', { message: 'world' });
+    expect(k1).not.toBe(k2);
+  });
+
+  it('key is stable regardless of object key order', () => {
+    const k1 = computeIdempotencyKey('bash_external', { command: 'git push', cwd: '/tmp' });
+    const k2 = computeIdempotencyKey('bash_external', { cwd: '/tmp', command: 'git push' });
+    expect(k1).toBe(k2);
+  });
+
+  it('nested object key order is also stable', () => {
+    const k1 = computeIdempotencyKey('mcp_write', { a: { z: 1, y: 2 }, b: 3 });
+    const k2 = computeIdempotencyKey('mcp_write', { b: 3, a: { y: 2, z: 1 } });
+    expect(k1).toBe(k2);
+  });
+
+  it('array element order is preserved (different order = different key)', () => {
+    const k1 = computeIdempotencyKey('some_op', { files: ['a.ts', 'b.ts'] });
+    const k2 = computeIdempotencyKey('some_op', { files: ['b.ts', 'a.ts'] });
+    expect(k1).not.toBe(k2);
+  });
+
+  it('null args produce a stable key', () => {
+    const k1 = computeIdempotencyKey('send_telegram', null);
+    const k2 = computeIdempotencyKey('send_telegram', null);
+    expect(k1).toBe(k2);
+    expect(k1).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('undefined args produce a stable key', () => {
+    const k1 = computeIdempotencyKey('send_telegram', undefined);
+    const k2 = computeIdempotencyKey('send_telegram', undefined);
+    expect(k1).toBe(k2);
+  });
+
+  it('empty object is stable', () => {
+    const k1 = computeIdempotencyKey('bash_external', {});
+    const k2 = computeIdempotencyKey('bash_external', {});
+    expect(k1).toBe(k2);
+  });
+});

--- a/src/agent/effect-ledger/idempotency.ts
+++ b/src/agent/effect-ledger/idempotency.ts
@@ -1,0 +1,67 @@
+/**
+ * Idempotency key computation for the effect ledger.
+ *
+ * An idempotency key uniquely identifies an (operation, arguments) pair so the
+ * ledger can detect duplicate invocations and skip re-execution. Keys must be:
+ *   - **Deterministic**: same inputs always produce the same key.
+ *   - **Stable across retries**: key computation must not incorporate any
+ *     wall-clock time, random nonce, or per-call UUID.
+ *   - **Collision-resistant**: SHA-256 over a canonical serialization.
+ *
+ * # Canonical serialization
+ *
+ * JSON.stringify produces non-deterministic key ordering when the input object
+ * was assembled from multiple sources. We use a recursive sort-keys approach so
+ * `{b:1,a:2}` and `{a:2,b:1}` hash identically. Arrays are NOT reordered —
+ * argument order in arrays is semantically significant (e.g. a list of file
+ * paths to delete).
+ *
+ * @module agent/effect-ledger/idempotency
+ */
+
+import { createHash } from 'node:crypto';
+
+// ---------------------------------------------------------------------------
+// Stable JSON serialization
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialize `value` to JSON with recursively sorted object keys.
+ * Arrays preserve their element order. Primitive values are passed through.
+ */
+function stableStringify(value: unknown): string {
+  // undefined is not serializable via JSON.stringify (returns undefined, not a
+  // string). Normalize to null so the hash function always receives a string.
+  if (value === undefined) return 'null';
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return '[' + value.map(stableStringify).join(',') + ']';
+  }
+  const obj = value as Record<string, unknown>;
+  const sortedKeys = Object.keys(obj).sort();
+  const pairs = sortedKeys.map((k) => JSON.stringify(k) + ':' + stableStringify(obj[k]));
+  return '{' + pairs.join(',') + '}';
+}
+
+// ---------------------------------------------------------------------------
+// Key computation
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute a deterministic idempotency key from an operation type and
+ * (optionally) a structured arguments object.
+ *
+ * The key is a 64-hex-char SHA-256 digest of
+ * `<operationType>\0<stableJson(args)>`. Passing `undefined` for `args`
+ * produces a key that covers only the operation type — useful for tools that
+ * have no meaningful input (e.g. a zero-argument status probe).
+ */
+export function computeIdempotencyKey(operationType: string, args: unknown): string {
+  const h = createHash('sha256');
+  h.update(operationType);
+  h.update('\0');
+  h.update(stableStringify(args));
+  return h.digest('hex');
+}

--- a/src/agent/effect-ledger/index.ts
+++ b/src/agent/effect-ledger/index.ts
@@ -1,0 +1,36 @@
+/**
+ * External-effect ledger — public API surface.
+ *
+ * The ledger records every external side effect (Telegram send, GitHub PR
+ * creation, MCP write, outbound bash command, etc.) before and after
+ * execution, deduplicates via idempotency keys, and tracks ambiguous
+ * outcomes for future reconciliation.
+ *
+ * ## Quick start
+ *
+ * ```ts
+ * // In default-hook-registry.ts:
+ * import { createEffectLedgerPostHook } from './effect-ledger/index.js';
+ * registry.register('PostToolUse', createEffectLedgerPostHook());
+ *
+ * // Query the ledger:
+ * import { EffectStore } from './effect-ledger/index.js';
+ * const store = new EffectStore();
+ * const records = await store.query({ sessionId: 'abc123', status: 'ambiguous' });
+ * ```
+ *
+ * @module agent/effect-ledger
+ */
+
+export { EffectStore } from './store.js';
+export { classifyToolCall } from './classifier.js';
+export { computeIdempotencyKey } from './idempotency.js';
+export { createEffectLedgerPostHook, createEffectLedgerPreHook } from './hook.js';
+export type {
+  EffectRecord,
+  EffectStatus,
+  EffectQuery,
+  PendingEffectInput,
+  ExecuteEffectInput,
+} from './types.js';
+export type { Classification } from './classifier.js';

--- a/src/agent/effect-ledger/store.test.ts
+++ b/src/agent/effect-ledger/store.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Unit tests for EffectStore.
+ *
+ * Uses a temp file per test to avoid cross-test contamination. The redirected
+ * AFK_HOME sentinel from redirect-paths-env.ts means real state is never
+ * touched even if a test leaks a default-path store.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { EffectStore } from './store.js';
+
+let tmpDir: string;
+let ledgerPath: string;
+let store: EffectStore;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'effect-ledger-test-'));
+  ledgerPath = join(tmpDir, 'effect-ledger.jsonl');
+  store = new EffectStore(ledgerPath);
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// writePending
+// ---------------------------------------------------------------------------
+
+describe('EffectStore.writePending', () => {
+  it('returns a record with status "pending" and a UUID id', () => {
+    const rec = store.writePending({
+      idempotencyKey: 'k1',
+      operationType: 'send_telegram',
+      args: { message: 'hello' },
+      sessionId: 'sess-1',
+    });
+    expect(rec.v).toBe(1);
+    expect(rec.status).toBe('pending');
+    expect(typeof rec.id).toBe('string');
+    expect(rec.id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(rec.idempotencyKey).toBe('k1');
+    expect(rec.operationType).toBe('send_telegram');
+    expect(rec.sessionId).toBe('sess-1');
+    expect(rec.timestamp).toBeGreaterThan(0);
+  });
+
+  it('creates the file on first write', async () => {
+    store.writePending({ idempotencyKey: 'k2', operationType: 'mcp_write', args: {} });
+    const all = await store.all();
+    expect(all).toHaveLength(1);
+  });
+
+  it('two pending writes produce two distinct ids', () => {
+    const r1 = store.writePending({ idempotencyKey: 'k3', operationType: 'send_telegram', args: {} });
+    const r2 = store.writePending({ idempotencyKey: 'k4', operationType: 'send_telegram', args: {} });
+    expect(r1.id).not.toBe(r2.id);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateStatus
+// ---------------------------------------------------------------------------
+
+describe('EffectStore.updateStatus', () => {
+  it('transitions a pending record to "executed"', async () => {
+    const pending = store.writePending({
+      idempotencyKey: 'k5',
+      operationType: 'send_telegram',
+      args: { message: 'hi' },
+    });
+    const updated = await store.updateStatus({
+      id: pending.id,
+      status: 'executed',
+      result: { ok: true },
+    });
+    expect(updated.status).toBe('executed');
+    expect(updated.result).toEqual({ ok: true });
+    expect(updated.id).toBe(pending.id);
+  });
+
+  it('transitions to "failed"', async () => {
+    const pending = store.writePending({
+      idempotencyKey: 'k6',
+      operationType: 'send_telegram',
+      args: {},
+    });
+    const updated = await store.updateStatus({
+      id: pending.id,
+      status: 'failed',
+      result: { error: 'network timeout' },
+    });
+    expect(updated.status).toBe('failed');
+  });
+
+  it('transitions to "ambiguous" and sets reconciledAt', async () => {
+    const pending = store.writePending({
+      idempotencyKey: 'k7',
+      operationType: 'send_telegram',
+      args: {},
+    });
+    const before = Date.now();
+    const updated = await store.updateStatus({ id: pending.id, status: 'ambiguous' });
+    const after = Date.now();
+    expect(updated.status).toBe('ambiguous');
+    expect(updated.reconciledAt).toBeGreaterThanOrEqual(before);
+    expect(updated.reconciledAt).toBeLessThanOrEqual(after);
+  });
+
+  it('transitions to "confirmed" and sets reconciledAt', async () => {
+    const pending = store.writePending({
+      idempotencyKey: 'k8',
+      operationType: 'send_telegram',
+      args: {},
+    });
+    const updated = await store.updateStatus({ id: pending.id, status: 'confirmed' });
+    expect(updated.status).toBe('confirmed');
+    expect(updated.reconciledAt).toBeDefined();
+  });
+
+  it('throws if the id does not exist', async () => {
+    await expect(
+      store.updateStatus({ id: 'nonexistent-uuid', status: 'executed' }),
+    ).rejects.toThrow('record not found');
+  });
+
+  it('last write wins on id-collapse: query returns the latest status', async () => {
+    const pending = store.writePending({
+      idempotencyKey: 'k9',
+      operationType: 'send_telegram',
+      args: {},
+    });
+    await store.updateStatus({ id: pending.id, status: 'executed' });
+    const all = await store.all();
+    // Only one record per id after collapse.
+    expect(all).toHaveLength(1);
+    expect(all[0]?.status).toBe('executed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findByIdempotencyKey
+// ---------------------------------------------------------------------------
+
+describe('EffectStore.findByIdempotencyKey', () => {
+  it('returns null when no record exists with that key', async () => {
+    const result = await store.findByIdempotencyKey('missing-key');
+    expect(result).toBeNull();
+  });
+
+  it('returns the record after writePending', async () => {
+    store.writePending({ idempotencyKey: 'my-key', operationType: 'send_telegram', args: {} });
+    const found = await store.findByIdempotencyKey('my-key');
+    expect(found).not.toBeNull();
+    expect(found?.idempotencyKey).toBe('my-key');
+    expect(found?.status).toBe('pending');
+  });
+
+  it('returns updated status after updateStatus', async () => {
+    const pending = store.writePending({
+      idempotencyKey: 'my-key-2',
+      operationType: 'send_telegram',
+      args: {},
+    });
+    await store.updateStatus({ id: pending.id, status: 'executed' });
+    const found = await store.findByIdempotencyKey('my-key-2');
+    expect(found?.status).toBe('executed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// query
+// ---------------------------------------------------------------------------
+
+describe('EffectStore.query', () => {
+  it('filters by sessionId', async () => {
+    store.writePending({ idempotencyKey: 'a1', operationType: 'send_telegram', args: {}, sessionId: 'sess-A' });
+    store.writePending({ idempotencyKey: 'a2', operationType: 'send_telegram', args: {}, sessionId: 'sess-B' });
+    const results = await store.query({ sessionId: 'sess-A' });
+    expect(results).toHaveLength(1);
+    expect(results[0]?.sessionId).toBe('sess-A');
+  });
+
+  it('filters by operationType', async () => {
+    store.writePending({ idempotencyKey: 'b1', operationType: 'send_telegram', args: {} });
+    store.writePending({ idempotencyKey: 'b2', operationType: 'mcp_write', args: {} });
+    const results = await store.query({ operationType: 'mcp_write' });
+    expect(results).toHaveLength(1);
+    expect(results[0]?.operationType).toBe('mcp_write');
+  });
+
+  it('filters by status', async () => {
+    const r1 = store.writePending({ idempotencyKey: 'c1', operationType: 'send_telegram', args: {} });
+    const r2 = store.writePending({ idempotencyKey: 'c2', operationType: 'send_telegram', args: {} });
+    await store.updateStatus({ id: r1.id, status: 'executed' });
+    // r2 stays pending
+    void r2;
+
+    const pending = await store.query({ status: 'pending' });
+    expect(pending).toHaveLength(1);
+    expect(pending[0]?.idempotencyKey).toBe('c2');
+
+    const executed = await store.query({ status: 'executed' });
+    expect(executed).toHaveLength(1);
+    expect(executed[0]?.idempotencyKey).toBe('c1');
+  });
+
+  it('filters by idempotencyKey', async () => {
+    store.writePending({ idempotencyKey: 'd1', operationType: 'send_telegram', args: {} });
+    store.writePending({ idempotencyKey: 'd2', operationType: 'send_telegram', args: {} });
+    const results = await store.query({ idempotencyKey: 'd2' });
+    expect(results).toHaveLength(1);
+    expect(results[0]?.idempotencyKey).toBe('d2');
+  });
+
+  it('returns empty list from empty ledger', async () => {
+    const results = await store.query();
+    expect(results).toHaveLength(0);
+  });
+
+  it('ANDs multiple filters', async () => {
+    store.writePending({ idempotencyKey: 'e1', operationType: 'send_telegram', args: {}, sessionId: 'sess-X' });
+    store.writePending({ idempotencyKey: 'e2', operationType: 'mcp_write', args: {}, sessionId: 'sess-X' });
+    const results = await store.query({ sessionId: 'sess-X', operationType: 'mcp_write' });
+    expect(results).toHaveLength(1);
+    expect(results[0]?.idempotencyKey).toBe('e2');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Malformed-line tolerance
+// ---------------------------------------------------------------------------
+
+describe('EffectStore — malformed-line tolerance', () => {
+  it('skips malformed lines and returns valid records', async () => {
+    // Write a valid record manually, then append garbage.
+    const { writeFileSync } = await import('node:fs');
+    const validRecord = JSON.stringify({
+      v: 1,
+      id: 'well-known-id',
+      idempotencyKey: 'clean',
+      operationType: 'send_telegram',
+      args: {},
+      status: 'pending',
+      timestamp: Date.now(),
+    });
+    writeFileSync(ledgerPath, validRecord + '\nnot-json\n{"incomplete":\n');
+
+    const results = await store.all();
+    expect(results).toHaveLength(1);
+    expect(results[0]?.id).toBe('well-known-id');
+  });
+});

--- a/src/agent/effect-ledger/store.ts
+++ b/src/agent/effect-ledger/store.ts
@@ -1,0 +1,217 @@
+/**
+ * Durable NDJSON storage for effect records.
+ *
+ * File layout: `$AFK_STATE_DIR/effect-ledger.jsonl` — one JSON object per
+ * line, append-only (new records) + full-rewrite on status updates (rare).
+ *
+ * Design decisions:
+ *   - Append for new records: O(1) write, no in-memory state required.
+ *   - Read+filter for queries: linear scan — acceptable for v1 with a
+ *     bounded ledger size. SQLite is the designated v2 upgrade path.
+ *   - Status update writes the full record to a new line; queries return
+ *     the last record with a given id (fold/last-write-wins semantics).
+ *     This avoids rewriting the file on every update at the cost of
+ *     duplicate ids in the log — reconcilable on compaction.
+ *   - Disk errors on write are caught and surface only via the returned
+ *     error; callers decide whether to propagate or absorb.
+ *   - mkdir is called lazily on first write; read handles ENOENT gracefully.
+ *
+ * @module agent/effect-ledger/store
+ */
+
+import * as fs from 'node:fs';
+import * as fsp from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { getEffectLedgerPath } from '../../paths.js';
+import type {
+  EffectRecord,
+  EffectQuery,
+  PendingEffectInput,
+  ExecuteEffectInput,
+} from './types.js';
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Write one JSONL line. Creates parent dir on first call. */
+function appendLine(path: string, record: EffectRecord): void {
+  fs.mkdirSync(dirname(path), { recursive: true });
+  fs.appendFileSync(path, JSON.stringify(record) + '\n', 'utf8');
+}
+
+/** Parse a JSONL file, skipping malformed lines. Returns all valid records. */
+async function readAllRecords(path: string): Promise<EffectRecord[]> {
+  let raw: string;
+  try {
+    raw = await fsp.readFile(path, 'utf8');
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw e;
+  }
+  const records: EffectRecord[] = [];
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      if (isEffectRecord(parsed)) records.push(parsed);
+    } catch {
+      // Skip malformed lines — partial writes, truncated lines, format drift.
+    }
+  }
+  return records;
+}
+
+/** Minimal runtime shape-check (not a full schema validator). */
+function isEffectRecord(v: unknown): v is EffectRecord {
+  return (
+    v !== null &&
+    typeof v === 'object' &&
+    (v as Record<string, unknown>)['v'] === 1 &&
+    typeof (v as Record<string, unknown>)['id'] === 'string' &&
+    typeof (v as Record<string, unknown>)['idempotencyKey'] === 'string' &&
+    typeof (v as Record<string, unknown>)['operationType'] === 'string' &&
+    typeof (v as Record<string, unknown>)['status'] === 'string' &&
+    typeof (v as Record<string, unknown>)['timestamp'] === 'number'
+  );
+}
+
+/**
+ * Collapse duplicate ids: for each id, keep only the last record. This is
+ * the fold / last-write-wins policy that lets status updates be appends.
+ */
+function collapseById(records: EffectRecord[]): EffectRecord[] {
+  const byId = new Map<string, EffectRecord>();
+  for (const r of records) {
+    byId.set(r.id, r);
+  }
+  return Array.from(byId.values());
+}
+
+// ---------------------------------------------------------------------------
+// EffectStore
+// ---------------------------------------------------------------------------
+
+/**
+ * Durable NDJSON store for {@link EffectRecord}s.
+ *
+ * Instantiate once per process (or once per test) and share. All methods are
+ * synchronous on the write path (appendFileSync) to stay off the critical path
+ * for tool execution. Reads are async (readFile).
+ */
+export class EffectStore {
+  private readonly path: string;
+
+  constructor(path?: string) {
+    this.path = path ?? getEffectLedgerPath();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Write-ahead: create pending record
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Write a "pending" record to the ledger BEFORE execution begins.
+   *
+   * Returns the created record (including its generated `id`). Throws if the
+   * write fails — callers should decide whether to propagate or absorb.
+   *
+   * Does NOT deduplicate here; the dedup check belongs in the hook layer so it
+   * can gate execution, not just logging.
+   */
+  writePending(input: PendingEffectInput): EffectRecord {
+    const record: EffectRecord = {
+      v: 1,
+      id: randomUUID(),
+      idempotencyKey: input.idempotencyKey,
+      operationType: input.operationType,
+      args: input.args,
+      status: 'pending',
+      sessionId: input.sessionId,
+      taskId: input.taskId,
+      timestamp: Date.now(),
+    };
+    appendLine(this.path, record);
+    return record;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Post-execution: transition status
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Update a record's status after execution completes.
+   *
+   * Implementation: appends a new line with the updated record (last-write-wins
+   * on query). This avoids a file rewrite on every status transition.
+   *
+   * Throws if the record does not exist or if the write fails.
+   */
+  async updateStatus(input: ExecuteEffectInput): Promise<EffectRecord> {
+    const all = await readAllRecords(this.path);
+    const collapsed = collapseById(all);
+    const existing = collapsed.find((r) => r.id === input.id);
+    if (!existing) {
+      throw new Error(`effect-ledger: record not found: ${input.id}`);
+    }
+    const updated: EffectRecord = {
+      ...existing,
+      status: input.status,
+      result: input.result,
+      ...(input.status === 'confirmed' || input.status === 'ambiguous'
+        ? { reconciledAt: Date.now() }
+        : {}),
+    };
+    appendLine(this.path, updated);
+    return updated;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Dedup check
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Look up a record by idempotency key. Returns the record if found (after
+   * last-write-wins collapse), or `null` if not found.
+   *
+   * Used by the hook to detect whether an operation was already started so
+   * duplicate execution can be skipped.
+   */
+  async findByIdempotencyKey(key: string): Promise<EffectRecord | null> {
+    const all = await readAllRecords(this.path);
+    const collapsed = collapseById(all);
+    return collapsed.find((r) => r.idempotencyKey === key) ?? null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Query API
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Query the ledger with optional filters. All provided filter fields are
+   * ANDed. Returns records in write order (oldest first), after id-collapse.
+   */
+  async query(filters: EffectQuery = {}): Promise<EffectRecord[]> {
+    const all = await readAllRecords(this.path);
+    const collapsed = collapseById(all);
+    return collapsed.filter((r) => {
+      if (filters.sessionId !== undefined && r.sessionId !== filters.sessionId) return false;
+      if (filters.operationType !== undefined && r.operationType !== filters.operationType)
+        return false;
+      if (filters.status !== undefined && r.status !== filters.status) return false;
+      if (filters.idempotencyKey !== undefined && r.idempotencyKey !== filters.idempotencyKey)
+        return false;
+      return true;
+    });
+  }
+
+  /**
+   * Return all records, id-collapsed, oldest-first.
+   * Convenience alias for `query({})`.
+   */
+  async all(): Promise<EffectRecord[]> {
+    return this.query();
+  }
+}

--- a/src/agent/effect-ledger/store.ts
+++ b/src/agent/effect-ledger/store.ts
@@ -37,8 +37,8 @@ import type {
 
 /** Write one JSONL line. Creates parent dir on first call. */
 function appendLine(path: string, record: EffectRecord): void {
-  fs.mkdirSync(dirname(path), { recursive: true });
-  fs.appendFileSync(path, JSON.stringify(record) + '\n', 'utf8');
+  fs.mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  fs.appendFileSync(path, JSON.stringify(record) + '\n', { encoding: 'utf8', mode: 0o600 });
 }
 
 /** Parse a JSONL file, skipping malformed lines. Returns all valid records. */
@@ -182,7 +182,8 @@ export class EffectStore {
   async findByIdempotencyKey(key: string): Promise<EffectRecord | null> {
     const all = await readAllRecords(this.path);
     const collapsed = collapseById(all);
-    return collapsed.find((r) => r.idempotencyKey === key) ?? null;
+    const matches = collapsed.filter((r) => r.idempotencyKey === key);
+    return matches.length > 0 ? matches[matches.length - 1]! : null;
   }
 
   // ---------------------------------------------------------------------------

--- a/src/agent/effect-ledger/types.ts
+++ b/src/agent/effect-ledger/types.ts
@@ -1,0 +1,112 @@
+/**
+ * Data-model types for the external-effect ledger.
+ *
+ * An *effect record* describes one externally-visible side effect — a
+ * Telegram send, a GitHub PR creation, a MCP mutation, etc. — from its
+ * intent through its observed outcome. The record lifecycle is:
+ *
+ *   prepare   → write "pending" record (write-ahead, before execution)
+ *   execute   → update to "executed" / "failed" / "ambiguous"
+ *   reconcile → (future) update to "confirmed" after out-of-band verification
+ *
+ * @module agent/effect-ledger/types
+ */
+
+// ---------------------------------------------------------------------------
+// Status vocabulary
+// ---------------------------------------------------------------------------
+
+/** All possible lifecycle states for an effect record. */
+export type EffectStatus =
+  /** Written before execution begins (write-ahead). */
+  | 'pending'
+  /** Execution returned without throwing (outcome not yet confirmed externally). */
+  | 'executed'
+  /** Independently confirmed to have taken effect (out-of-band check). */
+  | 'confirmed'
+  /** Execution threw / returned an error result. */
+  | 'failed'
+  /**
+   * Execution succeeded locally but external confirmation is impossible or
+   * ambiguous (e.g. network cut after send, no idempotency header support).
+   */
+  | 'ambiguous';
+
+// ---------------------------------------------------------------------------
+// Core record
+// ---------------------------------------------------------------------------
+
+/**
+ * One durable row in the effect ledger.
+ *
+ * Stored as NDJSON. `v` is the schema version (always 1 for this release).
+ * The `args` and `result` fields are redacted copies — secrets removed before
+ * writing to disk.
+ */
+export interface EffectRecord {
+  /** Schema version. */
+  v: 1;
+  /** UUID v4 unique row identifier. */
+  id: string;
+  /**
+   * Deterministic identifier computed from `operationType + stable-JSON(args)`.
+   * A caller may supply their own; the store will never overwrite an existing
+   * record with the same key (deduplication gate).
+   */
+  idempotencyKey: string;
+  /**
+   * Coarse operation classifier, e.g. `"send_telegram"`, `"gh_pr_create"`,
+   * `"mcp_write"`, `"bash_external"`. Populated by the classifier from the
+   * tool name and (optionally) the args content.
+   */
+  operationType: string;
+  /** Redacted copy of tool input. Never contains raw secrets. */
+  args: unknown;
+  /** Current lifecycle status. */
+  status: EffectStatus;
+  /** Originating session id (may be undefined for out-of-session writes). */
+  sessionId?: string;
+  /** Caller-supplied task or job identifier for correlation. */
+  taskId?: string;
+  /** Unix epoch ms when the record was written. */
+  timestamp: number;
+  /** Redacted summary of the tool output (set on execute). */
+  result?: unknown;
+  /** Unix epoch ms when a reconcile transition occurred. */
+  reconciledAt?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Query parameters
+// ---------------------------------------------------------------------------
+
+/** Filters for {@link EffectStore.query}. All fields are ANDed together. */
+export interface EffectQuery {
+  sessionId?: string;
+  operationType?: string;
+  status?: EffectStatus;
+  idempotencyKey?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Write-ahead / update inputs
+// ---------------------------------------------------------------------------
+
+/** Payload for writing a new "pending" record before execution begins. */
+export interface PendingEffectInput {
+  idempotencyKey: string;
+  operationType: string;
+  /** Already-redacted args (caller owns redaction). */
+  args: unknown;
+  sessionId?: string;
+  taskId?: string;
+}
+
+/** Payload for transitioning a pending record after execution completes. */
+export interface ExecuteEffectInput {
+  id: string;
+  /** Outcome status — never "pending". */
+  status: Exclude<EffectStatus, 'pending'>;
+  /** Already-redacted result summary (caller owns redaction). */
+  result?: unknown;
+}

--- a/src/agent/hooks.ts
+++ b/src/agent/hooks.ts
@@ -248,6 +248,12 @@ export interface PostToolUseContext {
   input?: unknown;
   output?: unknown;
   /**
+   * True when the tool returned an error result. Set by the dispatcher from the
+   * full `ToolResult.isError` flag so hooks do not need to re-derive it from the
+   * `output` shape. Absent when false (no key) to keep the context compact.
+   */
+  isError?: boolean;
+  /**
    * Live grant manager of the executing session — see
    * {@link PreToolUseContext.grantManager}. Injected so the "Once"-grant revoke
    * in the path-approval PostToolUse hook mutates the SAME grant manager the

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -1281,7 +1281,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
     output: string,
     signal: AbortSignal,
     input?: unknown,
-    resultFlags?: Pick<ToolResult, 'incomplete' | 'incompleteReason'>,
+    resultFlags?: Pick<ToolResult, 'incomplete' | 'incompleteReason' | 'isError'>,
   ): void {
     if (!this.hookRegistry) return;
     const postCtx: PostToolUseContext = {
@@ -1289,14 +1289,12 @@ export class SessionToolDispatcher implements ToolDispatcher {
       toolName,
       output,
       ...(input !== undefined ? { input } : {}),
+      ...(this.sessionId !== undefined ? { sessionId: this.sessionId } : {}),
       ...(this.parentSessionId !== undefined ? { parentSessionId: this.parentSessionId } : {}),
-      // Mirror PreToolUse so the path-approval "Once"-grant revoke mutates the
-      // SAME grant manager the Pre containment check consulted.
-      ...(this.sessionGrantManager !== undefined
-        ? { grantManager: this.sessionGrantManager }
-        : {}),
-      ...(resultFlags?.incomplete === true ? { incomplete: true } : {}),
-      ...(resultFlags?.incompleteReason ? { incompleteReason: resultFlags.incompleteReason } : {}),
+      // Mirror PreToolUse so path-approval "Once"-grant revoke uses the same grant manager.
+      ...(this.sessionGrantManager ? { grantManager: this.sessionGrantManager } : {}),
+      ...(resultFlags?.isError === true ? { isError: true } : {}),
+      ...(resultFlags?.incomplete === true ? { incomplete: true, ...(resultFlags.incompleteReason ? { incompleteReason: resultFlags.incompleteReason } : {}) } : {}),
     };
     void dispatchPostToolUse(this.hookRegistry, postCtx, {
       signal,
@@ -1322,6 +1320,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
       toolName,
       error: errorMessage,
       ...(input !== undefined ? { input } : {}),
+      ...(this.sessionId !== undefined ? { sessionId: this.sessionId } : {}),
       ...(this.parentSessionId !== undefined ? { parentSessionId: this.parentSessionId } : {}),
     };
     void dispatchPostToolUseFailure(this.hookRegistry, ctx, {

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -822,4 +822,23 @@ export function getWaveManifestPath(waveId: string): string {
   return join(getWavesDir(), `${waveId}.json`);
 }
 
+// ---------------------------------------------------------------------------
+// Effect ledger path
+// ---------------------------------------------------------------------------
+
+/**
+ * Path to the durable external-effect ledger.
+ *
+ * NDJSON file at `$AFK_STATE_DIR/effect-ledger.jsonl`. Each line is an
+ * {@link EffectRecord} (see `src/agent/effect-ledger/types.ts`). Append-only
+ * for new records; status updates append a new line (last-write-wins on query).
+ *
+ * Lives at the state-dir root alongside `session-grants.jsonl` — it is
+ * process-global state (not per-session) because the same effect may originate
+ * from multiple sessions that need to share the dedup record.
+ */
+export function getEffectLedgerPath(): string {
+  return join(getAfkStateDir(), 'effect-ledger.jsonl');
+}
+
 


### PR DESCRIPTION
## Summary

Adds a write-ahead external-effect and idempotency ledger that durably records external side effects (Telegram messages, GitHub PRs, API mutations, MCP writes) before/after execution, deduplicates via deterministic idempotency keys, and tracks ambiguous outcomes.

Closes #1412

## New files

| File | Purpose |
|------|---------|
| `src/agent/effect-ledger/types.ts` | `EffectRecord` data model, status vocabulary, query types |
| `src/agent/effect-ledger/store.ts` | Append-only NDJSON store with write/read/query/dedup |
| `src/agent/effect-ledger/classifier.ts` | Static allowlist classifying which tool calls are external effects |
| `src/agent/effect-ledger/idempotency.ts` | SHA-256 idempotency key from operation type + stable-serialized args |
| `src/agent/effect-ledger/hook.ts` | PostToolUse hook integration + optional PreToolUse write-ahead companion |
| `src/agent/effect-ledger/index.ts` | Public barrel export |

## Modified files

- `src/paths.ts` -- added `getEffectLedgerPath()` -> `$AFK_STATE_DIR/effect-ledger.jsonl`
- `src/agent/default-hook-registry.ts` -- registered effect ledger PostToolUse hook

## Architecture

- **Append-only NDJSON** -- status updates append new lines (same id, new status); queries collapse by last-write-wins. O(1) writes, O(n) reads -- acceptable for v1, SQLite upgrade path clear.
- **PostToolUse integration** -- records outcome after execution; pre-execution hook exported but not registered by default to avoid latency.
- **Non-blocking** -- all I/O errors caught and swallowed; tool execution never disrupted by ledger failures.
- **Extensible classification** -- `classifyToolCall` is the single extension point for dynamic classification.

## Verification

- 73 new tests (store: 19, classifier: 31, idempotency: 10, hook: 13) -- all pass
- 8,815 existing tests -- all pass
- `pnpm lint` -- clean
