### PR TITLE
feat(daemon): cap exponential backoff growth in computeBackoffMs (#1442)

### DIFF
--- a/src/agent/daemon/task-lifecycle.test.ts
+++ b/src/agent/daemon/task-lifecycle.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   DEFAULT_RETRY_POLICY,
   DEFAULT_LEASE_TTL_MS,
+  DEFAULT_MAX_BACKOFF_MS,
   computeBackoffMs,
   type TaskRecord,
   type TaskState,
@@ -72,5 +73,41 @@ describe('computeBackoffMs', () => {
   it('exponential strategy with attempts=0 uses base delay', () => {
     const policy = { maxAttempts: 1, backoffStrategy: 'exponential' as const, backoffBaseMs: 2_000 };
     expect(computeBackoffMs(0, policy)).toBe(2_000); // 2^max(0,-1)=2^0=1
+  });
+
+  it('exponential strategy caps at DEFAULT_MAX_BACKOFF_MS for high attempt counts', () => {
+    // attempts=20, backoffBaseMs=1000 → 1000 * 2^19 ≈ 524M ms (~145 hours) without cap
+    const policy = { maxAttempts: 30, backoffStrategy: 'exponential' as const, backoffBaseMs: 1_000 };
+    expect(computeBackoffMs(20, policy)).toBe(DEFAULT_MAX_BACKOFF_MS);
+    expect(computeBackoffMs(30, policy)).toBe(DEFAULT_MAX_BACKOFF_MS);
+  });
+
+  it('exponential strategy respects custom maxBackoffMs', () => {
+    const policy = {
+      maxAttempts: 10,
+      backoffStrategy: 'exponential' as const,
+      backoffBaseMs: 1_000,
+      maxBackoffMs: 10_000,
+    };
+    // attempts=4 → 1000 * 2^3 = 8000 (under cap)
+    expect(computeBackoffMs(4, policy)).toBe(8_000);
+    // attempts=5 → 1000 * 2^4 = 16000, capped at 10_000
+    expect(computeBackoffMs(5, policy)).toBe(10_000);
+    expect(computeBackoffMs(10, policy)).toBe(10_000);
+  });
+
+  it('normal backoff below the cap is unchanged', () => {
+    const policy = { maxAttempts: 5, backoffStrategy: 'exponential' as const, backoffBaseMs: 1_000 };
+    // Low attempt counts stay well under the 5-minute cap
+    expect(computeBackoffMs(1, policy)).toBe(1_000);
+    expect(computeBackoffMs(2, policy)).toBe(2_000);
+    expect(computeBackoffMs(3, policy)).toBe(4_000);
+    expect(computeBackoffMs(4, policy)).toBe(8_000);
+  });
+
+  it('fixed strategy is unaffected by cap when base is below cap', () => {
+    const policy = { maxAttempts: 5, backoffStrategy: 'fixed' as const, backoffBaseMs: 5_000 };
+    expect(computeBackoffMs(1, policy)).toBe(5_000);
+    expect(computeBackoffMs(10, policy)).toBe(5_000);
   });
 });

--- a/src/agent/daemon/task-lifecycle.ts
+++ b/src/agent/daemon/task-lifecycle.ts
@@ -93,6 +93,12 @@ export interface RetryPolicy {
   maxAttempts: number;
   backoffStrategy: 'fixed' | 'exponential';
   backoffBaseMs: number;
+  /**
+   * Hard ceiling on the computed backoff delay in ms.
+   * Prevents unbounded growth on exponential strategies at high attempt counts.
+   * Defaults to DEFAULT_MAX_BACKOFF_MS (5 minutes) when omitted.
+   */
+  maxBackoffMs?: number;
 }
 
 /**
@@ -104,6 +110,15 @@ export const DEFAULT_RETRY_POLICY: RetryPolicy = {
   backoffStrategy: 'fixed',
   backoffBaseMs: 30_000,
 };
+
+/**
+ * Maximum backoff delay: 5 minutes.
+ * Applied as a hard ceiling in computeBackoffMs when policy.maxBackoffMs is
+ * not explicitly set. Prevents exponential strategies from producing
+ * multi-hour delays at high attempt counts (e.g. attempts=20 with
+ * backoffBaseMs=1000 would otherwise compute ~145 hours).
+ */
+export const DEFAULT_MAX_BACKOFF_MS = 5 * 60 * 1_000; // 5 minutes
 
 // ---------------------------------------------------------------------------
 // Lease TTL
@@ -124,10 +139,12 @@ export const DEFAULT_LEASE_TTL_MS = 10 * 60 * 1_000; // 10 minutes
  *
  * @param attempts - Number of attempts already made (1-based after first fail).
  * @param policy   - RetryPolicy governing the backoff.
+ * @returns Delay in ms, capped at policy.maxBackoffMs ?? DEFAULT_MAX_BACKOFF_MS.
  */
 export function computeBackoffMs(attempts: number, policy: RetryPolicy): number {
+  const cap = policy.maxBackoffMs ?? DEFAULT_MAX_BACKOFF_MS;
   if (policy.backoffStrategy === 'exponential') {
-    return policy.backoffBaseMs * Math.pow(2, Math.max(0, attempts - 1));
+    return Math.min(policy.backoffBaseMs * Math.pow(2, Math.max(0, attempts - 1)), cap);
   }
-  return policy.backoffBaseMs;
+  return Math.min(policy.backoffBaseMs, cap);
 }


### PR DESCRIPTION
Closes #1442

## Problem

`computeBackoffMs` for the exponential strategy was unbounded:
`backoffBaseMs * 2^(attempts-1)` grows without limit. With
`attempts=20` and `backoffBaseMs=1000` this computes ~524 million ms
(~145 hours) — far beyond any useful retry window.

## Changes

**`src/agent/daemon/task-lifecycle.ts`**

- Add `maxBackoffMs?: number` to `RetryPolicy` — optional, fully
  backward-compatible (existing callers that don't set it get the
  5-minute default).
- Export `DEFAULT_MAX_BACKOFF_MS = 300_000` (5 minutes).
- Cap the result in `computeBackoffMs`:
  ```ts
  const cap = policy.maxBackoffMs ?? DEFAULT_MAX_BACKOFF_MS;
  return Math.min(computed, cap);
  ```
  Applied to both exponential and fixed strategies for consistency.

**`src/agent/daemon/task-lifecycle.test.ts`**

Four new test cases:

| Test | What it verifies |
|---|---|
| `caps at DEFAULT_MAX_BACKOFF_MS for high attempt counts` | attempts=20 and 30 both return 300_000 |
| `respects custom maxBackoffMs` | attempts=4 (under cap) passes through; attempts=5 (over cap) clamps |
| `normal backoff below the cap is unchanged` | attempts 1–4 with backoffBaseMs=1000 return original values |
| `fixed strategy is unaffected by cap when base is below cap` | no regression on the fixed path |

## Verification

```
pnpm lint         # passes clean (tsc --noEmit)
pnpm test src/agent/daemon   # 282 tests, 0 failures
```
