### PR TITLE
fix(security): align PID=1 threshold between parseInput and evaluateProcess (#1443)

### DIFF
--- a/src/agent/tools/handlers/wait-for.test.ts
+++ b/src/agent/tools/handlers/wait-for.test.ts
@@ -102,6 +102,15 @@ describe('waitForHandler — input validation', () => {
     expect(result.content).toMatch(/pid/);
   });
 
+  // #1443: parseInput and evaluateProcess must share the same PID=1 threshold.
+  // PID 1 (init/launchd) is a reserved system process and must be rejected at
+  // the input-validation layer, not allowed through to evaluateProcess.
+  it('returns error when process pid is 1 (reserved system PID)', async () => {
+    const result = await waitForHandler({ type: 'process', pid: 1 }, neverSignal);
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatch(/pid/);
+  });
+
   it('returns error when timeout_ms is not a number', async () => {
     const result = await waitForHandler({ type: 'command', command: 'true', timeout_ms: 'long' }, neverSignal);
     expect(result.isError).toBe(true);

--- a/src/agent/tools/handlers/wait-for.ts
+++ b/src/agent/tools/handlers/wait-for.ts
@@ -138,8 +138,8 @@ function parseInput(
       return { condition, timeoutMs, pollIntervalMs, backoff };
     }
     case 'process': {
-      if (typeof input.pid !== 'number' || !Number.isInteger(input.pid) || input.pid <= 0) {
-        throw new Error('"pid" is required for type "process" and must be a positive integer');
+      if (typeof input.pid !== 'number' || !Number.isInteger(input.pid) || input.pid <= 1) {
+        throw new Error('"pid" is required for type "process" and must be an integer > 1');
       }
       const condition: WaitCondition = { type: 'process', pid: input.pid };
       return { condition, timeoutMs, pollIntervalMs, backoff };

--- a/src/agent/tools/types.ts
+++ b/src/agent/tools/types.ts
@@ -116,9 +116,8 @@ export interface ToolHandlerContext {
    * this session actually spawned. Any PID not in the registry is rejected
    * with `blocked: true` so the model cannot probe arbitrary host processes.
    *
-   * When absent (e.g. legacy call sites, subagents that do not carry a
-   * registry), the old behaviour is preserved: any PID > 1 is probed. New
-   * session construction paths should always supply this field.
+   * All current session construction paths supply this field. When absent,
+   * the pre-registry behaviour is preserved: any PID > 1 is probed.
    */
   spawnedPidRegistry?: SpawnedPidRegistry;
 }


### PR DESCRIPTION
Fixes #1443

## Problem

Two layers encoded the same PID validity invariant at different thresholds:

| Layer | Check | PID 1 allowed? |
|-------|-------|----------------|
| `parseInput` (`wait-for.ts:141`) | `pid <= 0` | ✅ yes (bug) |
| `evaluateProcess` (`wait-for-conditions.ts:192`) | `pid <= 1` | ❌ no (correct) |

PID 1 (`init`/`launchd`/`systemd`) is a reserved system process. Probing it via
`process.kill(1, 0)` is an information-disclosure channel with no legitimate
`wait_for` use case. The condition layer already rejected it; this change closes
the gap at the input-validation layer so both layers share the same threshold.

## Changes

### `src/agent/tools/handlers/wait-for.ts`
- Line 141: `input.pid <= 0` → `input.pid <= 1`
- Error message updated: "must be a positive integer" → "must be an integer > 1"

### `src/agent/tools/handlers/wait-for.test.ts`
- New test: `returns error when process pid is 1 (reserved system PID)` — explicitly
  covers the previously-open boundary at the `parseInput` layer

### `src/agent/tools/types.ts`
- JSDoc on `ToolHandlerContext.spawnedPidRegistry`: removes "legacy callers" framing
  since all current session construction paths supply a registry

## Verification

```
pnpm lint    ✅ clean
pnpm test src/agent/tools/handlers/wait-for.test.ts            ✅ 29/29
pnpm test src/agent/tools/handlers/wait-for-conditions.test.ts ✅ 31/31
pnpm test src/agent/tools/handlers/wait-for-poller.test.ts     ✅ 13/13
```
