### PR TITLE
refactor(render): remove dead TTFB code after double-spinner fix

### DIFF
--- a/src/cli/_lib/stream-renderer-lifecycle.ts
+++ b/src/cli/_lib/stream-renderer-lifecycle.ts
@@ -95,15 +95,6 @@ export function registerOverlaySlots(
      */
     getSoftStopping: () => boolean;
     /**
-     * Live TTFB state accessors. Used by `checkTtfbAnnotation` to drive the
-     * 1 Hz dirty-mark cycle that keeps the overlay fresh during the pre-first-
-     * byte window. The SpinnerController is the visible TTFB indicator; these
-     * accessors support the annotation-change tick, not a rendered line.
-     * Optional so existing non-TTY callers and tests are unchanged.
-     */
-    getTtfbStartedAt?: () => number | undefined;
-    isTtfbDone?: () => boolean;
-    /**
      * Live accessor for the active subagent status bar specs, keyed by subagentId.
      * Optional so existing non-TTY callers and tests register slots unchanged;
      * when absent the subagent-status slot always renders empty.
@@ -234,12 +225,6 @@ export function registerOverlaySlots(
           ),
         );
       }
-      // TTFB waiting progress: suppressed. The SpinnerController already
-      // renders a braille spinner + elapsed timer during this same window,
-      // so the TTFB "Generating…" line was redundant — both appeared in the
-      // frame simultaneously (double-spinner bug). The spinner is the
-      // canonical TTFB indicator; this slot stays empty until real
-      // ProgressEvent data arrives.
       return bannerLines.length > 0 ? bannerLines.join('\n') : '';
     },
   });

--- a/src/cli/_lib/stream-renderer-ttfb.test.ts
+++ b/src/cli/_lib/stream-renderer-ttfb.test.ts
@@ -3,10 +3,8 @@ import { StreamRenderer } from './stream-renderer.js';
 import {
   applyFirstContent,
   checkTtfbAnnotation,
-  renderTtfbWaitingProgress,
   type TtfbTickCtx,
 } from './stream-renderer-ttfb.js';
-import { stripAnsi } from '../display.js';
 import type { OverlayComposer } from './overlay-composer.js';
 import type { Writer } from '../slash/types.js';
 
@@ -45,15 +43,14 @@ describe('applyFirstContent', () => {
   });
 });
 
-// ─── checkTtfbAnnotation — spinner frame tracking ────────────────────────────
+// ─── checkTtfbAnnotation ─────────────────────────────────────────────────────
 
-describe('checkTtfbAnnotation — spinner frame increments on each second advance', () => {
+describe('checkTtfbAnnotation — marks dirty on each second advance', () => {
   function makeCtx(overrides?: Partial<TtfbTickCtx>): TtfbTickCtx {
     return {
       ttfbStartedAt: Date.now() - 3_000, // 3s ago → past grace period
       ttfbDone: false,
       lastTtfbAnnotation: '',
-      ttfbSpinnerFrame: 0,
       isTTY: true,
       disposed: false,
       overlayComposer: {
@@ -64,185 +61,47 @@ describe('checkTtfbAnnotation — spinner frame increments on each second advanc
     };
   }
 
-  it('returns false and does not increment when inside grace period', () => {
+  it('returns false when inside grace period', () => {
     const ctx = makeCtx({ ttfbStartedAt: Date.now() - 500 });
     const fired = checkTtfbAnnotation(ctx, Date.now());
     expect(fired).toBe(false);
-    expect(ctx.ttfbSpinnerFrame).toBe(0);
   });
 
-  it('increments spinnerFrame on the first tick past the grace period', () => {
+  it('returns true on the first tick past the grace period', () => {
     const ctx = makeCtx();
     const fired = checkTtfbAnnotation(ctx, Date.now());
     expect(fired).toBe(true);
-    expect(ctx.ttfbSpinnerFrame).toBe(1);
   });
 
-  it('does NOT increment spinnerFrame on a repeat tick within the same second', () => {
+  it('does NOT fire again on a repeat tick within the same second', () => {
     const ctx = makeCtx();
     checkTtfbAnnotation(ctx, Date.now());
-    const frameAfterFirst = ctx.ttfbSpinnerFrame;
-    // Second call with same timestamp → same second → no increment
-    checkTtfbAnnotation(ctx, Date.now());
-    expect(ctx.ttfbSpinnerFrame).toBe(frameAfterFirst);
+    // Second call with same timestamp → same second → no change
+    const fired = checkTtfbAnnotation(ctx, Date.now());
+    expect(fired).toBe(false);
   });
 
-  it('increments spinnerFrame on each new second', () => {
+  it('fires on each new second', () => {
     const now = Date.now();
     const ctx = makeCtx({ ttfbStartedAt: now - 3_000 });
-    checkTtfbAnnotation(ctx, now); // 3s → fires
-    expect(ctx.ttfbSpinnerFrame).toBe(1);
-    checkTtfbAnnotation(ctx, now + 1_000); // 4s → fires
-    expect(ctx.ttfbSpinnerFrame).toBe(2);
-    checkTtfbAnnotation(ctx, now + 2_000); // 5s → fires
-    expect(ctx.ttfbSpinnerFrame).toBe(3);
+    expect(checkTtfbAnnotation(ctx, now)).toBe(true); // 3s
+    expect(checkTtfbAnnotation(ctx, now + 1_000)).toBe(true); // 4s
+    expect(checkTtfbAnnotation(ctx, now + 2_000)).toBe(true); // 5s
   });
 
   it('returns false when ttfbDone is true', () => {
     const ctx = makeCtx({ ttfbDone: true });
     expect(checkTtfbAnnotation(ctx, Date.now())).toBe(false);
-    expect(ctx.ttfbSpinnerFrame).toBe(0);
   });
 
   it('returns false when disposed', () => {
     const ctx = makeCtx({ disposed: true });
     expect(checkTtfbAnnotation(ctx, Date.now())).toBe(false);
-    expect(ctx.ttfbSpinnerFrame).toBe(0);
   });
 });
 
-// ─── renderTtfbWaitingProgress — uses streamProgress component ───────────────
 
-describe('renderTtfbWaitingProgress', () => {
-  it('returns empty string when isTtfbDone is true', () => {
-    const result = renderTtfbWaitingProgress(
-      () => Date.now() - 5_000,
-      () => true,
-      () => 0,
-    );
-    expect(result).toBe('');
-  });
-
-  it('returns empty string when getTtfbStartedAt is undefined', () => {
-    const result = renderTtfbWaitingProgress(
-      () => undefined,
-      () => false,
-      () => 0,
-    );
-    expect(result).toBe('');
-  });
-
-  it('returns empty string inside the grace period (< 2s)', () => {
-    const result = renderTtfbWaitingProgress(
-      () => Date.now() - 1_000, // 1s → inside 2s grace
-      () => false,
-      () => 0,
-    );
-    expect(result).toBe('');
-  });
-
-  it('returns empty string when getTtfbStartedAt is not provided', () => {
-    const result = renderTtfbWaitingProgress(undefined, () => false, () => 0);
-    expect(result).toBe('');
-  });
-
-  it('returns empty string when isTtfbDone is not provided', () => {
-    const result = renderTtfbWaitingProgress(() => Date.now() - 5_000, undefined, () => 0);
-    expect(result).toBe('');
-  });
-
-  it('renders a non-empty line past the grace period', () => {
-    const result = renderTtfbWaitingProgress(
-      () => Date.now() - 5_000,
-      () => false,
-      () => 0,
-    );
-    expect(result).not.toBe('');
-  });
-
-  it('contains the "Generating…" label from streamProgress', () => {
-    const result = stripAnsi(
-      renderTtfbWaitingProgress(
-        () => Date.now() - 5_000,
-        () => false,
-        () => 0,
-      ),
-    );
-    expect(result).toContain('Generating…');
-  });
-
-  it('renders a braille spinner glyph (not the legacy ◦ glyph)', () => {
-    const result = stripAnsi(
-      renderTtfbWaitingProgress(
-        () => Date.now() - 5_000,
-        () => false,
-        () => 0,
-      ),
-    );
-    // The braille glyph at frame 0 is ⠋
-    expect(result).toContain('⠋');
-    expect(result).not.toContain('◦');
-  });
-
-  it('advances the spinner glyph with spinnerFrame', () => {
-    const at0 = stripAnsi(
-      renderTtfbWaitingProgress(
-        () => Date.now() - 5_000,
-        () => false,
-        () => 0,
-      ),
-    );
-    const at3 = stripAnsi(
-      renderTtfbWaitingProgress(
-        () => Date.now() - 5_000,
-        () => false,
-        () => 3,
-      ),
-    );
-    // frame 0 → ⠋, frame 3 → ⠸
-    expect(at0).toContain('⠋');
-    expect(at3).toContain('⠸');
-    expect(at0).not.toContain('⠸');
-    expect(at3).not.toContain('⠋');
-  });
-
-  it('contains the elapsed time', () => {
-    const result = stripAnsi(
-      renderTtfbWaitingProgress(
-        () => Date.now() - 5_000,
-        () => false,
-        () => 0,
-      ),
-    );
-    // formatElapsed for ~5000ms → '5s'
-    expect(result).toMatch(/\d+s/);
-  });
-
-  it('defaults spinnerFrame to 0 when getSpinnerFrame is not provided', () => {
-    const result = stripAnsi(
-      renderTtfbWaitingProgress(
-        () => Date.now() - 5_000,
-        () => false,
-        undefined,
-      ),
-    );
-    // frame 0 → ⠋
-    expect(result).toContain('⠋');
-  });
-
-  it('does NOT contain the old "waiting for response…" copy', () => {
-    const result = stripAnsi(
-      renderTtfbWaitingProgress(
-        () => Date.now() - 5_000,
-        () => false,
-        () => 0,
-      ),
-    );
-    expect(result).not.toContain('waiting for response');
-  });
-});
-
-// ─── StreamRenderer integration — ttfbSpinnerFrame write-back ────────────────
+// ─── StreamRenderer integration ──────────────────────────────────────────────
 
 describe('StreamRenderer.notifyFirstContent', () => {
   it('guarantees one post-notification flush in a later event-loop turn', () => {
@@ -276,14 +135,3 @@ describe('StreamRenderer.notifyFirstContent', () => {
   });
 });
 
-describe('StreamRenderer — ttfbSpinnerFrame lifecycle', () => {
-  it('initialises ttfbSpinnerFrame to 0', () => {
-    const renderer = new StreamRenderer({
-      out: writer,
-      forceNonTty: true,
-      turnStartedAt: Date.now(),
-    });
-    const priv = renderer as unknown as { ttfbSpinnerFrame: number };
-    expect(priv.ttfbSpinnerFrame).toBe(0);
-  });
-});

--- a/src/cli/_lib/stream-renderer-ttfb.ts
+++ b/src/cli/_lib/stream-renderer-ttfb.ts
@@ -2,21 +2,19 @@
  * TTFB (time-to-first-byte) elapsed timer helpers for StreamRenderer.
  *
  * Extracted from stream-renderer-lifecycle.ts to keep that file under the
- * 350-line ceiling. Contains the per-tick TTFB annotation checker that drives
- * the live overlay spinner update at ~1 Hz via {@link streamProgress}, and the
- * shared TTFB_GRACE_MS constant.
+ * 350-line ceiling. Contains the per-tick TTFB annotation checker
+ * (`checkTtfbAnnotation`) and the first-content applier (`applyFirstContent`).
+ * The shared `TTFB_GRACE_MS` constant is also exported from here.
  *
  * Invariant: this module has no side effects and no singleton state. All
  * functions are pure or take their mutable state as explicit arguments. The
- * lifecycle context carries the mutable `lastTtfbAnnotation` and
- * `ttfbSpinnerFrame` fields; callers write them back after each tick
- * (stream-renderer.ts:checkPauseAnnotations).
+ * lifecycle context carries the mutable `lastTtfbAnnotation` field; callers
+ * write it back after each tick (stream-renderer.ts:checkPauseAnnotations).
  *
  * @module cli/_lib/stream-renderer-ttfb
  */
 
 import type { OverlayComposer } from './overlay-composer.js';
-import { streamProgress } from '../render/stream-progress.js';
 
 /**
  * Minimum elapsed time before showing the TTFB waiting line, in milliseconds.
@@ -51,13 +49,6 @@ export interface TtfbTickCtx {
    * only re-flushed when the displayed second value changes.
    */
   lastTtfbAnnotation: string;
-  /**
-   * Braille spinner frame index for the TTFB waiting indicator, incremented
-   * once per second by `checkTtfbAnnotation`. Passed directly to
-   * `streamProgress` so the braille glyph animates at ~1 Hz during the
-   * pre-first-byte wait — the same 1 Hz tick that advances the elapsed counter.
-   */
-  ttfbSpinnerFrame: number;
   isTTY: boolean;
   disposed: boolean;
   overlayComposer: OverlayComposer | null;
@@ -69,13 +60,12 @@ export interface TtfbTickCtx {
  * on the annotation string, same pattern as the stall annotation in
  * `checkPauseAnnotations`).
  *
- * Contract: mutates `ctx.lastTtfbAnnotation` and `ctx.ttfbSpinnerFrame` when
- * the displayed second advances. The caller (stream-renderer.ts
- * `checkPauseAnnotations`) writes the updated values back to its own instance
- * fields so successive ticks see them. This avoids the LifecycleContext
- * snapshot becoming stale between the read and the write-back — the snapshot
- * is rebuilt from instance fields on every tick, so writing to the snapshot's
- * fields propagates on write-back.
+ * Contract: mutates `ctx.lastTtfbAnnotation` when the displayed second
+ * advances. The caller (stream-renderer.ts `checkPauseAnnotations`) writes
+ * the updated value back to its own instance field so successive ticks see it.
+ * This avoids the LifecycleContext snapshot becoming stale between the read
+ * and the write-back — the snapshot is rebuilt from instance fields on every
+ * tick, so writing to the snapshot's fields propagates on write-back.
  *
  * Returns true when the progress-banner was marked dirty (caller must flush).
  */
@@ -97,7 +87,6 @@ export function checkTtfbAnnotation(ctx: TtfbTickCtx, now: number): boolean {
   if (ctx.lastTtfbAnnotation === annotation) return false;
 
   ctx.lastTtfbAnnotation = annotation;
-  ctx.ttfbSpinnerFrame += 1;
   ctx.overlayComposer.markDirty('progress-banner');
   // No flush() here — checkPauseAnnotations batches all dirty marks and
   // issues one flush per tick to prevent double-setOverlay compositor desyncs.
@@ -138,32 +127,3 @@ export function applyFirstContent(
   return false;
 }
 
-/**
- * Render the TTFB waiting progress line for the progress-banner overlay slot
- * using the {@link streamProgress} component, or return `''` when the timer
- * is not active, done, or inside the grace period.
- *
- * Visual output (example at 4.7s elapsed, spinner frame 4):
- *   ⠴ Generating…  4.7s
- *
- * Replaces the previous ad-hoc `  ◦ waiting for response… Ns` string with the
- * shared component so the overlay spinner is driven uniformly. Pure — no side
- * effects.
- */
-export function renderTtfbWaitingProgress(
-  getTtfbStartedAt: (() => number | undefined) | undefined,
-  isTtfbDone: (() => boolean) | undefined,
-  getSpinnerFrame: (() => number) | undefined,
-): string {
-  if (!getTtfbStartedAt || !isTtfbDone || isTtfbDone()) return '';
-  const startedAt = getTtfbStartedAt();
-  if (startedAt === undefined) return '';
-  const elapsedMs = Date.now() - startedAt;
-  if (elapsedMs < TTFB_GRACE_MS) return '';
-  const spinnerFrame = getSpinnerFrame ? getSpinnerFrame() : 0;
-  return streamProgress({
-    label: 'Generating…',
-    spinnerFrame,
-    elapsedMs,
-  });
-}

--- a/src/cli/_lib/stream-renderer.ts
+++ b/src/cli/_lib/stream-renderer.ts
@@ -177,12 +177,6 @@ export class StreamRenderer {
   private ttfbDone: boolean;
   /** Last annotation string rendered for the TTFB line — drives 1 Hz change detection. */
   private lastTtfbAnnotation = '';
-  /**
-   * Braille spinner frame index for the TTFB waiting indicator. Incremented
-   * once per second by `checkTtfbAnnotation` (via the lifecycle context
-   * write-back in `checkPauseAnnotations`) so the glyph animates at ~1 Hz.
-   */
-  private ttfbSpinnerFrame = 0;
 
   /** Ref wired in arm() so the edit-preview hook can push diffs to the tool lane. */
   private readonly addPreviewDiffRef: PreviewDiffRef | undefined;
@@ -369,8 +363,6 @@ export class StreamRenderer {
       childActivity: this.childActivity,
       getInterrupting: () => this.interrupting,
       getSoftStopping: () => this.softStopping,
-      getTtfbStartedAt: () => this.ttfbStartedAt,
-      isTtfbDone: () => this.ttfbDone,
       getActiveSubagents: () => this.activeSubagents,
     });
 
@@ -652,12 +644,10 @@ export class StreamRenderer {
       ttfbStartedAt: this.ttfbStartedAt,
       ttfbDone: this.ttfbDone,
       lastTtfbAnnotation: this.lastTtfbAnnotation,
-      ttfbSpinnerFrame: this.ttfbSpinnerFrame,
     };
     checkProgressBannerStaleness(lifecycleCtx);
     checkPauseAnnotations(lifecycleCtx);
     this.lastTtfbAnnotation = lifecycleCtx.lastTtfbAnnotation;
-    this.ttfbSpinnerFrame = lifecycleCtx.ttfbSpinnerFrame;
   }
 
 }


### PR DESCRIPTION
## Follow-up to #1445

Removes dead code left behind after the double-spinner fix:

- **`renderTtfbWaitingProgress`** — exported function with zero production callers (only call site removed in #1445)
- **`ttfbSpinnerFrame`** — field incremented every second but never read for any rendering output
- **`getTtfbStartedAt` / `isTtfbDone` accessor callbacks** — accepted by `registerOverlaySlots` but never consumed inside the function body (`checkTtfbAnnotation` reads the direct `TtfbTickCtx` fields, not these callbacks)
- **`streamProgress` import** — only consumer was the removed `renderTtfbWaitingProgress`
- Tests and JSDoc updated to match

Net -231 lines across 4 files.

### Verification
- `pnpm lint` clean
- 96/96 tests pass across `stream-renderer-ttfb`, `stream-renderer-lifecycle`, `stream-renderer`
- `pnpm audit:filesize:check` passing
