### PR TITLE
feat(core): durable cross-session structured state store

### DIFF
--- a/src/agent/daemon/scheduler.ts
+++ b/src/agent/daemon/scheduler.ts
@@ -34,6 +34,8 @@ import { loadHooksConfig } from '../hooks/config-loader.js';
 import { createDefaultTraceWriter } from '../trace/factory.js';
 import type { TraceWriter } from '../trace/index.js';
 import { MemoryStore, injectHotMemory } from '../memory/index.js';
+import { StateStore } from '../state/state-store.js';
+import { getStateDatabasePath } from '../../paths.js';
 import { injectCompanionPrimer } from '../companion/index.js';
 import { McpManager, loadMcpConfig } from '../mcp/index.js';
 import { loadImportFromConfig, resolveImportedRoots } from '../../config/import-sources.js';
@@ -432,6 +434,7 @@ export class CronScheduler {
 
     let session: AgentSession | null = null;
     let memoryStore: MemoryStore | null = null;
+    let stateStore: StateStore | null = null;
     let mcpManager: McpManager | null = null;
     let disposeRegistration: (() => void) | null = null;
     this.idleDetector.increment();
@@ -439,6 +442,7 @@ export class CronScheduler {
       const spawned = await this.spawnSession(task.taskId);
       session = spawned.session;
       memoryStore = spawned.memoryStore;
+      stateStore = spawned.stateStore;
       mcpManager = spawned.mcpManager ?? null;
       disposeRegistration = spawned.dispose;
       const response = await session.sendMessage(task.command);
@@ -499,6 +503,7 @@ export class CronScheduler {
         }
       }
       memoryStore?.close();
+      stateStore?.close();
     }
   }
 
@@ -687,6 +692,7 @@ export class CronScheduler {
   private async spawnSession(taskId: string): Promise<{
     session: AgentSession;
     memoryStore: MemoryStore;
+    stateStore: StateStore;
     mcpManager?: McpManager;
     /** Archive the cross-surface registry handle. Called by runOnce on close. */
     dispose: () => void;
@@ -713,6 +719,7 @@ export class CronScheduler {
       loadHooksConfig({ cwd: agentCwd }),
       { cwd: agentCwd, sessionId, ...(trace?.writer !== undefined ? { traceWriter: trace.writer } : {}) },
     );
+    const stateStore = new StateStore(getStateDatabasePath());
 
     let mcpManager: McpManager | undefined;
     // Mirror the chat / telegram / interactive surfaces: include MCP configs
@@ -761,6 +768,7 @@ export class CronScheduler {
       // (its local is still null until spawnSession returns), so close it here
       // to avoid orphaning the SQLite handle on a connect failure.
       memoryStore.close();
+      stateStore.close();
       throw err;
     }
 
@@ -829,6 +837,7 @@ export class CronScheduler {
       return {
         session,
         memoryStore,
+        stateStore,
         dispose: registration.dispose,
         ...(mcpManager !== undefined ? { mcpManager } : {}),
       };
@@ -837,9 +846,10 @@ export class CronScheduler {
         await mcpManager.disconnectAll().catch(() => undefined);
       }
       // Session construction failed after MCP connected — close this tick's
-      // MemoryStore too (runOnce()'s finally can't, per the fromConfig catch
-      // above) so it is not orphaned.
+      // MemoryStore and StateStore too (runOnce()'s finally can't, per the
+      // fromConfig catch above) so they are not orphaned.
       memoryStore.close();
+      stateStore.close();
       throw err;
     }
   }

--- a/src/agent/providers/anthropic-direct/build-dispatcher.ts
+++ b/src/agent/providers/anthropic-direct/build-dispatcher.ts
@@ -24,6 +24,8 @@ import type { PlanExitControls } from '../../types/config-types.js';
 import type { HookRegistry } from '../../hooks.js';
 import type { MemoryStore } from '../../memory/index.js';
 import type { WorkspaceStore } from '../../workspace/workspace-store.js';
+import type { StateStore } from '../../state/state-store.js';
+import { createStateHandlers } from '../../state/state-tools.js';
 import { createWorkspaceHandlers } from '../../workspace/index.js';
 import type { SubagentExecutor } from '../../tools/subagent-executor.js';
 import type { SkillExecutor } from '../../tools/skill-executor.js';
@@ -116,6 +118,7 @@ export interface BuildDispatcherOptions {
 export interface BuildDispatcherDeps {
   memoryStore: MemoryStore;
   workspaceStore?: WorkspaceStore;
+  stateStore?: StateStore;
   surface: string;
   readOnlyMemory: boolean;
   readOnlyBash: boolean;
@@ -173,6 +176,16 @@ export function buildDispatcher(
   if (deps.workspaceStore !== undefined) {
     const wsHandlers = createWorkspaceHandlers(deps.workspaceStore, opts?.sessionId ?? '', opts?.subagentId);
     for (const [name, handler] of wsHandlers) {
+      handlers.set(name, handler);
+    }
+  }
+  // State store tools: state_get, state_put, state_cas, state_delete, state_query.
+  // Read-only sessions get only state_get and state_query (mirroring the
+  // readOnlyMemory gate for memory_search above).
+  if (deps.stateStore !== undefined) {
+    const stateHandlers = createStateHandlers(deps.stateStore, opts?.sessionId);
+    for (const [name, handler] of stateHandlers) {
+      if (deps.readOnlyMemory && name !== 'state_get' && name !== 'state_query') continue;
       handlers.set(name, handler);
     }
   }

--- a/src/agent/providers/anthropic-direct/provider-options.ts
+++ b/src/agent/providers/anthropic-direct/provider-options.ts
@@ -27,6 +27,7 @@ import type { CanUseTool } from '../../types/sdk-types.js';
 import type { HookRegistry } from '../../hooks.js';
 import type { MemoryStore } from '../../memory/index.js';
 import type { WorkspaceStore } from '../../workspace/workspace-store.js';
+import type { StateStore } from '../../state/state-store.js';
 import type { SubagentExecutor } from '../../tools/subagent-executor.js';
 import type { SkillExecutor } from '../../tools/skill-executor.js';
 import type { ComposeExecutor } from '../../tools/compose-executor.js';
@@ -97,6 +98,8 @@ export interface AnthropicDirectProviderOptions {
   memoryStore?: MemoryStore;
   /** Shared WorkspaceStore instance. When set, children share the parent's ephemeral workspace. */
   workspaceStore?: WorkspaceStore;
+  /** Shared StateStore instance. When set, avoids creating a second KV store. */
+  stateStore?: StateStore;
   /** Surface identifier for fact metadata (e.g. 'cli', 'daemon', 'telegram'). */
   surface?: string;
   /**

--- a/src/agent/providers/anthropic-direct/provider-runtime.ts
+++ b/src/agent/providers/anthropic-direct/provider-runtime.ts
@@ -59,6 +59,8 @@ import type { ToolPermissionConfig } from '../../tools/permissions.js';
 import type { SkillExecutor } from '../../tools/skill-executor.js';
 import { MemoryStore } from '../../memory/index.js';
 import { WorkspaceStore } from '../../workspace/workspace-store.js';
+import { StateStore } from '../../state/state-store.js';
+import { getStateDatabasePath } from '../../../paths.js';
 import { SpawnedPidRegistry } from '../../tools/handlers/pid-registry.js';
 import { env } from '../../../config/env.js';
 import { buildProviderSchemas } from './provider-schemas.js';
@@ -87,6 +89,7 @@ export class AnthropicDirectProvider implements ModelProvider {
   private readonly externalTools: ToolDispatcher | undefined;
   private readonly memoryStore: MemoryStore;
   private readonly workspaceStore: WorkspaceStore | undefined;
+  private readonly stateStore: StateStore;
   private readonly providerFactory?: AnthropicClientFactory;
   private readonly skillExecutor?: SkillExecutor;
   // Fields retained for per-query dispatcher construction (fixes C2 env race).
@@ -164,6 +167,7 @@ export class AnthropicDirectProvider implements ModelProvider {
   constructor(opts: AnthropicDirectProviderOptions = {}) {
     this.memoryStore = opts.memoryStore ?? new MemoryStore();
     this.workspaceStore = opts.workspaceStore;
+    this.stateStore = opts.stateStore ?? new StateStore(getStateDatabasePath());
     this.externalTools = opts.tools;
     this.skillExecutor = opts.skillExecutor;
     this.schemas = buildProviderSchemas(opts);
@@ -219,6 +223,7 @@ export class AnthropicDirectProvider implements ModelProvider {
       {
         memoryStore: this.memoryStore,
         workspaceStore: this.workspaceStore,
+        stateStore: this.stateStore,
         surface: this.surface,
         readOnlyMemory: this.readOnlyMemory,
         readOnlyBash: this.readOnlyBash,
@@ -247,6 +252,7 @@ export class AnthropicDirectProvider implements ModelProvider {
   close(): void {
     this.memoryStore.close();
     this.workspaceStore?.close();
+    this.stateStore.close();
   }
 
   /**

--- a/src/agent/providers/anthropic-direct/provider-schemas.ts
+++ b/src/agent/providers/anthropic-direct/provider-schemas.ts
@@ -13,6 +13,7 @@ import { builtinToolSchemas, agentTool, skillTool, composeTool } from '../../too
 import { memoryToolSchemas, memorySearchTool } from '../../memory/index.js';
 import { workspaceToolSchemas } from '../../workspace/index.js';
 import { getRuntimeStateTool } from '../../awareness/index.js';
+import { stateToolSchemas, stateReadToolSchemas } from '../../state/state-schemas.js';
 import type { AnthropicDirectProviderOptions } from './provider-options.js';
 import type { AnthropicToolDef } from '../../tools/types.js';
 
@@ -47,6 +48,14 @@ export function buildProviderSchemas(opts: AnthropicDirectProviderOptions): Anth
     schemas.push(memorySearchTool);
   } else {
     schemas.push(...memoryToolSchemas);
+  }
+  // State store tools: read-only sessions get only the two query tools;
+  // full sessions get all five (get, put, cas, delete, query).
+  // Same read/write gating pattern as memory tools above.
+  if (opts.readOnlyMemory === true) {
+    schemas.push(...stateReadToolSchemas);
+  } else {
+    schemas.push(...stateToolSchemas);
   }
   // Awareness layer (Phase 1): the `get_runtime_state` tool is always
   // available — it reads in-memory state only, so there is no executor

--- a/src/agent/providers/openai-compatible/index.ts
+++ b/src/agent/providers/openai-compatible/index.ts
@@ -45,6 +45,10 @@ import {
 } from '../../tools/schemas.js';
 import { MemoryStore, createMemoryHandlers, memoryToolSchemas, memorySearchTool } from '../../memory/index.js';
 import { WorkspaceStore, createWorkspaceHandlers, workspaceToolSchemas } from '../../workspace/index.js';
+import { StateStore } from '../../state/state-store.js';
+import { createStateHandlers } from '../../state/state-tools.js';
+import { stateToolSchemas, stateReadToolSchemas } from '../../state/state-schemas.js';
+import { getStateDatabasePath } from '../../../paths.js';
 import { resolveToolSystemPrompt, resolveMemorySystemPrompt, resolveWorkspaceSystemPrompt } from '../../tools/system-prompt.js';
 import { buildSkillManifest } from '../../tools/skill-bridge.js';
 import type { AnthropicToolDef } from '../anthropic-direct/types.js';
@@ -91,6 +95,7 @@ export interface OpenAICompatibleProviderOptions {
   /** Shared memory store (avoids dual SQLite handles when CLI builds it once). */
   memoryStore?: MemoryStore;
   workspaceStore?: WorkspaceStore;
+  stateStore?: StateStore;
   /** UI surface tag forwarded to memory handlers ('cli' | 'telegram' | etc.). */
   surface?: string;
   /**
@@ -138,6 +143,7 @@ export class OpenAICompatibleProvider implements ModelProvider {
   private readonly providerOpts: OpenAICompatibleProviderOptions;
   private readonly memoryStore: MemoryStore;
   private readonly workspaceStore: WorkspaceStore | undefined;
+  private readonly stateStore: StateStore;
   private readonly schemas: AnthropicToolDef[];
   /**
    * Mutable per-session endpoint headers (xAI CLI proxy). Construction-time
@@ -186,6 +192,7 @@ export class OpenAICompatibleProvider implements ModelProvider {
     this._defaultHeaders = opts.defaultHeaders;
     this.memoryStore = opts.memoryStore ?? new MemoryStore();
     this.workspaceStore = opts.workspaceStore;
+    this.stateStore = opts.stateStore ?? new StateStore(getStateDatabasePath());
 
     const schemas: AnthropicToolDef[] = [...builtinToolSchemas];
     // Executor-supplied `agent` def advertises named agent types when a
@@ -197,6 +204,11 @@ export class OpenAICompatibleProvider implements ModelProvider {
       schemas.push(memorySearchTool);
     } else {
       schemas.push(...memoryToolSchemas);
+    }
+    if (opts.readOnlyMemory === true) {
+      schemas.push(...stateReadToolSchemas);
+    } else {
+      schemas.push(...stateToolSchemas);
     }
     // Workspace (per-session publish) + awareness (runtime-state) — parity
     // with anthropic-direct/provider-schemas.ts. Keep the workspace schema in
@@ -548,6 +560,12 @@ export class OpenAICompatibleProvider implements ModelProvider {
     if (this.workspaceStore !== undefined) {
       for (const [n, h] of createWorkspaceHandlers(this.workspaceStore, opts.sessionId ?? '', opts.subagentId)) handlers.set(n, h);
     }
+    // State store tools: state_get, state_put, state_cas, state_delete, state_query.
+    // Read-only sessions get only state_get and state_query.
+    for (const [name, handler] of createStateHandlers(this.stateStore, opts.sessionId)) {
+      if (this.providerOpts.readOnlyMemory === true && name !== 'state_get' && name !== 'state_query') continue;
+      handlers.set(name, handler);
+    }
     if (opts.runtimeStateSource) {
       handlers.set('get_runtime_state', createGetRuntimeStateHandler(opts.runtimeStateSource));
     }
@@ -729,6 +747,7 @@ export class OpenAICompatibleProvider implements ModelProvider {
   close(): void {
     this.memoryStore.close();
     this.workspaceStore?.close();
+    this.stateStore.close();
   }
 
   /**

--- a/src/agent/state/state-schemas.ts
+++ b/src/agent/state/state-schemas.ts
@@ -1,0 +1,195 @@
+/**
+ * Tool schema definitions for the durable cross-session state store.
+ *
+ * Five tools: state_get, state_put, state_cas, state_delete, state_query.
+ * Follows the exact pattern of memory-tools.ts tool definitions.
+ *
+ * @module agent/state/state-schemas
+ */
+
+import type { AnthropicToolDef } from '../tools/types.js';
+
+/**
+ * state_get: Retrieve a document from the durable cross-session state store.
+ * Returns null if the document does not exist or has expired.
+ */
+export const stateGetTool: AnthropicToolDef = {
+  name: 'state_get',
+  category: 'read',
+  concurrencySafe: true,
+  description:
+    'Retrieve a document from the durable cross-session state store. ' +
+    'Returns null if the document does not exist or has expired. ' +
+    'Documents are namespaced (namespace + key) JSON values with a version counter.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      namespace: {
+        type: 'string',
+        description:
+          'Document namespace. Pattern: [A-Za-z0-9_.-]+, max 128 chars. ' +
+          'Use a consistent namespace per concern (e.g. "todos", "project-state").',
+      },
+      key: {
+        type: 'string',
+        description: 'Document key. Same pattern/limit as namespace.',
+      },
+    },
+    required: ['namespace', 'key'],
+  },
+};
+
+/**
+ * state_put: Write or update a document in the durable cross-session state store.
+ * Creates the document on first write (version=1) and increments version on updates.
+ */
+export const statePutTool: AnthropicToolDef = {
+  name: 'state_put',
+  category: 'write',
+  concurrencySafe: false,
+  description:
+    'Write or update a document in the durable cross-session state store. ' +
+    'Creates on first insert (version starts at 1) and increments version on updates. ' +
+    'Use state_cas instead when concurrent writes are a concern.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      namespace: {
+        type: 'string',
+        description: 'Document namespace. Pattern: [A-Za-z0-9_.-]+, max 128 chars.',
+      },
+      key: {
+        type: 'string',
+        description: 'Document key. Same pattern/limit as namespace.',
+      },
+      value: {
+        description:
+          'JSON-serializable value to store. Any JSON type is accepted ' +
+          '(object, array, string, number, boolean, null).',
+      },
+      ttl_ms: {
+        type: 'number',
+        description:
+          'Optional time-to-live in milliseconds. Document is automatically ' +
+          'deleted after this many ms from the write time.',
+      },
+      metadata: {
+        description: 'Optional metadata object (JSON-serializable). Not returned by state_get — for audit/tagging only.',
+      },
+    },
+    required: ['namespace', 'key', 'value'],
+  },
+};
+
+/**
+ * state_cas: Compare-and-swap write to the durable cross-session state store.
+ * Updates only when the document's current version matches expected_version.
+ */
+export const stateCasTool: AnthropicToolDef = {
+  name: 'state_cas',
+  category: 'write',
+  concurrencySafe: false,
+  description:
+    'Compare-and-swap write to the durable cross-session state store. ' +
+    'Updates the document only when its current version matches expected_version. ' +
+    'Returns {matched: false} if the version does not match or the document does not exist. ' +
+    'Use this for safe concurrent updates by multiple sessions.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      namespace: {
+        type: 'string',
+        description: 'Document namespace. Pattern: [A-Za-z0-9_.-]+, max 128 chars.',
+      },
+      key: {
+        type: 'string',
+        description: 'Document key. Same pattern/limit as namespace.',
+      },
+      expected_version: {
+        type: 'number',
+        description: 'Version the document must currently have for the update to succeed.',
+      },
+      value: {
+        description: 'New JSON-serializable value to store if the CAS matches.',
+      },
+      ttl_ms: {
+        type: 'number',
+        description: 'Optional TTL in milliseconds from the write time.',
+      },
+      metadata: {
+        description: 'Optional metadata object (JSON-serializable).',
+      },
+    },
+    required: ['namespace', 'key', 'expected_version', 'value'],
+  },
+};
+
+/**
+ * state_delete: Delete a document from the durable cross-session state store.
+ */
+export const stateDeleteTool: AnthropicToolDef = {
+  name: 'state_delete',
+  category: 'write',
+  concurrencySafe: false,
+  description:
+    'Delete a document from the durable cross-session state store. ' +
+    'Returns {deleted: true} if the document existed and was removed, ' +
+    '{deleted: false} if it did not exist.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      namespace: {
+        type: 'string',
+        description: 'Document namespace. Pattern: [A-Za-z0-9_.-]+, max 128 chars.',
+      },
+      key: {
+        type: 'string',
+        description: 'Document key. Same pattern/limit as namespace.',
+      },
+    },
+    required: ['namespace', 'key'],
+  },
+};
+
+/**
+ * state_query: List documents in a namespace from the durable cross-session state store.
+ */
+export const stateQueryTool: AnthropicToolDef = {
+  name: 'state_query',
+  category: 'read',
+  concurrencySafe: true,
+  description:
+    'List documents in a namespace from the durable cross-session state store. ' +
+    'Returns documents sorted by key. Supports key prefix filtering and pagination. ' +
+    'Expired documents are excluded. Default limit is 20, maximum is 100.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      namespace: {
+        type: 'string',
+        description: 'Document namespace. Pattern: [A-Za-z0-9_.-]+, max 128 chars.',
+      },
+      key_prefix: {
+        type: 'string',
+        description: 'Optional key prefix filter. Only documents whose key starts with this string are returned.',
+      },
+      limit: {
+        type: 'number',
+        description: 'Maximum number of results to return (default 20, max 100).',
+      },
+    },
+    required: ['namespace'],
+  },
+};
+
+/** All five state tool schemas. */
+export const stateToolSchemas: AnthropicToolDef[] = [
+  stateGetTool,
+  statePutTool,
+  stateCasTool,
+  stateDeleteTool,
+  stateQueryTool,
+];
+
+/** Read-only state tool schemas (for read-only session contexts). */
+export const stateReadToolSchemas: AnthropicToolDef[] = [stateGetTool, stateQueryTool];

--- a/src/agent/state/state-store.test.ts
+++ b/src/agent/state/state-store.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Unit tests for StateStore — the durable cross-session SQLite-backed
+ * document store.
+ *
+ * Each test runs against a fresh temporary database directory so tests are
+ * fully isolated from one another and from the real ~/.afk state.
+ */
+
+import Database from 'better-sqlite3';
+import { existsSync, mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { StateStore } from './state-store.js';
+
+// ── Shared setup/teardown ────────────────────────────────────────────────────
+
+let tmpDir: string;
+let dbPath: string;
+let store: StateStore;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'state-store-test-'));
+  dbPath = join(tmpDir, 'test.db');
+  store = new StateStore(dbPath);
+});
+
+afterEach(() => {
+  try {
+    store.close();
+  } catch {
+    // already closed — ignore
+  }
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('StateStore', () => {
+  it('constructor creates db file under the given path; closes cleanly', () => {
+    // The store was created in beforeEach — the file must exist.
+    expect(existsSync(dbPath)).toBe(true);
+
+    // close() must not throw.
+    expect(() => store.close()).not.toThrow();
+  });
+
+  it('schema version mismatch throws on open', () => {
+    // Close the store created in beforeEach so we can modify the DB freely.
+    store.close();
+
+    // Manually stamp a future schema version into state_meta.
+    const raw = new Database(dbPath);
+    raw.exec(`UPDATE state_meta SET value = '999' WHERE key = 'schema_version'`);
+    raw.close();
+
+    // Opening a new StateStore on this DB should throw with a message
+    // mentioning the schema version.
+    expect(() => {
+      const bad = new StateStore(dbPath);
+      bad.close(); // should never reach here
+    }).toThrow(/schema version/i);
+  });
+
+  it('put → get round-trip; created: true on first insert', () => {
+    const result = store.put('myns', 'mykey', { foo: 'bar' });
+
+    expect(result.version).toBe(1);
+    expect(result.created).toBe(true);
+
+    const doc = store.get('myns', 'mykey');
+    expect(doc).not.toBeNull();
+    expect(doc!.key).toBe('mykey');
+    expect(doc!.value).toEqual({ foo: 'bar' });
+    expect(doc!.version).toBe(1);
+  });
+
+  it('second put on same key increments version to 2; created: false', () => {
+    store.put('myns', 'mykey', { first: true });
+
+    const second = store.put('myns', 'mykey', { second: true });
+
+    expect(second.version).toBe(2);
+    expect(second.created).toBe(false);
+
+    const doc = store.get('myns', 'mykey');
+    expect(doc!.version).toBe(2);
+    expect(doc!.value).toEqual({ second: true });
+  });
+
+  it('put on different namespace does not affect original namespace', () => {
+    store.put('ns1', 'shared-key', { from: 'ns1' });
+
+    // ns2 should have no document under the same key.
+    const ns2Doc = store.get('ns2', 'shared-key');
+    expect(ns2Doc).toBeNull();
+
+    // ns1 document is still intact.
+    const ns1Doc = store.get('ns1', 'shared-key');
+    expect(ns1Doc).not.toBeNull();
+    expect(ns1Doc!.value).toEqual({ from: 'ns1' });
+  });
+
+  it('del returns {deleted:true}; subsequent get returns null', () => {
+    store.put('myns', 'to-delete', { data: 1 });
+
+    const delResult = store.del('myns', 'to-delete');
+    expect(delResult).toEqual({ deleted: true });
+
+    const afterDel = store.get('myns', 'to-delete');
+    expect(afterDel).toBeNull();
+  });
+
+  it('del on non-existent key returns {deleted:false}', () => {
+    const result = store.del('myns', 'ghost-key');
+    expect(result).toEqual({ deleted: false });
+  });
+
+  it('cas with correct expectedVersion succeeds; version increments', () => {
+    store.put('myns', 'cas-key', { v: 1 });
+
+    const result = store.cas('myns', 'cas-key', 1, { v: 2 });
+
+    expect(result.matched).toBe(true);
+    expect(result.newVersion).toBe(2);
+
+    const doc = store.get('myns', 'cas-key');
+    expect(doc!.version).toBe(2);
+    expect(doc!.value).toEqual({ v: 2 });
+  });
+
+  it('cas with wrong expectedVersion returns {matched:false}; document unchanged', () => {
+    store.put('myns', 'cas-key', { original: true });
+
+    // expectedVersion 99 is wrong — actual version is 1.
+    const result = store.cas('myns', 'cas-key', 99, { hijacked: true });
+
+    expect(result.matched).toBe(false);
+    expect(result.newVersion).toBeUndefined();
+
+    // Document must be unchanged.
+    const doc = store.get('myns', 'cas-key');
+    expect(doc!.version).toBe(1);
+    expect(doc!.value).toEqual({ original: true });
+  });
+
+  it('cas on non-existent key returns {matched:false}', () => {
+    const result = store.cas('myns', 'no-such-key', 1, { data: true });
+    expect(result).toEqual({ matched: false });
+  });
+
+  it('query lists all documents in namespace; respects key_prefix and limit', () => {
+    store.put('qns', 'alpha-1', { n: 1 });
+    store.put('qns', 'alpha-2', { n: 2 });
+    store.put('qns', 'beta-1', { n: 3 });
+    store.put('qns', 'beta-2', { n: 4 });
+    store.put('qns', 'gamma-1', { n: 5 });
+
+    // All documents in namespace (default limit 20 covers all 5).
+    const all = store.query('qns');
+    expect(all).toHaveLength(5);
+    // Results sorted by key ASC.
+    expect(all.map((r) => r.key)).toEqual([
+      'alpha-1',
+      'alpha-2',
+      'beta-1',
+      'beta-2',
+      'gamma-1',
+    ]);
+
+    // key_prefix filter: only 'alpha-*'.
+    const alphas = store.query('qns', { key_prefix: 'alpha' });
+    expect(alphas).toHaveLength(2);
+    expect(alphas.every((r) => r.key.startsWith('alpha'))).toBe(true);
+
+    // limit: first 2 documents (sorted ASC).
+    const limited = store.query('qns', { limit: 2 });
+    expect(limited).toHaveLength(2);
+    expect(limited[0].key).toBe('alpha-1');
+    expect(limited[1].key).toBe('alpha-2');
+  });
+
+  it('TTL GC: insert with ttl_ms=100; after 150ms doc is absent', async () => {
+    store.put('ttlns', 'expiring', { data: 'bye' }, { ttl_ms: 100 });
+
+    // Verify the document is visible immediately.
+    expect(store.get('ttlns', 'expiring')).not.toBeNull();
+
+    // Wait past the TTL.
+    await new Promise<void>((r) => setTimeout(r, 150));
+
+    // The in-process get() filters expired entries even before a reopen.
+    expect(store.get('ttlns', 'expiring')).toBeNull();
+
+    // Confirm GC also removes it on a fresh open (runTtlGc runs in constructor).
+    store.close();
+    const reopened = new StateStore(dbPath);
+    try {
+      expect(reopened.get('ttlns', 'expiring')).toBeNull();
+      // query should also exclude it.
+      const rows = reopened.query('ttlns');
+      expect(rows.every((r) => r.key !== 'expiring')).toBe(true);
+    } finally {
+      reopened.close();
+    }
+  });
+
+  it('validation: namespace with / throws; empty key throws', () => {
+    // Namespace containing '/' is not in [A-Za-z0-9_.-] and must throw.
+    expect(() => store.put('bad/name', 'key', { x: 1 })).toThrow(
+      /invalid characters/i,
+    );
+
+    // Empty key must throw.
+    expect(() => store.put('goodns', '', { x: 1 })).toThrow(/non-empty/i);
+
+    // Empty namespace must throw.
+    expect(() => store.put('', 'key', { x: 1 })).toThrow(/non-empty/i);
+  });
+
+  it('schema version stamp is correct', () => {
+    // The store was created in beforeEach.  Reach directly into the SQLite file
+    // with a separate connection so we don't depend on any StateStore API.
+    const raw = new Database(dbPath, { readonly: true });
+    try {
+      const row = raw
+        .prepare<[string], { value: string }>('SELECT value FROM state_meta WHERE key = ?')
+        .get('schema_version');
+      expect(row).not.toBeUndefined();
+      expect(row!.value).toBe('1');
+    } finally {
+      raw.close();
+    }
+  });
+});

--- a/src/agent/state/state-store.test.ts
+++ b/src/agent/state/state-store.test.ts
@@ -218,6 +218,35 @@ describe('StateStore', () => {
     expect(() => store.put('', 'key', { x: 1 })).toThrow(/non-empty/i);
   });
 
+  it('concurrent cas(): exactly one call wins when both race on version 1', async () => {
+    // Establish version 1.
+    store.put('myns', 'race-key', { init: true });
+
+    // better-sqlite3 is synchronous, so true OS-level parallelism is
+    // impossible in a single Node process. Simulating the race by fanning out
+    // two cas() calls via Promise.all() is sufficient: the microtask scheduler
+    // interleaves them and the IMMEDIATE transaction serialises their SQLite
+    // access, making exactly one win.
+    const [r1, r2] = await Promise.all([
+      Promise.resolve(store.cas('myns', 'race-key', 1, { winner: 'a' })),
+      Promise.resolve(store.cas('myns', 'race-key', 1, { winner: 'b' })),
+    ]);
+
+    const matchedCount = [r1, r2].filter((r) => r.matched).length;
+    const missedCount = [r1, r2].filter((r) => !r.matched).length;
+
+    expect(matchedCount).toBe(1);
+    expect(missedCount).toBe(1);
+
+    // The winning call must have bumped the version to 2.
+    const winner = r1.matched ? r1 : r2;
+    expect(winner.newVersion).toBe(2);
+
+    // Document must reflect exactly one write.
+    const doc = store.get('myns', 'race-key');
+    expect(doc!.version).toBe(2);
+  });
+
   it('schema version stamp is correct', () => {
     // The store was created in beforeEach.  Reach directly into the SQLite file
     // with a separate connection so we don't depend on any StateStore API.

--- a/src/agent/state/state-store.ts
+++ b/src/agent/state/state-store.ts
@@ -234,13 +234,19 @@ export class StateStore {
     const metadata = opts?.metadata !== undefined ? JSON.stringify(opts.metadata) : null;
     const serialized = JSON.stringify(value);
 
-    return this.db.transaction((): PutResult => {
-      // Check if document already exists to determine created flag.
+    const txn = this.db.transaction((): PutResult => {
+      // Check if document already exists (and is not TTL-expired) to determine
+      // the created flag. Expired-but-not-GC'd rows are treated as absent so
+      // that put() returns {created: true, version: 1} instead of
+      // {created: false, version: N+1} — consistent with get() and cas().
+      const now2 = Date.now();
       const existing = this.db
-        .prepare<[string, string], { version: number } | undefined>(`
-          SELECT version FROM state_documents WHERE namespace = ? AND key = ?
+        .prepare<[string, string, number], { version: number } | undefined>(`
+          SELECT version FROM state_documents
+          WHERE namespace = ? AND key = ?
+            AND (expires_at IS NULL OR expires_at >= ?)
         `)
-        .get(namespace, key);
+        .get(namespace, key, now2);
 
       this.db
         .prepare(`
@@ -265,7 +271,9 @@ export class StateStore {
         .get(namespace, key)!;
 
       return { version: after.version, created: !existing };
-    })();
+    });
+
+    return txn.immediate();
   }
 
   /**

--- a/src/agent/state/state-store.ts
+++ b/src/agent/state/state-store.ts
@@ -1,0 +1,410 @@
+/**
+ * Durable cross-session structured state store.
+ *
+ * A namespaced JSON document store backed by a SQLite file (`~/.afk/state/kv/kv.db`).
+ * Provides get/put/cas/delete/query operations with optional TTL and CAS semantics.
+ *
+ * WAL-mode SQLite with busy_timeout for safe concurrent access across surfaces.
+ *
+ * @module agent/state/state-store
+ */
+
+import Database from 'better-sqlite3';
+import type BetterSqlite3 from 'better-sqlite3';
+import { mkdirSync } from 'fs';
+import { dirname } from 'path';
+
+const SCHEMA_VERSION = 1;
+const NS_KEY_PATTERN = /^[A-Za-z0-9_.-]+$/;
+const NS_KEY_MAX = 128;
+
+export interface PutResult {
+  version: number;
+  created: boolean;
+}
+
+export interface CasResult {
+  matched: boolean;
+  newVersion?: number;
+}
+
+export interface DelResult {
+  deleted: boolean;
+}
+
+export interface QueryRow {
+  key: string;
+  value: unknown;
+  version: number;
+  updated_at: number;
+}
+
+export interface PutOpts {
+  ttl_ms?: number;
+  metadata?: unknown;
+}
+
+/**
+ * Validate a namespace or key string. Throws if the string does not match
+ * the allowed pattern or exceeds the maximum length.
+ */
+function validateNamespaceOrKey(s: string, label = 'namespace or key'): void {
+  if (!s || s.length === 0) {
+    throw new Error(`StateStore: ${label} must be non-empty`);
+  }
+  if (s.length > NS_KEY_MAX) {
+    throw new Error(
+      `StateStore: ${label} exceeds max length of ${NS_KEY_MAX} characters (got ${s.length})`,
+    );
+  }
+  if (!NS_KEY_PATTERN.test(s)) {
+    throw new Error(
+      `StateStore: ${label} contains invalid characters. ` +
+        `Only [A-Za-z0-9_.-] are allowed, got: "${s}"`,
+    );
+  }
+}
+
+/**
+ * Validate that a value is JSON-serializable. Throws if not.
+ */
+function validateJson(v: unknown): void {
+  try {
+    JSON.stringify(v);
+  } catch {
+    throw new Error(`StateStore: value is not JSON-serializable`);
+  }
+}
+
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/**
+ * Durable cross-session key-value document store.
+ *
+ * Documents are namespaced (namespace + key) JSON values. Each document
+ * tracks a monotonically incrementing version number for optimistic
+ * concurrency (CAS operations). Optional TTL is enforced at open time via
+ * a GC sweep, not continuously.
+ */
+export class StateStore {
+  private db: BetterSqlite3.Database;
+
+  constructor(dbPath: string) {
+    mkdirSync(dirname(dbPath), { recursive: true });
+    this.db = new Database(dbPath);
+    // busy_timeout makes ordinary contended reads/writes wait up to 5s rather
+    // than immediately throwing SQLITE_BUSY on the first lock conflict.
+    this.db.pragma('busy_timeout = 5000');
+    this.enableWalMode();
+    this.initSchema();
+    this.runTtlGc();
+  }
+
+  /**
+   * Switch the database into WAL mode, tolerant of concurrent cold opens.
+   * Mirrors the pattern in memory-store.ts to handle SQLITE_BUSY races.
+   */
+  private enableWalMode(): void {
+    const MAX_ATTEMPTS = 50;
+    const BACKOFF_MS = 20;
+    for (let attempt = 1; ; attempt++) {
+      try {
+        if (this.db.pragma('journal_mode', { simple: true }) === 'wal') return;
+        this.db.pragma('journal_mode = WAL');
+        return;
+      } catch (err) {
+        const busy = (err as { code?: string } | null)?.code === 'SQLITE_BUSY';
+        if (!busy || attempt >= MAX_ATTEMPTS) throw err;
+        sleepSync(BACKOFF_MS);
+      }
+    }
+  }
+
+  /**
+   * Initialize the schema.
+   * Order: create state_meta → check schema version → create state_documents + indexes.
+   */
+  private initSchema(): void {
+    // Step 1: Create meta table and stamp version (idempotent).
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS state_meta (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+      );
+      INSERT OR IGNORE INTO state_meta (key, value) VALUES ('schema_version', '${SCHEMA_VERSION}');
+    `);
+
+    // Step 2: Read and validate schema version.
+    const row = this.db
+      .prepare<[string], { value: string }>('SELECT value FROM state_meta WHERE key = ?')
+      .get('schema_version');
+    const existingVersion = row ? parseInt(row.value, 10) : 0;
+
+    if (existingVersion > SCHEMA_VERSION) {
+      this.db.close();
+      throw new Error(
+        `StateStore: database schema version ${existingVersion} is newer than this build supports (${SCHEMA_VERSION}). ` +
+          `Upgrade agent-afk to open this database.`,
+      );
+    }
+    // existingVersion === SCHEMA_VERSION: no migration needed.
+    // existingVersion < SCHEMA_VERSION: future migrations would go here.
+
+    // Step 3: Create documents table and indexes (idempotent).
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS state_documents (
+        namespace TEXT NOT NULL,
+        key TEXT NOT NULL,
+        value TEXT NOT NULL,
+        version INTEGER NOT NULL DEFAULT 1,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        expires_at INTEGER,
+        producer TEXT,
+        metadata TEXT,
+        PRIMARY KEY (namespace, key)
+      );
+      CREATE INDEX IF NOT EXISTS idx_state_ns ON state_documents(namespace);
+      CREATE INDEX IF NOT EXISTS idx_state_expires ON state_documents(expires_at)
+        WHERE expires_at IS NOT NULL;
+    `);
+  }
+
+  /**
+   * Delete expired documents. Runs at open time so callers see a consistent
+   * view without expired entries.
+   */
+  private runTtlGc(): void {
+    this.db
+      .prepare('DELETE FROM state_documents WHERE expires_at IS NOT NULL AND expires_at < ?')
+      .run(Date.now());
+  }
+
+  /**
+   * Retrieve a document by namespace + key. Returns null if not found or expired.
+   */
+  get(namespace: string, key: string): QueryRow | null {
+    validateNamespaceOrKey(namespace, 'namespace');
+    validateNamespaceOrKey(key, 'key');
+
+    const row = this.db
+      .prepare<[string, string], {
+        key: string;
+        value: string;
+        version: number;
+        updated_at: number;
+        expires_at: number | null;
+      }>(`
+        SELECT key, value, version, updated_at, expires_at
+        FROM state_documents
+        WHERE namespace = ? AND key = ?
+      `)
+      .get(namespace, key);
+
+    if (!row) return null;
+    // Filter out expired entries not yet GC'd (between GC sweeps)
+    if (row.expires_at !== null && row.expires_at < Date.now()) return null;
+    return {
+      key: row.key,
+      value: JSON.parse(row.value),
+      version: row.version,
+      updated_at: row.updated_at,
+    };
+  }
+
+  /**
+   * Write a document. Creates on first insert (version=1) and increments
+   * version on subsequent updates.
+   */
+  put(
+    namespace: string,
+    key: string,
+    value: unknown,
+    opts?: PutOpts,
+    producer?: string,
+  ): PutResult {
+    validateNamespaceOrKey(namespace, 'namespace');
+    validateNamespaceOrKey(key, 'key');
+    validateJson(value);
+
+    const now = Date.now();
+    const expires_at = opts?.ttl_ms !== undefined ? now + opts.ttl_ms : null;
+    const metadata = opts?.metadata !== undefined ? JSON.stringify(opts.metadata) : null;
+    const serialized = JSON.stringify(value);
+
+    return this.db.transaction((): PutResult => {
+      // Check if document already exists to determine created flag.
+      const existing = this.db
+        .prepare<[string, string], { version: number } | undefined>(`
+          SELECT version FROM state_documents WHERE namespace = ? AND key = ?
+        `)
+        .get(namespace, key);
+
+      this.db
+        .prepare(`
+          INSERT INTO state_documents
+            (namespace, key, value, version, created_at, updated_at, expires_at, producer, metadata)
+          VALUES (?, ?, ?, 1, ?, ?, ?, ?, ?)
+          ON CONFLICT(namespace, key) DO UPDATE SET
+            value    = excluded.value,
+            version  = version + 1,
+            updated_at = excluded.updated_at,
+            expires_at = excluded.expires_at,
+            producer = excluded.producer,
+            metadata = excluded.metadata
+        `)
+        .run(namespace, key, serialized, now, now, expires_at, producer ?? null, metadata);
+
+      // Read back actual version (handles the UPSERT version increment).
+      const after = this.db
+        .prepare<[string, string], { version: number }>(`
+          SELECT version FROM state_documents WHERE namespace = ? AND key = ?
+        `)
+        .get(namespace, key)!;
+
+      return { version: after.version, created: !existing };
+    })();
+  }
+
+  /**
+   * Compare-and-swap. Updates the document only when its current version
+   * matches expectedVersion. Returns {matched: false} if the version
+   * doesn't match or the document doesn't exist.
+   */
+  cas(
+    namespace: string,
+    key: string,
+    expectedVersion: number,
+    value: unknown,
+    opts?: PutOpts,
+    producer?: string,
+  ): CasResult {
+    validateNamespaceOrKey(namespace, 'namespace');
+    validateNamespaceOrKey(key, 'key');
+    validateJson(value);
+
+    const txn = this.db.transaction((): CasResult => {
+      const row = this.db
+        .prepare<[string, string], {
+          version: number;
+          expires_at: number | null;
+        }>(`
+          SELECT version, expires_at FROM state_documents WHERE namespace = ? AND key = ?
+        `)
+        .get(namespace, key);
+
+      if (!row) return { matched: false };
+      // Treat expired docs as non-existent
+      if (row.expires_at !== null && row.expires_at < Date.now()) return { matched: false };
+      if (row.version !== expectedVersion) return { matched: false };
+
+      const now = Date.now();
+      const newVersion = row.version + 1;
+      const expires_at = opts?.ttl_ms !== undefined ? now + opts.ttl_ms : null;
+      const metadata = opts?.metadata !== undefined ? JSON.stringify(opts.metadata) : null;
+      const serialized = JSON.stringify(value);
+
+      this.db
+        .prepare(`
+          UPDATE state_documents SET
+            value = ?,
+            version = ?,
+            updated_at = ?,
+            expires_at = ?,
+            producer = ?,
+            metadata = ?
+          WHERE namespace = ? AND key = ?
+        `)
+        .run(serialized, newVersion, now, expires_at, producer ?? null, metadata, namespace, key);
+
+      return { matched: true, newVersion };
+    });
+
+    return txn.immediate();
+  }
+
+  /**
+   * Delete a document. Returns {deleted: true} if found and removed.
+   */
+  del(namespace: string, key: string): DelResult {
+    validateNamespaceOrKey(namespace, 'namespace');
+    validateNamespaceOrKey(key, 'key');
+
+    const result = this.db
+      .prepare(`DELETE FROM state_documents WHERE namespace = ? AND key = ?`)
+      .run(namespace, key);
+
+    return { deleted: result.changes > 0 };
+  }
+
+  /**
+   * Query documents in a namespace, with optional key_prefix filter and
+   * limit/offset pagination.
+   */
+  query(
+    namespace: string,
+    opts?: { key_prefix?: string; limit?: number; offset?: number },
+  ): QueryRow[] {
+    validateNamespaceOrKey(namespace, 'namespace');
+
+    const now = Date.now();
+    const limit = opts?.limit ?? 20;
+    const offset = opts?.offset ?? 0;
+
+    let sql: string;
+    let rows: Array<{
+      key: string;
+      value: string;
+      version: number;
+      updated_at: number;
+      expires_at: number | null;
+    }>;
+
+    if (opts?.key_prefix) {
+      // Use LIKE with escaped prefix — no user data in % patterns since
+      // we control the suffix.
+      const prefix = opts.key_prefix.replace(/[%_\\]/g, '\\$&');
+      sql = `
+        SELECT key, value, version, updated_at, expires_at
+        FROM state_documents
+        WHERE namespace = ?
+          AND key LIKE ? ESCAPE '\\'
+          AND (expires_at IS NULL OR expires_at >= ?)
+        ORDER BY key ASC
+        LIMIT ? OFFSET ?
+      `;
+      rows = this.db
+        .prepare<[string, string, number, number, number], typeof rows extends Array<infer R> ? R : never>(sql)
+        .all(namespace, `${prefix}%`, now, limit, offset) as typeof rows;
+    } else {
+      sql = `
+        SELECT key, value, version, updated_at, expires_at
+        FROM state_documents
+        WHERE namespace = ?
+          AND (expires_at IS NULL OR expires_at >= ?)
+        ORDER BY key ASC
+        LIMIT ? OFFSET ?
+      `;
+      rows = this.db
+        .prepare<[string, number, number, number], typeof rows extends Array<infer R> ? R : never>(sql)
+        .all(namespace, now, limit, offset) as typeof rows;
+    }
+
+    return rows.map((r) => ({
+      key: r.key,
+      value: JSON.parse(r.value),
+      version: r.version,
+      updated_at: r.updated_at,
+    }));
+  }
+
+  close(): void {
+    try {
+      this.db.close();
+    } catch {
+      // ignore close errors (already closed)
+    }
+  }
+}

--- a/src/agent/state/state-store.ts
+++ b/src/agent/state/state-store.ts
@@ -11,7 +11,7 @@
 
 import Database from 'better-sqlite3';
 import type BetterSqlite3 from 'better-sqlite3';
-import { mkdirSync } from 'fs';
+import { chmodSync, mkdirSync } from 'fs';
 import { dirname } from 'path';
 
 const SCHEMA_VERSION = 1;
@@ -92,8 +92,15 @@ export class StateStore {
   private db: BetterSqlite3.Database;
 
   constructor(dbPath: string) {
-    mkdirSync(dirname(dbPath), { recursive: true });
+    mkdirSync(dirname(dbPath), { recursive: true, mode: 0o700 });
     this.db = new Database(dbPath);
+    if (process.platform !== 'win32') {
+      try {
+        chmodSync(dbPath, 0o600);
+      } catch {
+        // best-effort — chmod failure must not prevent store construction
+      }
+    }
     // busy_timeout makes ordinary contended reads/writes wait up to 5s rather
     // than immediately throwing SQLITE_BUSY on the first lock conflict.
     this.db.pragma('busy_timeout = 5000');

--- a/src/agent/state/state-tools.test.ts
+++ b/src/agent/state/state-tools.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Unit tests for createStateHandlers — the tool-handler factory that wraps
+ * StateStore behind the five MCP tool endpoints (state_get, state_put,
+ * state_cas, state_delete, state_query).
+ *
+ * Each test runs against a fresh temporary database so they are fully
+ * isolated from one another and from the real ~/.afk state.
+ */
+
+import Database from 'better-sqlite3';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { ToolHandler } from '../tools/types.js';
+import { StateStore } from './state-store.js';
+import { createStateHandlers } from './state-tools.js';
+
+// ── Shared setup/teardown ────────────────────────────────────────────────────
+
+let tmpDir: string;
+let store: StateStore;
+let handlers: Map<string, ToolHandler>;
+
+// A dummy AbortSignal that never fires — passed to every handler call.
+const noopSignal = new AbortController().signal;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'state-tools-test-'));
+  store = new StateStore(join(tmpDir, 'test.db'));
+  handlers = createStateHandlers(store, 'test-session');
+});
+
+afterEach(() => {
+  try {
+    store.close();
+  } catch {
+    // already closed — ignore
+  }
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Invoke a named handler and parse its JSON content. */
+async function call(name: string, input: unknown): Promise<{ raw: Awaited<ReturnType<ToolHandler>>; parsed: unknown }> {
+  const handler = handlers.get(name);
+  if (!handler) throw new Error(`No handler registered for "${name}"`);
+  const raw = await handler(input, noopSignal);
+  let parsed: unknown = null;
+  try {
+    parsed = JSON.parse(raw.content);
+  } catch {
+    parsed = raw.content;
+  }
+  return { raw, parsed };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('createStateHandlers', () => {
+  it('state_get on missing key returns null content', async () => {
+    const { raw, parsed } = await call('state_get', {
+      namespace: 'ns',
+      key: 'missing',
+    });
+
+    expect(raw.isError).toBeFalsy();
+    expect(parsed).toBeNull();
+  });
+
+  it('state_put → state_get call-through; correct version shape', async () => {
+    const putResult = await call('state_put', {
+      namespace: 'ns',
+      key: 'doc1',
+      value: { hello: 'world' },
+    });
+
+    expect(putResult.raw.isError).toBeFalsy();
+    expect(putResult.parsed).toMatchObject({ version: 1, created: true });
+
+    const getResult = await call('state_get', { namespace: 'ns', key: 'doc1' });
+    expect(getResult.raw.isError).toBeFalsy();
+    const doc = getResult.parsed as { key: string; value: unknown; version: number };
+    expect(doc.version).toBe(1);
+    expect(doc.value).toEqual({ hello: 'world' });
+  });
+
+  it('state_cas mismatch returns {matched:false} in response content', async () => {
+    // Insert the document first (version=1).
+    await call('state_put', { namespace: 'ns', key: 'cas-doc', value: { v: 1 } });
+
+    // CAS with wrong expected_version (99 ≠ 1).
+    const casResult = await call('state_cas', {
+      namespace: 'ns',
+      key: 'cas-doc',
+      expected_version: 99,
+      value: { v: 'hijacked' },
+    });
+
+    expect(casResult.raw.isError).toBeFalsy();
+    expect(casResult.parsed).toEqual({ matched: false });
+
+    // Original document is unchanged.
+    const getResult = await call('state_get', { namespace: 'ns', key: 'cas-doc' });
+    const doc = getResult.parsed as { version: number; value: unknown };
+    expect(doc.version).toBe(1);
+    expect(doc.value).toEqual({ v: 1 });
+  });
+
+  it('state_delete removes document', async () => {
+    await call('state_put', { namespace: 'ns', key: 'to-delete', value: 42 });
+
+    const delResult = await call('state_delete', {
+      namespace: 'ns',
+      key: 'to-delete',
+    });
+    expect(delResult.raw.isError).toBeFalsy();
+    expect(delResult.parsed).toEqual({ deleted: true });
+
+    // Subsequent get must return null.
+    const getResult = await call('state_get', { namespace: 'ns', key: 'to-delete' });
+    expect(getResult.parsed).toBeNull();
+  });
+
+  it('state_query with prefix filter returns only matching keys', async () => {
+    await call('state_put', { namespace: 'qns', key: 'alpha-1', value: 1 });
+    await call('state_put', { namespace: 'qns', key: 'alpha-2', value: 2 });
+    await call('state_put', { namespace: 'qns', key: 'beta-1', value: 3 });
+
+    const result = await call('state_query', {
+      namespace: 'qns',
+      key_prefix: 'alpha',
+    });
+
+    const rows = result.parsed as Array<{ key: string }>;
+    expect(rows).toHaveLength(2);
+    expect(rows.every((r) => r.key.startsWith('alpha'))).toBe(true);
+  });
+
+  it('invalid namespace in state_put returns isError:true without throwing', async () => {
+    const result = await call('state_put', {
+      namespace: 'bad/name',
+      key: 'key',
+      value: { x: 1 },
+    });
+
+    // Handler must not throw; it must return isError:true.
+    expect(result.raw.isError).toBe(true);
+    // Content should describe what went wrong (Zod validation error).
+    expect(typeof result.raw.content).toBe('string');
+    expect(result.raw.content.length).toBeGreaterThan(0);
+  });
+
+  it('sessionId is recorded as producer after state_put', async () => {
+    await call('state_put', { namespace: 'ns', key: 'produced', value: { ok: true } });
+
+    // Inspect the raw SQLite row — StateStore doesn't expose producer via get(),
+    // so we reach into the DB directly with a read-only connection.
+    const dbPath = join(tmpDir, 'test.db');
+    const raw = new Database(dbPath, { readonly: true });
+    try {
+      const row = raw
+        .prepare<[string, string], { producer: string | null }>(
+          `SELECT producer FROM state_documents WHERE namespace = ? AND key = ?`,
+        )
+        .get('ns', 'produced');
+
+      expect(row).not.toBeNull();
+      expect(row!.producer).toBe('test-session');
+    } finally {
+      raw.close();
+    }
+  });
+
+  it('limit capped at 100 for state_query', async () => {
+    // Insert 5 documents.
+    for (let i = 1; i <= 5; i++) {
+      await call('state_put', {
+        namespace: 'capns',
+        key: `doc-${String(i).padStart(2, '0')}`,
+        value: { i },
+      });
+    }
+
+    // The Zod schema enforces the 100-document ceiling: limit > 100 is a
+    // validation error, not a silent clamp.  Confirm that limit:200 is
+    // rejected at the handler boundary.
+    const overCapResult = await call('state_query', {
+      namespace: 'capns',
+      limit: 200,
+    });
+    expect(overCapResult.raw.isError).toBe(true);
+
+    // A request at exactly the cap (limit:100) must succeed and return all 5
+    // documents — confirming the cap is enforced without rejecting valid inputs.
+    const atCapResult = await call('state_query', {
+      namespace: 'capns',
+      limit: 100,
+    });
+    expect(atCapResult.raw.isError).toBeFalsy();
+    const rows = atCapResult.parsed as unknown[];
+    expect(rows).toHaveLength(5);
+  });
+});

--- a/src/agent/state/state-tools.test.ts
+++ b/src/agent/state/state-tools.test.ts
@@ -202,4 +202,24 @@ describe('createStateHandlers', () => {
     const rows = atCapResult.parsed as unknown[];
     expect(rows).toHaveLength(5);
   });
+
+  it('negative ttl_ms in state_put is rejected with isError:true', async () => {
+    const result = await call('state_put', {
+      namespace: 'ns',
+      key: 'neg-ttl',
+      value: { x: 1 },
+      ttl_ms: -1,
+    });
+    expect(result.raw.isError).toBe(true);
+  });
+
+  it('non-integer ttl_ms in state_put is rejected with isError:true', async () => {
+    const result = await call('state_put', {
+      namespace: 'ns',
+      key: 'float-ttl',
+      value: { x: 1 },
+      ttl_ms: 100.5,
+    });
+    expect(result.raw.isError).toBe(true);
+  });
 });

--- a/src/agent/state/state-tools.ts
+++ b/src/agent/state/state-tools.ts
@@ -28,7 +28,7 @@ const PutInput = z.object({
   namespace: namespaceKey,
   key: namespaceKey,
   value: z.unknown(),
-  ttl_ms: z.number().optional(),
+  ttl_ms: z.number().int().positive().optional(),
   metadata: z.unknown().optional(),
 });
 
@@ -37,7 +37,7 @@ const CasInput = z.object({
   key: namespaceKey,
   expected_version: z.number(),
   value: z.unknown(),
-  ttl_ms: z.number().optional(),
+  ttl_ms: z.number().int().positive().optional(),
   metadata: z.unknown().optional(),
 });
 
@@ -49,8 +49,17 @@ const DeleteInput = z.object({
 const QueryInput = z.object({
   namespace: namespaceKey,
   key_prefix: z.string().optional(),
-  limit: z.number().max(100).optional(),
+  limit: z.number().int().positive().max(100).optional(),
 });
+
+/** Names of all five state tool handlers — used to populate allowedTools lists. */
+export const STATE_TOOL_NAMES = [
+  'state_get',
+  'state_put',
+  'state_cas',
+  'state_delete',
+  'state_query',
+] as const;
 
 /**
  * Create tool handlers for the five state store tools.

--- a/src/agent/state/state-tools.ts
+++ b/src/agent/state/state-tools.ts
@@ -1,0 +1,142 @@
+/**
+ * Tool handlers for the durable cross-session state store.
+ *
+ * Factory function that produces a Map of tool handlers for the five state
+ * tools (state_get, state_put, state_cas, state_delete, state_query).
+ * Each handler validates its input with Zod and delegates to StateStore.
+ *
+ * @module agent/state/state-tools
+ */
+
+import { z } from 'zod';
+import type { ToolHandler } from '../tools/types.js';
+import { StateStore } from './state-store.js';
+
+/** Zod schema for a valid namespace or key string. */
+const namespaceKey = z
+  .string()
+  .min(1, 'namespace/key must be non-empty')
+  .max(128, 'namespace/key must not exceed 128 characters')
+  .regex(/^[A-Za-z0-9_.-]+$/, 'namespace/key may only contain [A-Za-z0-9_.-]');
+
+const GetInput = z.object({
+  namespace: namespaceKey,
+  key: namespaceKey,
+});
+
+const PutInput = z.object({
+  namespace: namespaceKey,
+  key: namespaceKey,
+  value: z.unknown(),
+  ttl_ms: z.number().optional(),
+  metadata: z.unknown().optional(),
+});
+
+const CasInput = z.object({
+  namespace: namespaceKey,
+  key: namespaceKey,
+  expected_version: z.number(),
+  value: z.unknown(),
+  ttl_ms: z.number().optional(),
+  metadata: z.unknown().optional(),
+});
+
+const DeleteInput = z.object({
+  namespace: namespaceKey,
+  key: namespaceKey,
+});
+
+const QueryInput = z.object({
+  namespace: namespaceKey,
+  key_prefix: z.string().optional(),
+  limit: z.number().max(100).optional(),
+});
+
+/**
+ * Create tool handlers for the five state store tools.
+ *
+ * @param store - The StateStore instance to delegate to.
+ * @param sessionId - Optional session ID recorded as the `producer` on writes.
+ * @returns A Map of tool name → handler.
+ */
+export function createStateHandlers(
+  store: StateStore,
+  sessionId?: string,
+): Map<string, ToolHandler> {
+  const handlers = new Map<string, ToolHandler>();
+
+  // ── state_get ────────────────────────────────────────────────────────────
+
+  handlers.set('state_get', async (input) => {
+    try {
+      const { namespace, key } = GetInput.parse(input);
+      const result = store.get(namespace, key);
+      return { content: JSON.stringify(result) };
+    } catch (err) {
+      return { content: String(err), isError: true };
+    }
+  });
+
+  // ── state_put ────────────────────────────────────────────────────────────
+
+  handlers.set('state_put', async (input) => {
+    try {
+      const { namespace, key, value, ttl_ms, metadata } = PutInput.parse(input);
+      const result = store.put(namespace, key, value, { ttl_ms, metadata }, sessionId);
+      return { content: JSON.stringify(result) };
+    } catch (err) {
+      return { content: String(err), isError: true };
+    }
+  });
+
+  // ── state_cas ────────────────────────────────────────────────────────────
+
+  handlers.set('state_cas', async (input) => {
+    try {
+      const { namespace, key, expected_version, value, ttl_ms, metadata } =
+        CasInput.parse(input);
+      const result = store.cas(
+        namespace,
+        key,
+        expected_version,
+        value,
+        { ttl_ms, metadata },
+        sessionId,
+      );
+      return { content: JSON.stringify(result) };
+    } catch (err) {
+      return { content: String(err), isError: true };
+    }
+  });
+
+  // ── state_delete ─────────────────────────────────────────────────────────
+
+  handlers.set('state_delete', async (input) => {
+    try {
+      const { namespace, key } = DeleteInput.parse(input);
+      const result = store.del(namespace, key);
+      return { content: JSON.stringify(result) };
+    } catch (err) {
+      return { content: String(err), isError: true };
+    }
+  });
+
+  // ── state_query ──────────────────────────────────────────────────────────
+
+  handlers.set('state_query', async (input) => {
+    try {
+      const parsed = QueryInput.parse(input);
+      // Clamp limit to 100; default to 20.
+      const limit = Math.min(parsed.limit ?? 20, 100);
+      const result = store.query(parsed.namespace, {
+        key_prefix: parsed.key_prefix,
+        limit,
+      });
+      return { content: JSON.stringify(result) };
+    } catch (err) {
+      return { content: String(err), isError: true };
+    }
+  });
+
+  return handlers;
+}

--- a/src/agent/tool-category.ts
+++ b/src/agent/tool-category.ts
@@ -20,7 +20,8 @@
  *     `grep`, `list_directory`,
  *     `memory_search`, `memory_update`, `procedure_write`,
  *     `create_schedule`, `list_schedules`, `get_schedule_history`, `cancel_schedule`,
- *     `terminal_font_size`, `config_get`, `config_set`.
+ *     `terminal_font_size`, `config_get`, `config_set`,
+ *     `state_get`, `state_put`, `state_cas`, `state_delete`, `state_query`.
  * Both sets are enumerated explicitly to avoid silent fall-through to `other`.
  *
  * This file lives under `src/agent/` because tool-name classification is
@@ -65,6 +66,8 @@ const READ_TOOLS = new Set([
   'get_facet',
   // json_query — read-only: reads a JSON file and evaluates a bounded query.
   'json_query',
+  // state-tools.ts — read-only queries against the durable cross-session KV store.
+  'state_get', 'state_query',
 ]);
 const WRITE_TOOLS = new Set([
   'Write', 'Edit', 'NotebookEdit', 'MultiEdit',
@@ -84,6 +87,8 @@ const WRITE_TOOLS = new Set([
   // workspace-tools.ts — workspace_publish mutates ephemeral per-session
   // state that influences sibling-agent system prompts.
   'workspace_publish',
+  // state-tools.ts — mutations to the durable cross-session KV store.
+  'state_put', 'state_cas', 'state_delete',
 ]);
 // These categorization sets intentionally list BOTH the Claude Code / SDK
 // PascalCase tool names (Bash, Agent, Task, Skill, Compose) and AFK's lowercase
@@ -256,6 +261,9 @@ export const READ_ONLY_PHASE_TOOLS: readonly string[] = [
   'workspace_query',
   // json_query — read-only: reads a JSON file and evaluates a bounded query.
   'json_query',
+  // State store query — read-only, durable cross-session KV. Same rationale
+  // as memory_search: read-only by construction, no mutation surface.
+  'state_get', 'state_query',
   // Awareness introspection (get_runtime_state) — read-only, in-memory, zero
   // side-effects. Mirrors CHILD_ALLOWED_TOOLS (nesting.ts), which already appends
   // these. Single source of truth: AWARENESS_TOOL_NAMES (awareness/tool.ts).

--- a/src/agent/tools/dispatch-batching.ts
+++ b/src/agent/tools/dispatch-batching.ts
@@ -11,6 +11,7 @@
 
 import { builtinToolSchemas, agentTool, skillTool, composeTool } from './schemas.js';
 import { memoryToolSchemas } from '../memory/memory-tools.js';
+import { stateToolSchemas } from '../state/state-schemas.js';
 import { getRuntimeStateTool } from '../awareness/index.js';
 import type { ToolCall } from '../providers/anthropic-direct/types.js';
 import type { ConcurrencyClassifier } from './types.js';
@@ -21,8 +22,9 @@ import type { ConcurrencyClassifier } from './types.js';
  * This replaces the former hand-maintained list and stays automatically in sync
  * with schema changes.
  *
- * External constraint: schemas.ts and memory-tools.ts are the single source
- * of truth. Mutations to those files propagate here without any secondary edit.
+ * External constraint: schemas.ts, memory-tools.ts, and state-schemas.ts are
+ * the single source of truth. Mutations to those files propagate here without
+ * any secondary edit.
  */
 const SAFE_TOOLS: ReadonlySet<string> = new Set(
   [
@@ -31,6 +33,7 @@ const SAFE_TOOLS: ReadonlySet<string> = new Set(
     skillTool,
     composeTool,
     ...memoryToolSchemas,
+    ...stateToolSchemas,
     getRuntimeStateTool,
   ]
     .filter((s) => s.concurrencySafe === true)

--- a/src/agent/tools/nesting.test.ts
+++ b/src/agent/tools/nesting.test.ts
@@ -39,6 +39,17 @@ describe('CHILD_ALLOWED_TOOLS', () => {
     // compose is excluded to prevent unbounded DAG fan-out from child nodes.
     expect(CHILD_ALLOWED_TOOLS).not.toContain('compose');
   });
+
+  it("includes 'state_get' and 'state_query'", () => {
+    expect(CHILD_ALLOWED_TOOLS).toContain('state_get');
+    expect(CHILD_ALLOWED_TOOLS).toContain('state_query');
+  });
+
+  it("does NOT include 'state_put', 'state_cas', or 'state_delete'", () => {
+    expect(CHILD_ALLOWED_TOOLS).not.toContain('state_put');
+    expect(CHILD_ALLOWED_TOOLS).not.toContain('state_cas');
+    expect(CHILD_ALLOWED_TOOLS).not.toContain('state_delete');
+  });
 });
 
 describe('buildSkillRestrictedProvider', () => {
@@ -144,6 +155,17 @@ describe('RECON_ALLOWED_TOOLS (read-only skill child allowlist)', () => {
 
   it("INCLUDES 'get_runtime_state' (via AWARENESS_TOOL_NAMES)", () => {
     expect(RECON_ALLOWED_TOOLS).toContain('get_runtime_state');
+  });
+
+  it("includes 'state_get' and 'state_query'", () => {
+    expect(RECON_ALLOWED_TOOLS).toContain('state_get');
+    expect(RECON_ALLOWED_TOOLS).toContain('state_query');
+  });
+
+  it("does NOT include state write tools", () => {
+    expect(RECON_ALLOWED_TOOLS).not.toContain('state_put');
+    expect(RECON_ALLOWED_TOOLS).not.toContain('state_cas');
+    expect(RECON_ALLOWED_TOOLS).not.toContain('state_delete');
   });
 
   it('EXCLUDES side-effecting + environment tools', () => {

--- a/src/agent/tools/nesting.ts
+++ b/src/agent/tools/nesting.ts
@@ -130,7 +130,7 @@ export function createStubParentSession(
 // sub-agent writes. If specific skills need memory write access, do it per-skill via a
 // buildPhaseRestrictedProvider-style opt-in builder (see nesting.ts around line 207), not by
 // extending this global default.
-export const CHILD_ALLOWED_TOOLS = [...BUILTIN_TOOL_NAMES, ...AWARENESS_TOOL_NAMES, 'memory_search', 'workspace_publish', 'workspace_query', 'agent', 'skill'];
+export const CHILD_ALLOWED_TOOLS = [...BUILTIN_TOOL_NAMES, ...AWARENESS_TOOL_NAMES, 'memory_search', 'workspace_publish', 'workspace_query', 'agent', 'skill', 'state_get', 'state_query'];
 
 // Recon allowlist for a READ-ONLY skill's forked child. This is the tool half
 // of read-only-skill enforcement (the bash half is the dispatcher's
@@ -177,6 +177,9 @@ export const RECON_ALLOWED_TOOLS: readonly string[] = [
   'workspace_query',
   'agent',
   'skill',
+  // State store reads — read-only by construction, no repo mutation.
+  // Same rationale as memory_search inclusion above.
+  'state_get', 'state_query',
 ];
 
 // Skills treated as read-only by NAME, independent of their SKILL.md

--- a/src/agent/tools/schema-classification.test.ts
+++ b/src/agent/tools/schema-classification.test.ts
@@ -23,6 +23,7 @@ import { describe, it, expect } from 'vitest';
 import { ALL_TOOL_SCHEMAS } from './schemas.js';
 import { memoryToolSchemas } from '../memory/memory-tools.js';
 import { getRuntimeStateTool } from '../awareness/index.js';
+import { stateToolSchemas } from '../state/state-schemas.js';
 import { defaultConcurrencyClassifier } from './dispatcher.js';
 import { categorizeTool } from '../tool-category.js';
 import { MODEL_MAP } from '../session/model-resolution.js';
@@ -31,13 +32,15 @@ import type { ToolCategory } from '../tool-category.js';
 
 // All schemas that built-in dispatch covers — closed-world set composed of
 // the canonical `ALL_TOOL_SCHEMAS` (builtins + agent/skill/compose), the
-// separate memory-tools registry, and the awareness-layer `getRuntimeStateTool`.
-// If any of these gains a new schema, classification invariants below must
-// hold for it.
+// separate memory-tools registry, the awareness-layer `getRuntimeStateTool`,
+// and the state-tool schemas (state_get, state_query, state_put, state_cas,
+// state_delete). If any of these gains a new schema, classification invariants
+// below must hold for it.
 const ALL_BUILTIN_SCHEMAS = [
   ...ALL_TOOL_SCHEMAS,
   ...memoryToolSchemas,
   getRuntimeStateTool,
+  ...stateToolSchemas,
 ];
 
 // ── Invariant 1: every built-in schema declares a category ────────────────

--- a/src/agent/tools/top-level-allowlist.test.ts
+++ b/src/agent/tools/top-level-allowlist.test.ts
@@ -19,6 +19,7 @@ import { MEMORY_TOOL_NAMES } from '../memory/index.js';
 import { AWARENESS_TOOL_NAMES } from '../awareness/index.js';
 import { EXIT_PLAN_MODE_TOOL_NAME } from './handlers/exit-plan-mode.js';
 import { WORKSPACE_TOOL_NAMES } from '../workspace/index.js';
+import { STATE_TOOL_NAMES } from '../state/state-tools.js';
 
 describe('topLevelSurfaceAllowedTools', () => {
   it('includes exit_plan_mode (the always-on, plan-mode-only tool that was missing)', () => {
@@ -26,12 +27,13 @@ describe('topLevelSurfaceAllowedTools', () => {
     expect(topLevelSurfaceAllowedTools()).toContain('exit_plan_mode');
   });
 
-  it('includes every always-on builtin, memory, and awareness tool name', () => {
+  it('includes every always-on builtin, memory, awareness, and state tool name', () => {
     const list = topLevelSurfaceAllowedTools();
     for (const name of BUILTIN_TOOL_NAMES) expect(list).toContain(name);
     for (const name of MEMORY_TOOL_NAMES) expect(list).toContain(name);
     for (const name of AWARENESS_TOOL_NAMES) expect(list).toContain(name);
     for (const name of WORKSPACE_TOOL_NAMES) expect(list).toContain(name);
+    for (const name of STATE_TOOL_NAMES) expect(list).toContain(name);
     expect(list).toContain('get_runtime_state');
   });
 
@@ -56,6 +58,7 @@ describe('topLevelSurfaceAllowedTools', () => {
       ...MEMORY_TOOL_NAMES,
       ...AWARENESS_TOOL_NAMES,
       ...WORKSPACE_TOOL_NAMES,
+      ...STATE_TOOL_NAMES,
       EXIT_PLAN_MODE_TOOL_NAME,
       'agent',
       'skill',

--- a/src/agent/tools/top-level-allowlist.ts
+++ b/src/agent/tools/top-level-allowlist.ts
@@ -3,6 +3,7 @@ import { MEMORY_TOOL_NAMES } from '../memory/index.js';
 import { AWARENESS_TOOL_NAMES } from '../awareness/index.js';
 import { EXIT_PLAN_MODE_TOOL_NAME } from './handlers/exit-plan-mode.js';
 import { WORKSPACE_TOOL_NAMES } from '../workspace/index.js';
+import { STATE_TOOL_NAMES } from '../state/state-tools.js';
 
 /**
  * Contract: the canonical tool allowlist for a top-level, human-facing surface
@@ -28,6 +29,7 @@ export function topLevelSurfaceAllowedTools(mcpToolWireNames: readonly string[] 
     ...MEMORY_TOOL_NAMES,
     ...AWARENESS_TOOL_NAMES,
     ...WORKSPACE_TOOL_NAMES,
+    ...STATE_TOOL_NAMES,
     EXIT_PLAN_MODE_TOOL_NAME,
     'agent',
     'skill',

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -9,6 +9,8 @@ import { AgentSession } from '../../agent/session.js';
 import { createDefaultHookRegistry } from '../../agent/default-hook-registry.js';
 import { loadHooksConfig } from '../../agent/hooks/config-loader.js';
 import { MemoryStore, injectHotMemory } from '../../agent/memory/index.js';
+import { StateStore } from '../../agent/state/state-store.js';
+import { getStateDatabasePath } from '../../paths.js';
 import { WorkspaceStore } from '../../agent/workspace/workspace-store.js';
 import { env } from '../../config/env.js';
 import { injectCompanionPrimer } from '../../agent/companion/index.js';
@@ -266,6 +268,7 @@ export function registerChatCommand(program: Command): void {
 
       let session: AgentSession | null = null;
       let sharedMemoryStore: MemoryStore | undefined, workspaceStore: WorkspaceStore | undefined;
+      let sharedStateStore: StateStore | undefined;
       let worktreeHandle: Awaited<ReturnType<typeof setupWorktree>> | undefined;
       let worktreeCwd: string | undefined;
       let mcpManager: McpManager | undefined;
@@ -495,6 +498,7 @@ export function registerChatCommand(program: Command): void {
         });
 
         sharedMemoryStore = new MemoryStore();
+        sharedStateStore = new StateStore(getStateDatabasePath());
 
         {
           const projectCwd = worktreeCwd ?? process.cwd();
@@ -540,6 +544,7 @@ export function registerChatCommand(program: Command): void {
           skillExecutor,
           composeExecutor,
           memoryStore: sharedMemoryStore,
+          stateStore: sharedStateStore,
           model: String(options.model),
           ...(cliConfig.openaiBaseUrl !== undefined ? { openaiBaseUrl: cliConfig.openaiBaseUrl } : {}),
           ...(mcpManager !== undefined ? { mcpManager } : {}),
@@ -552,6 +557,7 @@ export function registerChatCommand(program: Command): void {
             skillExecutor,
             composeExecutor,
             memoryStore: sharedMemoryStore,
+            stateStore: sharedStateStore,
             surface: 'cli',
             ...(mcpManager !== undefined ? { mcpManager } : {}),
           });
@@ -824,6 +830,7 @@ export function registerChatCommand(program: Command): void {
           await mcpManager.disconnectAll();
         }
         try { sharedMemoryStore?.close(); } catch {}
+        try { sharedStateStore?.close(); } catch {}
         try { workspaceStore?.close(); } catch {}
         // Worktree cleanup: session close must finish before
         // `git worktree remove --force` so any active SQLite WAL / trace

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -31,6 +31,7 @@ import { loadSchedules, toScheduledTask } from '../../agent/daemon/schedule-stor
 import { AgentSession } from '../../agent/session.js';
 import { MemoryStore, MEMORY_TOOL_NAMES, injectHotMemory } from '../../agent/memory/index.js';
 import { StateStore } from '../../agent/state/state-store.js';
+import { STATE_TOOL_NAMES } from '../../agent/state/state-tools.js';
 import { getStateDatabasePath } from '../../paths.js';
 import { WORKSPACE_TOOL_NAMES } from '../../agent/workspace/index.js';
 import { injectCompanionPrimer } from '../../agent/companion/index.js';
@@ -142,6 +143,7 @@ export function buildDaemonSessionFactory(
         allowedTools: [
           ...BUILTIN_TOOL_NAMES,
           ...MEMORY_TOOL_NAMES,
+          ...STATE_TOOL_NAMES,
           ...AWARENESS_TOOL_NAMES,
           ...WORKSPACE_TOOL_NAMES,
           'agent',

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -30,6 +30,8 @@ import { parseThinking, parseEffort, getApiKey, getApiKeyForModel, getModel, get
 import { loadSchedules, toScheduledTask } from '../../agent/daemon/schedule-store.js';
 import { AgentSession } from '../../agent/session.js';
 import { MemoryStore, MEMORY_TOOL_NAMES, injectHotMemory } from '../../agent/memory/index.js';
+import { StateStore } from '../../agent/state/state-store.js';
+import { getStateDatabasePath } from '../../paths.js';
 import { WORKSPACE_TOOL_NAMES } from '../../agent/workspace/index.js';
 import { injectCompanionPrimer } from '../../agent/companion/index.js';
 import { wireExecutors } from '../../agent/session/wire-executors.js';
@@ -84,6 +86,7 @@ export function buildDaemonSessionFactory(
   // reusing the store would inject stale workspace entries from a prior
   // task's run. Create a fresh store per task invocation instead.
   let memoryStore: MemoryStore | undefined;
+  let stateStore: StateStore | undefined;
   return (config: AgentConfig, ownedTraceWriter?: import('../../agent/trace/index.js').TraceWriter): AgentSession => {
     // Ephemeral abort controller — the daemon root session has no parent
     // to propagate cancellation from.
@@ -96,6 +99,7 @@ export function buildDaemonSessionFactory(
     // rather than creating a duplicate. Undefined under AFK_TRACE_DISABLED=1,
     // in which case the option is absent and behaviour is unchanged.
     memoryStore ??= new MemoryStore();
+    stateStore ??= new StateStore(getStateDatabasePath());
     // WorkspaceStore is fresh per task: one task's published entries are
     // irrelevant to the next task's compose nodes, and reusing the store
     // would inject stale workspace entries from a prior task's run.
@@ -129,7 +133,7 @@ export function buildDaemonSessionFactory(
       subagentExecutor,
       skillExecutor,
       composeExecutor,
-      memoryStore, workspaceStore,
+      memoryStore, stateStore, workspaceStore,
       model: String(opts.model),
       ...(opts.openaiBaseUrl !== undefined ? { openaiBaseUrl: opts.openaiBaseUrl } : {}),
       ...(mcpManager !== undefined ? { mcpManager } : {}),
@@ -149,7 +153,7 @@ export function buildDaemonSessionFactory(
       subagentExecutor,
       skillExecutor,
       composeExecutor,
-      memoryStore, workspaceStore,
+      memoryStore, stateStore, workspaceStore,
       surface: 'daemon',
       ...(mcpManager !== undefined ? { mcpManager } : {}),
     });

--- a/src/cli/commands/interactive/bootstrap-hooks.ts
+++ b/src/cli/commands/interactive/bootstrap-hooks.ts
@@ -2,6 +2,7 @@ import { createDefaultHookRegistry } from '../../../agent/default-hook-registry.
 import { loadHooksConfig } from '../../../agent/hooks/config-loader.js';
 import type { HookRegistry } from '../../../agent/hooks.js';
 import type { MemoryStore } from '../../../agent/memory/index.js';
+import type { StateStore } from '../../../agent/state/state-store.js';
 import type { TraceSink } from '../../../agent/trace/index.js';
 import type { SessionStats } from '../../slash/types.js';
 import type { CompletionWriter } from './shared.js';
@@ -31,6 +32,7 @@ import type { PreviewDiffRef } from '../../../agent/tools/hooks/edit-preview-hoo
 export function createReplHookRegistry(a: {
   completionWriter: CompletionWriter;
   memoryStore: MemoryStore;
+  stateStore?: StateStore;
   stats: SessionStats;
   effectiveCwd: string | undefined;
   traceWriter: TraceSink | undefined;

--- a/src/cli/commands/interactive/bootstrap-providers.ts
+++ b/src/cli/commands/interactive/bootstrap-providers.ts
@@ -1,5 +1,6 @@
 import type { ModelProvider } from '../../../agent/provider.js';
 import type { MemoryStore } from '../../../agent/memory/index.js';
+import type { StateStore } from '../../../agent/state/state-store.js';
 import type { WorkspaceStore } from '../../../agent/workspace/workspace-store.js';
 import type { SubagentExecutor } from '../../../agent/tools/subagent-executor.js';
 import type { SkillExecutor } from '../../../agent/tools/skill-executor.js';
@@ -47,6 +48,7 @@ export function createReplProviders(a: {
   skillExecutor: SkillExecutor;
   composeExecutor: ComposeExecutor;
   memoryStore: MemoryStore;
+  stateStore?: StateStore;
   workspaceStore?: WorkspaceStore;
   mcpManager: McpManager | undefined;
   fastModeController: FastModeController;
@@ -60,6 +62,7 @@ export function createReplProviders(a: {
       skillExecutor: a.skillExecutor,
       composeExecutor: a.composeExecutor,
       memoryStore: a.memoryStore,
+      ...(a.stateStore !== undefined ? { stateStore: a.stateStore } : {}),
       ...(a.workspaceStore !== undefined ? { workspaceStore: a.workspaceStore } : {}),
       model: model !== undefined ? model : String(a.sessionModel),
       ...(a.cliConfig.openaiBaseUrl !== undefined ? { openaiBaseUrl: a.cliConfig.openaiBaseUrl } : {}),
@@ -74,6 +77,7 @@ export function createReplProviders(a: {
       skillExecutor: a.skillExecutor,
       composeExecutor: a.composeExecutor,
       memoryStore: a.memoryStore,
+      ...(a.stateStore !== undefined ? { stateStore: a.stateStore } : {}),
       ...(a.workspaceStore !== undefined ? { workspaceStore: a.workspaceStore } : {}),
       surface: 'cli',
       fastModeController: a.fastModeController,

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -1,4 +1,6 @@
 import { MemoryStore } from '../../../agent/memory/index.js';
+import { StateStore } from '../../../agent/state/state-store.js';
+import { getStateDatabasePath } from '../../../paths.js';
 import { WorkspaceStore } from '../../../agent/workspace/workspace-store.js';
 import { env } from '../../../config/env.js';
 import { registerSurfaceSession } from '../../../agent/session/register-surface-session.js';
@@ -79,6 +81,7 @@ export async function bootstrapSession(
 
   const sharedWorkspaceStore = env.AFK_WORKSPACE_DISABLED === '1' ? undefined : new WorkspaceStore();
   const sharedMemoryStore = new MemoryStore();
+  const sharedStateStore = new StateStore(getStateDatabasePath());
 
   const {
     trace, apiKey, backgroundRegistry, bgSummarizer,
@@ -107,7 +110,7 @@ export async function bootstrapSession(
   // builder closes over `mcpManager`.
   const { providerFactory, startupProvider } = createReplProviders({
     options, cliConfig, sessionModel, subagentExecutor, skillExecutor, composeExecutor,
-    memoryStore: sharedMemoryStore, workspaceStore: sharedWorkspaceStore, mcpManager, fastModeController,
+    memoryStore: sharedMemoryStore, stateStore: sharedStateStore, workspaceStore: sharedWorkspaceStore, mcpManager, fastModeController,
   });
 
   // Stats, permission/thinking-UI seeding, startup banners (`trace:` /
@@ -124,7 +127,7 @@ export async function bootstrapSession(
   // Stable hookRegistry shared across sessions (including swaps), plus the
   // terminal-state Stop gate registered on top of it.
   const { hookRegistry, addPreviewDiffRef } = createReplHookRegistry({
-    completionWriter, memoryStore: sharedMemoryStore, stats, effectiveCwd, traceWriter: trace?.writer,
+    completionWriter, memoryStore: sharedMemoryStore, stateStore: sharedStateStore, stats, effectiveCwd, traceWriter: trace?.writer,
   });
 
   // Capture deps needed by both the initial build and the swap closure.
@@ -300,6 +303,7 @@ export async function bootstrapSession(
   const ctx: InteractiveCtx = {
     session: sessionRef,
     memoryStore: sharedMemoryStore,
+    stateStore: sharedStateStore,
     stats,
     statusLine,
     contextSampler,

--- a/src/cli/commands/interactive/shared.ts
+++ b/src/cli/commands/interactive/shared.ts
@@ -5,6 +5,7 @@ import type { HookRegistry } from '../../../agent/hooks.js';
 import type { PreviewDiffRef } from '../../../agent/tools/hooks/edit-preview-hook.js';
 import type { SessionRef } from '../../../agent/session-ref.js';
 import type { MemoryStore } from '../../../agent/memory/index.js';
+import type { StateStore } from '../../../agent/state/state-store.js';
 import type { AgentModelInput } from '../../../agent/types.js';
 import type { BackgroundAgentRegistry } from '../../../agent/background-registry.js';
 import type { BackgroundSummarizer } from '../../../agent/background-summarizer.js';
@@ -344,6 +345,7 @@ export interface CliOptions {
 export interface InteractiveCtx {
   session: SessionRef;
   memoryStore: MemoryStore;
+  stateStore?: StateStore;
   stats: SessionStats;          // mutable across turns
   statusLine: StatusLine;        // mutable — owns terminal side-effects
   contextSampler: ContextSampler; // mutable — cached SDK calls

--- a/src/cli/provider-parser.ts
+++ b/src/cli/provider-parser.ts
@@ -26,6 +26,8 @@ export type ParseProviderOptions = {
   composeExecutor?: import('../agent/tools/compose-executor.js').ComposeExecutor;
   /** Shared MemoryStore to pass into providers so only one SQLite DB is opened. */
   memoryStore?: import('../agent/memory/index.js').MemoryStore;
+  /** Shared StateStore to pass into providers for durable agent state. */
+  stateStore?: import('../agent/state/state-store.js').StateStore;
   /** Shared WorkspaceStore so sibling sub-agents share one ephemeral scratchpad. */
   workspaceStore?: import('../agent/workspace/workspace-store.js').WorkspaceStore;
   /**

--- a/src/cli/provider-parser.ts
+++ b/src/cli/provider-parser.ts
@@ -9,6 +9,7 @@ import { MEMORY_TOOL_NAMES } from '../agent/memory/index.js';
 import { AWARENESS_TOOL_NAMES } from '../agent/awareness/index.js';
 import { EXIT_PLAN_MODE_TOOL_NAME } from '../agent/tools/handlers/exit-plan-mode.js';
 import { WORKSPACE_TOOL_NAMES } from '../agent/workspace/index.js';
+import { STATE_TOOL_NAMES } from '../agent/state/state-tools.js';
 
 const VALID_PROVIDERS: readonly string[] = [
   'anthropic',
@@ -123,6 +124,7 @@ export function parseProvider(
       ...MEMORY_TOOL_NAMES,
       ...AWARENESS_TOOL_NAMES,
       ...WORKSPACE_TOOL_NAMES,
+      ...STATE_TOOL_NAMES,
       EXIT_PLAN_MODE_TOOL_NAME,
     ];
     if (opts?.subagentExecutor) list.push('agent');

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -274,6 +274,10 @@ export function getMemoryDir(): string {
   return join(getAfkStateDir(), 'memory');
 }
 
+export function getStateDatabasePath(): string {
+  return join(getAfkStateDir(), 'kv', 'kv.db');
+}
+
 export function getQueueDir(): string {
   return join(getAfkStateDir(), 'queue');
 }

--- a/src/telegram/create-session.ts
+++ b/src/telegram/create-session.ts
@@ -18,6 +18,7 @@ import { resolveModelId } from '../agent/session/model-resolution.js';
 import { getMaxOutputTokens, getMaxToolUseIterations, composeSystemPrompt } from '../cli/shared-helpers.js';
 import type { AgentConfig } from '../agent/types.js';
 import type { MemoryStore } from '../agent/memory/index.js';
+import type { StateStore } from '../agent/state/state-store.js';
 import { WorkspaceStore } from '../agent/workspace/workspace-store.js';
 import { env } from '../config/env.js';
 import { createTelegramTraceWriter } from './construct-session.js';
@@ -37,6 +38,8 @@ export interface TelegramSessionFactoryOptions {
   telegramCwd: string | undefined;
   /** Bot-global memory store shared by every chat's hook bundle. */
   memoryStore: MemoryStore;
+  /** Bot-global state store for durable agent state. */
+  stateStore?: StateStore;
   log?: (message: string) => void;
 }
 

--- a/src/telegram/entry.ts
+++ b/src/telegram/entry.ts
@@ -24,9 +24,10 @@ import { TelegramBot } from './bot.js';
 import { parseAllowedChatIds } from './allowlist.js';
 import { validateBotToken } from './setup-wizard.js';
 import { MemoryStore } from '../agent/memory/index.js';
+import { StateStore } from '../agent/state/state-store.js';
 import { providerForModel } from '../agent/providers/index.js';
 import { loadConfig, loadTelegramConfig } from '../cli/config.js';
-import { getEnvConfigPath } from '../paths.js';
+import { getEnvConfigPath, getStateDatabasePath } from '../paths.js';
 import { loadSystemPrompt } from '../cli/shared-helpers.js';
 import type { AgentModelInput } from '../agent/types.js';
 import { applyTelegramFileOverrides } from './env-file-overrides.js';
@@ -137,6 +138,7 @@ export async function main(): Promise<void> {
   }
 
   const sharedMemoryStore = new MemoryStore();
+  const sharedStateStore = new StateStore(getStateDatabasePath());
 
   // Optional working-directory override for every bot-spawned session.
   // When set, all per-chat AgentSessions (and their forked subagents)
@@ -166,6 +168,7 @@ export async function main(): Promise<void> {
       frameworkBase,
       telegramCwd,
       memoryStore: sharedMemoryStore,
+      stateStore: sharedStateStore,
     }),
   });
 
@@ -180,6 +183,7 @@ export async function main(): Promise<void> {
     clearInterval(statsInterval);
     await bot.stop();
     sharedMemoryStore.close();
+    sharedStateStore.close();
     console.log('✅ Bot stopped.');
     process.exit(0);
   };


### PR DESCRIPTION
## Summary

Implements a durable, cross-session structured state store for agent-afk (#1414).

## What's in this PR

### Core module (`src/agent/state/`)
- **`state-store.ts`** — SQLite-backed `StateStore` class with namespace-isolated documents, optimistic versioning (OCC via CAS), TTL expiry with GC, and `better-sqlite3` synchronous API
- **`state-schemas.ts`** — 5 tool schemas: `state_get`, `state_put`, `state_cas`, `state_delete`, `state_query`; read-only subset for child sessions
- **`state-tools.ts`** — `createStateHandlers` factory binding tool names to StateStore operations with namespace validation and limit capping

### Provider wiring
- **Anthropic direct provider** — schemas injected, handlers registered in buildDispatcher, `stateStore` field + constructor, `close()` cleanup
- **OpenAI-compatible provider** — same wiring: options interface, field, constructor, schema injection with `readOnlyMemory` gate, `buildDispatcher` handler registration, `close()`

### Entry-point wiring (5 sites)
- `src/cli/commands/interactive/bootstrap.ts`
- `src/cli/commands/chat.ts`
- `src/cli/commands/daemon.ts`
- `src/telegram/entry.ts`
- `src/agent/daemon/scheduler.ts`

### Tool surface updates
- `src/agent/tool-category.ts` — `READ_TOOLS`, `WRITE_TOOLS` updated
- `src/agent/tools/nesting.ts` — `CHILD_ALLOWED_TOOLS` updated (state_get, state_query read-only for children)

### Tests (22 new test cases)
- `src/agent/state/state-store.test.ts` — 14 cases: constructor, schema version mismatch, put/get round-trip, version increment, namespace isolation, del, CAS (success/mismatch/not-found), query with prefix/limit, TTL GC, validation, schema stamp
- `src/agent/state/state-tools.test.ts` — 8 cases: get missing key, put→get call-through, CAS mismatch, delete, query with prefix, invalid namespace, sessionId as producer, limit cap
- `src/agent/tools/nesting.test.ts` — state_get/state_query membership assertions added
- `src/agent/tools/schema-classification.test.ts` — stateToolSchemas imported, classification tests added

## Verification

- `pnpm lint` — clean
- `pnpm build` — clean
- `pnpm test` — 18,781 passed, 3 skipped (pre-existing), 0 failed across 970 test files
