### PR TITLE
fix(tui): clamp content lines to terminal width in task-view-mid-turn

### DIFF
--- a/src/cli/commands/interactive/task-view-mid-turn.test.ts
+++ b/src/cli/commands/interactive/task-view-mid-turn.test.ts
@@ -137,3 +137,117 @@ function makeHost(
     ...overrides,
   } as never;
 }
+
+// ---------------------------------------------------------------------------
+// Width clamping — launchMidTurnTaskView content writes
+// ---------------------------------------------------------------------------
+
+describe('launchMidTurnTaskView width clamping', () => {
+  it('clamps long subagent history lines to terminal width', async () => {
+    const { launchMidTurnTaskView } = await import('./task-view-mid-turn.js');
+
+    // Collect every chunk written to our fake stdout.
+    const written: string[] = [];
+    const fakeStdout = {
+      columns: 40,
+      write: (s: string) => { written.push(s); return true; },
+    };
+
+    // A history line that is far wider than 40 columns.
+    const longLine = 'A'.repeat(200);
+
+    // Minimal fake session: non-empty history, immediate-complete stream.
+    const fakeSession = {
+      getHistory: () => [
+        { role: 'assistant' as const, content: longLine },
+      ],
+      getOutputStream: async function* () {
+        // yield nothing — subagent already done
+      },
+    };
+
+    // Fake handle — already completed so the view returns immediately.
+    const fakeHandle = {
+      status: 'succeeded' as const,
+      session: fakeSession,
+      sendMessage: vi.fn(),
+    };
+
+    const fakeManager = {
+      list: () => [{ id: 'sub-1', status: 'running' as const }],
+      get: (_id: string) => fakeHandle as never,
+    };
+
+    const fakeCompositor = {
+      stdout: fakeStdout as never,
+      suspendInput: vi.fn(),
+      resumeInput: vi.fn(),
+      repaint: vi.fn(),
+    };
+
+    await launchMidTurnTaskView({
+      manager: fakeManager as never,
+      compositor: fakeCompositor as never,
+    });
+
+    // Every non-ANSI-only line written must be ≤ 40 visible characters.
+    // We join all written chunks and split by newline, then check each line.
+    const allOutput = written.join('');
+    const lines = allOutput.split('\n');
+
+    // Strip ANSI escape sequences for width measurement (CSI + OSC patterns).
+    const stripAnsi = (s: string): string =>
+      s.replace(/\x1b\[[0-9;]*[A-Za-z]/g, '').replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '');
+
+    // Cursor-positioning sequences like \r\x1b[K (erase line) are fine —
+    // they should not be clamped. Only visible content lines must be ≤ cols.
+    for (const line of lines) {
+      const visible = stripAnsi(line);
+      // Skip empty lines and bare CR (cursor movement remnants).
+      if (visible.replace(/\r/g, '').trim() === '') continue;
+      // Skip the clear-screen line (\x1b[2J\x1b[H).
+      if (line.includes('\x1b[2J')) continue;
+      expect(visible.length).toBeLessThanOrEqual(40);
+    }
+  });
+
+  it('does not clamp cursor-movement ANSI sequences (CSI codes)', async () => {
+    const { launchMidTurnTaskView } = await import('./task-view-mid-turn.js');
+
+    const written: string[] = [];
+    const fakeStdout = {
+      columns: 40,
+      write: (s: string) => { written.push(s); return true; },
+    };
+
+    const fakeSession = {
+      getHistory: () => [],
+      getOutputStream: async function* () {},
+    };
+    const fakeHandle = {
+      status: 'succeeded' as const,
+      session: fakeSession,
+      sendMessage: vi.fn(),
+    };
+    const fakeManager = {
+      list: () => [{ id: 'sub-2', status: 'running' as const }],
+      get: (_id: string) => fakeHandle as never,
+    };
+    const fakeCompositor = {
+      stdout: fakeStdout as never,
+      suspendInput: vi.fn(),
+      resumeInput: vi.fn(),
+      repaint: vi.fn(),
+    };
+
+    await launchMidTurnTaskView({
+      manager: fakeManager as never,
+      compositor: fakeCompositor as never,
+    });
+
+    const allOutput = written.join('');
+    // Cursor-movement sequences must still be present in the raw output.
+    // The clear-screen + cursor-home sequence (\x1b[2J\x1b[H) is always written first.
+    expect(allOutput).toContain('\x1b[2J\x1b[H');
+  });
+});

--- a/src/cli/commands/interactive/task-view-mid-turn.ts
+++ b/src/cli/commands/interactive/task-view-mid-turn.ts
@@ -83,8 +83,16 @@ export async function launchMidTurnTaskView(
   // `truncateDisplayWidth` is ANSI-aware — it preserves color codes while
   // clamping display width. Cursor-movement ANSI sequences (CSI codes) are
   // NOT passed through this helper; they bypass clamp() entirely.
+  //
+  // Invariant: multiline strings must be split on \n and clamped per-line.
+  // `string-width` treats \n as zero-width, so a multiline string's total
+  // display width is the SUM of its lines — truncateDisplayWidth would cut
+  // mid-string and drop later lines instead of clamping each independently.
+  const width = stdout.columns || 80;
   const clamp = (s: string): string =>
-    truncateDisplayWidth(s, stdout.columns || 80);
+    s.includes('\n')
+      ? s.split('\n').map(line => truncateDisplayWidth(line, width)).join('\n')
+      : truncateDisplayWidth(s, width);
 
   // FIX-1: Mark the view as active AFTER all early-return guards so the
   // flag is never stuck true when no subagent is found or handle is null.

--- a/src/cli/commands/interactive/task-view-mid-turn.ts
+++ b/src/cli/commands/interactive/task-view-mid-turn.ts
@@ -25,6 +25,7 @@ import {
 } from './task-view-mode.js';
 import { getTasksManager } from '../../slash/commands/tasks.js';
 import { stripEscapeSequences } from '../../../utils/terminal-sanitize.js';
+import { truncateDisplayWidth } from '../../display.js';
 import type { SubagentManager } from '../../../agent/subagent.js';
 import type { TerminalCompositor } from '../../terminal-compositor.js';
 import type { OutputEvent } from '../../../agent/types/session-types.js';
@@ -78,6 +79,12 @@ export async function launchMidTurnTaskView(
   const agentType = (handle as unknown as { _agentType?: string })?._agentType;
 
   const stdout = compositor.stdout;
+  // Contract: clamp any user-visible content line to terminal width.
+  // `truncateDisplayWidth` is ANSI-aware — it preserves color codes while
+  // clamping display width. Cursor-movement ANSI sequences (CSI codes) are
+  // NOT passed through this helper; they bypass clamp() entirely.
+  const clamp = (s: string): string =>
+    truncateDisplayWidth(s, stdout.columns || 80);
 
   // FIX-1: Mark the view as active AFTER all early-return guards so the
   // flag is never stuck true when no subagent is found or handle is null.
@@ -94,7 +101,7 @@ export async function launchMidTurnTaskView(
   // Clear screen and render the task view header.
   stdout.write('\x1b[2J\x1b[H'); // clear screen + cursor home
   const status = handle.status ?? 'running';
-  stdout.write(renderTaskViewHeader(id, status, agentType) + '\n\n');
+  stdout.write(clamp(renderTaskViewHeader(id, status, agentType)) + '\n\n');
 
   // Render in-memory history if available.
   if (typeof handle.session.getHistory === 'function') {
@@ -114,13 +121,13 @@ export async function launchMidTurnTaskView(
               .join('\n')
           : JSON.stringify(raw);
       const safe = stripEscapeSequences(text);
-      for (const l of safe.split('\n')) stdout.write(`  ${l}\n`);
+      for (const l of safe.split('\n')) stdout.write(clamp(`  ${l}`) + '\n');
       stdout.write('\n');
     }
   }
 
   const isRunning = status === 'running' || status === 'idle';
-  stdout.write(buildTaskFooterLine(isRunning) + '\n');
+  stdout.write(clamp(buildTaskFooterLine(isRunning)) + '\n');
 
   if (!isRunning) {
     // Already completed — show briefly then return.
@@ -155,7 +162,7 @@ export async function launchMidTurnTaskView(
       if (msg) {
         handle.sendMessage(msg);
         // FIX-3: Sanitize echo to prevent ANSI injection from paste content.
-        stdout.write(`\r\x1b[K${palette.user('you')}: ${stripEscapeSequences(msg)}\n`);
+        stdout.write(`\r\x1b[K${clamp(palette.user('you') + ': ' + stripEscapeSequences(msg))}\n`);
         inputBuf = '';
         renderPrompt();
       }
@@ -180,7 +187,7 @@ export async function launchMidTurnTaskView(
   };
   process.stdin.on('data', onData);
 
-  stdout.write(palette.dim('  Type a message + Enter to send, Esc to return\n'));
+  stdout.write(clamp(palette.dim('  Type a message + Enter to send, Esc to return')) + '\n');
   renderPrompt();
 
   try {
@@ -189,7 +196,7 @@ export async function launchMidTurnTaskView(
       const text = formatOutputEvent(event);
       if (text !== null) {
         // Clear the input prompt line, write output, re-render prompt.
-        stdout.write(`\r\x1b[K${text}\n`);
+        stdout.write(`\r\x1b[K${clamp(text)}\n`);
         renderPrompt();
       }
     }
@@ -199,7 +206,7 @@ export async function launchMidTurnTaskView(
     process.stdin.removeListener('data', onData);
 
     if (!signal.aborted) {
-      stdout.write('\r\x1b[K\n' + palette.dim('  Subagent completed. Press Esc to return.') + '\n');
+      stdout.write('\r\x1b[K\n' + clamp(palette.dim('  Subagent completed. Press Esc to return.')) + '\n');
       await waitForEsc();
     }
 


### PR DESCRIPTION
## Problem

`launchMidTurnTaskView` (the Tab-triggered mid-turn subagent view) wrote subagent conversation history, live output events, and user input echo directly to `stdout.write` with **no width guard**. The compositor is suspended during this view, so the normal repaint/overlay width-clamping path is bypassed entirely. Subagent history lines, tool output, and live streaming events could easily exceed the terminal width, corrupting the TUI layout.

## Fix

Added a local `clamp` helper using the existing `truncateDisplayWidth` from `../../display.js`:

```ts
const clamp = (s: string): string =>
  truncateDisplayWidth(s, stdout.columns || 80);
```

Applied `clamp()` to every user-visible content string before writing:

| Write site | Applied |
|---|---|
| Header line (`renderTaskViewHeader`) | ✅ |
| Each history line in the `for … split('\n')` loop | ✅ |
| Footer/separator (`buildTaskFooterLine`) | ✅ |
| User input echo on Enter | ✅ |
| "Type a message + Enter to send, Esc to return" hint | ✅ |
| Each `formatOutputEvent` result in the live stream loop | ✅ |
| "Subagent completed. Press Esc to return." tail line | ✅ |

Cursor-movement ANSI sequences (`\x1b[2J\x1b[H`, `\r\x1b[K`) bypass `clamp()` entirely — they are positional codes, not content, and must not be truncated. `truncateDisplayWidth` is ANSI-aware: it preserves SGR color codes while clamping visible display width.

## Tests

Two new tests in `task-view-mid-turn.test.ts` under **"launchMidTurnTaskView width clamping"**:

1. **Long history line is clamped** — drives `launchMidTurnTaskView` with a mock compositor whose `stdout.columns = 40` and a history entry containing 200 `'A'` characters; asserts every visible-content line in the captured output is ≤ 40 characters wide.
2. **Cursor-movement ANSI sequences are not clamped** — asserts the raw output still contains `\x1b[2J\x1b[H` (clear-screen + cursor-home) after the view runs.

All 10 tests in the file pass (8 pre-existing + 2 new). `pnpm lint` and `pnpm build` clean.
