### PR TITLE
fix(tui): hard-wrap code block body lines at maxTableWidth

### DIFF
--- a/src/cli/formatter.block.ts
+++ b/src/cli/formatter.block.ts
@@ -31,7 +31,9 @@ export function renderBlockquote(
 ): string {
   const prefix = palette.dim('  │ ');
   const prefixCols = 4; // "  │ " = 2 spaces + box-draw + space
-  const innerWidth = maxTableWidth ? Math.max(1, maxTableWidth - prefixCols) : undefined;
+  const innerWidth = maxTableWidth !== undefined
+    ? Math.max(1, maxTableWidth - prefixCols)
+    : undefined;
   // Render nested blocks against the space left after this blockquote's
   // prefix. In particular, code blocks must wrap once at their final inner
   // width rather than first at the terminal width and then again here.
@@ -43,7 +45,7 @@ export function renderBlockquote(
     // here over budget, and the indent-blind commit-time wrap would
     // re-split it at column 0, orphaning the continuation outside the
     // `│ ` gutter.
-    const wrapped = innerWidth
+    const wrapped = innerWidth !== undefined
       ? wrapToWidth(para, innerWidth, { breakLongWords: true })
       : para;
     for (const line of wrapped.split('\n')) {
@@ -111,13 +113,22 @@ export function renderCodeBlock(
   // on continuation rows. hardWrapToWidth is character-level (not word-aware),
   // matching terminal behavior for code, and preserves ANSI styling across rows.
   // When maxTableWidth is undefined (non-streaming path), leave behavior unchanged.
-  const gutterCols = 2; // fixed — do not use displayWidth; the string is ASCII
+  // U+2502 is one column on standard terminals, plus the following space.
+  // Terminals that render East Asian Ambiguous characters wide remain a
+  // broader, pre-existing edge case for the TUI's box-drawing characters.
+  const gutterCols = 2;
   const contentWidth = maxTableWidth !== undefined ? Math.max(1, maxTableWidth - gutterCols) : undefined;
   const bodyLines: string[] = [];
   for (const line of rawBodyLines) {
     if (contentWidth !== undefined) {
       const wrapped = hardWrapToWidth(line, contentWidth);
-      for (const row of wrapped.split('\n')) {
+      const rows = wrapped.split('\n');
+      // A wrapping implementation may terminate an exactly-full final row
+      // with a newline. Do not turn that implementation detail into a
+      // content-free gutter row; genuine blank source lines still arrive as
+      // their own entry in rawBodyLines and remain visible.
+      if (rows.length > 1 && rows[rows.length - 1] === '') rows.pop();
+      for (const row of rows) {
         bodyLines.push(row);
       }
     } else {

--- a/src/cli/formatter.block.ts
+++ b/src/cli/formatter.block.ts
@@ -1,5 +1,5 @@
 import { type Token, type Tokens } from 'marked';
-import { wrapToWidth } from './wrap.js';
+import { wrapToWidth, hardWrapToWidth } from './wrap.js';
 import { highlightCode } from './syntax-highlight.js';
 import { palette } from './palette.js';
 import { registerCodeBlock } from './code-block-register.js';
@@ -75,10 +75,6 @@ export function renderCodeBlock(
   code: Tokens.Code,
   maxTableWidth: number | undefined,
 ): string {
-  // maxTableWidth is accepted but not currently used — reserved for a future
-  // hard-wrap pass on code blocks, and accepted here so the signature is
-  // forward-compatible without a breaking API change.
-  void maxTableWidth;
   const lang = code.lang || 'text';
   // Loud-fail empty fences. Without this guard, a model emitting
   // "```bash\n```" (open + language + close with no body) renders as
@@ -101,10 +97,30 @@ export function renderCodeBlock(
   const blockIndex = registerCodeBlock(lang, code.text);
 
   const highlighted = highlightCode(code.text, lang);
-  const bodyLines = highlighted.split('\n');
+  const rawBodyLines = highlighted.split('\n');
   // Drop trailing empty line so adjacent blocks don't double-space.
-  if (bodyLines.length > 0 && bodyLines[bodyLines.length - 1] === '') bodyLines.pop();
+  if (rawBodyLines.length > 0 && rawBodyLines[rawBodyLines.length - 1] === '') rawBodyLines.pop();
   const gutter = palette.dim('│ ');
+  // Invariant: gutter is "│ " — exactly 2 display columns (box-draw char + space).
+  // When maxTableWidth is provided, hard-wrap each body line to the available
+  // content width (maxTableWidth - 2) so that lines wider than the terminal do
+  // not cause the terminal to auto-wrap at column 0 and lose the gutter prefix
+  // on continuation rows. hardWrapToWidth is character-level (not word-aware),
+  // matching terminal behavior for code, and preserves ANSI styling across rows.
+  // When maxTableWidth is undefined (non-streaming path), leave behavior unchanged.
+  const gutterCols = 2; // fixed — do not use displayWidth; the string is ASCII
+  const contentWidth = maxTableWidth !== undefined ? Math.max(1, maxTableWidth - gutterCols) : undefined;
+  const bodyLines: string[] = [];
+  for (const line of rawBodyLines) {
+    if (contentWidth !== undefined) {
+      const wrapped = hardWrapToWidth(line, contentWidth);
+      for (const row of wrapped.split('\n')) {
+        bodyLines.push(row);
+      }
+    } else {
+      bodyLines.push(line);
+    }
+  }
   const body = bodyLines.map((line) => gutter + line).join('\n');
   // Language tag + copy hint. The `/cp N` hint tells the user which index
   // to pass to `/copy` to grab this block. When there is no explicit

--- a/src/cli/formatter.block.ts
+++ b/src/cli/formatter.block.ts
@@ -27,12 +27,15 @@ import { registerCodeBlock } from './code-block-register.js';
 export function renderBlockquote(
   bq: Tokens.Blockquote,
   maxTableWidth: number | undefined,
-  renderTokens: (tokens: Token[]) => string,
+  renderTokens: (tokens: Token[], maxWidth?: number) => string,
 ): string {
-  const inner = bq.tokens ? renderTokens(bq.tokens as Token[]) : bq.text;
   const prefix = palette.dim('  │ ');
   const prefixCols = 4; // "  │ " = 2 spaces + box-draw + space
   const innerWidth = maxTableWidth ? Math.max(1, maxTableWidth - prefixCols) : undefined;
+  // Render nested blocks against the space left after this blockquote's
+  // prefix. In particular, code blocks must wrap once at their final inner
+  // width rather than first at the terminal width and then again here.
+  const inner = bq.tokens ? renderTokens(bq.tokens as Token[], innerWidth) : bq.text;
   const lines: string[] = [];
   for (const para of inner.split('\n')) {
     // breakLongWords: same contract as the list branch above — an

--- a/src/cli/formatter.list.ts
+++ b/src/cli/formatter.list.ts
@@ -38,7 +38,7 @@ function padDisplay_(
 export function renderList(
   list: Tokens.List,
   maxTableWidth: number | undefined,
-  renderTokens: (tokens: Token[]) => string,
+  renderTokens: (tokens: Token[], maxWidth?: number) => string,
 ): string {
   const items: string[] = [];
   // marked preserves the source-level starting index in `list.start`
@@ -73,7 +73,6 @@ export function renderList(
     const renderableTokens: Token[] = item.tokens
       ? (isTask ? (item.tokens as Token[]).filter((t) => t.type !== 'checkbox') : (item.tokens as Token[]))
       : [];
-    const itemText = renderableTokens.length > 0 ? renderTokens(renderableTokens) : item.text;
     const lines: string[] = [];
     let first = true;
     const prefixWidth = visualWidth(prefix);
@@ -96,6 +95,13 @@ export function renderList(
     // hanging indent. That is precisely the dissolution the invariant
     // above forbids; enforcing the width here is what makes it true.
     const innerWidth = maxTableWidth ? Math.max(1, maxTableWidth - prefixWidth) : undefined;
+    // Give nested blocks their actual budget before rendering them. Otherwise
+    // a code block is split at the outer width here, then split a second time
+    // after the list prefix is applied, producing fragmented rows and missing
+    // code gutters on continuations.
+    const itemText = renderableTokens.length > 0
+      ? renderTokens(renderableTokens, innerWidth)
+      : item.text;
     for (const srcLine of itemText.trim().split('\n')) {
       const wrapped = innerWidth
         ? wrapToWidth(srcLine, innerWidth, { breakLongWords: true })

--- a/src/cli/formatter.list.ts
+++ b/src/cli/formatter.list.ts
@@ -94,7 +94,9 @@ export function renderList(
     // indent-blind commit pass breaks it at column 0, dropping the
     // hanging indent. That is precisely the dissolution the invariant
     // above forbids; enforcing the width here is what makes it true.
-    const innerWidth = maxTableWidth ? Math.max(1, maxTableWidth - prefixWidth) : undefined;
+    const innerWidth = maxTableWidth !== undefined
+      ? Math.max(1, maxTableWidth - prefixWidth)
+      : undefined;
     // Give nested blocks their actual budget before rendering them. Otherwise
     // a code block is split at the outer width here, then split a second time
     // after the list prefix is applied, producing fragmented rows and missing
@@ -103,7 +105,7 @@ export function renderList(
       ? renderTokens(renderableTokens, innerWidth)
       : item.text;
     for (const srcLine of itemText.trim().split('\n')) {
-      const wrapped = innerWidth
+      const wrapped = innerWidth !== undefined
         ? wrapToWidth(srcLine, innerWidth, { breakLongWords: true })
         : srcLine;
       const segs = wrapped.split('\n');

--- a/src/cli/formatter.test.ts
+++ b/src/cli/formatter.test.ts
@@ -920,9 +920,11 @@ describe('renderMarkdownToTerminal', () => {
       const out = stripAnsi(
         renderMarkdownToTerminal(`\`\`\`\n${longLine}\n\`\`\`\n`, { maxWidth: 20 }),
       );
-      const lines = out.split('\n').filter((l) => l.startsWith('│ ') && l.trim() !== '│');
-      // Expect two gutter body rows (not one overflowing row).
-      expect(lines.length).toBeGreaterThanOrEqual(2);
+      const lines = out.split('\n').filter((l) => l.includes('x'));
+      // Expect exactly two gutter body rows (not one overflowing row or an
+      // extra, content-free gutter row).
+      expect(lines).toEqual([`│ ${'x'.repeat(18)}`, `│ ${'x'.repeat(18)}`]);
+      expect(out).not.toMatch(/^│ $/m);
       // Each row must not exceed maxTableWidth (20) display columns.
       for (const l of lines) {
         expect(stringWidth(l)).toBeLessThanOrEqual(20);
@@ -947,6 +949,32 @@ describe('renderMarkdownToTerminal', () => {
       const bodyLines = out.split('\n').filter((l) => l.startsWith('│ ') && l.includes('z'));
       expect(bodyLines.length).toBe(1);
       expect(bodyLines[0]).toBe(`│ ${longLine}`);
+    });
+
+    it('preserves balanced syntax-highlighting ANSI across wrapped rows', () => {
+      const raw = renderMarkdownToTerminal(
+        '```json\n{"longPropertyName":"abcdefghijklmnopqrstuvwxyz"}\n```\n',
+        { maxWidth: 20 },
+      );
+      const bodyLines = raw.split('\n').filter((line) => stripAnsi(line).startsWith('│ ') &&
+        !stripAnsi(line).includes('/cp'));
+
+      expect(bodyLines.length).toBeGreaterThan(1);
+      for (const line of bodyLines) {
+        expect(stringWidth(stripAnsi(line))).toBeLessThanOrEqual(20);
+        expect(line).toContain('\x1b[');
+        expect(line.match(/\x1b\[3m/g)?.length ?? 0).toBe(line.match(/\x1b\[23m/g)?.length ?? 0);
+        expect(line.match(/\x1b\[33m/g)?.length ?? 0).toBe(line.match(/\x1b\[39m/g)?.length ?? 0);
+      }
+    });
+
+    it('does not emit a gutter-only row after an exactly-full wrapped row', () => {
+      const out = stripAnsi(
+        renderMarkdownToTerminal(`\`\`\`\n${'x'.repeat(18)}\n\`\`\`\n`, { maxWidth: 20 }),
+      );
+
+      expect(out.split('\n').filter((line) => line.includes('x'))).toEqual([`│ ${'x'.repeat(18)}`]);
+      expect(out).not.toMatch(/^│ $/m);
     });
 
     it('wraps code nested in a list against the width after the list prefix', () => {

--- a/src/cli/formatter.test.ts
+++ b/src/cli/formatter.test.ts
@@ -907,6 +907,49 @@ describe('renderMarkdownToTerminal', () => {
     });
   });
 
+  // ──────────────────────────────────────────────────────────────────────────
+  // Code block width capping (HIGH-severity fix): renderCodeBlock must use
+  // maxTableWidth to hard-wrap body lines so that wide code lines do not cause
+  // the terminal to auto-wrap at col 0, losing the │ gutter on continuation rows.
+  // ──────────────────────────────────────────────────────────────────────────
+  describe('code block width capping', () => {
+    it('wraps a line wider than maxTableWidth and stamps gutter on every physical row', () => {
+      // maxWidth 20 → contentWidth 18 (20 - 2 for "│ " gutter).
+      // A 36-char line should split into two 18-char rows, each prefixed with │.
+      const longLine = 'x'.repeat(36);
+      const out = stripAnsi(
+        renderMarkdownToTerminal(`\`\`\`\n${longLine}\n\`\`\`\n`, { maxWidth: 20 }),
+      );
+      const lines = out.split('\n').filter((l) => l.startsWith('│ ') && l.trim() !== '│');
+      // Expect two gutter body rows (not one overflowing row).
+      expect(lines.length).toBeGreaterThanOrEqual(2);
+      // Each row must not exceed maxTableWidth (20) display columns.
+      for (const l of lines) {
+        expect(stringWidth(l)).toBeLessThanOrEqual(20);
+      }
+    });
+
+    it('leaves short lines unaffected when maxTableWidth is set', () => {
+      const out = stripAnsi(
+        renderMarkdownToTerminal('```bash\ngit status\n```\n', { maxWidth: 80 }),
+      );
+      // The short line must appear verbatim (single gutter row).
+      const bodyLines = out.split('\n').filter((l) => l.startsWith('│ ') && l.includes('git'));
+      expect(bodyLines.length).toBe(1);
+      expect(bodyLines[0]).toBe('│ git status');
+    });
+
+    it('does not wrap when maxTableWidth is undefined', () => {
+      // Without maxWidth, renderMarkdownToTerminal does not pass maxTableWidth,
+      // so the long line must pass through unsplit.
+      const longLine = 'z'.repeat(200);
+      const out = stripAnsi(renderMarkdownToTerminal(`\`\`\`\n${longLine}\n\`\`\`\n`));
+      const bodyLines = out.split('\n').filter((l) => l.startsWith('│ ') && l.includes('z'));
+      expect(bodyLines.length).toBe(1);
+      expect(bodyLines[0]).toBe(`│ ${longLine}`);
+    });
+  });
+
   describe('headings', () => {
     it('H2 emits a trailing newline so the next block does not glue onto it', () => {
       const input = '## State reality-check\n\nSome text.\n';

--- a/src/cli/formatter.test.ts
+++ b/src/cli/formatter.test.ts
@@ -948,6 +948,33 @@ describe('renderMarkdownToTerminal', () => {
       expect(bodyLines.length).toBe(1);
       expect(bodyLines[0]).toBe(`│ ${longLine}`);
     });
+
+    it('wraps code nested in a list against the width after the list prefix', () => {
+      const out = stripAnsi(
+        renderMarkdownToTerminal(`- \`\`\`\n  ${'x'.repeat(36)}\n  \`\`\`\n`, { maxWidth: 20 }),
+      );
+      const body = out.split('\n').filter((line) => line.includes('x'));
+
+      expect(body).toEqual([
+        `    │ ${'x'.repeat(14)}`,
+        `    │ ${'x'.repeat(14)}`,
+        `    │ ${'x'.repeat(8)}`,
+      ]);
+      for (const line of body) expect(stringWidth(line)).toBeLessThanOrEqual(20);
+    });
+
+    it('wraps code nested in a blockquote against the width after its prefix', () => {
+      const out = stripAnsi(
+        renderMarkdownToTerminal(`> \`\`\`\n> ${'x'.repeat(28)}\n> \`\`\`\n`, { maxWidth: 20 }),
+      );
+      const body = out.split('\n').filter((line) => line.includes('x'));
+
+      expect(body).toEqual([
+        `  │ │ ${'x'.repeat(14)}`,
+        `  │ │ ${'x'.repeat(14)}`,
+      ]);
+      for (const line of body) expect(stringWidth(line)).toBeLessThanOrEqual(20);
+    });
   });
 
   describe('headings', () => {

--- a/src/cli/formatter.ts
+++ b/src/cli/formatter.ts
@@ -159,7 +159,7 @@ export function renderMarkdownToTerminal(text: string, opts: RenderMarkdownOptio
     return renderInlineTokens(tokens, commitOnly);
   }
 
-  function renderTokens(tokens: Token[]): string {
+  function renderTokens(tokens: Token[], availableWidth = maxTableWidth): string {
     return tokens.map((token, idx) => {
       // Repeated, compatible headers represent one logical table. Merge the
       // rows before rendering so the group shares column widths and emits no
@@ -186,7 +186,7 @@ export function renderMarkdownToTerminal(text: string, opts: RenderMarkdownOptio
           tokens[nextIndex] = { type: 'space', raw: '' } as Token;
           end = nextIndex + 1;
         }
-        return renderTable({ ...table, rows }, maxTableWidth, renderInline);
+        return renderTable({ ...table, rows }, availableWidth, renderInline);
       }
       let result: string;
       switch (token.type) {
@@ -234,7 +234,7 @@ export function renderMarkdownToTerminal(text: string, opts: RenderMarkdownOptio
           break;
         }
         case 'code':
-          result = renderCodeBlock(token as Tokens.Code, maxTableWidth);
+          result = renderCodeBlock(token as Tokens.Code, availableWidth);
           break;
         case 'codespan': {
           const raw = (token as Tokens.Codespan).text;
@@ -260,7 +260,7 @@ export function renderMarkdownToTerminal(text: string, opts: RenderMarkdownOptio
           break;
         }
         case 'list':
-          result = renderList(token as Tokens.List, maxTableWidth, renderTokens);
+          result = renderList(token as Tokens.List, availableWidth, renderTokens);
           break;
         case 'space':
           return token.raw ? '\n' : '';
@@ -269,12 +269,12 @@ export function renderMarkdownToTerminal(text: string, opts: RenderMarkdownOptio
           // instead of overflowing or falling short — it is already the
           // compositor's row budget, so no separate capping is needed. Fall
           // back to 40 when no width is set (e.g. direct callers that omit opts).
-          const hrWidth = maxTableWidth ?? 40;
+          const hrWidth = availableWidth ?? 40;
           result = palette.dim('─'.repeat(hrWidth)) + '\n';
           break;
         }
         case 'blockquote':
-          result = renderBlockquote(token as Tokens.Blockquote, maxTableWidth, renderTokens);
+          result = renderBlockquote(token as Tokens.Blockquote, availableWidth, renderTokens);
           break;
         default:
           result = token.raw;


### PR DESCRIPTION
## Problem

`renderCodeBlock` in the markdown formatter wrote code block body lines directly without any width constraint. When a code line exceeded `maxTableWidth`, the terminal auto-wrapped at column 0, losing the `│ ` gutter prefix on continuation rows. This produced misaligned output in the streaming TUI renderer where `maxTableWidth` is set.

## Fix

Added `hardWrapToWidth` using `wrap-ansi` with `{ hard: true, trim: false }` to character-wrap code block body lines at `contentWidth = maxTableWidth - gutterCols`. This matches terminal auto-wrap physics (character-level, no word-awareness) while preserving the gutter prefix on every physical row.

The wrap is only active when `maxTableWidth` is provided (streaming path); the non-streaming path (`maxTableWidth === undefined`) passes through unchanged.

## Verification

- `pnpm build` clean
- `pnpm lint` clean  
- `pnpm test src/cli/formatter.test.ts` — all tests pass, including 3 new test cases covering wide-line wrap, short-line passthrough, and no-maxTableWidth passthrough
