### PR TITLE
fix(facets): restore statSync optimization and session_id trace path

### DIFF
--- a/src/agent/tools/handlers/get-facet.ts
+++ b/src/agent/tools/handlers/get-facet.ts
@@ -8,7 +8,10 @@
  * @module agent/tools/handlers/get-facet
  */
 
-import { getOrDeriveFacet, listSessionIds, loadStoredSession } from '../../facets/index.js';
+import { statSync } from 'node:fs';
+import { join } from 'node:path';
+import { getOrDeriveFacet, listSessionIds } from '../../facets/index.js';
+import { getSessionsDir } from '../../../paths.js';
 import { resolveSessionByName } from '../../trace/session-name-resolver.js';
 import { FACET_INTERNAL_FIELDS } from '../schemas.facet.js';
 import type { ToolHandler } from '../types.js';
@@ -21,15 +24,21 @@ export const getFacetHandler: ToolHandler = async (input, _signal) => {
   let sessionId: string | undefined;
 
   if (sessionArg === 'latest') {
+    // Contract: use filesystem mtime to find the newest sidecar without
+    // deserializing every sidecar file. The O(N) loadStoredSession scan
+    // was a blocking perf regression on installations with hundreds of sessions.
     const ids = listSessionIds();
-    const entries = ids
-      .map((id) => ({ id, session: loadStoredSession(id) }))
-      .filter(
-        (e): e is { id: string; session: NonNullable<ReturnType<typeof loadStoredSession>> } =>
-          e.session != null,
-      )
-      .sort((a, b) => (b.session.savedAt ?? 0) - (a.session.savedAt ?? 0));
-    sessionId = entries[0]?.id;
+    if (ids.length > 0) {
+      const sessionsDir = getSessionsDir();
+      let best: { id: string; mtimeMs: number } | undefined;
+      for (const id of ids) {
+        try {
+          const mt = statSync(join(sessionsDir, `${id}.json`)).mtimeMs;
+          if (!best || mt > best.mtimeMs) best = { id, mtimeMs: mt };
+        } catch { /* skip unreadable */ }
+      }
+      sessionId = best?.id;
+    }
   } else {
     const resolved = resolveSessionByName(sessionArg);
     sessionId = resolved?.sidecarId;

--- a/src/insights/aggregators/traces.ts
+++ b/src/insights/aggregators/traces.ts
@@ -107,7 +107,10 @@ export function aggregateTraces(options: InsightsOptions): TraceAggregates {
     // The trace path only writes: toolDurationsMs, compactionCount,
     // closureReasons, totalInputTokens, totalOutputTokens, totalCacheReadTokens,
     // totalCacheCreationTokens, totalCostUsd, sessionsWithCost.
-    const tracePath = join(witnessRoot, sessionId, 'trace.jsonl');
+    // Contract: use facet.session_id (the SDK session ID / witness dir name)
+    // rather than sidecarId — they can differ when saveSession uses an override.
+    const traceSessionId = facet.session_id;
+    const tracePath = join(witnessRoot, traceSessionId, 'trace.jsonl');
     if (!existsSync(tracePath)) continue;
     let raw: string | null = null;
     try {


### PR DESCRIPTION
## Problem

PR #1451's squash-merge onto main reverted two fixes that had been amended into the already-merged #1450:

### 1. `get_facet session:"latest"` O(N) full-scan regression (high severity)

The squash-merge restored the `loadStoredSession` scan that loads and Zod-validates every persisted session sidecar to find the newest by `savedAt`. On installations with hundreds of sessions, this blocks the event loop per `get_facet` call. The `statSync` mtime optimization from #1450's amendment was overwritten.

### 2. `traces.ts` witness path uses wrong session identifier

The trace path used `sessionId` (the sidecar filename) instead of `facet.session_id` (the SDK session ID / witness directory name). These can differ when `saveSession(stats, overrideId)` is used, causing trace lookups to silently miss valid trace files.

## Fix

1. **`src/agent/tools/handlers/get-facet.ts`**: Restore `statSync` mtime-based latest resolution -- iterate session IDs, `stat` each sidecar file, keep the highest `mtimeMs`, load only that one.

2. **`src/insights/aggregators/traces.ts`**: Use `facet.session_id` for the witness trace path instead of the loop variable `sessionId`.

## Verification

- `pnpm lint` clean
- `pnpm test src/agent/tools/handlers/get-facet.test.ts` -- 6/6 pass
- `pnpm test src/insights/aggregators/traces.test.ts` -- 16/16 pass
- `pnpm audit:filesize:check` -- all within ceiling
