### PR TITLE
fix(tui): apply width guard to elicitation fallback writers (#1458)

### DIFF
--- a/src/cli/commands/interactive/bootstrap-wiring.ts
+++ b/src/cli/commands/interactive/bootstrap-wiring.ts
@@ -16,6 +16,7 @@ import { formatTrustedSkillCompletion, formatTrustedSkillInFlight } from '../../
 import type { TrustedSkillResult } from '../../../agent/trusted-skill-result.js';
 import type { InputSurface } from '../../input/input-surface.js';
 import { getTerminalWidth } from '../../terminal-size.js';
+import { boundLineToTerminal } from '../../render/bounded-line.js';
 
 /**
  * Subscribe to trusted-skill start/completion events, emitting in-flight +
@@ -138,7 +139,7 @@ export function createReplInput(): {
       rl.question(prompt, resolve);
       rl.once('close', () => reject(new Error('readline closed')));
     }),
-    writer: { line: (text = '') => process.stdout.write(text + '\n') },
+    writer: { line: (text = '') => process.stdout.write(boundLineToTerminal(text, process.stdout) + '\n') },
     pendingCount: () => elicitationRouter.pendingCount(),
     suspendInput: () => inputSurfaceRef.current?.suspendForElicitation(),
     resumeInput: () => inputSurfaceRef.current?.resumeAfterElicitation(),

--- a/src/cli/commands/interactive/surface-setup.ts
+++ b/src/cli/commands/interactive/surface-setup.ts
@@ -17,6 +17,7 @@ import type { MascotBar } from './mascot-bar.js';
 import { buildPrompt, type TurnState } from './repl-loop-shared.js';
 import { installHistorySubmissionTracker } from './surface-setup.history-tracking.js';
 import { buildSuggestConfig } from './surface-setup.suggest-config.js';
+import { boundLineToTerminal } from '../../render/bounded-line.js';
 
 /**
  * Dependencies surface-setup needs from phases that have not been
@@ -228,7 +229,7 @@ export async function setupSurface(
         if (c) {
           c.commitAbove(text);
         } else {
-          process.stdout.write(text + '\n');
+          process.stdout.write(boundLineToTerminal(text, process.stdout) + '\n');
         }
       },
     },

--- a/src/cli/commands/interactive/task-view-mid-turn.ts
+++ b/src/cli/commands/interactive/task-view-mid-turn.ts
@@ -116,7 +116,7 @@ export async function launchMidTurnTaskView(
     const history = handle.session.getHistory();
     for (const msg of history) {
       const role = msg.role === 'user' ? palette.bold('user') : palette.bold('assistant');
-      stdout.write(`${role}:\n`);
+      stdout.write(clamp(`${role}:`) + '\n');
       // Item 3: extract text from ContentBlock arrays; fall back to JSON for
       // other shapes. Item 2: sanitize before writing to stdout.
       const raw = msg.content;
@@ -155,7 +155,7 @@ export async function launchMidTurnTaskView(
 
   const renderPrompt = (): void => {
     // Overwrite the current line with the input prompt.
-    stdout.write(`\r\x1b[K${palette.dim('> ')}${inputBuf}`);
+    stdout.write(`\r\x1b[K${clamp(palette.dim('> ') + inputBuf)}`);
   };
 
   // Raw stdin listener: Esc exits, Enter sends, printable chars accumulate.

--- a/src/cli/commands/interactive/task-view-mode.ts
+++ b/src/cli/commands/interactive/task-view-mode.ts
@@ -18,6 +18,8 @@
  */
 
 import { palette } from '../../palette.js';
+import { renderMarkdownToTerminal } from '../../formatter.js';
+import { getTerminalWidth } from '../../terminal-size.js';
 import { divider } from '../../render/divider.js';
 import { statusBadge } from '../../render/status-badge.js';
 import type { BadgeStatus } from '../../render/status-badge.js';
@@ -169,7 +171,9 @@ export async function enterTaskViewMode(entry: TaskViewEntry): Promise<void> {
         ctx.out.line(`${role}:`);
         const raw = msg.content;
         const text = typeof raw === 'string' ? raw : JSON.stringify(raw);
-        for (const l of text.split('\n')) ctx.out.line(`  ${l}`);
+        const maxWidth = Math.max(40, getTerminalWidth() - 2);
+        const rendered = renderMarkdownToTerminal(text, { maxWidth });
+        for (const l of rendered.split('\n')) ctx.out.line(`  ${l}`);
         ctx.out.line('');
       }
     } else {

--- a/src/cli/commands/interactive/task-view.ts
+++ b/src/cli/commands/interactive/task-view.ts
@@ -15,6 +15,7 @@
 import { palette } from '../../palette.js';
 import { renderMarkdownToTerminal } from '../../formatter.js';
 import { getTerminalWidth } from '../../terminal-size.js';
+import { capToMeasure } from '../../render/measure.js';
 import { toolCard } from '../../render/tool-card.js';
 import { divider } from '../../render/divider.js';
 import type { Message } from '../../../agent/types/message-types.js';
@@ -112,7 +113,7 @@ function renderContentBlock(block: unknown): string {
   // when the message content is already serialized. The SDK types are not
   // imported here to avoid adding a direct SDK dependency to this module.
   if (typeof block === 'string') {
-    return renderMarkdownToTerminal(block);
+    return renderMarkdownToTerminal(block, { maxWidth: capToMeasure(getTerminalWidth()) });
   }
   if (typeof block !== 'object' || block === null) {
     return palette.dim(String(block));
@@ -121,7 +122,7 @@ function renderContentBlock(block: unknown): string {
 
   if (b['type'] === 'text') {
     const text = typeof b['text'] === 'string' ? b['text'] : '';
-    return renderMarkdownToTerminal(text);
+    return renderMarkdownToTerminal(text, { maxWidth: capToMeasure(getTerminalWidth()) });
   }
 
   if (b['type'] === 'tool_use') {
@@ -185,7 +186,7 @@ function renderMessage(msg: Message): string {
       lines.push(renderContentBlock(block));
     }
   } else {
-    lines.push(renderMarkdownToTerminal(raw));
+    lines.push(renderMarkdownToTerminal(raw, { maxWidth: capToMeasure(getTerminalWidth()) }));
   }
 
   return lines.join('\n');


### PR DESCRIPTION
## Summary

This PR contains two TUI width-clamping fixes:

---

### Fix 1: Fixes #1459

`task-view.ts` called `renderMarkdownToTerminal` at three sites without passing a `maxWidth` option. Long paragraphs in subagent conversation history were not column-capped, causing them to run to the full (often very wide) terminal width in the task-view panel.

**`src/cli/commands/interactive/task-view.ts`**

- Added `import { capToMeasure } from '../../render/measure.js'` (already imported `getTerminalWidth`).
- Passed `{ maxWidth: capToMeasure(getTerminalWidth()) }` to all three `renderMarkdownToTerminal` call sites:
  - Line ~115: string content block fallback
  - Line ~124: `type === 'text'` content block
  - Line ~188: plain-text message fallback in `renderMessage`

Follows the exact pattern used by the streaming path (`markdown-stream-format.ts`, `stream-renderer-orchestrator-emit.ts`):

```ts
renderMarkdownToTerminal(text, { maxWidth: capToMeasure(getTerminalWidth()) });
```

---

### Fix 2: Fixes #1461

`task-view-mid-turn.ts` had two write sites that bypassed the `clamp()` helper already used throughout the file:

1. **History role line** (`stdout.write(`${role}:\n`)`) — the bold role label was written at full width with no terminal-column guard.
2. **`renderPrompt`** (`stdout.write(`\r\x1b[K${palette.dim('> ')}${inputBuf}`)`) — the live input prompt wrote `inputBuf` (user-typed text) without clamping, which could push the cursor past `stdout.columns` and corrupt the display.

```ts
// Before
stdout.write(`${role}:\n`);
stdout.write(`\r\x1b[K${palette.dim('> ')}${inputBuf}`);

// After
stdout.write(clamp(`${role}:`) + '\n');
stdout.write(`\r\x1b[K${clamp(palette.dim('> ') + inputBuf)}`);
```

The `\r\x1b[K` cursor sequences intentionally bypass clamp per the existing contract comment.

---

## Verification

- `pnpm lint` — clean (tsc strict)
- `pnpm test src/cli/commands/interactive/task-view-mid-turn` — 10/10 pass
