### PR TITLE
fix(web-server): replace timing-based sync with rendezvous signal in flaky test

### DIFF
--- a/src/web-server/server.test.ts
+++ b/src/web-server/server.test.ts
@@ -272,14 +272,30 @@ describe('routing', () => {
     const pending = new Promise<{ name: string }[]>((resolve) => {
       release = resolve;
     });
-    const loader = vi.fn(() => pending);
+    // Contract: signal when the loader is actually invoked by the server,
+    // replacing the previous setTimeout(10) which was a timing assumption
+    // that failed on loaded CI runners (the event loop can take >10ms to
+    // accept loopback TCP connections under contention).
+    let signalLoaderReached!: () => void;
+    const loaderReached = new Promise<void>((r) => { signalLoaderReached = r; });
+    const loader = vi.fn(() => {
+      signalLoaderReached();
+      return pending;
+    });
     setCommandUniverseLoaderForTests(loader);
     const h = await start();
     const headers = { authorization: `Bearer ${h.token}` };
 
     const first = fetch(api(h, '/api/commands'), { headers });
     const second = fetch(api(h, '/api/commands'), { headers });
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    // Wait for the first request to enter the loader, then yield so the
+    // second request can be accepted and enter handleCommands (where it
+    // hits the ??= branch and shares the in-flight promise). Without this
+    // second yield, release() could resolve the loader before the second
+    // request arrives, letting it read from the populated cache instead of
+    // proving the dedup path.
+    await loaderReached;
+    await new Promise((r) => { setImmediate(r); });
     expect(loader).toHaveBeenCalledTimes(1);
     release([{ name: '/help' }]);
 


### PR DESCRIPTION
## Problem

The test "shares one in-flight command initialization across concurrent requests" in `src/web-server/server.test.ts` fails intermittently on Ubuntu CI:

```
AssertionError: expected "spy" to be called 1 times, but got 0 times
 > src/web-server/server.test.ts:283:20
```

Accompanied by `ECONNRESET` unhandled rejections from the same test file.

## Root Cause

The test used `setTimeout(resolve, 10)` as a synchronization barrier between firing two `fetch` requests and asserting the loader spy was called exactly once. On loaded CI runners, the Node.js event loop can take >10ms to accept loopback TCP connections, causing the assertion to fire before any request reaches the server handler.

When the assertion throws, `release()` is skipped, the `pending` promise never resolves, and `afterEach`'s `closeAllConnections()` destroys the still-waiting sockets -- producing the ECONNRESET unhandled rejections. Both symptoms share this single root cause.

## Fix

Replace the fixed timeout with a `loaderReached` promise that the mock resolves when the server actually invokes it. This makes the test deterministic regardless of CI load -- it waits for the real event (loader called) instead of guessing how long it takes.

## Verification

- 5 consecutive local runs: 75/75 pass each
- `pnpm lint` clean
