### PR TITLE
fix(effect-ledger): harden dedup, session scoping, error safety, and read caching

### DIFF
--- a/src/agent/effect-ledger/hook.test.ts
+++ b/src/agent/effect-ledger/hook.test.ts
@@ -184,6 +184,31 @@ describe('createEffectLedgerPostHook — dedup behavior', () => {
     const statuses = all.map((r) => r.status);
     expect(statuses.every((s) => s === 'executed')).toBe(true);
   });
+
+  it('third identical call is still caught as ambiguous (N>=3)', async () => {
+    const hook = createEffectLedgerPostHook(store);
+    const ctx = makeCtx();
+    await hook(ctx); // executed
+    await hook(ctx); // ambiguous
+    await hook(ctx); // must also be ambiguous, not executed
+
+    const all = await store.all();
+    expect(all).toHaveLength(3);
+    const statuses = all.map((r) => r.status);
+    expect(statuses.filter((s) => s === 'executed')).toHaveLength(1);
+    expect(statuses.filter((s) => s === 'ambiguous')).toHaveLength(2);
+  });
+
+  it('two sessions sending the same message are independent (no cross-session dedup)', async () => {
+    const hook = createEffectLedgerPostHook(store);
+    await hook(makeCtx({ sessionId: 'session-A' }));
+    await hook(makeCtx({ sessionId: 'session-B' }));
+
+    const all = await store.all();
+    expect(all).toHaveLength(2);
+    // Both should be 'executed' -- no false dedup across sessions.
+    expect(all.every((r) => r.status === 'executed')).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/agent/effect-ledger/hook.ts
+++ b/src/agent/effect-ledger/hook.ts
@@ -95,19 +95,28 @@ export function createEffectLedgerPostHook(store?: EffectStore): HookHandler {
       const classification = classifyToolCall(toolName, input);
       if (!classification.isExternal) return {};
 
-      const ikey = computeIdempotencyKey(classification.operationType, input);
+      let ikey: string;
+      try {
+        ikey = computeIdempotencyKey(classification.operationType, input);
+      } catch {
+        // Best-effort: stableStringify can throw on exotic objects (e.g.
+        // MCP-constructed inputs with getters that throw). Swallow so the
+        // hook's non-blocking contract is maintained.
+        return {};
+      }
 
       // Dedup check: mirror the PostToolUse path so retried failures with the
       // same idempotency key are recorded as 'ambiguous' rather than producing
       // duplicate 'failed' records that break reconciliation queries.
+      // Includes 'ambiguous' so call N>=3 is still caught.
       let prior;
       try {
-        prior = await effectStore.findByIdempotencyKey(ikey);
+        prior = await effectStore.findByIdempotencyKey(ikey, sessionId);
       } catch {
         prior = null;
       }
 
-      if (prior !== null && (prior.status === 'executed' || prior.status === 'confirmed' || prior.status === 'failed')) {
+      if (prior !== null && (prior.status === 'executed' || prior.status === 'confirmed' || prior.status === 'failed' || prior.status === 'ambiguous')) {
         try {
           const pending = effectStore.writePending({
             idempotencyKey: ikey,
@@ -147,19 +156,26 @@ export function createEffectLedgerPostHook(store?: EffectStore): HookHandler {
     const classification = classifyToolCall(toolName, input);
     if (!classification.isExternal) return {};
 
-    const ikey = computeIdempotencyKey(classification.operationType, input);
+    let ikey: string;
+    try {
+      ikey = computeIdempotencyKey(classification.operationType, input);
+    } catch {
+      // Best-effort: stableStringify can throw on exotic objects.
+      return {};
+    }
 
-    // Dedup check: look for a prior record with the same key.
+    // Dedup check: look for a prior record with the same key, scoped to the
+    // current session so two sessions sending the same message are independent.
     let prior;
     try {
-      prior = await effectStore.findByIdempotencyKey(ikey);
+      prior = await effectStore.findByIdempotencyKey(ikey, sessionId);
     } catch {
       // Best-effort: if the store read fails, proceed without dedup check.
       prior = null;
     }
 
-    if (prior !== null && (prior.status === 'executed' || prior.status === 'confirmed')) {
-      // A prior executed/confirmed record exists — this looks like a duplicate.
+    if (prior !== null && (prior.status === 'executed' || prior.status === 'confirmed' || prior.status === 'ambiguous')) {
+      // A prior executed/confirmed/ambiguous record exists — duplicate.
       // Record it as "ambiguous" to surface in reconciliation rather than
       // silently dropping the duplicate.
       try {

--- a/src/agent/effect-ledger/store.ts
+++ b/src/agent/effect-ledger/store.ts
@@ -103,9 +103,23 @@ function collapseById(records: EffectRecord[]): EffectRecord[] {
  */
 export class EffectStore {
   private readonly path: string;
+  /** In-memory cache to avoid O(N) re-reads within the same hook cycle. */
+  private cachedRecords: EffectRecord[] | null = null;
 
   constructor(path?: string) {
     this.path = path ?? getEffectLedgerPath();
+  }
+
+  /** Read records, returning the cached copy if still valid. */
+  private async readCached(): Promise<EffectRecord[]> {
+    if (this.cachedRecords !== null) return this.cachedRecords;
+    this.cachedRecords = await readAllRecords(this.path);
+    return this.cachedRecords;
+  }
+
+  /** Invalidate the cache after a write so the next read sees the new data. */
+  private invalidateCache(): void {
+    this.cachedRecords = null;
   }
 
   // ---------------------------------------------------------------------------
@@ -134,6 +148,7 @@ export class EffectStore {
       timestamp: Date.now(),
     };
     appendLine(this.path, record);
+    this.invalidateCache();
     return record;
   }
 
@@ -150,7 +165,7 @@ export class EffectStore {
    * Throws if the record does not exist or if the write fails.
    */
   async updateStatus(input: ExecuteEffectInput): Promise<EffectRecord> {
-    const all = await readAllRecords(this.path);
+    const all = await this.readCached();
     const collapsed = collapseById(all);
     const existing = collapsed.find((r) => r.id === input.id);
     if (!existing) {
@@ -165,6 +180,7 @@ export class EffectStore {
         : {}),
     };
     appendLine(this.path, updated);
+    this.invalidateCache();
     return updated;
   }
 
@@ -176,13 +192,18 @@ export class EffectStore {
    * Look up a record by idempotency key. Returns the record if found (after
    * last-write-wins collapse), or `null` if not found.
    *
+   * When `sessionId` is provided, only records from that session are considered
+   * so two independent sessions sending the same message are not falsely deduped.
+   *
    * Used by the hook to detect whether an operation was already started so
    * duplicate execution can be skipped.
    */
-  async findByIdempotencyKey(key: string): Promise<EffectRecord | null> {
-    const all = await readAllRecords(this.path);
+  async findByIdempotencyKey(key: string, sessionId?: string): Promise<EffectRecord | null> {
+    const all = await this.readCached();
     const collapsed = collapseById(all);
-    const matches = collapsed.filter((r) => r.idempotencyKey === key);
+    const matches = collapsed.filter(
+      (r) => r.idempotencyKey === key && (sessionId === undefined || r.sessionId === sessionId),
+    );
     return matches.length > 0 ? matches[matches.length - 1]! : null;
   }
 


### PR DESCRIPTION
## Summary

Fix-forward for #1440 (merged as 32609e37). Addresses the four blocking findings from the automated hourly review sweep.

## Changes

| # | Finding | File | Fix |
|---|---------|------|-----|
| F1 | Dedup guard missing `'ambiguous'` - call N>=3 fell through | `hook.ts` | Add `'ambiguous'` to both guards |
| F2 | Cross-session false dedup - same message from two sessions wrongly deduped | `hook.ts` + `store.ts` | Scope `findByIdempotencyKey` to `sessionId` |
| F3 | `computeIdempotencyKey` unguarded throw violated non-blocking contract | `hook.ts` | Wrap in try/catch on both event paths |
| F4 | O(N^2) double file reads per external tool call | `store.ts` | In-memory cache with invalidation on write |

## Verification

- 83/83 effect-ledger tests pass (2 new: N>=3 dedup, cross-session independence)
- `pnpm lint` clean
- `pnpm audit:filesize:check` clean
