### PR TITLE
fix(effect-ledger): guard computeIdempotencyKey throw in pre-hook (#1475)

### DIFF
--- a/src/agent/effect-ledger/hook.test.ts
+++ b/src/agent/effect-ledger/hook.test.ts
@@ -9,9 +9,9 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { createEffectLedgerPostHook } from './hook.js';
+import { createEffectLedgerPostHook, createEffectLedgerPreHook } from './hook.js';
 import { EffectStore } from './store.js';
-import type { PostToolUseContext, PostToolUseFailureContext } from '../hooks.js';
+import type { PostToolUseContext, PostToolUseFailureContext, PreToolUseContext } from '../hooks.js';
 
 let tmpDir: string;
 let ledgerPath: string;
@@ -308,5 +308,38 @@ describe('createEffectLedgerPostHook — return value', () => {
     const decision = await hook(makeCtx());
     expect(decision).toEqual({});
     expect((decision as Record<string, unknown>)['decision']).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PreToolUse hook — computeIdempotencyKey throw guard (#1475)
+// ---------------------------------------------------------------------------
+
+describe('createEffectLedgerPreHook — computeIdempotencyKey throw guard', () => {
+  it('returns {} instead of throwing when input causes computeIdempotencyKey to throw', () => {
+    const pendingIds = new Map<string, string>();
+    const hook = createEffectLedgerPreHook(pendingIds, store);
+
+    // An object with a getter that throws causes stableStringify (used inside
+    // computeIdempotencyKey) to throw. The hook must swallow the error and
+    // return {} to satisfy its non-blocking contract.
+    const throwingInput: Record<string, unknown> = {};
+    Object.defineProperty(throwingInput, 'message', {
+      get() { throw new Error('getter throws'); },
+      enumerable: true,
+    });
+
+    const ctx: PreToolUseContext = {
+      event: 'PreToolUse',
+      toolName: 'send_telegram',
+      input: throwingInput,
+      toolUseId: 'tool-use-1',
+    };
+
+    expect(() => hook(ctx)).not.toThrow();
+    const decision = hook(ctx);
+    expect(decision).toEqual({});
+    // No pending record should have been written for the failing input.
+    expect(pendingIds.size).toBe(0);
   });
 });

--- a/src/agent/effect-ledger/hook.ts
+++ b/src/agent/effect-ledger/hook.ts
@@ -255,7 +255,13 @@ export function createEffectLedgerPreHook(
     const classification = classifyToolCall(toolName, input);
     if (!classification.isExternal) return {};
 
-    const ikey = computeIdempotencyKey(classification.operationType, input);
+    let ikey: string;
+    try {
+      ikey = computeIdempotencyKey(classification.operationType, input);
+    } catch {
+      // Best-effort: stableStringify can throw on exotic objects.
+      return {};
+    }
 
     try {
       const pending = effectStore.writePending({


### PR DESCRIPTION
## Summary

Closes #1475

`createEffectLedgerPreHook` in `src/agent/effect-ledger/hook.ts` called `computeIdempotencyKey` without a try/catch guard. Both call sites in `createEffectLedgerPostHook` (lines 100 and 161) are already guarded — the pre-hook was missed in PR #1474.

`computeIdempotencyKey` can throw when `stableStringify` encounters exotic objects (e.g. inputs with getters that throw). An unhandled throw violates the hook's non-blocking contract.

## Changes

- **`src/agent/effect-ledger/hook.ts`** — wrap the `computeIdempotencyKey` call in `createEffectLedgerPreHook` with the same try/catch + early-return pattern used in the post-hook.
- **`src/agent/effect-ledger/hook.test.ts`** — add a test that exercises the pre-hook with an input whose getter throws, verifying the hook returns `{}` instead of propagating.

## Testing

```
pnpm test src/agent/effect-ledger/hook.test.ts   # 21 passed
pnpm lint                                          # clean
pnpm audit:filesize:check                          # within ceiling
```
