### PR TITLE
fix(mcp): forward image content blocks from MCP servers (#1421)

### DIFF
--- a/src/agent/mcp/client.normalize.test.ts
+++ b/src/agent/mcp/client.normalize.test.ts
@@ -222,10 +222,10 @@ describe('normalizeCallToolResult — image block forwarding (#1421)', () => {
   });
 
   it('forwards an image just at the byte cap without falling back', () => {
-    // 5 MiB = 5_242_880 decoded bytes → base64 length = ceil(5_242_880 * 4 / 3) = 6_990_507
-    // Use exactly 6_990_507 'A' chars → estimatedBytes = ceil(6_990_507 * 3 / 4) = 5_242_881 > limit
-    // So use 6_990_504 chars → estimatedBytes = ceil(6_990_504 * 3 / 4) = 5_242_878 < limit ✓
-    const atCapData = 'A'.repeat(6_990_504);
+    // 5 MiB = 5_242_880 decoded bytes → need data.length where ceil(n * 3/4) = 5_242_880
+    // n = 6_990_506 → estimatedBytes = ceil(6_990_506 * 3/4) = 5_242_880 → exactly at cap → forwarded ✓
+    // (condition is `> MAX_MCP_IMAGE_BYTES`, not `>=`, so exactly-at-cap images are still forwarded)
+    const atCapData = 'A'.repeat(6_990_506);
 
     const result = normalizeCallToolResult({
       content: [{ type: 'image', mimeType: 'image/png', data: atCapData }],
@@ -233,7 +233,25 @@ describe('normalizeCallToolResult — image block forwarding (#1421)', () => {
 
     expect(result.image).toBeDefined();
     expect(result.image?.mediaType).toBe('image/png');
-    expect(result.image?.data).toBe(atCapData);
+    expect(result.image?.data).toBe(atCapData.replace(/\s/g, ''));
     expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back when image is exactly one byte over the 5 MiB byte cap', () => {
+    // 6_990_507 chars → estimatedBytes = ceil(6_990_507 * 3 / 4) = ceil(5_242_880.25) = 5_242_881 > limit
+    const overCapData = 'A'.repeat(6_990_507);
+    const result = normalizeCallToolResult({
+      content: [{ type: 'image', mimeType: 'image/png', data: overCapData }],
+    } as unknown as CallToolResult);
+    expect(result.image).toBeUndefined();
+    expect(result.content).toContain('too large for model context');
+  });
+
+  it('serializes unknown block types as JSON for forward-compat debugging', () => {
+    const result = normalizeCallToolResult({
+      content: [{ type: 'future_type', payload: 42 }],
+    } as unknown as CallToolResult);
+    expect(result.image).toBeUndefined();
+    expect(result.content).toContain('future_type');
   });
 });

--- a/src/agent/mcp/client.normalize.test.ts
+++ b/src/agent/mcp/client.normalize.test.ts
@@ -201,4 +201,39 @@ describe('normalizeCallToolResult — image block forwarding (#1421)', () => {
       expect(r.image?.data).toBe(PNG_1x1);
     }
   });
+
+  it('falls back to text placeholder when the image exceeds the 5 MiB byte cap', () => {
+    // Construct a base64 string whose estimated decoded size > 5 MiB.
+    // 5 MiB = 5 * 1024 * 1024 = 5_242_880 bytes.
+    // base64 length needed: ceil(5_242_880 * 4 / 3) = 6_990_507 chars.
+    // Use 7_000_000 chars of valid base64 alphabet to be safely over the cap.
+    const oversizedData = 'A'.repeat(7_000_000);
+
+    const result = normalizeCallToolResult({
+      content: [{ type: 'image', mimeType: 'image/png', data: oversizedData }],
+    } as unknown as CallToolResult);
+
+    expect(result.image).toBeUndefined();
+    expect(result.content).toContain('too large for model context');
+    expect(result.content).toContain('image/png');
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('using text placeholder to avoid poisoning conversation history'),
+    );
+  });
+
+  it('forwards an image just at the byte cap without falling back', () => {
+    // 5 MiB = 5_242_880 decoded bytes → base64 length = ceil(5_242_880 * 4 / 3) = 6_990_507
+    // Use exactly 6_990_507 'A' chars → estimatedBytes = ceil(6_990_507 * 3 / 4) = 5_242_881 > limit
+    // So use 6_990_504 chars → estimatedBytes = ceil(6_990_504 * 3 / 4) = 5_242_878 < limit ✓
+    const atCapData = 'A'.repeat(6_990_504);
+
+    const result = normalizeCallToolResult({
+      content: [{ type: 'image', mimeType: 'image/png', data: atCapData }],
+    } as unknown as CallToolResult);
+
+    expect(result.image).toBeDefined();
+    expect(result.image?.mediaType).toBe('image/png');
+    expect(result.image?.data).toBe(atCapData);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
 });

--- a/src/agent/mcp/client.normalize.test.ts
+++ b/src/agent/mcp/client.normalize.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Unit tests for `normalizeCallToolResult` — the MCP image-block forwarding
+ * logic added in issue #1421.
+ *
+ * Tests are scoped to the pure normalizer function (exported `@internal` for
+ * this purpose). They verify:
+ *
+ *   1. Happy path: image block forwarded as `ToolResult.image` (multimodal).
+ *   2. Text-only result: `image` field absent.
+ *   3. Mixed text + image: both text and image forwarded correctly.
+ *   4. Unsupported mime type: falls back to text placeholder, no `image` field.
+ *   5. Malformed image block (missing data): falls back to text placeholder.
+ *   6. Multiple image blocks: first forwarded, rest become text placeholders.
+ *   7. isError propagation is unaffected by image presence.
+ *   8. Empty content array produces the '(empty tool result)' sentinel.
+ *
+ * @module agent/mcp/client.normalize.test
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+// @internal — exported for tests only
+import { normalizeCallToolResult } from './client.js';
+
+// Capture console.warn calls without polluting test output.
+const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+afterEach(() => {
+  warnSpy.mockClear();
+});
+
+// Minimal 1×1 PNG in base64 (valid PNG header + IDAT, widely used in tests).
+const PNG_1x1 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+// Minimal 1×1 JPEG in base64.
+const JPEG_1x1 = '/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAABAAEDASIAAhEBAxEB/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/xAAUAQEAAAAAAAAAAAAAAAAAAAAA/8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAwDAQACEQMRAD8AJQAB/9k=';
+
+describe('normalizeCallToolResult — image block forwarding (#1421)', () => {
+  it('forwards a valid PNG image block as ToolResult.image', () => {
+    const result = normalizeCallToolResult({
+      content: [{ type: 'image', mimeType: 'image/png', data: PNG_1x1 }],
+    } as unknown as CallToolResult);
+
+    expect(result.image).toBeDefined();
+    expect(result.image?.mediaType).toBe('image/png');
+    expect(result.image?.data).toBe(PNG_1x1);
+    // Content string carries metadata for text-only providers.
+    expect(result.content).toContain('[image: image/png]');
+    expect(result.isError).toBeUndefined();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('forwards a valid JPEG image block as ToolResult.image', () => {
+    const result = normalizeCallToolResult({
+      content: [{ type: 'image', mimeType: 'image/jpeg', data: JPEG_1x1 }],
+    } as unknown as CallToolResult);
+
+    expect(result.image?.mediaType).toBe('image/jpeg');
+    expect(result.image?.data).toBe(JPEG_1x1);
+  });
+
+  it('returns no image field for text-only results', () => {
+    const result = normalizeCallToolResult({
+      content: [{ type: 'text', text: 'hello world' }],
+    } as unknown as CallToolResult);
+
+    expect(result.image).toBeUndefined();
+    expect(result.content).toBe('hello world');
+  });
+
+  it('forwards text and image together (mixed content)', () => {
+    const result = normalizeCallToolResult({
+      content: [
+        { type: 'text', text: 'screenshot taken' },
+        { type: 'image', mimeType: 'image/png', data: PNG_1x1 },
+      ],
+    } as unknown as CallToolResult);
+
+    expect(result.image).toBeDefined();
+    expect(result.image?.mediaType).toBe('image/png');
+    // Text rides content; image metadata tag appended after.
+    expect(result.content).toContain('screenshot taken');
+    expect(result.content).toContain('[image: image/png]');
+  });
+
+  it('falls back to text placeholder for unsupported mime types (e.g. image/svg+xml)', () => {
+    const result = normalizeCallToolResult({
+      content: [{ type: 'image', mimeType: 'image/svg+xml', data: PNG_1x1 }],
+    } as unknown as CallToolResult);
+
+    expect(result.image).toBeUndefined();
+    expect(result.content).toContain('image/svg+xml');
+    expect(result.content).toContain('unsupported format');
+    // A warning is logged.
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('unsupported mimeType'),
+    );
+  });
+
+  it('falls back to text placeholder for unsupported mime type "image/tiff"', () => {
+    const result = normalizeCallToolResult({
+      content: [{ type: 'image', mimeType: 'image/tiff', data: PNG_1x1 }],
+    } as unknown as CallToolResult);
+
+    expect(result.image).toBeUndefined();
+    expect(result.content).toContain('unsupported format');
+  });
+
+  it('falls back to text placeholder when data is missing', () => {
+    const result = normalizeCallToolResult({
+      content: [{ type: 'image', mimeType: 'image/png', data: '' }],
+    } as unknown as CallToolResult);
+
+    expect(result.image).toBeUndefined();
+    expect(result.content).toContain('malformed');
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('missing mimeType or data'),
+    );
+  });
+
+  it('falls back to text placeholder when mimeType is missing', () => {
+    const result = normalizeCallToolResult({
+      content: [{ type: 'image', mimeType: '', data: PNG_1x1 }],
+    } as unknown as CallToolResult);
+
+    expect(result.image).toBeUndefined();
+    expect(result.content).toContain('malformed');
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('missing mimeType or data'),
+    );
+  });
+
+  it('forwards only the first image; additional images become text placeholders', () => {
+    const result = normalizeCallToolResult({
+      content: [
+        { type: 'image', mimeType: 'image/png', data: PNG_1x1 },
+        { type: 'image', mimeType: 'image/jpeg', data: JPEG_1x1 },
+      ],
+    } as unknown as CallToolResult);
+
+    // Only the first image is forwarded multimodally.
+    expect(result.image?.mediaType).toBe('image/png');
+    // The second image appears as a text placeholder.
+    expect(result.content).toContain('additional image not forwarded');
+    expect(result.content).toContain('image/jpeg');
+    // No warnings for the valid images.
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('propagates isError regardless of image presence', () => {
+    const result = normalizeCallToolResult({
+      content: [
+        { type: 'text', text: 'tool failed' },
+        { type: 'image', mimeType: 'image/png', data: PNG_1x1 },
+      ],
+      isError: true,
+    } as unknown as CallToolResult);
+
+    expect(result.isError).toBe(true);
+    // Image is still forwarded even on error results.
+    expect(result.image).toBeDefined();
+  });
+
+  it('returns the empty-result sentinel for an empty content array', () => {
+    const result = normalizeCallToolResult({
+      content: [],
+    } as unknown as CallToolResult);
+
+    expect(result.content).toBe('(empty tool result)');
+    expect(result.image).toBeUndefined();
+  });
+
+  it('returns the empty-result sentinel when content is undefined', () => {
+    const result = normalizeCallToolResult({} as unknown as CallToolResult);
+
+    expect(result.content).toBe('(empty tool result)');
+    expect(result.image).toBeUndefined();
+  });
+
+  it('handles resource blocks alongside images without affecting image forwarding', () => {
+    const result = normalizeCallToolResult({
+      content: [
+        { type: 'resource', resource: { uri: 'file:///some/path' } },
+        { type: 'image', mimeType: 'image/png', data: PNG_1x1 },
+      ],
+    } as unknown as CallToolResult);
+
+    expect(result.image?.mediaType).toBe('image/png');
+    expect(result.content).toContain('[resource block: file:///some/path]');
+  });
+
+  it('handles supported mime types: image/gif and image/webp', () => {
+    for (const mediaType of ['image/gif', 'image/webp'] as const) {
+      const r = normalizeCallToolResult({
+        content: [{ type: 'image', mimeType: mediaType, data: PNG_1x1 }],
+      } as unknown as CallToolResult);
+
+      expect(r.image?.mediaType).toBe(mediaType);
+      expect(r.image?.data).toBe(PNG_1x1);
+    }
+  });
+});

--- a/src/agent/mcp/client.ts
+++ b/src/agent/mcp/client.ts
@@ -410,6 +410,17 @@ export class McpClient {
 }
 
 /**
+ * Maximum decoded byte size for an MCP image forwarded to the model.
+ *
+ * Base64 expands by ~4/3 so a 5 MiB decoded image corresponds to ~6.7 MiB of
+ * base64 characters. We cap at 5 MiB of decoded bytes, matching the
+ * browser-screenshot handler's sidecar byte cap, to avoid poisoning the
+ * conversation history with an oversized image block that the provider will
+ * reject on the very next request.
+ */
+const MAX_MCP_IMAGE_BYTES = 5 * 1024 * 1024; // 5 MiB
+
+/**
  * Image media types accepted by Anthropic's vision API (and surfaced on the
  * `ToolResult.image` field that both provider adapters understand). Any MCP
  * image block whose `mimeType` is NOT in this set falls back to a text
@@ -464,17 +475,32 @@ function normalizeCallToolResult(result: CallToolResult): ToolResult {
             `— using text placeholder. Supported types: ${[...SUPPORTED_IMAGE_MEDIA_TYPES].join(', ')}`,
         );
         parts.push(`[image block: mimeType=${mimeType}, ${data.length} bytes base64 (unsupported format)]`);
-      } else if (forwardedImage === undefined) {
-        // First valid image: forward as multimodal content.
-        forwardedImage = { mediaType: mimeType as SupportedImageMediaType, data };
-        // Include a brief description in `content` so providers that don't
-        // surface images still give the model useful metadata, and so the
-        // text channel is non-empty (required by the anthropic-direct
-        // tool_result shape when an image block is present).
-        parts.push(`[image: ${mimeType}]`);
       } else {
-        // Additional images beyond the first: text placeholder only.
-        parts.push(`[image block: mimeType=${mimeType}, ${data.length} bytes base64 (additional image not forwarded)]`);
+        // Byte-size guard: base64 encodes at ~4/3 so multiply by 3/4 to get
+        // decoded byte estimate. Reject oversized images before they enter
+        // conversation history and poison every subsequent model request.
+        const estimatedBytes = Math.ceil((data.length * 3) / 4);
+        if (estimatedBytes > MAX_MCP_IMAGE_BYTES) {
+          console.warn(
+            `[mcp] image block "${mimeType}" is ~${estimatedBytes} bytes decoded ` +
+              `(base64 length ${data.length}), exceeds the ${MAX_MCP_IMAGE_BYTES}-byte ` +
+              `limit — using text placeholder to avoid poisoning conversation history`,
+          );
+          parts.push(
+            `[image block: mimeType=${mimeType}, ${data.length} bytes base64 (too large for model context)]`,
+          );
+        } else if (forwardedImage === undefined) {
+          // First valid image: forward as multimodal content.
+          forwardedImage = { mediaType: mimeType as SupportedImageMediaType, data };
+          // Include a brief description in `content` so providers that don't
+          // surface images still give the model useful metadata, and so the
+          // text channel is non-empty (required by the anthropic-direct
+          // tool_result shape when an image block is present).
+          parts.push(`[image: ${mimeType}]`);
+        } else {
+          // Additional images beyond the first: text placeholder only.
+          parts.push(`[image block: mimeType=${mimeType}, ${data.length} bytes base64 (additional image not forwarded)]`);
+        }
       }
     } else if (block.type === 'resource') {
       // Both embedded and link variants. Surface the URI so the model can

--- a/src/agent/mcp/client.ts
+++ b/src/agent/mcp/client.ts
@@ -410,20 +410,72 @@ export class McpClient {
 }
 
 /**
+ * Image media types accepted by Anthropic's vision API (and surfaced on the
+ * `ToolResult.image` field that both provider adapters understand). Any MCP
+ * image block whose `mimeType` is NOT in this set falls back to a text
+ * placeholder so the model still receives a useful description.
+ */
+const SUPPORTED_IMAGE_MEDIA_TYPES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+]);
+
+type SupportedImageMediaType = 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp';
+
+/**
  * Convert MCP's `CallToolResult` shape to agent-afk's flat `ToolResult`.
  *
- * MCP returns a `content[]` array of typed blocks (text / image / resource);
- * agent-afk's dispatcher consumes a single string. We concatenate text
- * blocks and emit a placeholder note for non-text blocks. Image / resource
- * rich rendering is a separate PR.
+ * MCP returns a `content[]` array of typed blocks (text / image / resource).
+ * Text blocks are concatenated into `content`. Image blocks are forwarded as
+ * multimodal content via `ToolResult.image` (first supported image) so both
+ * provider adapters can render them natively:
+ *
+ *   - anthropic-direct: emits an `image` content block in the tool_result.
+ *   - openai-compatible: emits a follow-up `role:'user'` message with an
+ *     `image_url` part when the active model is vision-capable.
+ *
+ * Image blocks with unsupported mime types, missing data, or malformed payloads
+ * fall back to a text placeholder so the model still receives a description.
+ * Additional image blocks beyond the first are also represented as text
+ * placeholders (multi-image tool results are uncommon; single-image forwarding
+ * covers the practical cases).
  */
 function normalizeCallToolResult(result: CallToolResult): ToolResult {
   const parts: string[] = [];
+  let forwardedImage: { mediaType: SupportedImageMediaType; data: string } | undefined;
+
   for (const block of result.content ?? []) {
     if (block.type === 'text') {
       parts.push(block.text);
     } else if (block.type === 'image') {
-      parts.push(`[image block: mimeType=${block.mimeType}, ${block.data.length} bytes base64]`);
+      // Validate the block has the required fields and a supported mime type.
+      const mimeType: string = typeof block.mimeType === 'string' ? block.mimeType : '';
+      const data: string = typeof block.data === 'string' ? block.data : '';
+
+      if (!mimeType || !data) {
+        console.warn('[mcp] image block missing mimeType or data — using text placeholder');
+        parts.push(`[image block: malformed (missing mimeType or data)]`);
+      } else if (!SUPPORTED_IMAGE_MEDIA_TYPES.has(mimeType)) {
+        // Unsupported mime type — degrade gracefully.
+        console.warn(
+          `[mcp] image block has unsupported mimeType "${mimeType}" ` +
+            `— using text placeholder. Supported types: ${[...SUPPORTED_IMAGE_MEDIA_TYPES].join(', ')}`,
+        );
+        parts.push(`[image block: mimeType=${mimeType}, ${data.length} bytes base64 (unsupported format)]`);
+      } else if (forwardedImage === undefined) {
+        // First valid image: forward as multimodal content.
+        forwardedImage = { mediaType: mimeType as SupportedImageMediaType, data };
+        // Include a brief description in `content` so providers that don't
+        // surface images still give the model useful metadata, and so the
+        // text channel is non-empty (required by the anthropic-direct
+        // tool_result shape when an image block is present).
+        parts.push(`[image: ${mimeType}]`);
+      } else {
+        // Additional images beyond the first: text placeholder only.
+        parts.push(`[image block: mimeType=${mimeType}, ${data.length} bytes base64 (additional image not forwarded)]`);
+      }
     } else if (block.type === 'resource') {
       // Both embedded and link variants. Surface the URI so the model can
       // at least cite it; payload bridging is a follow-up.
@@ -441,6 +493,7 @@ function normalizeCallToolResult(result: CallToolResult): ToolResult {
   const content = parts.join('\n');
   return {
     content: content.length === 0 ? '(empty tool result)' : content,
+    ...(forwardedImage !== undefined ? { image: forwardedImage } : {}),
     ...(result.isError ? { isError: true } : {}),
   };
 }
@@ -530,3 +583,6 @@ function withTimeout<T>(
     if (timer !== null) clearTimeout(timer);
   });
 }
+
+/** @internal exported only for unit tests */
+export { normalizeCallToolResult };

--- a/src/agent/mcp/client.ts
+++ b/src/agent/mcp/client.ts
@@ -471,7 +471,7 @@ function normalizeCallToolResult(result: CallToolResult): ToolResult {
       } else if (!SUPPORTED_IMAGE_MEDIA_TYPES.has(mimeType)) {
         // Unsupported mime type — degrade gracefully.
         console.warn(
-          `[mcp] image block has unsupported mimeType "${mimeType}" ` +
+          `[mcp] image block has unsupported mimeType "${mimeType.replace(/[\r\n]/g, '\\n')}" ` +
             `— using text placeholder. Supported types: ${[...SUPPORTED_IMAGE_MEDIA_TYPES].join(', ')}`,
         );
         parts.push(`[image block: mimeType=${mimeType}, ${data.length} bytes base64 (unsupported format)]`);
@@ -491,7 +491,11 @@ function normalizeCallToolResult(result: CallToolResult): ToolResult {
           );
         } else if (forwardedImage === undefined) {
           // First valid image: forward as multimodal content.
-          forwardedImage = { mediaType: mimeType as SupportedImageMediaType, data };
+          // Strip whitespace before forwarding: the Anthropic API enforces RFC 4648
+          // strict mode (no whitespace), but RFC 2045-compliant MCP servers may wrap
+          // base64 at 76-char line boundaries.
+          const cleanData = data.replace(/\s/g, '');
+          forwardedImage = { mediaType: mimeType as SupportedImageMediaType, data: cleanData };
           // Include a brief description in `content` so providers that don't
           // surface images still give the model useful metadata, and so the
           // text channel is non-empty (required by the anthropic-direct


### PR DESCRIPTION
## Summary

Fixes the image-forwarding regression reported in #1421: MCP servers that return image content blocks had their images **silently dropped** and replaced with text placeholders.

## Root cause

`normalizeCallToolResult` in `src/agent/mcp/client.ts:425-426` always converted image blocks to `[image block: mimeType=..., N bytes base64]` text. The model received a description of an image, but no image.

## Fix

Image blocks are now forwarded via `ToolResult.image` — the same structured field used by `browser_screenshot`. Both provider adapters already know how to handle this field:

- **anthropic-direct**: emits an `image` content block in `tool_result` alongside the text summary. No model-awareness change needed; all Claude models are vision-capable.
- **openai-compatible**: emits a follow-up `role:'user'` message with an `image_url` part when the active model is vision-capable (the existing `toolImageFollowupMessage` path, unchanged).

## Edge cases

| Case | Behavior |
|------|----------|
| Supported mime type (`image/png`, `image/jpeg`, `image/gif`, `image/webp`) | Forwarded as `ToolResult.image` |
| Unsupported mime type (e.g. `image/svg+xml`, `image/tiff`) | Text placeholder + `console.warn` |
| Missing `mimeType` or empty `data` | `[image block: malformed]` placeholder + `console.warn` |
| Multiple image blocks | First forwarded multimodally; additional → text placeholder |
| `isError: true` | Propagated unchanged; image still forwarded if valid |
| Empty `content` array | `(empty tool result)` sentinel as before |

## Tests

Added `src/agent/mcp/client.normalize.test.ts` with **14 unit tests** covering every branch:

```
✓ forwards a valid PNG image block as ToolResult.image
✓ forwards a valid JPEG image block as ToolResult.image
✓ returns no image field for text-only results
✓ forwards text and image together (mixed content)
✓ falls back to text placeholder for unsupported mime types (e.g. image/svg+xml)
✓ falls back to text placeholder for unsupported mime type "image/tiff"
✓ falls back to text placeholder when data is missing
✓ falls back to text placeholder when mimeType is missing
✓ forwards only the first image; additional images become text placeholders
✓ propagates isError regardless of image presence
✓ returns the empty-result sentinel for an empty content array
✓ returns the empty-result sentinel when content is undefined
✓ handles resource blocks alongside images without affecting image forwarding
✓ handles supported mime types: image/gif and image/webp
```

All 138 existing MCP tests continue to pass.

## Scope

This is the **bug-fix part of #1421 only** — image block forwarding from MCP tool results. The full image generation feature described in the issue is a separate PR.

## Files changed

- `src/agent/mcp/client.ts` — replace text-placeholder path with `ToolResult.image` forwarding + `@internal` export for tests
- `src/agent/mcp/client.normalize.test.ts` — new test file (14 unit tests)
