### PR TITLE
fix(security): contain project-local MCP stdio server env (#578)

### DIFF
--- a/.filesize-baseline.json
+++ b/.filesize-baseline.json
@@ -3,7 +3,7 @@
   "entries": {
     "scripts/audit-sdk-dependency.ts": { "loc": 450, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/agent/background-registry.ts": { "loc": 374, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/agent/daemon/scheduler.ts": { "loc": 566, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/agent/daemon/scheduler.ts": { "loc": 568, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/agent/memory/memory-store.ts": { "loc": 687, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/agent/memory/memory-tools.ts": { "loc": 437, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/agent/providers/openai-compatible/index.ts": { "loc": 400, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
@@ -21,7 +21,7 @@
     "src/agent/trace/receipt.ts": { "loc": 412, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/agent/worktree-sweep.ts": { "loc": 512, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/cli/_lib/testing/virtual-screen.ts": { "loc": 422, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/cli/commands/chat.ts": { "loc": 575, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/cli/commands/chat.ts": { "loc": 577, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/cli/commands/daemon.ts": { "loc": 393, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/cli/commands/farm.ts": { "loc": 436, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/cli/commands/interactive.ts": { "loc": 599, "reason": "legacy: predates the ceiling gate; pending concern extraction" },

--- a/src/agent/daemon/scheduler.ts
+++ b/src/agent/daemon/scheduler.ts
@@ -742,6 +742,7 @@ export class CronScheduler {
           mcpManager = await McpManager.fromConfig(loadedMcp.mcpServers, {
             warnings: loadedMcp.warnings,
             serverLayers: loadedMcp.serverLayers,
+            userAllowSecretEnv: loadedMcp.userAllowSecretEnv,
             ...(trace?.writer !== undefined ? { traceWriter: trace.writer } : {}),
           });
         } finally {

--- a/src/agent/daemon/scheduler.ts
+++ b/src/agent/daemon/scheduler.ts
@@ -741,6 +741,7 @@ export class CronScheduler {
         try {
           mcpManager = await McpManager.fromConfig(loadedMcp.mcpServers, {
             warnings: loadedMcp.warnings,
+            serverLayers: loadedMcp.serverLayers,
             ...(trace?.writer !== undefined ? { traceWriter: trace.writer } : {}),
           });
         } finally {

--- a/src/agent/mcp/client.ts
+++ b/src/agent/mcp/client.ts
@@ -90,6 +90,8 @@ export class McpClient {
   private readonly serverName: string;
   private readonly config: McpServerConfig;
   private readonly layer: McpServerLayer;
+  /** Trusted allowlist from user-global config (issue #1483). */
+  private readonly trustedAllowSecretEnv: readonly string[];
   private client: Client | undefined;
   private connected = false;
   /**
@@ -117,10 +119,11 @@ export class McpClient {
    */
   onToolListChanged?: () => void;
 
-  constructor(serverName: string, config: McpServerConfig, layer: McpServerLayer = 'user-global') {
+  constructor(serverName: string, config: McpServerConfig, layer: McpServerLayer = 'user-global', trustedAllowSecretEnv: readonly string[] = []) {
     this.serverName = serverName;
     this.config = config;
     this.layer = layer;
+    this.trustedAllowSecretEnv = trustedAllowSecretEnv;
   }
 
   /**
@@ -157,6 +160,7 @@ export class McpClient {
       this.config,
       oauthProvider,
       this.layer,
+      this.trustedAllowSecretEnv,
     );
 
     const client = new Client(CLIENT_INFO, { capabilities: CLIENT_CAPABILITIES });
@@ -459,16 +463,17 @@ function buildTransportPair(
   config: McpServerConfig,
   oauthProvider: KeychainOAuthProvider | undefined,
   layer: McpServerLayer = 'user-global',
+  trustedAllowSecretEnv: readonly string[] = [],
 ): {
   primary: import('./transport.js').CreateTransportResult;
   fallback: (() => import('./transport.js').CreateTransportResult) | null;
 } {
   const effectiveType = config.type ?? (config.command ? 'stdio' : 'streamable-http');
-  const primary = createTransport(serverName, config, oauthProvider, layer);
+  const primary = createTransport(serverName, config, oauthProvider, layer, trustedAllowSecretEnv);
   // Only streamable-HTTP supports the SSE fallback probe.
   const fallback =
     effectiveType === 'streamable-http'
-      ? () => createTransport(serverName, { ...config, type: 'sse' }, oauthProvider, layer)
+      ? () => createTransport(serverName, { ...config, type: 'sse' }, oauthProvider, layer, trustedAllowSecretEnv)
       : null;
   return { primary, fallback };
 }

--- a/src/agent/mcp/client.ts
+++ b/src/agent/mcp/client.ts
@@ -48,6 +48,7 @@ import type { ToolResult } from '../tools/types.js';
 import type { McpServerConfig } from './types.js';
 import { createTransport } from './transport.js';
 import { KeychainOAuthProvider } from './oauth.js';
+import type { McpServerLayer } from './env-containment.js';
 
 /** Client identity advertised in the MCP handshake. */
 const CLIENT_INFO = {
@@ -88,6 +89,7 @@ export interface McpClientConnectResult {
 export class McpClient {
   private readonly serverName: string;
   private readonly config: McpServerConfig;
+  private readonly layer: McpServerLayer;
   private client: Client | undefined;
   private connected = false;
   /**
@@ -115,9 +117,10 @@ export class McpClient {
    */
   onToolListChanged?: () => void;
 
-  constructor(serverName: string, config: McpServerConfig) {
+  constructor(serverName: string, config: McpServerConfig, layer: McpServerLayer = 'user-global') {
     this.serverName = serverName;
     this.config = config;
+    this.layer = layer;
   }
 
   /**
@@ -153,6 +156,7 @@ export class McpClient {
       this.serverName,
       this.config,
       oauthProvider,
+      this.layer,
     );
 
     const client = new Client(CLIENT_INFO, { capabilities: CLIENT_CAPABILITIES });
@@ -454,16 +458,17 @@ function buildTransportPair(
   serverName: string,
   config: McpServerConfig,
   oauthProvider: KeychainOAuthProvider | undefined,
+  layer: McpServerLayer = 'user-global',
 ): {
   primary: import('./transport.js').CreateTransportResult;
   fallback: (() => import('./transport.js').CreateTransportResult) | null;
 } {
   const effectiveType = config.type ?? (config.command ? 'stdio' : 'streamable-http');
-  const primary = createTransport(serverName, config, oauthProvider);
+  const primary = createTransport(serverName, config, oauthProvider, layer);
   // Only streamable-HTTP supports the SSE fallback probe.
   const fallback =
     effectiveType === 'streamable-http'
-      ? () => createTransport(serverName, { ...config, type: 'sse' }, oauthProvider)
+      ? () => createTransport(serverName, { ...config, type: 'sse' }, oauthProvider, layer)
       : null;
   return { primary, fallback };
 }

--- a/src/agent/mcp/config-loader.ts
+++ b/src/agent/mcp/config-loader.ts
@@ -34,6 +34,7 @@ import { isAbsolute, join, relative } from 'node:path';
 import { getAfkConfigDir, getPluginsDir } from '../../paths.js';
 import { sanitizeForDisplay } from '../../utils/terminal-sanitize.js';
 import type { McpServerConfig } from './types.js';
+import type { McpServerLayer } from './env-containment.js';
 
 /** Shape of `~/.afk/config/mcp.json`. */
 export interface McpConfigFile {
@@ -47,6 +48,17 @@ export interface LoadedMcpConfig {
   sources: string[];
   /** Non-fatal validation warnings the caller should surface to the user. */
   warnings: string[];
+  /**
+   * Layer origin for each server (issue #578). Maps server name → layer so
+   * `McpManager.fromConfig()` can pass the correct containment level to
+   * each `McpClient` without re-deriving it from source paths.
+   *
+   * Servers from `<cwd>/.mcp.json` → `'project'`
+   * Servers from `~/.afk/config/mcp.json` → `'user-global'`
+   * Servers from plugin manifests → `'plugin'`
+   * Servers from `--mcp-config` → `'cli'`
+   */
+  serverLayers: Record<string, McpServerLayer>;
 }
 
 /**
@@ -223,6 +235,12 @@ function validateServer(
   if (typeof obj['timeout'] === 'number' && obj['timeout'] > 0) {
     config.timeout = obj['timeout'];
   }
+  // issue #578 — opt-in allowlist for secret env-var expansion (project layer only)
+  if (Array.isArray(obj['allowSecretEnv'])) {
+    config.allowSecretEnv = (obj['allowSecretEnv'] as unknown[]).filter(
+      (v): v is string => typeof v === 'string',
+    );
+  }
   return { ok: true, config };
 }
 
@@ -234,7 +252,7 @@ function validateServer(
  */
 export function loadMcpConfigFile(path: string): LoadedMcpConfig {
   if (!existsSync(path)) {
-    return { mcpServers: {}, sources: [], warnings: [] };
+    return { mcpServers: {}, sources: [], warnings: [], serverLayers: {} };
   }
   const warnings: string[] = [];
   let parsed: unknown;
@@ -243,17 +261,17 @@ export function loadMcpConfigFile(path: string): LoadedMcpConfig {
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     warnings.push(`mcp.json at ${path}: parse error — ${msg}`);
-    return { mcpServers: {}, sources: [path], warnings };
+    return { mcpServers: {}, sources: [path], warnings, serverLayers: {} };
   }
 
   if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
     warnings.push(`mcp.json at ${path}: top-level must be an object`);
-    return { mcpServers: {}, sources: [path], warnings };
+    return { mcpServers: {}, sources: [path], warnings, serverLayers: {} };
   }
   const file = parsed as McpConfigFile;
   const rawServers = file.mcpServers;
   if (rawServers === undefined || rawServers === null || typeof rawServers !== 'object') {
-    return { mcpServers: {}, sources: [path], warnings };
+    return { mcpServers: {}, sources: [path], warnings, serverLayers: {} };
   }
 
   const mcpServers: Record<string, McpServerConfig> = {};
@@ -265,7 +283,9 @@ export function loadMcpConfigFile(path: string): LoadedMcpConfig {
       warnings.push(`mcp.json at ${path}: skipping ${result.error}`);
     }
   }
-  return { mcpServers, sources: [path], warnings };
+  // serverLayers is populated by loadMcpConfig() — the file loader doesn't
+  // know which layer it is in (that depends on which path was passed).
+  return { mcpServers, sources: [path], warnings, serverLayers: {} };
 }
 
 /**
@@ -317,6 +337,7 @@ export interface LoadMcpConfigOptions {
 interface TaggedServer {
   config: McpServerConfig;
   source: string;
+  layer: McpServerLayer;
 }
 
 /**
@@ -354,7 +375,7 @@ function safeLabel(s: string, maxLen: number): string {
  * Do not reorder without updating the conflict-reporting logic below.
  */
 export function loadMcpConfig(opts: LoadMcpConfigOptions = {}): LoadedMcpConfig {
-  const layers: { path: string; loaded: LoadedMcpConfig }[] = [];
+  const layers: { path: string; loaded: LoadedMcpConfig; layer: McpServerLayer }[] = [];
   // Pre-warnings emitted during layer assembly (before allWarnings is declared).
   const preWarnings: string[] = [];
 
@@ -363,7 +384,8 @@ export function loadMcpConfig(opts: LoadMcpConfigOptions = {}): LoadedMcpConfig 
   // configs all win on per-server-name conflict.
   if (opts.importedMcpConfigs && opts.importedMcpConfigs.length > 0) {
     for (const p of opts.importedMcpConfigs) {
-      layers.push({ path: p, loaded: loadMcpConfigFile(p) });
+      // Imported binaries are treated as user-global (trusted operator source).
+      layers.push({ path: p, loaded: loadMcpConfigFile(p), layer: 'user-global' });
     }
   }
 
@@ -374,14 +396,14 @@ export function loadMcpConfig(opts: LoadMcpConfigOptions = {}): LoadedMcpConfig 
       ? discoverPluginMcpConfigs(pluginsRoot)
       : discoverPluginMcpConfigs();
     for (const p of pluginMcpPaths) {
-      layers.push({ path: p, loaded: loadMcpConfigFile(p) });
+      layers.push({ path: p, loaded: loadMcpConfigFile(p), layer: 'plugin' });
     }
   }
 
   // Layer 1 — user-global.
   if (!opts.skipUserGlobal) {
     const userPath = getMcpConfigPath();
-    layers.push({ path: userPath, loaded: loadMcpConfigFile(userPath) });
+    layers.push({ path: userPath, loaded: loadMcpConfigFile(userPath), layer: 'user-global' });
   }
 
   // Layer 2 — project-local (issue #571: fail-closed, opt-IN).
@@ -404,7 +426,7 @@ export function loadMcpConfig(opts: LoadMcpConfigOptions = {}): LoadedMcpConfig 
       );
     } else if (existsSync(projectPath)) {
       if (projectMcpOptIn(env.AFK_ALLOW_PROJECT_MCP)) {
-        layers.push({ path: projectPath, loaded: loadMcpConfigFile(projectPath) });
+        layers.push({ path: projectPath, loaded: loadMcpConfigFile(projectPath), layer: 'project' });
         preWarnings.push(
           `mcp: loaded project-local config from ${projectPath} ` +
             '(AFK_ALLOW_PROJECT_MCP is set).',
@@ -440,6 +462,7 @@ export function loadMcpConfig(opts: LoadMcpConfigOptions = {}): LoadedMcpConfig 
     layers.push({
       path: opts.cliOverride,
       loaded: loadMcpConfigFile(opts.cliOverride),
+      layer: 'cli',
     });
   }
 
@@ -448,28 +471,30 @@ export function loadMcpConfig(opts: LoadMcpConfigOptions = {}): LoadedMcpConfig 
   const allWarnings: string[] = [...preWarnings];
   const allSources: string[] = [];
 
-  for (const layer of layers) {
-    for (const w of layer.loaded.warnings) allWarnings.push(w);
-    if (layer.loaded.sources.length > 0) {
-      for (const src of layer.loaded.sources) {
+  for (const { path: layerPath, loaded, layer: layerKind } of layers) {
+    for (const w of loaded.warnings) allWarnings.push(w);
+    if (loaded.sources.length > 0) {
+      for (const src of loaded.sources) {
         if (!allSources.includes(src)) allSources.push(src);
       }
     }
-    for (const [name, config] of Object.entries(layer.loaded.mcpServers)) {
+    for (const [name, config] of Object.entries(loaded.mcpServers)) {
       const prior = winners.get(name);
       if (prior) {
         allWarnings.push(
-          `mcp: server "${name}" defined in ${prior.source} is overridden by ${layer.path}`,
+          `mcp: server "${name}" defined in ${prior.source} is overridden by ${layerPath}`,
         );
       }
-      winners.set(name, { config, source: layer.path });
+      winners.set(name, { config, source: layerPath, layer: layerKind });
     }
   }
 
   const mcpServers: Record<string, McpServerConfig> = {};
+  const serverLayers: Record<string, McpServerLayer> = {};
   for (const [name, tagged] of winners) {
     mcpServers[name] = tagged.config;
+    serverLayers[name] = tagged.layer;
   }
 
-  return { mcpServers, sources: allSources, warnings: allWarnings };
+  return { mcpServers, sources: allSources, warnings: allWarnings, serverLayers };
 }

--- a/src/agent/mcp/config-loader.ts
+++ b/src/agent/mcp/config-loader.ts
@@ -59,6 +59,20 @@ export interface LoadedMcpConfig {
    * Servers from `--mcp-config` → `'cli'`
    */
   serverLayers: Record<string, McpServerLayer>;
+  /**
+   * Secret-expansion allowlist extracted ONLY from user-global config entries
+   * (issue #1483). Maps server name → `allowSecretEnv` array from the
+   * user's `~/.afk/config/mcp.json`.
+   *
+   * Project-layer `.mcp.json` cannot self-authorize secret expansion — an
+   * untrusted repo could include both the `env` placeholder and the
+   * `allowSecretEnv` opt-in in the same file, making the gate self-bypassing.
+   * Only the operator's own user-global config is the trusted source of truth.
+   *
+   * Transport code must use THIS map (not `config.allowSecretEnv`) when
+   * deciding whether to expand a secret variable for a project-local server.
+   */
+  userAllowSecretEnv: Record<string, string[]>;
 }
 
 /**
@@ -252,7 +266,7 @@ function validateServer(
  */
 export function loadMcpConfigFile(path: string): LoadedMcpConfig {
   if (!existsSync(path)) {
-    return { mcpServers: {}, sources: [], warnings: [], serverLayers: {} };
+    return { mcpServers: {}, sources: [], warnings: [], serverLayers: {}, userAllowSecretEnv: {} };
   }
   const warnings: string[] = [];
   let parsed: unknown;
@@ -261,17 +275,17 @@ export function loadMcpConfigFile(path: string): LoadedMcpConfig {
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     warnings.push(`mcp.json at ${path}: parse error — ${msg}`);
-    return { mcpServers: {}, sources: [path], warnings, serverLayers: {} };
+    return { mcpServers: {}, sources: [path], warnings, serverLayers: {}, userAllowSecretEnv: {} };
   }
 
   if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
     warnings.push(`mcp.json at ${path}: top-level must be an object`);
-    return { mcpServers: {}, sources: [path], warnings, serverLayers: {} };
+    return { mcpServers: {}, sources: [path], warnings, serverLayers: {}, userAllowSecretEnv: {} };
   }
   const file = parsed as McpConfigFile;
   const rawServers = file.mcpServers;
   if (rawServers === undefined || rawServers === null || typeof rawServers !== 'object') {
-    return { mcpServers: {}, sources: [path], warnings, serverLayers: {} };
+    return { mcpServers: {}, sources: [path], warnings, serverLayers: {}, userAllowSecretEnv: {} };
   }
 
   const mcpServers: Record<string, McpServerConfig> = {};
@@ -283,9 +297,9 @@ export function loadMcpConfigFile(path: string): LoadedMcpConfig {
       warnings.push(`mcp.json at ${path}: skipping ${result.error}`);
     }
   }
-  // serverLayers is populated by loadMcpConfig() — the file loader doesn't
-  // know which layer it is in (that depends on which path was passed).
-  return { mcpServers, sources: [path], warnings, serverLayers: {} };
+  // serverLayers and userAllowSecretEnv are populated by loadMcpConfig() —
+  // the file loader doesn't know which layer it is in.
+  return { mcpServers, sources: [path], warnings, serverLayers: {}, userAllowSecretEnv: {} };
 }
 
 /**
@@ -491,10 +505,16 @@ export function loadMcpConfig(opts: LoadMcpConfigOptions = {}): LoadedMcpConfig 
 
   const mcpServers: Record<string, McpServerConfig> = {};
   const serverLayers: Record<string, McpServerLayer> = {};
+  // issue #1483 — collect allowSecretEnv ONLY from user-global / cli / plugin
+  // winners so a project-layer .mcp.json cannot self-authorize secret expansion.
+  const userAllowSecretEnv: Record<string, string[]> = {};
   for (const [name, tagged] of winners) {
     mcpServers[name] = tagged.config;
     serverLayers[name] = tagged.layer;
+    if (tagged.layer !== 'project' && tagged.config.allowSecretEnv && tagged.config.allowSecretEnv.length > 0) {
+      userAllowSecretEnv[name] = tagged.config.allowSecretEnv;
+    }
   }
 
-  return { mcpServers, sources: allSources, warnings: allWarnings, serverLayers };
+  return { mcpServers, sources: allSources, warnings: allWarnings, serverLayers, userAllowSecretEnv };
 }

--- a/src/agent/mcp/env-containment.test.ts
+++ b/src/agent/mcp/env-containment.test.ts
@@ -191,6 +191,43 @@ describe('checkSecretExpansion', () => {
   });
 });
 
+// ── trust boundary: project layer cannot self-authorize ────────────────────────
+
+describe('trust boundary: project-layer allowSecretEnv ignored', () => {
+  it('checkSecretExpansion blocks secret when no trusted list is passed (project config cannot self-authorize)', () => {
+    // Simulate: project .mcp.json has allowSecretEnv but caller passes empty trusted list
+    // (transport now uses trustedAllowSecretEnv from user config, not config.allowSecretEnv)
+    const result = checkSecretExpansion(
+      'AWS_SECRET_ACCESS_KEY',
+      'project',
+      'evil-server',
+      [], // <-- empty trusted list; project config's allowSecretEnv is NOT passed here
+    );
+    expect(result.allowed).toBe(false);
+    // Warning should point to the user-global config, not the project file
+    expect(result.warning).toMatch(/~\/.afk\/config\/mcp\.json/);
+  });
+
+  it('warning directs user to ~/.afk/config/mcp.json, not project .mcp.json', () => {
+    const result = checkSecretExpansion('OPENAI_API_KEY', 'project', 'my-srv');
+    expect(result.allowed).toBe(false);
+    expect(result.warning).toContain('~/.afk/config/mcp.json');
+    expect(result.warning).toContain('project files cannot self-authorize');
+  });
+
+  it('user-global config allowSecretEnv (passed as trusted list) is still honoured', () => {
+    // When the CALLER (transport) passes the user-global allowlist, it works
+    const result = checkSecretExpansion(
+      'MY_PROJECT_TOKEN',
+      'project',
+      'my-server',
+      ['MY_PROJECT_TOKEN'], // comes from user-global config, not project file
+    );
+    expect(result.allowed).toBe(true);
+    expect(result.warning).toBeUndefined();
+  });
+});
+
 // ── scrubDangerousEnv ────────────────────────────────────────────────────────
 
 describe('scrubDangerousEnv', () => {

--- a/src/agent/mcp/env-containment.test.ts
+++ b/src/agent/mcp/env-containment.test.ts
@@ -1,0 +1,364 @@
+/**
+ * Tests for MCP stdio server environment containment (issue #578).
+ *
+ * Covers:
+ *  - Secret pattern matching (`isSecretPattern`)
+ *  - Dangerous inherited-env detection (`isDangerousInherited`)
+ *  - Layer-aware expansion gate (`checkSecretExpansion`)
+ *  - Dangerous env scrubber (`scrubDangerousEnv`)
+ *  - Integration: `expandEnvStringForLayer` / `expandEnvRecordForLayer`
+ *
+ * @module agent/mcp/env-containment.test
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  isSecretPattern,
+  isDangerousInherited,
+  checkSecretExpansion,
+  scrubDangerousEnv,
+} from './env-containment.js';
+
+import {
+  expandEnvStringForLayer,
+  expandEnvRecordForLayer,
+} from './env.js';
+
+// ── isSecretPattern ──────────────────────────────────────────────────────────
+
+describe('isSecretPattern', () => {
+  it('matches *_API_KEY pattern', () => {
+    expect(isSecretPattern('MY_SERVICE_API_KEY')).toBe(true);
+    expect(isSecretPattern('OPENAI_API_KEY')).toBe(true);
+    expect(isSecretPattern('API_KEY')).toBe(false); // no prefix
+  });
+
+  it('matches *_TOKEN pattern', () => {
+    expect(isSecretPattern('GITHUB_TOKEN')).toBe(true);
+    expect(isSecretPattern('ACCESS_TOKEN')).toBe(true);
+    expect(isSecretPattern('TOKEN_VERSION')).toBe(false); // suffix, not matched
+  });
+
+  it('matches *_SECRET and *_SECRET_* patterns', () => {
+    expect(isSecretPattern('MY_SECRET')).toBe(true);
+    expect(isSecretPattern('CLIENT_SECRET_KEY')).toBe(true);
+    expect(isSecretPattern('JWT_SECRET_VALUE')).toBe(true);
+  });
+
+  it('matches *_PASSWORD pattern', () => {
+    expect(isSecretPattern('DB_PASSWORD')).toBe(true);
+    expect(isSecretPattern('MYSQL_ROOT_PASSWORD')).toBe(true);
+  });
+
+  it('matches AWS_* family', () => {
+    expect(isSecretPattern('AWS_SECRET_ACCESS_KEY')).toBe(true);
+    expect(isSecretPattern('AWS_ACCESS_KEY_ID')).toBe(true);
+    expect(isSecretPattern('AWS_SESSION_TOKEN')).toBe(true);
+  });
+
+  it('matches GCP_* family', () => {
+    expect(isSecretPattern('GCP_SERVICE_ACCOUNT_KEY')).toBe(true);
+  });
+
+  it('matches AZURE_* family', () => {
+    expect(isSecretPattern('AZURE_CLIENT_SECRET')).toBe(true);
+    expect(isSecretPattern('AZURE_STORAGE_KEY')).toBe(true);
+  });
+
+  it('matches ANTHROPIC_* family', () => {
+    expect(isSecretPattern('ANTHROPIC_API_KEY')).toBe(true);
+    expect(isSecretPattern('ANTHROPIC_MODEL')).toBe(true); // prefix match — classified as secret
+  });
+
+  it('matches OPENAI_* family', () => {
+    expect(isSecretPattern('OPENAI_API_KEY')).toBe(true);
+    expect(isSecretPattern('OPENAI_ORG_ID')).toBe(true); // prefix match
+  });
+
+  it('does not match benign vars', () => {
+    expect(isSecretPattern('PATH')).toBe(false);
+    expect(isSecretPattern('HOME')).toBe(false);
+    expect(isSecretPattern('NODE_ENV')).toBe(false);
+    expect(isSecretPattern('PORT')).toBe(false);
+    expect(isSecretPattern('DATABASE_URL')).toBe(false);
+    expect(isSecretPattern('REDIS_HOST')).toBe(false);
+  });
+
+  it('is case-insensitive', () => {
+    expect(isSecretPattern('my_api_key')).toBe(true);
+    expect(isSecretPattern('aws_secret_access_key')).toBe(true);
+  });
+});
+
+// ── isDangerousInherited ─────────────────────────────────────────────────────
+
+describe('isDangerousInherited', () => {
+  it('flags NODE_OPTIONS exactly', () => {
+    expect(isDangerousInherited('NODE_OPTIONS')).toBe(true);
+    expect(isDangerousInherited('NODE_OPTIONS_EXTRA')).toBe(false); // only exact
+  });
+
+  it('flags LD_PRELOAD exactly', () => {
+    expect(isDangerousInherited('LD_PRELOAD')).toBe(true);
+  });
+
+  it('flags RUBYOPT exactly', () => {
+    expect(isDangerousInherited('RUBYOPT')).toBe(true);
+  });
+
+  it('flags DYLD_* family by prefix', () => {
+    expect(isDangerousInherited('DYLD_LIBRARY_PATH')).toBe(true);
+    expect(isDangerousInherited('DYLD_INSERT_LIBRARIES')).toBe(true);
+    expect(isDangerousInherited('DYLD_FORCE_FLAT_NAMESPACE')).toBe(true);
+  });
+
+  it('flags PYTHON* family by prefix', () => {
+    expect(isDangerousInherited('PYTHONPATH')).toBe(true);
+    expect(isDangerousInherited('PYTHONSTARTUP')).toBe(true);
+    expect(isDangerousInherited('PYTHONINSPECT')).toBe(true);
+  });
+
+  it('flags PERL5* family by prefix', () => {
+    expect(isDangerousInherited('PERL5LIB')).toBe(true);
+    expect(isDangerousInherited('PERL5OPT')).toBe(true);
+  });
+
+  it('does not flag safe vars', () => {
+    expect(isDangerousInherited('PATH')).toBe(false);
+    expect(isDangerousInherited('HOME')).toBe(false);
+    expect(isDangerousInherited('NODE_ENV')).toBe(false);
+    expect(isDangerousInherited('LD_LIBRARY_PATH')).toBe(false); // not LD_PRELOAD
+  });
+});
+
+// ── checkSecretExpansion ─────────────────────────────────────────────────────
+
+describe('checkSecretExpansion', () => {
+  it('allows any var for user-global layer', () => {
+    const result = checkSecretExpansion('AWS_SECRET_ACCESS_KEY', 'user-global', 'my-server');
+    expect(result.allowed).toBe(true);
+    expect(result.warning).toBeUndefined();
+  });
+
+  it('allows any var for cli layer', () => {
+    const result = checkSecretExpansion('OPENAI_API_KEY', 'cli', 'my-server');
+    expect(result.allowed).toBe(true);
+  });
+
+  it('allows any var for plugin layer', () => {
+    const result = checkSecretExpansion('ANTHROPIC_API_KEY', 'plugin', 'my-server');
+    expect(result.allowed).toBe(true);
+  });
+
+  it('blocks secret patterns for project layer', () => {
+    const result = checkSecretExpansion('AWS_SECRET_ACCESS_KEY', 'project', 'my-server');
+    expect(result.allowed).toBe(false);
+    expect(result.warning).toMatch(/blocked secret expansion/);
+    expect(result.warning).toMatch(/AWS_SECRET_ACCESS_KEY/);
+    expect(result.warning).toMatch(/allowSecretEnv/);
+  });
+
+  it('allows non-secret vars for project layer', () => {
+    const result = checkSecretExpansion('DATABASE_URL', 'project', 'my-server');
+    expect(result.allowed).toBe(true);
+  });
+
+  it('respects allowSecretEnv opt-in for project layer', () => {
+    const result = checkSecretExpansion(
+      'MY_PROJECT_TOKEN',
+      'project',
+      'my-server',
+      ['MY_PROJECT_TOKEN'],
+    );
+    expect(result.allowed).toBe(true);
+    expect(result.warning).toBeUndefined();
+  });
+
+  it('still blocks vars not in the allowSecretEnv list', () => {
+    const result = checkSecretExpansion(
+      'OTHER_SECRET',
+      'project',
+      'my-server',
+      ['MY_PROJECT_TOKEN'],
+    );
+    expect(result.allowed).toBe(false);
+  });
+
+  it('includes server name in warning', () => {
+    const result = checkSecretExpansion('AWS_ACCESS_KEY_ID', 'project', 'cool-server');
+    expect(result.warning).toMatch(/\[mcp:cool-server\]/);
+  });
+});
+
+// ── scrubDangerousEnv ────────────────────────────────────────────────────────
+
+describe('scrubDangerousEnv', () => {
+  it('removes dangerous vars and returns scrubbed list', () => {
+    const base: Record<string, string> = {
+      PATH: '/usr/bin',
+      HOME: '/home/user',
+      NODE_OPTIONS: '--require evil.js',
+      LD_PRELOAD: '/evil/lib.so',
+      DYLD_LIBRARY_PATH: '/evil/dylib',
+      PYTHONPATH: '/evil/pypath',
+    };
+    const scrubbed = scrubDangerousEnv(base);
+    expect(scrubbed.sort()).toEqual(['DYLD_LIBRARY_PATH', 'LD_PRELOAD', 'NODE_OPTIONS', 'PYTHONPATH'].sort());
+    expect(base).toEqual({ PATH: '/usr/bin', HOME: '/home/user' });
+  });
+
+  it('returns empty array when nothing to scrub', () => {
+    const base = { PATH: '/usr/bin', HOME: '/home/user' };
+    const scrubbed = scrubDangerousEnv(base);
+    expect(scrubbed).toEqual([]);
+    expect(base).toEqual({ PATH: '/usr/bin', HOME: '/home/user' });
+  });
+
+  it('mutates base in-place', () => {
+    const base: Record<string, string> = { NODE_OPTIONS: '--bad', PORT: '3000' };
+    scrubDangerousEnv(base);
+    expect('NODE_OPTIONS' in base).toBe(false);
+    expect(base['PORT']).toBe('3000');
+  });
+});
+
+// ── expandEnvStringForLayer ───────────────────────────────────────────────────
+
+describe('expandEnvStringForLayer', () => {
+  it('expands non-secret vars for project layer normally', () => {
+    const warn = vi.fn();
+    const result = expandEnvStringForLayer(
+      'host=${DATABASE_HOST}',
+      { layer: 'project', serverName: 'db' },
+      { DATABASE_HOST: 'localhost' },
+      warn,
+    );
+    expect(result.value).toBe('host=localhost');
+    expect(result.blocked).toEqual([]);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('blocks secret vars for project layer and emits warning', () => {
+    const warn = vi.fn();
+    const result = expandEnvStringForLayer(
+      'Bearer ${OPENAI_API_KEY}',
+      { layer: 'project', serverName: 'openai-tool' },
+      { OPENAI_API_KEY: 'sk-secret' },
+      warn,
+    );
+    expect(result.value).toBe('Bearer ');
+    expect(result.blocked).toEqual(['OPENAI_API_KEY']);
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0][0]).toMatch(/OPENAI_API_KEY/);
+  });
+
+  it('allows secret vars for user-global layer without warning', () => {
+    const warn = vi.fn();
+    const result = expandEnvStringForLayer(
+      'Bearer ${OPENAI_API_KEY}',
+      { layer: 'user-global', serverName: 'openai-tool' },
+      { OPENAI_API_KEY: 'sk-secret' },
+      warn,
+    );
+    expect(result.value).toBe('Bearer sk-secret');
+    expect(result.blocked).toEqual([]);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('respects allowSecretEnv opt-in for project layer', () => {
+    const warn = vi.fn();
+    const result = expandEnvStringForLayer(
+      '${MY_TOKEN}',
+      { layer: 'project', serverName: 'my-server', allowSecretEnv: ['MY_TOKEN'] },
+      { MY_TOKEN: 'tok-xyz' },
+      warn,
+    );
+    expect(result.value).toBe('tok-xyz');
+    expect(result.blocked).toEqual([]);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('escapes $${VAR} regardless of layer', () => {
+    const warn = vi.fn();
+    const result = expandEnvStringForLayer(
+      '$${LITERAL}',
+      { layer: 'project', serverName: 'test' },
+      { LITERAL: 'unused' },
+      warn,
+    );
+    expect(result.value).toBe('${LITERAL}');
+    expect(result.blocked).toEqual([]);
+  });
+
+  it('reports missing (unset) vars separately from blocked vars', () => {
+    const warn = vi.fn();
+    const result = expandEnvStringForLayer(
+      '${MISSING_VAR} ${AWS_SECRET_KEY}',
+      { layer: 'project', serverName: 'srv' },
+      { /* nothing set */ },
+      warn,
+    );
+    // MISSING_VAR is not a secret pattern — goes in missing
+    expect(result.missing).toContain('MISSING_VAR');
+    // AWS_SECRET_KEY is a secret pattern — goes in blocked
+    expect(result.blocked).toContain('AWS_SECRET_KEY');
+  });
+});
+
+// ── expandEnvRecordForLayer ───────────────────────────────────────────────────
+
+describe('expandEnvRecordForLayer', () => {
+  it('returns empty result for undefined input', () => {
+    const warn = vi.fn();
+    const result = expandEnvRecordForLayer(
+      undefined,
+      { layer: 'project', serverName: 'srv' },
+      {},
+      warn,
+    );
+    expect(result).toEqual({ value: {}, missing: [], blocked: [] });
+  });
+
+  it('aggregates blocked across all values, de-duplicated', () => {
+    const warn = vi.fn();
+    const result = expandEnvRecordForLayer(
+      { A: '${AWS_ACCESS_KEY_ID}', B: '${AWS_ACCESS_KEY_ID}', C: '${OPENAI_API_KEY}' },
+      { layer: 'project', serverName: 'srv' },
+      { AWS_ACCESS_KEY_ID: 'key', OPENAI_API_KEY: 'sk' },
+      warn,
+    );
+    expect(result.blocked.sort()).toEqual(['AWS_ACCESS_KEY_ID', 'OPENAI_API_KEY'].sort());
+    // 3 placeholder occurrences but 2 warn calls per unique blocking event
+    // (2 expansions of AWS + 1 OPENAI = 3 total warn calls is fine too,
+    //  what matters is blocked list is de-duped)
+    expect(result.blocked).toHaveLength(2);
+  });
+
+  it('does not block anything for user-global layer', () => {
+    const warn = vi.fn();
+    const result = expandEnvRecordForLayer(
+      { KEY: '${ANTHROPIC_API_KEY}', HOST: '${DB_HOST}' },
+      { layer: 'user-global', serverName: 'srv' },
+      { ANTHROPIC_API_KEY: 'ak-secret', DB_HOST: 'localhost' },
+      warn,
+    );
+    expect(result.value).toEqual({ KEY: 'ak-secret', HOST: 'localhost' });
+    expect(result.blocked).toEqual([]);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('handles mixed secret + safe vars for project layer', () => {
+    const warn = vi.fn();
+    const result = expandEnvRecordForLayer(
+      { SAFE: '${APP_PORT}', SECRET: '${DB_PASSWORD}' },
+      { layer: 'project', serverName: 'mixed' },
+      { APP_PORT: '3000', DB_PASSWORD: 's3cr3t' },
+      warn,
+    );
+    expect(result.value['SAFE']).toBe('3000');
+    expect(result.value['SECRET']).toBe(''); // blocked → empty
+    expect(result.blocked).toContain('DB_PASSWORD');
+    expect(warn).toHaveBeenCalled();
+  });
+});

--- a/src/agent/mcp/env-containment.ts
+++ b/src/agent/mcp/env-containment.ts
@@ -40,8 +40,8 @@ export type McpServerLayer = 'project' | 'user-global' | 'plugin' | 'cli';
  */
 const SECRET_PATTERNS: RegExp[] = [
   /^.+_API_KEY$/i,
-  /^.+_TOKEN$/i,
-  /^.+_SECRET/i,      // prefix match: *_SECRET, *_SECRET_KEY, *_SECRET_VALUE …
+  /^.+_TOKEN/i,       // prefix match: *_TOKEN, *_TOKEN_READONLY, *_TOKEN_EXPIRY …
+  /^.+_SECRET/i,      // prefix match: *_SECRET, *_SECRET_KEY, *_SECRET_VALUE … (consistent with _TOKEN: no $)
   /^.+_PASSWORD$/i,
   /^AWS_/i,
   /^GCP_/i,
@@ -67,6 +67,7 @@ export function isSecretPattern(varName: string): boolean {
  * parent session's runtime environment.
  *
  * - `NODE_OPTIONS`   — can inject `--require`, `--experimental-*`, etc.
+ * - `NODE_PATH`      — redirects Node.js module resolution order
  * - `LD_PRELOAD`     — Linux dynamic-linker injection
  * - `DYLD_*`         — macOS dynamic-linker injection (family match)
  * - `PYTHON*`        — can redirect imports, set encoding, alter paths
@@ -75,6 +76,7 @@ export function isSecretPattern(varName: string): boolean {
  */
 const DANGEROUS_INHERIT_EXACT: ReadonlySet<string> = new Set([
   'NODE_OPTIONS',
+  'NODE_PATH',
   'LD_PRELOAD',
   'RUBYOPT',
 ]);

--- a/src/agent/mcp/env-containment.ts
+++ b/src/agent/mcp/env-containment.ts
@@ -1,0 +1,170 @@
+/**
+ * Defense-in-depth environment containment for project-local MCP stdio servers.
+ *
+ * Issue #578: project-local `.mcp.json` servers are untrusted — they come from
+ * the working directory, not the user's own `~/.afk/config/mcp.json`. Two attack
+ * surfaces are closed here:
+ *
+ *   1. **Secret expansion refusal** — `${AWS_SECRET_ACCESS_KEY}` in a project
+ *      server's `env` block would silently forward host credentials to the child
+ *      process. Known-secret patterns are blocked; the user must opt-in explicitly
+ *      via `allowSecretEnv: ["SPECIFIC_TOKEN"]` in the server config.
+ *
+ *   2. **Dangerous env inheritance scrub** — variables like `NODE_OPTIONS` or
+ *      `LD_PRELOAD` can fundamentally alter the child's runtime without being
+ *      visible in the MCP config. These are stripped from the inherited base env
+ *      before being handed to `StdioClientTransport`.
+ *
+ * User-global servers (`~/.afk/config/mcp.json`) are fully trusted and bypass
+ * both restrictions.
+ *
+ * @module agent/mcp/env-containment
+ */
+
+/** Which config layer a server originates from. */
+export type McpServerLayer = 'project' | 'user-global' | 'plugin' | 'cli';
+
+// ── Secret-pattern matching ──────────────────────────────────────────────────
+
+/**
+ * Glob-style patterns that identify env vars that commonly hold credentials.
+ * Stored as RegExp objects built once at module load time. The list covers the
+ * most common naming conventions; it is intentionally conservative — any false
+ * positives are immediately visible via a console.warn and the user has an
+ * `allowSecretEnv` opt-out.
+ *
+ * Pattern rationale:
+ *   - `*_API_KEY`, `*_TOKEN`, `*_SECRET*`, `*_PASSWORD` — universal conventions
+ *   - `AWS_*`, `GCP_*`, `AZURE_*` — cloud provider families
+ *   - `ANTHROPIC_*`, `OPENAI_*` — AI provider keys used by the host tool
+ */
+const SECRET_PATTERNS: RegExp[] = [
+  /^.+_API_KEY$/i,
+  /^.+_TOKEN$/i,
+  /^.+_SECRET/i,      // prefix match: *_SECRET, *_SECRET_KEY, *_SECRET_VALUE …
+  /^.+_PASSWORD$/i,
+  /^AWS_/i,
+  /^GCP_/i,
+  /^AZURE_/i,
+  /^ANTHROPIC_/i,
+  /^OPENAI_/i,
+];
+
+/**
+ * Return `true` when `varName` matches at least one of the known-secret
+ * patterns. Case-insensitive (patterns carry `/i`).
+ */
+export function isSecretPattern(varName: string): boolean {
+  return SECRET_PATTERNS.some((re) => re.test(varName));
+}
+
+// ── Dangerous inherited-env scrub list ──────────────────────────────────────
+
+/**
+ * Env vars that alter the child process's runtime in ways that are
+ * impossible to audit from the MCP config alone. Stripping them from the
+ * inherited base prevents a project `.mcp.json` from silently exploiting the
+ * parent session's runtime environment.
+ *
+ * - `NODE_OPTIONS`   — can inject `--require`, `--experimental-*`, etc.
+ * - `LD_PRELOAD`     — Linux dynamic-linker injection
+ * - `DYLD_*`         — macOS dynamic-linker injection (family match)
+ * - `PYTHON*`        — can redirect imports, set encoding, alter paths
+ * - `PERL5*`         — Perl module/lib path injection
+ * - `RUBYOPT`        — Ruby runtime option injection
+ */
+const DANGEROUS_INHERIT_EXACT: ReadonlySet<string> = new Set([
+  'NODE_OPTIONS',
+  'LD_PRELOAD',
+  'RUBYOPT',
+]);
+
+const DANGEROUS_INHERIT_PREFIX: readonly string[] = [
+  'DYLD_',
+  'PYTHON',
+  'PERL5',
+];
+
+/**
+ * Return `true` when `varName` is on the dangerous-inheritance scrub list.
+ * Exact matches are O(1); prefix matches scan a short array.
+ */
+export function isDangerousInherited(varName: string): boolean {
+  if (DANGEROUS_INHERIT_EXACT.has(varName)) return true;
+  for (const prefix of DANGEROUS_INHERIT_PREFIX) {
+    if (varName.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+// ── Layer-aware expansion gate ───────────────────────────────────────────────
+
+/**
+ * Result of a layer-aware secret-expansion check on a single variable name
+ * that appeared inside a `${VAR}` placeholder in a project-local env block.
+ */
+export interface SecretCheckResult {
+  /** Whether the expansion should be allowed to proceed. */
+  allowed: boolean;
+  /**
+   * When `allowed` is false, a human-readable warning message that the
+   * caller should emit via `console.warn`. `undefined` when `allowed` is
+   * true.
+   */
+  warning?: string;
+}
+
+/**
+ * Decide whether a `${VAR}` expansion for `varName` is permitted given the
+ * server's layer and its optional `allowSecretEnv` allowlist.
+ *
+ * Rules:
+ *  - User-global / CLI / plugin servers: always allowed (trusted operator).
+ *  - Project-layer servers: blocked when `varName` matches a secret pattern,
+ *    UNLESS `varName` appears in `allowSecretEnv`.
+ */
+export function checkSecretExpansion(
+  varName: string,
+  layer: McpServerLayer,
+  serverName: string,
+  allowSecretEnv: readonly string[] = [],
+): SecretCheckResult {
+  // Non-project layers are unconditionally trusted.
+  if (layer !== 'project') return { allowed: true };
+
+  // Variable is not a secret pattern — allow.
+  if (!isSecretPattern(varName)) return { allowed: true };
+
+  // Explicitly allowed by the server config's opt-in list.
+  if (allowSecretEnv.includes(varName)) return { allowed: true };
+
+  return {
+    allowed: false,
+    warning:
+      `[mcp:${serverName}] blocked secret expansion: \${${varName}} matches a known-secret ` +
+      `pattern and this is a project-local server. ` +
+      `To opt in, add \`"allowSecretEnv": ["${varName}"]\` to this server's config in .mcp.json.`,
+  };
+}
+
+// ── Dangerous inherited-env scrubber ────────────────────────────────────────
+
+/**
+ * Remove dangerous inherited variables from `base` in-place and return the
+ * list of variable names that were scrubbed (for logging).
+ *
+ * **Only call this for project-layer servers.** User-global / CLI / plugin
+ * servers receive the full inherited base without modification.
+ */
+export function scrubDangerousEnv(
+  base: Record<string, string>,
+): string[] {
+  const scrubbed: string[] = [];
+  for (const key of Object.keys(base)) {
+    if (isDangerousInherited(key)) {
+      delete base[key];
+      scrubbed.push(key);
+    }
+  }
+  return scrubbed;
+}

--- a/src/agent/mcp/env-containment.ts
+++ b/src/agent/mcp/env-containment.ts
@@ -143,7 +143,8 @@ export function checkSecretExpansion(
     warning:
       `[mcp:${serverName}] blocked secret expansion: \${${varName}} matches a known-secret ` +
       `pattern and this is a project-local server. ` +
-      `To opt in, add \`"allowSecretEnv": ["${varName}"]\` to this server's config in .mcp.json.`,
+      `To opt in, add \`"allowSecretEnv": ["${varName}"]\` to this server's entry in ` +
+      `~/.afk/config/mcp.json (not in the project .mcp.json — project files cannot self-authorize).`,
   };
 }
 

--- a/src/agent/mcp/env.ts
+++ b/src/agent/mcp/env.ts
@@ -158,3 +158,42 @@ export function expandEnvRecordForLayer(
 
   return { value: out, missing: [...missingSet], blocked: [...blockedSet] };
 }
+
+/**
+ * Layer-aware expansion for HTTP/SSE `headers` maps (issue #578).
+ *
+ * Mirrors `expandEnvRecordForLayer` but matches the `expandHeaders` semantics:
+ * a header that references a missing variable is omitted entirely (returning
+ * an empty string for a Bearer token is worse than no header). Headers whose
+ * expansion is blocked by the secret-pattern gate are also omitted and recorded
+ * in `blocked` so the caller can warn.
+ *
+ * For non-project layers the caller should use `expandHeaders` from
+ * `transport.ts` directly; this variant is only needed by the project-layer
+ * branch of `createTransport()`.
+ */
+export function expandHeadersForLayer(
+  headers: Record<string, string> | undefined,
+  ctx: EnvExpansionContext,
+  source: NodeJS.ProcessEnv = process.env,
+  warn: (msg: string) => void = console.warn,
+): { headers: Record<string, string>; missing: string[]; blocked: string[] } {
+  if (headers === undefined) return { headers: {}, missing: [], blocked: [] };
+  const filtered: Record<string, string> = {};
+  const missingSet = new Set<string>();
+  const blockedSet = new Set<string>();
+  for (const [key, raw] of Object.entries(headers)) {
+    const { value, missing, blocked } = expandEnvStringForLayer(raw, ctx, source, warn);
+    if (missing.length > 0) {
+      // At least one variable was unset — omit the header entirely
+      // (mirrors expandHeaders behaviour: partial header value is worse than none).
+      for (const m of missing) missingSet.add(m);
+    } else if (blocked.length === 0) {
+      filtered[key] = value;
+    } else {
+      // Expansion blocked by secret gate — omit header (fail-safe).
+      for (const b of blocked) blockedSet.add(b);
+    }
+  }
+  return { headers: filtered, missing: [...missingSet], blocked: [...blockedSet] };
+}

--- a/src/agent/mcp/env.ts
+++ b/src/agent/mcp/env.ts
@@ -10,6 +10,13 @@
  *     `alwaysLoad: true`).
  *   - Leaves escaped placeholders `$${VAR}` literal (consumes one `$`).
  *
+ * Layer-aware variants (`expandEnvStringForLayer`, `expandEnvRecordForLayer`)
+ * add defense-in-depth for project-local servers (issue #578):
+ *   - Secret-pattern placeholders (`${AWS_SECRET}`, `${OPENAI_API_KEY}`, …)
+ *     are blocked and emitted as warnings unless the server's `allowSecretEnv`
+ *     list explicitly permits them.
+ *   - User-global / plugin / CLI servers bypass the restriction entirely.
+ *
  * Used by the connection path in `client.ts` immediately before constructing
  * the transport — keeps secret values out of the in-memory `McpServerConfig`
  * that we surface to `/mcp` and persist to state files.
@@ -17,11 +24,15 @@
  * @module agent/mcp/env
  */
 
+import { checkSecretExpansion, type McpServerLayer } from './env-containment.js';
+
 const PLACEHOLDER = /\$(\$)?\{([A-Z_][A-Z0-9_]*)\}/gi;
 
 export interface EnvExpansionResult<T> {
   value: T;
   missing: string[];
+  /** Var names whose expansion was blocked by the secret-pattern gate. */
+  blocked: string[];
 }
 
 /**
@@ -33,7 +44,7 @@ export interface EnvExpansionResult<T> {
 export function expandEnvString(
   input: string,
   source: NodeJS.ProcessEnv = process.env,
-): EnvExpansionResult<string> {
+): Omit<EnvExpansionResult<string>, 'blocked'> {
   const missing: string[] = [];
   const expanded = input.replace(PLACEHOLDER, (_match, escape: string | undefined, name: string) => {
     if (escape === '$') {
@@ -57,7 +68,7 @@ export function expandEnvString(
 export function expandEnvRecord(
   input: Record<string, string> | undefined,
   source: NodeJS.ProcessEnv = process.env,
-): EnvExpansionResult<Record<string, string>> {
+): Omit<EnvExpansionResult<Record<string, string>>, 'blocked'> {
   if (input === undefined) return { value: {}, missing: [] };
   const out: Record<string, string> = {};
   const missingSet = new Set<string>();
@@ -67,4 +78,83 @@ export function expandEnvRecord(
     for (const name of missing) missingSet.add(name);
   }
   return { value: out, missing: [...missingSet] };
+}
+
+// ── Layer-aware variants (issue #578) ───────────────────────────────────────
+
+/**
+ * Layer-aware context for secret-guarded expansion.
+ */
+export interface EnvExpansionContext {
+  /** Which config layer the server originates from. */
+  layer: McpServerLayer;
+  /** Server name for warning messages. */
+  serverName: string;
+  /** Variables the server config explicitly permits expanding (project layer only). */
+  allowSecretEnv?: readonly string[];
+}
+
+/**
+ * Layer-aware variant of `expandEnvString`. For project-layer servers, any
+ * `${VAR}` whose name matches a known-secret pattern is blocked (expansion is
+ * replaced with the empty string) and recorded in `blocked`. A caller-supplied
+ * `warn` callback receives the human-readable warning so the call site can
+ * route it via `console.warn` or the structured logger.
+ */
+export function expandEnvStringForLayer(
+  input: string,
+  ctx: EnvExpansionContext,
+  source: NodeJS.ProcessEnv = process.env,
+  warn: (msg: string) => void = console.warn,
+): EnvExpansionResult<string> {
+  const missing: string[] = [];
+  const blocked: string[] = [];
+
+  const expanded = input.replace(PLACEHOLDER, (_match, escape: string | undefined, name: string) => {
+    if (escape === '$') {
+      return `\${${name}}`;
+    }
+
+    // Secret-gate check (project layer only).
+    const check = checkSecretExpansion(name, ctx.layer, ctx.serverName, ctx.allowSecretEnv);
+    if (!check.allowed) {
+      if (check.warning) warn(check.warning);
+      blocked.push(name);
+      return '';
+    }
+
+    const value = source[name];
+    if (value === undefined || value === '') {
+      missing.push(name);
+      return '';
+    }
+    return value;
+  });
+
+  return { value: expanded, missing, blocked };
+}
+
+/**
+ * Layer-aware variant of `expandEnvRecord`. Aggregates `missing` and
+ * `blocked` across all values, de-duplicated.
+ */
+export function expandEnvRecordForLayer(
+  input: Record<string, string> | undefined,
+  ctx: EnvExpansionContext,
+  source: NodeJS.ProcessEnv = process.env,
+  warn: (msg: string) => void = console.warn,
+): EnvExpansionResult<Record<string, string>> {
+  if (input === undefined) return { value: {}, missing: [], blocked: [] };
+  const out: Record<string, string> = {};
+  const missingSet = new Set<string>();
+  const blockedSet = new Set<string>();
+
+  for (const [key, raw] of Object.entries(input)) {
+    const { value, missing, blocked } = expandEnvStringForLayer(raw, ctx, source, warn);
+    out[key] = value;
+    for (const name of missing) missingSet.add(name);
+    for (const name of blocked) blockedSet.add(name);
+  }
+
+  return { value: out, missing: [...missingSet], blocked: [...blockedSet] };
 }

--- a/src/agent/mcp/manager.ts
+++ b/src/agent/mcp/manager.ts
@@ -73,6 +73,12 @@ export interface McpManagerInitOptions {
    * tracking so call sites don't have to repeat the logic.
    */
   serverLayers?: Record<string, McpServerLayer>;
+  /**
+   * Trusted secret-expansion allowlists from user-global config only (issue #1483).
+   * Maps server name → allowed variable names. Passed to `createTransport` so
+   * project-layer servers cannot self-authorize their own `allowSecretEnv`.
+   */
+  userAllowSecretEnv?: Record<string, string[]>;
 }
 
 /**
@@ -155,6 +161,7 @@ export class McpManager {
       }
 
       const serverLayer: McpServerLayer = opts.serverLayers?.[serverName] ?? 'user-global';
+      const trustedAllow: readonly string[] = opts.userAllowSecretEnv?.[serverName] ?? [];
 
       if (config.disabled) {
         records.set(serverName, {
@@ -180,7 +187,7 @@ export class McpManager {
       const record: ServerRecord = { client: undefined, tools: [], state, layer: serverLayer };
       records.set(serverName, record);
 
-      const client = new McpClient(serverName, config, serverLayer);
+      const client = new McpClient(serverName, config, serverLayer, trustedAllow);
       record.client = client;
 
       // Capture stderr-style transport errors so a server that dies mid-

--- a/src/agent/mcp/manager.ts
+++ b/src/agent/mcp/manager.ts
@@ -30,6 +30,7 @@ import { buildMcpNameRegistry, sanitizeNameSegment } from './naming.js';
 import type { McpClientState, McpServerConfig } from './types.js';
 import { emitSessionPhase } from '../trace/emit.js';
 import type { TraceSink } from '../trace/index.js';
+import type { McpServerLayer } from './env-containment.js';
 
 /**
  * Per-server runtime record. Holds the live client, the list of tools the
@@ -40,6 +41,8 @@ interface ServerRecord {
   client: McpClient | undefined;
   tools: McpTool[];
   state: McpClientState;
+  /** Config layer origin — drives env-containment policy (issue #578). */
+  layer: McpServerLayer;
 }
 
 export interface McpManagerInitOptions {
@@ -57,6 +60,19 @@ export interface McpManagerInitOptions {
    * connect behavior or timing.
    */
   traceWriter?: TraceSink;
+  /**
+   * Layer origin for each server name (issue #578). When a server name is
+   * present in this map, the corresponding layer drives the env-containment
+   * policy in `transport.ts`:
+   *   - `'project'` — project-local `.mcp.json` (secret expansion blocked,
+   *     dangerous inherited env scrubbed)
+   *   - `'user-global'` / `'plugin'` / `'cli'` — fully trusted, no restrictions
+   *
+   * Servers whose names are NOT in the map default to `'user-global'`
+   * (trusted). The config-loader populates this from its internal layer-
+   * tracking so call sites don't have to repeat the logic.
+   */
+  serverLayers?: Record<string, McpServerLayer>;
 }
 
 /**
@@ -138,6 +154,8 @@ export class McpManager {
         );
       }
 
+      const serverLayer: McpServerLayer = opts.serverLayers?.[serverName] ?? 'user-global';
+
       if (config.disabled) {
         records.set(serverName, {
           client: undefined,
@@ -148,6 +166,7 @@ export class McpManager {
             status: 'disabled',
             toolCount: 0,
           },
+          layer: serverLayer,
         });
         continue;
       }
@@ -158,10 +177,10 @@ export class McpManager {
         status: 'connecting',
         toolCount: 0,
       };
-      const record: ServerRecord = { client: undefined, tools: [], state };
+      const record: ServerRecord = { client: undefined, tools: [], state, layer: serverLayer };
       records.set(serverName, record);
 
-      const client = new McpClient(serverName, config);
+      const client = new McpClient(serverName, config, serverLayer);
       record.client = client;
 
       // Capture stderr-style transport errors so a server that dies mid-
@@ -436,7 +455,7 @@ export class McpManager {
     });
 
     // Step 4: fresh client + connect.
-    const freshClient = new McpClient(serverName, rec.state.config);
+    const freshClient = new McpClient(serverName, rec.state.config, rec.layer);
     freshClient.onTransportError = (err) => {
       rec.state.status = 'error';
       rec.state.error = truncate(err.message, 200);

--- a/src/agent/mcp/manager.ts
+++ b/src/agent/mcp/manager.ts
@@ -43,6 +43,8 @@ interface ServerRecord {
   state: McpClientState;
   /** Config layer origin — drives env-containment policy (issue #578). */
   layer: McpServerLayer;
+  /** Trusted secret-expansion allowlist for this server (issue #1483). Preserved so completeAuth() reconnect passes the same trust boundary. */
+  trustedAllowSecretEnv: readonly string[];
 }
 
 export interface McpManagerInitOptions {
@@ -174,6 +176,7 @@ export class McpManager {
             toolCount: 0,
           },
           layer: serverLayer,
+          trustedAllowSecretEnv: trustedAllow,
         });
         continue;
       }
@@ -184,7 +187,7 @@ export class McpManager {
         status: 'connecting',
         toolCount: 0,
       };
-      const record: ServerRecord = { client: undefined, tools: [], state, layer: serverLayer };
+      const record: ServerRecord = { client: undefined, tools: [], state, layer: serverLayer, trustedAllowSecretEnv: trustedAllow };
       records.set(serverName, record);
 
       const client = new McpClient(serverName, config, serverLayer, trustedAllow);
@@ -462,7 +465,7 @@ export class McpManager {
     });
 
     // Step 4: fresh client + connect.
-    const freshClient = new McpClient(serverName, rec.state.config, rec.layer);
+    const freshClient = new McpClient(serverName, rec.state.config, rec.layer, rec.trustedAllowSecretEnv);
     freshClient.onTransportError = (err) => {
       rec.state.status = 'error';
       rec.state.error = truncate(err.message, 200);

--- a/src/agent/mcp/transport.ts
+++ b/src/agent/mcp/transport.ts
@@ -139,6 +139,8 @@ export function createTransport(
   config: McpServerConfig,
   oauthProvider?: OAuthClientProvider,
   layer: McpServerLayer = 'user-global',
+  /** Trusted allowlist from user-global config only (issue #1483). */
+  trustedAllowSecretEnv: readonly string[] = [],
 ): CreateTransportResult {
   // Resolve effective type (loader already sets it, but guard in case the
   // factory is called outside the normal load path).
@@ -154,7 +156,7 @@ export function createTransport(
     if (layer === 'project') {
       const { value: env, missing, blocked } = expandEnvRecordForLayer(
         config.env,
-        { layer, serverName, allowSecretEnv: config.allowSecretEnv ?? [] },
+        { layer, serverName, allowSecretEnv: trustedAllowSecretEnv },
       );
       if (missing.length > 0) {
         console.warn(

--- a/src/agent/mcp/transport.ts
+++ b/src/agent/mcp/transport.ts
@@ -37,7 +37,7 @@ import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js';
 
 import type { McpServerConfig } from './types.js';
-import { expandEnvRecord, expandEnvRecordForLayer, expandEnvString } from './env.js';
+import { expandEnvRecord, expandEnvRecordForLayer, expandEnvString, expandHeadersForLayer } from './env.js';
 import { scrubDangerousEnv, type McpServerLayer } from './env-containment.js';
 
 /**
@@ -223,10 +223,28 @@ export function createTransport(
       );
     }
 
-    const { headers: expandedHeaders, missing } = expandHeaders(config.headers);
-    if (missing.length > 0) {
+    let expandedHeaders: Record<string, string>;
+    let missingHeaders: string[];
+    if (layer === 'project') {
+      const { headers: h, missing: m, blocked } = expandHeadersForLayer(
+        config.headers,
+        { layer, serverName, allowSecretEnv: trustedAllowSecretEnv },
+      );
+      if (blocked.length > 0) {
+        console.warn(
+          `[mcp:${serverName}] ${blocked.length} secret header expansion(s) blocked for project-local server`,
+        );
+      }
+      expandedHeaders = h;
+      missingHeaders = m;
+    } else {
+      const { headers: h, missing: m } = expandHeaders(config.headers);
+      expandedHeaders = h;
+      missingHeaders = m;
+    }
+    if (missingHeaders.length > 0) {
       console.warn(
-        `[mcp:${serverName}] missing header vars (passing as omitted): ${missing.join(', ')}`,
+        `[mcp:${serverName}] missing header vars (passing as omitted): ${missingHeaders.join(', ')}`,
       );
     }
 

--- a/src/agent/mcp/transport.ts
+++ b/src/agent/mcp/transport.ts
@@ -37,7 +37,8 @@ import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js';
 
 import type { McpServerConfig } from './types.js';
-import { expandEnvRecord, expandEnvString } from './env.js';
+import { expandEnvRecord, expandEnvRecordForLayer, expandEnvString } from './env.js';
+import { scrubDangerousEnv, type McpServerLayer } from './env-containment.js';
 
 /**
  * True for hostnames whose traffic never leaves the local machine — the
@@ -122,6 +123,13 @@ export interface CreateTransportResult {
  * For streamable-HTTP + SSE variants an optional `oauthProvider` is wired
  * into the transport options so the SDK can handle token refresh internally.
  *
+ * The `layer` parameter drives defense-in-depth for project-local stdio
+ * servers (issue #578):
+ *   - Secret `${VAR}` expansions are blocked unless `allowSecretEnv` opts in.
+ *   - Dangerous inherited env vars (`NODE_OPTIONS`, `LD_PRELOAD`, …) are
+ *     scrubbed from the inherited base env before the child process is spawned.
+ * User-global, plugin, and CLI servers are fully trusted and bypass both checks.
+ *
  * Throws when the config is internally inconsistent (e.g. `type === 'stdio'`
  * with no `command`) — the loader validates these upfront, but the factory
  * guards defensively.
@@ -130,6 +138,7 @@ export function createTransport(
   serverName: string,
   config: McpServerConfig,
   oauthProvider?: OAuthClientProvider,
+  layer: McpServerLayer = 'user-global',
 ): CreateTransportResult {
   // Resolve effective type (loader already sets it, but guard in case the
   // factory is called outside the normal load path).
@@ -140,19 +149,55 @@ export function createTransport(
       throw new Error(`McpTransport(${serverName}): stdio requires \`command\``);
     }
 
-    const { value: env, missing } = expandEnvRecord(config.env);
-    if (missing.length > 0) {
-      // Forward as a console warn — manager logs the per-server status
-      // separately; this gives per-variable visibility.
-      console.warn(
-        `[mcp:${serverName}] missing env vars (passing as empty): ${missing.join(', ')}`,
+    // ── Env expansion (layer-aware for project servers) ──────────────
+    let expandedEnv: Record<string, string>;
+    if (layer === 'project') {
+      const { value: env, missing, blocked } = expandEnvRecordForLayer(
+        config.env,
+        { layer, serverName, allowSecretEnv: config.allowSecretEnv ?? [] },
       );
+      if (missing.length > 0) {
+        console.warn(
+          `[mcp:${serverName}] missing env vars (passing as empty): ${missing.join(', ')}`,
+        );
+      }
+      if (blocked.length > 0) {
+        // Individual warnings already emitted by expandEnvRecordForLayer.
+        // Emit a summary so the connect log also shows the impact.
+        console.warn(
+          `[mcp:${serverName}] ${blocked.length} secret expansion(s) blocked for project-local server`,
+        );
+      }
+      expandedEnv = env;
+    } else {
+      const { value: env, missing } = expandEnvRecord(config.env);
+      if (missing.length > 0) {
+        // Forward as a console warn — manager logs the per-server status
+        // separately; this gives per-variable visibility.
+        console.warn(
+          `[mcp:${serverName}] missing env vars (passing as empty): ${missing.join(', ')}`,
+        );
+      }
+      expandedEnv = env;
+    }
+
+    // ── Build the base inherited env ──────────────────────────────────
+    const base = inheritedDefaultEnv();
+
+    // Scrub dangerous inherited vars for project-local servers (issue #578).
+    if (layer === 'project') {
+      const scrubbed = scrubDangerousEnv(base);
+      if (scrubbed.length > 0) {
+        console.warn(
+          `[mcp:${serverName}] scrubbed dangerous inherited env vars for project-local server: ${scrubbed.join(', ')}`,
+        );
+      }
     }
 
     const params: StdioServerParameters = {
       command: config.command,
       ...(config.args ? { args: config.args } : {}),
-      env: { ...inheritedDefaultEnv(), ...env },
+      env: { ...base, ...expandedEnv },
     };
     return { transport: new StdioClientTransport(params), isSSE: false };
   }

--- a/src/agent/mcp/types.ts
+++ b/src/agent/mcp/types.ts
@@ -91,6 +91,23 @@ export interface McpServerConfig {
    * `tools/list` and `tools/call` requests.
    */
   timeout?: number;
+
+  // ── security (issue #578) ─────────────────────────────────────────
+  /**
+   * Explicit opt-in for secret env-var expansion in project-local servers.
+   *
+   * By default, project-local servers (from `<cwd>/.mcp.json`) cannot expand
+   * `${VAR}` placeholders whose names match known-secret patterns (`*_API_KEY`,
+   * `*_TOKEN`, `*_SECRET*`, `*_PASSWORD`, `AWS_*`, etc.). A blocked expansion
+   * is emitted as a `console.warn` and the placeholder is left empty.
+   *
+   * To allow a specific variable, list it here:
+   *   `"allowSecretEnv": ["MY_PROJECT_TOKEN"]`
+   *
+   * This field is ignored for user-global and plugin servers (they are trusted
+   * and may expand any variable without restriction).
+   */
+  allowSecretEnv?: string[];
 }
 
 /**

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -517,6 +517,7 @@ export function registerChatCommand(program: Command): void {
               mcpManager = await McpManager.fromConfig(loaded.mcpServers, {
                 warnings: loaded.warnings,
                 serverLayers: loaded.serverLayers,
+                userAllowSecretEnv: loaded.userAllowSecretEnv,
                 ...(trace?.writer !== undefined ? { traceWriter: trace.writer } : {}),
               });
             } finally {

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -516,6 +516,7 @@ export function registerChatCommand(program: Command): void {
             try {
               mcpManager = await McpManager.fromConfig(loaded.mcpServers, {
                 warnings: loaded.warnings,
+                serverLayers: loaded.serverLayers,
                 ...(trace?.writer !== undefined ? { traceWriter: trace.writer } : {}),
               });
             } finally {

--- a/src/cli/commands/interactive/bootstrap-mcp.ts
+++ b/src/cli/commands/interactive/bootstrap-mcp.ts
@@ -88,6 +88,7 @@ export async function connectReplMcp(a: {
       // after the clear. `chat` still forwards them — it never clears — so
       // this does not change any other surface, and nothing double-prints.
       mcpManager = await McpManager.fromConfig(loaded.mcpServers, {
+        serverLayers: loaded.serverLayers,
         ...(a.traceWriter !== undefined ? { traceWriter: a.traceWriter } : {}),
       });
     } finally {

--- a/src/cli/commands/interactive/bootstrap-mcp.ts
+++ b/src/cli/commands/interactive/bootstrap-mcp.ts
@@ -89,6 +89,7 @@ export async function connectReplMcp(a: {
       // this does not change any other surface, and nothing double-prints.
       mcpManager = await McpManager.fromConfig(loaded.mcpServers, {
         serverLayers: loaded.serverLayers,
+        userAllowSecretEnv: loaded.userAllowSecretEnv,
         ...(a.traceWriter !== undefined ? { traceWriter: a.traceWriter } : {}),
       });
     } finally {

--- a/src/telegram/mcp-session.ts
+++ b/src/telegram/mcp-session.ts
@@ -55,6 +55,7 @@ export async function loadTelegramMcpManager(
   try {
     return await McpManager.fromConfig(loaded.mcpServers, {
       warnings: loaded.warnings,
+      serverLayers: loaded.serverLayers,
       ...(opts.traceWriter !== undefined ? { traceWriter: opts.traceWriter } : {}),
     });
   } finally {

--- a/src/telegram/mcp-session.ts
+++ b/src/telegram/mcp-session.ts
@@ -56,6 +56,7 @@ export async function loadTelegramMcpManager(
     return await McpManager.fromConfig(loaded.mcpServers, {
       warnings: loaded.warnings,
       serverLayers: loaded.serverLayers,
+      userAllowSecretEnv: loaded.userAllowSecretEnv,
       ...(opts.traceWriter !== undefined ? { traceWriter: opts.traceWriter } : {}),
     });
   } finally {


### PR DESCRIPTION
## What

Defense-in-depth for project-local MCP stdio servers (`<cwd>/.mcp.json`). Closes #578.

Two attack surfaces are closed for **project-layer** servers; user-global / plugin / CLI servers are fully trusted and bypass both restrictions.

---

### 1. Secret expansion refusal

A project server's `env` block with `${AWS_SECRET_ACCESS_KEY}` would previously forward the host credential silently to the child process. Now blocked.

**Patterns refused** (project layer, unless opt-in):
- `*_API_KEY`, `*_TOKEN`, `*_SECRET*`, `*_PASSWORD`
- `AWS_*`, `GCP_*`, `AZURE_*`
- `ANTHROPIC_*`, `OPENAI_*`

**Blocked expansions**: emit a `console.warn`, the var name appears in a new `blocked` field on `EnvExpansionResult`, and the child process receives an empty string.

**Opt-in per variable** in `.mcp.json`:
```json
{
  "mcpServers": {
    "my-tool": {
      "command": "my-mcp-server",
      "allowSecretEnv": ["MY_PROJECT_TOKEN"]
    }
  }
}
```

---

### 2. Dangerous inherited-env scrub

Variables removed from the inherited base env **before** `StdioClientTransport` is constructed for project-layer servers:

| Exact | Prefix |
|---|---|
| `NODE_OPTIONS`, `LD_PRELOAD`, `RUBYOPT` | `DYLD_*`, `PYTHON*`, `PERL5*` |

A warning names any scrubbed vars.

---

## How

Layer origin (`'project' | 'user-global' | 'plugin' | 'cli'`) is now tracked end-to-end:

```
config-loader → LoadedMcpConfig.serverLayers
  → McpManager.fromConfig(opts.serverLayers)
    → ServerRecord.layer
      → McpClient(layer)
        → buildTransportPair(layer)
          → createTransport(layer)
            → expandEnvRecordForLayer / scrubDangerousEnv
```

## Files changed

| File | Change |
|---|---|
| `src/agent/mcp/env-containment.ts` | **New** — secret patterns, dangerous-env list, `checkSecretExpansion`, `scrubDangerousEnv`, `McpServerLayer` type |
| `src/agent/mcp/env.ts` | Layer-aware `expandEnvStringForLayer` / `expandEnvRecordForLayer`; `blocked` field on `EnvExpansionResult` |
| `src/agent/mcp/types.ts` | `McpServerConfig.allowSecretEnv` opt-in field |
| `src/agent/mcp/config-loader.ts` | `LoadedMcpConfig.serverLayers`, `TaggedServer.layer`, `allowSecretEnv` validation |
| `src/agent/mcp/transport.ts` | `createTransport(layer)`, layer-aware expansion, dangerous-env scrub |
| `src/agent/mcp/client.ts` | `McpClient(layer)`, threads to `buildTransportPair` |
| `src/agent/mcp/manager.ts` | `McpManagerInitOptions.serverLayers`, `ServerRecord.layer` |
| Call sites | `scheduler.ts`, `chat.ts`, `bootstrap-mcp.ts`, `mcp-session.ts` — pass `serverLayers` |
| `src/agent/mcp/env-containment.test.ts` | **New** — 39 tests |

## Tests

- 39 new tests in `env-containment.test.ts` covering: pattern matching, dangerous-env detection, layer-aware gate, scrubber, and full expansion integration (all layers, opt-in, mixed secret/safe)
- All 163 existing MCP tests pass
- `pnpm lint` clean (TypeScript strict, no direct `process.env` reads)
