### PR TITLE
feat(tui): show inline colored diffs for patch_apply tool

### DIFF
--- a/src/agent/tools/handlers/patch-apply-engine.ts
+++ b/src/agent/tools/handlers/patch-apply-engine.ts
@@ -12,6 +12,7 @@ import { createHash, randomBytes } from 'crypto';
 import { writeFile, rename, mkdir, unlink, chmod, stat } from 'fs/promises';
 import { dirname, join, isAbsolute, resolve } from 'path';
 import { computeLineDiff } from '../../../utils/diff.js';
+import type { DiffPayload, DiffHunk } from '../../../utils/diff.js';
 import type { PatchFileChange, ValidationError } from './patch-validate.js';
 
 // ---------------------------------------------------------------------------
@@ -23,6 +24,12 @@ export interface PatchApplyResult {
   status: 'applied' | 'dry_run' | 'validation_failed' | 'partial_failure';
   /** Unified diff of all changes (empty string if no changes). */
   diff: string;
+  /**
+   * Structured diff payload merging all per-file diffs. Consumed by the
+   * handler to populate `ToolResult.render.diff` for TUI rendering.
+   * Undefined when no files changed.
+   */
+  structuredDiff?: DiffPayload;
   files_changed: Array<{
     path: string;
     before_hash: string;
@@ -41,17 +48,17 @@ function sha256Hex(content: string): string {
 }
 
 /**
- * Format a structured {@link DiffPayload} as a unified-diff string for a
- * given file pair. Returns an empty string when the payload is null (identical
- * content).
+ * Compute a unified-diff string AND the structured {@link DiffPayload} for a
+ * single file pair. Returns `{ text: '', payload: null }` when the content is
+ * identical.
  */
-function formatUnifiedDiff(
+function computeFileDiff(
   filePath: string,
   before: string,
   after: string,
-): string {
+): { text: string; payload: DiffPayload | null } {
   const payload = computeLineDiff(before, after);
-  if (!payload) return '';
+  if (!payload) return { text: '', payload: null };
 
   const lines: string[] = [
     `--- a/${filePath}`,
@@ -67,7 +74,7 @@ function formatUnifiedDiff(
     }
   }
 
-  return lines.join('\n') + '\n';
+  return { text: lines.join('\n') + '\n', payload };
 }
 
 /**
@@ -125,6 +132,8 @@ export async function applyPatch(
     originalContent: string;
     newContent: string;
     diffBlock: string;
+    diffPayload: DiffPayload | null;
+    filePath: string;
     /** True when the file did not exist before the patch (null sentinel in fileContents). */
     isNewFile: boolean;
   }> = [];
@@ -153,13 +162,31 @@ export async function applyPatch(
       throw new Error(`patch_apply engine: change for ${change.path} has neither content nor edits.`);
     }
 
-    const diffBlock = formatUnifiedDiff(change.path, originalContent, newContent);
+    const fileDiff = computeFileDiff(change.path, originalContent, newContent);
 
-    planned.push({ resolvedPath, originalContent, newContent, diffBlock, isNewFile });
+    planned.push({ resolvedPath, originalContent, newContent, diffBlock: fileDiff.text, diffPayload: fileDiff.payload, filePath: change.path, isNewFile });
   }
 
   // Build combined diff string.
   const combinedDiff = planned.map((p) => p.diffBlock).filter(Boolean).join('\n');
+
+  // Merge per-file structured diffs into a single DiffPayload.
+  // Stamp each hunk with its source filePath so the TUI can render
+  // file-boundary headers when hunks from different files are adjacent.
+  const mergedHunks: DiffHunk[] = [];
+  let totalAdded = 0;
+  let totalRemoved = 0;
+  for (const p of planned) {
+    if (!p.diffPayload) continue;
+    for (const hunk of p.diffPayload.hunks) {
+      mergedHunks.push({ ...hunk, filePath: p.filePath });
+    }
+    totalAdded += p.diffPayload.addedLines;
+    totalRemoved += p.diffPayload.removedLines;
+  }
+  const structuredDiff: DiffPayload | undefined = mergedHunks.length > 0
+    ? { hunks: mergedHunks, addedLines: totalAdded, removedLines: totalRemoved }
+    : undefined;
 
   // Compute result metadata (before/after hashes).
   const filesChanged = planned.map((p) => ({
@@ -173,6 +200,7 @@ export async function applyPatch(
     return {
       status: 'dry_run',
       diff: combinedDiff,
+      structuredDiff,
       files_changed: filesChanged,
       errors: [],
     };
@@ -295,6 +323,7 @@ export async function applyPatch(
   return {
     status: 'applied',
     diff: combinedDiff,
+    structuredDiff,
     files_changed: filesChanged,
     errors: [],
   };

--- a/src/agent/tools/handlers/patch-apply.test.ts
+++ b/src/agent/tools/handlers/patch-apply.test.ts
@@ -201,3 +201,90 @@ describe('patch_apply handler — dry_run', () => {
     expect(Array.isArray(parsed.errors)).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// render.diff sidecar
+// ---------------------------------------------------------------------------
+
+describe('patch_apply — render.diff sidecar', () => {
+  it('attaches structured DiffPayload on successful apply', async () => {
+    const filePath = await writeTemp('render-diff.txt', 'hello world\n');
+    const handler = createPatchApplyHandler(tempDir);
+
+    const result = await handler(
+      {
+        changes: [
+          { path: filePath, edits: [{ old: 'hello', new: 'goodbye' }] },
+        ],
+      },
+      signal,
+      makeCtx(),
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(result.render).toBeDefined();
+    expect(result.render!.diff).toBeDefined();
+    const diff = result.render!.diff!;
+    expect(diff.hunks.length).toBeGreaterThan(0);
+    expect(diff.addedLines).toBeGreaterThan(0);
+    expect(diff.removedLines).toBeGreaterThan(0);
+  });
+
+  it('stamps filePath on hunks for multi-file patches', async () => {
+    await writeTemp('a.txt', 'aaa\n');
+    await writeTemp('b.txt', 'bbb\n');
+    const handler = createPatchApplyHandler(tempDir);
+
+    const result = await handler(
+      {
+        changes: [
+          { path: path.join(tempDir, 'a.txt'), edits: [{ old: 'aaa', new: 'AAA' }] },
+          { path: path.join(tempDir, 'b.txt'), edits: [{ old: 'bbb', new: 'BBB' }] },
+        ],
+      },
+      signal,
+      makeCtx(),
+    );
+
+    expect(result.isError).toBeFalsy();
+    const diff = result.render!.diff!;
+    // Two files, each contributing at least one hunk.
+    expect(diff.hunks.length).toBeGreaterThanOrEqual(2);
+    // Each hunk should have a filePath set.
+    const filePaths = new Set(diff.hunks.map((h) => h.filePath));
+    expect(filePaths.size).toBe(2);
+  });
+
+  it('attaches structured DiffPayload on dry_run', async () => {
+    await writeTemp('dry-render.txt', 'original\n');
+    const handler = createPatchApplyHandler(tempDir);
+
+    const result = await handler(
+      {
+        changes: [
+          { path: path.join(tempDir, 'dry-render.txt'), edits: [{ old: 'original', new: 'modified' }] },
+        ],
+        dry_run: true,
+      },
+      signal,
+      makeCtx(),
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(result.render).toBeDefined();
+    expect(result.render!.diff!.hunks.length).toBeGreaterThan(0);
+  });
+
+  it('omits render.diff when no changes produce a diff', async () => {
+    const handler = createPatchApplyHandler(tempDir);
+
+    const result = await handler(
+      { changes: [] },
+      signal,
+      makeCtx(),
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(result.render).toBeUndefined();
+  });
+});

--- a/src/agent/tools/handlers/patch-apply.ts
+++ b/src/agent/tools/handlers/patch-apply.ts
@@ -194,6 +194,7 @@ export function createPatchApplyHandler(cwd?: string): ToolHandler {
         2,
       ),
       isError,
+      ...(applyResult.structuredDiff ? { render: { diff: applyResult.structuredDiff } } : {}),
     };
   };
 }

--- a/src/cli/commands/interactive/tool-lane-format-diff.ts
+++ b/src/cli/commands/interactive/tool-lane-format-diff.ts
@@ -216,7 +216,16 @@ export function formatDiffBlock(
     | { kind: 'body'; text: string };
   const items: Item[] = [];
 
+  // Track the last-seen filePath so multi-file diffs (e.g. patch_apply)
+  // get a dim file-path header at each file boundary. Single-file diffs
+  // (edit_file) never set filePath on hunks so this is a no-op for them.
+  let lastFilePath: string | undefined;
+
   for (const hunk of diff.hunks) {
+    if (hunk.filePath && hunk.filePath !== lastFilePath) {
+      items.push({ kind: 'header', text: palette.dim(hunk.filePath) });
+      lastFilePath = hunk.filePath;
+    }
     const header = `@@ -${hunk.oldStart},${hunk.oldLines} +${hunk.newStart},${hunk.newLines} @@`;
     items.push({ kind: 'header', text: palette.diffHunk(header) });
     for (const line of hunk.lines) {

--- a/src/cli/commands/interactive/tool-lane-format-diff.ts
+++ b/src/cli/commands/interactive/tool-lane-format-diff.ts
@@ -223,7 +223,8 @@ export function formatDiffBlock(
 
   for (const hunk of diff.hunks) {
     if (hunk.filePath && hunk.filePath !== lastFilePath) {
-      items.push({ kind: 'header', text: palette.dim(hunk.filePath) });
+      const safePath = stripAnsi(hunk.filePath).replace(CONTROL_CHAR_RE, '');
+      items.push({ kind: 'header', text: palette.dim(safePath) });
       lastFilePath = hunk.filePath;
     }
     const header = `@@ -${hunk.oldStart},${hunk.oldLines} +${hunk.newStart},${hunk.newLines} @@`;

--- a/src/cli/commands/interactive/tool-lane-format.test.ts
+++ b/src/cli/commands/interactive/tool-lane-format.test.ts
@@ -1286,6 +1286,59 @@ describe('formatDiffBlock — render-only diff rendering', () => {
     // The visible text content should still appear.
     expect(stripped).toContain('colored content');
   });
+
+  it('renders file-path headers between hunks from different files', () => {
+    const diff: DiffPayload = {
+      addedLines: 2,
+      removedLines: 0,
+      hunks: [
+        {
+          oldStart: 1, oldLines: 1, newStart: 1, newLines: 2, filePath: 'src/a.ts',
+          lines: [{ kind: '+', text: 'a line' }],
+        },
+        {
+          oldStart: 1, oldLines: 1, newStart: 1, newLines: 2, filePath: 'src/b.ts',
+          lines: [{ kind: '+', text: 'b line' }],
+        },
+      ],
+    };
+    const lines = formatDiffBlock(diff, 'flush', '  ').map(stripAnsi);
+    // Should contain both file-path headers before their respective @@ lines.
+    expect(lines).toContain('  src/a.ts');
+    expect(lines).toContain('  src/b.ts');
+    // File headers come before their hunk headers.
+    const aIdx = lines.indexOf('  src/a.ts');
+    const aHunkIdx = lines.findIndex((l, i) => i > aIdx && l.includes('@@'));
+    expect(aHunkIdx).toBeGreaterThan(aIdx);
+  });
+
+  it('omits file-path header when all hunks share the same file', () => {
+    const diff: DiffPayload = {
+      addedLines: 2,
+      removedLines: 0,
+      hunks: [
+        {
+          oldStart: 1, oldLines: 1, newStart: 1, newLines: 2, filePath: 'src/a.ts',
+          lines: [{ kind: '+', text: 'line 1' }],
+        },
+        {
+          oldStart: 10, oldLines: 1, newStart: 11, newLines: 2, filePath: 'src/a.ts',
+          lines: [{ kind: '+', text: 'line 2' }],
+        },
+      ],
+    };
+    const lines = formatDiffBlock(diff, 'flush', '').map(stripAnsi);
+    // Only one file-path header (first hunk), not before the second.
+    const fileHeaders = lines.filter((l) => l === 'src/a.ts');
+    expect(fileHeaders.length).toBe(1);
+  });
+
+  it('does not emit file-path headers when filePath is absent (single-file edit)', () => {
+    const lines = formatDiffBlock(makeDiff(), 'flush', '').map(stripAnsi);
+    // No line should look like a bare file-path header.
+    // Lines are: stat header, @@ hunk header, context/add/remove body lines.
+    expect(lines.some((l) => /^\s*src\//.test(l))).toBe(false);
+  });
 });
 
 /**

--- a/src/utils/diff.ts
+++ b/src/utils/diff.ts
@@ -33,6 +33,13 @@ export interface DiffHunk {
   /** Number of NEW-side lines in this hunk (context + insertions). */
   newLines: number;
   lines: DiffLine[];
+  /**
+   * Source file path for this hunk. Set by multi-file tools (e.g.
+   * `patch_apply`) so the TUI can render file-boundary headers when hunks
+   * from different files are merged into a single {@link DiffPayload}.
+   * Absent for single-file diffs (e.g. `edit_file`).
+   */
+  filePath?: string;
 }
 
 /** A structured render-only diff payload. */


### PR DESCRIPTION
## Summary

`patch_apply` now shows inline colored diffs in the TUI, matching the rendering that `edit_file` already has. Previously, `patch_apply` embedded the diff as a string inside JSON `content` -- the user saw raw JSON instead of a formatted diff block.

## Problem

The `patch_apply` tool returned its diff as a plain string buried inside `JSON.stringify`'d content with no `render.diff` sidecar. The entire TUI rendering pipeline (`tool.diff` provider event -> `tool_diff` stream chunk -> `formatDiffBlock`) already existed for `edit_file` but `patch_apply` never plugged into it.

## Changes

**`src/utils/diff.ts`** -- Added optional `filePath` field to `DiffHunk` interface. Multi-file tools stamp each hunk with its source file path so the TUI can render file-boundary headers. Backward-compatible: single-file diffs don't set it.

**`src/agent/tools/handlers/patch-apply-engine.ts`** -- Refactored `formatUnifiedDiff` into `computeFileDiff` which returns both the string representation AND the structured `DiffPayload` (previously discarded). Added `structuredDiff` field to `PatchApplyResult` carrying a merged `DiffPayload` across all files.

**`src/agent/tools/handlers/patch-apply.ts`** -- Attached `render: { diff }` to the `ToolResult` when a structured diff is available, enabling the existing provider sidecar pipeline.

**`src/cli/commands/interactive/tool-lane-format-diff.ts`** -- Added file-path header rendering at file boundaries in `formatDiffBlock`. When consecutive hunks have different `filePath` values, a dim file-path line is emitted before the `@@` header.

## What it looks like

Multi-file patch rendering:
```
  +5 -3 across 4 hunks
  src/a.ts
  @@ -10,3 +10,5 @@
    context
  - old line
  + new line
  src/b.ts
  @@ -1,2 +1,3 @@
  + added line
```

Single-file patches render identically to `edit_file`.

## Testing

- 7 new tests across `patch-apply.test.ts` (4 tests: render.diff on apply, multi-file filePath stamps, dry_run, empty changes) and `tool-lane-format.test.ts` (3 tests: file-path headers between files, same-file dedup, absence for single-file diffs)
- All 199 tests pass across the 4 affected test suites
- `pnpm lint` passes
- No provider or stream-consumer changes needed -- both Anthropic and OpenAI providers already emit `tool.diff` when `render.diff` is present
