### PR TITLE
fix(improve): detect `truncated` closure reason as anomalous

### DIFF
--- a/src/agent/session/closure-guidance.test.ts
+++ b/src/agent/session/closure-guidance.test.ts
@@ -2,8 +2,8 @@
  * Tests for the `closure-anomaly` guardrail — {@link buildClosureGuidance}.
  *
  * Pure function: maps a {@link ClosureReason} to an actionable recovery hint
- * (abort, iteration_cap, timeout subtypes) or `null` (benign closes +
- * anomalous reasons not yet covered). The wiring onto the closure trace event
+ * (abort, iteration_cap, timeout, truncated subtypes) or `null` (benign
+ * closes + anomalous reasons not yet covered). The wiring onto the closure trace event
  * is covered in `trace/closure.test.ts`; the eval-run contract is covered in
  * `improve/eval-run/contracts.test.ts`.
  */
@@ -15,6 +15,7 @@ import {
   CLOSURE_ABORT_RECOVERY_HINT,
   CLOSURE_ITERATION_CAP_RECOVERY_HINT,
   CLOSURE_TIMEOUT_RECOVERY_HINT,
+  CLOSURE_TRUNCATED_RECOVERY_HINT,
 } from './closure-guidance.js';
 
 describe('buildClosureGuidance', () => {
@@ -60,10 +61,19 @@ describe('buildClosureGuidance', () => {
     expect(CLOSURE_TIMEOUT_RECOVERY_HINT).toMatch(/trace|slow tool/i);
   });
 
+  // -- truncated --
+  it('returns the canonical recovery hint for a truncated closure', () => {
+    expect(buildClosureGuidance('truncated')).toBe(CLOSURE_TRUNCATED_RECOVERY_HINT);
+    expect(CLOSURE_TRUNCATED_RECOVERY_HINT.trim().length).toBeGreaterThan(0);
+  });
+
+  it('the truncated hint names a concrete recovery action', () => {
+    expect(buildClosureGuidance('truncated')).toMatch(/\b(resume|re-run|rerun|retry)\b/i);
+  });
+
   // -- benign --
   it('returns null for benign closes — no false-positive guidance', () => {
     expect(buildClosureGuidance('model_end_turn')).toBeNull();
-    expect(buildClosureGuidance('truncated')).toBeNull();
   });
 
   // -- deferred anomalous subtypes --

--- a/src/agent/session/closure-guidance.ts
+++ b/src/agent/session/closure-guidance.ts
@@ -13,11 +13,11 @@
  * deterministic builder, wired at one production site and exercised directly
  * by an `afk improve eval-run` contract (no LLM, no network).
  *
- * Coverage: `abort`, `iteration_cap`, and `timeout` carry guidance today.
- * The detector flags six anomalous reasons; the remaining three
- * (budget_exceeded, hook_blocked, max_turns_exceeded) each get their own
- * hint in a follow-up. Benign reasons (model_end_turn, truncated) never
- * carry guidance — a clean close needs no recovery action.
+ * Coverage: `abort`, `iteration_cap`, `timeout`, and `truncated` carry
+ * guidance today. The detector flags seven anomalous reasons; the remaining
+ * three (budget_exceeded, hook_blocked, max_turns_exceeded) each get their
+ * own hint in a follow-up. Only `model_end_turn` is benign — a clean close
+ * needs no recovery action.
  *
  * @module agent/session/closure-guidance
  */
@@ -58,6 +58,18 @@ export const CLOSURE_TIMEOUT_RECOVERY_HINT =
   'waiting on a slow tool call.';
 
 /**
+ * Recovery hint for a `truncated` closure. The model's final turn was cut off
+ * by the output-token ceiling (Anthropic `max_tokens`, OpenAI `length` /
+ * `max_output_tokens`) — the session may have been mid-tool-call or
+ * mid-response when the provider stopped generating.
+ */
+export const CLOSURE_TRUNCATED_RECOVERY_HINT =
+  'Session output was truncated by the model provider\'s output-token ceiling ' +
+  'before the response completed. The transcript and witness trace are ' +
+  'preserved — resume with `afk --resume <sessionId>` to continue from where ' +
+  'the output was cut off.';
+
+/**
  * Map a closure reason to an actionable recovery hint, or `null` when no
  * guidance applies (benign closes, and anomalous reasons not yet covered).
  *
@@ -73,6 +85,8 @@ export function buildClosureGuidance(reason: ClosureReason): string | null {
       return CLOSURE_ITERATION_CAP_RECOVERY_HINT;
     case 'timeout':
       return CLOSURE_TIMEOUT_RECOVERY_HINT;
+    case 'truncated':
+      return CLOSURE_TRUNCATED_RECOVERY_HINT;
     default:
       return null;
   }

--- a/src/improve/propose/template-engine.ts
+++ b/src/improve/propose/template-engine.ts
@@ -452,6 +452,8 @@ function closureAdviceFor(reason: string): string {
       return 'Loop iteration ceiling tripped. The model could not make progress in N turns. Either the task is genuinely impossible at that budget, or a tool is in an unproductive loop (cross-reference repeated-tool-use cards).';
     case 'max_turns_exceeded':
       return 'Turn ceiling tripped. Same diagnostic as iteration_cap.';
+    case 'truncated':
+      return 'The model hit the output-token ceiling mid-response. Check `max_tokens` and the model\'s output limit. Consider retrying with a larger output budget or splitting the task into smaller steps.';
     default:
       return 'Reason not in the known anomalous set. Inspect the trace and update the detector if this is a new closure variant.';
   }

--- a/src/improve/scan/detectors/closure-anomaly.test.ts
+++ b/src/improve/scan/detectors/closure-anomaly.test.ts
@@ -179,6 +179,20 @@ describe('detectClosureAnomaly — threshold + severity', () => {
     ];
     expect(detectClosureAnomaly(s3)[0]?.severity).toBe('medium');
   });
+
+  it('truncated starts medium, escalates to high at >=3', () => {
+    resetSeq();
+    const s1 = [makeSession('s1', [closureLine('truncated')])];
+    expect(detectClosureAnomaly(s1)[0]?.severity).toBe('medium');
+
+    resetSeq();
+    const s3 = [
+      makeSession('a', [closureLine('truncated')]),
+      makeSession('b', [closureLine('truncated')]),
+      makeSession('c', [closureLine('truncated')]),
+    ];
+    expect(detectClosureAnomaly(s3)[0]?.severity).toBe('high');
+  });
 });
 
 describe('detectClosureAnomaly — slug + schema conformance', () => {

--- a/src/improve/scan/detectors/closure-anomaly.ts
+++ b/src/improve/scan/detectors/closure-anomaly.ts
@@ -58,7 +58,7 @@ import type { SessionRead } from '../reader.js';
 /** Default minimum sessions sharing a reason before a card fires. */
 export const DEFAULT_CLOSURE_ANOMALY_MIN_OCCURRENCES = 1;
 
-/** Closure reasons we treat as anomalous. `model_end_turn` is excluded. */
+/** Closure reasons we treat as anomalous. Only `model_end_turn` is excluded. */
 const ANOMALOUS_REASONS = new Set<string>([
   'budget_exceeded',
   'timeout',
@@ -66,6 +66,7 @@ const ANOMALOUS_REASONS = new Set<string>([
   'abort',
   'iteration_cap',
   'max_turns_exceeded',
+  'truncated',
 ]);
 
 export interface ClosureAnomalyOptions {

--- a/src/improve/scan/detectors/closure-anomaly.ts
+++ b/src/improve/scan/detectors/closure-anomaly.ts
@@ -3,8 +3,8 @@
  *
  * The runtime writes a terminal `closure` event on every session teardown
  * (`src/agent/session/agent-session.ts:680` emits it; the writer's `seal()`
- * follows). The payload carries a `reason` discriminated union with seven
- * values; six of them indicate something other than a clean end-of-turn
+ * follows). The payload carries a `reason` discriminated union with eight
+ * values; seven of them indicate something other than a clean end-of-turn
  * stop:
  *
  *   - `budget_exceeded`     — monetary ceiling crossed
@@ -13,6 +13,7 @@
  *   - `abort`               — explicit cancellation / cascade
  *   - `iteration_cap`       — loop iteration ceiling
  *   - `max_turns_exceeded`  — turn ceiling
+ *   - `truncated`           — model output-token ceiling hit mid-response
  *
  * `model_end_turn` is the only normal exit. Everything else is surfaced
  * as a card. One card per anomalous reason; sessions sharing that reason

--- a/src/improve/scan/detectors/closure-anomaly.ts
+++ b/src/improve/scan/detectors/closure-anomaly.ts
@@ -241,6 +241,8 @@ function buildResult(
  *   - `budget_exceeded` / `timeout` → high regardless of count (one is bad).
  *   - `hook_blocked` / `iteration_cap` / `max_turns_exceeded` → medium;
  *     escalates to high at ≥3 occurrences.
+ *   - `truncated` → medium (model hit output-token ceiling mid-response);
+ *     escalates to high at ≥3 occurrences.
  *   - `abort` → low by default (often user-initiated), medium at ≥3.
  *
  * The ladder is intentionally conservative; reviewers can escalate via
@@ -254,6 +256,7 @@ function severityFor(reason: string, count: number): Severity {
     case 'hook_blocked':
     case 'iteration_cap':
     case 'max_turns_exceeded':
+    case 'truncated':
       return count >= 3 ? 'high' : 'medium';
     case 'abort':
       return count >= 3 ? 'medium' : 'low';


### PR DESCRIPTION
## Problem

The `ClosureReason` type gained `'truncated'` (output-token ceiling hit from Anthropic `max_tokens` / OpenAI `length`) but the `closure-anomaly` detector's `ANOMALOUS_REASONS` set was never updated. Sessions where the model's output was cut off by the token ceiling were silently dropped -- neither flagged as anomalous nor excluded as benign.

Found during a full `afk improve` pipeline health check.

## Fix

- Add `'truncated'` to `ANOMALOUS_REASONS` in the closure-anomaly detector so token-ceiling truncations surface as failure cards
- Add `CLOSURE_TRUNCATED_RECOVERY_HINT` with actionable guidance (resume from where output was cut off)
- Wire `'truncated'` case in `buildClosureGuidance` switch
- Update tests: move `truncated` from "benign" assertion to its own covered-reason test group with canonical-constant + recovery-action checks

## Verification

- `pnpm lint` clean
- `closure-guidance.test.ts`: 14 tests pass (2 new for truncated)
- `closure-anomaly.test.ts`: 26 tests pass
- `contracts.test.ts`: 21 tests pass
- Live `afk improve eval-run closure-anomaly-abort` still passes (8/8 checks)

## Files changed

| File | What |
|------|------|
| `src/improve/scan/detectors/closure-anomaly.ts` | Add `'truncated'` to `ANOMALOUS_REASONS` |
| `src/agent/session/closure-guidance.ts` | Add `CLOSURE_TRUNCATED_RECOVERY_HINT`, wire in switch, update doc comment |
| `src/agent/session/closure-guidance.test.ts` | Move `truncated` to covered-reason tests, add import |
