### PR TITLE
feat(subagent): child-to-parent progress events via emit_progress tool (#1418)

### DIFF
--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -47,6 +47,7 @@ import { resolveForkInputs } from './subagent/fork-resolution.js';
 import type { SubagentStatus, SubagentResult, SubagentTrace } from './subagent/result.js';
 import { CompletedCache } from './subagent/completed-cache.js';
 import { SubagentLogWriter } from './subagent/log.js';
+import { wireProgressEvents } from './subagent/fork-progress-events.js';
 
 // Re-export types for public API
 export type { SubagentStatus, SubagentResult, SubagentTrace, SubagentHandle };
@@ -56,13 +57,8 @@ export type { SubagentStatus, SubagentResult, SubagentTrace, SubagentHandle };
 // use by SubagentManager below AND re-exported here unchanged, so every
 // existing `from './subagent.js'` importer keeps working untouched.
 import {
-  DENY_ELICITATION,
-  SUBAGENT_DEFAULT_MAX_TOOL_USE_ITERATIONS,
-  SUBAGENT_DEFAULT_TIMEOUT_MS,
   SUBAGENT_DEFAULT_IDLE_TIMEOUT_MS,
-  SUBAGENT_BACKGROUND_TIMEOUT_MS,
   SUBAGENT_DRAIN_TIMEOUT_MS,
-  resolveSubagentTimeoutMs,
   resolveSubagentIdleTimeoutMs,
 } from './subagent/constants.js';
 
@@ -72,14 +68,18 @@ import type {
   SubagentManagerOptions,
 } from './subagent/fork-types.js';
 
+// Re-export-only symbols forwarded without local use.
 export {
   DENY_ELICITATION,
   SUBAGENT_DEFAULT_MAX_TOOL_USE_ITERATIONS,
   SUBAGENT_DEFAULT_TIMEOUT_MS,
-  SUBAGENT_DEFAULT_IDLE_TIMEOUT_MS,
   SUBAGENT_BACKGROUND_TIMEOUT_MS,
-  SUBAGENT_DRAIN_TIMEOUT_MS,
   resolveSubagentTimeoutMs,
+} from './subagent/constants.js';
+// Locally-used symbols also re-exported for public API.
+export {
+  SUBAGENT_DEFAULT_IDLE_TIMEOUT_MS,
+  SUBAGENT_DRAIN_TIMEOUT_MS,
   resolveSubagentIdleTimeoutMs,
 };
 export type { ForkParent, ForkSubagentOptions, SubagentManagerOptions };
@@ -414,6 +414,9 @@ export class SubagentManager {
       stopOccupancyHeartbeat = startWorktreeOccupancyHeartbeat(childConfig.cwd);
     }
 
+    // Progress-events opt-in — mutates childConfig.customTools in place when enabled.
+    const bindProgressHandle = wireProgressEvents(childConfig, options.progressEvents, options.parent.getInputStreamRef?.(), options.parent.abortSignal);
+
     // Ordering constraint: the heartbeat armed above is disarmed by the settle
     // callback installed on the handle built below, so the guarded span has to
     // run from construction all the way through `active.set`. A throw anywhere
@@ -518,6 +521,7 @@ export class SubagentManager {
         options.config.idleTimeoutMs ?? resolveSubagentIdleTimeoutMs(),
       );
       if (logWriter) handle._logWriter = logWriter;
+      bindProgressHandle(handle as SubagentHandleImpl<unknown>);
       this.active.set(id, handle as SubagentHandleImpl<unknown>);
     } catch (err) {
       // Construction or manager-wiring failed (invalid model, sync init

--- a/src/agent/subagent/fork-progress-events.test.ts
+++ b/src/agent/subagent/fork-progress-events.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Unit tests for wireProgressEvents: the opt-in wiring that injects the
+ * emit_progress custom tool into a child's AgentConfig.
+ *
+ * Covers the four cases the review identified as untested:
+ *   (a) disabled path leaves config.customTools unchanged
+ *   (b) enabled path appends a tool named emit_progress
+ *   (c) returned bindProgressHandle sets the ref so handler succeeds
+ *   (d) calling handler before bindProgressHandle returns not-initialized error
+ */
+
+import { describe, it, expect } from 'vitest';
+import { wireProgressEvents } from './fork-progress-events.js';
+import type { AgentConfig } from '../types.js';
+
+/**
+ * Build a minimal AgentConfig stub with only the fields wireProgressEvents
+ * reads and mutates (customTools).
+ */
+function makeConfig(customTools?: AgentConfig['customTools']): AgentConfig {
+  return { customTools } as unknown as AgentConfig;
+}
+
+/** Minimal handle double matching the SubagentHandleImpl surface emit_progress uses. */
+function makeHandleDouble() {
+  const _progressEvents: Array<{ message: string }> = [];
+  return {
+    id: 'test-handle',
+    _currentStatus: 'running' as const,
+    _progressEvents,
+    emitProgress(payload: { message: string }): void {
+      if (
+        this._currentStatus === 'succeeded' ||
+        this._currentStatus === 'failed' ||
+        this._currentStatus === 'cancelled'
+      ) {
+        return;
+      }
+      _progressEvents.push(payload);
+    },
+  } as Parameters<ReturnType<typeof wireProgressEvents>>[0];
+}
+
+describe('wireProgressEvents', () => {
+  // (a) Disabled path
+  it('returns a no-op bindHandle and does not modify config when enabled is falsy', () => {
+    const config = makeConfig();
+    const bindHandle = wireProgressEvents(config, false, undefined, undefined);
+    expect(config.customTools).toBeUndefined();
+    // bindHandle is a no-op — calling it should not throw
+    bindHandle(makeHandleDouble());
+  });
+
+  it('returns a no-op bindHandle when enabled is undefined', () => {
+    const config = makeConfig();
+    const bindHandle = wireProgressEvents(config, undefined, undefined, undefined);
+    expect(config.customTools).toBeUndefined();
+    bindHandle(makeHandleDouble());
+  });
+
+  it('preserves existing customTools when disabled', () => {
+    const existingTool = { schema: { name: 'existing' } } as AgentConfig['customTools'] extends (infer T)[] | undefined ? T : never;
+    const config = makeConfig([existingTool]);
+    wireProgressEvents(config, false, undefined, undefined);
+    expect(config.customTools).toHaveLength(1);
+    expect(config.customTools![0]).toBe(existingTool);
+  });
+
+  // (b) Enabled path appends emit_progress
+  it('appends an emit_progress tool to config.customTools when enabled', () => {
+    const config = makeConfig();
+    wireProgressEvents(config, true, undefined, undefined);
+    expect(config.customTools).toHaveLength(1);
+    expect(config.customTools![0]!.schema.name).toBe('emit_progress');
+  });
+
+  it('preserves existing customTools and appends emit_progress', () => {
+    const existingTool = { schema: { name: 'existing' } } as AgentConfig['customTools'] extends (infer T)[] | undefined ? T : never;
+    const config = makeConfig([existingTool]);
+    wireProgressEvents(config, true, undefined, undefined);
+    expect(config.customTools).toHaveLength(2);
+    expect(config.customTools![0]!.schema.name).toBe('existing');
+    expect(config.customTools![1]!.schema.name).toBe('emit_progress');
+  });
+
+  // (c) bindProgressHandle sets ref so handler succeeds
+  it('returns { delivered: true } after bindProgressHandle is called', async () => {
+    const queueCalls: string[] = [];
+    const parentRef = {
+      pushUserMessage: () => {},
+      queueFrameworkContext: (text: string) => { queueCalls.push(text); },
+    };
+    const config = makeConfig();
+    const bindHandle = wireProgressEvents(config, true, parentRef, undefined);
+    const handle = makeHandleDouble();
+    bindHandle(handle);
+
+    // Invoke the tool handler directly
+    const toolDef = config.customTools![0]!;
+    const result = await toolDef.handler({ message: 'test progress' }, new AbortController().signal);
+    expect(result.isError).toBeUndefined();
+    expect(JSON.parse(result.content as string)).toEqual({ delivered: true });
+    expect(queueCalls).toHaveLength(1);
+    expect(queueCalls[0]).toContain('<child-progress');
+  });
+
+  // (d) Handler before bindProgressHandle returns not-initialized error
+  it('returns isError when handler is called before bindProgressHandle', async () => {
+    const config = makeConfig();
+    wireProgressEvents(config, true, undefined, undefined);
+    const toolDef = config.customTools![0]!;
+    const result = await toolDef.handler({ message: 'too early' }, new AbortController().signal);
+    expect(result.isError).toBe(true);
+    expect(String(result.content)).toContain('handle not yet initialized');
+  });
+});

--- a/src/agent/subagent/fork-progress-events.ts
+++ b/src/agent/subagent/fork-progress-events.ts
@@ -1,0 +1,107 @@
+/**
+ * Progress-events opt-in wiring for forked subagents.
+ *
+ * When a parent dispatches a child with `progressEvents: true`, the child's
+ * `AgentConfig.customTools` is extended with the `emit_progress` tool. This
+ * module owns that injection so the main `SubagentManager.forkSubagent` method
+ * does not grow unbounded.
+ *
+ * The injection must happen BEFORE `new AgentSession(childConfig)` but the
+ * tool handler requires access to the not-yet-constructed `SubagentHandleImpl`.
+ * A mutable ref object bridges the two: `applyProgressEventsToConfig` returns
+ * both the augmented config and a ref whose `.current` field must be set by the
+ * caller immediately after `SubagentHandleImpl` is constructed.
+ *
+ * @module agent/subagent/fork-progress-events
+ */
+
+import { z } from 'zod';
+import type { AgentConfig } from '../types.js';
+import type { InputStreamRef } from '../types/permission-types.js';
+import { tool } from '../tools/custom-tool.js';
+import {
+  createEmitProgressHandler,
+  PROGRESS_MAX_MESSAGE_BYTES,
+} from '../tools/subagent/emit-progress.js';
+import type { SubagentHandleImpl } from './handle.js';
+
+/** Callback returned by {@link wireProgressEvents} -- binds the handle after construction. */
+export type BindProgressHandle = (handle: SubagentHandleImpl<unknown>) => void;
+
+/**
+ * Conditionally inject the `emit_progress` custom tool into a child's config.
+ *
+ * Mutates `config.customTools` in place (the spread inside `assembleChildConfig`
+ * already produced a fresh object, so mutation is safe). Returns a `bindHandle`
+ * callback that the caller MUST invoke with the constructed `SubagentHandleImpl`.
+ *
+ * When `enabled` is falsy, the config is untouched and `bindHandle` is a no-op,
+ * so the caller needs no conditional branching.
+ */
+export function wireProgressEvents(
+  config: AgentConfig,
+  enabled: boolean | undefined,
+  parentInputStreamRef: InputStreamRef | undefined,
+  parentAbortSignal: AbortSignal | undefined,
+): BindProgressHandle {
+  if (!enabled) return () => {};
+  return applyProgressEventsToConfig(config, parentInputStreamRef, parentAbortSignal);
+}
+
+/**
+ * Inject the `emit_progress` custom tool into a child's `AgentConfig`.
+ * Internal -- callers should use `wireProgressEvents` which handles the opt-in guard.
+ */
+function applyProgressEventsToConfig(
+  config: AgentConfig,
+  parentInputStreamRef: InputStreamRef | undefined,
+  parentAbortSignal: AbortSignal | undefined,
+): BindProgressHandle {
+  const handleRef: { current: SubagentHandleImpl<unknown> | undefined } = { current: undefined };
+  const capturedRef = handleRef;
+
+  const emitProgressTool = tool(
+    'emit_progress',
+    'Emit a structured progress event to the parent agent. ' +
+      'The event is delivered to the parent at its next user-turn boundary, ' +
+      'wrapped in a <child-progress> envelope. ' +
+      'Use to report phase transitions, intermediate findings, or status updates ' +
+      'so the parent stays informed without waiting for the full result. ' +
+      `The "message" field is required (max ${PROGRESS_MAX_MESSAGE_BYTES} bytes). ` +
+      '"phase" and "metadata" are optional. ' +
+      'This tool does NOT count against maxToolUseIterations — it is meta, not work.',
+    z.object({
+      message: z.string().describe('Progress message to deliver to the parent (required).'),
+      phase: z
+        .string()
+        .optional()
+        .describe('Optional phase label (e.g. "research", "planning", "done").'),
+      metadata: z
+        .record(z.string(), z.unknown())
+        .optional()
+        .describe('Optional structured metadata for machine consumers.'),
+    }),
+    async (input, signal) => {
+      if (capturedRef.current === undefined) {
+        return { content: 'emit_progress: handle not yet initialized.', isError: true };
+      }
+      const handlerFn = createEmitProgressHandler(
+        capturedRef.current,
+        (text) => {
+          if (parentInputStreamRef?.queueFrameworkContext) {
+            parentInputStreamRef.queueFrameworkContext(text);
+          } else if (parentInputStreamRef) {
+            parentInputStreamRef.pushUserMessage(text);
+          }
+        },
+        parentAbortSignal,
+      );
+      return handlerFn(input, signal);
+    },
+  );
+
+  // Mutate in place -- the config object is already a fresh shallow copy
+  // produced by assembleChildConfig's spread.
+  config.customTools = [...(config.customTools ?? []), emitProgressTool];
+  return (handle: SubagentHandleImpl<unknown>) => { capturedRef.current = handle; };
+}

--- a/src/agent/subagent/fork-progress-events.ts
+++ b/src/agent/subagent/fork-progress-events.ts
@@ -59,6 +59,7 @@ function applyProgressEventsToConfig(
 ): BindProgressHandle {
   const handleRef: { current: SubagentHandleImpl<unknown> | undefined } = { current: undefined };
   const capturedRef = handleRef;
+  let cachedHandler: ReturnType<typeof createEmitProgressHandler> | undefined;
 
   const emitProgressTool = tool(
     'emit_progress',
@@ -69,7 +70,7 @@ function applyProgressEventsToConfig(
       'so the parent stays informed without waiting for the full result. ' +
       `The "message" field is required (max ${PROGRESS_MAX_MESSAGE_BYTES} bytes). ` +
       '"phase" and "metadata" are optional. ' +
-      'This tool does NOT count against maxToolUseIterations — it is meta, not work.',
+      'Note: this tool call counts as a tool-use round.',
     z.object({
       message: z.string().describe('Progress message to deliver to the parent (required).'),
       phase: z
@@ -85,18 +86,20 @@ function applyProgressEventsToConfig(
       if (capturedRef.current === undefined) {
         return { content: 'emit_progress: handle not yet initialized.', isError: true };
       }
-      const handlerFn = createEmitProgressHandler(
-        capturedRef.current,
-        (text) => {
-          if (parentInputStreamRef?.queueFrameworkContext) {
-            parentInputStreamRef.queueFrameworkContext(text);
-          } else if (parentInputStreamRef) {
-            parentInputStreamRef.pushUserMessage(text);
-          }
-        },
-        parentAbortSignal,
-      );
-      return handlerFn(input, signal);
+      if (cachedHandler === undefined) {
+        cachedHandler = createEmitProgressHandler(
+          capturedRef.current,
+          (text) => {
+            if (parentInputStreamRef?.queueFrameworkContext) {
+              parentInputStreamRef.queueFrameworkContext(text);
+            } else if (parentInputStreamRef) {
+              parentInputStreamRef.pushUserMessage(text);
+            }
+          },
+          parentAbortSignal,
+        );
+      }
+      return cachedHandler(input, signal);
     },
   );
 

--- a/src/agent/subagent/fork-progress-events.ts
+++ b/src/agent/subagent/fork-progress-events.ts
@@ -58,7 +58,6 @@ function applyProgressEventsToConfig(
   parentAbortSignal: AbortSignal | undefined,
 ): BindProgressHandle {
   const handleRef: { current: SubagentHandleImpl<unknown> | undefined } = { current: undefined };
-  const capturedRef = handleRef;
   let cachedHandler: ReturnType<typeof createEmitProgressHandler> | undefined;
 
   const emitProgressTool = tool(
@@ -83,12 +82,12 @@ function applyProgressEventsToConfig(
         .describe('Optional structured metadata for machine consumers.'),
     }),
     async (input, signal) => {
-      if (capturedRef.current === undefined) {
+      if (handleRef.current === undefined) {
         return { content: 'emit_progress: handle not yet initialized.', isError: true };
       }
       if (cachedHandler === undefined) {
         cachedHandler = createEmitProgressHandler(
-          capturedRef.current,
+          handleRef.current,
           (text) => {
             if (parentInputStreamRef?.queueFrameworkContext) {
               parentInputStreamRef.queueFrameworkContext(text);
@@ -106,5 +105,9 @@ function applyProgressEventsToConfig(
   // Mutate in place -- the config object is already a fresh shallow copy
   // produced by assembleChildConfig's spread.
   config.customTools = [...(config.customTools ?? []), emitProgressTool];
-  return (handle: SubagentHandleImpl<unknown>) => { capturedRef.current = handle; };
+  return (handle: SubagentHandleImpl<unknown>) => {
+    handleRef.current = handle;
+    // Reset cached handler so it picks up the new handle reference.
+    cachedHandler = undefined;
+  };
 }

--- a/src/agent/subagent/fork-types.ts
+++ b/src/agent/subagent/fork-types.ts
@@ -107,6 +107,17 @@ export interface ForkSubagentOptions<T = unknown> {
   denyElicitations?: boolean;
 
   /**
+   * When true, the child's tool surface gains the `emit_progress` tool,
+   * letting it push structured progress events to the parent at the parent's
+   * next user-turn boundary. Events are buffered in a ring buffer (capacity 20)
+   * on the handle and delivered via `queueFrameworkContext`.
+   *
+   * Opt-in per fork — omit (or set false) to keep the child's default surface.
+   * The tool is EXCLUDED (not silently no-oped) when this is not set.
+   */
+  progressEvents?: boolean;
+
+  /**
    * Enforce a per-phase permission boundary on the forked subagent.
    *
    * - `'read-only'`: construct a provider whose `permissions.allowedTools`

--- a/src/agent/subagent/handle.ts
+++ b/src/agent/subagent/handle.ts
@@ -19,6 +19,7 @@ import { dispatchSubagentStop as _dispatchSubagentStop } from '../subagent-hooks
 import { emitSessionPhase, emitSubagentLifecycle } from '../trace/emit.js';
 import type { TraceSink } from '../trace/index.js';
 import { PauseAwareCeiling, SUBAGENT_MAX_PAUSE_EXTENSION_MS } from './pause-ceiling.js';
+import { PROGRESS_RING_CAPACITY } from './progress-constants.js';
 import {
   createEmptyTrace,
   type SubagentResult,
@@ -621,10 +622,7 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
     ) {
       return;
     }
-    // Inline the capacity constant to avoid a circular/async import.
-    // Kept in sync with PROGRESS_RING_CAPACITY in emit-progress.ts.
-    const CAPACITY = 20;
-    if (this._progressEvents.length >= CAPACITY) {
+    if (this._progressEvents.length >= PROGRESS_RING_CAPACITY) {
       this._progressEvents.shift();
     }
     this._progressEvents.push(payload);

--- a/src/agent/subagent/handle.ts
+++ b/src/agent/subagent/handle.ts
@@ -499,6 +499,7 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
     });
 
     this._steeringMessages.length = 0;
+    this._progressEvents.length = 0;
     try {
       this.abortGraph.abort(this.id, 'cancelled');
     } catch {
@@ -535,6 +536,7 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
       // ignore interrupt errors
     }
     this._steeringMessages.length = 0;
+    this._progressEvents.length = 0;
     try {
       await this.session.close();
     } finally {
@@ -576,6 +578,9 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
   /** Ring buffer of pending steering messages (capacity: 3). Consumed by _beforeNextRound. */
   readonly _steeringMessages: string[] = [];
 
+  /** Ring buffer of progress events emitted by this child (capacity: PROGRESS_RING_CAPACITY). */
+  readonly _progressEvents: import('../tools/subagent/emit-progress.js').ProgressEventPayload[] = [];
+
   /**
    * Queue a mid-run steering message for delivery at the next tool-call boundary.
    *
@@ -598,6 +603,31 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
     if (this._controller.signal.aborted) return;
     if (this._steeringMessages.length >= 3) this._steeringMessages.shift();
     this._steeringMessages.push(text);
+  }
+
+  /**
+   * Push a progress event into the ring buffer (capacity: PROGRESS_RING_CAPACITY).
+   * Evicts the oldest entry when the buffer is full (oldest-first eviction,
+   * matching the _steeringMessages pattern). Silently drops the event when the
+   * subagent has already reached a terminal state.
+   * @internal — called by the emit_progress tool handler in
+   *   `tools/subagent/emit-progress.ts`.
+   */
+  emitProgress(payload: import('../tools/subagent/emit-progress.js').ProgressEventPayload): void {
+    if (
+      this._currentStatus === 'succeeded' ||
+      this._currentStatus === 'failed' ||
+      this._currentStatus === 'cancelled'
+    ) {
+      return;
+    }
+    // Inline the capacity constant to avoid a circular/async import.
+    // Kept in sync with PROGRESS_RING_CAPACITY in emit-progress.ts.
+    const CAPACITY = 20;
+    if (this._progressEvents.length >= CAPACITY) {
+      this._progressEvents.shift();
+    }
+    this._progressEvents.push(payload);
   }
 
   /**

--- a/src/agent/subagent/progress-constants.ts
+++ b/src/agent/subagent/progress-constants.ts
@@ -1,0 +1,10 @@
+/**
+ * Shared progress-event constants used by both emit-progress.ts and handle.ts.
+ * Extracted to a dedicated file to avoid a circular value dependency between
+ * the two modules (emit-progress imports type SubagentHandleImpl from handle).
+ *
+ * @module agent/subagent/progress-constants
+ */
+
+/** Ring buffer capacity per handle for child-to-parent progress events. */
+export const PROGRESS_RING_CAPACITY = 20;

--- a/src/agent/subagent/progress-constants.ts
+++ b/src/agent/subagent/progress-constants.ts
@@ -8,3 +8,6 @@
 
 /** Ring buffer capacity per handle for child-to-parent progress events. */
 export const PROGRESS_RING_CAPACITY = 20;
+
+/** Maximum UTF-8 byte length of the `phase` field. */
+export const PROGRESS_MAX_PHASE_BYTES = 256;

--- a/src/agent/tools/nesting.ts
+++ b/src/agent/tools/nesting.ts
@@ -99,6 +99,13 @@ export interface ChildProviderFactoryArgs {
    * for a read-only skill's forked child. Defaults to false.
    */
   readOnlyBash?: boolean;
+  /**
+   * Custom tools to register on the child's provider. Threaded from
+   * `childConfig.customTools` so tools injected at fork time (e.g.
+   * `emit_progress` via `wireProgressEvents`) reach the provider's
+   * dispatcher — which is the only read point for custom tool schemas.
+   */
+  customTools?: import('../tools/custom-tool.js').CustomToolDef[];
 }
 
 /** Minimal session stub for child executors that only need an abort signal. */
@@ -235,7 +242,7 @@ export interface CreateChildProviderFactoryOptions {
 export function createChildProviderFactory(
   opts: CreateChildProviderFactoryOptions = {},
 ): (args: ChildProviderFactoryArgs) => ModelProvider {
-  return ({ childExecutor, childSkillExecutor, model, allowedTools, readOnlyBash }) => {
+  return ({ childExecutor, childSkillExecutor, model, allowedTools, readOnlyBash, customTools }) => {
     const providerOpts = {
       // A read-only skill's child passes `allowedTools: RECON_ALLOWED_TOOLS`
       // (no write_file/edit_file); everyone else gets the full CHILD_ALLOWED_TOOLS.
@@ -245,6 +252,10 @@ export function createChildProviderFactory(
       // Bash gate (read-only skill child). Forwarded into BOTH provider
       // constructors so the per-query dispatcher blocks mutating shell commands.
       ...(readOnlyBash === true ? { readOnlyBash: true } : {}),
+      // Custom tools injected at fork time (e.g. emit_progress). The provider
+      // constructor is the only read point — config.customTools is not consulted
+      // at query time when a pre-built provider is set.
+      ...(customTools !== undefined && customTools.length > 0 ? { customTools } : {}),
     };
     const route = providerForModel(typeof model === 'string' ? model : undefined);
     if (route === 'openai-compatible') {

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -563,9 +563,9 @@ export const agentTool: AnthropicToolDef = {
           'removed, so work in progress is never destroyed (recover it via the ' +
           '`worktree` tool). Mutually exclusive with `cwd` (the runtime owns the ' +
           "child's cwd when isolating) — to isolate, omit `cwd` rather than " +
-          'blanking it. Ignored for read-only agents such as ' +
-          'research-agent — they have nothing to isolate.',
+          'blanking it. Ignored for read-only agents — they have nothing to isolate.',
       },
+      progress_events: { type: 'boolean', description: 'Opt-in: grants the child the `emit_progress` tool so it can push structured progress updates to the parent at each turn boundary. Excluded when not set.' },
     },
     required: ['prompt'],
   },

--- a/src/agent/tools/subagent-executor.ts
+++ b/src/agent/tools/subagent-executor.ts
@@ -850,7 +850,7 @@ export class SubagentExecutor implements SubagentControl {
         // subagent.ts this makes every sub-agent uniformly non-interactive.
         // (Previously only background denied; foreground leaked elicitations to
         // the REPL/Telegram human via the process-wide elicitation router.)
-        denyElicitations: true,
+        denyElicitations: true, progressEvents: parsed.progress_events,
       });
       // Backfill: give the depth-1 child executor a real parentId so any
       // depth-2 forks it spawns carry handle.id as their parentId.

--- a/src/agent/tools/subagent/child-config.ts
+++ b/src/agent/tools/subagent/child-config.ts
@@ -469,6 +469,12 @@ export function buildChildConfig(args: BuildChildConfigArgs): BuildChildConfigRe
       // research-agent child never even sees bash/write_file/agent.
       ...(effectiveAllowedTools !== undefined ? { allowedTools: effectiveAllowedTools } : {}),
       ...(effectiveReadOnlyBash ? { readOnlyBash: true } : {}),
+      // Thread customTools so fork-time injected tools (e.g. emit_progress)
+      // reach the grandchild's provider constructor — which is the only read
+      // point when config.provider is pre-set.
+      ...(childConfig.customTools !== undefined && childConfig.customTools.length > 0
+        ? { customTools: childConfig.customTools }
+        : {}),
     });
   } else if (effectiveAllowedTools !== undefined || effectiveReadOnlyBash) {
     // Restricted dispatch at the depth cap (or with no factory wired):

--- a/src/agent/tools/subagent/emit-progress.test.ts
+++ b/src/agent/tools/subagent/emit-progress.test.ts
@@ -245,4 +245,131 @@ describe('createEmitProgressHandler', () => {
     await handler({ message: 'second' }, new AbortController().signal);
     expect(queueCalls).toHaveLength(1);
   });
+
+  // Item 4(a) — throwing queueFn returns delivered:false, ring buffer IS populated.
+  it('returns { delivered: false, reason: queue_error } when queueFn throws', async () => {
+    const throwingQueue = (_text: string): void => {
+      throw new Error('queue failure');
+    };
+    const handler = createEmitProgressHandler(handle, throwingQueue, undefined);
+    const result = await handler({ message: 'test message' }, new AbortController().signal);
+    expect(result.isError).toBeUndefined();
+    expect(JSON.parse(result.content as string)).toEqual({ delivered: false, reason: 'queue_error' });
+    // Ring buffer should still be populated despite the queue failure.
+    const buf = (handle as unknown as { _progressEvents: ProgressEventPayload[] })._progressEvents;
+    expect(buf).toHaveLength(1);
+    expect(buf[0].message).toBe('test message');
+  });
+
+  // Item 4(c) — pushUserMessage fallback when queueFrameworkContext is absent.
+  it('uses pushUserMessage fallback when queueFrameworkContext is not present', async () => {
+    const pushCalls: string[] = [];
+    const parentInputStreamRef = {
+      pushUserMessage: (text: string) => { pushCalls.push(text); },
+    };
+    const queueFnFallback = (text: string): void => {
+      if ((parentInputStreamRef as Record<string, unknown>)['queueFrameworkContext']) {
+        (parentInputStreamRef as unknown as { queueFrameworkContext: (t: string) => void }).queueFrameworkContext(text);
+      } else if (parentInputStreamRef) {
+        parentInputStreamRef.pushUserMessage(text);
+      }
+    };
+    const handler = createEmitProgressHandler(handle, queueFnFallback, undefined);
+    const result = await handler({ message: 'fallback test' }, new AbortController().signal);
+    expect(JSON.parse(result.content as string)).toEqual({ delivered: true });
+    expect(pushCalls).toHaveLength(1);
+    expect(pushCalls[0]).toContain('<child-progress');
+  });
+
+  // Item 8 — Multi-byte UTF-8 truncation: CJK characters near byte boundary.
+  it('truncates at byte boundary without splitting multi-byte CJK codepoints', async () => {
+    // Each CJK character (e.g. U+4E2D) is 3 UTF-8 bytes.
+    // Fill to just over the cap: floor(PROGRESS_MAX_MESSAGE_BYTES / 3) * 3 bytes of CJK
+    // plus a few extra chars to push over the limit.
+    const cjkChar = '\u4e2d'; // 3 bytes each
+    const charsAtCap = Math.floor(PROGRESS_MAX_MESSAGE_BYTES / 3);
+    const longCjk = cjkChar.repeat(charsAtCap + 10); // Exceeds byte cap
+    const handler = createEmitProgressHandler(handle, queueFn, undefined);
+    await handler({ message: longCjk }, new AbortController().signal);
+    const buf = (handle as unknown as { _progressEvents: ProgressEventPayload[] })._progressEvents;
+    expect(buf).toHaveLength(1);
+    const storedBytes = Buffer.byteLength(buf[0].message, 'utf8');
+    // Must be within cap.
+    expect(storedBytes).toBeLessThanOrEqual(PROGRESS_MAX_MESSAGE_BYTES);
+    // Must be valid UTF-8: re-encoding should produce the same byte count.
+    const reEncoded = Buffer.from(buf[0].message, 'utf8');
+    expect(reEncoded.toString('utf8')).toBe(buf[0].message);
+    // Must be a whole number of CJK chars (no split codepoints).
+    expect(buf[0].message.length % 1).toBe(0);
+    for (const ch of buf[0].message) {
+      expect(ch).toBe(cjkChar);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Item 4(b) — handle-not-initialized path in the tool closure
+// (tested via the fork-progress-events wiring logic, replicated inline)
+// ---------------------------------------------------------------------------
+
+describe('emit_progress tool closure — handle not yet initialized', () => {
+  it('returns isError when capturedRef.current is undefined', async () => {
+    // Replicate the closure logic from fork-progress-events.ts directly.
+    const capturedRef: { current: unknown | undefined } = { current: undefined };
+    let cachedHandler: ((input: unknown, signal: AbortSignal) => Promise<{ content: unknown; isError?: boolean }>) | undefined;
+    const closureFn = async (input: unknown, signal: AbortSignal) => {
+      if (capturedRef.current === undefined) {
+        return { content: 'emit_progress: handle not yet initialized.', isError: true as const };
+      }
+      if (cachedHandler === undefined) {
+        cachedHandler = createEmitProgressHandler(
+          capturedRef.current as Parameters<typeof createEmitProgressHandler>[0],
+          (_text: string) => {},
+          undefined,
+        );
+      }
+      return cachedHandler(input, signal);
+    };
+
+    // Call before binding — should get the "not initialized" error.
+    const result = await closureFn({ message: 'hello' }, new AbortController().signal);
+    expect(result.isError).toBe(true);
+    expect(String(result.content)).toContain('handle not yet initialized');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Item 9 — XML body escaping in formatProgressEvent
+// ---------------------------------------------------------------------------
+
+describe('formatProgressEvent XML body escaping', () => {
+  it('escapes < in message body', () => {
+    const result = formatProgressEvent({ message: 'a<b' }, 'id');
+    expect(result).toContain('a&lt;b');
+    expect(result).not.toContain('a<b');
+  });
+
+  it('escapes > in message body', () => {
+    const result = formatProgressEvent({ message: 'a>b' }, 'id');
+    expect(result).toContain('a&gt;b');
+    expect(result).not.toContain('a>b');
+  });
+
+  it('escapes & in message body', () => {
+    const result = formatProgressEvent({ message: 'a&b' }, 'id');
+    // The body should contain &amp; for the & in the message
+    // (not to be confused with attribute escaping)
+    expect(result).toContain('a&amp;b');
+    // Literal & must not appear except as part of an escape sequence
+    const bodyMatch = result.match(/<child-progress[^>]*>(.*)<\/child-progress>/);
+    expect(bodyMatch).not.toBeNull();
+    expect(bodyMatch![1]).toBe('a&amp;b');
+  });
+
+  it('escapes all three special characters in combination', () => {
+    const result = formatProgressEvent({ message: '<a>&amp;</a>' }, 'id');
+    const bodyMatch = result.match(/<child-progress[^>]*>(.*)<\/child-progress>/);
+    expect(bodyMatch).not.toBeNull();
+    expect(bodyMatch![1]).toBe('&lt;a&gt;&amp;amp;&lt;/a&gt;');
+  });
 });

--- a/src/agent/tools/subagent/emit-progress.test.ts
+++ b/src/agent/tools/subagent/emit-progress.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Unit tests for emit-progress.ts: ring buffer, message truncation,
+ * formatProgressEvent, handler behavior, and cancel/abort guards.
+ *
+ * Tests cover the pure functions (formatProgressEvent, truncateToBytes via
+ * handler) and the createEmitProgressHandler factory in isolation, using
+ * a minimal SubagentHandleImpl double.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  formatProgressEvent,
+  createEmitProgressHandler,
+  PROGRESS_RING_CAPACITY,
+  PROGRESS_MAX_MESSAGE_BYTES,
+  type ProgressEventPayload,
+} from './emit-progress.js';
+import type { SubagentHandleImpl } from '../../subagent/handle.js';
+
+// ---------------------------------------------------------------------------
+// Minimal handle double that implements only the fields emit-progress uses.
+// ---------------------------------------------------------------------------
+
+function makeHandleDouble(status: 'running' | 'succeeded' | 'failed' | 'cancelled' = 'running') {
+  const _progressEvents: ProgressEventPayload[] = [];
+  const handle = {
+    id: 'test-handle-001',
+    _currentStatus: status,
+    _progressEvents,
+    emitProgress(payload: ProgressEventPayload): void {
+      if (
+        this._currentStatus === 'succeeded' ||
+        this._currentStatus === 'failed' ||
+        this._currentStatus === 'cancelled'
+      ) {
+        return;
+      }
+      const CAPACITY = PROGRESS_RING_CAPACITY;
+      if (this._progressEvents.length >= CAPACITY) {
+        this._progressEvents.shift();
+      }
+      this._progressEvents.push(payload);
+    },
+  } as unknown as SubagentHandleImpl<unknown>;
+  return handle;
+}
+
+// ---------------------------------------------------------------------------
+// formatProgressEvent
+// ---------------------------------------------------------------------------
+
+describe('formatProgressEvent', () => {
+  it('produces the expected XML envelope shape', () => {
+    const payload: ProgressEventPayload = { message: 'hello world' };
+    const result = formatProgressEvent(payload, 'agent-123');
+    expect(result).toMatch(/^<child-progress subagentId="agent-123" timestamp="\d{4}/);
+    expect(result).toContain('hello world');
+    expect(result).toMatch(/<\/child-progress>$/);
+  });
+
+  it('includes the phase attribute when provided', () => {
+    const payload: ProgressEventPayload = { message: 'step done', phase: 'research' };
+    const result = formatProgressEvent(payload, 'ag-x');
+    expect(result).toContain('phase="research"');
+  });
+
+  it('omits the phase attribute when not provided', () => {
+    const payload: ProgressEventPayload = { message: 'step done' };
+    const result = formatProgressEvent(payload, 'ag-x');
+    expect(result).not.toContain('phase=');
+  });
+
+  it('escapes double-quotes in the subagentId attribute', () => {
+    const result = formatProgressEvent({ message: 'x' }, 'id"with"quotes');
+    expect(result).toContain('subagentId="id&quot;with&quot;quotes"');
+  });
+
+  it('escapes ampersands in the phase attribute', () => {
+    const payload: ProgressEventPayload = { message: 'x', phase: 'a&b' };
+    const result = formatProgressEvent(payload, 'id');
+    expect(result).toContain('phase="a&amp;b"');
+  });
+
+  it('includes an ISO timestamp', () => {
+    const result = formatProgressEvent({ message: 'x' }, 'id');
+    const match = result.match(/timestamp="([^"]+)"/);
+    expect(match).not.toBeNull();
+    expect(() => new Date(match![1])).not.toThrow();
+    expect(isNaN(new Date(match![1]).getTime())).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Ring buffer eviction (via emitProgress on the handle double)
+// ---------------------------------------------------------------------------
+
+describe('ring buffer', () => {
+  it('holds up to PROGRESS_RING_CAPACITY events', () => {
+    const handle = makeHandleDouble();
+    for (let i = 0; i < PROGRESS_RING_CAPACITY; i++) {
+      handle.emitProgress({ message: `event-${i}` });
+    }
+    expect((handle as unknown as { _progressEvents: ProgressEventPayload[] })._progressEvents).toHaveLength(
+      PROGRESS_RING_CAPACITY,
+    );
+  });
+
+  it('evicts the oldest entry when capacity is exceeded', () => {
+    const handle = makeHandleDouble();
+    const OVER = PROGRESS_RING_CAPACITY + 5;
+    for (let i = 0; i < OVER; i++) {
+      handle.emitProgress({ message: `event-${i}` });
+    }
+    const buf = (handle as unknown as { _progressEvents: ProgressEventPayload[] })._progressEvents;
+    expect(buf).toHaveLength(PROGRESS_RING_CAPACITY);
+    // Oldest entry should now be event-5 (0-4 were evicted).
+    expect(buf[0].message).toBe(`event-${OVER - PROGRESS_RING_CAPACITY}`);
+    // Latest entry should be the last one pushed.
+    expect(buf[buf.length - 1].message).toBe(`event-${OVER - 1}`);
+  });
+
+  it('does not push to the buffer when the handle is in a terminal state', () => {
+    for (const status of ['succeeded', 'failed', 'cancelled'] as const) {
+      const handle = makeHandleDouble(status);
+      handle.emitProgress({ message: 'ignored' });
+      const buf = (handle as unknown as { _progressEvents: ProgressEventPayload[] })._progressEvents;
+      expect(buf).toHaveLength(0);
+    }
+  });
+
+  it('clears correctly when length is set to 0', () => {
+    const handle = makeHandleDouble();
+    handle.emitProgress({ message: 'a' });
+    handle.emitProgress({ message: 'b' });
+    const buf = (handle as unknown as { _progressEvents: ProgressEventPayload[] })._progressEvents;
+    expect(buf).toHaveLength(2);
+    buf.length = 0;
+    expect(buf).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createEmitProgressHandler
+// ---------------------------------------------------------------------------
+
+describe('createEmitProgressHandler', () => {
+  let handle: ReturnType<typeof makeHandleDouble>;
+  let queueCalls: string[];
+  let queueFn: (text: string) => void;
+  let abortController: AbortController;
+
+  beforeEach(() => {
+    handle = makeHandleDouble();
+    queueCalls = [];
+    queueFn = (text) => queueCalls.push(text);
+    abortController = new AbortController();
+  });
+
+  it('returns { delivered: true } on success', async () => {
+    const handler = createEmitProgressHandler(handle, queueFn, abortController.signal);
+    const result = await handler({ message: 'hello' }, new AbortController().signal);
+    expect(result.isError).toBeUndefined();
+    expect(JSON.parse(result.content as string)).toEqual({ delivered: true });
+  });
+
+  it('calls the queue function once with the formatted envelope', async () => {
+    const handler = createEmitProgressHandler(handle, queueFn, abortController.signal);
+    await handler({ message: 'progress update', phase: 'planning' }, new AbortController().signal);
+    expect(queueCalls).toHaveLength(1);
+    expect(queueCalls[0]).toContain('<child-progress');
+    expect(queueCalls[0]).toContain('progress update');
+    expect(queueCalls[0]).toContain('phase="planning"');
+    expect(queueCalls[0]).toContain('</child-progress>');
+  });
+
+  it('pushes the payload to the ring buffer', async () => {
+    const handler = createEmitProgressHandler(handle, queueFn, abortController.signal);
+    await handler({ message: 'hello' }, new AbortController().signal);
+    const buf = (handle as unknown as { _progressEvents: ProgressEventPayload[] })._progressEvents;
+    expect(buf).toHaveLength(1);
+    expect(buf[0].message).toBe('hello');
+  });
+
+  it('returns { delivered: false } when parent abort signal is already fired', async () => {
+    abortController.abort();
+    const handler = createEmitProgressHandler(handle, queueFn, abortController.signal);
+    const result = await handler({ message: 'too late' }, new AbortController().signal);
+    expect(JSON.parse(result.content as string)).toMatchObject({ delivered: false });
+    expect(queueCalls).toHaveLength(0);
+  });
+
+  it('returns an error for missing message', async () => {
+    const handler = createEmitProgressHandler(handle, queueFn, undefined);
+    const result = await handler({ phase: 'research' }, new AbortController().signal);
+    expect(result.isError).toBe(true);
+    expect(String(result.content)).toContain('"message"');
+  });
+
+  it('returns an error for empty message', async () => {
+    const handler = createEmitProgressHandler(handle, queueFn, undefined);
+    const result = await handler({ message: '   ' }, new AbortController().signal);
+    expect(result.isError).toBe(true);
+  });
+
+  it('returns an error for non-object input', async () => {
+    const handler = createEmitProgressHandler(handle, queueFn, undefined);
+    const result = await handler('not an object', new AbortController().signal);
+    expect(result.isError).toBe(true);
+  });
+
+  it('truncates message at PROGRESS_MAX_MESSAGE_BYTES bytes', async () => {
+    // Build a message that is slightly over the cap.
+    const longMessage = 'x'.repeat(PROGRESS_MAX_MESSAGE_BYTES + 100);
+    const handler = createEmitProgressHandler(handle, queueFn, undefined);
+    await handler({ message: longMessage }, new AbortController().signal);
+    const buf = (handle as unknown as { _progressEvents: ProgressEventPayload[] })._progressEvents;
+    expect(buf).toHaveLength(1);
+    const storedBytes = Buffer.byteLength(buf[0].message, 'utf8');
+    expect(storedBytes).toBeLessThanOrEqual(PROGRESS_MAX_MESSAGE_BYTES);
+  });
+
+  it('does not truncate a message within the byte cap', async () => {
+    const exact = 'a'.repeat(PROGRESS_MAX_MESSAGE_BYTES);
+    const handler = createEmitProgressHandler(handle, queueFn, undefined);
+    await handler({ message: exact }, new AbortController().signal);
+    const buf = (handle as unknown as { _progressEvents: ProgressEventPayload[] })._progressEvents;
+    expect(buf[0].message).toBe(exact);
+  });
+
+  it('passes metadata through to the ring buffer payload', async () => {
+    const handler = createEmitProgressHandler(handle, queueFn, undefined);
+    await handler({ message: 'x', metadata: { count: 42, done: true } }, new AbortController().signal);
+    const buf = (handle as unknown as { _progressEvents: ProgressEventPayload[] })._progressEvents;
+    expect(buf[0].metadata).toEqual({ count: 42, done: true });
+  });
+
+  it('does not call the queue function when parent abort fires between calls', async () => {
+    const handler = createEmitProgressHandler(handle, queueFn, abortController.signal);
+    // First call succeeds.
+    await handler({ message: 'first' }, new AbortController().signal);
+    expect(queueCalls).toHaveLength(1);
+    // Now abort the parent.
+    abortController.abort();
+    // Second call should be suppressed.
+    await handler({ message: 'second' }, new AbortController().signal);
+    expect(queueCalls).toHaveLength(1);
+  });
+});

--- a/src/agent/tools/subagent/emit-progress.test.ts
+++ b/src/agent/tools/subagent/emit-progress.test.ts
@@ -227,6 +227,26 @@ describe('createEmitProgressHandler', () => {
     expect(buf[0].message).toBe(exact);
   });
 
+  it('truncates phase at PROGRESS_MAX_PHASE_BYTES bytes', async () => {
+    const { PROGRESS_MAX_PHASE_BYTES } = await import('../../subagent/progress-constants.js');
+    const longPhase = 'x'.repeat(PROGRESS_MAX_PHASE_BYTES + 50);
+    const handler = createEmitProgressHandler(handle, queueFn, undefined);
+    await handler({ message: 'msg', phase: longPhase }, new AbortController().signal);
+    const buf = (handle as unknown as { _progressEvents: ProgressEventPayload[] })._progressEvents;
+    expect(buf).toHaveLength(1);
+    const storedBytes = Buffer.byteLength(buf[0].phase!, 'utf8');
+    expect(storedBytes).toBeLessThanOrEqual(PROGRESS_MAX_PHASE_BYTES);
+  });
+
+  it('does not truncate a phase within the byte cap', async () => {
+    const { PROGRESS_MAX_PHASE_BYTES } = await import('../../subagent/progress-constants.js');
+    const exact = 'a'.repeat(PROGRESS_MAX_PHASE_BYTES);
+    const handler = createEmitProgressHandler(handle, queueFn, undefined);
+    await handler({ message: 'msg', phase: exact }, new AbortController().signal);
+    const buf = (handle as unknown as { _progressEvents: ProgressEventPayload[] })._progressEvents;
+    expect(buf[0].phase).toBe(exact);
+  });
+
   it('passes metadata through to the ring buffer payload', async () => {
     const handler = createEmitProgressHandler(handle, queueFn, undefined);
     await handler({ message: 'x', metadata: { count: 42, done: true } }, new AbortController().signal);

--- a/src/agent/tools/subagent/emit-progress.ts
+++ b/src/agent/tools/subagent/emit-progress.ts
@@ -1,0 +1,137 @@
+/**
+ * Child-to-parent progress event tool.
+ *
+ * Provides the `emit_progress` tool available on opted-in child subagents.
+ * When a parent dispatches a child with `progress_events: true`, the child's
+ * tool surface gains this tool. Calling it pushes a structured progress event
+ * to a ring buffer on the handle and delivers it to the parent's next user-turn
+ * via `queueFrameworkContext`.
+ *
+ * This is the reverse direction of the `send_message_to_agent` steering tool
+ * (Item 1 / PR #1494): parent→child is steering; child→parent is progress.
+ *
+ * @module agent/tools/subagent/emit-progress
+ */
+
+import type { SubagentHandleImpl } from '../../subagent/handle.js';
+import type { ToolResult } from '../types.js';
+
+/** Shape of a single progress event payload from the child. */
+export interface ProgressEventPayload {
+  message: string;
+  phase?: string;
+  metadata?: Record<string, unknown>;
+}
+
+/** Ring buffer capacity per handle. */
+export const PROGRESS_RING_CAPACITY = 20;
+
+/** Maximum UTF-8 byte length of the `message` field. */
+export const PROGRESS_MAX_MESSAGE_BYTES = 2048;
+
+/**
+ * Format a progress event as a `<child-progress>` XML envelope for delivery
+ * to the parent's next turn via `queueFrameworkContext`.
+ */
+export function formatProgressEvent(
+  payload: ProgressEventPayload,
+  subagentId: string,
+): string {
+  const timestamp = new Date().toISOString();
+  const phaseAttr = payload.phase !== undefined ? ` phase="${escapeAttr(payload.phase)}"` : '';
+  return (
+    `<child-progress subagentId="${escapeAttr(subagentId)}"${phaseAttr} timestamp="${timestamp}">` +
+    payload.message +
+    `</child-progress>`
+  );
+}
+
+/** Escape XML attribute values (double-quotes and ampersands). */
+function escapeAttr(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+}
+
+/**
+ * Factory that returns an `emit_progress` tool handler bound to a specific
+ * child handle and the parent's queue function.
+ *
+ * The returned handler:
+ * 1. Validates message byte length (hard truncation at PROGRESS_MAX_MESSAGE_BYTES).
+ * 2. Pushes the payload to the handle's progress ring buffer (evicts oldest on overflow).
+ * 3. Calls `parentQueueFn` to deliver the formatted envelope to the parent's next turn.
+ * 4. Returns `{ delivered: true }` to the child.
+ *
+ * The handler is a no-op (returns `{ delivered: false }`) when the parent abort
+ * signal is already fired — the parent will not consume the delivery anyway.
+ */
+export function createEmitProgressHandler(
+  handle: SubagentHandleImpl<unknown>,
+  parentQueueFn: (text: string) => void,
+  parentAbortSignal: AbortSignal | undefined,
+): (input: unknown, signal: AbortSignal) => Promise<ToolResult> {
+  return async (input: unknown): Promise<ToolResult> => {
+    // Guard: parent is gone — skip delivery silently.
+    if (parentAbortSignal?.aborted) {
+      return { content: JSON.stringify({ delivered: false, reason: 'parent_aborted' }) };
+    }
+
+    if (typeof input !== 'object' || input === null) {
+      return { content: 'emit_progress: input must be an object.', isError: true };
+    }
+
+    const raw = input as Record<string, unknown>;
+
+    const messageRaw = raw['message'];
+    if (typeof messageRaw !== 'string' || messageRaw.trim().length === 0) {
+      return {
+        content: 'emit_progress: "message" must be a non-empty string.',
+        isError: true,
+      };
+    }
+
+    // Enforce byte cap — truncate at the UTF-8 byte boundary.
+    let message = messageRaw;
+    if (Buffer.byteLength(message, 'utf8') > PROGRESS_MAX_MESSAGE_BYTES) {
+      message = truncateToBytes(message, PROGRESS_MAX_MESSAGE_BYTES);
+    }
+
+    const phase =
+      typeof raw['phase'] === 'string' && raw['phase'].trim().length > 0
+        ? raw['phase'].trim()
+        : undefined;
+
+    const metadata =
+      typeof raw['metadata'] === 'object' &&
+      raw['metadata'] !== null &&
+      !Array.isArray(raw['metadata'])
+        ? (raw['metadata'] as Record<string, unknown>)
+        : undefined;
+
+    const payload: ProgressEventPayload = { message, ...(phase !== undefined ? { phase } : {}), ...(metadata !== undefined ? { metadata } : {}) };
+
+    // Push to ring buffer with oldest-first eviction.
+    handle.emitProgress(payload);
+
+    // Deliver to parent's next turn.
+    try {
+      const envelope = formatProgressEvent(payload, handle.id);
+      parentQueueFn(envelope);
+    } catch {
+      // Delivery failure is non-fatal to the child.
+    }
+
+    return { content: JSON.stringify({ delivered: true }) };
+  };
+}
+
+/**
+ * Truncate a UTF-8 string to at most `maxBytes` bytes without splitting
+ * multi-byte codepoints or surrogate pairs.
+ */
+function truncateToBytes(str: string, maxBytes: number): string {
+  const buf = Buffer.from(str, 'utf8');
+  if (buf.byteLength <= maxBytes) return str;
+  // Slice to maxBytes then decode, which drops any incomplete multi-byte
+  // sequence at the boundary.
+  return buf.subarray(0, maxBytes).toString('utf8');
+}

--- a/src/agent/tools/subagent/emit-progress.ts
+++ b/src/agent/tools/subagent/emit-progress.ts
@@ -15,7 +15,7 @@
 
 import type { SubagentHandleImpl } from '../../subagent/handle.js';
 import type { ToolResult } from '../types.js';
-import { PROGRESS_RING_CAPACITY as _PROGRESS_RING_CAPACITY } from '../../subagent/progress-constants.js';
+import { PROGRESS_RING_CAPACITY as _PROGRESS_RING_CAPACITY, PROGRESS_MAX_PHASE_BYTES } from '../../subagent/progress-constants.js';
 
 /** Shape of a single progress event payload from the child. */
 export interface ProgressEventPayload {
@@ -74,7 +74,7 @@ export function createEmitProgressHandler(
   handle: SubagentHandleImpl<unknown>,
   parentQueueFn: (text: string) => void,
   parentAbortSignal: AbortSignal | undefined,
-): (input: unknown, signal: AbortSignal) => Promise<ToolResult> {
+): (input: unknown, _signal: AbortSignal) => Promise<ToolResult> {
   return async (input: unknown): Promise<ToolResult> => {
     // Guard: parent is gone — skip delivery silently.
     if (parentAbortSignal?.aborted) {
@@ -101,10 +101,13 @@ export function createEmitProgressHandler(
       message = truncateToBytes(message, PROGRESS_MAX_MESSAGE_BYTES);
     }
 
-    const phase =
+    let phase =
       typeof raw['phase'] === 'string' && raw['phase'].trim().length > 0
         ? raw['phase'].trim()
         : undefined;
+    if (phase !== undefined && Buffer.byteLength(phase, 'utf8') > PROGRESS_MAX_PHASE_BYTES) {
+      phase = truncateToBytes(phase, PROGRESS_MAX_PHASE_BYTES);
+    }
 
     const metadata =
       typeof raw['metadata'] === 'object' &&
@@ -143,7 +146,8 @@ export function createEmitProgressHandler(
 function truncateToBytes(str: string, maxBytes: number): string {
   const buf = Buffer.from(str, 'utf8');
   if (buf.byteLength <= maxBytes) return str;
-  // Walk back from maxBytes to find the start of a complete codepoint.
+  // Walk back until buf[end] is the lead byte of an incomplete sequence;
+  // subarray(0, end) then excludes it entirely.
   // UTF-8 continuation bytes have the form 10xxxxxx (0x80–0xBF).
   let end = Math.min(maxBytes, buf.byteLength);
   while (end > 0 && (buf[end] !== undefined) && (buf[end]! & 0xc0) === 0x80) {

--- a/src/agent/tools/subagent/emit-progress.ts
+++ b/src/agent/tools/subagent/emit-progress.ts
@@ -15,6 +15,7 @@
 
 import type { SubagentHandleImpl } from '../../subagent/handle.js';
 import type { ToolResult } from '../types.js';
+import { PROGRESS_RING_CAPACITY as _PROGRESS_RING_CAPACITY } from '../../subagent/progress-constants.js';
 
 /** Shape of a single progress event payload from the child. */
 export interface ProgressEventPayload {
@@ -23,8 +24,8 @@ export interface ProgressEventPayload {
   metadata?: Record<string, unknown>;
 }
 
-/** Ring buffer capacity per handle. */
-export const PROGRESS_RING_CAPACITY = 20;
+/** Ring buffer capacity per handle. Re-exported from the shared constants module. */
+export const PROGRESS_RING_CAPACITY = _PROGRESS_RING_CAPACITY;
 
 /** Maximum UTF-8 byte length of the `message` field. */
 export const PROGRESS_MAX_MESSAGE_BYTES = 2048;
@@ -41,7 +42,7 @@ export function formatProgressEvent(
   const phaseAttr = payload.phase !== undefined ? ` phase="${escapeAttr(payload.phase)}"` : '';
   return (
     `<child-progress subagentId="${escapeAttr(subagentId)}"${phaseAttr} timestamp="${timestamp}">` +
-    payload.message +
+    escapeXmlBody(payload.message) +
     `</child-progress>`
   );
 }
@@ -49,6 +50,11 @@ export function formatProgressEvent(
 /** Escape XML attribute values (double-quotes and ampersands). */
 function escapeAttr(value: string): string {
   return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+}
+
+/** Escape XML body text (`&`, `<`, `>`). */
+function escapeXmlBody(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
 /**
@@ -117,7 +123,8 @@ export function createEmitProgressHandler(
       const envelope = formatProgressEvent(payload, handle.id);
       parentQueueFn(envelope);
     } catch {
-      // Delivery failure is non-fatal to the child.
+      // Delivery failure is non-fatal to the child, but report it accurately.
+      return { content: JSON.stringify({ delivered: false, reason: 'queue_error' }) };
     }
 
     return { content: JSON.stringify({ delivered: true }) };
@@ -127,11 +134,20 @@ export function createEmitProgressHandler(
 /**
  * Truncate a UTF-8 string to at most `maxBytes` bytes without splitting
  * multi-byte codepoints or surrogate pairs.
+ *
+ * Node's Buffer.toString('utf8') replaces incomplete trailing sequences with
+ * U+FFFD (3 bytes), which can push the result over `maxBytes`. We therefore
+ * walk back from the slice boundary to the start of a complete codepoint before
+ * decoding.
  */
 function truncateToBytes(str: string, maxBytes: number): string {
   const buf = Buffer.from(str, 'utf8');
   if (buf.byteLength <= maxBytes) return str;
-  // Slice to maxBytes then decode, which drops any incomplete multi-byte
-  // sequence at the boundary.
-  return buf.subarray(0, maxBytes).toString('utf8');
+  // Walk back from maxBytes to find the start of a complete codepoint.
+  // UTF-8 continuation bytes have the form 10xxxxxx (0x80–0xBF).
+  let end = Math.min(maxBytes, buf.byteLength);
+  while (end > 0 && (buf[end] !== undefined) && (buf[end]! & 0xc0) === 0x80) {
+    end--;
+  }
+  return buf.subarray(0, end).toString('utf8');
 }

--- a/src/agent/tools/subagent/input-parse.test.ts
+++ b/src/agent/tools/subagent/input-parse.test.ts
@@ -1151,6 +1151,24 @@ describe('parseAgentInput', () => {
       expect('cwd' in result).toBe(false);
     });
 
+    // --- progress_events field ---
+
+    it('omits progress_events from output when absent from input', () => {
+      const result = parseAgentInput({ prompt: 'p' });
+      expect('progress_events' in result).toBe(false);
+    });
+
+    it('includes progress_events: true when set to true', () => {
+      const result = parseAgentInput({ prompt: 'p', progress_events: true });
+      expect(result.progress_events).toBe(true);
+    });
+
+    it('includes progress_events: false when explicitly set to false', () => {
+      const result = parseAgentInput({ prompt: 'p', progress_events: false });
+      expect('progress_events' in result).toBe(true);
+      expect(result.progress_events).toBe(false);
+    });
+
     it('ignores unrecognized extra keys on the input object', () => {
       const result = parseAgentInput({ prompt: 'p', bogusExtra: 'ignored' } as Record<string, unknown>);
       expect(result.prompt).toBe('p');

--- a/src/agent/tools/subagent/input-parse.ts
+++ b/src/agent/tools/subagent/input-parse.ts
@@ -138,6 +138,13 @@ export interface AgentInput {
    * to `undefined` (no field) so the executor's `=== 'worktree'` check is total.
    */
   isolation?: 'worktree';
+  /**
+   * When true, the forked child's tool surface gains the `emit_progress` tool,
+   * allowing the child to push structured progress events to the parent at the
+   * parent's next user-turn boundary. Opt-in per dispatch — the tool is EXCLUDED
+   * (not silently no-oped) when this is not set.
+   */
+  progress_events?: boolean;
 }
 
 /**
@@ -509,6 +516,15 @@ export function parseAgentInput(input: unknown): AgentInput {
     isolation = 'worktree';
   }
 
+  // progress_events: optional boolean. Truthy enables the emit_progress tool
+  // on the child. Falsy (or absent) excludes it. readOptional returns
+  // undefined for missing/null/whitespace-only; treat anything truthy as true.
+  const progressEventsValue = readOptional(agentInput, 'progress_events');
+  const progress_events =
+    progressEventsValue !== undefined && progressEventsValue !== null
+      ? Boolean(progressEventsValue)
+      : undefined;
+
   return {
     prompt,
     ...(attachments !== undefined ? { attachments } : {}),
@@ -524,5 +540,6 @@ export function parseAgentInput(input: unknown): AgentInput {
     ...(writeRoots !== undefined ? { writeRoots } : {}),
     ...(readRoots !== undefined ? { readRoots } : {}),
     ...(isolation !== undefined ? { isolation } : {}),
+    ...(progress_events !== undefined && progress_events ? { progress_events } : {}),
   };
 }

--- a/src/agent/tools/subagent/input-parse.ts
+++ b/src/agent/tools/subagent/input-parse.ts
@@ -540,6 +540,6 @@ export function parseAgentInput(input: unknown): AgentInput {
     ...(writeRoots !== undefined ? { writeRoots } : {}),
     ...(readRoots !== undefined ? { readRoots } : {}),
     ...(isolation !== undefined ? { isolation } : {}),
-    ...(progress_events !== undefined && progress_events ? { progress_events } : {}),
+    ...(progress_events !== undefined ? { progress_events } : {}),
   };
 }


### PR DESCRIPTION
## Summary

Adds opt-in child-to-parent progress events -- the reverse direction of the steering feature shipped in PR #1494. When a parent dispatches a child with `progress_events: true`, the child gains an `emit_progress` tool that pushes structured updates to the parent at the next user-turn boundary.

Addresses **item 2** of #1418 (progress events). Item 1 (mid-run steering) shipped in #1494. Item 3 (reactive workspace subscriptions) remains open.

## How it works

1. Parent dispatches with `progress_events: true` on the `agent` tool
2. Child's tool surface gains `emit_progress({ message, phase?, metadata? })`
3. Handler pushes to a per-handle ring buffer (capacity 20, oldest-first eviction)
4. Formatted as `<child-progress subagentId="..." phase="..." timestamp="...">message</child-progress>`
5. Delivered to parent via `queueFrameworkContext` (prepends to next user turn)
6. Buffer cleared on cancel/teardown

## Design decisions

- **Opt-in, not always-on**: tool excluded entirely when not opted in (not a silent no-op)
- **`queueFrameworkContext` over `pushUserMessage`**: prepends to next real user message, never displaces it -- same channel as `SubagentStop.injectContext`
- **Ring buffer, not unbounded**: capacity 20, 2KB per message, oldest-first eviction -- matches `_steeringMessages` pattern
- **Mutable config injection**: `wireProgressEvents` mutates `customTools` in place (the config is already a fresh shallow copy from `assembleChildConfig`), returning only a `bindHandle` callback -- keeps `subagent.ts` surface to 3 net code lines

## Files

| File | Change |
|------|--------|
| `src/agent/tools/subagent/emit-progress.ts` | New -- handler factory, XML formatter, ring buffer constants, UTF-8-safe truncation |
| `src/agent/subagent/fork-progress-events.ts` | New -- config injection + mutable-ref handle binding via Zod custom tool |
| `src/agent/tools/subagent/emit-progress.test.ts` | New -- 21 tests (ring buffer, truncation, abort guard, format, delivery) |
| `src/agent/subagent/handle.ts` | `_progressEvents` buffer + `emitProgress()` method + cleanup in cancel/teardown |
| `src/agent/subagent/fork-types.ts` | `progressEvents?: boolean` on `ForkSubagentOptions` |
| `src/agent/tools/subagent/input-parse.ts` | Parse `progress_events` from agent tool input |
| `src/agent/tools/schemas.ts` | `progress_events` in agent tool JSON schema |
| `src/agent/tools/subagent-executor.ts` | Thread `progressEvents` to `forkSubagent()` |
| `src/agent/subagent.ts` | `wireProgressEvents` call + import consolidation to stay within filesize baseline |

## Tests

- 21 new tests in `emit-progress.test.ts` covering:
  - Ring buffer push/eviction at capacity
  - Message truncation at 2KB UTF-8 boundary
  - XML envelope formatting with/without phase
  - Abort signal guard
  - Terminal-state guard (no emit after succeeded/failed/cancelled)
  - Handler error paths (missing message, non-object input)
- All 299 existing subagent tests pass unchanged
