### PR TITLE
test(subagent): add teardown/cancel clearing assertions for steer() ring buffer (#1496)

### DIFF
--- a/src/agent/subagent/handle.test.ts
+++ b/src/agent/subagent/handle.test.ts
@@ -578,4 +578,20 @@ describe('SubagentHandleImpl.steer()', () => {
     expect(cb()).toBe('second');
     expect(cb()).toBeUndefined();
   });
+
+  it('cancel() clears pending steering messages', async () => {
+    const handle = makeSteerHandle();
+    handle.steer('focus on auth');
+    expect(handle._steeringMessages).toHaveLength(1);
+    await handle.cancel();
+    expect(handle._steeringMessages).toHaveLength(0);
+  });
+
+  it('teardown() clears pending steering messages', async () => {
+    const handle = makeSteerHandle();
+    handle.steer('focus on auth');
+    expect(handle._steeringMessages).toHaveLength(1);
+    await handle.teardown();
+    expect(handle._steeringMessages).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary

Adds the two missing test cases called out in issue #1496: the `steer()` describe block header promised "teardown clearing" coverage but no test actually exercised it.

## What changed

**`src/agent/subagent/handle.test.ts`** — two new `it()` cases inside `SubagentHandleImpl.steer()`:

- **`cancel() clears pending steering messages`** — steers a message, calls `await handle.cancel()`, asserts `_steeringMessages` is empty.
- **`teardown() clears pending steering messages`** — steers a message, calls `await handle.teardown()`, asserts `_steeringMessages` is empty.

Both tests use the existing `makeSteerHandle()` factory and read `handle._steeringMessages` directly (the public-readonly field already used by the other steer tests).

## Verification

```
pnpm lint   → exit 0 (tsc + tsc -p tsconfig.web.json)
pnpm test src/agent/subagent/handle.test.ts → 21 tests passed (was 19)
```

Closes #1496
