### PR TITLE
fix(repl): clear pendingStopInjection on /resume session swap (#1512)

### DIFF
--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -257,6 +257,10 @@ export async function bootstrapSession(
         // settled just before it may already sit in the notifier's buffer
         // and would otherwise inject into the resumed session's first turn.
         ctx.clearBgResultBuffer?.();
+        // Drop any pending Stop-hook injection from the outgoing session so
+        // its injectContext cannot leak into the resumed session's first turn.
+        // Mirrors clearVerdictLedger and clearBgResultBuffer above.
+        ctx.clearPendingStopInjection?.();
         // Re-point every long-lived holder of the outgoing (now sealed) writer
         // at the incoming session's live one. These are built once in
         // createBootstrapInfra and survive the swap, so without this the

--- a/src/cli/commands/interactive/loop-iteration.ts
+++ b/src/cli/commands/interactive/loop-iteration.ts
@@ -186,6 +186,13 @@ export async function runInputLoop(
   // Cross-turn state is exactly what the v1 Stop wiring deferred (see the Stop
   // dispatch site at the bottom of the loop).
   let pendingStopInjection: string | undefined;
+  // Expose a clear-setter on ctx so the /resume swap path (onSwapped callback
+  // in bootstrap.ts) can drop a stale Stop-hook injection from the outgoing
+  // session before the resumed session's first turn. Mirrors clearVerdictLedger
+  // and clearBgResultBuffer (which serve the same role for the ledger and the
+  // bg-result buffer). Optional on ctx — early /resume calls before runInputLoop
+  // runs are a safe no-op.
+  ctx.clearPendingStopInjection = () => { pendingStopInjection = undefined; };
   // Parsed terminal-state kind + corroborating-evidence flag of the current
   // turn, captured from onTerminalState (which fires during runTurn) so the
   // post-turn Stop dispatch can carry them on StopContext for policy handlers.

--- a/src/cli/commands/interactive/resume-swap.test.ts
+++ b/src/cli/commands/interactive/resume-swap.test.ts
@@ -820,3 +820,59 @@ describe('performResumeSwap — C1: background jobs preserved on rollback', () =
     expect(order).toEqual(['build', 'init', 'cancelAll']);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Tests — clearPendingStopInjection invoked on successful swap (#1512)
+// The Stop-hook injection lives in runInputLoop's closure; the clear-setter is
+// wired onto ctx by runInputLoop and called from the onSwapped callback in
+// bootstrap.ts. Here we verify the wiring contract from performResumeSwap's
+// perspective: onSwapped fires on success so the clearPendingStopInjection
+// call (installed there by bootstrap.ts) will execute, and does NOT fire on
+// failure paths — the injection must stay intact when the swap rolls back.
+// ---------------------------------------------------------------------------
+
+describe('performResumeSwap — clearPendingStopInjection wiring (#1512)', () => {
+  it('invokes onSwapped on successful swap (clearPendingStopInjection fires via onSwapped)', async () => {
+    // The clearPendingStopInjection call lives inside the onSwapped callback
+    // wired by bootstrap.ts. performResumeSwap calls onSwapped exactly once
+    // on success — this confirms the call site that drives the clear fires.
+    const { deps, onSwappedSpy } = buildDeps();
+    await performResumeSwap(makeTarget('t-clear', makeStoredSession()), deps);
+    expect(onSwappedSpy).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT invoke onSwapped (and thus not clearPendingStopInjection) on buildSession throw', async () => {
+    const { deps, onSwappedSpy } = buildDeps();
+    deps.buildSession = vi.fn().mockImplementation(() => {
+      throw new Error('constructor boom');
+    });
+    await performResumeSwap(makeTarget('t-clear-fail', makeStoredSession()), deps);
+    expect(onSwappedSpy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT invoke onSwapped (and thus not clearPendingStopInjection) on init failure', async () => {
+    const { deps, onSwappedSpy } = buildDeps();
+    const newSession = makeFakeSession('failing-session');
+    newSession.waitForInitialization = vi.fn().mockRejectedValue(new Error('init boom'));
+    deps.buildSession = vi.fn().mockReturnValue(
+      newSession as unknown as import('../../../agent/session.js').AgentSession,
+    );
+    await performResumeSwap(makeTarget('t-clear-init-fail', makeStoredSession()), deps);
+    expect(onSwappedSpy).not.toHaveBeenCalled();
+  });
+
+  it('a clearPendingStopInjection callback supplied via onSwapped is invoked and clears the injection', async () => {
+    // Simulate the bootstrap.ts wiring: onSwapped calls ctx.clearPendingStopInjection?.()
+    // We verify the pattern by passing an onSwapped that calls a clear function and
+    // checking the clear function was invoked.
+    let injectionCleared = false;
+    const clearSpy = vi.fn(() => { injectionCleared = true; });
+
+    const { deps } = buildDeps();
+    deps.onSwapped = vi.fn((_target) => { clearSpy(); });
+
+    await performResumeSwap(makeTarget('t-clear-direct', makeStoredSession()), deps);
+    expect(clearSpy).toHaveBeenCalledOnce();
+    expect(injectionCleared).toBe(true);
+  });
+});

--- a/src/cli/commands/interactive/shared.ts
+++ b/src/cli/commands/interactive/shared.ts
@@ -463,6 +463,14 @@ export interface InteractiveCtx {
    */
   clearBgResultBuffer?: () => void;
   /**
+   * Clears the `pendingStopInjection` binding in `runInputLoop` so a
+   * mid-session /resume swap cannot leak a Stop-hook `injectContext` from
+   * the outgoing session into the resumed session's first turn. Mirrors
+   * the `clearVerdictLedger` / `clearBgResultBuffer` pattern: owned by
+   * `runInputLoop`'s closure, wired onto `ctx` at loop entry, invoked
+   * from the swap's `onSwapped` callback in bootstrap.ts.
+   */
+  clearPendingStopInjection?: () => void;
   /**
    * Cursor row (1-based) at the moment `armCompositor` will be invoked,
    * computed by counting `


### PR DESCRIPTION
## Problem

`pendingStopInjection` is a function-scope `let` in `runInputLoop` (`src/cli/commands/interactive/loop-iteration.ts`). It is:
- Set when a Stop hook returns `injectContext` (e.g. the terminal-state gate bouncing a self-certified `Done`)
- Drained (prepended to `runText`) on the next turn
- Cleared on `/clear`

The `/resume` hot-swap path (`resume-swap.ts`) did **not** clear it, so a stale Stop-hook correction from the outgoing session could leak into the resumed session's first turn.

## Fix

Mirrors the existing `clearVerdictLedger` / `clearBgResultBuffer` pattern:

1. **`shared.ts`** — add `clearPendingStopInjection?: () => void` to `InteractiveCtx`
2. **`loop-iteration.ts`** — wire it immediately after `pendingStopInjection` is declared:
   ```ts
   ctx.clearPendingStopInjection = () => { pendingStopInjection = undefined; };
   ```
3. **`bootstrap.ts`** — call it in the `onSwapped` callback alongside `clearVerdictLedger` and `clearBgResultBuffer`:
   ```ts
   ctx.clearPendingStopInjection?.();
   ```
4. **`resume-swap.test.ts`** — 4 new tests covering the wiring contract

Also removes a pre-existing doubled `/**` JSDoc marker in `shared.ts`.

## Tests

```
✓ src/cli/commands/interactive/resume-swap.test.ts (52 tests) — 4 new
✓ 50 test files, 1398 tests total — all pass
pnpm lint — clean (tsc --noEmit)
```

Closes #1512
