### PR TITLE
fix(repl): spine severed on multi-line tool outcomes in nested tree

### DIFF
--- a/src/cli/commands/interactive/tool-lane-nested-spine.test.ts
+++ b/src/cli/commands/interactive/tool-lane-nested-spine.test.ts
@@ -23,8 +23,8 @@ import { ToolLane } from './tool-lane.js';
 import { stripAnsi } from '../../display.js';
 import type { ToolResultChunk } from '../../../agent/types/message-types.js';
 
-function makeResult(content: string, isError = false): ToolResultChunk {
-  return { type: 'tool_result', toolUseId: 'unused', content, isError };
+function makeResult(content: string, isError = false, extra?: Partial<ToolResultChunk>): ToolResultChunk {
+  return { type: 'tool_result', toolUseId: 'unused', content, isError, ...extra };
 }
 
 /** Column (0-based) of the first tree connector (├ or ╰) on a row, or -1. */
@@ -103,5 +103,77 @@ describe('nested-spine continuity (non-last ancestor, last child has children)',
     expect(leafRow, `dump:\n${rows.join('\n')}`).toBeDefined();
     const aCol = connectorCol(aRow);
     expect(leafRow[aCol], `A vertical SEVERED in scrollback\n${rows.join('\n')}`).toBe('│');
+  });
+});
+
+describe('multi-line outcome spine continuity (hiddenLineCount + tailPreview)', () => {
+  /**
+   * Regression: formatOutcome returns a multi-line string when
+   * hiddenLineCount and/or tailPreview are set. The continuation lines
+   * (e.g. "151 earlier lines hidden", tail preview lines) carried a
+   * hardcoded 4-space indent that lacked tree-spine glyphs, severing
+   * the spine in nested views.
+   */
+
+  function buildMultiLineTree(): ToolLane {
+    const lane = new ToolLane();
+    lane.addStartWithAgentContext('root', 'skill', '(root)', undefined);
+    lane.addStartWithAgentContext('A', 'Agent', '(A)', 'root');
+    // A second sibling of A under root, so root's spine stays open
+    lane.addStartWithAgentContext('A2', 'Agent', '(A2)', 'root');
+    // bash with multi-line output (hiddenLineCount + tailPreview)
+    lane.addStartWithAgentContext('bash1', 'bash', 'cmd1', 'A');
+    lane.addResult('bash1', makeResult('', false, {
+      lineCount: 160,
+      hiddenLineCount: 151,
+      tailPreview: ['line 152', 'line 153'],
+    }));
+    // A second sibling under A to keep A's spine open through bash1's continuation
+    lane.addStartWithAgentContext('bash2', 'bash', 'cmd2', 'A');
+    return lane;
+  }
+
+  it('overlay: continuation lines of multi-line outcome carry spine glyphs', () => {
+    const lane = buildMultiLineTree();
+    const rawOverlay = lane.getOverlay();
+    const rows = stripAnsi(rawOverlay).split('\n');
+
+    // Find the "earlier lines hidden" row
+    const hiddenRow = rows.find((l) => l.includes('earlier lines hidden'));
+    expect(hiddenRow, `no hidden-lines row found\n${rows.join('\n')}`).toBeDefined();
+
+    // The root skill anchors at col 0 with ◉. A is NOT last (A2 follows),
+    // so root's spine (col 0) must be '│'. A's spine (col 2) must also be '│'
+    // since bash1 is not last (bash2 follows).
+    expect(hiddenRow![0], `root spine severed on hidden-lines row\n${rows.join('\n')}`).toBe('│');
+    expect(hiddenRow![2], `A spine severed on hidden-lines row\n${rows.join('\n')}`).toBe('│');
+
+    // Tail preview lines must also carry spine glyphs
+    const tailRow = rows.find((l) => l.includes('line 152'));
+    expect(tailRow, `no tail-preview row found\n${rows.join('\n')}`).toBeDefined();
+    expect(tailRow![0], `root spine severed on tail-preview row\n${rows.join('\n')}`).toBe('│');
+    expect(tailRow![2], `A spine severed on tail-preview row\n${rows.join('\n')}`).toBe('│');
+  });
+
+  it('flush: continuation lines carry spine glyphs in scrollback', () => {
+    const lane = buildMultiLineTree();
+    // Settle everything
+    lane.addResult('bash2', makeResult('ok'));
+    lane.setAgentResultSummary('A', 'Done');
+    lane.addResult('A', makeResult('done'));
+    lane.setAgentResultSummary('A2', 'Done');
+    lane.addResult('A2', makeResult('done'));
+    lane.setAgentResultSummary('root', 'Done');
+    lane.addResult('root', makeResult('done'));
+
+    const rows = lane.flush().flatMap((s) => s.split('\n')).map(stripAnsi).filter((l) => l.length > 0);
+
+    const hiddenRow = rows.find((l) => l.includes('earlier lines hidden'));
+    expect(hiddenRow, `no hidden-lines row in scrollback\n${rows.join('\n')}`).toBeDefined();
+    expect(hiddenRow![0], `root spine severed in scrollback hidden-lines row\n${rows.join('\n')}`).toBe('│');
+
+    const tailRow = rows.find((l) => l.includes('line 152'));
+    expect(tailRow, `no tail-preview row in scrollback\n${rows.join('\n')}`).toBeDefined();
+    expect(tailRow![0], `root spine severed in scrollback tail-preview row\n${rows.join('\n')}`).toBe('│');
   });
 });

--- a/src/cli/commands/interactive/tool-lane-render-children.ts
+++ b/src/cli/commands/interactive/tool-lane-render-children.ts
@@ -18,6 +18,7 @@ import {
   renderTextChildLines,
   getGlyphs,
   toolLaneWidth,
+  pushOutcomeLines,
 } from './tool-lane-render.js';
 import {
   groupSiblings,
@@ -259,15 +260,15 @@ function renderOverlayChildren(
         // child will draw its own connector row from the current parent's
         // indented spine column — exactly what the caller renders next.
       } else if (child.result) {
-        lines.push(clampLineToTerminal(indentColored + connector + child.prefix + palette.dim(' — ') + doneGlyph(child.result.isError, child.result.failureClass) + ' ' + formatOutcome(child.result, undefined, 60, child.toolName), cols));
+        // formatOutcome may return multi-line content (hiddenLineCount +
+        // tailPreview). pushOutcomeLines splits on \n so continuation lines
+        // carry the spine-aware indent instead of the bare 4-space indent
+        // that formatOutcome embeds.
+        const outcomeText = formatOutcome(child.result, undefined, 60, child.toolName);
+        const headLine = indentColored + connector + child.prefix + palette.dim(' — ') + doneGlyph(child.result.isError, child.result.failureClass) + ' ';
+        const continuationIndent = indentColored + (isLast ? g.spineClosed : palette.dim(g.spine)) + '  ';
+        pushOutcomeLines(lines, headLine, outcomeText, continuationIndent, cols);
         if (child.diff && !child.result.isError) {
-          // Diff sits under the child entry. Indent = current row's indent
-          // + 1 spine slot (continuing this child's column iff it's not the
-          // last sibling) + a 1-cell pad to clear past the connector. We
-          // approximate the post-connector position with `'    '` extension
-          // since the connector itself is 3 cells (`├─ ` / `╰─ `) — the diff
-          // hangs visually past it without claiming a sibling slot.
-          const diffIndent = indentColored + (isLast ? g.spineClosed : palette.dim(g.spine)) + '  ';
           // Clamp each diff body line to terminal width. Diff lines are
           // model-controlled (file content) and routinely exceed `cols`;
           // without clamping the terminal soft-wraps the overflow to column 0
@@ -278,7 +279,7 @@ function renderOverlayChildren(
           // log-update's wrap-aware count, making the block flicker on each
           // repaint. Mirrors the clamp on the root-overlay diff path in
           // tool-lane.ts.
-          for (const line of formatDiffBlock(child.diff, 'overlay', diffIndent)) {
+          for (const line of formatDiffBlock(child.diff, 'overlay', continuationIndent)) {
             lines.push(clampLineToTerminal(line, cols));
           }
         }
@@ -446,18 +447,18 @@ function renderFlushChildren(
         const parentSlot = parentIsLast ?? isLast;
         lines.push(...renderFlushChildren(grandchildren, childMap, homeDir, undefined, cols, [...ancestorIsLast, parentSlot], g, isLast));
       } else if (child.result) {
-        lines.push(clampLineToTerminal(indentColored + connector + child.prefix + palette.dim(' — ') + doneGlyph(child.result.isError, child.result.failureClass) + ' ' + formatOutcome(child.result, homeDir, 60, child.toolName), cols));
+        // Mirror overlay path: pushOutcomeLines splits on \n so continuation
+        // lines carry the spine-aware indent in scrollback.
+        const outcomeText = formatOutcome(child.result, homeDir, 60, child.toolName);
+        const headLine = indentColored + connector + child.prefix + palette.dim(' — ') + doneGlyph(child.result.isError, child.result.failureClass) + ' ';
+        const continuationIndent = indentColored + (isLast ? g.spineClosed : palette.dim(g.spine)) + '  ';
+        pushOutcomeLines(lines, headLine, outcomeText, continuationIndent, cols);
         if (child.diff && !child.result.isError) {
-          // Scrollback renders the full diff (no overlay cap). Indent matches
-          // the overlay path: continue (or close) this child's spine column,
-          // then 2 cells past the connector.
-          const diffIndent = indentColored + (isLast ? g.spineClosed : palette.dim(g.spine)) + '  ';
-          // Clamp each diff body line to terminal width — see the matching
-          // note on the overlay diff path above. Scrollback is append-only:
-          // an unclamped line that soft-wraps to column 0 orphans its
-          // continuation past the spine gutter permanently, with no repaint
-          // able to repair it.
-          for (const line of formatDiffBlock(child.diff, 'flush', diffIndent)) {
+          // Clamp each diff body line to terminal width -- scrollback is
+          // append-only: an unclamped line that soft-wraps to column 0
+          // orphans its continuation past the spine gutter permanently,
+          // with no repaint able to repair it.
+          for (const line of formatDiffBlock(child.diff, 'flush', continuationIndent)) {
             lines.push(clampLineToTerminal(line, cols));
           }
         }

--- a/src/cli/commands/interactive/tool-lane-render.ts
+++ b/src/cli/commands/interactive/tool-lane-render.ts
@@ -371,6 +371,34 @@ export function renderTextChildLines(text: string, indent: string, g: Readonly<G
 }
 
 
+/**
+ * Push a possibly multi-line outcome string into `lines`, splitting on `\n` so
+ * every continuation line (hiddenLineCount notice, tailPreview rows) carries the
+ * spine-aware `continuationIndent` instead of the hardcoded 4-space indent that
+ * `formatOutcome` embeds. The first line is concatenated with `headPrefix`;
+ * subsequent lines get `continuationIndent` prepended. Every emitted line is
+ * clamped to `cols`.
+ *
+ * Centralizes the split-and-re-indent pattern used by both the overlay and flush
+ * child-render paths (tool-lane-render-children.ts) and the root NESTING-entry
+ * path (tool-lane.ts), so the spine is never severed on multi-line outcomes.
+ */
+export function pushOutcomeLines(
+  lines: string[],
+  headPrefix: string,
+  outcomeText: string,
+  continuationIndent: string,
+  cols: number,
+  headSuffix = '',
+): void {
+  const parts = outcomeText.split('\n');
+  lines.push(clampLineToTerminal(headPrefix + parts[0]! + headSuffix, cols));
+  for (let i = 1; i < parts.length; i++) {
+    lines.push(clampLineToTerminal(continuationIndent + parts[i]!, cols));
+  }
+}
+
+
 // Re-export from grouping module
 export {
   assignConnectors,

--- a/src/cli/commands/interactive/tool-lane.ts
+++ b/src/cli/commands/interactive/tool-lane.ts
@@ -11,9 +11,9 @@ import {
   formatAgentHeader,
   formatAgentChildren,
   renderGroupedRootTools,
-  getGlyphs,
-  toolLaneWidth,
+  getGlyphs, toolLaneWidth,
   freshToolEntry,
+  pushOutcomeLines,
   type ToolEntry,
   type TextEntry,
   type Entry,
@@ -597,7 +597,9 @@ export class ToolLane {
         // never carries a `diff` payload (diffs originate from edit/write
         // tool_diff chunks), so no diff block is rendered here.
         if (entry.result) {
-          lines.push(clamp(palette.dim(g.turnRoot) + entry.prefix + palette.dim(' — ') + doneGlyph(entry.result.isError, entry.result.failureClass) + ' ' + formatOutcome(entry.result, undefined, 60, entry.toolName) + batchBadge(entry.result)));
+          // pushOutcomeLines splits multi-line formatOutcome so continuation
+          // lines carry the spine glyph, not a bare 4-space indent.
+          pushOutcomeLines(lines, palette.dim(g.turnRoot) + entry.prefix + palette.dim(' — ') + doneGlyph(entry.result.isError, entry.result.failureClass) + ' ', formatOutcome(entry.result, undefined, 60, entry.toolName), palette.dim(g.spine) + '  ', cols, batchBadge(entry.result));
         } else {
           // Live elapsed counter: computed at repaint time so the counter ticks
           // on every overlay refresh without a dedicated timer. Grace period


### PR DESCRIPTION
## Problem

`formatOutcome()` returns a string with embedded `\n` when `hiddenLineCount` or `tailPreview` are set (e.g. "151 earlier lines hidden" + tail lines). The tree renderer pushed this multi-line string as a single entry, so continuation lines carried only the hardcoded 4-space indent from `formatOutcome` -- completely lacking the tree spine glyphs (`│`). This severed the spine on every line after the first in nested compose/agent views.

**Before** (from the reported screenshot):
```
│ ├─ ◌ bashcmd1 — ✓ 160 lines
    151 earlier lines hidden      ← no spine, bare indent
    line 152                      ← no spine
```

**After:**
```
│ ├─ ◌ bashcmd1 — ✓ 160 lines
│ │       151 earlier lines hidden   ← spine preserved
│ │       line 152                   ← spine preserved
```

## Fix

Extract `pushOutcomeLines()` helper in `tool-lane-render.ts` that splits multi-line outcome text on `\n` and re-indents continuation lines with the correct spine column prefix. Applied to all three affected render paths:

- **Overlay** child-render path (`tool-lane-render-children.ts`)
- **Flush** (scrollback) child-render path (`tool-lane-render-children.ts`)
- **Root NESTING-entry** completion path (`tool-lane.ts`)

## Tests

2 new regression tests in `tool-lane-nested-spine.test.ts` verify spine continuity on `hiddenLineCount` + `tailPreview` rows in both overlay and scrollback. All 392 existing tool-lane tests pass unchanged.
