### PR TITLE
fix(repl): apply pushOutcomeLines to grouped-root single-entry path

### DIFF
--- a/src/cli/commands/interactive/tool-lane-render-grouped-root.ts
+++ b/src/cli/commands/interactive/tool-lane-render-grouped-root.ts
@@ -11,7 +11,7 @@ import {
   shortenPaths,
 } from './tool-lane-format.js';
 import type { ToolEntry } from './tool-lane-render.js';
-import { clampLineToTerminal, toolLaneWidth } from './tool-lane-render.js';
+import { clampLineToTerminal, pushOutcomeLines, toolLaneWidth } from './tool-lane-render.js';
 
 function groupedResultSuffix(
   entries: ToolEntry[],
@@ -51,7 +51,7 @@ function groupedResultSuffix(
 
   if (completed.length > 0) {
     const outcomes = completed.map((entry) =>
-      formatOutcome(entry.result!, homeDir, 60, entry.toolName),
+      formatOutcome(entry.result!, homeDir, 60, entry.toolName).replace(/\n[\s\S]*/u, '…'),
     );
     return palette.dim(' — ') + outcomes.join(palette.dim(', '));
   }
@@ -120,12 +120,19 @@ export function renderGroupedRootTools(
     if (entries.length === 1) {
       const e = entries[0]!;
       if (e.result) {
-        // Plain clamp, not suffix-reservation as in the grouped path: for a
-        // single entry the args ARE the identity and the outcome is the
-        // expendable tail, which is exactly how the overlay clamps the same
-        // row ("clamping should elide the outcome tail, not the leading
-        // prefix that carries the tool identity" — tool-lane.test.ts).
-        lines.push(clampLineToTerminal('   ' + e.prefix + palette.dim(' — ') + doneGlyph(e.result.isError, e.result.failureClass) + ' ' + formatOutcome(e.result, homeDir, 60, e.toolName) + batchBadge(e.result), cols));
+        // pushOutcomeLines splits multi-line formatOutcome so continuation
+        // lines carry '   ' (the same 3-space root indent) instead of a
+        // bare inline join that would embed a raw \n into the row. This
+        // mirrors the child-render and overlay paths — see
+        // tool-lane-render-children.ts and tool-lane.ts.
+        pushOutcomeLines(
+          lines,
+          '   ' + e.prefix + palette.dim(' — ') + doneGlyph(e.result.isError, e.result.failureClass) + ' ',
+          formatOutcome(e.result, homeDir, 60, e.toolName),
+          '   ',
+          cols,
+          batchBadge(e.result),
+        );
         if (e.diff && !e.result.isError) {
           // Root-level scrollback diff: indent 4 spaces so it sits under
           // the outcome line (3 for the row indent, 1 more to clear the


### PR DESCRIPTION
## Summary

Fixes #1532 — two rendering correctness bugs in `renderGroupedRootTools` for grouped-root tool lanes.

### Fix 1: Apply `pushOutcomeLines` to single-entry path (line 128)

**Before:** The single-entry branch built the result row as one long inline string using `formatOutcome(...)`. When `formatOutcome` returns multi-line content (`hiddenLineCount` or `tailPreview` set), the raw `\n` was embedded directly into the string passed to `clampLineToTerminal`, breaking the scrollback row.

**After:** Uses `pushOutcomeLines()` (introduced in #1530), which splits on `\n` and emits each continuation line with the 3-space root indent (`'   '`), consistent with the child-render and overlay paths in `tool-lane-render-children.ts` and `tool-lane.ts`. `batchBadge(e.result)` is passed as `headSuffix` so the badge stays on the first line.

### Fix 2: Strip `\n` from outcomes in `groupedResultSuffix` (lines 52-56)

**Before:** Per-entry `formatOutcome` results were joined with `', '`. If any individual outcome contained `\n` (multi-line content), the comma-joined string embedded a raw newline in the group header row.

**After:** Each outcome is truncated at the first `\n` with a `…` ellipsis before joining, keeping the group header row a single line.

### Changes

- `src/cli/commands/interactive/tool-lane-render-grouped-root.ts`
  - Import `pushOutcomeLines` from `tool-lane-render.js`
  - Replace inline `clampLineToTerminal(... + formatOutcome(...) ...)` with `pushOutcomeLines(...)`
  - Add `.replace(/\n[\s\S]*/u, '…')` to each `formatOutcome` result in `groupedResultSuffix`

### Verification

- `pnpm lint` — clean (TypeScript `--noEmit` passes)
- `pnpm exec vitest run src/cli/render/measure.test.ts src/cli/commands/interactive/tool-lane.test.ts` — **149 tests pass**
- `pnpm audit:filesize:check` — the modified file is not flagged (pre-existing violations are unrelated)
