### PR TITLE
fix(repl): warn on Ctrl+B promotion of non-isolated write-capable child

### DIFF
--- a/src/cli/commands/interactive/turn-handler.test.ts
+++ b/src/cli/commands/interactive/turn-handler.test.ts
@@ -1321,6 +1321,85 @@ describe('runTurn — borrowed-compositor regression (PR 424 / Stage 3e)', () =>
     expect(writerCalls.some((l) => l.includes('backgrounded'))).toBe(false);
   });
 
+  // Worktree-conflict warning (#1513): non-isolated children share the parent's
+  // worktree and can cause concurrent write conflicts when promoted to background.
+  it('Ctrl+B emits a worktree-conflict warning when the promoted child shares the parent worktree', async () => {
+    const writerCalls: string[] = [];
+    const completionWriter = { fn: (line: string) => { writerCalls.push(line); } };
+
+    // sharesWorktree: true — no isolation: "worktree" was set on the dispatch.
+    const promoteActiveForeground = vi.fn().mockResolvedValue([
+      { jobId: 'bg-warn', label: 'non-isolated job', sharesWorktree: true },
+    ]);
+    const subagentControl = {
+      hasPromotableForeground: () => true,
+      promoteActiveForeground,
+      hasActiveForeground: () => false,
+      cancelActiveForeground: vi.fn().mockResolvedValue(0),
+    };
+
+    const { h } = makeHandles();
+    const handles: TurnHandles = {
+      ...h,
+      subagentControl,
+      setBackgroundHandler: (handler) => { handler?.(); },
+    };
+
+    await runTurn(
+      { text: 'q', attachments: [] },
+      streamFrom([{ type: 'done', metadata: { durationMs: 1 } }]),
+      makeStats(),
+      handles,
+      'summary',
+      completionWriter,
+    );
+    await new Promise((r) => setImmediate(r));
+
+    expect(promoteActiveForeground).toHaveBeenCalledTimes(1);
+    // The worktree-conflict warning must appear.
+    expect(writerCalls.some((l) => l.includes('Background child'))).toBe(true);
+    expect(writerCalls.some((l) => l.includes('worktree'))).toBe(true);
+  });
+
+  it('Ctrl+B does NOT emit a worktree-conflict warning when the promoted child is isolated', async () => {
+    const writerCalls: string[] = [];
+    const completionWriter = { fn: (line: string) => { writerCalls.push(line); } };
+
+    // sharesWorktree: false — isolation: "worktree" was set; child has its own tree.
+    const promoteActiveForeground = vi.fn().mockResolvedValue([
+      { jobId: 'bg-iso', label: 'isolated job', sharesWorktree: false },
+    ]);
+    const subagentControl = {
+      hasPromotableForeground: () => true,
+      promoteActiveForeground,
+      hasActiveForeground: () => false,
+      cancelActiveForeground: vi.fn().mockResolvedValue(0),
+    };
+
+    const { h } = makeHandles();
+    const handles: TurnHandles = {
+      ...h,
+      subagentControl,
+      setBackgroundHandler: (handler) => { handler?.(); },
+    };
+
+    await runTurn(
+      { text: 'q', attachments: [] },
+      streamFrom([{ type: 'done', metadata: { durationMs: 1 } }]),
+      makeStats(),
+      handles,
+      'summary',
+      completionWriter,
+    );
+    await new Promise((r) => setImmediate(r));
+
+    expect(promoteActiveForeground).toHaveBeenCalledTimes(1);
+    // The isolated job backgrounded normally — confirmation line present.
+    expect(writerCalls.some((l) => l.includes('backgrounded as bg-iso'))).toBe(true);
+    // No worktree-conflict warning for an isolated child.
+    expect(writerCalls.some((l) => l.includes('Background child'))).toBe(false);
+  });
+
   it('routes paused usage-limit box through completionWriter.fn (not console.log) when compositor armed', async () => {
     const { stub } = makeStubCompositor();
     const writerCalls: string[] = [];


### PR DESCRIPTION
## Summary

Fixes #1513 — warn on Ctrl+B promotion of a write-capable, non-isolated child.

When a user presses Ctrl+B to background a foreground subagent that **shares the parent's worktree** (dispatched without `isolation: "worktree"`), the parent gets their prompt back immediately while the child continues writing to the same tree. This creates a concurrent-write hazard with no coordination — last write wins silently.

## What's in this PR

The implementation was already wired across three files:

| File | What it does |
|------|-------------|
| `foreground-promotion.ts:241` | Sets `sharesWorktree: !isoTd` on the `PromotedSubagentInfo` returned from `resolveJob` |
| `queued-flush.ts:42,48` | Propagates `sharesWorktree?` through the `QueuedFlushControl` return type |
| `turn-handler.ts:143` | Emits `palette.warning('⚠ Background child is writing to your worktree — edits may conflict until it finishes')` when `jobs.some(j => j.sharesWorktree)` |

**This PR adds the missing test coverage** for that wired mitigation:

### New tests in `turn-handler.test.ts`

1. **Non-isolated promotion shows warning** — when `promoteActiveForeground` returns `{ sharesWorktree: true }`, the warning text `'Background child'` and `'worktree'` appear in `completionWriter` output.

2. **Isolated promotion suppresses warning** — when `promoteActiveForeground` returns `{ sharesWorktree: false }`, the normal `'backgrounded as bg-iso'` confirmation line is written but no warning appears.

## Verification

```
pnpm lint            # TypeScript clean (tsc --noEmit)
pnpm exec vitest run src/cli/commands/interactive/turn-handler.test.ts
# → 80 passed (78 existing + 2 new)
pnpm audit:filesize:check
# → .test.ts files are excluded from the ceiling; no new production file touched
```

## Notes

- `palette.warning` used throughout (never raw `chalk.<color>`) — consistent with palette constraints
- No force push
- Pre-existing `GREW` violations in `background-registry.ts`, `schemas.ts`, `interactive.ts`, `template-engine.ts` are unrelated to this PR
