### PR TITLE
chore(improve): extend closure contract to cover truncated guidance

### DIFF
--- a/.filesize-baseline.json
+++ b/.filesize-baseline.json
@@ -35,7 +35,7 @@
     "src/cli/terminal-compositor.ts": { "loc": 353, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/config/env.ts": { "loc": 1719, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/config/import-sources.ts": { "loc": 373, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
-    "src/improve/eval-run/contracts.ts": { "loc": 491, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/improve/eval-run/contracts.ts": { "loc": 500, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/improve/eval-run/runner.ts": { "loc": 372, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/improve/propose/template-engine.ts": { "loc": 459, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
     "src/skills/audit-fit/index.ts": { "loc": 424, "reason": "legacy: predates the ceiling gate; pending concern extraction" },

--- a/src/improve/eval-run/contracts.test.ts
+++ b/src/improve/eval-run/contracts.test.ts
@@ -253,7 +253,7 @@ describe('tool-failure-density classification (synthetic SessionRead corpus)', (
 });
 
 // ---------------------------------------------------------------------------
-// Contract: closure-anomaly abort recovery hint
+// Contract: closure-anomaly recovery hint (abort + truncated subtypes)
 // ---------------------------------------------------------------------------
 
 describe('closure-abort-recovery-hint contract', () => {
@@ -263,6 +263,7 @@ describe('closure-abort-recovery-hint contract', () => {
       'abort-closure-has-guidance',
       'guidance-names-a-recovery-action',
       'guidance-is-the-canonical-constant',
+      'truncated-closure-has-canonical-guidance',
       'benign-closure-has-no-guidance',
     ]);
     for (const c of result.checks) {

--- a/src/improve/eval-run/contracts.ts
+++ b/src/improve/eval-run/contracts.ts
@@ -19,8 +19,8 @@
  *   - `repeated-tool-use`    → the repeat-loop circuit breaker (PR #80).
  *   - `subagent-block`       → the skill max-depth recovery hint (PR #80).
  *   - `tool-failure-density` → that detector being enabled by default (PR #80).
- *   - `closure-anomaly`      → the abort-closure recovery hint
- *                              (`session/closure-guidance.ts`; abort subtype).
+ *   - `closure-anomaly`      → the closure recovery hint (`session/closure-guidance.ts`;
+ *                              abort + truncated subtypes).
  *
  * Patterns with no registered contract resolve to `undefined`; the runner
  * records an `unsupported` result rather than failing.
@@ -46,6 +46,7 @@ import {
 } from '../../agent/tools/skill-depth-message.js';
 import {
   CLOSURE_ABORT_RECOVERY_HINT,
+  CLOSURE_TRUNCATED_RECOVERY_HINT,
   buildClosureGuidance,
 } from '../../agent/session/closure-guidance.js';
 import {
@@ -622,12 +623,14 @@ async function runToolFailureDensityContract(): Promise<ContractProbeResult> {
  * `emitClosure` wires onto the `closure` trace event — a regression that
  * drops the hint (or starts emitting one on clean closes) is caught here.
  *
- * Scoped to the `abort` subtype: the only closure reason the guardrail covers
- * today (see `closure-guidance.ts`). The contract validates the GUARDRAIL the
+ * Covers `abort` (canonical check + recovery-action presence + canonical-constant
+ * identity) and `truncated` (canonical-constant identity) — the two subtypes
+ * most likely to silently regress. The contract validates the GUARDRAIL the
  * pattern maps to, not a fixture replay — matching the other contracts.
  */
 async function runClosureAnomalyRecoveryHint(): Promise<ContractProbeResult> {
   const abortGuidance = buildClosureGuidance('abort');
+  const truncatedGuidance = buildClosureGuidance('truncated');
   const benignGuidance = buildClosureGuidance('model_end_turn');
 
   const checks: EvalCheck[] = [
@@ -651,6 +654,13 @@ async function runClosureAnomalyRecoveryHint(): Promise<ContractProbeResult> {
       pass: abortGuidance === CLOSURE_ABORT_RECOVERY_HINT,
       expected: 'buildClosureGuidance("abort") === CLOSURE_ABORT_RECOVERY_HINT',
       actual: abortGuidance === null ? 'null' : snapshot(abortGuidance),
+    }),
+    makeCheck({
+      name: 'truncated-closure-has-canonical-guidance',
+      description: 'A truncated closure maps to the exported CLOSURE_TRUNCATED_RECOVERY_HINT (no drift)',
+      pass: truncatedGuidance === CLOSURE_TRUNCATED_RECOVERY_HINT,
+      expected: 'buildClosureGuidance("truncated") === CLOSURE_TRUNCATED_RECOVERY_HINT',
+      actual: truncatedGuidance === null ? 'null' : snapshot(truncatedGuidance),
     }),
     makeCheck({
       name: 'benign-closure-has-no-guidance',
@@ -703,7 +713,7 @@ const CONTRACTS: readonly EvalContract[] = Object.freeze([
   {
     id: 'closure-abort-recovery-hint',
     patternId: 'closure-anomaly',
-    title: 'Anomalous abort closure carries an actionable recovery hint',
+    title: 'Anomalous closure (abort, truncated) carries an actionable recovery hint',
     run: runClosureAnomalyRecoveryHint,
   },
 ] satisfies EvalContract[]);


### PR DESCRIPTION
## Summary

Extends the `closure-anomaly` eval-run contract to assert `buildClosureGuidance('truncated') === CLOSURE_TRUNCATED_RECOVERY_HINT`, closing the contract-layer gap reported in #1529.

This is a **contract-layer gap fix only** — the guardrail itself (`buildClosureGuidance`) has always handled `truncated` correctly, and `closure-guidance.test.ts` already covers it at the unit layer. The eval-run contract was scoped to `abort` only, while `buildClosureGuidance` now covers four subtypes.

## Changes

### `src/improve/eval-run/contracts.ts`
- **Import**: add `CLOSURE_TRUNCATED_RECOVERY_HINT` to the `closure-guidance.js` import.
- **Scoping comment** (line 625): reworded from "Scoped to the `abort` subtype" to accurately reflect that the contract now covers `abort` and `truncated`.
- **`runClosureAnomalyRecoveryHint`**: add `truncatedGuidance` variable and a new `truncated-closure-has-canonical-guidance` check that asserts `buildClosureGuidance('truncated') === CLOSURE_TRUNCATED_RECOVERY_HINT`.
- **Registry title**: updated from "Anomalous abort closure carries an actionable recovery hint" to "Anomalous closure (abort, truncated) carries an actionable recovery hint". The contract `id` (`closure-abort-recovery-hint`) is preserved for backward compatibility.
- **Module-level comment**: updated the `closure-anomaly` entry to say "abort + truncated subtypes".
- **`.filesize-baseline.json`**: ratcheted `contracts.ts` from 491 → 500 LOC to reflect the 9 net new code lines added by the truncated check.

### `src/improve/eval-run/contracts.test.ts`
- Updated the describe-block comment to reflect `abort + truncated subtypes`.
- Added `'truncated-closure-has-canonical-guidance'` to the expected check-names array in the `closure-abort-recovery-hint contract` describe block.

## Verification

```
pnpm lint           # tsc --noEmit passes clean
pnpm test src/improve/eval-run/contracts.test.ts   # 21/21 pass
pnpm test src/agent/session/closure-guidance.test.ts  # 14/14 pass
pnpm audit:filesize:check  # contracts.ts no longer a GREW violation
```

## What was NOT changed

- `closure-guidance.ts` — the guardrail itself was already correct.
- The contract `id` (`closure-abort-recovery-hint`) — kept for backward compatibility with any tooling that references it by id.
- The three deferred anomalous subtypes (`budget_exceeded`, `hook_blocked`, `max_turns_exceeded`) — still return `null` and are not yet covered, as documented in `closure-guidance.ts`.

Fixes #1529
