### PR TITLE
feat(bundled): add orient skill to awa-bundled

### DIFF
--- a/src/bundled-plugins/awa-bundled/bundled.test.ts
+++ b/src/bundled-plugins/awa-bundled/bundled.test.ts
@@ -131,6 +131,11 @@ const PINNED_HASHES = {
   // simplify is bundled-only (no upstream counterpart).
   simplify:
     'a984a507872949e17c87ab72979cb089524ba1da899f38af80fd0e725ebff667',
+  // orient: end-of-session orientation prompt generator. Bundled from the
+  // awa-private plugin (awa-dev/skills/orient). context: load — loads into the
+  // current session and dispatches a single read-only research sub-agent.
+  // No upstream counterpart in the public plugin — bundled-only.
+  orient: 'decf46404d299d84c590773b8e4a672c02b6c93fd5ce7c5334ae5fe8b33be318',
   spec: '167e7cbb84de5b716efa11bb9f20a6e4b940f6f9a6d1812a7fbd735dae4f67dd',
 } as const;
 

--- a/src/bundled-plugins/awa-bundled/skills/orient/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/orient/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: orient
+description: At end-of-session, dispatches a read-only sub-agent to survey recent work and drafts a vaguely-specific priming prompt the next session can paste to orient itself and plan its next sprint. Produces orientation, not prescription — candidate directions are framed as questions, not decisions.
+context: load
+---
+
+## Sub-agent contract
+/contract
+
+Dispatch one read-only research sub-agent to survey recent work across four narrow targets, then produce a single markdown prompt block the user can paste into a fresh session.
+
+**Sub-agent surveys:**
+- Memory: the **`memory_search` tool** (2–3 keyword queries on the current work; FTS5 syntax) + hot memory at `~/.afk/state/memory/HOT.md`. Do **not** grep `~/.claude/projects/**/memory/` — that path is vestigial and empty on both trees; the archive is SQLite and only `memory_search` reaches it. Report which stores you consulted.
+- Git activity in this repo + sibling repos the session touched (`git log --oneline -10`, open PRs, dirty state)
+- `experiments/` docs (if present) relevant to the current work
+- Telemetry/state files the session interacted with (e.g. `~/.afk/agent-framework/*.jsonl`)
+
+**Return exactly this shape (≤ 60 lines total):**
+1. One-line project identity + one-line "where we are" (current phase / latest milestone)
+2. 3–5 bullets on what shipped recently — commits, PRs, empirical closures; be specific
+3. Memory pointers by filename only (next session's memory system auto-loads — don't restate)
+4. 2–4 **candidate directions** framed as questions or possibilities, **never** as a decided plan
+5. Closing line inviting the next session to run `/ground-state` first, then propose a plan
+
+**Discipline the contract enforces:** orientation, not execution. Handoff briefs drift toward prescription by default; the "questions-as-possibilities" framing is the guardrail so the receiving session plans with fresh judgment.
+
+Relay the prompt to the user. On request, save to `/tmp/orient-<ISO8601>.md`.
+
+**Skip when:** no substantive work to carry forward, user wants a bare `/compact`, or user already has a decided plan (use `/mint` or draft directly).


### PR DESCRIPTION
Bundle `/orient` into `awa-bundled` so it ships with the npm package for all users.

## What orient does

End-of-session skill that dispatches a single read-only research sub-agent to survey recent work across four targets (memory, git, experiments, telemetry) and produces a compact priming prompt the next session can paste to orient itself. Produces orientation, not prescription -- candidate directions are framed as questions so the receiving session plans with fresh judgment.

- `context: load` -- loads into the current session (no separate fork)
- Depends on `/contract` (already bundled)
- Read-only: dispatches a `research-agent` sub-agent

## Changes

- **New:** `src/bundled-plugins/awa-bundled/skills/orient/SKILL.md`
- **Modified:** `bundled.test.ts` -- added SHA-256 pin + inventory registration

## Source

Copied from `awa-private` plugin (`awa-dev/skills/orient`). Bundled-only; no upstream counterpart in the public plugin.

## Verification

- `pnpm test src/bundled-plugins/awa-bundled/bundled.test.ts` -- 23/23 pass
- `pnpm fix:pins:check` -- clean
- `pnpm lint` -- clean
