### PR TITLE
fix(telegram): re-read record in persistRouteAndMessageId to prevent race (#1549)

### DIFF
--- a/src/telegram/handoff-answer.test.ts
+++ b/src/telegram/handoff-answer.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { HandoffRecord } from '../agent/daemon/handoff-store.js';
-import { writeHandoff } from '../agent/daemon/handoff-store.js';
+import { writeHandoff, readHandoff, updateHandoffAnswer } from '../agent/daemon/handoff-store.js';
 import {
   sendHandoffQuestion,
   matchReplyToHandoff,
@@ -155,6 +155,53 @@ describe('sendHandoffQuestion', () => {
     const result = await sendHandoffQuestion({ bot, record, chatId: 12345, handoffsDir });
     expect(result.ok).toBe(false);
     expect(result.messageId).toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // persistRouteAndMessageId race-condition tests (#1549)
+  // -------------------------------------------------------------------------
+
+  it('persistRouteAndMessageId: updates route/messageId on a still-pending record', async () => {
+    const bot = mockBot();
+    const record = makeRecord();
+    await writeHandoff(record, handoffsDir);
+
+    await sendHandoffQuestion({ bot, record, chatId: 55555, threadId: 7, handoffsDir });
+
+    const updated = JSON.parse(
+      await readFile(join(handoffsDir, `${record.taskId}.json`), 'utf-8'),
+    ) as HandoffRecord;
+    expect(updated.status).toBe('pending');
+    expect(updated.route).toEqual({ chatId: 55555, threadId: 7 });
+    expect(updated.telegramMessageId).toBe(42);
+  });
+
+  it('persistRouteAndMessageId: skips write when record transitions to answered before persist', async () => {
+    const bot = mockBot();
+    const record = makeRecord();
+    await writeHandoff(record, handoffsDir);
+
+    // Intercept sendMessage to simulate the operator answering in the narrow
+    // window between sendMessage resolving and persistRouteAndMessageId writing.
+    (bot.telegram.sendMessage as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+      // Concurrent answer lands while the Telegram send is "in-flight".
+      await updateHandoffAnswer(record.taskId, { value: true }, 'telegram', handoffsDir);
+      return { message_id: 42 };
+    });
+
+    await sendHandoffQuestion({ bot, record, chatId: 99999, handoffsDir });
+
+    // The record on disk must reflect the answer, not the stale pending+route overwrite.
+    const onDisk = await readHandoff(record.taskId, handoffsDir);
+    expect(onDisk).not.toBeNull();
+    expect(onDisk!.status).toBe('answered');
+    // route and telegramMessageId must NOT have been written (would require status=pending)
+    expect(onDisk!.route).toBeUndefined();
+    expect(onDisk!.telegramMessageId).toBeUndefined();
+  });
+
+  afterEach(async () => {
+    if (handoffsDir) await rm(handoffsDir, { recursive: true, force: true }).catch(() => {});
   });
 });
 

--- a/src/telegram/handoff-answer.ts
+++ b/src/telegram/handoff-answer.ts
@@ -375,7 +375,14 @@ export async function matchReplyToHandoff(
 // Internals
 // ---------------------------------------------------------------------------
 
-/** Update the HandoffRecord with Telegram route and message ID for restart recovery. */
+/**
+ * Update the HandoffRecord with Telegram route and message ID for restart recovery.
+ *
+ * Invariant: re-reads the record from disk before writing so a concurrent answer
+ * that transitioned the record to 'answered' between sendMessage and this call is
+ * never clobbered. If the fresh copy is no longer 'pending', we skip the write --
+ * the answer already landed and erasing it would be a data loss bug (#1549).
+ */
 async function persistRouteAndMessageId(
   record: HandoffRecord,
   chatId: number,
@@ -384,12 +391,15 @@ async function persistRouteAndMessageId(
   handoffsDir?: string,
 ): Promise<void> {
   const route: HandoffRoute = { chatId, ...(threadId ? { threadId } : {}) };
-  const updated: HandoffRecord = {
-    ...record,
-    route,
-    telegramMessageId: messageId,
-  };
   try {
+    const fresh = await readHandoff(record.taskId, handoffsDir);
+    // Answer won the race -- skip the write to preserve it.
+    if (fresh === null || fresh.status !== 'pending') return;
+    const updated: HandoffRecord = {
+      ...fresh,
+      route,
+      telegramMessageId: messageId,
+    };
     await writeHandoff(updated, handoffsDir);
   } catch {
     // Best-effort: the handoff still works without route/messageId; restart


### PR DESCRIPTION
## Problem

`persistRouteAndMessageId` in `src/telegram/handoff-answer.ts` did a full-record
overwrite of the HandoffRecord after sending the Telegram message. If the operator
answered in the narrow window between `sendMessage` resolving and `writeHandoff`
completing, `answerHandoff` transitioned the record to `answered` via CAS (lock
file in handoff-store.ts), then `persistRouteAndMessageId` overwrote it with the
stale `pending` copy -- erasing the answer.

## Fix

`persistRouteAndMessageId` now re-reads the record from disk before writing:

1. Calls `readHandoff(record.taskId, handoffsDir)` to get the current on-disk state.
2. If the result is `null` or `status !== 'pending'`, returns without writing -- the
   concurrent answer already landed and must not be clobbered.
3. Merges only `route` and `telegramMessageId` onto the fresh copy.
4. Writes the merged record via `writeHandoff`.

## Tests

Two new tests added to `src/telegram/handoff-answer.test.ts`:

- **Normal case**: `persistRouteAndMessageId` correctly updates `route` and
  `telegramMessageId` on a still-pending record.
- **Race case**: when `updateHandoffAnswer` is called concurrently (simulated by
  intercepting `sendMessage`), the stale write is skipped and the `answered` record
  is preserved intact.

All 12 tests pass; `pnpm lint` is clean.

Closes #1549
