### PR TITLE
feat(telegram): honor allowCustom in durable handoff questions (#1551)

### DIFF
--- a/src/telegram/handoff-answer.test.ts
+++ b/src/telegram/handoff-answer.test.ts
@@ -224,6 +224,161 @@ describe('matchReplyToHandoff', () => {
 });
 
 // ---------------------------------------------------------------------------
+// allowCustom behavior
+// ---------------------------------------------------------------------------
+
+describe('allowCustom', () => {
+  let handoffsDir: string;
+
+  beforeEach(async () => {
+    handoffsDir = await makeTmpDir();
+    clearPendingTextHandoff('q-1716000000000-abc123');
+  });
+
+  afterEach(async () => {
+    if (handoffsDir) await rm(handoffsDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('choice+allowCustom: pendingTextHandoffs is populated after sendHandoffQuestion', async () => {
+    const bot = mockBot();
+    const record = makeRecord({
+      question: {
+        message: 'Pick a deployment target',
+        type: 'choice',
+        choices: ['prod', 'staging'],
+        allowCustom: true,
+      },
+    });
+    await writeHandoff(record, handoffsDir);
+
+    const result = await sendHandoffQuestion({ bot, record, chatId: 12345, handoffsDir });
+    expect(result.ok).toBe(true);
+
+    // Should have included the custom hint in the message
+    const call = (bot.telegram.sendMessage as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(call[1]).toContain('custom answer');
+
+    // Should still have inline keyboard buttons
+    expect(call[2]).toHaveProperty('reply_markup');
+
+    // The message_id should be registered for reply-to matching
+    // Verify by replying -- if not registered, matchReplyToHandoff returns false
+    const consumed = await matchReplyToHandoff(bot, 12345, 42, 'my-custom-env', handoffsDir);
+    expect(consumed).toBe(true);
+  });
+
+  it('choice+allowCustom: matchReplyToHandoff accepts free text as custom_value', async () => {
+    const bot = mockBot();
+    const record = makeRecord({
+      question: {
+        message: 'Pick a deployment target',
+        type: 'choice',
+        choices: ['prod', 'staging'],
+        allowCustom: true,
+      },
+    });
+    await writeHandoff(record, handoffsDir);
+    await sendHandoffQuestion({ bot, record, chatId: 12345, handoffsDir });
+
+    const consumed = await matchReplyToHandoff(bot, 12345, 42, 'canary', handoffsDir);
+    expect(consumed).toBe(true);
+
+    const updated = JSON.parse(
+      await readFile(join(handoffsDir, `${record.taskId}.json`), 'utf-8'),
+    ) as HandoffRecord;
+    expect(updated.status).toBe('answered');
+    expect(updated.answer).toEqual({ value: null, custom_value: 'canary' });
+  });
+
+  it('choice without allowCustom: no reply-to path registered', async () => {
+    const bot = mockBot();
+    const record = makeRecord({
+      question: {
+        message: 'Pick a color',
+        type: 'choice',
+        choices: ['Red', 'Green'],
+      },
+    });
+    await writeHandoff(record, handoffsDir);
+    await sendHandoffQuestion({ bot, record, chatId: 12345, handoffsDir });
+
+    // Without allowCustom, reply-to should not be registered
+    const consumed = await matchReplyToHandoff(bot, 12345, 42, 'Blue');
+    expect(consumed).toBe(false);
+  });
+
+  it('multi_choice+allowCustom: accepts non-numeric text as custom_value', async () => {
+    const bot = mockBot();
+    const record = makeRecord({
+      question: {
+        message: 'Pick features',
+        type: 'multi_choice',
+        choices: ['auth', 'logging', 'metrics'],
+        allowCustom: true,
+      },
+    });
+    await writeHandoff(record, handoffsDir);
+    await sendHandoffQuestion({ bot, record, chatId: 12345, handoffsDir });
+
+    const consumed = await matchReplyToHandoff(bot, 12345, 42, 'tracing', handoffsDir);
+    expect(consumed).toBe(true);
+
+    const updated = JSON.parse(
+      await readFile(join(handoffsDir, `${record.taskId}.json`), 'utf-8'),
+    ) as HandoffRecord;
+    expect(updated.status).toBe('answered');
+    expect(updated.answer).toEqual({ value: null, custom_value: 'tracing' });
+  });
+
+  it('multi_choice without allowCustom: rejects non-numeric text', async () => {
+    const bot = mockBot();
+    const record = makeRecord({
+      question: {
+        message: 'Pick features',
+        type: 'multi_choice',
+        choices: ['auth', 'logging', 'metrics'],
+      },
+    });
+    await writeHandoff(record, handoffsDir);
+    await sendHandoffQuestion({ bot, record, chatId: 12345, handoffsDir });
+
+    // Non-numeric text should be rejected (consumed=true, but still pending)
+    const consumed = await matchReplyToHandoff(bot, 12345, 42, 'tracing', handoffsDir);
+    expect(consumed).toBe(true);
+
+    // Should have sent an error message
+    const sendCalls = (bot.telegram.sendMessage as ReturnType<typeof vi.fn>).mock.calls;
+    // First call is sendHandoffQuestion, second is the error reply
+    expect(sendCalls.length).toBeGreaterThan(1);
+    const errorCall = sendCalls[sendCalls.length - 1]!;
+    expect(errorCall[1]).toContain('comma-separated numbers');
+  });
+
+  it('multi_choice+allowCustom: still accepts valid numeric lists', async () => {
+    const bot = mockBot();
+    const record = makeRecord({
+      question: {
+        message: 'Pick features',
+        type: 'multi_choice',
+        choices: ['auth', 'logging', 'metrics'],
+        allowCustom: true,
+      },
+    });
+    await writeHandoff(record, handoffsDir);
+    await sendHandoffQuestion({ bot, record, chatId: 12345, handoffsDir });
+
+    const consumed = await matchReplyToHandoff(bot, 12345, 42, '1,3', handoffsDir);
+    expect(consumed).toBe(true);
+
+    const updated = JSON.parse(
+      await readFile(join(handoffsDir, `${record.taskId}.json`), 'utf-8'),
+    ) as HandoffRecord;
+    expect(updated.status).toBe('answered');
+    expect(updated.answer).toEqual({ value: ['auth', 'metrics'] });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // registerHandoffAnswerHandlers
 // ---------------------------------------------------------------------------
 

--- a/src/telegram/handoff-answer.ts
+++ b/src/telegram/handoff-answer.ts
@@ -141,6 +141,7 @@ export async function sendHandoffQuestion(opts: SendHandoffOpts): Promise<SendHa
     }
 
     if (qType === 'choice') {
+      const allowCustom = Boolean(question['allowCustom']);
       const MAX_CHOICES = 20;
       const visibleChoices = choices.slice(0, MAX_CHOICES);
       const buttons = visibleChoices.map((choice, i) => [
@@ -149,19 +150,30 @@ export async function sendHandoffQuestion(opts: SendHandoffOpts): Promise<SendHa
           buildHandoffCallback(record.taskId, i),
         ),
       ]);
-      const sent = await bot.telegram.sendMessage(chatId, displayText, {
+      let choiceText = displayText;
+      if (allowCustom) {
+        choiceText += '\n\n<i>Or reply to this message with a custom answer</i>';
+      }
+      const sent = await bot.telegram.sendMessage(chatId, choiceText, {
         parse_mode: 'HTML',
         ...threadOpts,
         reply_markup: Markup.inlineKeyboard(buttons).reply_markup,
       });
+      if (allowCustom) {
+        pendingTextHandoffs.set(sent.message_id, record.taskId);
+      }
       await persistRouteAndMessageId(record, chatId, threadId, sent.message_id, handoffsDir);
       return { ok: true, messageId: sent.message_id };
     }
 
     // text / number / multi_choice: plain message with reply hint
+    const allowCustomMulti = qType === 'multi_choice' && Boolean(question['allowCustom']);
     if (qType === 'multi_choice' && choices.length > 0) {
       const choiceList = choices.map((c, i) => `${i + 1}. ${escapeHtml(String(c))}`).join('\n');
-      displayText += `\n\n${choiceList}\n\n<i>Reply with comma-separated numbers (e.g. 1,3)</i>`;
+      const hint = allowCustomMulti
+        ? '<i>Reply with comma-separated numbers (e.g. 1,3) or a custom answer</i>'
+        : '<i>Reply with comma-separated numbers (e.g. 1,3)</i>';
+      displayText += `\n\n${choiceList}\n\n${hint}`;
     } else if (qType === 'number') {
       const min = question['min'] as number | undefined;
       const max = question['max'] as number | undefined;
@@ -325,15 +337,22 @@ export async function matchReplyToHandoff(
       return true;
     }
     answer = { value: n };
+  } else if (qType === 'choice' && record.question['allowCustom']) {
+    // Free-form custom answer for a choice question with allowCustom enabled.
+    answer = { value: null, custom_value: trimmed };
   } else if (qType === 'multi_choice') {
     const choices = Array.isArray(record.question['choices'])
       ? record.question['choices'] as string[]
       : [];
     const parts = trimmed.split(',').map(s => s.trim());
-    const selected: string[] = [];
-    for (const part of parts) {
-      const idx = parseInt(part, 10);
-      if (!Number.isInteger(idx) || String(idx) !== part || idx < 1 || idx > choices.length) {
+    const isNumericList = parts.every(p => {
+      const idx = parseInt(p, 10);
+      return Number.isInteger(idx) && String(idx) === p && idx >= 1 && idx <= choices.length;
+    });
+    if (!isNumericList) {
+      if (record.question['allowCustom']) {
+        answer = { value: null, custom_value: trimmed };
+      } else {
         await bot.telegram.sendMessage(
           chatId,
           `Please reply with comma-separated numbers between 1 and ${choices.length}.`,
@@ -341,9 +360,9 @@ export async function matchReplyToHandoff(
         ).catch(() => {});
         return true;
       }
-      selected.push(choices[idx - 1]!);
+    } else {
+      answer = { value: parts.map(p => choices[parseInt(p, 10) - 1]!) };
     }
-    answer = { value: selected };
   } else {
     // text (default)
     answer = { value: trimmed };


### PR DESCRIPTION
## Summary

Honors `allowCustom` in durable handoff questions sent via Telegram. Previously, `choice` and `multi_choice` questions with `allowCustom: true` offered no path for the operator to type a free-form custom answer — this PR wires up both the send and reply-parsing paths.

Closes #1551

## Changes

### `src/telegram/handoff-answer.ts`

**`sendHandoffQuestion`**
- **choice + allowCustom**: When `question['allowCustom']` is truthy, appends `Or reply to this message with a custom answer` to the display text and calls `pendingTextHandoffs.set(sent.message_id, record.taskId)`, enabling reply-to matching in addition to the inline buttons.
- **multi_choice + allowCustom**: Updates the reply hint to mention the custom answer option alongside the numeric list format.

**`matchReplyToHandoff`**
- **choice custom answer path**: New branch for `qType === 'choice' && record.question['allowCustom']` -- accepts reply text as `{ value: null, custom_value: trimmed }`.
- **multi_choice custom answer path**: Refactors the validation loop into an `isNumericList` predicate. When the text is not a valid numeric list and `allowCustom` is truthy, produces `{ value: null, custom_value: trimmed }` instead of sending an error. Valid numeric lists still produce `{ value: string[] }` as before.

### `src/telegram/handoff-answer.test.ts`

Adds a new `allowCustom` describe block with 6 tests:
1. `choice+allowCustom`: `pendingTextHandoffs` is populated after `sendHandoffQuestion` (verified via a successful `matchReplyToHandoff` call)
2. `choice+allowCustom`: `matchReplyToHandoff` accepts free text and produces `{ value: null, custom_value: ... }`
3. `choice` without `allowCustom`: no reply-to path registered (existing behavior unchanged)
4. `multi_choice+allowCustom`: non-numeric text accepted as `custom_value`
5. `multi_choice` without `allowCustom`: non-numeric text rejected with error message (existing behavior unchanged)
6. `multi_choice+allowCustom`: valid numeric lists still accepted and produce `{ value: string[] }`

## Gates

- pnpm lint: pass
- pnpm exec vitest run src/telegram/handoff-answer.test.ts: 16/16 pass
- pnpm audit:filesize:check: pass (handoff-answer.ts is 306 code lines, well under the 350 ceiling)
