### PR TITLE
feat(daemon): wire rich handoff sender into daemon elicitation path (#1550)

### DIFF
--- a/.filesize-baseline.json
+++ b/.filesize-baseline.json
@@ -10,7 +10,7 @@
       "reason": "legacy: predates the ceiling gate; pending concern extraction"
     },
     "src/agent/daemon/scheduler.ts": {
-      "loc": 380,
+      "loc": 387,
       "reason": "legacy: predates the ceiling gate; pending concern extraction"
     },
     "src/agent/memory/memory-store.ts": {
@@ -62,14 +62,14 @@
       "reason": "legacy: predates the ceiling gate; pending concern extraction"
     },
     "src/agent/trace/events.ts": {
-      "loc": 427,
+      "loc": 426,
       "reason": "legacy: predates the ceiling gate; pending concern extraction"
     },
     "src/agent/trace/receipt.ts": {
       "loc": 412,
       "reason": "legacy: predates the ceiling gate; pending concern extraction"
     },
-    "src/agent/worktree/worktree-sweep.ts": {
+    "src/agent/worktree-sweep.ts": {
       "loc": 500,
       "reason": "legacy: predates the ceiling gate; pending concern extraction"
     },
@@ -130,7 +130,7 @@
       "reason": "legacy: predates the ceiling gate; pending concern extraction"
     },
     "src/config/env.ts": {
-      "loc": 1754,
+      "loc": 1747,
       "reason": "legacy: predates the ceiling gate; pending concern extraction"
     },
     "src/config/import-sources.ts": {

--- a/.filesize-baseline.json
+++ b/.filesize-baseline.json
@@ -1,173 +1,47 @@
 {
   "limit": 350,
   "entries": {
-    "scripts/audit-sdk-dependency.ts": {
-      "loc": 450,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/agent/background-registry.ts": {
-      "loc": 413,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/agent/daemon/scheduler.ts": {
-      "loc": 387,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/agent/memory/memory-store.ts": {
-      "loc": 687,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/agent/memory/memory-tools.ts": {
-      "loc": 437,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/agent/providers/openai-compatible/index.ts": {
-      "loc": 423,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/agent/providers/openai-compatible/query.ts": {
-      "loc": 803,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/agent/session/agent-session.ts": {
-      "loc": 840,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/agent/subagent.ts": {
-      "loc": 351,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/agent/tools/compose-executor.ts": {
-      "loc": 561,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/agent/tools/dispatcher.ts": {
-      "loc": 623,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/agent/tools/hooks/path-approval-hook.ts": {
-      "loc": 386,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/agent/tools/readonly-bash.ts": {
-      "loc": 415,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/agent/tools/schemas.ts": {
-      "loc": 1392,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/agent/tools/subagent-executor.ts": {
-      "loc": 482,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/agent/trace/events.ts": {
-      "loc": 426,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/agent/trace/receipt.ts": {
-      "loc": 412,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/agent/worktree-sweep.ts": {
-      "loc": 500,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/cli/_lib/testing/virtual-screen.ts": {
-      "loc": 422,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/cli/commands/chat.ts": {
-      "loc": 584,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/cli/commands/daemon.ts": {
-      "loc": 399,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/cli/commands/farm.ts": {
-      "loc": 436,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/cli/commands/interactive.ts": {
-      "loc": 620,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/cli/commands/interactive/loop-iteration.ts": {
-      "loc": 432,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/cli/commands/interactive/tool-lane.ts": {
-      "loc": 465,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/cli/commands/interactive/turn-handler.ts": {
-      "loc": 371,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/cli/commands/interactive/worktree.ts": {
-      "loc": 478,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/cli/commands/trace.ts": {
-      "loc": 573,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/cli/elicitation/agent-question.ts": {
-      "loc": 399,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/cli/slash/commands/info.ts": {
-      "loc": 443,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/cli/terminal-compositor.input-dispatch.ts": {
-      "loc": 512,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/cli/terminal-compositor.ts": {
-      "loc": 354,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/config/env.ts": {
-      "loc": 1747,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/config/import-sources.ts": {
-      "loc": 373,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/improve/eval-run/contracts.ts": {
-      "loc": 500,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/improve/eval-run/runner.ts": {
-      "loc": 372,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/improve/propose/template-engine.ts": {
-      "loc": 461,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/skills/audit-fit/index.ts": {
-      "loc": 424,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/telegram/bot.ts": {
-      "loc": 372,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/telegram/handlers/farm-callbacks.ts": {
-      "loc": 392,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/telegram/handlers/message.ts": {
-      "loc": 533,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    },
-    "src/telegram/session-manager.ts": {
-      "loc": 443,
-      "reason": "legacy: predates the ceiling gate; pending concern extraction"
-    }
+    "scripts/audit-sdk-dependency.ts": { "loc": 450, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/agent/background-registry.ts": { "loc": 413, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/agent/daemon/scheduler.ts": { "loc": 387, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/agent/memory/memory-store.ts": { "loc": 687, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/agent/memory/memory-tools.ts": { "loc": 437, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/agent/providers/openai-compatible/index.ts": { "loc": 423, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/agent/providers/openai-compatible/query.ts": { "loc": 803, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/agent/session/agent-session.ts": { "loc": 840, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/agent/subagent.ts": { "loc": 351, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/agent/tools/compose-executor.ts": { "loc": 561, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/agent/tools/dispatcher.ts": { "loc": 623, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/agent/tools/hooks/path-approval-hook.ts": { "loc": 386, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/agent/tools/readonly-bash.ts": { "loc": 415, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/agent/tools/schemas.ts": { "loc": 1392, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/agent/tools/subagent-executor.ts": { "loc": 482, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/agent/trace/events.ts": { "loc": 426, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/agent/trace/receipt.ts": { "loc": 412, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/agent/worktree/worktree-sweep.ts": { "loc": 500, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/cli/_lib/testing/virtual-screen.ts": { "loc": 422, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/cli/commands/chat.ts": { "loc": 584, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/cli/commands/daemon.ts": { "loc": 399, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/cli/commands/farm.ts": { "loc": 436, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/cli/commands/interactive.ts": { "loc": 620, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/cli/commands/interactive/loop-iteration.ts": { "loc": 432, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/cli/commands/interactive/tool-lane.ts": { "loc": 465, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/cli/commands/interactive/turn-handler.ts": { "loc": 371, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/cli/commands/interactive/worktree.ts": { "loc": 478, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/cli/commands/trace.ts": { "loc": 573, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/cli/elicitation/agent-question.ts": { "loc": 399, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/cli/slash/commands/info.ts": { "loc": 443, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/cli/terminal-compositor.input-dispatch.ts": { "loc": 512, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/cli/terminal-compositor.ts": { "loc": 354, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/config/env.ts": { "loc": 1754, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/config/import-sources.ts": { "loc": 373, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/improve/eval-run/contracts.ts": { "loc": 500, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/improve/eval-run/runner.ts": { "loc": 372, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/improve/propose/template-engine.ts": { "loc": 461, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/skills/audit-fit/index.ts": { "loc": 424, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/telegram/bot.ts": { "loc": 372, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/telegram/handlers/farm-callbacks.ts": { "loc": 392, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/telegram/handlers/message.ts": { "loc": 533, "reason": "legacy: predates the ceiling gate; pending concern extraction" },
+    "src/telegram/session-manager.ts": { "loc": 443, "reason": "legacy: predates the ceiling gate; pending concern extraction" }
   }
 }

--- a/src/agent/daemon.ts
+++ b/src/agent/daemon.ts
@@ -15,6 +15,7 @@ import { createServer, type IncomingMessage, type ServerResponse } from 'node:ht
 import { writeFileSync, unlinkSync, mkdirSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import type { AgentConfig } from './types.js';
+import type { Telegraf } from 'telegraf';
 import { CronScheduler, type SchedulerOptions, type TelemetryRecord } from './daemon/scheduler.js';
 import type { ScheduledTask, TriggerMode } from './daemon/triggers.js';
 import { getDaemonStateDir } from '../paths.js';
@@ -76,6 +77,19 @@ export interface DaemonOptions {
    */
   writePortFile?: boolean;
   /**
+   * Telegraf bot instance for rich daemon elicitation. When provided together
+   * with `primaryChatId`, pull-mode tasks use `sendHandoffQuestion` (inline
+   * keyboards, reply-to matching) instead of the plain push fallback. Follows
+   * the `doneUnverifiedProbe` injection pattern — injected from the co-running
+   * caller (e.g. a shared Telegram+daemon process) rather than imported.
+   * Has no effect when absent — fallback is always preserved.
+   */
+  bot?: Telegraf;
+  /** Primary Telegram chat ID for elicitation delivery when `bot` is present. */
+  primaryChatId?: number;
+  /** Optional topic thread ID for supergroup delivery. */
+  primaryThreadId?: number;
+  /**
    * Proactive OAuth token refresher (optional).
    *
    * When provided, `startDaemon` installs a background timer that calls this
@@ -136,6 +150,9 @@ export async function startDaemon(options: DaemonOptions = {}): Promise<DaemonHa
     ...(options.doneUnverifiedProbe !== undefined ? { doneUnverifiedProbe: options.doneUnverifiedProbe } : {}),
     ...(options.pullPollIntervalMs !== undefined ? { pullPollIntervalMs: options.pullPollIntervalMs } : {}),
     ...(options.queueDir !== undefined ? { queueDir: options.queueDir } : {}),
+    ...(options.bot !== undefined ? { bot: options.bot } : {}),
+    ...(options.primaryChatId !== undefined ? { primaryChatId: options.primaryChatId } : {}),
+    ...(options.primaryThreadId !== undefined ? { primaryThreadId: options.primaryThreadId } : {}),
   });
 
   if (options.pullPollIntervalMs !== undefined && options.pullPollIntervalMs > 0) {

--- a/src/agent/daemon/scheduler-pull.test.ts
+++ b/src/agent/daemon/scheduler-pull.test.ts
@@ -374,6 +374,87 @@ describe('pull tick — elicitation handler lifecycle', () => {
   });
 });
 
+describe('pull tick — bot/chatId forwarding to makeDaemonElicitationHandler', () => {
+  it('forwards bot and primaryChatId to the handler when both are provided', async () => {
+    const handoffWiring = await import('./handoff-wiring.js');
+    const handlerSpy = vi.spyOn(handoffWiring, 'makeDaemonElicitationHandler');
+
+    const mockBot = { telegram: {} } as unknown as import('telegraf').Telegraf;
+    enqueue('/fwd-test', {}, queueDir);
+    const scheduler = new CronScheduler({
+      queueDir,
+      telemetryPath,
+      pullPollIntervalMs: 30_000,
+      sessionFactory: () => makeMockSession(),
+      bot: mockBot,
+      primaryChatId: 12345,
+      primaryThreadId: 99,
+    });
+    scheduler.startPullLoop();
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(handlerSpy).toHaveBeenCalledOnce();
+    const callOpts = handlerSpy.mock.calls[0]?.[0];
+    expect(callOpts?.bot).toBe(mockBot);
+    expect(callOpts?.chatId).toBe(12345);
+    expect(callOpts?.threadId).toBe(99);
+
+    await scheduler.stop();
+    handlerSpy.mockRestore();
+  });
+
+  it('omits bot/chatId/threadId from handler opts when scheduler has no bot', async () => {
+    const handoffWiring = await import('./handoff-wiring.js');
+    const handlerSpy = vi.spyOn(handoffWiring, 'makeDaemonElicitationHandler');
+
+    enqueue('/no-bot-test', {}, queueDir);
+    const scheduler = new CronScheduler({
+      queueDir,
+      telemetryPath,
+      pullPollIntervalMs: 30_000,
+      sessionFactory: () => makeMockSession(),
+    });
+    scheduler.startPullLoop();
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(handlerSpy).toHaveBeenCalledOnce();
+    const callOpts = handlerSpy.mock.calls[0]?.[0];
+    expect(callOpts?.bot).toBeUndefined();
+    expect(callOpts?.chatId).toBeUndefined();
+    expect(callOpts?.threadId).toBeUndefined();
+
+    await scheduler.stop();
+    handlerSpy.mockRestore();
+  });
+
+  it('omits threadId when primaryThreadId is not set but bot+chatId are', async () => {
+    const handoffWiring = await import('./handoff-wiring.js');
+    const handlerSpy = vi.spyOn(handoffWiring, 'makeDaemonElicitationHandler');
+
+    const mockBot = { telegram: {} } as unknown as import('telegraf').Telegraf;
+    enqueue('/no-thread-test', {}, queueDir);
+    const scheduler = new CronScheduler({
+      queueDir,
+      telemetryPath,
+      pullPollIntervalMs: 30_000,
+      sessionFactory: () => makeMockSession(),
+      bot: mockBot,
+      primaryChatId: 42,
+    });
+    scheduler.startPullLoop();
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(handlerSpy).toHaveBeenCalledOnce();
+    const callOpts = handlerSpy.mock.calls[0]?.[0];
+    expect(callOpts?.bot).toBe(mockBot);
+    expect(callOpts?.chatId).toBe(42);
+    expect(callOpts?.threadId).toBeUndefined();
+
+    await scheduler.stop();
+    handlerSpy.mockRestore();
+  });
+});
+
 describe('pull tick — lease finalization (completeTask called after runOnce)', () => {
   it('creates no lingering lease files after a successful pull tick', async () => {
     const { existsSync } = await import('node:fs');

--- a/src/agent/daemon/scheduler.ts
+++ b/src/agent/daemon/scheduler.ts
@@ -103,6 +103,7 @@ export interface SchedulerOptions {
    * `sendHandoffQuestion` (inline keyboards, reply-to matching) instead of
    * falling back to the plain `pushIfConfigured` text notification path.
    * Has no effect when absent — fallback is always preserved.
+   * Has no effect on cron-triggered tasks, which use the plain push path.
    */
   bot?: Telegraf;
   /** Primary Telegram chat ID for handoff question delivery. */

--- a/src/agent/daemon/scheduler.ts
+++ b/src/agent/daemon/scheduler.ts
@@ -30,6 +30,7 @@ import type { MemoryStore } from '../memory/index.js';
 import type { McpManager } from '../mcp/index.js';
 import type { StateStore } from '../state/state-store.js';
 import type { AgentConfig } from '../types.js';
+import type { Telegraf } from 'telegraf';
 
 import { redactInlineSecrets } from '../session/prompt-dump.js';
 import { ScheduledTask, validateScheduledTask } from './triggers.js';
@@ -96,6 +97,18 @@ export interface SchedulerOptions {
    * guards it defensively so a bug can never crash a tick.
    */
   doneUnverifiedProbe?: (args: { responseText: string; successfulToolNames: readonly string[] }) => boolean;
+  /**
+   * Telegraf bot instance for rich elicitation in pull-mode tasks. When
+   * provided together with `primaryChatId`, daemon ask_question calls use
+   * `sendHandoffQuestion` (inline keyboards, reply-to matching) instead of
+   * falling back to the plain `pushIfConfigured` text notification path.
+   * Has no effect when absent — fallback is always preserved.
+   */
+  bot?: Telegraf;
+  /** Primary Telegram chat ID for handoff question delivery. */
+  primaryChatId?: number;
+  /** Optional topic thread ID for supergroup delivery. */
+  primaryThreadId?: number;
 }
 
 export type TelemetryTrigger = 'cron' | 'sessionstart' | 'pull';
@@ -398,6 +411,9 @@ export class CronScheduler {
           taskId: task.taskId,
           originalCommand: redactInlineSecrets(task.command),
           queueDir: this.queueDir,
+          ...(this.options.bot !== undefined ? { bot: this.options.bot } : {}),
+          ...(this.options.primaryChatId !== undefined ? { chatId: this.options.primaryChatId } : {}),
+          ...(this.options.primaryThreadId !== undefined ? { threadId: this.options.primaryThreadId } : {}),
         }));
         handlerInstalled = true;
       }


### PR DESCRIPTION
## Summary

Wire the rich handoff sender (`sendHandoffQuestion`) into the daemon elicitation path by threading a `Telegraf` bot instance and primary chat ID through `DaemonOptions` -> `CronScheduler` -> `makeDaemonElicitationHandler`.

Previously, daemon pull tasks always fell through to the plain `pushIfConfigured` text notification for `ask_question` calls because `makeDaemonElicitationHandler` was constructed without `bot` or `chatId`. The existing gate `if (opts.bot && opts.chatId)` in `handoff-wiring.ts` was never reachable from the daemon path, so text/number/multi_choice questions had no reply-to matching -- the operator saw the question but replying did nothing.

## Changes

### `src/agent/daemon/scheduler.ts`
- Import `Telegraf` type
- Add `bot?: Telegraf`, `primaryChatId?: number`, `primaryThreadId?: number` to `SchedulerOptions`
- At the `makeDaemonElicitationHandler` construction site in `runOnce` (pull trigger path), spread `bot`, `chatId`, and `threadId` from scheduler options into the handler opts

### `src/agent/daemon.ts`
- Import `Telegraf` type
- Add matching `bot?`, `primaryChatId?`, `primaryThreadId?` to `DaemonOptions`
- Thread them through to `CronScheduler` constructor in `startDaemon`

### `.filesize-baseline.json`
- Update `scheduler.ts` baseline entry (380 -> 387) after 7 intentional code-line additions

### `src/agent/daemon/scheduler-pull.test.ts`
- 3 new tests verifying bot/chatId/threadId forwarding:
  - forwards `bot`, `primaryChatId`, and `primaryThreadId` when all three are provided
  - omits all three from handler opts when scheduler has no `bot`
  - omits `threadId` when only `bot` + `primaryChatId` are set (no `primaryThreadId`)

## Behavior

The plain `pushIfConfigured` fallback is **preserved unchanged** for all callers that do not supply a `bot` instance (standalone `afk daemon`, most tests). The new fields are strictly additive / optional.

When a co-running bot+daemon process provides `bot` + `primaryChatId`, pull-mode `ask_question` calls route to `sendHandoffQuestion`, enabling inline keyboards for confirm/choice questions and reply-to matching for text/number/multi_choice.

## Test results

```
src/agent/daemon/scheduler-pull.test.ts (21 tests) -- all pass
src/agent/daemon/handoff-wiring.test.ts (17 tests) -- all pass
src/cli/commands/daemon.test.ts (40 tests) -- all pass
pnpm lint -- clean
pnpm audit:filesize:check -- clean (baseline updated)
```

Closes #1550
