### PR TITLE
fix(telegram): close TOCTOU window in persistRouteAndMessageId (#1557)

### DIFF
--- a/src/agent/daemon/handoff-store.test.ts
+++ b/src/agent/daemon/handoff-store.test.ts
@@ -8,6 +8,7 @@ import {
   deleteHandoff,
   listPendingHandoffs,
   updateHandoffAnswer,
+  withHandoffLock,
   type HandoffRecord,
 } from './handoff-store.js';
 
@@ -381,6 +382,65 @@ describe('concurrent writes', () => {
     for (let i = 0; i < count; i++) {
       expect(reads[i]?.sessionId).toBe(`sess-batch-${i}`);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// withHandoffLock
+// ---------------------------------------------------------------------------
+
+describe('withHandoffLock', () => {
+  it('runs the callback and returns its value when the lock is free', async () => {
+    const result = await withHandoffLock('q-lock-free', testDir, async () => 'hello');
+    expect(result).toBe('hello');
+  });
+
+  it('returns null immediately when an existing fresh lock file blocks acquisition', async () => {
+    const lockFile = join(testDir, 'q-lock-blocked.lock');
+    // Simulate a live holder by creating the lock file with a fresh mtime.
+    await writeFile(lockFile, '', { mode: 0o600 });
+
+    const result = await withHandoffLock('q-lock-blocked', testDir, async () => 'should-not-run');
+    expect(result).toBeNull();
+  });
+
+  it('clears a stale lock file (>30 s) and runs the callback', async () => {
+    const lockFile = join(testDir, 'q-lock-stale.lock');
+    await writeFile(lockFile, '', { mode: 0o600 });
+    const staleTime = new Date(Date.now() - 60_000);
+    await utimes(lockFile, staleTime, staleTime);
+
+    const result = await withHandoffLock('q-lock-stale', testDir, async () => 'ran-after-stale');
+    expect(result).toBe('ran-after-stale');
+  });
+
+  it('releases the lock after the callback succeeds', async () => {
+    await withHandoffLock('q-lock-release', testDir, async () => 'ok');
+    // Lock file must be gone so a second call can acquire it.
+    const result2 = await withHandoffLock('q-lock-release', testDir, async () => 'second');
+    expect(result2).toBe('second');
+  });
+
+  it('releases the lock even when the callback throws', async () => {
+    await expect(
+      withHandoffLock('q-lock-throws', testDir, async () => { throw new Error('boom'); }),
+    ).rejects.toThrow('boom');
+    // Lock must be released so subsequent callers are not blocked.
+    const result = await withHandoffLock('q-lock-throws', testDir, async () => 'after-throw');
+    expect(result).toBe('after-throw');
+  });
+
+  it('only one concurrent caller succeeds when two race for the same taskId', async () => {
+    const order: string[] = [];
+    const [r1, r2] = await Promise.all([
+      withHandoffLock('q-lock-race', testDir, async () => { order.push('winner'); return 'w'; }),
+      withHandoffLock('q-lock-race', testDir, async () => { order.push('should-not-run'); return 's'; }),
+    ]);
+    // Exactly one call ran.
+    const results = [r1, r2];
+    expect(results.filter(r => r !== null)).toHaveLength(1);
+    expect(results.filter(r => r === null)).toHaveLength(1);
+    expect(order).toEqual(['winner']);
   });
 });
 

--- a/src/agent/daemon/handoff-store.test.ts
+++ b/src/agent/daemon/handoff-store.test.ts
@@ -432,15 +432,20 @@ describe('withHandoffLock', () => {
 
   it('only one concurrent caller succeeds when two race for the same taskId', async () => {
     const order: string[] = [];
+    // Hold the lock long enough for the loser to attempt acquisition while
+    // it is still held. Without the delay, both can succeed sequentially
+    // on fast CI (macOS) where the first callback completes and releases
+    // before the second even tries.
+    const delay = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
     const [r1, r2] = await Promise.all([
-      withHandoffLock('q-lock-race', testDir, async () => { order.push('winner'); return 'w'; }),
-      withHandoffLock('q-lock-race', testDir, async () => { order.push('should-not-run'); return 's'; }),
+      withHandoffLock('q-lock-race', testDir, async () => { order.push('a'); await delay(50); return 'w'; }),
+      withHandoffLock('q-lock-race', testDir, async () => { order.push('b'); await delay(50); return 's'; }),
     ]);
-    // Exactly one call ran.
+    // Exactly one call ran (the other got null from the O_EXCL contention).
     const results = [r1, r2];
     expect(results.filter(r => r !== null)).toHaveLength(1);
     expect(results.filter(r => r === null)).toHaveLength(1);
-    expect(order).toEqual(['winner']);
+    expect(order).toHaveLength(1);
   });
 });
 

--- a/src/agent/daemon/handoff-store.ts
+++ b/src/agent/daemon/handoff-store.ts
@@ -252,38 +252,33 @@ export async function listPendingHandoffs(
 }
 
 /**
- * Record a human answer for the given taskId using an exclusive-create lock
- * file as a compare-and-swap gate to prevent TOCTOU races.
+ * Acquire the O_EXCL lock for a taskId, run `cb` inside the lock, then release.
  *
  * Protocol:
- *   1. Try to create `<taskId>.lock` with O_EXCL — fails with EEXIST if
- *      another caller already holds it.
- *   2. EEXIST → return { won: false } (not an error; first-writer-wins).
- *   3. On lock acquisition, re-read the record and verify status is still
- *      'pending'; if not, return { won: false }.
- *   4. Write the updated record atomically, then release the lock.
- *   5. Return { won: true } on success.
+ *   1. Try to create `<taskId>.lock` with O_EXCL — fails immediately with EEXIST
+ *      if another caller already holds it (returns null without running cb).
+ *   2. On EEXIST, check whether the lock file is older than STALE_LOCK_TTL_MS.
+ *      If stale (crash leftover), unlink and retry once. A second EEXIST means a
+ *      genuine concurrent holder — return null.
+ *   3. Run `cb()` with the lock held.
+ *   4. Release the lock in a finally block regardless of cb outcome.
  *
- * @param taskId      - The daemon task ID to update.
- * @param answer      - The human's response value.
- * @param source      - Which surface provided the answer ('telegram' | 'web' | 'repl').
- * @param handoffsDir - Override the handoffs directory (defaults to `getHandoffsDir()`).
- * @throws If no record exists for the taskId.
- * @returns UpdateHandoffResult — won: true if this caller claimed the record.
+ * Returns the value returned by `cb`, or `null` when the lock could not be acquired.
+ *
+ * @param taskId      - The daemon task ID whose lock to acquire.
+ * @param handoffsDir - Directory containing the lock file.
+ * @param cb          - Callback to run while the lock is held.
  */
 // Invariant: a lock file older than this threshold is assumed to be a crash
 // leftover (SIGKILL/OOM between lock creation and the finally-unlink). We retry
 // once after unlinking; a second EEXIST means a genuine concurrent holder.
 const STALE_LOCK_TTL_MS = 30_000;
 
-export async function updateHandoffAnswer(
+export async function withHandoffLock<T>(
   taskId: string,
-  answer: unknown,
-  source: string,
-  handoffsDir: string = getHandoffsDir(),
-): Promise<UpdateHandoffResult> {
-  assertSafeJobId(taskId);
-  await ensureHandoffsDir(handoffsDir);
+  handoffsDir: string,
+  cb: () => Promise<T>,
+): Promise<T | null> {
   const lock = lockPath(handoffsDir, taskId);
 
   // Step 1: acquire exclusive lock via O_EXCL create.
@@ -299,12 +294,12 @@ export async function updateHandoffAnswer(
         lockMtime = lockStat.mtimeMs;
       } catch {
         // Lock disappeared between our failed write and the stat — another
-        // process cleaned it up. Return { won: false }; caller can retry.
-        return { won: false };
+        // process cleaned it up. Caller can retry.
+        return null;
       }
       if (Date.now() - lockMtime <= STALE_LOCK_TTL_MS) {
         // Lock is fresh — genuine concurrent holder; do not steal it.
-        return { won: false };
+        return null;
       }
       // Lock is older than TTL — stale crash leftover. Unlink and retry once.
       try { await unlink(lock); } catch { /* ignore — may have been cleaned concurrently */ }
@@ -313,7 +308,7 @@ export async function updateHandoffAnswer(
       } catch (retryErr) {
         if ((retryErr as NodeJS.ErrnoException).code === 'EEXIST') {
           // Genuine race on the retry — another process won.
-          return { won: false };
+          return null;
         }
         throw retryErr;
       }
@@ -324,19 +319,54 @@ export async function updateHandoffAnswer(
 
   // Lock acquired — release in finally regardless of outcome.
   try {
-    // Step 2: re-read record inside lock.
+    return await cb();
+  } finally {
+    try { await unlink(lock); } catch { /* ignore — lock cleanup is best-effort */ }
+  }
+}
+
+/**
+ * Record a human answer for the given taskId using an exclusive-create lock
+ * file as a compare-and-swap gate to prevent TOCTOU races.
+ *
+ * Protocol:
+ *   1. Acquire the O_EXCL lock via withHandoffLock — returns { won: false } if
+ *      another caller already holds it (first-writer-wins CAS).
+ *   2. Re-read the record and verify status is still 'pending'; if not, return
+ *      { won: false }.
+ *   3. Write the updated record atomically, then release the lock.
+ *   4. Return { won: true } on success.
+ *
+ * @param taskId      - The daemon task ID to update.
+ * @param answer      - The human's response value.
+ * @param source      - Which surface provided the answer ('telegram' | 'web' | 'repl').
+ * @param handoffsDir - Override the handoffs directory (defaults to `getHandoffsDir()`).
+ * @throws If no record exists for the taskId.
+ * @returns UpdateHandoffResult — won: true if this caller claimed the record.
+ */
+export async function updateHandoffAnswer(
+  taskId: string,
+  answer: unknown,
+  source: string,
+  handoffsDir: string = getHandoffsDir(),
+): Promise<UpdateHandoffResult> {
+  assertSafeJobId(taskId);
+  await ensureHandoffsDir(handoffsDir);
+
+  const result = await withHandoffLock(taskId, handoffsDir, async () => {
+    // Re-read record inside lock.
     const existing = await readHandoff(taskId, handoffsDir);
     if (existing === null) {
       throw new Error(`handoff-store: no record found for taskId ${taskId}`);
     }
 
-    // Step 3: guard — another winner may have landed between our EEXIST check
+    // Guard — another winner may have landed between our EEXIST check
     // and this read (shouldn't happen with O_EXCL, but be defensive).
     if (existing.status !== 'pending') {
       return { won: false };
     }
 
-    // Step 4: write updated record atomically.
+    // Write updated record atomically.
     const updated: HandoffRecord = {
       ...existing,
       status: 'answered',
@@ -346,7 +376,8 @@ export async function updateHandoffAnswer(
     };
     await atomicWriteJson(handoffPath(handoffsDir, taskId), updated);
     return { won: true };
-  } finally {
-    try { await unlink(lock); } catch { /* ignore — lock cleanup is best-effort */ }
-  }
+  });
+
+  // null means the lock was not acquired — another caller holds it.
+  return result ?? { won: false };
 }

--- a/src/telegram/handoff-answer.ts
+++ b/src/telegram/handoff-answer.ts
@@ -30,7 +30,8 @@
 import { Markup, type Telegraf } from 'telegraf';
 import { answerHandoff } from '../agent/daemon/handoff-wiring.js';
 import type { HandoffRecord, HandoffRoute } from '../agent/daemon/handoff-store.js';
-import { writeHandoff, readHandoff } from '../agent/daemon/handoff-store.js';
+import { writeHandoff, readHandoff, withHandoffLock } from '../agent/daemon/handoff-store.js';
+import { getHandoffsDir } from '../paths.js';
 import {
   buildHandoffCallback,
   parseHandoffCallback,
@@ -397,10 +398,16 @@ export async function matchReplyToHandoff(
 /**
  * Update the HandoffRecord with Telegram route and message ID for restart recovery.
  *
- * Invariant: re-reads the record from disk before writing so a concurrent answer
- * that transitioned the record to 'answered' between sendMessage and this call is
- * never clobbered. If the fresh copy is no longer 'pending', we skip the write --
- * the answer already landed and erasing it would be a data loss bug (#1549).
+ * Invariant: acquires the same O_EXCL lock that updateHandoffAnswer uses, then
+ * re-reads the record inside the lock. This closes the TOCTOU window (#1557):
+ * without the lock, a concurrent updateHandoffAnswer completing between the read
+ * and write would have its 'answered' status clobbered by our pending+route write.
+ * If the fresh copy is no longer 'pending' (answer won the race), we skip the
+ * write — erasing an answer would be a data loss bug (#1549).
+ *
+ * Best-effort contract: all errors (including lock-not-acquired) are swallowed.
+ * The handoff still functions without route/messageId; restart recovery re-sends
+ * to the default target instead of the original chat.
  */
 async function persistRouteAndMessageId(
   record: HandoffRecord,
@@ -409,17 +416,20 @@ async function persistRouteAndMessageId(
   messageId: number,
   handoffsDir?: string,
 ): Promise<void> {
+  const dir = handoffsDir ?? getHandoffsDir();
   const route: HandoffRoute = { chatId, ...(threadId ? { threadId } : {}) };
   try {
-    const fresh = await readHandoff(record.taskId, handoffsDir);
-    // Answer won the race -- skip the write to preserve it.
-    if (fresh === null || fresh.status !== 'pending') return;
-    const updated: HandoffRecord = {
-      ...fresh,
-      route,
-      telegramMessageId: messageId,
-    };
-    await writeHandoff(updated, handoffsDir);
+    await withHandoffLock(record.taskId, dir, async () => {
+      const fresh = await readHandoff(record.taskId, dir);
+      // Answer won the race -- skip the write to preserve it.
+      if (fresh === null || fresh.status !== 'pending') return;
+      const updated: HandoffRecord = {
+        ...fresh,
+        route,
+        telegramMessageId: messageId,
+      };
+      await writeHandoff(updated, dir);
+    });
   } catch {
     // Best-effort: the handoff still works without route/messageId; restart
     // recovery will just re-send to the default target instead of the original chat.


### PR DESCRIPTION
## Problem

`persistRouteAndMessageId` in `src/telegram/handoff-answer.ts` performed a
read-check-write without holding the same O_EXCL lock that `updateHandoffAnswer`
uses in `src/agent/daemon/handoff-store.ts`. A concurrent `updateHandoffAnswer`
completing between the read and write could overwrite the answered record, clobbering
the answer status with a stale pending+route write.

## Fix

Extracted the lock acquisition/release logic from `updateHandoffAnswer` into a new
`withHandoffLock<T>` helper exported from `handoff-store.ts`:

- Acquires `<taskId>.lock` with O_EXCL (same protocol as before)
- Runs a typed callback with the lock held
- Releases the lock in a finally block
- Handles stale lock detection (>30 s TTL) with a single retry, matching the
  existing behavior

Refactored `updateHandoffAnswer` to use `withHandoffLock` internally
(behavior-preserving — same lock protocol, same stale-lock handling, same CAS
semantics).

`persistRouteAndMessageId` now calls `withHandoffLock` before doing its
read-check-write, eliminating the TOCTOU window. Under the lock it re-reads the
record, skips if no longer pending, and writes if still pending. The existing
best-effort error-swallowing contract is preserved (lock-not-acquired returns null,
which the try/catch absorbs just like any other error).

## Tests

Added a `withHandoffLock` test suite to `handoff-store.test.ts` covering:

- Callback runs and return value is propagated when lock is free
- Returns `null` immediately when a fresh lock file blocks acquisition
- Clears a stale lock (>30 s) and runs the callback
- Releases the lock after callback success
- Releases the lock even when the callback throws
- Exactly one concurrent caller wins when two race for the same taskId

All 25 existing `handoff-store` tests continue to pass (2 skipped on non-Linux,
as before). All 18 existing `handoff-answer` tests continue to pass, including
the #1549 TOCTOU regression test that exercises the concurrent-answer scenario.

## Verification

```
pnpm lint        -- exit 0
pnpm test src/agent/daemon/handoff-store.test.ts   -- 25 passed, 2 skipped
pnpm test src/telegram/handoff-answer.test.ts      -- 18 passed
pnpm audit:filesize:check  -- no new violations (pre-existing events.ts baseline violation unrelated)
handoff-store.ts: 175 code lines (ceiling: 350)
handoff-answer.ts: 297 code lines (ceiling: 350)
```
