### PR TITLE
feat(web): add schedule CRUD UI to afk web

### DIFF
--- a/scripts/build-web-ui.mjs
+++ b/scripts/build-web-ui.mjs
@@ -46,7 +46,7 @@ async function main() {
   });
 
   // Static shell files sit beside the bundle.
-  for (const name of ['index.html', 'styles.css', 'approvals.css']) {
+  for (const name of ['index.html', 'styles.css', 'approvals.css', 'schedules.css']) {
     const from = join(frontendDir, name);
     if (!existsSync(from)) {
       console.error(`build-web-ui: missing ${name}`);

--- a/src/web-server/frontend/app.ts
+++ b/src/web-server/frontend/app.ts
@@ -31,6 +31,9 @@ import {
 import { QueuePanel } from './queue-panel.js';
 import { isPinnedToBottom } from './scroll-pin.js';
 import type { TranscriptItem } from './view-model.js';
+import { SchedulesView } from './schedules-view.js';
+import { openScheduleForm } from './schedule-form.js';
+import { openScheduleHistory } from './schedule-history.js';
 
 const token = readAndScrubToken();
 
@@ -53,6 +56,9 @@ let turnActive = false;
 
 /** True while the SSE transport is in a reconnecting state. */
 let sseReconnecting = false;
+
+/** Lazy singleton for the schedules view. */
+let schedulesView: SchedulesView | undefined;
 
 /**
  * Contract: constructed lazily on first use so this module can be imported
@@ -254,6 +260,62 @@ function syncStop(): void {
 }
 
 /**
+ * Switch between the sessions and schedules top-level views.
+ *
+ * The sessions view includes transcript, approvals, and composer. The schedules
+ * view is a standalone panel for CRUD of daemon-scheduled tasks. Switching
+ * toggles visibility rather than destroying DOM -- the SSE stream stays alive
+ * while viewing schedules so notifications are not missed.
+ */
+function switchView(view: 'sessions' | 'schedules'): void {
+  // Nav buttons
+  const navSessions = document.getElementById('nav-sessions');
+  const navSchedules = document.getElementById('nav-schedules');
+  navSessions?.classList.toggle('is-active', view === 'sessions');
+  navSchedules?.classList.toggle('is-active', view === 'schedules');
+
+  // Session-view elements
+  const transcript = document.getElementById('transcript');
+  const approvals = document.getElementById('approvals');
+  const composer = document.getElementById('composer');
+  const sidebarHead = document.querySelector('.sidebar-head') as HTMLElement | null;
+  const sessionsEl = document.getElementById('sessions');
+
+  // Schedule-view element
+  const schedView = document.getElementById('schedules-view');
+
+  if (view === 'sessions') {
+    if (transcript) transcript.style.display = '';
+    if (approvals) approvals.style.display = '';
+    if (composer) composer.style.display = '';
+    if (sidebarHead) sidebarHead.style.display = '';
+    if (sessionsEl) sessionsEl.style.display = '';
+    schedView?.classList.remove('is-active');
+  } else {
+    if (transcript) transcript.style.display = 'none';
+    if (approvals) approvals.style.display = 'none';
+    if (composer) composer.style.display = 'none';
+    if (sidebarHead) sidebarHead.style.display = 'none';
+    if (sessionsEl) sessionsEl.style.display = 'none';
+    schedView?.classList.add('is-active');
+
+    if (!schedulesView && schedView) {
+      schedulesView = new SchedulesView({
+        container: schedView,
+        api,
+        onEdit: (schedule) =>
+          openScheduleForm(schedule.id ? schedule : null, {
+            api,
+            onSaved: () => void schedulesView?.load(),
+          }),
+        onShowHistory: (id) => openScheduleHistory(id, api),
+      });
+    }
+    void schedulesView?.load();
+  }
+}
+
+/**
  * Start a session this process owns, then select it.
  *
  * Contract: the sidebar is refreshed BEFORE selecting, because `selectSession`
@@ -362,6 +424,10 @@ async function main(): Promise<void> {
   $('new-session').addEventListener('click', () => toggleNewSessionForm(
     (model, cwd) => void createSession(model, cwd),
   ));
+
+  // Wire nav tab switching
+  document.getElementById('nav-sessions')?.addEventListener('click', () => switchView('sessions'));
+  document.getElementById('nav-schedules')?.addEventListener('click', () => switchView('schedules'));
   wireSidebarClose();
   $('stop').addEventListener('click', () => {
     void stopTurn().catch((err: unknown) => {

--- a/src/web-server/frontend/index.html
+++ b/src/web-server/frontend/index.html
@@ -22,6 +22,7 @@
     />
     <link rel="stylesheet" href="/styles.css" />
     <link rel="stylesheet" href="/approvals.css" />
+    <link rel="stylesheet" href="/schedules.css" />
   </head>
   <body>
     <header class="topbar">
@@ -37,6 +38,10 @@
 
     <main class="layout">
       <aside id="sidebar" class="sidebar">
+        <nav class="sidebar-nav">
+          <button id="nav-sessions" class="sidebar-nav-btn is-active" data-view="sessions">Sessions</button>
+          <button id="nav-schedules" class="sidebar-nav-btn" data-view="schedules">Schedules</button>
+        </nav>
         <div class="sidebar-head">
           <span>Sessions</span>
           <button id="new-session" class="new-session" title="Start a new session">+ New</button>
@@ -47,6 +52,7 @@
 
       <section class="main">
         <div id="transcript" class="transcript"></div>
+        <div id="schedules-view" class="sched-view"></div>
         <div id="approvals" class="approvals"></div>
         <div id="composer" class="composer">
           <div id="slash-menu" class="slash-menu" hidden></div>

--- a/src/web-server/frontend/schedule-form.ts
+++ b/src/web-server/frontend/schedule-form.ts
@@ -38,6 +38,9 @@ function describeCron(expr: string): string {
   const parts = expr.trim().split(/\s+/);
   if (parts.length < 5) return '';
   const [min, hour, dom, mon, dow] = parts as [string, string, string, string, string];
+  if (dom === '*' && mon === '*' && dow === '*' && hour.startsWith('*/')) {
+    return `Runs every ${hour.slice(2)} hours`;
+  }
   if (dom === '*' && mon === '*' && dow === '*' && hour !== '*' && min !== '*') {
     return `Runs daily at ${hour.padStart(2, '0')}:${min.padStart(2, '0')}`;
   }
@@ -49,9 +52,7 @@ function describeCron(expr: string): string {
   if (dom === '*' && mon === '*' && dow === '*' && hour === '*') {
     return min === '*' ? 'Runs every minute' : `Runs every hour at :${min.padStart(2, '0')}`;
   }
-  if (hour === '*/6' || hour === '*/4' || hour === '*/2' || hour === '*/8' || hour === '*/12') {
-    return `Runs every ${hour.slice(2)} hours`;
-  }
+  // Step-interval patterns now handled above the daily branch.
   return `Cron: ${expr}`;
 }
 

--- a/src/web-server/frontend/schedule-form.ts
+++ b/src/web-server/frontend/schedule-form.ts
@@ -1,0 +1,268 @@
+/**
+ * Create/edit form for scheduled tasks.
+ *
+ * Renders an overlay modal with fields for name, command, cron expression
+ * (with human-readable preview), trigger mode, and notify settings.
+ * All DOM construction uses textContent -- never innerHTML.
+ */
+
+import { showToast } from './app-chrome.js';
+import type { ScheduleConfig } from './schedules-view.js';
+
+interface ScheduleFormOptions {
+  api: <T>(path: string, init?: RequestInit) => Promise<T>;
+  onSaved: () => void;
+}
+
+function el<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  className?: string,
+  text?: string,
+): HTMLElementTagNameMap[K] {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text !== undefined) node.textContent = text;
+  return node;
+}
+
+const CRON_PRESETS: Array<{ label: string; value: string }> = [
+  { label: 'Every hour', value: '0 * * * *' },
+  { label: 'Daily at 2:00 AM', value: '0 2 * * *' },
+  { label: 'Daily at 9:00 AM', value: '0 9 * * *' },
+  { label: 'Every 6 hours', value: '0 */6 * * *' },
+  { label: 'Weekly (Monday 9 AM)', value: '0 9 * * 1' },
+  { label: 'Custom...', value: '' },
+];
+
+function describeCron(expr: string): string {
+  const parts = expr.trim().split(/\s+/);
+  if (parts.length < 5) return '';
+  const [min, hour, dom, mon, dow] = parts as [string, string, string, string, string];
+  if (dom === '*' && mon === '*' && dow === '*' && hour !== '*' && min !== '*') {
+    return `Runs daily at ${hour.padStart(2, '0')}:${min.padStart(2, '0')}`;
+  }
+  if (dom === '*' && mon === '*' && dow !== '*' && hour !== '*') {
+    const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+    const dayName = days[Number(dow)] ?? dow;
+    return `Runs every ${dayName} at ${hour.padStart(2, '0')}:${min.padStart(2, '0')}`;
+  }
+  if (dom === '*' && mon === '*' && dow === '*' && hour === '*') {
+    return min === '*' ? 'Runs every minute' : `Runs every hour at :${min.padStart(2, '0')}`;
+  }
+  if (hour === '*/6' || hour === '*/4' || hour === '*/2' || hour === '*/8' || hour === '*/12') {
+    return `Runs every ${hour.slice(2)} hours`;
+  }
+  return `Cron: ${expr}`;
+}
+
+export function openScheduleForm(
+  schedule: ScheduleConfig | null,
+  opts: ScheduleFormOptions,
+): void {
+  const isEdit = schedule !== null && schedule.id !== '';
+
+  // Remove any existing form overlay
+  document.getElementById('sched-form-overlay')?.remove();
+
+  const overlay = el('div', 'sched-overlay');
+  overlay.id = 'sched-form-overlay';
+
+  const modal = el('div', 'sched-modal');
+
+  // Title
+  modal.appendChild(el('h3', 'sched-modal-title', isEdit ? 'Edit Schedule' : 'New Schedule'));
+
+  // Name
+  const nameGroup = el('div', 'sched-field');
+  nameGroup.appendChild(el('label', 'sched-label', 'Name'));
+  const nameInput = document.createElement('input');
+  nameInput.type = 'text';
+  nameInput.className = 'sched-input';
+  nameInput.placeholder = 'e.g. Nightly forge';
+  nameInput.value = schedule?.name ?? '';
+  nameGroup.appendChild(nameInput);
+  modal.appendChild(nameGroup);
+
+  // Command
+  const cmdGroup = el('div', 'sched-field');
+  cmdGroup.appendChild(el('label', 'sched-label', 'Command'));
+  const cmdInput = document.createElement('input');
+  cmdInput.type = 'text';
+  cmdInput.className = 'sched-input sched-input-mono';
+  cmdInput.placeholder = 'e.g. /forge-friction --auto';
+  cmdInput.value = schedule?.command ?? '';
+  cmdGroup.appendChild(cmdInput);
+  modal.appendChild(cmdGroup);
+
+  // Cron
+  const cronGroup = el('div', 'sched-field');
+  cronGroup.appendChild(el('label', 'sched-label', 'Schedule'));
+
+  const cronSelect = document.createElement('select');
+  cronSelect.className = 'sched-select';
+  for (const preset of CRON_PRESETS) {
+    const opt = document.createElement('option');
+    opt.value = preset.value;
+    opt.textContent = preset.label;
+    cronSelect.appendChild(opt);
+  }
+
+  const cronInput = document.createElement('input');
+  cronInput.type = 'text';
+  cronInput.className = 'sched-input sched-input-mono';
+  cronInput.placeholder = '0 2 * * *';
+  cronInput.value = schedule?.cron ?? '';
+
+  const cronPreview = el('div', 'sched-cron-preview');
+
+  // Set initial state
+  const initialCron = schedule?.cron ?? '';
+  const matchingPreset = CRON_PRESETS.find((p) => p.value === initialCron);
+  if (matchingPreset && matchingPreset.value !== '') {
+    cronSelect.value = matchingPreset.value;
+    cronInput.style.display = 'none';
+  } else if (initialCron) {
+    cronSelect.value = '';
+    cronInput.style.display = '';
+  } else {
+    cronSelect.value = CRON_PRESETS[0]?.value ?? '';
+    cronInput.style.display = 'none';
+    cronInput.value = cronSelect.value;
+  }
+
+  const updatePreview = (): void => {
+    const val = cronInput.style.display === 'none' ? cronSelect.value : cronInput.value;
+    cronPreview.textContent = val ? describeCron(val) : '';
+  };
+
+  cronSelect.addEventListener('change', () => {
+    if (cronSelect.value === '') {
+      cronInput.style.display = '';
+      cronInput.focus();
+    } else {
+      cronInput.style.display = 'none';
+      cronInput.value = cronSelect.value;
+    }
+    updatePreview();
+  });
+  cronInput.addEventListener('input', updatePreview);
+  updatePreview();
+
+  cronGroup.appendChild(cronSelect);
+  cronGroup.appendChild(cronInput);
+  cronGroup.appendChild(cronPreview);
+  modal.appendChild(cronGroup);
+
+  // Trigger mode
+  const trigGroup = el('div', 'sched-field');
+  trigGroup.appendChild(el('label', 'sched-label', 'Trigger'));
+  const trigSelect = document.createElement('select');
+  trigSelect.className = 'sched-select';
+  for (const [val, label] of [
+    ['cron', 'Cron schedule only'],
+    ['sessionstart', 'On daemon start'],
+    ['both', 'Both (cron + daemon start)'],
+  ] as const) {
+    const opt = document.createElement('option');
+    opt.value = val;
+    opt.textContent = label;
+    if (val === (schedule?.trigger ?? 'cron')) opt.selected = true;
+    trigSelect.appendChild(opt);
+  }
+  trigGroup.appendChild(trigSelect);
+  modal.appendChild(trigGroup);
+
+  // Notify
+  const notifyGroup = el('div', 'sched-field');
+  notifyGroup.appendChild(el('label', 'sched-label', 'Notifications'));
+  const notifySelect = document.createElement('select');
+  notifySelect.className = 'sched-select';
+  for (const [val, label] of [
+    ['failure', 'On failure only'],
+    ['always', 'On every run'],
+    ['never', 'Never'],
+  ] as const) {
+    const opt = document.createElement('option');
+    opt.value = val;
+    opt.textContent = label;
+    if (val === (schedule?.notifyOn ?? 'failure')) opt.selected = true;
+    notifySelect.appendChild(opt);
+  }
+  notifyGroup.appendChild(notifySelect);
+  modal.appendChild(notifyGroup);
+
+  // Buttons
+  const btnRow = el('div', 'sched-btn-row');
+  const cancelBtn = el('button', 'sched-cancel-btn', 'Cancel');
+  cancelBtn.addEventListener('click', () => overlay.remove());
+
+  const saveBtn = el('button', 'sched-save-btn', isEdit ? 'Save Changes' : 'Create Schedule');
+  saveBtn.addEventListener('click', () => {
+    void save();
+  });
+
+  btnRow.appendChild(cancelBtn);
+  btnRow.appendChild(saveBtn);
+  modal.appendChild(btnRow);
+
+  overlay.appendChild(modal);
+  document.body.appendChild(overlay);
+  nameInput.focus();
+
+  // Close on Escape or overlay click
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) overlay.remove();
+  });
+  const escHandler = (e: KeyboardEvent): void => {
+    if (e.key === 'Escape') {
+      overlay.remove();
+      document.removeEventListener('keydown', escHandler);
+    }
+  };
+  document.addEventListener('keydown', escHandler);
+
+  async function save(): Promise<void> {
+    const name = nameInput.value.trim();
+    const command = cmdInput.value.trim();
+    const cron = cronInput.style.display === 'none' ? cronSelect.value : cronInput.value.trim();
+
+    if (!name || !command || !cron) {
+      showToast('Name, command, and schedule are required');
+      return;
+    }
+
+    saveBtn.disabled = true;
+    saveBtn.textContent = 'Saving...';
+
+    try {
+      const payload = {
+        name,
+        command,
+        cron,
+        trigger: trigSelect.value,
+        notifyOn: notifySelect.value,
+        enabled: schedule?.enabled ?? true,
+      };
+
+      if (isEdit) {
+        await opts.api(`/api/schedules/${encodeURIComponent(schedule!.id)}`, {
+          method: 'PATCH',
+          body: JSON.stringify(payload),
+        });
+      } else {
+        await opts.api('/api/schedules', {
+          method: 'POST',
+          body: JSON.stringify(payload),
+        });
+      }
+
+      overlay.remove();
+      document.removeEventListener('keydown', escHandler);
+      opts.onSaved();
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'save failed');
+      saveBtn.disabled = false;
+      saveBtn.textContent = isEdit ? 'Save Changes' : 'Create Schedule';
+    }
+  }
+}

--- a/src/web-server/frontend/schedule-history.ts
+++ b/src/web-server/frontend/schedule-history.ts
@@ -1,0 +1,159 @@
+/**
+ * Schedule execution history overlay for the `afk web` SPA.
+ *
+ * Fetches and renders the last 20 executions of a scheduled task.
+ * All DOM construction uses textContent -- never innerHTML.
+ */
+
+import { showToast } from './app-chrome.js';
+
+/** Shape of a telemetry record from `GET /api/schedules/:id/history`. */
+interface HistoryRecord {
+  taskId: string;
+  command?: string;
+  trigger?: string;
+  triggeredAt: string;
+  durationMs: number;
+  status: 'success' | 'error' | 'skipped';
+  errorMessage?: string;
+  responseExcerpt?: string;
+  skipReason?: string;
+  name?: string;
+}
+
+function el<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  className?: string,
+  text?: string,
+): HTMLElementTagNameMap[K] {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text !== undefined) node.textContent = text;
+  return node;
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const s = ms / 1000;
+  if (s < 60) return `${s.toFixed(1)}s`;
+  const m = Math.floor(s / 60);
+  const remainder = Math.floor(s % 60);
+  return `${m}m ${remainder}s`;
+}
+
+function formatTime(iso: string): string {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+export function openScheduleHistory(
+  scheduleId: string,
+  api: <T>(path: string, init?: RequestInit) => Promise<T>,
+): void {
+  // Remove any existing history overlay
+  document.getElementById('sched-history-overlay')?.remove();
+
+  const overlay = el('div', 'sched-overlay');
+  overlay.id = 'sched-history-overlay';
+
+  const modal = el('div', 'sched-modal sched-modal-wide');
+  modal.appendChild(el('h3', 'sched-modal-title', `History: ${scheduleId}`));
+
+  const body = el('div', 'sched-history-body');
+  body.appendChild(el('div', 'sched-history-loading', 'Loading...'));
+  modal.appendChild(body);
+
+  const closeBtn = el('button', 'sched-cancel-btn', 'Close');
+  closeBtn.addEventListener('click', () => overlay.remove());
+  modal.appendChild(closeBtn);
+
+  overlay.appendChild(modal);
+  document.body.appendChild(overlay);
+
+  // Close on Escape or overlay click
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) overlay.remove();
+  });
+  const escHandler = (e: KeyboardEvent): void => {
+    if (e.key === 'Escape') {
+      overlay.remove();
+      document.removeEventListener('keydown', escHandler);
+    }
+  };
+  document.addEventListener('keydown', escHandler);
+
+  // Fetch and render
+  void loadHistory(scheduleId, api, body);
+}
+
+async function loadHistory(
+  id: string,
+  api: <T>(path: string, init?: RequestInit) => Promise<T>,
+  container: HTMLElement,
+): Promise<void> {
+  try {
+    const data = await api<{ history: HistoryRecord[] }>(
+      `/api/schedules/${encodeURIComponent(id)}/history`,
+    );
+    container.textContent = '';
+
+    if (data.history.length === 0) {
+      container.appendChild(el('div', 'sched-empty', 'No executions recorded yet.'));
+      return;
+    }
+
+    // Render newest first
+    const reversed = [...data.history].reverse();
+    for (const record of reversed) {
+      container.appendChild(renderRecord(record));
+    }
+  } catch (err) {
+    showToast(err instanceof Error ? err.message : 'failed to load history');
+    container.textContent = '';
+    container.appendChild(el('div', 'sched-empty', 'Failed to load history.'));
+  }
+}
+
+function renderRecord(r: HistoryRecord): HTMLElement {
+  const row = el('div', `sched-hist-row sched-hist-${r.status}`);
+
+  // Status dot + time
+  const header = el('div', 'sched-hist-header');
+  const dot = el('span', `sched-hist-dot sched-hist-dot-${r.status}`);
+  header.appendChild(dot);
+  header.appendChild(el('span', 'sched-hist-status', r.status));
+  header.appendChild(el('span', 'sched-hist-time', formatTime(r.triggeredAt)));
+  header.appendChild(el('span', 'sched-hist-duration', formatDuration(r.durationMs)));
+  if (r.trigger) {
+    header.appendChild(el('span', 'sched-hist-trigger', r.trigger));
+  }
+  row.appendChild(header);
+
+  // Error message if any
+  if (r.status === 'error' && r.errorMessage) {
+    const errEl = el('div', 'sched-hist-error', r.errorMessage);
+    row.appendChild(errEl);
+  }
+
+  // Skip reason
+  if (r.status === 'skipped' && r.skipReason) {
+    row.appendChild(el('div', 'sched-hist-skip', `Skipped: ${r.skipReason}`));
+  }
+
+  // Response excerpt
+  if (r.responseExcerpt) {
+    const excerpt = el('div', 'sched-hist-excerpt', r.responseExcerpt);
+    row.appendChild(excerpt);
+  }
+
+  return row;
+}

--- a/src/web-server/frontend/schedules-view.ts
+++ b/src/web-server/frontend/schedules-view.ts
@@ -1,0 +1,252 @@
+/**
+ * Schedule list view for the `afk web` SPA.
+ *
+ * Renders the schedule table, toggle switches, delete actions, and wires
+ * create/edit/history interactions. All DOM construction uses textContent
+ * or typed element creation -- never innerHTML.
+ */
+
+import { showToast } from './app-chrome.js';
+
+/** Shape returned by `GET /api/schedules`. */
+export interface ScheduleConfig {
+  id: string;
+  name: string;
+  command: string;
+  cron: string;
+  trigger?: 'cron' | 'sessionstart' | 'both';
+  enabled: boolean;
+  notifyOn?: 'failure' | 'always' | 'never';
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Shape returned by `GET /api/daemon/status`. */
+interface DaemonStatus {
+  running: boolean;
+  tasks?: number;
+  detail?: string;
+}
+
+interface SchedulesViewOptions {
+  container: HTMLElement;
+  api: <T>(path: string, init?: RequestInit) => Promise<T>;
+  onEdit: (schedule: ScheduleConfig) => void;
+  onShowHistory: (id: string) => void;
+}
+
+function el<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  className?: string,
+  text?: string,
+): HTMLElementTagNameMap[K] {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text !== undefined) node.textContent = text;
+  return node;
+}
+
+/** Human-readable cron description (simple cases). */
+function describeCron(expr: string): string {
+  const parts = expr.trim().split(/\s+/);
+  if (parts.length < 5) return expr;
+  const [min, hour, dom, mon, dow] = parts as [string, string, string, string, string];
+  if (dom === '*' && mon === '*' && dow === '*' && hour !== '*' && min !== '*') {
+    return `Daily at ${hour.padStart(2, '0')}:${min.padStart(2, '0')}`;
+  }
+  if (dom === '*' && mon === '*' && dow !== '*' && hour !== '*') {
+    const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+    const dayName = days[Number(dow)] ?? dow;
+    return `${dayName} at ${hour.padStart(2, '0')}:${min.padStart(2, '0')}`;
+  }
+  if (dom === '*' && mon === '*' && dow === '*' && hour === '*' && min !== '*') {
+    return `Every hour at :${min.padStart(2, '0')}`;
+  }
+  if (dom === '*' && mon === '*' && dow === '*' && hour === '*' && min === '*') {
+    return 'Every minute';
+  }
+  return expr;
+}
+
+function relativeTime(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  const sec = Math.floor(ms / 1000);
+  if (sec < 60) return 'just now';
+  const mins = Math.floor(sec / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d ago`;
+}
+
+export class SchedulesView {
+  private container: HTMLElement;
+  private api: <T>(path: string, init?: RequestInit) => Promise<T>;
+  private onEdit: (schedule: ScheduleConfig) => void;
+  private onShowHistory: (id: string) => void;
+  private schedules: ScheduleConfig[] = [];
+  private daemonStatus: DaemonStatus = { running: false };
+
+  constructor(opts: SchedulesViewOptions) {
+    this.container = opts.container;
+    this.api = opts.api;
+    this.onEdit = opts.onEdit;
+    this.onShowHistory = opts.onShowHistory;
+  }
+
+  async load(): Promise<void> {
+    try {
+      const [schedData, statusData] = await Promise.all([
+        this.api<{ schedules: ScheduleConfig[] }>('/api/schedules'),
+        this.api<DaemonStatus>('/api/daemon/status'),
+      ]);
+      this.schedules = schedData.schedules;
+      this.daemonStatus = statusData;
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'failed to load schedules');
+    }
+    this.render();
+  }
+
+  private render(): void {
+    this.container.textContent = '';
+
+    // Header
+    const header = el('div', 'sched-header');
+    const titleRow = el('div', 'sched-title-row');
+    titleRow.appendChild(el('h2', 'sched-title', 'Schedules'));
+    const addBtn = el('button', 'sched-add-btn', '+ New Schedule');
+    addBtn.addEventListener('click', () =>
+      this.onEdit({
+        id: '',
+        name: '',
+        command: '',
+        cron: '',
+        enabled: true,
+        createdAt: '',
+        updatedAt: '',
+      }),
+    );
+    titleRow.appendChild(addBtn);
+    header.appendChild(titleRow);
+
+    // Daemon status
+    const statusRow = el('div', 'sched-daemon-status');
+    const dot = el('span', this.daemonStatus.running ? 'sched-dot-ok' : 'sched-dot-off');
+    statusRow.appendChild(dot);
+    statusRow.appendChild(
+      el(
+        'span',
+        'sched-daemon-text',
+        this.daemonStatus.running
+          ? `Daemon running (${this.daemonStatus.tasks ?? 0} tasks)`
+          : 'Daemon not running',
+      ),
+    );
+    header.appendChild(statusRow);
+    this.container.appendChild(header);
+
+    // Empty state
+    if (this.schedules.length === 0) {
+      const empty = el('div', 'sched-empty');
+      empty.appendChild(el('div', 'sched-empty-icon', '\u23F0'));
+      empty.appendChild(el('div', 'sched-empty-title', 'No schedules yet'));
+      empty.appendChild(
+        el('div', 'sched-empty-sub', 'Create a schedule to run tasks on a cron timer.'),
+      );
+      this.container.appendChild(empty);
+      return;
+    }
+
+    // Schedule cards
+    const list = el('div', 'sched-list');
+    for (const s of this.schedules) {
+      list.appendChild(this.renderCard(s));
+    }
+    this.container.appendChild(list);
+  }
+
+  private renderCard(s: ScheduleConfig): HTMLElement {
+    const card = el('div', `sched-card${s.enabled ? '' : ' sched-card-disabled'}`);
+
+    // Top row: name + toggle
+    const topRow = el('div', 'sched-card-top');
+    const nameEl = el('span', 'sched-card-name', s.name);
+    topRow.appendChild(nameEl);
+
+    const toggle = el('button', `sched-toggle${s.enabled ? ' is-on' : ''}`) as HTMLButtonElement;
+    const toggleDot = el('span', 'sched-toggle-dot');
+    toggle.appendChild(toggleDot);
+    toggle.title = s.enabled ? 'Disable' : 'Enable';
+    toggle.addEventListener('click', () => void this.toggleSchedule(s.id));
+    topRow.appendChild(toggle);
+    card.appendChild(topRow);
+
+    // Schedule details
+    const details = el('div', 'sched-card-details');
+    const cronRow = el('div', 'sched-detail-row');
+    cronRow.appendChild(el('span', 'sched-detail-label', 'Schedule'));
+    const cronVal = el('span', 'sched-detail-value');
+    cronVal.appendChild(el('span', undefined, describeCron(s.cron)));
+    cronVal.appendChild(el('span', 'sched-cron-raw', s.cron));
+    cronRow.appendChild(cronVal);
+    details.appendChild(cronRow);
+
+    const cmdRow = el('div', 'sched-detail-row');
+    cmdRow.appendChild(el('span', 'sched-detail-label', 'Command'));
+    cmdRow.appendChild(el('code', 'sched-detail-code', s.command));
+    details.appendChild(cmdRow);
+
+    if (s.trigger && s.trigger !== 'cron') {
+      const trigRow = el('div', 'sched-detail-row');
+      trigRow.appendChild(el('span', 'sched-detail-label', 'Trigger'));
+      trigRow.appendChild(el('span', 'sched-detail-value', s.trigger));
+      details.appendChild(trigRow);
+    }
+
+    const metaRow = el('div', 'sched-card-meta');
+    metaRow.appendChild(el('span', 'sched-card-id', s.id));
+    if (s.updatedAt) {
+      metaRow.appendChild(el('span', 'sched-card-time', relativeTime(s.updatedAt)));
+    }
+    details.appendChild(metaRow);
+    card.appendChild(details);
+
+    // Actions row
+    const actions = el('div', 'sched-card-actions');
+    const histBtn = el('button', 'sched-action-btn', 'History');
+    histBtn.addEventListener('click', () => this.onShowHistory(s.id));
+    actions.appendChild(histBtn);
+
+    const editBtn = el('button', 'sched-action-btn', 'Edit');
+    editBtn.addEventListener('click', () => this.onEdit(s));
+    actions.appendChild(editBtn);
+
+    const deleteBtn = el('button', 'sched-action-btn sched-action-danger', 'Delete');
+    deleteBtn.addEventListener('click', () => void this.deleteSchedule(s.id, s.name));
+    actions.appendChild(deleteBtn);
+
+    card.appendChild(actions);
+    return card;
+  }
+
+  private async toggleSchedule(id: string): Promise<void> {
+    try {
+      await this.api(`/api/schedules/${encodeURIComponent(id)}/toggle`, { method: 'POST' });
+      await this.load();
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'toggle failed');
+    }
+  }
+
+  private async deleteSchedule(id: string, name: string): Promise<void> {
+    if (!confirm(`Delete schedule "${name}"? This cannot be undone.`)) return;
+    try {
+      await this.api(`/api/schedules/${encodeURIComponent(id)}`, { method: 'DELETE' });
+      await this.load();
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'delete failed');
+    }
+  }
+}

--- a/src/web-server/frontend/schedules-view.ts
+++ b/src/web-server/frontend/schedules-view.ts
@@ -51,6 +51,9 @@ function describeCron(expr: string): string {
   const parts = expr.trim().split(/\s+/);
   if (parts.length < 5) return expr;
   const [min, hour, dom, mon, dow] = parts as [string, string, string, string, string];
+  if (dom === '*' && mon === '*' && dow === '*' && hour.startsWith('*/')) {
+    return `Every ${hour.slice(2)} hours`;
+  }
   if (dom === '*' && mon === '*' && dow === '*' && hour !== '*' && min !== '*') {
     return `Daily at ${hour.padStart(2, '0')}:${min.padStart(2, '0')}`;
   }

--- a/src/web-server/frontend/schedules.css
+++ b/src/web-server/frontend/schedules.css
@@ -1,0 +1,202 @@
+/* ── schedules view ─────────────────────────────────────────────────────── */
+
+.sched-view { display: none; flex: 1; flex-direction: column; overflow-y: auto; padding: 24px; }
+.sched-view.is-active { display: flex; }
+
+.sched-header { max-width: 900px; width: 100%; margin: 0 auto 20px; }
+.sched-title-row {
+  display: flex; align-items: center; justify-content: space-between; gap: 12px;
+  margin-bottom: 10px;
+}
+.sched-title { margin: 0; font-size: 18px; font-weight: 600; color: var(--text); }
+.sched-add-btn {
+  font: inherit; font-size: 12px; font-weight: 600;
+  color: var(--accent); background: transparent;
+  border: 1px solid var(--border); border-radius: 6px;
+  padding: 6px 14px; cursor: pointer; white-space: nowrap;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+.sched-add-btn:hover { border-color: var(--accent); background: var(--bg-raised); }
+
+.sched-daemon-status {
+  display: flex; align-items: center; gap: 8px;
+  font-size: 12px; color: var(--text-dim);
+}
+.sched-dot-ok, .sched-dot-off {
+  width: 8px; height: 8px; border-radius: 50%; flex: 0 0 8px;
+}
+.sched-dot-ok { background: var(--success); }
+.sched-dot-off { background: var(--text-faint); }
+
+/* ── empty state ────────────────────────────────────────────────────────── */
+.sched-empty {
+  text-align: center; padding: 48px 20px; color: var(--text-dim);
+  max-width: 900px; width: 100%; margin: 0 auto;
+}
+.sched-empty-icon { font-size: 36px; margin-bottom: 12px; }
+.sched-empty-title { font-size: 16px; font-weight: 600; margin-bottom: 6px; color: var(--text); }
+.sched-empty-sub { font-size: 13px; }
+
+/* ── schedule cards ─────────────────────────────────────────────────────── */
+.sched-list { max-width: 900px; width: 100%; margin: 0 auto; display: flex; flex-direction: column; gap: 10px; }
+.sched-card {
+  background: var(--bg-raised); border: 1px solid var(--border);
+  border-radius: var(--radius); padding: 14px 16px;
+  transition: border-color 0.15s ease;
+}
+.sched-card:hover { border-color: color-mix(in srgb, var(--accent) 40%, transparent); }
+.sched-card-disabled { opacity: 0.6; }
+.sched-card-disabled:hover { border-color: var(--border); }
+
+.sched-card-top { display: flex; align-items: center; justify-content: space-between; margin-bottom: 10px; }
+.sched-card-name { font-size: 14px; font-weight: 600; color: var(--text); }
+
+/* ── toggle switch ──────────────────────────────────────────────────────── */
+.sched-toggle {
+  position: relative; width: 36px; height: 20px;
+  background: var(--border); border: none; border-radius: 10px;
+  cursor: pointer; padding: 0;
+  transition: background 0.2s ease;
+}
+.sched-toggle.is-on { background: var(--success); }
+.sched-toggle-dot {
+  position: absolute; top: 2px; left: 2px;
+  width: 16px; height: 16px; border-radius: 50%;
+  background: var(--text); transition: transform 0.2s ease;
+}
+.sched-toggle.is-on .sched-toggle-dot { transform: translateX(16px); }
+
+/* ── card details ───────────────────────────────────────────────────────── */
+.sched-card-details { display: flex; flex-direction: column; gap: 5px; margin-bottom: 10px; }
+.sched-detail-row { display: flex; align-items: baseline; gap: 10px; font-size: 12px; }
+.sched-detail-label {
+  color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.06em;
+  font-size: 10px; min-width: 68px; flex: 0 0 auto;
+}
+.sched-detail-value { color: var(--text-dim); display: flex; align-items: baseline; gap: 8px; }
+.sched-detail-code {
+  font-family: var(--mono); font-size: 12px; color: var(--accent);
+  background: var(--bg-sunken); border: 1px solid var(--border);
+  border-radius: 4px; padding: 1px 6px;
+}
+.sched-cron-raw {
+  font-family: var(--mono); font-size: 10px; color: var(--text-faint);
+  background: var(--bg-sunken); border: 1px solid var(--border);
+  border-radius: 3px; padding: 0 4px;
+}
+
+.sched-card-meta {
+  display: flex; align-items: center; gap: 10px;
+  font-size: 10px; color: var(--text-faint); margin-top: 4px;
+}
+.sched-card-id { font-family: var(--mono); }
+.sched-card-time { margin-left: auto; }
+
+/* ── card actions ───────────────────────────────────────────────────────── */
+.sched-card-actions {
+  display: flex; gap: 8px; padding-top: 10px;
+  border-top: 1px solid var(--border);
+}
+.sched-action-btn {
+  font: inherit; font-size: 11px; color: var(--text-dim);
+  background: transparent; border: 1px solid var(--border);
+  border-radius: 5px; padding: 3px 10px; cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+.sched-action-btn:hover { color: var(--text); border-color: var(--accent); }
+.sched-action-danger { color: var(--error); }
+.sched-action-danger:hover { color: var(--error); border-color: var(--error); }
+
+/* ── modal overlay ──────────────────────────────────────────────────────── */
+.sched-overlay {
+  position: fixed; inset: 0; z-index: 50;
+  display: flex; align-items: center; justify-content: center;
+  background: rgba(0, 0, 0, 0.65);
+}
+.sched-modal {
+  background: var(--bg-raised); border: 1px solid var(--border);
+  border-radius: var(--radius); padding: 24px;
+  width: 480px; max-width: 92vw; max-height: 85vh; overflow-y: auto;
+}
+.sched-modal-wide { width: 600px; }
+.sched-modal-title { margin: 0 0 18px; font-size: 16px; font-weight: 600; color: var(--text); }
+
+/* ── form fields ────────────────────────────────────────────────────────── */
+.sched-field { margin-bottom: 14px; }
+.sched-label {
+  display: block; font-size: 11px; text-transform: uppercase;
+  letter-spacing: 0.06em; color: var(--text-dim); margin-bottom: 5px;
+}
+.sched-input, .sched-select {
+  width: 100%; padding: 8px 10px;
+  background: var(--bg-sunken); border: 1px solid var(--border);
+  border-radius: 6px; color: var(--text); font: inherit; font-size: 13px;
+}
+.sched-input:focus, .sched-select:focus { outline: none; border-color: var(--accent); }
+.sched-input-mono { font-family: var(--mono); font-size: 12px; }
+.sched-cron-preview {
+  font-size: 11px; color: var(--text-dim); margin-top: 5px;
+  font-style: italic; min-height: 16px;
+}
+
+.sched-btn-row { display: flex; gap: 10px; justify-content: flex-end; margin-top: 20px; }
+.sched-cancel-btn {
+  font: inherit; font-size: 13px; color: var(--text-dim);
+  background: transparent; border: 1px solid var(--border);
+  border-radius: 6px; padding: 8px 18px; cursor: pointer;
+}
+.sched-cancel-btn:hover { border-color: var(--text-dim); }
+.sched-save-btn {
+  font: inherit; font-size: 13px; font-weight: 600;
+  color: #1a0d05; background: var(--accent);
+  border: none; border-radius: 6px; padding: 8px 22px; cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+.sched-save-btn:hover:not(:disabled) { opacity: 0.88; }
+.sched-save-btn:disabled { opacity: 0.5; cursor: default; }
+
+/* ── history records ────────────────────────────────────────────────────── */
+.sched-history-body { max-height: 50vh; overflow-y: auto; margin-bottom: 16px; }
+.sched-history-loading { padding: 20px; color: var(--text-dim); text-align: center; }
+.sched-hist-row {
+  padding: 10px 12px; border-radius: 6px; margin-bottom: 6px;
+  background: var(--bg-sunken); border: 1px solid var(--border);
+}
+.sched-hist-header { display: flex; align-items: center; gap: 8px; font-size: 12px; }
+.sched-hist-dot { width: 7px; height: 7px; border-radius: 50%; flex: 0 0 7px; }
+.sched-hist-dot-success { background: var(--success); }
+.sched-hist-dot-error { background: var(--error); }
+.sched-hist-dot-skipped { background: var(--warning); }
+.sched-hist-status { color: var(--text-dim); text-transform: uppercase; font-size: 10px; letter-spacing: 0.06em; font-family: var(--mono); }
+.sched-hist-time { color: var(--text-faint); font-size: 11px; }
+.sched-hist-duration { color: var(--text-dim); font-family: var(--mono); font-size: 11px; margin-left: auto; }
+.sched-hist-trigger {
+  font-size: 10px; color: var(--text-faint); border: 1px solid var(--border);
+  border-radius: 3px; padding: 0 4px;
+}
+.sched-hist-error {
+  margin-top: 6px; font-size: 12px; color: var(--error);
+  font-family: var(--mono); white-space: pre-wrap; word-break: break-word;
+}
+.sched-hist-skip { margin-top: 6px; font-size: 12px; color: var(--warning); }
+.sched-hist-excerpt {
+  margin-top: 6px; font-size: 11px; color: var(--text-faint);
+  font-family: var(--mono); white-space: pre-wrap; word-break: break-word;
+  max-height: 80px; overflow: hidden;
+}
+
+/* ── nav tabs ───────────────────────────────────────────────────────────── */
+.sidebar-nav {
+  display: flex; border-bottom: 1px solid var(--border);
+}
+.sidebar-nav-btn {
+  flex: 1; padding: 8px 0; background: none; border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-dim); font: inherit; font-size: 11px;
+  text-transform: uppercase; letter-spacing: 0.06em;
+  cursor: pointer; transition: color 0.15s ease, border-color 0.15s ease;
+}
+.sidebar-nav-btn:hover { color: var(--text); }
+.sidebar-nav-btn.is-active {
+  color: var(--accent); border-bottom-color: var(--accent);
+}

--- a/src/web-server/routes.schedules.test.ts
+++ b/src/web-server/routes.schedules.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ServerResponse } from 'node:http';
+import {
+  handleListSchedules,
+  handleCreateSchedule,
+  handleUpdateSchedule,
+  handleDeleteSchedule,
+  handleToggleSchedule,
+  handleScheduleHistory,
+  handleDaemonStatus,
+} from './routes.schedules.js';
+
+// ---- mocks -----------------------------------------------------------------
+
+const mockSchedules = [
+  {
+    id: 'nightly-forge',
+    name: 'Nightly forge',
+    command: '/forge-friction --auto',
+    cron: '0 2 * * *',
+    trigger: 'cron' as const,
+    enabled: true,
+    notifyOn: 'failure' as const,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+  },
+];
+
+vi.mock('../agent/daemon/schedule-store.js', () => ({
+  loadSchedules: vi.fn(() => [...mockSchedules]),
+  saveSchedules: vi.fn(),
+  addSchedule: vi.fn((config: Record<string, unknown>) => ({
+    id: 'test-schedule',
+    ...config,
+    notifyOn: config['notifyOn'] ?? 'failure',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  })),
+  removeSchedule: vi.fn((id: string) => id === 'nightly-forge'),
+  getSchedule: vi.fn((id: string) =>
+    id === 'nightly-forge' ? mockSchedules[0] : undefined,
+  ),
+  toScheduledTask: vi.fn((config: Record<string, unknown>) => ({
+    taskId: config['id'],
+    command: config['command'],
+    cronExpression: config['cron'],
+    trigger: config['trigger'] ?? 'cron',
+  })),
+}));
+
+vi.mock('../agent/daemon/http-client.js', () => ({
+  trySyncToDaemon: vi.fn(async () => ({ synced: true, detail: 'synced' })),
+  SYNC_FAILED_NOTE: 'sync note',
+  parsePortFile: vi.fn(() => ({ host: '127.0.0.1', port: 7777 })),
+}));
+
+vi.mock('../paths.js', () => ({
+  getTelemetryPath: vi.fn(() => '/tmp/nonexistent-telemetry.jsonl'),
+  getDaemonStateDir: vi.fn(() => '/tmp/nonexistent-daemon'),
+}));
+
+// ---- helpers ---------------------------------------------------------------
+
+function makeRes(): { res: ServerResponse; json: () => { status: number; body: unknown } } {
+  let status = 0;
+  const chunks: string[] = [];
+  const headers: Record<string, string> = {};
+  const res = {
+    writeHead(s: number, h: Record<string, string>) {
+      status = s;
+      Object.assign(headers, h);
+    },
+    end(payload: string) {
+      chunks.push(payload);
+    },
+  } as unknown as ServerResponse;
+  return {
+    res,
+    json: () => ({ status, body: JSON.parse(chunks.join('')) as unknown }),
+  };
+}
+
+// ---- tests -----------------------------------------------------------------
+
+describe('routes.schedules', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('handleListSchedules', () => {
+    it('returns the schedule list', async () => {
+      const { res, json } = makeRes();
+      await handleListSchedules(res);
+      const { status, body } = json();
+      expect(status).toBe(200);
+      expect(body).toHaveProperty('schedules');
+      expect((body as { schedules: unknown[] }).schedules).toHaveLength(1);
+    });
+  });
+
+  describe('handleCreateSchedule', () => {
+    it('creates a schedule with valid input', async () => {
+      const { res, json } = makeRes();
+      await handleCreateSchedule(res, {
+        name: 'Test',
+        command: '/test',
+        cron: '0 * * * *',
+      });
+      const { status, body } = json();
+      expect(status).toBe(201);
+      expect(body).toHaveProperty('schedule');
+      expect(body).toHaveProperty('daemonSynced', true);
+    });
+
+    it('rejects missing fields', async () => {
+      const { res, json } = makeRes();
+      await handleCreateSchedule(res, { name: 'Test' });
+      expect(json().status).toBe(400);
+    });
+
+    it('rejects invalid cron', async () => {
+      const { res, json } = makeRes();
+      await handleCreateSchedule(res, {
+        name: 'Test',
+        command: '/test',
+        cron: 'bad',
+      });
+      expect(json().status).toBe(400);
+    });
+  });
+
+  describe('handleUpdateSchedule', () => {
+    it('updates an existing schedule', async () => {
+      const { res, json } = makeRes();
+      await handleUpdateSchedule(res, 'nightly-forge', { name: 'Updated' });
+      const { status, body } = json();
+      expect(status).toBe(200);
+      expect((body as { schedule: { name: string } }).schedule.name).toBe('Updated');
+    });
+
+    it('returns 404 for unknown id', async () => {
+      const { res, json } = makeRes();
+      await handleUpdateSchedule(res, 'nonexistent', { name: 'x' });
+      expect(json().status).toBe(404);
+    });
+  });
+
+  describe('handleDeleteSchedule', () => {
+    it('deletes an existing schedule', async () => {
+      const { res, json } = makeRes();
+      await handleDeleteSchedule(res, 'nightly-forge');
+      expect(json().status).toBe(200);
+    });
+
+    it('returns 404 for unknown id', async () => {
+      const { res, json } = makeRes();
+      await handleDeleteSchedule(res, 'nonexistent');
+      expect(json().status).toBe(404);
+    });
+  });
+
+  describe('handleToggleSchedule', () => {
+    it('toggles an existing schedule', async () => {
+      const { res, json } = makeRes();
+      await handleToggleSchedule(res, 'nightly-forge');
+      const { status, body } = json();
+      expect(status).toBe(200);
+      // Was enabled, now disabled
+      expect((body as { enabled: boolean }).enabled).toBe(false);
+    });
+
+    it('returns 404 for unknown id', async () => {
+      const { res, json } = makeRes();
+      await handleToggleSchedule(res, 'nonexistent');
+      expect(json().status).toBe(404);
+    });
+  });
+
+  describe('handleScheduleHistory', () => {
+    it('returns empty history when telemetry file missing', async () => {
+      const { res, json } = makeRes();
+      await handleScheduleHistory(res, 'nightly-forge');
+      const { status, body } = json();
+      expect(status).toBe(200);
+      expect((body as { history: unknown[] }).history).toEqual([]);
+    });
+  });
+
+  describe('handleDaemonStatus', () => {
+    it('returns running: false when port file missing', async () => {
+      const { res, json } = makeRes();
+      await handleDaemonStatus(res);
+      const { status, body } = json();
+      expect(status).toBe(200);
+      expect((body as { running: boolean }).running).toBe(false);
+    });
+  });
+});

--- a/src/web-server/routes.schedules.ts
+++ b/src/web-server/routes.schedules.ts
@@ -1,0 +1,305 @@
+/**
+ * Schedule CRUD routes for the `afk web` surface.
+ *
+ * Contract: these handlers are dispatched from `server.ts` after bearer-token
+ * and Origin checks have already passed. They read/write `schedules.json` via
+ * the same store functions the CLI and agent tools use, and attempt live-sync
+ * to a running daemon via `http-client.ts`. The file store is the source of
+ * truth; a failed sync is surfaced, never thrown.
+ */
+
+import type { ServerResponse } from 'node:http';
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import {
+  addSchedule,
+  getSchedule,
+  loadSchedules,
+  removeSchedule,
+  saveSchedules,
+  toScheduledTask,
+  type ScheduledTaskConfig,
+} from '../agent/daemon/schedule-store.js';
+import { trySyncToDaemon, SYNC_FAILED_NOTE } from '../agent/daemon/http-client.js';
+import { getTelemetryPath } from '../paths.js';
+import { sendJson } from './routes.js';
+
+// ---- helpers ---------------------------------------------------------------
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null;
+}
+
+function str(body: unknown, field: string): string | undefined {
+  if (!isRecord(body)) return undefined;
+  const v = body[field];
+  return typeof v === 'string' ? v : undefined;
+}
+
+function bool(body: unknown, field: string): boolean | undefined {
+  if (!isRecord(body)) return undefined;
+  const v = body[field];
+  return typeof v === 'boolean' ? v : undefined;
+}
+
+/** Minimal cron expression validation: 5 or 6 space-separated fields. */
+function isValidCron(expr: string): boolean {
+  const parts = expr.trim().split(/\s+/);
+  return parts.length >= 5 && parts.length <= 6;
+}
+
+// ---- route handlers --------------------------------------------------------
+
+/** `GET /api/schedules` — list all scheduled tasks. */
+export async function handleListSchedules(res: ServerResponse): Promise<void> {
+  const schedules = loadSchedules();
+  sendJson(res, 200, { schedules });
+}
+
+/** `POST /api/schedules` — create a new scheduled task. */
+export async function handleCreateSchedule(
+  res: ServerResponse,
+  body: unknown,
+): Promise<void> {
+  const name = str(body, 'name');
+  const command = str(body, 'command');
+  const cron = str(body, 'cron');
+  if (!name || !command || !cron) {
+    sendJson(res, 400, {
+      error: 'bad_request',
+      message: 'body must include name (string), command (string), and cron (string)',
+    });
+    return;
+  }
+  if (!isValidCron(cron)) {
+    sendJson(res, 400, {
+      error: 'bad_request',
+      message: 'cron must be a valid 5- or 6-field cron expression',
+    });
+    return;
+  }
+
+  const trigger = str(body, 'trigger') as ScheduledTaskConfig['trigger'] | undefined;
+  const notifyOn = str(body, 'notifyOn') as ScheduledTaskConfig['notifyOn'] | undefined;
+  const enabled = bool(body, 'enabled') ?? true;
+
+  const config = addSchedule({ name, command, cron, trigger, notifyOn, enabled });
+
+  let daemonSynced = false;
+  let syncDetail = '';
+  if (config.enabled) {
+    const sync = await trySyncToDaemon('POST', '/tasks', toScheduledTask(config));
+    daemonSynced = sync.synced;
+    syncDetail = sync.detail;
+  }
+
+  sendJson(res, 201, {
+    schedule: config,
+    daemonSynced,
+    syncDetail,
+    ...(daemonSynced ? {} : { syncNote: SYNC_FAILED_NOTE }),
+  });
+}
+
+/** `PATCH /api/schedules/:id` — update fields on an existing task. */
+export async function handleUpdateSchedule(
+  res: ServerResponse,
+  id: string,
+  body: unknown,
+): Promise<void> {
+  const schedules = loadSchedules();
+  const idx = schedules.findIndex((s) => s.id === id);
+  if (idx === -1) {
+    sendJson(res, 404, { error: 'not_found', message: `schedule ${id} not found` });
+    return;
+  }
+
+  const existing = schedules[idx] as ScheduledTaskConfig;
+  const name = str(body, 'name');
+  const command = str(body, 'command');
+  const cron = str(body, 'cron');
+  const trigger = str(body, 'trigger') as ScheduledTaskConfig['trigger'] | undefined;
+  const notifyOn = str(body, 'notifyOn') as ScheduledTaskConfig['notifyOn'] | undefined;
+  const enabled = bool(body, 'enabled');
+
+  if (cron !== undefined && !isValidCron(cron)) {
+    sendJson(res, 400, {
+      error: 'bad_request',
+      message: 'cron must be a valid 5- or 6-field cron expression',
+    });
+    return;
+  }
+
+  const updated: ScheduledTaskConfig = {
+    ...existing,
+    ...(name !== undefined ? { name } : {}),
+    ...(command !== undefined ? { command } : {}),
+    ...(cron !== undefined ? { cron } : {}),
+    ...(trigger !== undefined ? { trigger } : {}),
+    ...(notifyOn !== undefined ? { notifyOn } : {}),
+    ...(enabled !== undefined ? { enabled } : {}),
+    updatedAt: new Date().toISOString(),
+  };
+
+  schedules[idx] = updated;
+  saveSchedules(schedules);
+
+  // Sync: if enabled, re-register; if disabled, unregister.
+  let daemonSynced = false;
+  let syncDetail = '';
+  if (updated.enabled) {
+    // Delete first to clear stale registration, then re-register.
+    await trySyncToDaemon('DELETE', `/tasks/${id}`);
+    const sync = await trySyncToDaemon('POST', '/tasks', toScheduledTask(updated));
+    daemonSynced = sync.synced;
+    syncDetail = sync.detail;
+  } else {
+    const sync = await trySyncToDaemon('DELETE', `/tasks/${id}`);
+    daemonSynced = sync.synced;
+    syncDetail = sync.detail;
+  }
+
+  sendJson(res, 200, {
+    schedule: updated,
+    daemonSynced,
+    syncDetail,
+    ...(daemonSynced ? {} : { syncNote: SYNC_FAILED_NOTE }),
+  });
+}
+
+/** `DELETE /api/schedules/:id` — permanently remove a scheduled task. */
+export async function handleDeleteSchedule(
+  res: ServerResponse,
+  id: string,
+): Promise<void> {
+  const removed = removeSchedule(id);
+  if (!removed) {
+    sendJson(res, 404, { error: 'not_found', message: `schedule ${id} not found` });
+    return;
+  }
+
+  const sync = await trySyncToDaemon('DELETE', `/tasks/${id}`);
+  sendJson(res, 200, {
+    ok: true,
+    daemonSynced: sync.synced,
+    syncDetail: sync.detail,
+    ...(sync.synced ? {} : { syncNote: SYNC_FAILED_NOTE }),
+  });
+}
+
+/** `POST /api/schedules/:id/toggle` — quick enable/disable. */
+export async function handleToggleSchedule(
+  res: ServerResponse,
+  id: string,
+): Promise<void> {
+  const existing = getSchedule(id);
+  if (!existing) {
+    sendJson(res, 404, { error: 'not_found', message: `schedule ${id} not found` });
+    return;
+  }
+
+  const newEnabled = !existing.enabled;
+  const schedules = loadSchedules();
+  const updated = schedules.map((s) =>
+    s.id === id ? { ...s, enabled: newEnabled, updatedAt: new Date().toISOString() } : s,
+  );
+  saveSchedules(updated);
+
+  let sync;
+  if (newEnabled) {
+    sync = await trySyncToDaemon(
+      'POST',
+      '/tasks',
+      toScheduledTask({ ...existing, enabled: true }),
+    );
+  } else {
+    sync = await trySyncToDaemon('DELETE', `/tasks/${id}`);
+  }
+
+  sendJson(res, 200, {
+    ok: true,
+    enabled: newEnabled,
+    daemonSynced: sync.synced,
+    syncDetail: sync.detail,
+    ...(sync.synced ? {} : { syncNote: SYNC_FAILED_NOTE }),
+  });
+}
+
+/** `GET /api/schedules/:id/history` — recent execution history. */
+export async function handleScheduleHistory(
+  res: ServerResponse,
+  id: string,
+): Promise<void> {
+  const telemetryPath = getTelemetryPath();
+  if (!existsSync(telemetryPath)) {
+    sendJson(res, 200, { history: [] });
+    return;
+  }
+
+  let content: string;
+  try {
+    const buf = await readFile(telemetryPath);
+    const tailBuf = buf.length > 1_048_576 ? buf.subarray(buf.length - 1_048_576) : buf;
+    content = tailBuf.toString('utf-8');
+  } catch {
+    sendJson(res, 200, { history: [] });
+    return;
+  }
+
+  const lines = content.split('\n');
+  const matching: unknown[] = [];
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const line = lines[i];
+    if (!line) continue;
+    try {
+      const record = JSON.parse(line) as { taskId?: string };
+      if (record.taskId !== id) continue;
+      matching.push(record);
+      if (matching.length >= 20) break;
+    } catch {
+      continue;
+    }
+  }
+
+  sendJson(res, 200, { history: matching.reverse() });
+}
+
+/** `GET /api/daemon/status` — probe whether the daemon is reachable. */
+export async function handleDaemonStatus(res: ServerResponse): Promise<void> {
+  // Reuse the same port-file + HTTP discovery the sync client uses, but
+  // target /health instead of /tasks.
+  try {
+    // Inline the port-file logic from http-client — it does not export a
+    // "probe health" helper, so we call /health ourselves.
+    const { existsSync: exists, readFileSync: readFs } = await import('node:fs');
+    const { join } = await import('node:path');
+    const { getDaemonStateDir } = await import('../paths.js');
+    const { parsePortFile } = await import('../agent/daemon/http-client.js');
+
+    const portFile = join(getDaemonStateDir('default'), 'port');
+    if (!exists(portFile)) {
+      sendJson(res, 200, { running: false, detail: 'no port file' });
+      return;
+    }
+
+    const raw = readFs(portFile, 'utf-8').trim();
+    const parsed = parsePortFile(raw);
+    if (!parsed) {
+      sendJson(res, 200, { running: false, detail: 'invalid port file' });
+      return;
+    }
+
+    const hostInUrl = parsed.host.includes(':') ? `[${parsed.host}]` : parsed.host;
+    const response = await fetch(`http://${hostInUrl}:${parsed.port}/health`, {
+      signal: AbortSignal.timeout(2000),
+    });
+    if (response.ok) {
+      const data = (await response.json()) as { status?: string; tasks?: number };
+      sendJson(res, 200, { running: true, tasks: data.tasks ?? 0 });
+    } else {
+      sendJson(res, 200, { running: false, detail: `HTTP ${response.status}` });
+    }
+  } catch {
+    sendJson(res, 200, { running: false, detail: 'unreachable' });
+  }
+}

--- a/src/web-server/routes.schedules.ts
+++ b/src/web-server/routes.schedules.ts
@@ -20,9 +20,14 @@ import {
   toScheduledTask,
   type ScheduledTaskConfig,
 } from '../agent/daemon/schedule-store.js';
-import { trySyncToDaemon, SYNC_FAILED_NOTE } from '../agent/daemon/http-client.js';
-import { getTelemetryPath } from '../paths.js';
+import { trySyncToDaemon, SYNC_FAILED_NOTE, parsePortFile } from '../agent/daemon/http-client.js';
+import { getTelemetryPath, getDaemonStateDir } from '../paths.js';
 import { sendJson } from './routes.js';
+import { join } from 'node:path';
+
+const VALID_TRIGGERS = new Set(['cron', 'sessionstart', 'both']);
+const VALID_NOTIFY_ON = new Set(['failure', 'always', 'never']);
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', 'localhost', '::1']);
 
 // ---- helpers ---------------------------------------------------------------
 
@@ -79,11 +84,32 @@ export async function handleCreateSchedule(
     return;
   }
 
-  const trigger = str(body, 'trigger') as ScheduledTaskConfig['trigger'] | undefined;
-  const notifyOn = str(body, 'notifyOn') as ScheduledTaskConfig['notifyOn'] | undefined;
+  const trigger = str(body, 'trigger');
+  const notifyOn = str(body, 'notifyOn');
+  if (trigger !== undefined && !VALID_TRIGGERS.has(trigger)) {
+    sendJson(res, 400, {
+      error: 'bad_request',
+      message: `trigger must be one of: ${[...VALID_TRIGGERS].join(', ')}`,
+    });
+    return;
+  }
+  if (notifyOn !== undefined && !VALID_NOTIFY_ON.has(notifyOn)) {
+    sendJson(res, 400, {
+      error: 'bad_request',
+      message: `notifyOn must be one of: ${[...VALID_NOTIFY_ON].join(', ')}`,
+    });
+    return;
+  }
   const enabled = bool(body, 'enabled') ?? true;
 
-  const config = addSchedule({ name, command, cron, trigger, notifyOn, enabled });
+  const config = addSchedule({
+    name,
+    command,
+    cron,
+    trigger: trigger as ScheduledTaskConfig['trigger'],
+    notifyOn: notifyOn as ScheduledTaskConfig['notifyOn'],
+    enabled,
+  });
 
   let daemonSynced = false;
   let syncDetail = '';
@@ -118,9 +144,24 @@ export async function handleUpdateSchedule(
   const name = str(body, 'name');
   const command = str(body, 'command');
   const cron = str(body, 'cron');
-  const trigger = str(body, 'trigger') as ScheduledTaskConfig['trigger'] | undefined;
-  const notifyOn = str(body, 'notifyOn') as ScheduledTaskConfig['notifyOn'] | undefined;
+  const trigger = str(body, 'trigger');
+  const notifyOn = str(body, 'notifyOn');
   const enabled = bool(body, 'enabled');
+
+  if (trigger !== undefined && !VALID_TRIGGERS.has(trigger)) {
+    sendJson(res, 400, {
+      error: 'bad_request',
+      message: `trigger must be one of: ${[...VALID_TRIGGERS].join(', ')}`,
+    });
+    return;
+  }
+  if (notifyOn !== undefined && !VALID_NOTIFY_ON.has(notifyOn)) {
+    sendJson(res, 400, {
+      error: 'bad_request',
+      message: `notifyOn must be one of: ${[...VALID_NOTIFY_ON].join(', ')}`,
+    });
+    return;
+  }
 
   if (cron !== undefined && !isValidCron(cron)) {
     sendJson(res, 400, {
@@ -135,8 +176,8 @@ export async function handleUpdateSchedule(
     ...(name !== undefined ? { name } : {}),
     ...(command !== undefined ? { command } : {}),
     ...(cron !== undefined ? { cron } : {}),
-    ...(trigger !== undefined ? { trigger } : {}),
-    ...(notifyOn !== undefined ? { notifyOn } : {}),
+    ...(trigger !== undefined ? { trigger: trigger as ScheduledTaskConfig['trigger'] } : {}),
+    ...(notifyOn !== undefined ? { notifyOn: notifyOn as ScheduledTaskConfig['notifyOn'] } : {}),
     ...(enabled !== undefined ? { enabled } : {}),
     updatedAt: new Date().toISOString(),
   };
@@ -269,23 +310,22 @@ export async function handleDaemonStatus(res: ServerResponse): Promise<void> {
   // Reuse the same port-file + HTTP discovery the sync client uses, but
   // target /health instead of /tasks.
   try {
-    // Inline the port-file logic from http-client — it does not export a
-    // "probe health" helper, so we call /health ourselves.
-    const { existsSync: exists, readFileSync: readFs } = await import('node:fs');
-    const { join } = await import('node:path');
-    const { getDaemonStateDir } = await import('../paths.js');
-    const { parsePortFile } = await import('../agent/daemon/http-client.js');
-
     const portFile = join(getDaemonStateDir('default'), 'port');
-    if (!exists(portFile)) {
+    if (!existsSync(portFile)) {
       sendJson(res, 200, { running: false, detail: 'no port file' });
       return;
     }
 
-    const raw = readFs(portFile, 'utf-8').trim();
+    const raw = (await readFile(portFile, 'utf-8')).trim();
     const parsed = parsePortFile(raw);
     if (!parsed) {
       sendJson(res, 200, { running: false, detail: 'invalid port file' });
+      return;
+    }
+
+    // SSRF guard: only connect to loopback addresses.
+    if (!LOOPBACK_HOSTS.has(parsed.host.toLowerCase())) {
+      sendJson(res, 200, { running: false, detail: 'non-loopback host in port file rejected' });
       return;
     }
 

--- a/src/web-server/server.ts
+++ b/src/web-server/server.ts
@@ -28,6 +28,15 @@ import {
   type RouteContext,
 } from './routes.js';
 import { handleStream } from './stream-route.js';
+import {
+  handleCreateSchedule,
+  handleDaemonStatus,
+  handleDeleteSchedule,
+  handleListSchedules,
+  handleScheduleHistory,
+  handleToggleSchedule,
+  handleUpdateSchedule,
+} from './routes.schedules.js';
 
 export const DEFAULT_WEB_PORT = 4141;
 export const DEFAULT_WEB_HOST = '127.0.0.1';
@@ -318,6 +327,39 @@ async function dispatch(
 
   if (path === '/api/commands' && method === 'GET') {
     await handleCommands(res);
+    return;
+  }
+
+  // ---- schedule management routes ------------------------------------------
+  if (path === '/api/schedules' && method === 'GET') {
+    await handleListSchedules(res);
+    return;
+  }
+  if (path === '/api/schedules' && method === 'POST') {
+    await handleCreateSchedule(res, await readBody(req));
+    return;
+  }
+  const scheduleIdMatch = /^\/api\/schedules\/([^/]+)$/.exec(path);
+  if (scheduleIdMatch?.[1] && method === 'PATCH') {
+    await handleUpdateSchedule(res, decodeURIComponent(scheduleIdMatch[1]), await readBody(req));
+    return;
+  }
+  if (scheduleIdMatch?.[1] && method === 'DELETE') {
+    await handleDeleteSchedule(res, decodeURIComponent(scheduleIdMatch[1]));
+    return;
+  }
+  const toggleMatch = /^\/api\/schedules\/([^/]+)\/toggle$/.exec(path);
+  if (toggleMatch?.[1] && method === 'POST') {
+    await handleToggleSchedule(res, decodeURIComponent(toggleMatch[1]));
+    return;
+  }
+  const historyMatch = /^\/api\/schedules\/([^/]+)\/history$/.exec(path);
+  if (historyMatch?.[1] && method === 'GET') {
+    await handleScheduleHistory(res, decodeURIComponent(historyMatch[1]));
+    return;
+  }
+  if (path === '/api/daemon/status' && method === 'GET') {
+    await handleDaemonStatus(res);
     return;
   }
 


### PR DESCRIPTION
## Summary

Adds a full schedule management UI to `afk web`, letting users CRUD daemon cron jobs through a friendly browser interface instead of the CLI or agent tools.

## What it looks like

- **Sidebar nav tabs** switch between Sessions and Schedules views
- **Schedule cards** show name, human-readable cron description + raw expression, command, trigger mode, and a toggle switch for enable/disable
- **Create/edit modal** with cron preset picker (every hour, daily at 2am, weekly, custom), trigger mode, and notification settings
- **Execution history overlay** per task with status dots, timestamps, duration, and error messages
- **Daemon status badge** showing whether the daemon is reachable and how many tasks are registered
- **Empty state** with guidance when no schedules exist

## Architecture

The web frontend calls `/api/schedules/*` routes on the `afk web` server (port 4141), which proxies to the same `schedule-store.ts` functions and `http-client.ts` daemon sync that the CLI and agent tools use. No changes to the daemon itself.

```
Browser  -->  afk web (4141)  -->  schedules.json (source of truth)
                                   |
                                   +--> daemon (7777) live-sync (best-effort)
```

### New API endpoints

| Method | Path | Purpose |
|--------|------|---------|
| `GET` | `/api/schedules` | List all tasks |
| `POST` | `/api/schedules` | Create a task |
| `PATCH` | `/api/schedules/:id` | Update task fields |
| `DELETE` | `/api/schedules/:id` | Remove a task |
| `POST` | `/api/schedules/:id/toggle` | Quick enable/disable |
| `GET` | `/api/schedules/:id/history` | Execution history (last 20 runs) |
| `GET` | `/api/daemon/status` | Daemon health probe |

### New files

| File | Purpose |
|------|---------|
| `src/web-server/routes.schedules.ts` | Backend route handlers |
| `src/web-server/routes.schedules.test.ts` | 12 tests covering all handlers |
| `src/web-server/frontend/schedules-view.ts` | Schedule list with cards and toggle switches |
| `src/web-server/frontend/schedule-form.ts` | Create/edit modal with cron presets |
| `src/web-server/frontend/schedule-history.ts` | Execution history overlay |
| `src/web-server/frontend/schedules.css` | Dark-theme styles |

### Modified files

- `src/web-server/server.ts` -- import + dispatch for schedule routes
- `src/web-server/frontend/app.ts` -- view switching logic
- `src/web-server/frontend/index.html` -- nav tabs, schedule container, CSS link
- `scripts/build-web-ui.mjs` -- copy `schedules.css` to output

## Testing

- 12 new route handler tests (create, update, delete, toggle, list, history, daemon status)
- All 376 existing web-server tests pass
- All CI gates green: lint, build, filesize, env, chalk, sdk, module-state, pins
