### PR TITLE
test(workspace): cover setSubscribeHandler injection path (#1563)

### DIFF
--- a/src/agent/subagent/workspace-subscription-wiring.test.ts
+++ b/src/agent/subagent/workspace-subscription-wiring.test.ts
@@ -126,6 +126,31 @@ describe('wireWorkspaceSubscriptions', () => {
     expect(firstSeqInBuffer).toBe(3); // entries 1 and 2 were evicted
   });
 
+  // provider injection path: setSubscribeHandler is called when a provider is passed
+  it('calls provider.setSubscribeHandler with the subscribeHandler when a provider is given', () => {
+    const store = new WorkspaceStore();
+    let injectedHandler: unknown;
+    const provider = {
+      setSubscribeHandler: (h: unknown) => {
+        injectedHandler = h;
+      },
+    };
+
+    const { subscribeHandler } = wireWorkspaceSubscriptions(store, 'agent-x', undefined, provider);
+
+    // The injected handler must be the exact same function reference
+    expect(injectedHandler).toBe(subscribeHandler);
+  });
+
+  // provider without setSubscribeHandler: no crash, no injection
+  it('does not throw when provider has no setSubscribeHandler', () => {
+    const store = new WorkspaceStore();
+    const provider = {};
+    expect(() =>
+      wireWorkspaceSubscriptions(store, 'agent-x', undefined, provider),
+    ).not.toThrow();
+  });
+
   // (c) drain resets _workspaceDroppedSinceDrain counter
   it('draining _pendingWorkspaceEntries resets the dropped counter', async () => {
     const store = new WorkspaceStore();


### PR DESCRIPTION
## Summary

Add test coverage for the `setSubscribeHandler` injection path in workspace subscription wiring.

## Problem

`wireWorkspaceSubscriptions()` accepts an optional `provider` arg and calls `provider.setSubscribeHandler(subscribeHandler)`, but no test exercised this injection path — production behavior was verified only by type-level compatibility.

## Tests added

1. **Provider with setSubscribeHandler**: Verifies the handler is called with the exact `subscribeHandler` function reference when a provider is passed.
2. **Provider without setSubscribeHandler**: Verifies the optional-chaining guard handles a provider missing the method without crashing.

All 7 tests pass (5 pre-existing + 2 new); lint clean.

Closes #1563
