### PR TITLE
chore: review follow-ups from #1554 and #1555 — tests and comments (#1566)

### DIFF
--- a/src/agent/providers/shared/tool-call-trace.test.ts
+++ b/src/agent/providers/shared/tool-call-trace.test.ts
@@ -227,6 +227,17 @@ describe('buildToolCallStartedPayload', () => {
     expect('resourceFingerprint' in agent).toBe(false);
   });
 
+  it('does not include resourceFingerprint for glob tool calls', () => {
+    // glob is a filesystem tool but has no single named resource that maps
+    // cleanly to a dedup key (pattern + base dir combo is not equivalent to
+    // a file identity), so resourceFingerprint must be absent.
+    const payload = buildToolCallStartedPayload({
+      toolUseId: 'gl_1', name: 'glob',
+      input: { pattern: 'src/**/*.ts', path: '/src' },
+    });
+    expect('resourceFingerprint' in payload).toBe(false);
+  });
+
   it('normalizes trailing slashes and consecutive slashes in read_file paths', () => {
     const clean = buildToolCallStartedPayload({
       toolUseId: 'norm_a', name: 'read_file',

--- a/src/agent/providers/shared/tool-call-trace.ts
+++ b/src/agent/providers/shared/tool-call-trace.ts
@@ -111,7 +111,16 @@ function redactSensitiveFields(toolName: string, input: unknown): unknown {
  * file path, ignoring offset/limit/pattern so that two reads of the same file
  * at different offsets share a fingerprint.
  *
- * Privacy: the returned value is a SHA-256 hex hash, never a raw path.
+ * Security note: the hash is plain SHA-256 with no salt and no HMAC. This is
+ * intentional. `redactSensitiveFields` is NOT called here — file paths are not
+ * secrets, and the witness trace these values land in is a local-only file
+ * under `~/.afk/state/witness/`. Note: the trace writer uses default umask
+ * (typically 0644 files / 0755 dirs), so on a multi-user host these hashes
+ * are world-readable. This is acceptable because the fingerprints are
+ * truncated SHA-256 digests of project-local paths — low value to other
+ * local users. If resource fingerprints are ever transmitted to an external
+ * service, or if paths may contain sensitive identifiers, add HMAC-SHA256
+ * keyed on a session secret so brute-force path recovery is infeasible.
  */
 function computeResourceFingerprint(
   toolName: string,

--- a/tests/workspace-ab-analyze.test.ts
+++ b/tests/workspace-ab-analyze.test.ts
@@ -178,7 +178,10 @@ describe('validate', () => {
     const noAgents = analyze({ ...baseArgs, calls: [] });
     const result = validate(noAgents);
     expect(result.valid).toBe(false);
-    expect(result.failures.some(f => f.rule === 'no-subagents')).toBe(true);
+    const noSubagentFailures = result.failures.filter(f => f.rule === 'no-subagents');
+    expect(noSubagentFailures.some(f => f.rule === 'no-subagents')).toBe(true);
+    // Guard against double-emission: exactly one failure for this rule.
+    expect(noSubagentFailures).toHaveLength(1);
   });
 
   it('fails when fewer than 2 agents performed reads', () => {


### PR DESCRIPTION
## Summary

Address three concrete review follow-ups from PRs #1554 and #1555.

## Changes

1. **Test: validate failure count** (`workspace-ab-analyze.test.ts`) — The `'fails when no subagents ran'` test now asserts `.toHaveLength(1)` on the filtered failures array, catching double-emission regressions.

2. **Test: glob fingerprint** (`tool-call-trace.test.ts`) — New test verifies a `glob` tool call produces no `resourceFingerprint` in the payload, guarding the documented exclusion.

3. **Security comments** (`tool-call-trace.ts`) — Expanded JSDoc on `computeResourceFingerprint` documenting: no salt/HMAC, `redactSensitiveFields` deliberately bypassed, and why both are correct (local traces, file paths not secrets). Notes what must change if fingerprints are ever transmitted externally.

All 51 tests pass; lint clean.

Partially addresses #1566
