### PR TITLE
chore(workspace): scope workspace_subscribe to child allowlists only (#1562)

### DIFF
--- a/src/agent/tools/nesting.ts
+++ b/src/agent/tools/nesting.ts
@@ -17,6 +17,7 @@ import type { ReadScopeInputs } from '../subagent-read-scope.js';
 import { AnthropicDirectProvider } from '../providers/anthropic-direct/index.js';
 import { OpenAICompatibleProvider } from '../providers/openai-compatible/index.js';
 import type { WorkspaceStore } from '../workspace/workspace-store.js';
+import { WORKSPACE_CHILD_TOOL_NAMES } from '../workspace/index.js';
 import { providerForModel } from '../providers/index.js';
 import { BUILTIN_TOOL_NAMES } from './schemas.js';
 import { AWARENESS_TOOL_NAMES } from '../awareness/index.js';
@@ -143,7 +144,7 @@ export function createStubParentSession(
 // sub-agent writes. If specific skills need memory write access, do it per-skill via a
 // buildPhaseRestrictedProvider-style opt-in builder (see nesting.ts around line 207), not by
 // extending this global default.
-export const CHILD_ALLOWED_TOOLS = [...BUILTIN_TOOL_NAMES, ...AWARENESS_TOOL_NAMES, 'memory_search', 'workspace_publish', 'workspace_query', 'workspace_subscribe', 'agent', 'skill', 'state_get', 'state_query'];
+export const CHILD_ALLOWED_TOOLS = [...BUILTIN_TOOL_NAMES, ...AWARENESS_TOOL_NAMES, 'memory_search', ...WORKSPACE_CHILD_TOOL_NAMES, 'agent', 'skill', 'state_get', 'state_query'];
 
 // Recon allowlist for a READ-ONLY skill's forked child. This is the tool half
 // of read-only-skill enforcement (the bash half is the dispatcher's

--- a/src/agent/tools/top-level-allowlist.test.ts
+++ b/src/agent/tools/top-level-allowlist.test.ts
@@ -18,7 +18,7 @@ import { BUILTIN_TOOL_NAMES } from './schemas.js';
 import { MEMORY_TOOL_NAMES } from '../memory/index.js';
 import { AWARENESS_TOOL_NAMES } from '../awareness/index.js';
 import { EXIT_PLAN_MODE_TOOL_NAME } from './handlers/exit-plan-mode.js';
-import { WORKSPACE_TOOL_NAMES } from '../workspace/index.js';
+import { WORKSPACE_TOOL_NAMES, WORKSPACE_CHILD_TOOL_NAMES } from '../workspace/index.js';
 import { STATE_TOOL_NAMES } from '../state/state-tools.js';
 
 describe('topLevelSurfaceAllowedTools', () => {
@@ -35,6 +35,14 @@ describe('topLevelSurfaceAllowedTools', () => {
     for (const name of WORKSPACE_TOOL_NAMES) expect(list).toContain(name);
     for (const name of STATE_TOOL_NAMES) expect(list).toContain(name);
     expect(list).toContain('get_runtime_state');
+  });
+
+  it('does not include workspace_subscribe (only wired in child/nesting allowlists, #1562)', () => {
+    const list = topLevelSurfaceAllowedTools();
+    expect(list).not.toContain('workspace_subscribe');
+    // Verify the split: WORKSPACE_CHILD_TOOL_NAMES contains subscribe, base does not.
+    expect(WORKSPACE_TOOL_NAMES).not.toContain('workspace_subscribe');
+    expect(WORKSPACE_CHILD_TOOL_NAMES).toContain('workspace_subscribe');
   });
 
   it('includes the full executor set (agent, skill, compose) these surfaces always wire', () => {

--- a/src/agent/workspace/index.ts
+++ b/src/agent/workspace/index.ts
@@ -23,6 +23,7 @@ export {
   workspaceToolSchemas,
   createWorkspaceHandlers,
   WORKSPACE_TOOL_NAMES,
+  WORKSPACE_CHILD_TOOL_NAMES,
 } from './workspace-tools.js';
 
 export {

--- a/src/agent/workspace/workspace-tools.ts
+++ b/src/agent/workspace/workspace-tools.ts
@@ -17,8 +17,30 @@ import type { AnthropicToolDef, ToolHandler } from '../tools/types.js';
 import type { WorkspaceEntry, WorkspacePublishInput, WorkspaceRelationType } from './workspace-store.js';
 import { WorkspaceStore } from './workspace-store.js';
 
-/** Tool names that must be permitted whenever a provider wires a workspace store. */
-export const WORKSPACE_TOOL_NAMES = ['workspace_publish', 'workspace_query', 'workspace_subscribe'] as const;
+/**
+ * Tool names wired on every surface that registers a workspace store.
+ *
+ * Invariant: `workspace_subscribe` is intentionally excluded from this base
+ * array. The subscribe handler is gated on `opts.subscribeHandler` at provider
+ * construction (see anthropic-direct/index.ts), so it is only registered on
+ * child / nesting surfaces where a subscribe handler is actually wired. Top-
+ * level surfaces (REPL, one-shot chat, Telegram, daemon) never pass that option
+ * and therefore have no handler — including the name here was dead weight that
+ * misleadingly implied the tool was available at those surfaces (#1562).
+ *
+ * Use `WORKSPACE_CHILD_TOOL_NAMES` where `workspace_subscribe` IS wired (child
+ * provider allowlists — see `CHILD_ALLOWED_TOOLS` in nesting.ts).
+ */
+export const WORKSPACE_TOOL_NAMES = ['workspace_publish', 'workspace_query'] as const;
+
+/**
+ * Workspace tool names for child / nesting provider allowlists where
+ * `workspace_subscribe` is actually wired via `subscribeHandler`.
+ *
+ * Callers: `CHILD_ALLOWED_TOOLS` (nesting.ts). Do NOT spread into top-level
+ * surface allowlists — those surfaces never wire a subscribeHandler.
+ */
+export const WORKSPACE_CHILD_TOOL_NAMES = ['workspace_publish', 'workspace_query', 'workspace_subscribe'] as const;
 
 /**
  * workspace_publish: Publish a structured finding to the shared session workspace.


### PR DESCRIPTION
## Summary

Scope `workspace_subscribe` to child allowlists only, removing it from top-level surfaces where it has no schema or handler.

## Problem

`workspace_subscribe` was in `WORKSPACE_TOOL_NAMES` and spread into top-level, daemon, and provider-parser allowlists. On those surfaces, no schema or handler is registered (gated on `opts.subscribeHandler`), making the name inert dead weight — the model never sees the tool and no handler fires.

## Fix

Split the constant:
- `WORKSPACE_TOOL_NAMES` = `['workspace_publish', 'workspace_query']` (for top-level consumers)
- `WORKSPACE_CHILD_TOOL_NAMES` = all three including `workspace_subscribe` (for child/nesting allowlists where it's actually wired)

Updated `nesting.ts` to use `WORKSPACE_CHILD_TOOL_NAMES` instead of inline string literals. Top-level consumers (`top-level-allowlist.ts`, `provider-parser.ts`, `daemon.ts`) naturally shed `workspace_subscribe` with no changes needed.

Added a regression test asserting `workspace_subscribe` is absent from the top-level allowlist.

All tests pass; lint clean.

Closes #1562
