### PR TITLE
fix(web,telegram): wire executors, MCP, and trace for web and Telegram OpenAI/xAI surfaces

### DIFF
--- a/src/telegram/session-anthropic.ts
+++ b/src/telegram/session-anthropic.ts
@@ -3,24 +3,18 @@
  *
  * Extracted verbatim from `src/telegram.ts`'s `createSession` closure. The
  * behaviour-preserving asymmetries called out inline (which executors receive
- * `cwd`, which receive the trace writer) are load-bearing — see each comment.
+ * `cwd`, which receive the trace writer) are load-bearing -- see each comment.
  */
 
-import { AgentSession } from '../agent/session.js';
 import { AnthropicDirectProvider } from '../agent/providers/index.js';
 import { seedPersistedGrants } from '../agent/permissions-store.js';
 import { assembleSystemPrompt } from '../agent/routing-directive.js';
 import { topLevelSurfaceAllowedTools } from '../agent/tools/top-level-allowlist.js';
-import { wireExecutors } from '../agent/session/wire-executors.js';
-import {
-  getDefaultSubagentModel,
-  getApiKeyForModel,
-} from '../cli/shared-helpers.js';
-import { BackgroundAgentRegistry } from '../agent/background-registry.js';
 import { createTelegramAfkHookBundle } from './afk-hook-bundle.js';
-import { TelegramBgResultNotifier } from './bg-result-notifier.js';
 import { constructTelegramSession } from './construct-session.js';
 import { attachMcpCleanup } from './mcp-session.js';
+import { wireTelegramExecutors } from './wire-telegram-executors.js';
+import type { AgentSession } from '../agent/session.js';
 import type { TelegramSessionBuildContext } from './session-context.js';
 
 export async function buildAnthropicTelegramSession(
@@ -42,65 +36,32 @@ export async function buildAnthropicTelegramSession(
     reportSession,
   } = ctx;
 
-  let boundSession: AgentSession | undefined;
   const telegramApiKey = sessionConfig.apiKey ?? config.apiKey ?? '';
   const telegramBaseUrl = config.baseUrl;
   // OpenAI-compatible endpoint (distinct from telegramBaseUrl, which is
-  // Anthropic-only) — threaded for parity with chat.ts's cliConfig.openaiBaseUrl wiring.
+  // Anthropic-only) -- threaded for parity with chat.ts's cliConfig.openaiBaseUrl wiring.
   const telegramOpenaiBaseUrl = sessionConfig.openaiBaseUrl ?? config.openaiBaseUrl;
-  // The session is constructed after the executors, so the parent view
-  // they fork from reads through `boundSession` lazily.
-  const deferredParent = {
-    get sessionId() { return boundSession?.sessionId; },
-    getInputStreamRef() { return boundSession?.getInputStreamRef?.() ?? { pushUserMessage: () => {} }; },
-    get abortSignal() { return boundSession?.abortSignal ?? new AbortController().signal; },
-    // Live registry so forked subagents resolve it via forkSubagent's
-    // parent fallback (SubagentStart/Stop + shadow-verify nudge).
-    get hookRegistry() { return boundSession?.hookRegistry; },
-  };
 
-  // Background agent registry — enables `agent` tool with mode="background"
-  // on Telegram. Mirrors the REPL's bootstrap-infra.ts wiring. Per-session
-  // lifetime: cancelAll is called via drainSubagents on session close.
-  const backgroundRegistry = new BackgroundAgentRegistry(
-    traceWriter ? { traceWriter } : {},
-  );
-  const bgNotifier = new TelegramBgResultNotifier(backgroundRegistry, chatId, threadId);
-
-  // Invariant: ONE root manager per session, shared by all three
-  // executors. Inherit configured-or-host cwd so forked subagents stay
-  // in the same working tree as the parent session — important when the
-  // bot is pointed at a worktree via AFK_TELEGRAM_CWD.
-  const { rootManager, subagentExecutor, skillExecutor, composeExecutor } = wireExecutors({
-    // Origin attribution: forked children inherit origin 'telegram'.
-    surface: 'telegram',
-    parentSession: deferredParent,
+  // Shared executor + background + drain scaffolding.
+  const wiring = wireTelegramExecutors({
     apiKey: telegramApiKey,
     model: sessionConfig.model,
-    // The Telegram credential is resolved for the session model itself,
-    // so it is also the manager's credential-fallback anchor.
-    managerParentModel: sessionConfig.model,
-    defaultSubagentModel: getDefaultSubagentModel(sessionConfig.model),
-    resolveApiKeyForModel: getApiKeyForModel,
-    // Framework base + operator overlay, but NOT ROUTING_DIRECTIVE /
-    // TOOL_SYSTEM_PROMPT — keeps children and DAG workers from recursing
-    // into skills or nested DAGs.
-    ...(layeredBasePrompt !== undefined ? { systemPrompt: layeredBasePrompt } : {}),
-    ...(telegramBaseUrl !== undefined ? { baseUrl: telegramBaseUrl } : {}),
-    ...(telegramOpenaiBaseUrl !== undefined ? { openaiBaseUrl: telegramOpenaiBaseUrl } : {}),
-    // Behaviour-preserving asymmetry: cwd anchors the root manager, the
-    // named-agent scan and compose DAG nodes, but NOT the `agent`/`skill`
-    // executors (no `nestedCwd`) — matching the pre-refactor wiring.
-    // Widening it to nestedCwd would change depth >= 2 anchoring.
-    ...(sessionCwd !== undefined && sessionCwd.length > 0 ? { cwd: sessionCwd } : {}),
-    // Behaviour-preserving asymmetry: the writer reaches the manager, the
-    // `agent` executor and compose nodes, but NOT the `skill` executor or
-    // the nested skill-executor factory (no `skillTraceWriter`) —
-    // matching the pre-refactor wiring.
-    ...(traceWriter !== null ? { traceWriter } : {}),
-    ...(workspaceStore !== undefined ? { workspaceStore } : {}),
-    backgroundRegistry,
+    layeredBasePrompt,
+    sessionCwd,
+    traceWriter,
+    chatId,
+    threadId,
+    wireExtras: {
+      // Behaviour-preserving asymmetry: the writer reaches the manager, the
+      // `agent` executor and compose nodes, but NOT the `skill` executor or
+      // the nested skill-executor factory (no `skillTraceWriter`) --
+      // matching the pre-refactor wiring.
+      ...(telegramBaseUrl !== undefined ? { baseUrl: telegramBaseUrl } : {}),
+      ...(telegramOpenaiBaseUrl !== undefined ? { openaiBaseUrl: telegramOpenaiBaseUrl } : {}),
+      ...(workspaceStore !== undefined ? { workspaceStore } : {}),
+    },
   });
+  const { subagentExecutor, skillExecutor, composeExecutor } = wiring.executors;
 
   const allowedTools = topLevelSurfaceAllowedTools(mcpManager?.getMcpToolWireNames() ?? []);
   const directProvider = new AnthropicDirectProvider({
@@ -113,9 +74,7 @@ export async function buildAnthropicTelegramSession(
     // Tag the presence file (~/.afk/state/presence/<id>.json) and
     // get_runtime_state as the Telegram surface. Without this the provider
     // defaults to 'cli' (anthropic-direct/index.ts) and `/watch`
-    // mis-classifies Telegram sessions as CLI. The hook registry already
-    // receives 'telegram' below — this aligns the provider-owned surface
-    // (presence/runtime-state) with the hook-registry surface.
+    // mis-classifies Telegram sessions as CLI.
     surface: 'telegram',
   });
 
@@ -128,10 +87,10 @@ export async function buildAnthropicTelegramSession(
 
   // permissionMode is omitted from session CONSTRUCTION: AgentSession
   // defaults to 'default'. A Telegram session becomes 'autonomous' only via
-  // an explicit `/afk on` (handlers/afk.ts) calling setPermissionMode —
+  // an explicit `/afk on` (handlers/afk.ts) calling setPermissionMode --
   // never at construction. The hook bundle carries the AFK autonomous-safety
-  // wiring (live mode getter → registers the afk-mode gate + tracks `/afk
-  // on`; afkPromptForApproval:false → hard-refuse high-risk ops) — see
+  // wiring (live mode getter -> registers the afk-mode gate + tracks `/afk
+  // on`; afkPromptForApproval:false -> hard-refuse high-risk ops) -- see
   // createTelegramAfkHookBundle + docs/afk-telegram-native-host.md.
   let telegramSessionForMode: AgentSession | undefined;
   const telegramHookBundle = createTelegramAfkHookBundle({
@@ -146,7 +105,7 @@ export async function buildAnthropicTelegramSession(
     // /switch resumes a prior conversation: thread the target SDK session
     // id AND the saved transcript so the AgentSession actually replays it
     // (see SessionManager.switchToSession + resumeConfigFor). Forwarding
-    // only `resume` (the SDK id) resumes an EMPTY conversation — the
+    // only `resume` (the SDK id) resumes an EMPTY conversation -- the
     // provider replays prior turns solely from resumeHistory
     // (anthropic-direct/index.ts resumeHistoryToMessages). sessionId is
     // threaded too because the provider prefers config.sessionId over
@@ -159,16 +118,7 @@ export async function buildAnthropicTelegramSession(
     ...(systemPrompt !== undefined ? { systemPrompt } : {}),
     ...(config.temperature !== undefined ? { temperature: config.temperature } : {}),
     maxTurns: 100,
-    // Cascade-abort and drain in-flight children before the writer seals, so a
-    // wave still running when this session ends emits real `cancelled` rows
-    // instead of vanishing (#733). Background jobs are cancelled alongside the
-    // SubagentManager drain; the notifier is disposed so the settled listener
-    // doesn't fire after the session is gone.
-    drainSubagents: async (reason) => {
-      bgNotifier.dispose();
-      await backgroundRegistry.cancelAll();
-      return rootManager.abortAllAndDrain('session_end', 'user_signal', undefined, reason === 'reset');
-    },
+    drainSubagents: wiring.drainSubagents,
     ...(maxOutputTokens !== undefined ? { maxOutputTokens } : {}),
     ...(maxToolUseIterations !== undefined ? { maxToolUseIterations } : {}),
     ...(telegramBaseUrl !== undefined ? { baseUrl: telegramBaseUrl } : {}),
@@ -180,24 +130,12 @@ export async function buildAnthropicTelegramSession(
   }, { traceWriter }), mcpManager);
   // Late-bind the mode source so the registry's getPermissionMode getter
   // (built above, before the session existed) reads this session's LIVE
-  // permission mode — flipped by /afk on (handlers/afk.ts).
+  // permission mode -- flipped by /afk on (handlers/afk.ts).
   telegramSessionForMode = session;
   reportSession(session);
   // Seed read/write roots from persisted `persist` grants so the
   // prompt's "future sessions inherit it" promise holds. No-op when none.
-  // The former pathApprovalGrantRef.current wiring has been retired (#528):
-  // the path-approval hook reads the grant manager from context.grantManager.
   seedPersistedGrants(directProvider);
-  boundSession = session;
-  // Subagent-success rollup: wire both the root manager and the compose
-  // executor so all subagent token/cost data (including compose DAG nodes)
-  // accumulates into this session's session_sealed telemetry. Late-bound here
-  // because the session is constructed after the executors.
-  rootManager.setOnSubagentSucceeded((usage, costUsd) => {
-    session.recordSubagentCompletion(usage, costUsd);
-  });
-  composeExecutor.setOnSubagentSucceeded((usage, costUsd) => {
-    session.recordSubagentCompletion(usage, costUsd);
-  });
+  wiring.bindSession(session);
   return session;
 }

--- a/src/telegram/session-openai.ts
+++ b/src/telegram/session-openai.ts
@@ -10,20 +10,14 @@
  * OpenAI-compatible Telegram sessions (PR #202 review H1).
  */
 
-import { AgentSession } from '../agent/session.js';
 import { OpenAICompatibleProvider } from '../agent/providers/index.js';
 import { seedPersistedGrants } from '../agent/permissions-store.js';
 import { assembleSystemPrompt } from '../agent/routing-directive.js';
-import { wireExecutors } from '../agent/session/wire-executors.js';
-import { BackgroundAgentRegistry } from '../agent/background-registry.js';
-import { TelegramBgResultNotifier } from './bg-result-notifier.js';
-import {
-  getDefaultSubagentModel,
-  getApiKeyForModel,
-} from '../cli/shared-helpers.js';
 import { createTelegramAfkHookBundle } from './afk-hook-bundle.js';
 import { constructTelegramSession } from './construct-session.js';
 import { attachMcpCleanup } from './mcp-session.js';
+import { wireTelegramExecutors } from './wire-telegram-executors.js';
+import type { AgentSession } from '../agent/session.js';
 import type { TelegramSessionBuildContext } from './session-context.js';
 
 export async function buildOpenAiTelegramSession(
@@ -54,38 +48,21 @@ export async function buildOpenAiTelegramSession(
   // (parity with the Anthropic branch's telegramOpenaiBaseUrl).
   const codexOpenaiBaseUrl = sessionConfig.openaiBaseUrl ?? config.openaiBaseUrl;
 
-  // Deferred parent proxy (session constructed after executors).
-  let boundSession: AgentSession | undefined;
-  const deferredParent = {
-    get sessionId() { return boundSession?.sessionId; },
-    getInputStreamRef() { return boundSession?.getInputStreamRef?.() ?? { pushUserMessage: () => {} }; },
-    get abortSignal() { return boundSession?.abortSignal ?? new AbortController().signal; },
-    get hookRegistry() { return boundSession?.hookRegistry; },
-  };
-
-  // Background agent registry — enables `agent` tool with mode="background".
-  const backgroundRegistry = new BackgroundAgentRegistry(
-    traceWriter ? { traceWriter } : {},
-  );
-  const bgNotifier = new TelegramBgResultNotifier(backgroundRegistry, chatId, threadId);
-
-  // Executor wiring: one root manager shared by all three executors so forked
-  // subagents inherit cwd, abort graph, and read scope.
-  const { rootManager, subagentExecutor, skillExecutor, composeExecutor } = wireExecutors({
-    surface: 'telegram',
-    parentSession: deferredParent,
+  // Shared executor + background + drain scaffolding.
+  const wiring = wireTelegramExecutors({
     apiKey: sessionConfig.apiKey,
     model: sessionConfig.model,
-    managerParentModel: sessionConfig.model,
-    defaultSubagentModel: getDefaultSubagentModel(sessionConfig.model),
-    resolveApiKeyForModel: getApiKeyForModel,
-    ...(rawPrompt !== undefined ? { systemPrompt: rawPrompt } : {}),
-    ...(codexOpenaiBaseUrl !== undefined ? { openaiBaseUrl: codexOpenaiBaseUrl } : {}),
-    ...(sessionCwd !== undefined && sessionCwd.length > 0 ? { cwd: sessionCwd } : {}),
-    ...(traceWriter !== null ? { traceWriter } : {}),
-    ...(workspaceStore !== undefined ? { workspaceStore } : {}),
-    backgroundRegistry,
+    layeredBasePrompt: rawPrompt,
+    sessionCwd,
+    traceWriter,
+    chatId,
+    threadId,
+    wireExtras: {
+      ...(codexOpenaiBaseUrl !== undefined ? { openaiBaseUrl: codexOpenaiBaseUrl } : {}),
+      ...(workspaceStore !== undefined ? { workspaceStore } : {}),
+    },
   });
+  const { subagentExecutor, skillExecutor, composeExecutor } = wiring.executors;
 
   // permissionMode is intentionally omitted here: AgentSession defaults
   // to 'default' (post-C2 fix), which is the correct mode for Telegram
@@ -101,7 +78,7 @@ export async function buildOpenAiTelegramSession(
   });
   // Same AFK autonomous-safety wiring as the Anthropic branch (live mode getter
   // registers the afk-mode gate + tracks `/afk on`; afkPromptForApproval:false
-  // hard-refuses high-risk ops) — see createTelegramAfkHookBundle +
+  // hard-refuses high-risk ops) -- see createTelegramAfkHookBundle +
   // docs/afk-telegram-native-host.md.
   let codexSessionForMode: AgentSession | undefined;
   const codexHookBundle = createTelegramAfkHookBundle({
@@ -125,12 +102,7 @@ export async function buildOpenAiTelegramSession(
     ...(systemPrompt !== undefined ? { systemPrompt } : {}),
     ...(config.temperature !== undefined ? { temperature: config.temperature } : {}),
     maxTurns: 100,
-    // Cascade-abort and drain in-flight children before the writer seals.
-    drainSubagents: async (reason) => {
-      bgNotifier.dispose();
-      await backgroundRegistry.cancelAll();
-      return rootManager.abortAllAndDrain('session_end', 'user_signal', undefined, reason === 'reset');
-    },
+    drainSubagents: wiring.drainSubagents,
     ...(maxOutputTokens !== undefined ? { maxOutputTokens } : {}),
     ...(maxToolUseIterations !== undefined ? { maxToolUseIterations } : {}),
     // Sets config.openaiBaseUrl -> effectiveBaseURL (openai-compatible/index.ts)
@@ -146,17 +118,9 @@ export async function buildOpenAiTelegramSession(
   codexSessionForMode = session;
   reportSession(session);
   // Seed persisted `persist` grants so the OpenAI Telegram surface gets the
-  // same persisted-grant replay as the Anthropic branch. The former
-  // pathApprovalGrantRef.current wiring has been retired (#528).
+  // same persisted-grant replay as the Anthropic branch.
   seedPersistedGrants(codexProvider);
-  boundSession = session;
-  // Subagent-success rollup (parity with Anthropic branch).
-  rootManager.setOnSubagentSucceeded((usage, costUsd) => {
-    session.recordSubagentCompletion(usage, costUsd);
-  });
-  composeExecutor.setOnSubagentSucceeded((usage, costUsd) => {
-    session.recordSubagentCompletion(usage, costUsd);
-  });
+  wiring.bindSession(session);
 
   return session;
 }

--- a/src/telegram/session-openai.ts
+++ b/src/telegram/session-openai.ts
@@ -14,6 +14,13 @@ import { AgentSession } from '../agent/session.js';
 import { OpenAICompatibleProvider } from '../agent/providers/index.js';
 import { seedPersistedGrants } from '../agent/permissions-store.js';
 import { assembleSystemPrompt } from '../agent/routing-directive.js';
+import { wireExecutors } from '../agent/session/wire-executors.js';
+import { BackgroundAgentRegistry } from '../agent/background-registry.js';
+import { TelegramBgResultNotifier } from './bg-result-notifier.js';
+import {
+  getDefaultSubagentModel,
+  getApiKeyForModel,
+} from '../cli/shared-helpers.js';
 import { createTelegramAfkHookBundle } from './afk-hook-bundle.js';
 import { constructTelegramSession } from './construct-session.js';
 import { attachMcpCleanup } from './mcp-session.js';
@@ -33,6 +40,8 @@ export async function buildOpenAiTelegramSession(
     mcpManager,
     memoryStore,
     workspaceStore,
+    chatId,
+    threadId,
     reportSession,
   } = ctx;
 
@@ -45,16 +54,48 @@ export async function buildOpenAiTelegramSession(
   // (parity with the Anthropic branch's telegramOpenaiBaseUrl).
   const codexOpenaiBaseUrl = sessionConfig.openaiBaseUrl ?? config.openaiBaseUrl;
 
+  // Deferred parent proxy (session constructed after executors).
+  let boundSession: AgentSession | undefined;
+  const deferredParent = {
+    get sessionId() { return boundSession?.sessionId; },
+    getInputStreamRef() { return boundSession?.getInputStreamRef?.() ?? { pushUserMessage: () => {} }; },
+    get abortSignal() { return boundSession?.abortSignal ?? new AbortController().signal; },
+    get hookRegistry() { return boundSession?.hookRegistry; },
+  };
+
+  // Background agent registry — enables `agent` tool with mode="background".
+  const backgroundRegistry = new BackgroundAgentRegistry(
+    traceWriter ? { traceWriter } : {},
+  );
+  const bgNotifier = new TelegramBgResultNotifier(backgroundRegistry, chatId, threadId);
+
+  // Executor wiring: one root manager shared by all three executors so forked
+  // subagents inherit cwd, abort graph, and read scope.
+  const { rootManager, subagentExecutor, skillExecutor, composeExecutor } = wireExecutors({
+    surface: 'telegram',
+    parentSession: deferredParent,
+    apiKey: sessionConfig.apiKey,
+    model: sessionConfig.model,
+    managerParentModel: sessionConfig.model,
+    defaultSubagentModel: getDefaultSubagentModel(sessionConfig.model),
+    resolveApiKeyForModel: getApiKeyForModel,
+    ...(rawPrompt !== undefined ? { systemPrompt: rawPrompt } : {}),
+    ...(codexOpenaiBaseUrl !== undefined ? { openaiBaseUrl: codexOpenaiBaseUrl } : {}),
+    ...(sessionCwd !== undefined && sessionCwd.length > 0 ? { cwd: sessionCwd } : {}),
+    ...(traceWriter !== null ? { traceWriter } : {}),
+    ...(workspaceStore !== undefined ? { workspaceStore } : {}),
+    backgroundRegistry,
+  });
+
   // permissionMode is intentionally omitted here: AgentSession defaults
   // to 'default' (post-C2 fix), which is the correct mode for Telegram
   // sessions that rely on hook-based permission enforcement.
-  // baseURL / apiKey / cwd / roots flow through the per-query config (not the
-  // constructor), so omitting them here is behavior-preserving vs.
-  // resolveProvider(). surface:'telegram' is the lone constructor arg — there
-  // is no per-query surface field — and prevents the presence file
-  // mis-labeling Telegram sessions as 'cli' in `/watch`.
+  // surface:'telegram' prevents the presence file mis-labeling as 'cli'.
   const codexProvider = new OpenAICompatibleProvider({
     surface: 'telegram',
+    subagentExecutor,
+    skillExecutor,
+    composeExecutor,
     ...(mcpManager !== undefined ? { mcpManager } : {}),
     workspaceStore,
   });
@@ -84,6 +125,12 @@ export async function buildOpenAiTelegramSession(
     ...(systemPrompt !== undefined ? { systemPrompt } : {}),
     ...(config.temperature !== undefined ? { temperature: config.temperature } : {}),
     maxTurns: 100,
+    // Cascade-abort and drain in-flight children before the writer seals.
+    drainSubagents: async (reason) => {
+      bgNotifier.dispose();
+      await backgroundRegistry.cancelAll();
+      return rootManager.abortAllAndDrain('session_end', 'user_signal', undefined, reason === 'reset');
+    },
     ...(maxOutputTokens !== undefined ? { maxOutputTokens } : {}),
     ...(maxToolUseIterations !== undefined ? { maxToolUseIterations } : {}),
     // Sets config.openaiBaseUrl -> effectiveBaseURL (openai-compatible/index.ts)
@@ -102,6 +149,14 @@ export async function buildOpenAiTelegramSession(
   // same persisted-grant replay as the Anthropic branch. The former
   // pathApprovalGrantRef.current wiring has been retired (#528).
   seedPersistedGrants(codexProvider);
+  boundSession = session;
+  // Subagent-success rollup (parity with Anthropic branch).
+  rootManager.setOnSubagentSucceeded((usage, costUsd) => {
+    session.recordSubagentCompletion(usage, costUsd);
+  });
+  composeExecutor.setOnSubagentSucceeded((usage, costUsd) => {
+    session.recordSubagentCompletion(usage, costUsd);
+  });
 
   return session;
 }

--- a/src/telegram/session-xai.ts
+++ b/src/telegram/session-xai.ts
@@ -9,21 +9,15 @@
  * @module telegram/session-xai
  */
 
-import { AgentSession } from '../agent/session.js';
 import { XaiProvider } from '../agent/providers/xai/index.js';
 import { resolveXaiConstructionAuthMode } from '../agent/providers/xai/force-mode.js';
 import { seedPersistedGrants } from '../agent/permissions-store.js';
 import { assembleSystemPrompt } from '../agent/routing-directive.js';
-import { wireExecutors } from '../agent/session/wire-executors.js';
-import { BackgroundAgentRegistry } from '../agent/background-registry.js';
-import { TelegramBgResultNotifier } from './bg-result-notifier.js';
-import {
-  getDefaultSubagentModel,
-  getApiKeyForModel,
-} from '../cli/shared-helpers.js';
 import { createTelegramAfkHookBundle } from './afk-hook-bundle.js';
 import { constructTelegramSession } from './construct-session.js';
 import { attachMcpCleanup } from './mcp-session.js';
+import { wireTelegramExecutors } from './wire-telegram-executors.js';
+import type { AgentSession } from '../agent/session.js';
 import type { TelegramSessionBuildContext } from './session-context.js';
 
 export async function buildXaiTelegramSession(
@@ -51,36 +45,22 @@ export async function buildXaiTelegramSession(
     ? assembleSystemPrompt(rawPrompt, telegramAutoRouting, 'telegram')
     : rawPrompt;
 
-  // Deferred parent proxy (session constructed after executors).
-  let boundSession: AgentSession | undefined;
-  const deferredParent = {
-    get sessionId() { return boundSession?.sessionId; },
-    getInputStreamRef() { return boundSession?.getInputStreamRef?.() ?? { pushUserMessage: () => {} }; },
-    get abortSignal() { return boundSession?.abortSignal ?? new AbortController().signal; },
-    get hookRegistry() { return boundSession?.hookRegistry; },
-  };
-
-  // Background agent registry — enables `agent` tool with mode="background".
-  const backgroundRegistry = new BackgroundAgentRegistry(
-    traceWriter ? { traceWriter } : {},
-  );
-  const bgNotifier = new TelegramBgResultNotifier(backgroundRegistry, chatId, threadId);
-
-  // Executor wiring: one root manager shared by all three executors.
-  const { rootManager, subagentExecutor, skillExecutor, composeExecutor } = wireExecutors({
-    surface: 'telegram',
-    parentSession: deferredParent,
+  // Shared executor + background + drain scaffolding.
+  const wiring = wireTelegramExecutors({
     apiKey: sessionConfig.apiKey,
     model: sessionConfig.model,
-    managerParentModel: sessionConfig.model,
-    defaultSubagentModel: getDefaultSubagentModel(sessionConfig.model),
-    resolveApiKeyForModel: getApiKeyForModel,
-    ...(rawPrompt !== undefined ? { systemPrompt: rawPrompt } : {}),
-    ...(sessionConfig.xaiBaseUrl !== undefined ? { xaiBaseUrl: sessionConfig.xaiBaseUrl } : {}),
-    ...(sessionCwd !== undefined && sessionCwd.length > 0 ? { cwd: sessionCwd } : {}),
-    ...(traceWriter !== null ? { traceWriter } : {}),
-    backgroundRegistry,
+    layeredBasePrompt: rawPrompt,
+    sessionCwd,
+    traceWriter,
+    chatId,
+    threadId,
+    wireExtras: {
+      // Invariant: do NOT forward config.openaiBaseUrl -- XaiProvider ignores
+      // AFK_OPENAI_BASE_URL and uses resolveXaiEndpoint + optional xaiBaseUrl.
+      ...(sessionConfig.xaiBaseUrl !== undefined ? { xaiBaseUrl: sessionConfig.xaiBaseUrl } : {}),
+    },
   });
+  const { subagentExecutor, skillExecutor, composeExecutor } = wiring.executors;
 
   // Slot/provider-forced oauth vs auto-routed apikey construction.
   const authMode = resolveXaiConstructionAuthMode(providerName, providerName === 'xai-oauth');
@@ -112,16 +92,9 @@ export async function buildXaiTelegramSession(
     ...(systemPrompt !== undefined ? { systemPrompt } : {}),
     ...(config.temperature !== undefined ? { temperature: config.temperature } : {}),
     maxTurns: 100,
-    // Cascade-abort and drain in-flight children before the writer seals.
-    drainSubagents: async (reason) => {
-      bgNotifier.dispose();
-      await backgroundRegistry.cancelAll();
-      return rootManager.abortAllAndDrain('session_end', 'user_signal', undefined, reason === 'reset');
-    },
+    drainSubagents: wiring.drainSubagents,
     ...(maxOutputTokens !== undefined ? { maxOutputTokens } : {}),
     ...(maxToolUseIterations !== undefined ? { maxToolUseIterations } : {}),
-    // Invariant: do NOT forward config.openaiBaseUrl — XaiProvider ignores
-    // AFK_OPENAI_BASE_URL and uses resolveXaiEndpoint + optional xaiBaseUrl.
     ...(sessionConfig.xaiBaseUrl !== undefined ? { xaiBaseUrl: sessionConfig.xaiBaseUrl } : {}),
     ...(sessionCwd !== undefined && sessionCwd.length > 0 ? { cwd: sessionCwd } : {}),
     provider: xaiProvider,
@@ -130,16 +103,8 @@ export async function buildXaiTelegramSession(
 
   sessionForMode = session;
   reportSession(session);
-  // The former pathApprovalGrantRef.current wiring has been retired (#528).
   seedPersistedGrants(xaiProvider);
-  boundSession = session;
-  // Subagent-success rollup (parity with Anthropic branch).
-  rootManager.setOnSubagentSucceeded((usage, costUsd) => {
-    session.recordSubagentCompletion(usage, costUsd);
-  });
-  composeExecutor.setOnSubagentSucceeded((usage, costUsd) => {
-    session.recordSubagentCompletion(usage, costUsd);
-  });
+  wiring.bindSession(session);
 
   return session;
 }

--- a/src/telegram/session-xai.ts
+++ b/src/telegram/session-xai.ts
@@ -14,6 +14,13 @@ import { XaiProvider } from '../agent/providers/xai/index.js';
 import { resolveXaiConstructionAuthMode } from '../agent/providers/xai/force-mode.js';
 import { seedPersistedGrants } from '../agent/permissions-store.js';
 import { assembleSystemPrompt } from '../agent/routing-directive.js';
+import { wireExecutors } from '../agent/session/wire-executors.js';
+import { BackgroundAgentRegistry } from '../agent/background-registry.js';
+import { TelegramBgResultNotifier } from './bg-result-notifier.js';
+import {
+  getDefaultSubagentModel,
+  getApiKeyForModel,
+} from '../cli/shared-helpers.js';
 import { createTelegramAfkHookBundle } from './afk-hook-bundle.js';
 import { constructTelegramSession } from './construct-session.js';
 import { attachMcpCleanup } from './mcp-session.js';
@@ -32,6 +39,8 @@ export async function buildXaiTelegramSession(
     traceWriter,
     mcpManager,
     memoryStore,
+    chatId,
+    threadId,
     reportSession,
     providerName,
   } = ctx;
@@ -42,10 +51,44 @@ export async function buildXaiTelegramSession(
     ? assembleSystemPrompt(rawPrompt, telegramAutoRouting, 'telegram')
     : rawPrompt;
 
+  // Deferred parent proxy (session constructed after executors).
+  let boundSession: AgentSession | undefined;
+  const deferredParent = {
+    get sessionId() { return boundSession?.sessionId; },
+    getInputStreamRef() { return boundSession?.getInputStreamRef?.() ?? { pushUserMessage: () => {} }; },
+    get abortSignal() { return boundSession?.abortSignal ?? new AbortController().signal; },
+    get hookRegistry() { return boundSession?.hookRegistry; },
+  };
+
+  // Background agent registry — enables `agent` tool with mode="background".
+  const backgroundRegistry = new BackgroundAgentRegistry(
+    traceWriter ? { traceWriter } : {},
+  );
+  const bgNotifier = new TelegramBgResultNotifier(backgroundRegistry, chatId, threadId);
+
+  // Executor wiring: one root manager shared by all three executors.
+  const { rootManager, subagentExecutor, skillExecutor, composeExecutor } = wireExecutors({
+    surface: 'telegram',
+    parentSession: deferredParent,
+    apiKey: sessionConfig.apiKey,
+    model: sessionConfig.model,
+    managerParentModel: sessionConfig.model,
+    defaultSubagentModel: getDefaultSubagentModel(sessionConfig.model),
+    resolveApiKeyForModel: getApiKeyForModel,
+    ...(rawPrompt !== undefined ? { systemPrompt: rawPrompt } : {}),
+    ...(sessionConfig.xaiBaseUrl !== undefined ? { xaiBaseUrl: sessionConfig.xaiBaseUrl } : {}),
+    ...(sessionCwd !== undefined && sessionCwd.length > 0 ? { cwd: sessionCwd } : {}),
+    ...(traceWriter !== null ? { traceWriter } : {}),
+    backgroundRegistry,
+  });
+
   // Slot/provider-forced oauth vs auto-routed apikey construction.
   const authMode = resolveXaiConstructionAuthMode(providerName, providerName === 'xai-oauth');
   const xaiProvider = new XaiProvider({
     surface: 'telegram',
+    subagentExecutor,
+    skillExecutor,
+    composeExecutor,
     ...(authMode !== undefined ? { authMode } : {}),
     ...(mcpManager !== undefined ? { mcpManager } : {}),
   });
@@ -69,6 +112,12 @@ export async function buildXaiTelegramSession(
     ...(systemPrompt !== undefined ? { systemPrompt } : {}),
     ...(config.temperature !== undefined ? { temperature: config.temperature } : {}),
     maxTurns: 100,
+    // Cascade-abort and drain in-flight children before the writer seals.
+    drainSubagents: async (reason) => {
+      bgNotifier.dispose();
+      await backgroundRegistry.cancelAll();
+      return rootManager.abortAllAndDrain('session_end', 'user_signal', undefined, reason === 'reset');
+    },
     ...(maxOutputTokens !== undefined ? { maxOutputTokens } : {}),
     ...(maxToolUseIterations !== undefined ? { maxToolUseIterations } : {}),
     // Invariant: do NOT forward config.openaiBaseUrl — XaiProvider ignores
@@ -83,6 +132,14 @@ export async function buildXaiTelegramSession(
   reportSession(session);
   // The former pathApprovalGrantRef.current wiring has been retired (#528).
   seedPersistedGrants(xaiProvider);
+  boundSession = session;
+  // Subagent-success rollup (parity with Anthropic branch).
+  rootManager.setOnSubagentSucceeded((usage, costUsd) => {
+    session.recordSubagentCompletion(usage, costUsd);
+  });
+  composeExecutor.setOnSubagentSucceeded((usage, costUsd) => {
+    session.recordSubagentCompletion(usage, costUsd);
+  });
 
   return session;
 }

--- a/src/telegram/wire-telegram-executors.ts
+++ b/src/telegram/wire-telegram-executors.ts
@@ -1,0 +1,135 @@
+/**
+ * Shared executor wiring for all three Telegram provider branches.
+ *
+ * Every Telegram session needs the same scaffolding regardless of provider:
+ * a deferred parent proxy, a background registry + notifier, the
+ * `wireExecutors` trio, a drain callback, and a late-bind step. This module
+ * extracts that boilerplate so each branch (`session-anthropic.ts`,
+ * `session-openai.ts`, `session-xai.ts`) focuses only on its
+ * provider-specific construction.
+ *
+ * Invariant: the returned {@link TelegramExecutorWiring.bindSession} MUST be
+ * called after the `AgentSession` is constructed. Until then the deferred
+ * parent proxy resolves to stub values, and the subagent-success rollup is
+ * unwired.
+ */
+
+import type { AgentSession } from '../agent/session/agent-session.js';
+import type { AgentConfig } from '../agent/types.js';
+import { wireExecutors, type WiredExecutors, type WireExecutorsOptions } from '../agent/session/wire-executors.js';
+import { BackgroundAgentRegistry } from '../agent/background-registry.js';
+import { TelegramBgResultNotifier } from './bg-result-notifier.js';
+import {
+  getDefaultSubagentModel,
+  getApiKeyForModel,
+} from '../cli/shared-helpers.js';
+import type { SubagentExecutorContext } from '../agent/tools/subagent-executor.js';
+import type { TelegramTraceWriter } from './session-context.js';
+
+export interface TelegramExecutorWiringOptions {
+  /** API key for the session model. */
+  apiKey: string | undefined;
+  /** Session model id. */
+  model: string;
+  /** Raw base prompt (pre-assembly). Forwarded to children as their system prompt. */
+  layeredBasePrompt: string | undefined;
+  /** Session cwd (from `AFK_TELEGRAM_CWD` or `sessionConfig.cwd`). */
+  sessionCwd: string | undefined;
+  /** Trace writer for the session. */
+  traceWriter: TelegramTraceWriter;
+  /** Telegram chat id for background-job notifications. */
+  chatId: number | undefined;
+  /** Telegram topic thread id for background-job notifications. */
+  threadId: number | undefined;
+  /**
+   * Provider-specific extras spread into `wireExecutors`. Each branch passes
+   * its own endpoint overrides (`baseUrl`, `openaiBaseUrl`, `xaiBaseUrl`) and
+   * optional stores (`workspaceStore`) here.
+   */
+  wireExtras?: Partial<WireExecutorsOptions>;
+}
+
+export interface TelegramExecutorWiring {
+  executors: WiredExecutors;
+  backgroundRegistry: BackgroundAgentRegistry;
+  bgNotifier: TelegramBgResultNotifier;
+  /** Wired into `AgentConfig.drainSubagents` to cascade-abort children on close. */
+  drainSubagents: AgentConfig['drainSubagents'];
+  /**
+   * Call after `new AgentSession(config)` to resolve the deferred parent proxy
+   * and wire the subagent-success rollup.
+   */
+  bindSession: (session: AgentSession) => void;
+}
+
+/**
+ * Build the shared executor + background + drain scaffolding for a Telegram
+ * session. Provider-agnostic: works for Anthropic, OpenAI, and xAI branches.
+ */
+export function wireTelegramExecutors(
+  opts: TelegramExecutorWiringOptions,
+): TelegramExecutorWiring {
+  const {
+    apiKey,
+    model,
+    layeredBasePrompt,
+    sessionCwd,
+    traceWriter,
+    chatId,
+    threadId,
+    wireExtras,
+  } = opts;
+
+  // -- Deferred parent proxy (session constructed after executors) -----------
+  let boundSession: AgentSession | undefined;
+  const deferredParent: SubagentExecutorContext['parentSession'] = {
+    get sessionId() { return boundSession?.sessionId; },
+    getInputStreamRef() { return boundSession?.getInputStreamRef?.() ?? { pushUserMessage: () => {} }; },
+    get abortSignal() { return boundSession?.abortSignal ?? new AbortController().signal; },
+    get hookRegistry() { return boundSession?.hookRegistry; },
+  };
+
+  // -- Background registry + notifier ---------------------------------------
+  const backgroundRegistry = new BackgroundAgentRegistry(
+    traceWriter ? { traceWriter } : {},
+  );
+  const bgNotifier = new TelegramBgResultNotifier(backgroundRegistry, chatId, threadId);
+
+  // -- wireExecutors --------------------------------------------------------
+  const executors = wireExecutors({
+    surface: 'telegram',
+    parentSession: deferredParent,
+    apiKey,
+    model,
+    managerParentModel: model,
+    defaultSubagentModel: getDefaultSubagentModel(model),
+    resolveApiKeyForModel: getApiKeyForModel,
+    ...(layeredBasePrompt !== undefined ? { systemPrompt: layeredBasePrompt } : {}),
+    ...(sessionCwd !== undefined && sessionCwd.length > 0 ? { cwd: sessionCwd } : {}),
+    ...(traceWriter !== null ? { traceWriter } : {}),
+    backgroundRegistry,
+    ...wireExtras,
+  });
+
+  // -- Drain callback -------------------------------------------------------
+  const drainSubagents: AgentConfig['drainSubagents'] = async (reason) => {
+    bgNotifier.dispose();
+    await backgroundRegistry.cancelAll();
+    return executors.rootManager.abortAllAndDrain(
+      'session_end', 'user_signal', undefined, reason === 'reset',
+    );
+  };
+
+  // -- Late-bind helper -----------------------------------------------------
+  const bindSession = (session: AgentSession): void => {
+    boundSession = session;
+    executors.rootManager.setOnSubagentSucceeded((usage, costUsd) => {
+      session.recordSubagentCompletion(usage, costUsd);
+    });
+    executors.composeExecutor.setOnSubagentSucceeded((usage, costUsd) => {
+      session.recordSubagentCompletion(usage, costUsd);
+    });
+  };
+
+  return { executors, backgroundRegistry, bgNotifier, drainSubagents, bindSession };
+}

--- a/src/web-server/session-owner.ts
+++ b/src/web-server/session-owner.ts
@@ -20,9 +20,12 @@
 
 import { AgentSession } from '../agent/session/agent-session.js';
 import { createDefaultHookRegistry } from '../agent/default-hook-registry.js';
+import { seedPersistedGrants } from '../agent/permissions-store.js';
 import { getApiKeyForModel, resolveBaseSystemPrompt } from '../cli/shared-helpers.js';
+import { wireWebSession, type WebSessionWiringInternal } from './session-owner.wiring.js';
 import type { AgentConfig } from '../agent/types.js';
 import type { PermissionMode } from '../agent/types/sdk-types.js';
+import type { McpManager } from '../agent/mcp/index.js';
 
 export interface CreateSessionRequest {
   /** Working directory. Ignored unless `allowArbitraryCwd` — see the guard. */
@@ -65,6 +68,8 @@ export class SessionOwner {
   readonly owned = new Set<string>();
   private readonly sessions = new Map<string, AgentSession>();
   private readonly info = new Map<string, OwnedSessionInfo>();
+  /** MCP managers per session — disconnected on close. */
+  private readonly mcpManagers = new Map<string, McpManager>();
   /** Per-session serialization chain — see {@link submitPrompt}. */
   private readonly turns = new Map<string, Promise<void>>();
   /**
@@ -92,26 +97,42 @@ export class SessionOwner {
   async create(request: CreateSessionRequest = {}): Promise<OwnedSessionInfo> {
     const cwd = this.options.allowArbitraryCwd === true ? (request.cwd ?? this.baseCwd) : this.baseCwd;
     const model = request.model ?? this.options.model;
+    const apiKey = getApiKeyForModel(model);
 
-    const { prompt, source } = resolveBaseSystemPrompt(cwd);
-    const { registry } = createDefaultHookRegistry(undefined, 'web', undefined, undefined, undefined, {
-      cwd,
-    });
+    const { prompt: rawPrompt, source: rawPromptSource } = resolveBaseSystemPrompt(cwd);
+
+    // Full executor + trace + MCP wiring (mirrors REPL/Telegram Anthropic).
+    const wiring = await wireWebSession({
+      model, apiKey, cwd, rawPrompt, rawPromptSource,
+    }) as WebSessionWiringInternal;
+
+    // Hook registry with the shared memory store so session-end writes land in
+    // the same instance the provider's memory tools read from.
+    const getPermissionMode = () => session?.getSessionMetadata().permissionMode ?? (this.options.permissionMode ?? 'default');
+    const { registry } = createDefaultHookRegistry(
+      undefined, 'web', wiring.memoryStore, getPermissionMode, undefined,
+      { cwd, traceWriter: wiring.traceWriter },
+    );
 
     const config: AgentConfig = {
       model,
-      // Trace `origin` attribution: distinguishes browser-started work from a
-      // REPL or daemon session in the witness trace.
       surface: 'web',
-      apiKey: getApiKeyForModel(model),
+      apiKey,
       cwd,
       hookRegistry: registry,
       permissionMode: this.options.permissionMode ?? 'default',
-      ...(prompt !== undefined ? { systemPrompt: prompt } : {}),
-      ...(source !== undefined ? { systemPromptSource: source } : {}),
+      provider: wiring.provider,
+      drainSubagents: wiring.drainSubagents,
+      ...(wiring.systemPrompt !== undefined ? { systemPrompt: wiring.systemPrompt } : {}),
+      ...(wiring.systemPromptSource !== undefined ? { systemPromptSource: wiring.systemPromptSource } : {}),
+      ...(wiring.traceWriter !== undefined ? { traceWriter: wiring.traceWriter } : {}),
     };
 
-    const session = new AgentSession(config);
+    const session = new AgentSession(config, wiring.traceWriter);
+
+    // Late-bind the deferred parent proxy so executors resolve session fields.
+    wiring.__bindSession(session);
+    seedPersistedGrants(wiring.provider);
 
     // Invariant: the id is provider-issued and undefined until initialization
     // resolves. Registering as owned before this point would make prompt and
@@ -132,6 +153,7 @@ export class SessionOwner {
     this.sessions.set(id, session);
     this.info.set(id, record);
     this.owned.add(id);
+    if (wiring.mcpManager !== undefined) this.mcpManagers.set(id, wiring.mcpManager);
     return record;
   }
 
@@ -204,11 +226,16 @@ export class SessionOwner {
    */
   async closeAll(): Promise<void> {
     const all = [...this.sessions.values()];
+    const mcps = [...this.mcpManagers.values()];
     this.sessions.clear();
     this.info.clear();
     this.owned.clear();
     this.pending.clear();
     this.turns.clear();
+    this.mcpManagers.clear();
+    // Sessions close BEFORE MCP disconnect: a closing session may raise a final
+    // tool call that needs the MCP transport alive.
     await Promise.all(all.map((s) => s.close().catch(() => {})));
+    await Promise.all(mcps.map((m) => m.disconnectAll().catch(() => {})));
   }
 }

--- a/src/web-server/session-owner.wiring.ts
+++ b/src/web-server/session-owner.wiring.ts
@@ -1,0 +1,215 @@
+/**
+ * Executor and infrastructure wiring for web-surface sessions.
+ *
+ * Extracted from {@link SessionOwner} so the owner stays under the 350-LOC
+ * ceiling. Mirrors the Telegram Anthropic branch (`session-anthropic.ts`)
+ * and the REPL (`bootstrap-infra.ts`): ONE root manager, three executors,
+ * trace writer, MCP, background registry, and drain callback.
+ *
+ * Invariant: every field returned here is session-scoped. A new call per
+ * `SessionOwner.create()` ensures no shared mutable state bleeds across
+ * sessions the browser starts.
+ */
+
+import { AnthropicDirectProvider } from '../agent/providers/index.js';
+import { wireExecutors, type WiredExecutors } from '../agent/session/wire-executors.js';
+import { topLevelSurfaceAllowedTools } from '../agent/tools/top-level-allowlist.js';
+import { assembleSystemPrompt } from '../agent/routing-directive.js';
+import { createDefaultTraceWriter, type CreatedTraceWriter } from '../agent/trace/factory.js';
+import { BackgroundAgentRegistry } from '../agent/background-registry.js';
+import { McpManager, loadMcpConfig } from '../agent/mcp/index.js';
+import { loadImportFromConfig, resolveImportedRoots } from '../config/import-sources.js';
+import { emitSessionPhase } from '../agent/trace/emit.js';
+import { WorkspaceStore } from '../agent/workspace/index.js';
+import {
+  getDefaultSubagentModel,
+  getApiKeyForModel,
+} from '../cli/shared-helpers.js';
+import { loadConfig } from '../cli/config.js';
+import { MemoryStore } from '../agent/memory/index.js';
+import type { AgentSession } from '../agent/session/agent-session.js';
+import type { AgentConfig } from '../agent/types.js';
+import type { TraceWriter } from '../agent/trace/index.js';
+import type { TraceSink } from '../agent/trace/writer.js';
+import type { SubagentExecutorContext } from '../agent/tools/subagent-executor.js';
+
+/** Everything `SessionOwner.create` needs beyond the base `AgentConfig`. */
+export interface WebSessionWiring {
+  provider: AnthropicDirectProvider;
+  executors: WiredExecutors;
+  traceWriter: TraceWriter | undefined;
+  /** Merged system prompt (base + routing directive + end-of-turn). */
+  systemPrompt: string | undefined;
+  systemPromptSource: string | undefined;
+  backgroundRegistry: BackgroundAgentRegistry;
+  mcpManager: McpManager | undefined;
+  memoryStore: MemoryStore;
+  workspaceStore: WorkspaceStore;
+  /** Wired into `AgentConfig.drainSubagents` to cascade-abort children on close. */
+  drainSubagents: AgentConfig['drainSubagents'];
+}
+
+export interface WireWebSessionOptions {
+  model: string;
+  apiKey: string | undefined;
+  cwd: string;
+  rawPrompt: string | undefined;
+  rawPromptSource: string | undefined;
+}
+
+/**
+ * Build the full executor/trace/MCP/provider stack for a single web session.
+ *
+ * Contract: the returned `provider` must be passed into `AgentConfig` so the
+ * session uses it instead of falling back to bare `resolveProvider()`.
+ */
+export async function wireWebSession(
+  opts: WireWebSessionOptions,
+): Promise<WebSessionWiring> {
+  const { model, apiKey, cwd, rawPrompt, rawPromptSource } = opts;
+
+  // -- 1. Trace writer (session-scoped UUID) ----------------------------------
+  const created: CreatedTraceWriter | null = createDefaultTraceWriter();
+  const traceWriter: TraceWriter | undefined = created?.writer ?? undefined;
+  const traceSink: TraceSink | undefined = traceWriter;
+
+  // -- 2. MCP servers ---------------------------------------------------------
+  const mcpManager = await loadWebMcpManager(cwd, traceSink);
+
+  // -- 3. Memory + workspace stores -------------------------------------------
+  const memoryStore = new MemoryStore();
+  const workspaceStore = new WorkspaceStore();
+
+  // -- 4. Background registry -------------------------------------------------
+  const backgroundRegistry = new BackgroundAgentRegistry(
+    traceSink ? { traceWriter: traceSink } : {},
+  );
+
+  // -- 5. Deferred parent proxy (session constructed after executors) ----------
+  let boundSession: AgentSession | undefined;
+  const deferredParent: SubagentExecutorContext['parentSession'] = {
+    get sessionId() { return boundSession?.sessionId; },
+    getInputStreamRef() { return boundSession?.getInputStreamRef?.() ?? { pushUserMessage: () => {} }; },
+    get abortSignal() { return boundSession?.abortSignal ?? new AbortController().signal; },
+    get hookRegistry() { return boundSession?.hookRegistry; },
+  };
+
+  // -- 6. wireExecutors (cwd, executors, root manager) ------------------------
+  const executors = wireExecutors({
+    surface: 'web',
+    parentSession: deferredParent,
+    apiKey,
+    model,
+    managerParentModel: model,
+    defaultSubagentModel: getDefaultSubagentModel(model),
+    resolveApiKeyForModel: getApiKeyForModel,
+    ...(rawPrompt !== undefined ? { systemPrompt: rawPrompt } : {}),
+    cwd,
+    // Web uses uniform cwd anchoring (same as REPL, unlike Telegram).
+    nestedCwd: cwd,
+    ...(traceSink !== undefined ? { traceWriter: traceSink, skillTraceWriter: traceSink } : {}),
+    backgroundRegistry,
+    workspaceStore,
+  });
+
+  // -- 7. Provider (with executors + MCP) ------------------------------------
+  const allowedTools = topLevelSurfaceAllowedTools(mcpManager?.getMcpToolWireNames() ?? []);
+  const provider = new AnthropicDirectProvider({
+    permissions: { allowedTools },
+    subagentExecutor: executors.subagentExecutor,
+    skillExecutor: executors.skillExecutor,
+    composeExecutor: executors.composeExecutor,
+    ...(mcpManager !== undefined ? { mcpManager } : {}),
+    workspaceStore,
+    surface: 'web',
+  });
+
+  // -- 8. System prompt (base + routing directive + end-of-turn) --------------
+  // Web is an interactive surface like the REPL: use `interactive` auto-routing
+  // and `'repl'` PromptSurface so the end-of-turn protocol is injected.
+  const config = loadConfig();
+  const autoRouting = config.autoRouting?.interactive ?? false;
+  const systemPrompt = typeof rawPrompt === 'string'
+    ? assembleSystemPrompt(rawPrompt, autoRouting, 'repl')
+    : rawPrompt;
+
+  // -- 9. Drain callback ------------------------------------------------------
+  const drainSubagents: AgentConfig['drainSubagents'] = async (reason) => {
+    await backgroundRegistry.cancelAll();
+    return executors.rootManager.abortAllAndDrain(
+      'session_end', 'user_signal', undefined, reason === 'reset',
+    );
+  };
+
+  // Late-bind helper so callers can wire after session construction.
+  const wiring: WebSessionWiring = {
+    provider,
+    executors,
+    traceWriter,
+    systemPrompt,
+    systemPromptSource: rawPromptSource,
+    backgroundRegistry,
+    mcpManager,
+    memoryStore,
+    workspaceStore,
+    drainSubagents,
+  };
+
+  // Attach the late-bind setter as a post-construction hook: the caller must
+  // invoke this after `new AgentSession(config)` so the deferred proxy resolves.
+  (wiring as WebSessionWiringInternal).__bindSession = (s: AgentSession) => {
+    boundSession = s;
+    executors.rootManager.setOnSubagentSucceeded((usage, costUsd) => {
+      s.recordSubagentCompletion(usage, costUsd);
+    });
+    executors.composeExecutor.setOnSubagentSucceeded((usage, costUsd) => {
+      s.recordSubagentCompletion(usage, costUsd);
+    });
+  };
+
+  return wiring;
+}
+
+/** @internal Exposed for `SessionOwner` only. */
+export interface WebSessionWiringInternal extends WebSessionWiring {
+  __bindSession: (s: AgentSession) => void;
+}
+
+// ---------------------------------------------------------------------------
+// MCP loader (mirrors telegram/mcp-session.ts for the web surface)
+// ---------------------------------------------------------------------------
+
+async function loadWebMcpManager(
+  cwd: string,
+  traceWriter?: TraceSink,
+): Promise<McpManager | undefined> {
+  const importedMcpConfigs = resolveImportedRoots(loadImportFromConfig())
+    .mcpConfigs.filter((c) => c.format === 'json')
+    .map((c) => c.source);
+  const loaded = loadMcpConfig({
+    cwd,
+    ...(importedMcpConfigs.length > 0 ? { importedMcpConfigs } : {}),
+  });
+  const enabledCount = Object.values(loaded.mcpServers).filter((s) => !s.disabled).length;
+  if (enabledCount === 0) return undefined;
+
+  const mcpStartedAt = Date.now();
+  void emitSessionPhase(traceWriter, {
+    phase: 'mcp_connect_start',
+    metadata: { serverCount: enabledCount },
+  });
+  try {
+    return await McpManager.fromConfig(loaded.mcpServers, {
+      warnings: loaded.warnings,
+      serverLayers: loaded.serverLayers,
+      userAllowSecretEnv: loaded.userAllowSecretEnv,
+      ...(traceWriter !== undefined ? { traceWriter } : {}),
+    });
+  } finally {
+    void emitSessionPhase(traceWriter, {
+      phase: 'mcp_connect_done',
+      durationMs: Date.now() - mcpStartedAt,
+      metadata: { serverCount: enabledCount },
+    });
+  }
+}


### PR DESCRIPTION
## Problem

The `afk web` surface created sessions without calling `wireExecutors()`, causing 11 issues:

**Critical:**
1. `agent`/`skill`/`compose` tools silently non-functional (no executors)
2. No MCP server wiring (`mcp__*` tools missing)
3. No `drainSubagents` (subagent trace rows lost on close, no abort cascade)

**Medium:**
4. No witness trace writer (`afk trace show` empty for web sessions)
5. Split-brain `MemoryStore` (hook registry vs provider each create their own)
6. Plan/AFK-mode gate hooks unwired
7. `assembleSystemPrompt` not called (no routing directive, no end-of-turn protocol)
8. No `BackgroundAgentRegistry`

The user-visible symptom: every subagent had to manually `cd` into the project directory because `parentCwd` was never set.

The Telegram OpenAI and xAI branches had the same executor gap -- sessions worked for single-turn requests but subagent dispatch silently failed.

## Fix

### Web surface
New `session-owner.wiring.ts` builds the full executor/trace/MCP/provider stack (extracted to keep `session-owner.ts` under the 350-LOC ceiling). `SessionOwner.create()` now:
- Calls `wireExecutors()` with cwd, nestedCwd, trace, background registry
- Loads MCP servers via `McpManager.fromConfig()`
- Creates a witness trace writer
- Shares one `MemoryStore` between hook registry and provider
- Wires `drainSubagents` for cascade-abort on close
- Calls `assembleSystemPrompt()` for routing directive + end-of-turn
- Constructs `AnthropicDirectProvider` explicitly with all three executors
- Disconnects MCP managers on `closeAll()`

### Telegram OpenAI + xAI
Both branches now call `wireExecutors()` with a deferred parent proxy, wire `BackgroundAgentRegistry` + `TelegramBgResultNotifier`, add `drainSubagents`, and late-bind the subagent-success rollup -- matching the Anthropic branch.

## Verification

- `pnpm lint` -- clean
- `pnpm build` -- clean  
- `pnpm test src/web-server/` -- 376 tests pass
- `pnpm test src/telegram/` -- 1102 tests pass
- `pnpm audit:filesize:check` -- all files under ceiling
- `pnpm audit:env:check`, `audit:chalk:check`, `fix:pins:check` -- all clean
