### PR TITLE
fix(web): make tool record toolUseId optional for backward compat

### DIFF
--- a/src/agent/session-ledger-project.ts
+++ b/src/agent/session-ledger-project.ts
@@ -40,7 +40,7 @@ export type LedgerPayload =
   /** Extended-thinking block (clipped). */
   | { kind: 'thinking'; text: string }
   /** A tool invocation starting. `input` is a preview, capped at source. */
-  | { kind: 'tool'; toolName: string; toolUseId: string; input: string }
+  | { kind: 'tool'; toolName: string; toolUseId?: string; input: string }
   /** A failed tool result. */
   | { kind: 'tool_error'; toolName?: string; content: string }
   /** A successful tool result (clipped). */


### PR DESCRIPTION
## Summary

Pre-PR ledger files on disk contain `tool` records without a `toolUseId` field, but the TypeScript type declared it as required (`toolUseId: string`). The React ledger-adapter already handles this correctly at runtime (it guards with `str(payload['toolUseId'])` before using it), but the type was inaccurate.

## Change

In `src/agent/session-ledger-project.ts`, changed `LedgerPayload`'s `tool` kind record from:
```ts
| { kind: 'tool'; toolName: string; toolUseId: string; input: string }
```
to:
```ts
| { kind: 'tool'; toolName: string; toolUseId?: string; input: string }
```

This is a type-only change — no runtime behavior is modified.

Closes #1588