### PR TITLE
fix(web): add URL scheme allowlist to MarkdownContent links

### DIFF
--- a/dashboard/src/components/markdown-content.tsx
+++ b/dashboard/src/components/markdown-content.tsx
@@ -16,11 +16,18 @@ const components: Components = {
       {children}
     </blockquote>
   ),
-  a: ({ href, children }) => (
-    <a href={href} className="text-brand underline underline-offset-2 hover:text-brand/80" target="_blank" rel="noreferrer">
-      {children}
-    </a>
-  ),
+  a: ({ href, children }) => {
+    // Only allow safe URL schemes: https, http, root-relative paths, and anchor links.
+    // Anything else (data:, javascript:, vbscript:, …) renders as plain text.
+    const isSafe = href && /^(https?:\/\/|\/|#)/i.test(href);
+    return isSafe ? (
+      <a href={href} className="text-brand underline underline-offset-2 hover:text-brand/80" target="_blank" rel="noreferrer">
+        {children}
+      </a>
+    ) : (
+      <span className="text-brand underline underline-offset-2">{children}</span>
+    );
+  },
   strong: ({ children }) => <strong className="font-semibold text-foreground">{children}</strong>,
   em: ({ children }) => <em className="italic text-muted-foreground">{children}</em>,
   hr: () => <hr className="my-3 border-border" />,

--- a/dashboard/src/components/markdown-content.tsx
+++ b/dashboard/src/components/markdown-content.tsx
@@ -19,13 +19,13 @@ const components: Components = {
   a: ({ href, children }) => {
     // Only allow safe URL schemes: https, http, root-relative paths, and anchor links.
     // Anything else (data:, javascript:, vbscript:, …) renders as plain text.
-    const isSafe = href && /^(https?:\/\/|\/|#)/i.test(href);
+    const isSafe = href && /^(https?:\/\/|\/(?!\/)|#)/i.test(href);
     return isSafe ? (
       <a href={href} className="text-brand underline underline-offset-2 hover:text-brand/80" target="_blank" rel="noreferrer">
         {children}
       </a>
     ) : (
-      <span className="text-brand underline underline-offset-2">{children}</span>
+      <span className="text-muted-foreground">{children}</span>
     );
   },
   strong: ({ children }) => <strong className="font-semibold text-foreground">{children}</strong>,


### PR DESCRIPTION
## Summary

Closes #1586

The `MarkdownContent` component rendered `<a href={href}>` with no URL scheme validation. React 19 blocks `javascript:` URIs, but does **not** block `data:text/html` URIs, leaving a XSS vector via markdown link injection.

## Change

Added a scheme allowlist to the custom `<a>` renderer in `dashboard/src/components/markdown-content.tsx`:

- **Allowed:** `https://`, `http://`, root-relative paths (`/`), anchor links (`#`)
- **Blocked:** everything else (`data:`, `vbscript:`, etc.) — renders as a `<span>` (plain text) instead of a clickable link, preserving the visible link text.

## Pattern

```ts
const isSafe = href && /^(https?:\/\/|\/|#)/i.test(href);
return isSafe ? <a href={href} ...>{children}</a> : <span ...>{children}</span>;
```

## Verification

- `pnpm lint` (runs `tsc --noEmit` + `tsc --noEmit -p tsconfig.web.json`) passes with no errors.