### PR TITLE
fix(web): approval error feedback and stable React keys in memory view

### DIFF
--- a/dashboard/src/components/approval-cards.tsx
+++ b/dashboard/src/components/approval-cards.tsx
@@ -34,14 +34,16 @@ function ApprovalCard({
     typeof request.questionDefault === 'string' ? request.questionDefault : '',
   );
   const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const answer = async (action: 'accept' | 'decline', content?: Record<string, unknown>) => {
     setBusy(true);
+    setError(null);
     try {
       await answerApproval({ requestId: id, response: { action, content } });
       onAnswered();
     } catch {
-      // Leave card visible on error
+      setError('Failed to submit — try again');
     } finally {
       setBusy(false);
     }
@@ -121,6 +123,10 @@ function ApprovalCard({
             />
           ))}
         </div>
+      )}
+
+      {error && (
+        <p className="text-xs text-red-400">{error}</p>
       )}
     </div>
   );

--- a/dashboard/src/components/memory-view.tsx
+++ b/dashboard/src/components/memory-view.tsx
@@ -218,7 +218,12 @@ export function MemoryView() {
                 No results found.
               </p>
             ) : (
-              results.map((r, i) => <ResultCard key={i} result={r} />)
+              results.map((r) => (
+                <ResultCard
+                  key={`${r.type}-${r.created_at}-${r.content.slice(0, 32)}`}
+                  result={r}
+                />
+              ))
             )}
           </div>
         )}


### PR DESCRIPTION
## Summary

Closes #1587

### Changes

****
- Added `error` state (`useState<string | null>(null)`) to `ApprovalCard`
- Clears the error at the start of each attempt (`setError(null)`)
- Sets `'Failed to submit — try again'` in the `catch` block instead of silently swallowing the error
- Renders a `<p className="text-xs text-red-400">` error message below the action buttons when the state is set

**`dashboard/src/components/memory-view.tsx`**
- Replaced `key={i}` (index) with a stable composite key ``${r.type}-${r.created_at}-${r.content.slice(0, 32)}``
- Each `MemorySearchResult` has `type`, `created_at`, and `content` fields; the composite is unique per record and stable across re-renders

### Verification
- `pnpm typecheck` passes with 0 errors