### PR TITLE
fix(web): fix stale caches in React dashboard (#1584)

### DIFF
--- a/dashboard/src/components/composer.tsx
+++ b/dashboard/src/components/composer.tsx
@@ -17,8 +17,13 @@ interface ComposerProps {
   isBusy: boolean;
 }
 
-/** Cached slash commands — fetched once per page lifecycle. */
+/** Cached slash commands — cleared on page focus to pick up new skills. */
 let commandsCache: SlashCommand[] | null = null;
+
+/** Clear the cached command list so the next '/' keystroke re-fetches. */
+export function clearCommandsCache(): void {
+  commandsCache = null;
+}
 
 async function fetchCommands(): Promise<SlashCommand[]> {
   if (commandsCache) return commandsCache;
@@ -47,6 +52,15 @@ export function Composer({ sessionId, sessionMode, isBusy }: ComposerProps) {
   const acFiltered = acVisible
     ? commands.filter((c) => c.name.startsWith(slashQuery)).slice(0, 8)
     : [];
+
+  // Clear the command cache when the tab regains focus so new skills are visible.
+  useEffect(() => {
+    const onVisible = () => {
+      if (document.visibilityState === 'visible') clearCommandsCache();
+    };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => document.removeEventListener('visibilitychange', onVisible);
+  }, []);
 
   // Auto-resize textarea (1–5 rows)
   useEffect(() => {

--- a/dashboard/src/hooks/use-sse-stream.ts
+++ b/dashboard/src/hooks/use-sse-stream.ts
@@ -158,6 +158,9 @@ export function useSseStream(sessionId: string | null): UseSseStreamResult {
 
         outer: for (;;) {
           const { done, value } = await reader.read();
+          // Guard: the effect may have been torn down while we were awaiting;
+          // discard this frame rather than forwarding it to a new session.
+          if (stoppedRef.current) break;
           if (done) break;
           buffer += decoder.decode(value, { stream: true });
           const { events: frames, remainder } = parseSseChunk(buffer);

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -13,6 +13,11 @@ let cachedToken: string | null = null;
 /** Evict the in-memory token cache (e.g. after a 401 response). */
 function clearTokenCache(): void {
   cachedToken = null;
+  try {
+    sessionStorage.removeItem(TOKEN_STORAGE_KEY);
+  } catch {
+    // sessionStorage may be unavailable in some contexts
+  }
 }
 
 /** Read the bearer token, preferring the meta tag, falling back to storage. */

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -10,6 +10,11 @@ const TOKEN_STORAGE_KEY = 'afk_web_token';
 
 let cachedToken: string | null = null;
 
+/** Evict the in-memory token cache (e.g. after a 401 response). */
+function clearTokenCache(): void {
+  cachedToken = null;
+}
+
 /** Read the bearer token, preferring the meta tag, falling back to storage. */
 export function getToken(): string {
   if (cachedToken) return cachedToken;
@@ -68,6 +73,9 @@ export async function apiFetch<T>(
 
   const res = await fetch(path, { ...options, headers });
   if (!res.ok) {
+    // On 401 the server may have rotated the token — clear the cache so the
+    // next request re-reads from the meta tag instead of reusing the stale one.
+    if (res.status === 401) clearTokenCache();
     const text = await res.text().catch(() => res.statusText);
     throw new ApiError(res.status, text);
   }


### PR DESCRIPTION
## Summary

Fixes #1584 — three independent stale-cache bugs in the React dashboard.

### Changes

**`dashboard/src/components/composer.tsx`**
- Added `export function clearCommandsCache()` to allow external invalidation.
- Added a `useEffect` that listens for `visibilitychange` and calls `clearCommandsCache()` when the tab regains focus. Skills added at runtime will appear in the autocomplete list on the next `/` keystroke after switching back to the tab — no page reload needed.

**`dashboard/src/lib/api.ts`**
- On a 401 response, `apiFetch` now calls a local `clearTokenCache()` helper to null out `cachedToken` before throwing. The next request re-reads the token from the `<meta name="afk-token">` tag, picking up a rotated server token transparently.

**`dashboard/src/hooks/use-sse-stream.ts`**
- Added a `stoppedRef.current` guard immediately after `await reader.read()` returns, before any frame processing. If the effect was torn down during the await (unmount or session change), the frame is discarded instead of being forwarded to the new session's state.

### Verification
- `pnpm lint` (tsc --noEmit on both tsconfigs) passes clean.
- All three files remain under 350 LOC (187 / 93 / 224).