### PR TITLE
test(web): add route-level tests for memory, models, and bg-jobs endpoints

### DIFF
--- a/src/web-server/routes.bg-jobs.test.ts
+++ b/src/web-server/routes.bg-jobs.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ServerResponse } from 'node:http';
+import { handleListBgJobs, handleGetBgJob } from './routes.bg-jobs.js';
+import type { BgJobMeta } from '../agent/bg-job-log.js';
+
+// ---- mocks -----------------------------------------------------------------
+
+const mockListJobs = vi.fn<() => Promise<BgJobMeta[]>>();
+const mockReadMeta = vi.fn<(jobId: string) => Promise<BgJobMeta | null>>();
+
+vi.mock('../agent/bg-job-log.js', () => ({
+  BgJobLogReader: {
+    listJobs: () => mockListJobs(),
+    readMeta: (id: string) => mockReadMeta(id),
+  },
+}));
+
+// ---- fixtures --------------------------------------------------------------
+
+const JOB_A: BgJobMeta = {
+  jobId: 'abc123',
+  subagentId: 'sub-1',
+  label: 'Research task',
+  promptHash: 'deadbeef',
+  model: 'sonnet',
+  startedAt: 1_700_000_000_000,
+  endedAt: 1_700_000_060_000,
+  status: 'completed',
+  schemaVersion: 1,
+};
+
+const JOB_B: BgJobMeta = {
+  jobId: 'def456',
+  subagentId: 'sub-2',
+  label: 'Build task',
+  promptHash: 'cafebabe',
+  model: 'haiku',
+  startedAt: 1_700_000_100_000,
+  status: 'running',
+  schemaVersion: 1,
+};
+
+// ---- helpers ---------------------------------------------------------------
+
+function makeRes(): { res: ServerResponse; json: () => { status: number; body: unknown } } {
+  let status = 0;
+  const chunks: string[] = [];
+  const res = {
+    writeHead(s: number) {
+      status = s;
+    },
+    end(payload: string) {
+      chunks.push(payload);
+    },
+  } as unknown as ServerResponse;
+  return {
+    res,
+    json: () => ({ status, body: JSON.parse(chunks.join('')) as unknown }),
+  };
+}
+
+// ---- tests -----------------------------------------------------------------
+
+describe('routes.bg-jobs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // --------------------------------------------------------------------------
+  // handleListBgJobs
+  // --------------------------------------------------------------------------
+
+  describe('handleListBgJobs', () => {
+    it('returns 200 with a jobs array', async () => {
+      mockListJobs.mockResolvedValue([JOB_A, JOB_B]);
+      const { res, json } = makeRes();
+      await handleListBgJobs(res);
+      const { status, body } = json();
+      expect(status).toBe(200);
+      expect(body).toHaveProperty('jobs');
+    });
+
+    it('returns all jobs from the registry', async () => {
+      mockListJobs.mockResolvedValue([JOB_A, JOB_B]);
+      const { res, json } = makeRes();
+      await handleListBgJobs(res);
+      const { jobs } = json().body as { jobs: BgJobMeta[] };
+      expect(jobs).toHaveLength(2);
+      expect(jobs[0]?.jobId).toBe('abc123');
+      expect(jobs[1]?.jobId).toBe('def456');
+    });
+
+    it('returns empty list when there are no jobs', async () => {
+      mockListJobs.mockResolvedValue([]);
+      const { res, json } = makeRes();
+      await handleListBgJobs(res);
+      const { status, body } = json();
+      expect(status).toBe(200);
+      expect((body as { jobs: unknown[] }).jobs).toEqual([]);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // handleGetBgJob
+  // --------------------------------------------------------------------------
+
+  describe('handleGetBgJob', () => {
+    it('returns 400 for an id with disallowed characters (path-traversal guard)', async () => {
+      const { res, json } = makeRes();
+      await handleGetBgJob(res, '../etc/passwd');
+      const { status, body } = json();
+      expect(status).toBe(400);
+      expect((body as { error: string }).error).toBe('bad_request');
+    });
+
+    it('returns 400 for an id with spaces', async () => {
+      const { res, json } = makeRes();
+      await handleGetBgJob(res, 'job id with spaces');
+      expect(json().status).toBe(400);
+    });
+
+    it('returns 404 when the job is not found', async () => {
+      mockReadMeta.mockResolvedValue(null);
+      const { res, json } = makeRes();
+      await handleGetBgJob(res, 'nonexistent-job-id');
+      const { status, body } = json();
+      expect(status).toBe(404);
+      expect((body as { error: string }).error).toBe('not_found');
+    });
+
+    it('returns 200 with the job for a known id', async () => {
+      mockReadMeta.mockResolvedValue(JOB_A);
+      const { res, json } = makeRes();
+      await handleGetBgJob(res, 'abc123');
+      const { status, body } = json();
+      expect(status).toBe(200);
+      expect((body as { job: BgJobMeta }).job).toEqual(JOB_A);
+    });
+
+    it('passes the jobId through to BgJobLogReader.readMeta', async () => {
+      mockReadMeta.mockResolvedValue(JOB_B);
+      const { res } = makeRes();
+      await handleGetBgJob(res, 'def456');
+      expect(mockReadMeta).toHaveBeenCalledWith('def456');
+    });
+
+    it('accepts alphanumeric-and-dash ids', async () => {
+      mockReadMeta.mockResolvedValue(JOB_A);
+      const { res, json } = makeRes();
+      await handleGetBgJob(res, 'job-abc-123');
+      expect(json().status).toBe(200);
+    });
+
+    it('returns the correct job shape (all BgJobMeta fields)', async () => {
+      mockReadMeta.mockResolvedValue(JOB_A);
+      const { res, json } = makeRes();
+      await handleGetBgJob(res, 'abc123');
+      const { job } = json().body as { job: BgJobMeta };
+      expect(job.jobId).toBe('abc123');
+      expect(job.model).toBe('sonnet');
+      expect(job.status).toBe('completed');
+      expect(job.schemaVersion).toBe(1);
+    });
+
+    it('returns a running job (no endedAt) correctly', async () => {
+      mockReadMeta.mockResolvedValue(JOB_B);
+      const { res, json } = makeRes();
+      await handleGetBgJob(res, 'def456');
+      const { job } = json().body as { job: BgJobMeta };
+      expect(job.status).toBe('running');
+      expect(job.endedAt).toBeUndefined();
+    });
+  });
+});

--- a/src/web-server/routes.memory.test.ts
+++ b/src/web-server/routes.memory.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ServerResponse } from 'node:http';
+import { handleSearchMemory, handleGetHotMemory } from './routes.memory.js';
+
+// ---- mocks -----------------------------------------------------------------
+
+// Each method mock is a stable vi.fn() so `vi.clearAllMocks()` resets call
+// history without destroying the function reference. The MemoryStore
+// constructor is also a stable vi.fn() — see below.
+const mockSearch = vi.fn();
+const mockLoadHot = vi.fn();
+const mockHotUsage = vi.fn();
+const mockClose = vi.fn();
+
+// The MemoryStore constructor mock is defined inside vi.mock (hoisted), so we
+// use vi.hoisted to keep a stable reference to it across the hoist boundary.
+const MockMemoryStore = vi.hoisted(() =>
+  vi.fn().mockImplementation(() => ({
+    search: mockSearch,
+    loadHot: mockLoadHot,
+    hotUsage: mockHotUsage,
+    close: mockClose,
+  })),
+);
+
+vi.mock('../agent/memory/memory-store.js', () => ({
+  MemoryStore: MockMemoryStore,
+}));
+
+// ---- helpers ---------------------------------------------------------------
+
+function makeRes(): { res: ServerResponse; json: () => { status: number; body: unknown } } {
+  let status = 0;
+  const chunks: string[] = [];
+  const res = {
+    writeHead(s: number) {
+      status = s;
+    },
+    end(payload: string) {
+      chunks.push(payload);
+    },
+  } as unknown as ServerResponse;
+  return {
+    res,
+    json: () => ({ status, body: JSON.parse(chunks.join('')) as unknown }),
+  };
+}
+
+function makeQuery(params: Record<string, string>): URLSearchParams {
+  return new URLSearchParams(params);
+}
+
+// ---- tests -----------------------------------------------------------------
+
+describe('routes.memory', () => {
+  beforeEach(() => {
+    // Reset call history for the per-method mocks (not the constructor mock,
+    // as clearAllMocks would wipe its mockImplementation too).
+    mockSearch.mockReset();
+    mockLoadHot.mockReset();
+    mockHotUsage.mockReset();
+    mockClose.mockReset();
+    MockMemoryStore.mockClear();
+  });
+
+  // --------------------------------------------------------------------------
+  // handleSearchMemory
+  // --------------------------------------------------------------------------
+
+  describe('handleSearchMemory', () => {
+    it('returns 400 when q is absent', async () => {
+      const { res, json } = makeRes();
+      await handleSearchMemory(res, makeQuery({}));
+      const { status, body } = json();
+      expect(status).toBe(400);
+      expect((body as { error: string }).error).toBe('bad_request');
+    });
+
+    it('returns 400 when q is blank/whitespace', async () => {
+      const { res, json } = makeRes();
+      await handleSearchMemory(res, makeQuery({ q: '   ' }));
+      expect(json().status).toBe(400);
+    });
+
+    it('returns 400 for an unknown category value', async () => {
+      const { res, json } = makeRes();
+      await handleSearchMemory(res, makeQuery({ q: 'test', category: 'bogus' }));
+      const { status, body } = json();
+      expect(status).toBe(400);
+      expect((body as { error: string }).error).toBe('bad_request');
+    });
+
+    it('returns 200 with results for a valid query', async () => {
+      const fakeResults = [{ id: 1, content: 'remembered thing', category: 'preference' }];
+      mockSearch.mockReturnValue(fakeResults);
+
+      const { res, json } = makeRes();
+      await handleSearchMemory(res, makeQuery({ q: 'remembered' }));
+      const { status, body } = json();
+      expect(status).toBe(200);
+      expect((body as { results: unknown[] }).results).toEqual(fakeResults);
+      expect(mockSearch).toHaveBeenCalledWith('remembered', { limit: 20 });
+    });
+
+    it('passes a valid category filter through to MemoryStore.search', async () => {
+      mockSearch.mockReturnValue([]);
+      const { res } = makeRes();
+      await handleSearchMemory(res, makeQuery({ q: 'pref', category: 'preference' }));
+      expect(mockSearch).toHaveBeenCalledWith('pref', {
+        category: 'preference',
+        limit: 20,
+      });
+    });
+
+    it('accepts all valid category values', async () => {
+      const validCategories = ['preference', 'convention', 'decision', 'learning'] as const;
+      for (const category of validCategories) {
+        mockSearch.mockReturnValue([]);
+        const { res, json } = makeRes();
+        await handleSearchMemory(res, makeQuery({ q: 'x', category }));
+        expect(json().status).toBe(200);
+      }
+    });
+
+    it('returns 200 with empty results when no matches', async () => {
+      mockSearch.mockReturnValue([]);
+      const { res, json } = makeRes();
+      await handleSearchMemory(res, makeQuery({ q: 'nothing here' }));
+      const { status, body } = json();
+      expect(status).toBe(200);
+      expect((body as { results: unknown[] }).results).toEqual([]);
+    });
+
+    it('clamps limit to MAX_LIMIT (100) when above ceiling', async () => {
+      mockSearch.mockReturnValue([]);
+      const { res } = makeRes();
+      await handleSearchMemory(res, makeQuery({ q: 'test', limit: '999' }));
+      const call = mockSearch.mock.calls[0] as [string, { limit: number }];
+      expect(call[1].limit).toBe(100);
+    });
+
+    it('uses DEFAULT_LIMIT when limit param is absent', async () => {
+      mockSearch.mockReturnValue([]);
+      const { res } = makeRes();
+      await handleSearchMemory(res, makeQuery({ q: 'test' }));
+      const call = mockSearch.mock.calls[0] as [string, { limit: number }];
+      expect(call[1].limit).toBe(20);
+    });
+
+    it('uses DEFAULT_LIMIT when limit is non-numeric', async () => {
+      mockSearch.mockReturnValue([]);
+      const { res } = makeRes();
+      await handleSearchMemory(res, makeQuery({ q: 'test', limit: 'abc' }));
+      const call = mockSearch.mock.calls[0] as [string, { limit: number }];
+      expect(call[1].limit).toBe(20);
+    });
+
+    it('closes the store even on success', async () => {
+      mockSearch.mockReturnValue([]);
+      const { res } = makeRes();
+      await handleSearchMemory(res, makeQuery({ q: 'hello' }));
+      expect(mockClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('closes the store if search throws', async () => {
+      mockSearch.mockImplementation(() => {
+        throw new Error('db error');
+      });
+      const { res } = makeRes();
+      await expect(handleSearchMemory(res, makeQuery({ q: 'boom' }))).rejects.toThrow('db error');
+      expect(mockClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // handleGetHotMemory
+  // --------------------------------------------------------------------------
+
+  describe('handleGetHotMemory', () => {
+    it('returns 200 with content and usage', async () => {
+      const fakeContent = '# HOT\nSome hot memory';
+      const fakeUsage = { chars: 18, tokens: 5, budgetChars: 10_000, ratio: 0.002 };
+      mockLoadHot.mockReturnValue(fakeContent);
+      mockHotUsage.mockReturnValue(fakeUsage);
+
+      const { res, json } = makeRes();
+      await handleGetHotMemory(res);
+      const { status, body } = json();
+      expect(status).toBe(200);
+      expect((body as { content: string }).content).toBe(fakeContent);
+      expect((body as { usage: unknown }).usage).toEqual(fakeUsage);
+    });
+
+    it('returns null content when HOT.md does not exist', async () => {
+      mockLoadHot.mockReturnValue(null);
+      mockHotUsage.mockReturnValue({ chars: 0, tokens: 0, budgetChars: 10_000, ratio: 0 });
+
+      const { res, json } = makeRes();
+      await handleGetHotMemory(res);
+      const { status, body } = json();
+      expect(status).toBe(200);
+      expect((body as { content: unknown }).content).toBeNull();
+    });
+
+    it('closes the store after reading', async () => {
+      mockLoadHot.mockReturnValue(null);
+      mockHotUsage.mockReturnValue({ chars: 0, tokens: 0, budgetChars: 10_000, ratio: 0 });
+
+      const { res } = makeRes();
+      await handleGetHotMemory(res);
+      expect(mockClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('closes the store even if loadHot throws', async () => {
+      mockLoadHot.mockImplementation(() => {
+        throw new Error('fs error');
+      });
+      const { res } = makeRes();
+      await expect(handleGetHotMemory(res)).rejects.toThrow('fs error');
+      expect(mockClose).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/web-server/routes.models.test.ts
+++ b/src/web-server/routes.models.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import type { ServerResponse } from 'node:http';
+import { handleListModels } from './routes.models.js';
+
+// ---- helpers ---------------------------------------------------------------
+
+function makeRes(): { res: ServerResponse; json: () => { status: number; body: unknown } } {
+  let status = 0;
+  const chunks: string[] = [];
+  const res = {
+    writeHead(s: number) {
+      status = s;
+    },
+    end(payload: string) {
+      chunks.push(payload);
+    },
+  } as unknown as ServerResponse;
+  return {
+    res,
+    json: () => ({ status, body: JSON.parse(chunks.join('')) as unknown }),
+  };
+}
+
+// ---- tests -----------------------------------------------------------------
+
+describe('routes.models', () => {
+  describe('handleListModels', () => {
+    it('returns 200', () => {
+      const { res, json } = makeRes();
+      handleListModels(res);
+      expect(json().status).toBe(200);
+    });
+
+    it('returns a models array', () => {
+      const { res, json } = makeRes();
+      handleListModels(res);
+      const body = json().body as { models: unknown[] };
+      expect(body).toHaveProperty('models');
+      expect(Array.isArray(body.models)).toBe(true);
+    });
+
+    it('includes the expected tier ids (sonnet, haiku, opus)', () => {
+      const { res, json } = makeRes();
+      handleListModels(res);
+      const { models } = json().body as { models: Array<{ id: string; label: string }> };
+      const ids = models.map((m) => m.id);
+      expect(ids).toContain('sonnet');
+      expect(ids).toContain('haiku');
+      expect(ids).toContain('opus');
+    });
+
+    it('every entry has an id (string) and a label (string)', () => {
+      const { res, json } = makeRes();
+      handleListModels(res);
+      const { models } = json().body as { models: Array<{ id: string; label: string }> };
+      for (const m of models) {
+        expect(typeof m.id).toBe('string');
+        expect(m.id.length).toBeGreaterThan(0);
+        expect(typeof m.label).toBe('string');
+        expect(m.label.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('returns the same list on repeated calls (static, no side effects)', () => {
+      const { res: res1, json: json1 } = makeRes();
+      const { res: res2, json: json2 } = makeRes();
+      handleListModels(res1);
+      handleListModels(res2);
+      expect(json1().body).toEqual(json2().body);
+    });
+  });
+});


### PR DESCRIPTION
Closes #1583

## What

Adds test coverage for the three new API route modules introduced in PR #1580:

| File | Tests | Handlers covered |
|---|---|---|
| `routes.memory.test.ts` | 16 | `handleSearchMemory`, `handleGetHotMemory` |
| `routes.models.test.ts` | 5 | `handleListModels` |
| `routes.bg-jobs.test.ts` | 11 | `handleListBgJobs`, `handleGetBgJob` |

**Total: 32 tests**

## Test coverage per handler

### `handleSearchMemory`
- 400 on missing `q` parameter
- 400 on blank/whitespace `q`
- 400 on unknown `category` value
- 200 happy path with results
- Category filter forwarded to MemoryStore correctly
- All four valid category values accepted
- Empty results case
- `limit` clamped to 100 (MAX_LIMIT)
- Default limit (20) applied when param absent or non-numeric
- `store.close()` called on success and on error

### `handleGetHotMemory`
- 200 with content + usage
- Null content when HOT.md does not exist
- `store.close()` called on success and on error

### `handleListModels`
- Returns 200 with a models array
- Includes the expected tier ids (sonnet, haiku, opus)
- Every entry has non-empty id and label strings
- Idempotent/static (repeated calls return identical body)

### `handleListBgJobs`
- 200 with all jobs from registry
- Empty list when no jobs exist

### `handleGetBgJob`
- 400 for path-traversal-shaped ids (VALID_JOB_ID guard)
- 400 for ids containing spaces
- 404 when job not found
- 200 happy path with correct BgJobMeta shape
- jobId forwarded to `BgJobLogReader.readMeta`
- Running jobs (no `endedAt`) handled correctly

## Approach

- Mocks all dependencies (`MemoryStore`, `BgJobLogReader`) — no SQLite or filesystem needed
- Follows the pattern from `routes.schedules.test.ts` (fake `ServerResponse`, inline JSON capture)
- Uses `vi.hoisted()` for the `MemoryStore` constructor mock to keep the implementation stable across `vi.clearAllMocks()` calls

## Verification

```
pnpm test  →  32 new tests pass, 0 failures
pnpm lint  →  clean (tsc + tsconfig.web.json)
```