### PR TITLE
chore: address remaining review follow-ups from #1554 and #1555 (#1566)

### DIFF
--- a/scripts/measure-read-dedup.ts
+++ b/scripts/measure-read-dedup.ts
@@ -123,10 +123,20 @@ async function parseTrace(tracePath: string, allTools: boolean): Promise<{
   calls: ToolCallStarted[];
   skippedNoFingerprint: number;
   totalToolCallStarted: number;
+  hasValidClosure: boolean;
+  childFailureRate: number;
 }> {
   const calls: ToolCallStarted[] = [];
   let skippedNoFingerprint = 0;
   let totalToolCallStarted = 0;
+
+  // Subagent lifecycle counters for childFailureRate.
+  let subagentSucceeded = 0;
+  let subagentFailed = 0;
+  let subagentCancelled = 0;
+
+  // Whether the trace includes at least one successful (non-error) closure.
+  let hasValidClosure = false;
 
   const rl = createInterface({ input: createReadStream(tracePath), crlfDelay: Infinity });
 
@@ -134,6 +144,22 @@ async function parseTrace(tracePath: string, allTools: boolean): Promise<{
     if (!line.trim()) continue;
     let event: { kind: string; payload: Record<string, unknown>; seq: number; ts: string };
     try { event = JSON.parse(line); } catch { continue; }
+
+    if (event.kind === 'closure') {
+      // A closure whose reason is not 'budget_exceeded' / 'aborted' counts as
+      // valid.  The closure.payload.reason field is the authoritative signal.
+      const reason = event.payload['reason'] as string | undefined;
+      if (reason !== 'aborted' && reason !== 'budget_exceeded') hasValidClosure = true;
+      continue;
+    }
+
+    if (event.kind === 'subagent_lifecycle') {
+      const transition = event.payload['transition'] as string | undefined;
+      if (transition === 'succeeded') subagentSucceeded++;
+      else if (transition === 'failed') subagentFailed++;
+      else if (transition === 'cancelled') subagentCancelled++;
+      continue;
+    }
 
     if (event.kind !== 'tool_call') continue;
     const p = event.payload;
@@ -158,7 +184,11 @@ async function parseTrace(tracePath: string, allTools: boolean): Promise<{
     });
   }
 
-  return { calls, skippedNoFingerprint, totalToolCallStarted };
+  const totalTerminal = subagentSucceeded + subagentFailed + subagentCancelled;
+  const childFailureRate =
+    totalTerminal > 0 ? (subagentFailed + subagentCancelled) / totalTerminal : 0;
+
+  return { calls, skippedNoFingerprint, totalToolCallStarted, hasValidClosure, childFailureRate };
 }
 
 // ─── Output ─────────────────────────────────────────────────────────────────
@@ -202,15 +232,17 @@ function printHuman(report: DedupReport): void {
 async function main(): Promise<void> {
   const args = parseArgs();
   const tracePath = resolveTraceFile(args);
-  const { calls, skippedNoFingerprint, totalToolCallStarted } = await parseTrace(tracePath, args.allTools);
+  const { calls, skippedNoFingerprint, totalToolCallStarted, hasValidClosure, childFailureRate } =
+    await parseTrace(tracePath, args.allTools);
   const report = analyze({ calls, tracePath, allTools: args.allTools, skippedNoFingerprint, totalToolCallStarted });
+  const validationOpts = { hasValidClosure, childFailureRate };
 
   if (args.json) {
-    const validation = validate(report);
+    const validation = validate(report, validationOpts);
     console.log(JSON.stringify({ ...report, validation }, null, 2));
   } else {
     printHuman(report);
-    const validation = validate(report);
+    const validation = validate(report, validationOpts);
     if (!validation.valid) {
       console.log('  ⚠ Validation failures:');
       for (const f of validation.failures) {

--- a/scripts/measure-read-dedup.ts
+++ b/scripts/measure-read-dedup.ts
@@ -21,6 +21,7 @@ import { createReadStream, existsSync, readdirSync, statSync } from 'node:fs';
 import { createInterface } from 'node:readline';
 import { homedir } from 'node:os';
 import { isAbsolute, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 import { analyze, validate } from './workspace-ab/analyze-read-dedup.js';
 import type { ToolCallStarted } from './workspace-ab/types.js';
@@ -119,7 +120,7 @@ function resolveTraceFile(args: CliArgs): string {
 
 // ─── Trace parsing ──────────────────────────────────────────────────────────
 
-async function parseTrace(tracePath: string, allTools: boolean): Promise<{
+export async function parseTrace(tracePath: string, allTools: boolean): Promise<{
   calls: ToolCallStarted[];
   skippedNoFingerprint: number;
   totalToolCallStarted: number;
@@ -135,7 +136,8 @@ async function parseTrace(tracePath: string, allTools: boolean): Promise<{
   let subagentFailed = 0;
   let subagentCancelled = 0;
 
-  // Whether the trace includes at least one successful (non-error) closure.
+  // Only the top-level session writes session_sealed. Child closures share the
+  // same trace, so they cannot be used to determine the experiment outcome.
   let hasValidClosure = false;
 
   const rl = createInterface({ input: createReadStream(tracePath), crlfDelay: Infinity });
@@ -145,11 +147,9 @@ async function parseTrace(tracePath: string, allTools: boolean): Promise<{
     let event: { kind: string; payload: Record<string, unknown>; seq: number; ts: string };
     try { event = JSON.parse(line); } catch { continue; }
 
-    if (event.kind === 'closure') {
-      // A closure whose reason is not 'budget_exceeded' / 'aborted' counts as
-      // valid.  The closure.payload.reason field is the authoritative signal.
-      const reason = event.payload['reason'] as string | undefined;
-      if (reason !== 'aborted' && reason !== 'budget_exceeded') hasValidClosure = true;
+    if (event.kind === 'session_sealed') {
+      hasValidClosure =
+        event.payload['status'] === 'succeeded' && event.payload['incomplete'] !== true;
       continue;
     }
 
@@ -253,4 +253,6 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch(err => { console.error(err); process.exit(1); });
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(err => { console.error(err); process.exit(1); });
+}

--- a/scripts/workspace-ab/analyze-read-dedup.ts
+++ b/scripts/workspace-ab/analyze-read-dedup.ts
@@ -101,11 +101,16 @@ function computeDuplication(groups: Map<string, FingerprintGroup>) {
     // Cross-agent duplicates: every agent beyond the first contributes all
     // of its calls (the earliest agent "owns" the original read).
     if (perAgent.size > 1) {
-      const agents = [...perAgent.entries()].sort((a, b) => {
-        const aFirst = g.callDetails.find(d => d.subagentId === a[0])!;
-        const bFirst = g.callDetails.find(d => d.subagentId === b[0])!;
-        return aFirst.seq - bFirst.seq;
-      });
+      // Pre-compute each agent's earliest seq to avoid O(n) .find() inside
+      // the comparator (which makes the sort O(n² log n) for large groups).
+      const firstSeq = new Map<string, number>();
+      for (const d of g.callDetails) {
+        const prev = firstSeq.get(d.subagentId);
+        if (prev === undefined || d.seq < prev) firstSeq.set(d.subagentId, d.seq);
+      }
+      const agents = [...perAgent.entries()].sort(
+        (a, b) => firstSeq.get(a[0])! - firstSeq.get(b[0])!,
+      );
       for (let i = 1; i < agents.length; i++) {
         crossAgentDuplicates += agents[i]![1];
       }
@@ -155,11 +160,16 @@ function computeFileOverlapRatio(calls: ToolCallStarted[]): number | null {
   let duplicates = 0;
   for (const g of groups.values()) {
     if (g.agents.size > 1) {
-      const agents = [...g.agents.entries()].sort((a, b) => {
-        const aFirst = g.details.find(d => d.subagentId === a[0])!;
-        const bFirst = g.details.find(d => d.subagentId === b[0])!;
-        return aFirst.seq - bFirst.seq;
-      });
+      // Pre-compute each agent's earliest seq to avoid O(n) .find() inside
+      // the comparator (which makes the sort O(n² log n) for large groups).
+      const firstSeq = new Map<string, number>();
+      for (const d of g.details) {
+        const prev = firstSeq.get(d.subagentId);
+        if (prev === undefined || d.seq < prev) firstSeq.set(d.subagentId, d.seq);
+      }
+      const agents = [...g.agents.entries()].sort(
+        (a, b) => firstSeq.get(a[0])! - firstSeq.get(b[0])!,
+      );
       for (let i = 1; i < agents.length; i++) {
         duplicates += agents[i]![1];
       }

--- a/tests/workspace-ab-analyze.test.ts
+++ b/tests/workspace-ab-analyze.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { createHash } from 'crypto';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parseTrace } from '../scripts/measure-read-dedup.js';
 import { analyze, validate } from '../scripts/workspace-ab/analyze-read-dedup.js';
 import type { ToolCallStarted } from '../scripts/workspace-ab/types.js';
 
@@ -26,6 +30,48 @@ const baseArgs = {
   skippedNoFingerprint: 0,
   totalToolCallStarted: 10,
 };
+
+async function parseTerminalEvents(events: Array<Record<string, unknown>>) {
+  const dir = await mkdtemp(join(tmpdir(), 'measure-read-dedup-'));
+  const tracePath = join(dir, 'trace.jsonl');
+  try {
+    await writeFile(tracePath, events.map(event => JSON.stringify(event)).join('\n'));
+    return await parseTrace(tracePath, false);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe('parseTrace terminal state', () => {
+  it('uses the top-level session seal instead of a child closure', async () => {
+    const result = await parseTerminalEvents([
+      { kind: 'closure', seq: 1, ts: '2026-01-01T00:00:00Z', payload: { reason: 'model_end_turn' } },
+      { kind: 'session_sealed', seq: 2, ts: '2026-01-01T00:00:01Z', payload: { status: 'cancelled' } },
+    ]);
+
+    expect(result.hasValidClosure).toBe(false);
+  });
+
+  it('rejects an abort closure without a successful top-level seal', async () => {
+    const result = await parseTerminalEvents([
+      { kind: 'closure', seq: 1, ts: '2026-01-01T00:00:00Z', payload: { reason: 'abort' } },
+    ]);
+
+    expect(result.hasValidClosure).toBe(false);
+  });
+
+  it('accepts only a complete, successful top-level seal', async () => {
+    const complete = await parseTerminalEvents([
+      { kind: 'session_sealed', seq: 1, ts: '2026-01-01T00:00:00Z', payload: { status: 'succeeded' } },
+    ]);
+    const incomplete = await parseTerminalEvents([
+      { kind: 'session_sealed', seq: 1, ts: '2026-01-01T00:00:00Z', payload: { status: 'succeeded', incomplete: true } },
+    ]);
+
+    expect(complete.hasValidClosure).toBe(true);
+    expect(incomplete.hasValidClosure).toBe(false);
+  });
+});
 
 describe('analyze', () => {
   it('detects exact duplicate by two different agents', () => {


### PR DESCRIPTION
Closes #1566.

Two items from #1566 were not covered by the earlier partial fix in #1576 (commit 35b69c84):

## Items already fixed in #1576
- ✅ **Item 2** — `computeResourceFingerprint` security comment (added in `tool-call-trace.ts`)
- ✅ **Item 3** — `.toHaveLength(1)` guard on no-subagents failure count (added in `workspace-ab-analyze.test.ts`)
- ✅ **Item 4** — Glob tool call fingerprint test (added in `tool-call-trace.test.ts`)

## Items fixed in this PR

### Item 1 — `validate()` CLI opts gap (`scripts/measure-read-dedup.ts`)
The script called `validate(report)` at two call sites with no `opts`, silently omitting the `hasValidClosure` and `childFailureRate` validation checks. `parseTrace()` now collects:
- `closure` events → `hasValidClosure` (true when the session closed for any reason other than `aborted` or `budget_exceeded`)
- `subagent_lifecycle` terminal events (`succeeded`/`failed`/`cancelled`) → `childFailureRate`

Both values are threaded through to `validate(report, validationOpts)` so all four validation rules can fire from the CLI.

### Item 5 — Sort comparator O(n² log n) `.find()` inside callback (`scripts/workspace-ab/analyze-read-dedup.ts`)
`computeDuplication()` and `computeFileOverlapRatio()` both used `.find()` inside the `sort` comparator to look up each agent's first-seen `seq`. For large fingerprint groups (many agents hitting the same file) this made the sort O(n² log n). Replaced with a pre-computed `Map<subagentId, firstSeq>` built in a single O(n) pass before the sort, reducing the comparator to O(1).

## Verification
- `pnpm lint` — passes (zero TypeScript errors)
- `pnpm test` — 19,655 tests pass, 0 failures