### PR TITLE
feat(web): wire slash-command dispatch into web UI prompt path

### DIFF
--- a/src/web-server/register-plugin-skills.ts
+++ b/src/web-server/register-plugin-skills.ts
@@ -1,0 +1,55 @@
+/**
+ * Session-free plugin-skill registration for the web surface.
+ *
+ * `registerAll()` (cli/slash/index.ts) registers built-in TS skills
+ * (`src/skills/`) and user/project-scope skills, but NOT plugin-discovered
+ * skills (from `~/.afk/plugins/` and `src/bundled-plugins/`). Those are
+ * normally registered by `registerPluginSkills(session)` after an
+ * `AgentSession` initializes -- a path the web server never takes.
+ *
+ * This module surfaces plugin skills (`review`, `ship`, `diagnose`, etc.)
+ * in the slash-command autocomplete menu AND makes them resolvable by the
+ * dispatch layer (`classifySlashInput`) by scanning plugin roots via
+ * `collectSkillEntries()` -- the same session-free disk walk the REPL's
+ * `supportedCommands()` delegates to -- and registering a minimal slash
+ * entry for each undiscovered plugin skill.
+ *
+ * Extracted into its own module so both `routes.ts` (menu population) and
+ * `slash-dispatch.ts` (command resolution) can call it without a circular
+ * dynamic-import dependency.
+ *
+ * Must be called AFTER `registerAll()` so built-in skills hold their
+ * bare-name slots. Best-effort: a failure leaves the menu with only
+ * built-in skills.
+ */
+
+export async function registerPluginSkillsForWeb(): Promise<void> {
+  try {
+    const [{ collectSkillEntries }, { extractHintFromDescription }, { has: registryHas, registerOrReplace }] =
+      await Promise.all([
+        import('../agent/tools/skill-bridge.js'),
+        import('../cli/slash/plugin-skills/flags.js'),
+        import('../cli/slash/registry.js'),
+      ]);
+    const entries = collectSkillEntries();
+    for (const entry of entries) {
+      const slashName = `/${entry.name}`;
+      if (registryHas(slashName)) continue;
+      // Register a menu-only entry -- acceptsAttachments marks it as a skill
+      // command so classifySlashInput builds the invocation payload.
+      const hint = extractHintFromDescription(entry.description);
+      registerOrReplace({
+        name: slashName,
+        summary: entry.description,
+        acceptsAttachments: true,
+        ...(entry.argumentHint ? { usage: `${slashName} ${entry.argumentHint}` } : {}),
+        ...(hint ? { hint } : {}),
+        async handler() {
+          return 'continue';
+        },
+      });
+    }
+  } catch {
+    // Plugin discovery is best-effort -- the menu stays usable without it.
+  }
+}

--- a/src/web-server/routes.ts
+++ b/src/web-server/routes.ts
@@ -252,8 +252,16 @@ export async function handlePrompt(
   // reservation is released inside dispatchSlashForWeb for non-skill paths.
   if (text.trimStart().startsWith('/')) {
     ctx.reserveTurn?.(sessionId);
-    const result = await dispatchSlashForWeb(ctx, res, sessionId, text);
-    if (result) return; // handled — response already sent
+    let slashHandled: boolean;
+    try {
+      slashHandled = await dispatchSlashForWeb(ctx, res, sessionId, text);
+    } catch (err) {
+      // Release the reservation on any unexpected throw so the session's
+      // pending counter doesn't get permanently stuck at > 0.
+      ctx.releaseTurn?.(sessionId);
+      throw err;
+    }
+    if (slashHandled) return; // handled — response already sent
   }
 
   await ctx.submitPrompt(sessionId, text);

--- a/src/web-server/routes.ts
+++ b/src/web-server/routes.ts
@@ -8,6 +8,7 @@
  */
 
 import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { ContentBlockParam } from '@anthropic-ai/sdk/resources';
 import { isSafeLedgerSessionId } from '../paths.js';
 import { jsonDateReplacer } from '../cli/json-date-replacer.js';
 import { listWebSessions } from './session-source.js';
@@ -24,6 +25,12 @@ export interface RouteContext {
   bridge: WebElicitationBridge;
   /** Submit a prompt to an owned session. */
   submitPrompt: (sessionId: string, text: string) => Promise<void>;
+  /** Submit a pre-built skill-invocation message (ContentBlockParam[]). */
+  submitSkillMessage?: (sessionId: string, message: ContentBlockParam[]) => Promise<void>;
+  /** Session cwd for preflight context. */
+  getSessionCwd?: (sessionId: string) => string | undefined;
+  /** Provider-issued session id for preflight artifact dirs. */
+  getProviderSessionId?: (sessionId: string) => string | undefined;
   /**
    * Whether an owned session already has a turn in flight — the backpressure
    * predicate `handlePrompt` gates on. Always present: `server.ts` defaults it
@@ -145,9 +152,10 @@ export function setCommandUniverseLoaderForTests(loader: CommandUniverseLoader):
  * 503 without crashing the server, and the next request retries rather than
  * memoizing a transient failure as an empty universe.
  *
- * The payload is deliberately descriptive only: name, summary, hint. It
- * carries NO claim that a command will execute, because in this surface none
- * of them do — the browser's prompt path sends text to the model verbatim.
+ * The payload is deliberately descriptive only: name, summary, hint. Skill
+ * commands (those with `acceptsAttachments`) are now dispatched via
+ * `classifySlashInput` in `slash-dispatch.ts` — see `handlePrompt`. Native
+ * REPL-only commands still cannot execute on this surface.
  *
  * Invariant: the slash layer is reached through a DYNAMIC import, and that is
  * structural rather than stylistic. `cli/slash/index.js` transitively pulls in
@@ -213,6 +221,16 @@ export async function handlePrompt(
     sendJson(res, 400, { error: 'bad_request', message: 'body must be { text: string }' });
     return;
   }
+
+  // Slash-command dispatch: intercept skill invocations before they reach
+  // the model as raw text. Native REPL-only commands are rejected; skill
+  // commands are built into the structured multi-block payload the model
+  // recognises as a skill dispatch.
+  if (text.trimStart().startsWith('/') && ctx.submitSkillMessage) {
+    const result = await dispatchSlashForWeb(ctx, res, sessionId, text);
+    if (result) return; // handled — response already sent
+  }
+
   await ctx.submitPrompt(sessionId, text);
   sendJson(res, 202, { ok: true });
 }
@@ -265,6 +283,51 @@ function approveByRequestId(ctx: RouteContext, res: ServerResponse, body: unknow
     return;
   }
   sendJson(res, 200, { ok: true });
+}
+
+/**
+ * Attempt slash-command dispatch for the web surface. Returns `true` when the
+ * input was handled (response already sent); `false` when it should fall
+ * through to the plain-text `submitPrompt` path.
+ */
+async function dispatchSlashForWeb(
+  ctx: RouteContext,
+  res: ServerResponse,
+  sessionId: string,
+  text: string,
+): Promise<boolean> {
+  // Dynamic import -- same lazy-load rationale as handleCommands.
+  const { classifySlashInput } = await import('./slash-dispatch.js');
+
+  const cwd = ctx.getSessionCwd?.(sessionId) ?? process.cwd();
+  const providerSessionId = ctx.getProviderSessionId?.(sessionId);
+  const result = await classifySlashInput(text, cwd, providerSessionId);
+
+  switch (result.kind) {
+    case 'passthrough':
+      return false;
+
+    case 'skill':
+      await ctx.submitSkillMessage!(sessionId, result.message);
+      sendJson(res, 202, { ok: true });
+      return true;
+
+    case 'repl-only':
+      sendJson(res, 422, {
+        error: 'repl_only_command',
+        message: `${result.command} is a terminal-only command and cannot run in the web UI.`,
+      });
+      return true;
+
+    case 'unknown':
+      sendJson(res, 422, {
+        error: 'unknown_command',
+        message: result.suggestion
+          ? `Unknown command: ${result.command} (did you mean ${result.suggestion}?)`
+          : `Unknown command: ${result.command}`,
+      });
+      return true;
+  }
 }
 
 export function header(req: IncomingMessage, name: string): string | undefined {

--- a/src/web-server/routes.ts
+++ b/src/web-server/routes.ts
@@ -39,6 +39,19 @@ export interface RouteContext {
    */
   isBusy: (sessionId: string) => boolean;
   /**
+   * Reserve a pending-turn slot before an async slash dispatch begins, so a
+   * concurrent prompt cannot pass the `isBusy` gate while the dispatch is in
+   * flight. `releaseTurn` must be called when no real turn is ultimately
+   * queued (passthrough / repl-only / unknown). When a skill turn IS queued,
+   * `submitSkillMessage` increments the count itself; the caller releases the
+   * reservation so the net count stays 1.
+   *
+   * Both are optional — absent in attach-only mode where ownership already
+   * 409s every prompt before `isBusy` is consulted.
+   */
+  reserveTurn?: (sessionId: string) => void;
+  releaseTurn?: (sessionId: string) => void;
+  /**
    * Start a new session in this process. Absent when the server was started
    * without an owner, in which case the surface is attach-only.
    */
@@ -228,7 +241,17 @@ export async function handlePrompt(
   // the model as raw text. Native REPL-only commands are rejected; skill
   // commands are built into the structured multi-block payload the model
   // recognises as a skill dispatch.
-  if (text.trimStart().startsWith('/') && ctx.submitSkillMessage) {
+  //
+  // Fix 2: Always run classify for any `/`-prefixed text regardless of
+  // whether ctx.submitSkillMessage is defined. This ensures REPL-only and
+  // unknown commands get proper 422 responses even in attach-only mode
+  // (where submitSkillMessage is absent). Only 'passthrough' falls through.
+  //
+  // Fix 4: Reserve a pending-turn slot BEFORE the async dispatch so a
+  // concurrent prompt cannot pass the isBusy gate during preflight. The
+  // reservation is released inside dispatchSlashForWeb for non-skill paths.
+  if (text.trimStart().startsWith('/')) {
+    ctx.reserveTurn?.(sessionId);
     const result = await dispatchSlashForWeb(ctx, res, sessionId, text);
     if (result) return; // handled — response already sent
   }
@@ -291,6 +314,16 @@ function approveByRequestId(ctx: RouteContext, res: ServerResponse, body: unknow
  * Attempt slash-command dispatch for the web surface. Returns `true` when the
  * input was handled (response already sent); `false` when it should fall
  * through to the plain-text `submitPrompt` path.
+ *
+ * Fix 4: The caller reserves a pending-turn slot before invoking this
+ * function. For every non-skill exit (passthrough, repl-only, unknown),
+ * we release that reservation because no real turn will be queued. For the
+ * skill exit, submitSkillMessage increments pending itself, so we also
+ * release the reservation — net count stays 1.
+ *
+ * Fix 2: For the skill case when submitSkillMessage is absent (attach-only
+ * mode), we return 501 skill_dispatch_unavailable. REPL-only and unknown
+ * always return 422 regardless of submitSkillMessage presence.
  */
 async function dispatchSlashForWeb(
   ctx: RouteContext,
@@ -307,14 +340,30 @@ async function dispatchSlashForWeb(
 
   switch (result.kind) {
     case 'passthrough':
+      // No turn queued — release the reservation and fall through.
+      ctx.releaseTurn?.(sessionId);
       return false;
 
     case 'skill':
-      await ctx.submitSkillMessage!(sessionId, result.message);
+      if (!ctx.submitSkillMessage) {
+        // Attach-only mode: skill dispatch requires an owned session.
+        ctx.releaseTurn?.(sessionId);
+        sendJson(res, 501, {
+          error: 'skill_dispatch_unavailable',
+          message: 'Skill dispatch requires an owned session. Start a session first.',
+        });
+        return true;
+      }
+      await ctx.submitSkillMessage(sessionId, result.message);
+      // submitSkillMessage already incremented pending; release the
+      // reservation so the net count stays 1.
+      ctx.releaseTurn?.(sessionId);
       sendJson(res, 202, { ok: true });
       return true;
 
     case 'repl-only':
+      // No turn queued — release the reservation.
+      ctx.releaseTurn?.(sessionId);
       sendJson(res, 422, {
         error: 'repl_only_command',
         message: `${result.command} is a terminal-only command and cannot run in the web UI.`,
@@ -322,6 +371,8 @@ async function dispatchSlashForWeb(
       return true;
 
     case 'unknown':
+      // No turn queued — release the reservation.
+      ctx.releaseTurn?.(sessionId);
       sendJson(res, 422, {
         error: 'unknown_command',
         message: result.suggestion

--- a/src/web-server/routes.ts
+++ b/src/web-server/routes.ts
@@ -109,11 +109,13 @@ let commandUniverseInitialization: Promise<CommandEntry[]> | null = null;
 type CommandUniverseLoader = () => Promise<CommandEntry[]>;
 
 const defaultCommandUniverseLoader: CommandUniverseLoader = async () => {
-  const [{ registerAll }, { buildSlashUniverse }] = await Promise.all([
+  const [{ registerAll }, { buildSlashUniverse }, { registerPluginSkillsForWeb }] = await Promise.all([
     import('../cli/slash/index.js'),
     import('../cli/input/trigger.js'),
+    import('./register-plugin-skills.js'),
   ]);
   registerAll();
+  await registerPluginSkillsForWeb();
   return buildSlashUniverse();
 };
 

--- a/src/web-server/server.ts
+++ b/src/web-server/server.ts
@@ -10,6 +10,7 @@
  */
 
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import type { ContentBlockParam } from '@anthropic-ai/sdk/resources';
 import { bearerFromHeader, checkBind, mintToken, originAllowed, tokensMatch } from './auth.js';
 import { serveStatic, type StaticAuth } from './static-assets.js';
 import { HandoffNonces } from './handoff.js';
@@ -164,6 +165,10 @@ export async function startWebServer(options: WebServerOptions = {}): Promise<We
       ? {
           createSession: (req: CreateSessionRequest) => options.owner!.create(req),
           interrupt: (id: string) => options.owner!.interrupt(id),
+          submitSkillMessage: (id: string, msg: ContentBlockParam[]) =>
+            options.owner!.submitSkillMessage(id, msg),
+          getSessionCwd: (id: string) => options.owner!.getSessionCwd(id),
+          getProviderSessionId: (id: string) => options.owner!.getProviderSessionId(id),
         }
       : {}),
   };

--- a/src/web-server/server.ts
+++ b/src/web-server/server.ts
@@ -169,6 +169,8 @@ export async function startWebServer(options: WebServerOptions = {}): Promise<We
             options.owner!.submitSkillMessage(id, msg),
           getSessionCwd: (id: string) => options.owner!.getSessionCwd(id),
           getProviderSessionId: (id: string) => options.owner!.getProviderSessionId(id),
+          reserveTurn: (id: string) => options.owner!.reserveTurn(id),
+          releaseTurn: (id: string) => options.owner!.releaseTurn(id),
         }
       : {}),
   };

--- a/src/web-server/session-owner.test.ts
+++ b/src/web-server/session-owner.test.ts
@@ -40,6 +40,29 @@ describe('SessionOwner — submitPrompt on an unknown id', () => {
   });
 });
 
+describe('SessionOwner — submitSkillMessage on an unknown id', () => {
+  it('rejects rather than silently no-op-ing', async () => {
+    const owner = freshOwner();
+    await expect(
+      owner.submitSkillMessage('nope', [{ type: 'text', text: 'mock' }]),
+    ).rejects.toThrow(/nope.*not owned by this process/);
+  });
+});
+
+describe('SessionOwner — getSessionCwd on an unknown id', () => {
+  it('returns undefined rather than throwing', () => {
+    const owner = freshOwner();
+    expect(owner.getSessionCwd('nope')).toBeUndefined();
+  });
+});
+
+describe('SessionOwner — getProviderSessionId on an unknown id', () => {
+  it('returns undefined rather than throwing', () => {
+    const owner = freshOwner();
+    expect(owner.getProviderSessionId('nope')).toBeUndefined();
+  });
+});
+
 describe('SessionOwner — interrupt on an unknown id', () => {
   it('rejects rather than silently no-op-ing', async () => {
     const owner = freshOwner();

--- a/src/web-server/session-owner.test.ts
+++ b/src/web-server/session-owner.test.ts
@@ -147,3 +147,48 @@ describe('SessionOwner — isBusy is raised synchronously on accept', () => {
     expect(owner.isBusy('s1')).toBe(false);
   });
 });
+
+/**
+ * Invariant: `reserveTurn` / `releaseTurn` correctly manage the pending
+ * counter for the backpressure gap fix (Item 4).
+ *
+ * `reserveTurn` claims a slot synchronously before an async slash dispatch.
+ * `releaseTurn` releases it on non-turn paths, keeping the net count at 0.
+ * When a skill turn IS queued, `submitSkillMessage` increments pending itself
+ * and then `releaseTurn` is called — net count stays 1 (the real turn).
+ */
+describe('SessionOwner — reserveTurn / releaseTurn', () => {
+  it('makes isBusy true after reserve and false after release', () => {
+    const owner = freshOwner();
+    expect(owner.isBusy('s1')).toBe(false);
+    owner.reserveTurn('s1');
+    expect(owner.isBusy('s1')).toBe(true);
+    owner.releaseTurn('s1');
+    expect(owner.isBusy('s1')).toBe(false);
+  });
+
+  it('is safe to releaseTurn on an unknown id (floors at 0)', () => {
+    const owner = freshOwner();
+    // Should not throw; isBusy stays false.
+    owner.releaseTurn('unknown');
+    expect(owner.isBusy('unknown')).toBe(false);
+  });
+
+  it('reserve then release nets to zero (non-turn path)', () => {
+    const owner = freshOwner();
+    owner.reserveTurn('s2');
+    expect(owner.isBusy('s2')).toBe(true);
+    owner.releaseTurn('s2');
+    expect(owner.isBusy('s2')).toBe(false);
+  });
+
+  it('reserve + submitPrompt increment + release nets to 1 (skill-turn path simulation)', () => {
+    const owner = freshOwner();
+    // Simulate: reserve (count=1), then submitSkillMessage increments
+    // (count=2), then releaseTurn releases the reservation (count=1).
+    owner.reserveTurn('s3');         // count = 1
+    owner.reserveTurn('s3');         // simulate submitSkillMessage increment → count = 2
+    owner.releaseTurn('s3');         // release reservation → count = 1
+    expect(owner.isBusy('s3')).toBe(true); // real turn still in flight
+  });
+});

--- a/src/web-server/session-owner.ts
+++ b/src/web-server/session-owner.ts
@@ -257,6 +257,32 @@ export class SessionOwner {
     return (this.pending.get(sessionId) ?? 0) > 0;
   }
 
+  /**
+   * Reserve a pending-turn slot synchronously, before an async slash dispatch
+   * begins. This closes the backpressure gap: without it, a second prompt could
+   * arrive after the first passed the `isBusy` gate but before
+   * `submitSkillMessage` incremented `pending`.
+   *
+   * Contract: every `reserveTurn` must be paired with exactly one
+   * `releaseTurn`. For skill turns, `submitSkillMessage` increments `pending`
+   * itself, so the caller releases the reservation after submitting — net
+   * pending stays 1. For non-skill exits (passthrough / repl-only / unknown),
+   * the caller releases immediately because no turn is queued.
+   */
+  reserveTurn(sessionId: string): void {
+    this.pending.set(sessionId, (this.pending.get(sessionId) ?? 0) + 1);
+  }
+
+  /**
+   * Release a previously reserved pending-turn slot. Safe to call even if
+   * the slot was never reserved (count floors at 0 and is deleted).
+   */
+  releaseTurn(sessionId: string): void {
+    const remaining = (this.pending.get(sessionId) ?? 1) - 1;
+    if (remaining > 0) this.pending.set(sessionId, remaining);
+    else this.pending.delete(sessionId);
+  }
+
   /** Soft-interrupt an in-flight turn. The session stays usable afterwards. */
   async interrupt(sessionId: string): Promise<void> {
     const session = this.sessions.get(sessionId);

--- a/src/web-server/session-owner.ts
+++ b/src/web-server/session-owner.ts
@@ -26,6 +26,7 @@ import { wireWebSession, type WebSessionWiringInternal } from './session-owner.w
 import type { AgentConfig } from '../agent/types.js';
 import type { PermissionMode } from '../agent/types/sdk-types.js';
 import type { McpManager } from '../agent/mcp/index.js';
+import type { ContentBlockParam } from '@anthropic-ai/sdk/resources';
 
 export interface CreateSessionRequest {
   /** Working directory. Ignored unless `allowArbitraryCwd` — see the guard. */
@@ -196,6 +197,56 @@ export class SessionOwner {
     // unhandled rejection: a failed turn records an `error` in the ledger,
     // which is the browser's channel for it.
     next.catch(() => {});
+  }
+
+  /**
+   * Queue a skill-invocation message (ContentBlockParam[]) for an owned session.
+   *
+   * Identical turn-serialization and backpressure semantics as `submitPrompt`,
+   * but accepts the pre-built multi-block payload that `buildSkillInvocationMessage`
+   * produces. `sendMessageStream` accepts `string | ContentBlockParam[]`, so the
+   * only difference is the input type.
+   */
+  async submitSkillMessage(sessionId: string, message: ContentBlockParam[]): Promise<void> {
+    const session = this.sessions.get(sessionId);
+    if (!session) throw new Error(`session ${sessionId} is not owned by this process`);
+
+    this.pending.set(sessionId, (this.pending.get(sessionId) ?? 0) + 1);
+
+    const previous = this.turns.get(sessionId) ?? Promise.resolve();
+    const next = previous
+      .catch(() => {})
+      .then(async () => {
+        try {
+          for await (const _event of session.sendMessageStream(message)) {
+            void _event;
+          }
+        } finally {
+          const remaining = (this.pending.get(sessionId) ?? 1) - 1;
+          if (remaining > 0) this.pending.set(sessionId, remaining);
+          else this.pending.delete(sessionId);
+        }
+      });
+
+    this.turns.set(sessionId, next);
+    next.catch(() => {});
+  }
+
+  /**
+   * The session's working directory. Needed by slash dispatch to run preflights
+   * that shell out (e.g. `gh pr view` for /review).
+   */
+  getSessionCwd(sessionId: string): string | undefined {
+    return this.info.get(sessionId)?.cwd;
+  }
+
+  /**
+   * The session id from the provider (may differ from the map key before
+   * initialization). Needed by slash dispatch for preflight artifact dirs.
+   */
+  getProviderSessionId(sessionId: string): string | undefined {
+    const session = this.sessions.get(sessionId);
+    return session?.sessionId;
   }
 
   /**

--- a/src/web-server/slash-dispatch.test.ts
+++ b/src/web-server/slash-dispatch.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Tests for `classifySlashInput` — the web surface's slash-command classifier.
+ *
+ * Uses vi.mock to stub the slash registry and skill bridge, avoiding real
+ * disk I/O and registration side effects. Each case verifies classification
+ * only — the HTTP response layer is tested in the routes integration tests.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Stubs set per-test.
+let mockParse: ReturnType<typeof vi.fn>;
+let mockLookup: ReturnType<typeof vi.fn>;
+let mockSuggest: ReturnType<typeof vi.fn>;
+let mockRegisterAll: ReturnType<typeof vi.fn>;
+let mockBuildSkillInvocationMessage: ReturnType<typeof vi.fn>;
+let mockGetPreflight: ReturnType<typeof vi.fn>;
+let mockRunPreflight: ReturnType<typeof vi.fn>;
+let mockGetSkillPreflightDir: ReturnType<typeof vi.fn>;
+let mockGetSkill: ReturnType<typeof vi.fn>;
+
+vi.mock('../cli/slash/index.js', () => ({
+  registerAll: (...args: unknown[]) => mockRegisterAll(...args),
+}));
+
+vi.mock('../cli/slash/registry.js', () => ({
+  parse: (...args: unknown[]) => mockParse(...args),
+  lookup: (...args: unknown[]) => mockLookup(...args),
+  suggest: (...args: unknown[]) => mockSuggest(...args),
+}));
+
+vi.mock('../cli/slash/_lib/skill-message-bridge.js', () => ({
+  buildSkillInvocationMessage: (...args: unknown[]) => mockBuildSkillInvocationMessage(...args),
+}));
+
+vi.mock('../cli/slash/preflight/index.js', () => ({
+  getPreflight: (...args: unknown[]) => mockGetPreflight(...args),
+  runPreflight: (...args: unknown[]) => mockRunPreflight(...args),
+  getSkillPreflightDir: (...args: unknown[]) => mockGetSkillPreflightDir(...args),
+}));
+
+vi.mock('../skills/index.js', () => ({
+  getSkill: (...args: unknown[]) => mockGetSkill(...args),
+}));
+
+import { classifySlashInput } from './slash-dispatch.js';
+
+beforeEach(() => {
+  mockRegisterAll = vi.fn();
+  mockParse = vi.fn().mockReturnValue(null);
+  mockLookup = vi.fn().mockReturnValue(undefined);
+  mockSuggest = vi.fn().mockReturnValue(undefined);
+  mockBuildSkillInvocationMessage = vi.fn().mockResolvedValue([{ type: 'text', text: 'mock' }]);
+  mockGetPreflight = vi.fn().mockReturnValue(undefined);
+  mockRunPreflight = vi.fn().mockResolvedValue(null);
+  mockGetSkillPreflightDir = vi.fn().mockReturnValue('/tmp/preflight');
+  mockGetSkill = vi.fn().mockReturnValue({
+    name: 'review',
+    description: 'review skill',
+    handler: async () => undefined,
+    context: 'load',
+  });
+});
+
+describe('classifySlashInput', () => {
+  it('returns passthrough for non-slash text', async () => {
+    const result = await classifySlashInput('hello world', '/tmp', undefined);
+    expect(result.kind).toBe('passthrough');
+    // Should not even call registerAll for plain text.
+    expect(mockRegisterAll).not.toHaveBeenCalled();
+  });
+
+  it('returns passthrough when parse returns null', async () => {
+    mockParse.mockReturnValue(null);
+    const result = await classifySlashInput('//', '/tmp', undefined);
+    expect(result.kind).toBe('passthrough');
+  });
+
+  it('returns repl-only for terminal-only commands', async () => {
+    mockParse.mockReturnValue({ name: '/clear', args: '' });
+    const result = await classifySlashInput('/clear', '/tmp', undefined);
+    expect(result).toEqual({ kind: 'repl-only', command: '/clear' });
+  });
+
+  it('returns repl-only for /exit', async () => {
+    mockParse.mockReturnValue({ name: '/exit', args: '' });
+    const result = await classifySlashInput('/exit', '/tmp', undefined);
+    expect(result).toEqual({ kind: 'repl-only', command: '/exit' });
+  });
+
+  it('returns unknown with suggestion for unrecognised command', async () => {
+    mockParse.mockReturnValue({ name: '/reveiw', args: '' });
+    mockLookup.mockReturnValue(undefined);
+    mockSuggest.mockReturnValue('/review');
+    const result = await classifySlashInput('/reveiw', '/tmp', undefined);
+    expect(result).toEqual({ kind: 'unknown', command: '/reveiw', suggestion: '/review' });
+  });
+
+  it('returns unknown without suggestion when no close match', async () => {
+    mockParse.mockReturnValue({ name: '/zzzzz', args: '' });
+    mockLookup.mockReturnValue(undefined);
+    mockSuggest.mockReturnValue(undefined);
+    const result = await classifySlashInput('/zzzzz', '/tmp', undefined);
+    expect(result).toEqual({ kind: 'unknown', command: '/zzzzz', suggestion: undefined });
+  });
+
+  it('returns passthrough for non-skill native commands (e.g. /help)', async () => {
+    mockParse.mockReturnValue({ name: '/help', args: '' });
+    mockLookup.mockReturnValue({
+      name: '/help',
+      summary: 'help',
+      handler: vi.fn(),
+      // No acceptsAttachments — native command, not a skill.
+    });
+    const result = await classifySlashInput('/help', '/tmp', undefined);
+    expect(result.kind).toBe('passthrough');
+  });
+
+  it('returns skill with built message for skill commands', async () => {
+    const fakeBlocks = [
+      { type: 'text', text: '<command-name>/review</command-name>' },
+      { type: 'text', text: 'Use the `skill` tool...' },
+    ];
+    mockParse.mockReturnValue({ name: '/review', args: '277' });
+    mockLookup.mockReturnValue({
+      name: '/review',
+      summary: 'Code review',
+      handler: vi.fn(),
+      acceptsAttachments: true,
+    });
+    mockBuildSkillInvocationMessage.mockResolvedValue(fakeBlocks);
+
+    const result = await classifySlashInput('/review 277', '/tmp', 'session-123');
+    expect(result.kind).toBe('skill');
+    if (result.kind === 'skill') {
+      expect(result.message).toEqual(fakeBlocks);
+    }
+    expect(mockBuildSkillInvocationMessage).toHaveBeenCalled();
+  });
+
+  it('runs preflight when one is registered', async () => {
+    const mockPreflightFn = vi.fn();
+    mockParse.mockReturnValue({ name: '/review', args: '277' });
+    mockLookup.mockReturnValue({
+      name: '/review',
+      summary: 'Code review',
+      handler: vi.fn(),
+      acceptsAttachments: true,
+    });
+    mockGetPreflight.mockReturnValue(mockPreflightFn);
+    mockRunPreflight.mockResolvedValue({ manifestBlock: 'PR #277 diff context...' });
+
+    await classifySlashInput('/review 277', '/tmp', 'session-123');
+
+    expect(mockRunPreflight).toHaveBeenCalledWith(
+      expect.objectContaining({ skillName: 'review', rawArgs: '277' }),
+      expect.objectContaining({ cwd: '/tmp' }),
+    );
+    expect(mockBuildSkillInvocationMessage).toHaveBeenCalledWith(
+      expect.anything(),
+      '277',
+      'PR #277 diff context...',
+      undefined,
+      'session-123',
+    );
+  });
+
+  it('still dispatches skill when preflight throws', async () => {
+    mockParse.mockReturnValue({ name: '/review', args: '277' });
+    mockLookup.mockReturnValue({
+      name: '/review',
+      summary: 'Code review',
+      handler: vi.fn(),
+      acceptsAttachments: true,
+    });
+    mockGetPreflight.mockReturnValue(vi.fn());
+    mockRunPreflight.mockRejectedValue(new Error('gh not found'));
+
+    const result = await classifySlashInput('/review 277', '/tmp', 'session-123');
+    expect(result.kind).toBe('skill');
+    // manifestBlock should be undefined (preflight failed gracefully).
+    expect(mockBuildSkillInvocationMessage).toHaveBeenCalledWith(
+      expect.anything(),
+      '277',
+      undefined,
+      undefined,
+      'session-123',
+    );
+  });
+
+  it('synthesises a minimal SkillMetadata when getSkill throws', async () => {
+    mockParse.mockReturnValue({ name: '/custom-plugin-skill', args: '' });
+    mockLookup.mockReturnValue({
+      name: '/custom-plugin-skill',
+      summary: 'Plugin skill',
+      handler: vi.fn(),
+      acceptsAttachments: true,
+    });
+    mockGetSkill.mockImplementation(() => {
+      throw new Error('Skill not found: custom-plugin-skill');
+    });
+
+    const result = await classifySlashInput('/custom-plugin-skill', '/tmp', undefined);
+    expect(result.kind).toBe('skill');
+    expect(mockBuildSkillInvocationMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'custom-plugin-skill', context: 'inline' }),
+      '',
+      undefined,
+      undefined,
+      undefined,
+    );
+  });
+
+  it('calls registerAll on first invocation', async () => {
+    mockParse.mockReturnValue({ name: '/review', args: '' });
+    mockLookup.mockReturnValue(undefined);
+    mockSuggest.mockReturnValue(undefined);
+
+    await classifySlashInput('/review', '/tmp', undefined);
+    expect(mockRegisterAll).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/web-server/slash-dispatch.test.ts
+++ b/src/web-server/slash-dispatch.test.ts
@@ -13,6 +13,7 @@ let mockParse: ReturnType<typeof vi.fn>;
 let mockLookup: ReturnType<typeof vi.fn>;
 let mockSuggest: ReturnType<typeof vi.fn>;
 let mockRegisterAll: ReturnType<typeof vi.fn>;
+let mockRegisterPluginSkillsForWeb: ReturnType<typeof vi.fn>;
 let mockBuildSkillInvocationMessage: ReturnType<typeof vi.fn>;
 let mockGetPreflight: ReturnType<typeof vi.fn>;
 let mockRunPreflight: ReturnType<typeof vi.fn>;
@@ -29,6 +30,10 @@ vi.mock('../cli/slash/registry.js', () => ({
   suggest: (...args: unknown[]) => mockSuggest(...args),
 }));
 
+vi.mock('./register-plugin-skills.js', () => ({
+  registerPluginSkillsForWeb: (...args: unknown[]) => mockRegisterPluginSkillsForWeb(...args),
+}));
+
 vi.mock('../cli/slash/_lib/skill-message-bridge.js', () => ({
   buildSkillInvocationMessage: (...args: unknown[]) => mockBuildSkillInvocationMessage(...args),
 }));
@@ -43,10 +48,15 @@ vi.mock('../skills/index.js', () => ({
   getSkill: (...args: unknown[]) => mockGetSkill(...args),
 }));
 
-import { classifySlashInput } from './slash-dispatch.js';
+import { classifySlashInput, resetSlashDispatchRegistration } from './slash-dispatch.js';
 
 beforeEach(() => {
+  // Reset memoization guard so each test exercises the registration path
+  // independently when needed.
+  resetSlashDispatchRegistration();
+
   mockRegisterAll = vi.fn();
+  mockRegisterPluginSkillsForWeb = vi.fn().mockResolvedValue(undefined);
   mockParse = vi.fn().mockReturnValue(null);
   mockLookup = vi.fn().mockReturnValue(undefined);
   mockSuggest = vi.fn().mockReturnValue(undefined);
@@ -77,14 +87,30 @@ describe('classifySlashInput', () => {
   });
 
   it('returns repl-only for terminal-only commands', async () => {
+    // Fix 5: REPL_ONLY is now checked after lookup using the resolved cmd.name.
+    // For /clear, lookup must return a cmd with name: '/clear'.
     mockParse.mockReturnValue({ name: '/clear', args: '' });
+    mockLookup.mockReturnValue({ name: '/clear', summary: 'clear', handler: vi.fn() });
     const result = await classifySlashInput('/clear', '/tmp', undefined);
     expect(result).toEqual({ kind: 'repl-only', command: '/clear' });
   });
 
   it('returns repl-only for /exit', async () => {
+    // Fix 5: lookup returns cmd with canonical name '/exit'.
     mockParse.mockReturnValue({ name: '/exit', args: '' });
+    mockLookup.mockReturnValue({ name: '/exit', summary: 'exit', handler: vi.fn() });
     const result = await classifySlashInput('/exit', '/tmp', undefined);
+    expect(result).toEqual({ kind: 'repl-only', command: '/exit' });
+  });
+
+  it('returns repl-only via alias resolution (Fix 5)', async () => {
+    // Simulate /quit alias resolving to /exit canonical name.
+    // Before Fix 5, /quit would not be in REPL_ONLY (by raw name) and would
+    // fall through to passthrough. After Fix 5, the resolved cmd.name '/exit'
+    // IS in REPL_ONLY, so it returns repl-only.
+    mockParse.mockReturnValue({ name: '/quit', args: '' });
+    mockLookup.mockReturnValue({ name: '/exit', summary: 'exit', handler: vi.fn() });
+    const result = await classifySlashInput('/quit', '/tmp', undefined);
     expect(result).toEqual({ kind: 'repl-only', command: '/exit' });
   });
 
@@ -136,6 +162,60 @@ describe('classifySlashInput', () => {
       expect(result.message).toEqual(fakeBlocks);
     }
     expect(mockBuildSkillInvocationMessage).toHaveBeenCalled();
+  });
+
+  it('uses full skill name for getSkill (Fix 3 — namespaced skill)', async () => {
+    // /user:mint should resolve to fullSkillName 'user:mint', not bare 'mint'.
+    mockParse.mockReturnValue({ name: '/user:mint', args: 'my idea' });
+    mockLookup.mockReturnValue({
+      name: '/user:mint',
+      summary: 'User-scoped mint',
+      handler: vi.fn(),
+      acceptsAttachments: true,
+    });
+    const userMintMeta = {
+      name: 'user:mint',
+      description: 'user-scoped mint',
+      handler: async () => undefined,
+      context: 'inline' as const,
+    };
+    mockGetSkill.mockReturnValue(userMintMeta);
+
+    await classifySlashInput('/user:mint my idea', '/tmp', 'session-abc');
+
+    // getSkill must be called with the full 'user:mint', not bare 'mint'.
+    expect(mockGetSkill).toHaveBeenCalledWith('user:mint');
+    // buildSkillInvocationMessage receives the full-name metadata.
+    expect(mockBuildSkillInvocationMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'user:mint' }),
+      'my idea',
+      undefined,
+      undefined,
+      'session-abc',
+    );
+  });
+
+  it('uses bare skill name for preflight lookup (Fix 3 — preflight keyed by bare name)', async () => {
+    // Preflight is keyed by bare name 'review', not 'user:review'.
+    mockParse.mockReturnValue({ name: '/user:review', args: '277' });
+    mockLookup.mockReturnValue({
+      name: '/user:review',
+      summary: 'User review',
+      handler: vi.fn(),
+      acceptsAttachments: true,
+    });
+    const mockPreflightFn = vi.fn();
+    mockGetPreflight.mockReturnValue(mockPreflightFn);
+    mockRunPreflight.mockResolvedValue({ manifestBlock: 'diff ctx' });
+
+    await classifySlashInput('/user:review 277', '/tmp', 'session-xyz');
+
+    // Preflight looked up by bare name 'review'.
+    expect(mockGetPreflight).toHaveBeenCalledWith('review');
+    expect(mockRunPreflight).toHaveBeenCalledWith(
+      expect.objectContaining({ skillName: 'review', rawArgs: '277' }),
+      expect.objectContaining({ cwd: '/tmp' }),
+    );
   });
 
   it('runs preflight when one is registered', async () => {
@@ -211,12 +291,31 @@ describe('classifySlashInput', () => {
     );
   });
 
-  it('calls registerAll on first invocation', async () => {
+  it('calls registerAll and registerPluginSkillsForWeb on first invocation', async () => {
     mockParse.mockReturnValue({ name: '/review', args: '' });
     mockLookup.mockReturnValue(undefined);
     mockSuggest.mockReturnValue(undefined);
 
     await classifySlashInput('/review', '/tmp', undefined);
     expect(mockRegisterAll).toHaveBeenCalledTimes(1);
+    expect(mockRegisterPluginSkillsForWeb).toHaveBeenCalledTimes(1);
+  });
+
+  it('only calls registerAll once across concurrent invocations (memoization guard)', async () => {
+    // The memoization guard ensures registration runs only once even when
+    // multiple slash invocations arrive concurrently.
+    mockParse.mockReturnValue({ name: '/review', args: '' });
+    mockLookup.mockReturnValue(undefined);
+    mockSuggest.mockReturnValue(undefined);
+
+    // Fire three concurrent invocations.
+    await Promise.all([
+      classifySlashInput('/review', '/tmp', undefined),
+      classifySlashInput('/review', '/tmp', undefined),
+      classifySlashInput('/review', '/tmp', undefined),
+    ]);
+
+    expect(mockRegisterAll).toHaveBeenCalledTimes(1);
+    expect(mockRegisterPluginSkillsForWeb).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/web-server/slash-dispatch.ts
+++ b/src/web-server/slash-dispatch.ts
@@ -71,11 +71,15 @@ export async function classifySlashInput(
 
   // Lazy-load the slash registry (matches handleCommands' dynamic import
   // pattern -- keeps the cli/slash import tree off the server's startup).
-  const [{ registerAll }, registry] = await Promise.all([
+  const [{ registerAll }, registry, { registerPluginSkillsForWeb }] = await Promise.all([
     import('../cli/slash/index.js'),
     import('../cli/slash/registry.js'),
+    import('./register-plugin-skills.js'),
   ]);
   registerAll();
+  // Invariant: registerAll() calls resetRegistry(), wiping any prior plugin
+  // registrations. Re-register plugin skills so lookup() resolves them.
+  await registerPluginSkillsForWeb();
 
   const parsed = registry.parse(text);
   if (!parsed) return { kind: 'passthrough' };

--- a/src/web-server/slash-dispatch.ts
+++ b/src/web-server/slash-dispatch.ts
@@ -1,0 +1,172 @@
+/**
+ * Slash-command dispatch for the `afk web` surface.
+ *
+ * The REPL has a full slash-dispatch pipeline in `cli/commands/interactive/
+ * loop-iteration.ts` that parses `/`-prefixed input, dispatches native
+ * commands, runs preflights, and injects skill-invocation messages. None of
+ * that existed on the web surface -- the prompt path sent text verbatim to
+ * `sendMessageStream`.
+ *
+ * This module bridges the gap for SKILL commands (the ones that matter for
+ * web users). Native REPL commands (`/clear`, `/exit`, `/model`, etc.) are
+ * rejected with a diagnostic -- they drive terminal machinery that doesn't
+ * exist here.
+ *
+ * Contract: the module uses DYNAMIC imports for the slash registry and skill
+ * bridge to match the lazy-loading pattern already established in
+ * `handleCommands` (routes.ts). This keeps the heavy `cli/slash` import
+ * tree off the web server's startup path.
+ */
+
+import type { ContentBlockParam } from '@anthropic-ai/sdk/resources';
+
+/**
+ * Commands that drive terminal-only machinery and cannot act on the web
+ * surface. Server-side mirror of the frontend's REPL_ONLY set.
+ *
+ * Invariant: this makes a NEGATIVE claim only. Presence means "verified
+ * REPL-only"; absence does not promise the command works here.
+ */
+const REPL_ONLY: ReadonlySet<string> = new Set([
+  '/clear',
+  '/compact',
+  '/editor',
+  '/exit',
+  '/fast',
+  '/font-size',
+  '/fork',
+  '/keys',
+  '/model',
+  '/reauth',
+  '/resume',
+  '/rewind',
+  '/sh',
+  '/theme',
+  '/thinking',
+]);
+
+export type SlashDispatchResult =
+  | { kind: 'passthrough' }
+  | { kind: 'skill'; message: ContentBlockParam[] }
+  | { kind: 'repl-only'; command: string }
+  | { kind: 'unknown'; command: string; suggestion?: string };
+
+/**
+ * Classify and, for skill commands, build the invocation payload.
+ *
+ * Returns:
+ * - `passthrough` -- not a slash command; send as plain text.
+ * - `skill` -- a skill invocation with a ready-to-send ContentBlockParam[].
+ * - `repl-only` -- a native REPL command that cannot run on this surface.
+ * - `unknown` -- unrecognised command (with an optional did-you-mean hint).
+ *
+ * The caller (`handlePrompt`) decides the HTTP response for each case.
+ */
+export async function classifySlashInput(
+  text: string,
+  cwd: string,
+  sessionId: string | undefined,
+): Promise<SlashDispatchResult> {
+  if (!text.trimStart().startsWith('/')) return { kind: 'passthrough' };
+
+  // Lazy-load the slash registry (matches handleCommands' dynamic import
+  // pattern -- keeps the cli/slash import tree off the server's startup).
+  const [{ registerAll }, registry] = await Promise.all([
+    import('../cli/slash/index.js'),
+    import('../cli/slash/registry.js'),
+  ]);
+  registerAll();
+
+  const parsed = registry.parse(text);
+  if (!parsed) return { kind: 'passthrough' };
+
+  if (REPL_ONLY.has(parsed.name)) {
+    return { kind: 'repl-only', command: parsed.name };
+  }
+
+  const cmd = registry.lookup(parsed.name);
+  if (!cmd) {
+    const suggestion = registry.suggest(parsed.name) ?? undefined;
+    return { kind: 'unknown', command: parsed.name, suggestion };
+  }
+
+  // Native commands that aren't REPL-only but also aren't skill dispatches
+  // (e.g. /help, /cost) -- let them pass through as text so the model can
+  // respond naturally. Only skill commands (those with acceptsAttachments)
+  // get the structured invocation treatment.
+  if (!cmd.acceptsAttachments) {
+    return { kind: 'passthrough' };
+  }
+
+  // Skill command -- build the invocation message.
+  const bareSkillName = parsed.name
+    .replace(/^\//, '')
+    .split(':')
+    .pop() ?? '';
+
+  const message = await buildSkillPayload(bareSkillName, parsed.args, cwd, sessionId);
+  return { kind: 'skill', message };
+}
+
+/**
+ * Build the ContentBlockParam[] payload for a skill invocation.
+ *
+ * Runs the registered preflight (if any) and produces the same multi-block
+ * message shape the REPL's `runSkillDispatchTurn` sends through
+ * `sendMessageStream`.
+ */
+async function buildSkillPayload(
+  bareSkillName: string,
+  args: string,
+  cwd: string,
+  sessionId: string | undefined,
+): Promise<ContentBlockParam[]> {
+  const [
+    { buildSkillInvocationMessage },
+    { getPreflight, runPreflight, getSkillPreflightDir },
+    { getSkill },
+  ] = await Promise.all([
+    import('../cli/slash/_lib/skill-message-bridge.js'),
+    import('../cli/slash/preflight/index.js'),
+    import('../skills/index.js'),
+  ]);
+
+  // Run preflight if registered (e.g. review-pr gathers diff context).
+  let manifestBlock: string | undefined;
+  const preflight = getPreflight(bareSkillName);
+  if (preflight) {
+    try {
+      const artifactDir = getSkillPreflightDir(sessionId);
+      const result = await runPreflight(
+        {
+          skillName: bareSkillName,
+          rawArgs: args,
+          source: 'plugin',
+          capabilities: { compose: true, subagents: true },
+        },
+        { cwd, artifactDir },
+      );
+      manifestBlock = result?.manifestBlock;
+    } catch {
+      // Preflight failure must never block a skill from running.
+    }
+  }
+
+  // Build the skill metadata adapter -- only .name and .context are consumed
+  // by buildSkillInvocationMessage.
+  let skillMeta;
+  try {
+    skillMeta = getSkill(bareSkillName);
+  } catch {
+    // Skill not in the TS registry (plugin-only skill). Synthesise a
+    // minimal adapter -- same pattern as makeForwardHandler in dispatch.ts.
+    skillMeta = {
+      name: bareSkillName,
+      description: '',
+      handler: async () => undefined,
+      context: 'inline' as const,
+    };
+  }
+
+  return buildSkillInvocationMessage(skillMeta, args, manifestBlock, undefined, sessionId);
+}

--- a/src/web-server/slash-dispatch.ts
+++ b/src/web-server/slash-dispatch.ts
@@ -52,6 +52,44 @@ export type SlashDispatchResult =
   | { kind: 'unknown'; command: string; suggestion?: string };
 
 /**
+ * Module-scope memoization guard: `registerAll()` + `registerPluginSkillsForWeb()`
+ * runs once per process. This mirrors the `commandUniverseInitialization` guard
+ * in `routes.ts`. The promise is cleared on failure so the next call retries
+ * rather than permanently caching a transient error.
+ */
+let registrationDone = false;
+let registrationPromise: Promise<void> | null = null;
+
+/** Test seam: drop the memo so a case can re-observe registration. */
+export function resetSlashDispatchRegistration(): void {
+  registrationDone = false;
+  registrationPromise = null;
+}
+
+async function ensureRegistered(): Promise<void> {
+  if (registrationDone) return;
+
+  registrationPromise ??= (async () => {
+    const [{ registerAll }, { registerPluginSkillsForWeb }] = await Promise.all([
+      import('../cli/slash/index.js'),
+      import('./register-plugin-skills.js'),
+    ]);
+    registerAll();
+    // Invariant: registerAll() calls resetRegistry(), wiping any prior plugin
+    // registrations. Re-register plugin skills so lookup() resolves them.
+    await registerPluginSkillsForWeb();
+    registrationDone = true;
+  })().finally(() => {
+    // Clear the in-flight promise so a failure allows retry on next call.
+    // (registrationDone is only set to true on success, so a failure leaves
+    // it false and the next call will retry via a fresh promise.)
+    registrationPromise = null;
+  });
+
+  await registrationPromise;
+}
+
+/**
  * Classify and, for skill commands, build the invocation payload.
  *
  * Returns:
@@ -71,27 +109,34 @@ export async function classifySlashInput(
 
   // Lazy-load the slash registry (matches handleCommands' dynamic import
   // pattern -- keeps the cli/slash import tree off the server's startup).
-  const [{ registerAll }, registry, { registerPluginSkillsForWeb }] = await Promise.all([
-    import('../cli/slash/index.js'),
-    import('../cli/slash/registry.js'),
-    import('./register-plugin-skills.js'),
-  ]);
-  registerAll();
-  // Invariant: registerAll() calls resetRegistry(), wiping any prior plugin
-  // registrations. Re-register plugin skills so lookup() resolves them.
-  await registerPluginSkillsForWeb();
+  // Registration is memoized: registerAll() resets the process-global registry,
+  // so concurrent calls without memoization would race and wipe each other.
+  await ensureRegistered();
+
+  const registry = await import('../cli/slash/registry.js');
 
   const parsed = registry.parse(text);
   if (!parsed) return { kind: 'passthrough' };
 
-  if (REPL_ONLY.has(parsed.name)) {
-    return { kind: 'repl-only', command: parsed.name };
-  }
-
+  // Fix 5: Look up the command first, then check REPL_ONLY on the RESOLVED
+  // canonical name (cmd.name) rather than the raw parsed token. This ensures
+  // aliases (e.g. /quit -> /exit) are correctly caught: the alias resolves to
+  // a cmd whose canonical name IS in REPL_ONLY even though the alias itself
+  // is not.
   const cmd = registry.lookup(parsed.name);
   if (!cmd) {
+    // For unknown commands, check the raw parsed name against REPL_ONLY
+    // (they can't resolve to an alias-target anyway).
+    if (REPL_ONLY.has(parsed.name)) {
+      return { kind: 'repl-only', command: parsed.name };
+    }
     const suggestion = registry.suggest(parsed.name) ?? undefined;
     return { kind: 'unknown', command: parsed.name, suggestion };
+  }
+
+  // Check the RESOLVED canonical name against REPL_ONLY.
+  if (REPL_ONLY.has(cmd.name)) {
+    return { kind: 'repl-only', command: cmd.name };
   }
 
   // Native commands that aren't REPL-only but also aren't skill dispatches
@@ -102,13 +147,17 @@ export async function classifySlashInput(
     return { kind: 'passthrough' };
   }
 
-  // Skill command -- build the invocation message.
-  const bareSkillName = parsed.name
-    .replace(/^\//, '')
-    .split(':')
-    .pop() ?? '';
+  // Fix 3: Use the FULL resolved command name (minus leading `/`) for
+  // getSkill() and buildSkillInvocationMessage. The bare `.split(':').pop()`
+  // would strip the namespace prefix, causing `/user:mint` to resolve to the
+  // vendored `mint` skill instead of the user-scoped one.
+  const fullSkillName = parsed.name.replace(/^\//, '');
 
-  const message = await buildSkillPayload(bareSkillName, parsed.args, cwd, sessionId);
+  // The preflight lookup uses the bare name because preflights are registered
+  // by bare name in the preflight registry.
+  const bareSkillName = fullSkillName.split(':').pop() ?? fullSkillName;
+
+  const message = await buildSkillPayload(fullSkillName, bareSkillName, parsed.args, cwd, sessionId);
   return { kind: 'skill', message };
 }
 
@@ -118,8 +167,13 @@ export async function classifySlashInput(
  * Runs the registered preflight (if any) and produces the same multi-block
  * message shape the REPL's `runSkillDispatchTurn` sends through
  * `sendMessageStream`.
+ *
+ * @param fullSkillName - Full skill name without leading `/` (e.g. `user:mint`).
+ * @param bareSkillName - Bare skill name without namespace (e.g. `mint`), used
+ *   for preflight lookup which is keyed by bare name.
  */
 async function buildSkillPayload(
+  fullSkillName: string,
   bareSkillName: string,
   args: string,
   cwd: string,
@@ -136,6 +190,7 @@ async function buildSkillPayload(
   ]);
 
   // Run preflight if registered (e.g. review-pr gathers diff context).
+  // Preflights are keyed by bare name.
   let manifestBlock: string | undefined;
   const preflight = getPreflight(bareSkillName);
   if (preflight) {
@@ -157,15 +212,16 @@ async function buildSkillPayload(
   }
 
   // Build the skill metadata adapter -- only .name and .context are consumed
-  // by buildSkillInvocationMessage.
+  // by buildSkillInvocationMessage. Use the FULL skill name so that namespaced
+  // skills (e.g. user:mint) resolve correctly in the skills registry.
   let skillMeta;
   try {
-    skillMeta = getSkill(bareSkillName);
+    skillMeta = getSkill(fullSkillName);
   } catch {
-    // Skill not in the TS registry (plugin-only skill). Synthesise a
-    // minimal adapter -- same pattern as makeForwardHandler in dispatch.ts.
+    // Skill not in the TS registry (plugin-only skill or namespaced). Synthesise
+    // a minimal adapter -- same pattern as makeForwardHandler in dispatch.ts.
     skillMeta = {
-      name: bareSkillName,
+      name: fullSkillName,
       description: '',
       handler: async () => undefined,
       context: 'inline' as const,


### PR DESCRIPTION
## Problem

The web UI's prompt path sent user text verbatim to `sendMessageStream`, completely bypassing the slash-command dispatch pipeline that the CLI REPL uses. Skills like `/review`, `/mint`, `/diagnose`, etc. could not execute from the web surface -- the model received `/review 277` as plain text with no skill body injection, no preflight context gathering, and no structured invocation message.

The autocomplete dropdown showed skill names but explicitly documented itself as an "INSERT affordance" only -- cosmetic, not functional.

## Solution

Wire slash-command dispatch into the web UI's prompt path via a new `slash-dispatch.ts` module:

### New: `src/web-server/slash-dispatch.ts`
- `classifySlashInput(text, cwd, sessionId)` classifies incoming text into one of:
  - **passthrough** -- non-slash text, or native non-skill commands (e.g. `/help`); sent to model as-is
  - **skill** -- builds a `ContentBlockParam[]` via `buildSkillInvocationMessage` (same payload shape the REPL produces)
  - **repl-only** -- terminal-only commands (`/clear`, `/exit`, `/model`, etc.); returns 422
  - **unknown** -- unrecognised command with optional did-you-mean suggestion; returns 422
- Runs registered preflights (e.g. `/review` gathers PR diff context via `gh`) with graceful failure isolation
- All imports are dynamic (lazy-loaded on first slash input) to match the existing pattern and keep the `cli/slash` import tree off the server startup path

### Modified: `src/web-server/session-owner.ts`
- `submitSkillMessage(sessionId, message: ContentBlockParam[])` -- same turn-serialization and backpressure as `submitPrompt`, but accepts the pre-built multi-block skill payload
- `getSessionCwd(sessionId)` -- exposes session cwd for preflight context
- `getProviderSessionId(sessionId)` -- exposes provider session id for preflight artifact dirs

### Modified: `src/web-server/routes.ts`
- `handlePrompt` now intercepts `/`-prefixed text before `submitPrompt`, delegates to `classifySlashInput`
- Returns structured HTTP errors: 422 for REPL-only commands and unknown commands
- Falls through to existing `submitPrompt` for passthrough cases (zero behavioral change for non-slash input)

### Modified: `src/web-server/server.ts`
- Wires the three new `SessionOwner` methods into `RouteContext`

## Tests

- **12 new tests** in `slash-dispatch.test.ts`: all classification paths, preflight integration, error isolation (preflight failure doesn't block skill dispatch), plugin-only skill fallback
- **3 new tests** in `session-owner.test.ts`: `submitSkillMessage`, `getSessionCwd`, `getProviderSessionId` on unknown session ids
- All **400 web-server tests** pass
- `pnpm lint` clean, `pnpm audit:filesize:check` clean, `pnpm audit:sdk:check` clean

## File sizes

| File | Code LOC | Headroom |
|------|----------|----------|
| `slash-dispatch.ts` (new) | ~100 | 250 |
| `routes.ts` | ~255 | 95 |
| `session-owner.ts` | ~156 | 194 |
| `server.ts` | ~285 | 65 |
