### PR TITLE
feat(dashboard): port @-file, model selector, and queue panels to React

### DIFF
--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Sidebar } from './components/sidebar';
 import { CommandPalette } from './components/command-palette';
 import { KeyboardShortcuts } from './components/keyboard-shortcuts';
@@ -15,6 +15,8 @@ import { useSessions } from './hooks/use-sessions';
 import { usePendingApprovals } from './hooks/use-pending-approvals';
 import { useTranscript } from './hooks/use-transcript';
 import { useScrollPin } from './hooks/use-scroll-pin';
+import { useQueue } from './hooks/use-queue';
+import { apiFetch } from './lib/api';
 
 type NavItem = 'sessions' | 'memory' | 'schedules' | 'jobs' | 'settings';
 
@@ -50,6 +52,28 @@ function Dashboard() {
   };
 
   const isBusy = status === 'open' || status === 'connecting';
+  const [selectedModel, setSelectedModel] = useState('sonnet');
+
+  const queue = useQueue({
+    submit: async (text: string) => {
+      if (!selectedSessionId) throw new Error('no session');
+      await apiFetch(`/api/sessions/${selectedSessionId}/prompt`, {
+        method: 'POST',
+        body: JSON.stringify({ text }),
+      });
+    },
+    isLive: selectedSession?.mode === 'live',
+    isBusy,
+  });
+
+  // Attempt to flush the queue when a turn completes (isBusy transitions to false).
+  const prevBusyRef = useRef(isBusy);
+  useEffect(() => {
+    if (prevBusyRef.current && !isBusy) {
+      void queue.flush();
+    }
+    prevBusyRef.current = isBusy;
+  }, [isBusy, queue]);
 
   const sidebarContent = (
     <Sidebar
@@ -140,6 +164,9 @@ function Dashboard() {
                 sessionId={selectedSession.id}
                 sessionMode={selectedSession.mode}
                 isBusy={isBusy}
+                queue={queue}
+                onModelSelect={setSelectedModel}
+                currentModel={selectedModel}
               />
             </div>
           )}

--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -38,7 +38,7 @@ function Dashboard() {
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
 
   const selectedSession = sessions.find((s) => s.id === selectedSessionId);
-  const { items, totals, status } = useTranscript(selectedSessionId);
+  const { items, totals, status, turnActive } = useTranscript(selectedSessionId);
   const { containerRef } = useScrollPin();
 
   const handleNavigate = (nav: string) => {
@@ -51,7 +51,7 @@ function Dashboard() {
     setMobileSidebarOpen(false);
   };
 
-  const isBusy = status === 'open' || status === 'connecting';
+  const isBusy = turnActive;
   const [selectedModel, setSelectedModel] = useState('sonnet');
 
   const queue = useQueue({
@@ -63,17 +63,23 @@ function Dashboard() {
       });
     },
     isLive: selectedSession?.mode === 'live',
-    isBusy,
   });
 
-  // Attempt to flush the queue when a turn completes (isBusy transitions to false).
-  const prevBusyRef = useRef(isBusy);
+  // Clear the queue when the selected session changes to prevent a prompt
+  // queued for session A from being sent to session B.
   useEffect(() => {
-    if (prevBusyRef.current && !isBusy) {
+    queue.clear();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- queue identity is stable; selectedSessionId is the real dep
+  }, [selectedSessionId]);
+
+  // Flush the queue when a turn completes (totals.turns increments on 'done' records).
+  const prevTurnsRef = useRef(totals.turns);
+  useEffect(() => {
+    if (totals.turns > prevTurnsRef.current) {
       void queue.flush();
     }
-    prevBusyRef.current = isBusy;
-  }, [isBusy, queue]);
+    prevTurnsRef.current = totals.turns;
+  }, [totals.turns, queue]);
 
   const sidebarContent = (
     <Sidebar

--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 import { Sidebar } from './components/sidebar';
 import { CommandPalette } from './components/command-palette';
 import { KeyboardShortcuts } from './components/keyboard-shortcuts';
@@ -38,7 +38,7 @@ function Dashboard() {
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
 
   const selectedSession = sessions.find((s) => s.id === selectedSessionId);
-  const { items, totals, status, turnActive } = useTranscript(selectedSessionId);
+  const { items, totals, status, turnActive, liveTurns } = useTranscript(selectedSessionId);
   const { containerRef } = useScrollPin();
 
   const handleNavigate = (nav: string) => {
@@ -54,32 +54,46 @@ function Dashboard() {
   const isBusy = turnActive;
   const [selectedModel, setSelectedModel] = useState('sonnet');
 
+  // Abort controller ref: abort in-flight POSTs when the session changes.
+  const abortRef = useRef<AbortController | null>(null);
+
+  const submitPrompt = useCallback(async (text: string) => {
+    if (!selectedSessionId) throw new Error('no session');
+    const controller = new AbortController();
+    abortRef.current = controller;
+    await apiFetch(`/api/sessions/${selectedSessionId}/prompt`, {
+      method: 'POST',
+      body: JSON.stringify({ text }),
+      signal: controller.signal,
+    });
+  }, [selectedSessionId]);
+
   const queue = useQueue({
-    submit: async (text: string) => {
-      if (!selectedSessionId) throw new Error('no session');
-      await apiFetch(`/api/sessions/${selectedSessionId}/prompt`, {
-        method: 'POST',
-        body: JSON.stringify({ text }),
-      });
-    },
+    submit: submitPrompt,
     isLive: selectedSession?.mode === 'live',
   });
 
-  // Clear the queue when the selected session changes to prevent a prompt
-  // queued for session A from being sent to session B.
+  // Clear the queue and abort any in-flight POST when the selected session
+  // changes to prevent a prompt queued for session A from being sent to
+  // session B.
   useEffect(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
     queue.clear();
+    prevTurnsRef.current = 0;
     // eslint-disable-next-line react-hooks/exhaustive-deps -- queue identity is stable; selectedSessionId is the real dep
   }, [selectedSessionId]);
 
-  // Flush the queue when a turn completes (totals.turns increments on 'done' records).
-  const prevTurnsRef = useRef(totals.turns);
+  // Flush the queue when a live turn completes (liveTurns increments only on
+  // non-replay 'done' records, preventing spurious flushes during initial
+  // replay on session load).
+  const prevTurnsRef = useRef(0);
   useEffect(() => {
-    if (totals.turns > prevTurnsRef.current) {
+    if (liveTurns > prevTurnsRef.current) {
       void queue.flush();
     }
-    prevTurnsRef.current = totals.turns;
-  }, [totals.turns, queue]);
+    prevTurnsRef.current = liveTurns;
+  }, [liveTurns, queue.flush]);
 
   const sidebarContent = (
     <Sidebar

--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -73,6 +73,9 @@ function Dashboard() {
     isLive: selectedSession?.mode === 'live',
   });
 
+  // Track the previous liveTurns value to detect new turn completions.
+  const prevTurnsRef = useRef(0);
+
   // Clear the queue and abort any in-flight POST when the selected session
   // changes to prevent a prompt queued for session A from being sent to
   // session B.
@@ -87,7 +90,6 @@ function Dashboard() {
   // Flush the queue when a live turn completes (liveTurns increments only on
   // non-replay 'done' records, preventing spurious flushes during initial
   // replay on session load).
-  const prevTurnsRef = useRef(0);
   useEffect(() => {
     if (liveTurns > prevTurnsRef.current) {
       void queue.flush();

--- a/dashboard/src/components/at-file-popover.tsx
+++ b/dashboard/src/components/at-file-popover.tsx
@@ -1,0 +1,159 @@
+/**
+ * @file context injection affordance for the React composer.
+ *
+ * Renders an '@' button that opens a popover where the user can type a file
+ * path. On submit, the callback fires with the `@<path>` token so the parent
+ * Composer can insert it at the cursor position.
+ *
+ * Port of src/web-server/frontend/at-file-panel.ts to React + Tailwind.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { FileText } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface AtFilePopoverProps {
+  /** Called with the full `@path` token string to insert into the composer. */
+  onInsert: (token: string) => void;
+}
+
+/**
+ * Contract: path must be non-empty and start with /, ./, ~/, or contain no
+ * leading slash (relative bare path like src/file.ts). Matches the validation
+ * in the old at-file-panel.ts.
+ */
+function looksLikePath(raw: string): boolean {
+  const s = raw.trim();
+  if (!s) return false;
+  return s.startsWith('/') || s.startsWith('./') || s.startsWith('~/') || /^[\w.]/.test(s);
+}
+
+export function AtFilePopover({ onInsert }: AtFilePopoverProps) {
+  const [open, setOpen] = useState(false);
+  const [path, setPath] = useState('');
+  const [error, setError] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  const close = useCallback(() => {
+    setOpen(false);
+    setError(false);
+    setPath('');
+  }, []);
+
+  const commit = useCallback(() => {
+    const trimmed = path.trim();
+    if (!looksLikePath(trimmed)) {
+      setError(true);
+      inputRef.current?.focus();
+      return;
+    }
+    onInsert(`@${trimmed}`);
+    close();
+  }, [path, onInsert, close]);
+
+  // Focus input when popover opens.
+  useEffect(() => {
+    if (open) {
+      // Defer to next frame so the input is mounted.
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
+  }, [open]);
+
+  // Dismiss on click outside.
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      const target = e.target as Node;
+      if (
+        popoverRef.current &&
+        !popoverRef.current.contains(target) &&
+        buttonRef.current &&
+        !buttonRef.current.contains(target)
+      ) {
+        close();
+      }
+    }
+    document.addEventListener('click', handleClick, { capture: true });
+    return () => document.removeEventListener('click', handleClick, { capture: true });
+  }, [open, close]);
+
+  return (
+    <div className="relative">
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={() => (open ? close() : setOpen(true))}
+        aria-label="Insert file reference"
+        aria-expanded={open}
+        className={cn(
+          'flex h-8 w-8 items-center justify-center rounded-md text-sm',
+          'transition-colors hover:bg-accent hover:text-accent-foreground',
+          open && 'bg-accent text-accent-foreground',
+        )}
+        title="Insert @file reference"
+      >
+        <FileText className="h-4 w-4" />
+      </button>
+
+      {open && (
+        <div
+          ref={popoverRef}
+          role="dialog"
+          aria-label="Insert file path"
+          className={cn(
+            'absolute bottom-full left-0 mb-2 w-72 rounded-lg border',
+            'bg-popover p-3 shadow-lg animate-fade-in',
+          )}
+        >
+          <p className="mb-2 text-xs text-muted-foreground">
+            Type a file path. <code className="text-[10px]">@~/file.ts</code> or{' '}
+            <code className="text-[10px]">@src/file.ts</code>
+          </p>
+
+          <div className="flex gap-2">
+            <input
+              ref={inputRef}
+              type="text"
+              value={path}
+              onChange={(e) => {
+                setPath(e.target.value);
+                setError(false);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  commit();
+                }
+                if (e.key === 'Escape') close();
+              }}
+              placeholder="src/foo.ts or ~/file.ts"
+              autoComplete="off"
+              spellCheck={false}
+              className={cn(
+                'flex-1 rounded-md border bg-secondary px-2 py-1 text-sm',
+                'placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring',
+                error && 'border-destructive',
+              )}
+            />
+            <button
+              type="button"
+              onClick={commit}
+              className={cn(
+                'rounded-md bg-primary px-3 py-1 text-sm font-medium',
+                'text-primary-foreground hover:bg-primary/90',
+              )}
+            >
+              Add
+            </button>
+          </div>
+
+          {error && (
+            <p className="mt-1 text-xs text-destructive">Enter a valid file path.</p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/components/composer.tsx
+++ b/dashboard/src/components/composer.tsx
@@ -143,7 +143,7 @@ export function Composer({
         }
       }
     },
-    [acVisible, acFiltered, acActiveIdx, selectCommand, submit],
+    [acVisible, acFiltered, acActiveIdx, selectCommand, submit, isBusy, text, queue],
   );
 
   /** Insert text at the current cursor position. */

--- a/dashboard/src/components/composer.tsx
+++ b/dashboard/src/components/composer.tsx
@@ -10,11 +10,21 @@ import { cn } from '@/lib/utils';
 import { apiFetch } from '@/lib/api';
 import type { SlashCommand } from '@/types/api';
 import { SlashAutocomplete, handleAutocompleteKey } from './slash-autocomplete';
+import { AtFilePopover } from './at-file-popover';
+import { ModelSelector } from './model-selector';
+import { QueuePanel } from './queue-panel';
+import type { UseQueueResult } from '@/hooks/use-queue';
 
 interface ComposerProps {
   sessionId: string;
   sessionMode: 'live' | 'readonly';
   isBusy: boolean;
+  /** Queue for mid-run message management. */
+  queue?: UseQueueResult;
+  /** Called when the operator picks a model from the selector. */
+  onModelSelect?: (modelId: string) => void;
+  /** Currently selected model id (shown in the selector). */
+  currentModel?: string;
 }
 
 /** Cached slash commands — fetched once per page lifecycle. */
@@ -34,7 +44,14 @@ function getSlashQuery(text: string): string | null {
 }
 
 /** Main prompt composer — textarea + send/stop controls. */
-export function Composer({ sessionId, sessionMode, isBusy }: ComposerProps) {
+export function Composer({
+  sessionId,
+  sessionMode,
+  isBusy,
+  queue,
+  onModelSelect,
+  currentModel,
+}: ComposerProps) {
   const [text, setText] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [commands, setCommands] = useState<SlashCommand[]>([]);
@@ -114,14 +131,43 @@ export function Composer({ sessionId, sessionMode, isBusy }: ComposerProps) {
 
       if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault();
-        void submit();
+        if (isBusy && queue) {
+          // When a turn is running, Enter queues instead of sending.
+          const trimmed = text.trim();
+          if (trimmed) {
+            queue.enqueue(trimmed);
+            setText('');
+          }
+        } else {
+          void submit();
+        }
       }
     },
     [acVisible, acFiltered, acActiveIdx, selectCommand, submit],
   );
 
+  /** Insert text at the current cursor position. */
+  const insertAtCursor = useCallback((token: string) => {
+    const ta = textareaRef.current;
+    if (!ta) { setText((t) => t + ' ' + token + ' '); return; }
+    const start = ta.selectionStart ?? ta.value.length;
+    const end = ta.selectionEnd ?? start;
+    const before = ta.value.slice(0, start);
+    const after = ta.value.slice(end);
+    const prefix = before.length > 0 && !/\s$/.test(before) ? ' ' : '';
+    const next = before + prefix + token + ' ' + after;
+    setText(next);
+    // Defer cursor placement to after React re-renders.
+    requestAnimationFrame(() => {
+      const pos = start + prefix.length + token.length + 1;
+      ta.setSelectionRange(pos, pos);
+      ta.focus();
+    });
+  }, []);
+
   return (
     <div className={cn('relative flex flex-col gap-2', disabled && 'opacity-50')}>
+      {queue && <QueuePanel queue={queue} />}
       <SlashAutocomplete
         query={slashQuery ?? ''}
         commands={commands}
@@ -129,6 +175,16 @@ export function Composer({ sessionId, sessionMode, isBusy }: ComposerProps) {
         visible={acVisible}
       />
       <div className="flex items-end gap-2">
+        {/* Toolbar: @-file + model selector */}
+        <div className="flex shrink-0 items-center gap-1">
+          <AtFilePopover onInsert={insertAtCursor} />
+          {onModelSelect && (
+            <ModelSelector
+              onSelect={onModelSelect}
+              current={currentModel}
+            />
+          )}
+        </div>
         <textarea
           ref={textareaRef}
           rows={1}

--- a/dashboard/src/components/model-selector.tsx
+++ b/dashboard/src/components/model-selector.tsx
@@ -1,0 +1,135 @@
+/**
+ * Model selector dropdown for the React dashboard.
+ *
+ * Fetches the model list from GET /api/models (with a static fallback) and
+ * renders a styled <select>. Fires onSelect on mount and on every change.
+ *
+ * Port of src/web-server/frontend/model-selector.ts to React + Tailwind.
+ * The badge helper is a bonus used by SessionCard.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { apiFetch } from '@/lib/api';
+import type { ModelInfo } from '@/types/api';
+import { cn } from '@/lib/utils';
+
+// ---- constants ----------------------------------------------------------------
+
+const DEFAULT_MODELS: readonly ModelInfo[] = [
+  { id: 'sonnet', label: 'Sonnet' },
+  { id: 'haiku', label: 'Haiku' },
+  { id: 'opus', label: 'Opus' },
+];
+
+const DEFAULT_MODEL_ID = 'sonnet';
+
+// ---- badge colour map ---------------------------------------------------------
+
+const BADGE_CLASSES: Readonly<Record<string, string>> = {
+  opus: 'bg-brand/15 text-brand',
+  sonnet: 'bg-status-running/15 text-status-running',
+  haiku: 'bg-muted text-muted-foreground',
+};
+
+function badgeClasses(modelId: string): string {
+  const lower = modelId.toLowerCase();
+  for (const key of Object.keys(BADGE_CLASSES)) {
+    if (lower.includes(key)) return BADGE_CLASSES[key] ?? '';
+  }
+  return 'bg-muted text-muted-foreground';
+}
+
+/**
+ * Derive a short display label from a model id.
+ *
+ * 'claude-3-5-sonnet-20241022' -> 'sonnet'
+ * 'sonnet'                      -> 'sonnet'
+ */
+function shortLabel(modelId: string): string {
+  const lower = modelId.toLowerCase();
+  for (const key of ['opus', 'sonnet', 'haiku']) {
+    if (lower.includes(key)) return key;
+  }
+  return modelId.length > 12 ? `${modelId.slice(0, 12)}\u2026` : modelId;
+}
+
+// ---- public components --------------------------------------------------------
+
+interface ModelSelectorProps {
+  /** Called with the chosen model id whenever the selection changes. */
+  onSelect: (modelId: string) => void;
+  /** Currently selected model id. */
+  current?: string;
+  className?: string;
+}
+
+export function ModelSelector({ onSelect, current, className }: ModelSelectorProps) {
+  const [models, setModels] = useState<readonly ModelInfo[]>(DEFAULT_MODELS);
+  const initialFired = useRef(false);
+
+  // Fetch the real model list once.
+  useEffect(() => {
+    let cancelled = false;
+    apiFetch<{ models: ModelInfo[] }>('/api/models')
+      .then((data) => {
+        if (!cancelled && data.models.length > 0) setModels(data.models);
+      })
+      .catch(() => {
+        // Swallow -- fallback list is already set.
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  // Fire onSelect on mount with the initial value.
+  const selected = current ?? DEFAULT_MODEL_ID;
+  useEffect(() => {
+    if (!initialFired.current) {
+      initialFired.current = true;
+      onSelect(selected);
+    }
+  }, [onSelect, selected]);
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      onSelect(e.target.value);
+    },
+    [onSelect],
+  );
+
+  return (
+    <div className={cn('relative inline-flex items-center', className)}>
+      <select
+        value={selected}
+        onChange={handleChange}
+        aria-label="Model"
+        className={cn(
+          'appearance-none rounded-md border bg-secondary pl-2 pr-7 py-1',
+          'text-xs font-medium text-secondary-foreground',
+          'cursor-pointer focus:outline-none focus:ring-1 focus:ring-ring',
+        )}
+      >
+        {models.map((m) => (
+          <option key={m.id} value={m.id}>
+            {m.label}
+          </option>
+        ))}
+      </select>
+      <ChevronDown className="pointer-events-none absolute right-1.5 h-3 w-3 text-muted-foreground" />
+    </div>
+  );
+}
+
+/** Small coloured pill badge showing the model tier. */
+export function ModelBadge({ model }: { model: string }) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium',
+        badgeClasses(model),
+      )}
+    >
+      {shortLabel(model)}
+    </span>
+  );
+}

--- a/dashboard/src/components/queue-panel.tsx
+++ b/dashboard/src/components/queue-panel.tsx
@@ -31,7 +31,6 @@ export function QueuePanel({ queue }: QueuePanelProps) {
         <QueueRow
           key={entry.id}
           text={entry.text}
-          index={i}
           isFirst={i === 0}
           isLast={i === entries.length - 1}
           onMoveUp={() => moveItemUp(i)}
@@ -48,7 +47,6 @@ export function QueuePanel({ queue }: QueuePanelProps) {
 
 interface QueueRowProps {
   text: string;
-  index: number;
   isFirst: boolean;
   isLast: boolean;
   onMoveUp: () => void;

--- a/dashboard/src/components/queue-panel.tsx
+++ b/dashboard/src/components/queue-panel.tsx
@@ -1,0 +1,181 @@
+/**
+ * Mid-run message queue panel for the React dashboard.
+ *
+ * Renders queued prompts above the composer with reorder (up/down), inline
+ * edit, and remove controls. Each row shows a truncated preview of the queued
+ * text with action buttons.
+ *
+ * Port of src/web-server/frontend/queue-panel.ts to React + Tailwind.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ArrowUp, ArrowDown, Pencil, X, Check } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { UseQueueResult } from '@/hooks/use-queue';
+
+interface QueuePanelProps {
+  queue: UseQueueResult;
+}
+
+export function QueuePanel({ queue }: QueuePanelProps) {
+  const { entries, moveItemUp, moveItemDown, removeItem, editItem } = queue;
+
+  if (entries.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-1 border-b border-border/50 px-3 py-2">
+      <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+        Queued ({entries.length})
+      </p>
+      {entries.map((text, i) => (
+        <QueueRow
+          key={`${i}-${text.slice(0, 20)}`}
+          text={text}
+          index={i}
+          isFirst={i === 0}
+          isLast={i === entries.length - 1}
+          onMoveUp={() => moveItemUp(i)}
+          onMoveDown={() => moveItemDown(i)}
+          onRemove={() => removeItem(i)}
+          onEdit={(value) => editItem(i, value)}
+        />
+      ))}
+    </div>
+  );
+}
+
+// ---- QueueRow ---------------------------------------------------------------
+
+interface QueueRowProps {
+  text: string;
+  index: number;
+  isFirst: boolean;
+  isLast: boolean;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  onRemove: () => void;
+  onEdit: (value: string) => void;
+}
+
+function QueueRow({
+  text,
+  isFirst,
+  isLast,
+  onMoveUp,
+  onMoveDown,
+  onRemove,
+  onEdit,
+}: QueueRowProps) {
+  const [editing, setEditing] = useState(false);
+  const [editValue, setEditValue] = useState(text);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (editing) inputRef.current?.focus();
+  }, [editing]);
+
+  const startEdit = useCallback(() => {
+    setEditValue(text);
+    setEditing(true);
+  }, [text]);
+
+  const commitEdit = useCallback(() => {
+    const trimmed = editValue.trim();
+    if (trimmed && trimmed !== text) {
+      onEdit(trimmed);
+    }
+    setEditing(false);
+  }, [editValue, text, onEdit]);
+
+  const cancelEdit = useCallback(() => {
+    setEditing(false);
+    setEditValue(text);
+  }, [text]);
+
+  return (
+    <div
+      className={cn(
+        'group flex items-center gap-1.5 rounded-md border border-border/50',
+        'bg-secondary/50 px-2 py-1 text-sm animate-fade-in',
+      )}
+    >
+      {editing ? (
+        <input
+          ref={inputRef}
+          type="text"
+          value={editValue}
+          onChange={(e) => setEditValue(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') commitEdit();
+            if (e.key === 'Escape') cancelEdit();
+          }}
+          onBlur={commitEdit}
+          className={cn(
+            'min-w-0 flex-1 bg-transparent text-sm',
+            'focus:outline-none',
+          )}
+        />
+      ) : (
+        <span className="min-w-0 flex-1 truncate text-foreground/80">{text}</span>
+      )}
+
+      <div className="flex shrink-0 items-center gap-0.5 opacity-60 group-hover:opacity-100">
+        {editing ? (
+          <QueueButton label="Confirm edit" onClick={commitEdit}>
+            <Check className="h-3 w-3" />
+          </QueueButton>
+        ) : (
+          <QueueButton label="Edit" onClick={startEdit}>
+            <Pencil className="h-3 w-3" />
+          </QueueButton>
+        )}
+        <QueueButton label="Move up" onClick={onMoveUp} disabled={isFirst}>
+          <ArrowUp className="h-3 w-3" />
+        </QueueButton>
+        <QueueButton label="Move down" onClick={onMoveDown} disabled={isLast}>
+          <ArrowDown className="h-3 w-3" />
+        </QueueButton>
+        <QueueButton label="Remove" onClick={onRemove} destructive>
+          <X className="h-3 w-3" />
+        </QueueButton>
+      </div>
+    </div>
+  );
+}
+
+// ---- tiny button helper -----------------------------------------------------
+
+function QueueButton({
+  label,
+  onClick,
+  disabled,
+  destructive,
+  children,
+}: {
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  destructive?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={label}
+      title={label}
+      className={cn(
+        'flex h-5 w-5 items-center justify-center rounded',
+        'transition-colors',
+        disabled
+          ? 'cursor-not-allowed opacity-30'
+          : destructive
+            ? 'hover:bg-destructive/20 hover:text-destructive'
+            : 'hover:bg-accent hover:text-accent-foreground',
+      )}
+    >
+      {children}
+    </button>
+  );
+}

--- a/dashboard/src/components/queue-panel.tsx
+++ b/dashboard/src/components/queue-panel.tsx
@@ -11,7 +11,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { ArrowUp, ArrowDown, Pencil, X, Check } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import type { UseQueueResult } from '@/hooks/use-queue';
+import type { UseQueueResult, QueueEntry } from '@/hooks/use-queue';
 
 interface QueuePanelProps {
   queue: UseQueueResult;
@@ -27,10 +27,10 @@ export function QueuePanel({ queue }: QueuePanelProps) {
       <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
         Queued ({entries.length})
       </p>
-      {entries.map((text, i) => (
+      {entries.map((entry: QueueEntry, i) => (
         <QueueRow
-          key={`${i}-${text.slice(0, 20)}`}
-          text={text}
+          key={entry.id}
+          text={entry.text}
           index={i}
           isFirst={i === 0}
           isLast={i === entries.length - 1}

--- a/dashboard/src/hooks/use-queue.ts
+++ b/dashboard/src/hooks/use-queue.ts
@@ -92,57 +92,74 @@ export function useQueue({ submit, isLive }: UseQueueOpts): UseQueueResult {
   const [queue, setQueue] = useState<QueueEntry[]>([]);
   const flushingRef = useRef(false);
   const nextIdRef = useRef(0);
+  // Mirror of the queue state readable synchronously without a state-updater
+  // side effect — avoids running side effects inside the setQueue updater
+  // (which React 18 StrictMode invokes twice).
+  const queueRef = useRef<QueueEntry[]>([]);
 
   const enqueue = useCallback((text: string) => {
     const id = nextIdRef.current++;
-    setQueue((prev) => [...prev, { id, text }]);
+    const next = [...queueRef.current, { id, text }];
+    queueRef.current = next;
+    setQueue(next);
   }, []);
 
   const moveItemUp = useCallback((i: number) => {
-    setQueue((prev) => moveUp(prev, i));
+    const next = moveUp(queueRef.current, i);
+    queueRef.current = next;
+    setQueue(next);
   }, []);
 
   const moveItemDown = useCallback((i: number) => {
-    setQueue((prev) => moveDown(prev, i));
+    const next = moveDown(queueRef.current, i);
+    queueRef.current = next;
+    setQueue(next);
   }, []);
 
   const removeItem = useCallback((i: number) => {
-    setQueue((prev) => removeAt(prev, i));
+    const next = removeAt(queueRef.current, i);
+    queueRef.current = next;
+    setQueue(next);
   }, []);
 
   const editItem = useCallback((i: number, text: string) => {
-    setQueue((prev) => editAt(prev, i, text));
+    const next = editAt(queueRef.current, i, text);
+    queueRef.current = next;
+    setQueue(next);
   }, []);
 
-  const clear = useCallback(() => setQueue([]), []);
+  const clear = useCallback(() => {
+    queueRef.current = [];
+    setQueue([]);
+  }, []);
 
   const flush = useCallback(async () => {
     if (flushingRef.current) return;
     if (!isLive) return;
 
-    setQueue((prev) => {
-      const head = prev[0];
-      if (head === undefined) return prev;
+    // Read the queue head synchronously from the ref — no state-updater side
+    // effect, so React 18 StrictMode double-invocation is harmless.
+    const head = queueRef.current[0];
+    if (head === undefined) return;
 
-      const headId = head.id;
-      const headText = head.text;
+    const headId = head.id;
+    const headText = head.text;
 
-      flushingRef.current = true;
-      // Fire-and-forget the submit, then remove by id on success.
-      void submit(headText)
-        .then(() => {
-          // Remove the entry that was submitted, identified by its stable id.
-          setQueue((q) => q.filter((entry) => entry.id !== headId));
-        })
-        .catch(() => {
-          // Keep entry in queue on failure; the UI will show error state.
-        })
-        .finally(() => {
-          flushingRef.current = false;
-        });
-
-      return prev;
-    });
+    flushingRef.current = true;
+    // Fire-and-forget the submit, then remove by id on success.
+    void submit(headText)
+      .then(() => {
+        // Remove the entry that was submitted, identified by its stable id.
+        const next = queueRef.current.filter((entry) => entry.id !== headId);
+        queueRef.current = next;
+        setQueue(next);
+      })
+      .catch(() => {
+        // Keep entry in queue on failure; the UI will show error state.
+      })
+      .finally(() => {
+        flushingRef.current = false;
+      });
   }, [submit, isLive]);
 
   return { entries: queue, enqueue, moveItemUp, moveItemDown, removeItem, editItem, clear, flush };

--- a/dashboard/src/hooks/use-queue.ts
+++ b/dashboard/src/hooks/use-queue.ts
@@ -1,0 +1,134 @@
+/**
+ * React hook for the mid-run message queue.
+ *
+ * Manages a list of queued prompts with reorder/edit/remove operations,
+ * and a one-at-a-time drain that sends the next entry only when the current
+ * turn is idle. Pure immutable list operations ported from
+ * src/web-server/frontend/queue-reorder.ts.
+ *
+ * Contract: the queue holds entries and drains them one at a time on turn
+ * boundaries. POST /prompt answers 202 on ACCEPTANCE, not completion, so a
+ * while(queue.length) drain would empty the list instantly. Holding the rest
+ * until the turn finishes is what lets entries dwell long enough to reorder.
+ */
+
+import { useCallback, useRef, useState } from 'react';
+
+// ---- pure list operations (from queue-reorder.ts) ---------------------------
+
+function isInBounds<T>(list: readonly T[], index: number): boolean {
+  return Number.isInteger(index) && index >= 0 && index < list.length;
+}
+
+function moveUp<T>(list: readonly T[], index: number): T[] {
+  if (!isInBounds(list, index) || index === 0) return list.slice();
+  const next = list.slice();
+  const above = next[index - 1];
+  const current = next[index];
+  if (above === undefined || current === undefined) return list.slice();
+  next[index - 1] = current;
+  next[index] = above;
+  return next;
+}
+
+function moveDown<T>(list: readonly T[], index: number): T[] {
+  if (!isInBounds(list, index) || index === list.length - 1) return list.slice();
+  const next = list.slice();
+  const below = next[index + 1];
+  const current = next[index];
+  if (below === undefined || current === undefined) return list.slice();
+  next[index + 1] = current;
+  next[index] = below;
+  return next;
+}
+
+function removeAt<T>(list: readonly T[], index: number): T[] {
+  if (!isInBounds(list, index)) return list.slice();
+  const next = list.slice();
+  next.splice(index, 1);
+  return next;
+}
+
+function editAt<T>(list: readonly T[], index: number, value: T): T[] {
+  if (!isInBounds(list, index)) return list.slice();
+  const next = list.slice();
+  next[index] = value;
+  return next;
+}
+
+// ---- hook -------------------------------------------------------------------
+
+interface UseQueueOpts {
+  /** POST one prompt; must reject unless the server accepted it. */
+  submit: (text: string) => Promise<void>;
+  /** Whether the active session can be driven from this process. */
+  isLive: boolean;
+  /** Whether a turn is already running. */
+  isBusy: boolean;
+}
+
+export interface UseQueueResult {
+  entries: readonly string[];
+  enqueue: (text: string) => void;
+  moveItemUp: (index: number) => void;
+  moveItemDown: (index: number) => void;
+  removeItem: (index: number) => void;
+  editItem: (index: number, value: string) => void;
+  clear: () => void;
+  /** Attempt to flush the next queued entry. Call on turn-boundary events. */
+  flush: () => Promise<void>;
+}
+
+export function useQueue({ submit, isLive, isBusy }: UseQueueOpts): UseQueueResult {
+  const [queue, setQueue] = useState<string[]>([]);
+  const flushingRef = useRef(false);
+
+  const enqueue = useCallback((text: string) => {
+    setQueue((prev) => [...prev, text]);
+  }, []);
+
+  const moveItemUp = useCallback((i: number) => {
+    setQueue((prev) => moveUp(prev, i));
+  }, []);
+
+  const moveItemDown = useCallback((i: number) => {
+    setQueue((prev) => moveDown(prev, i));
+  }, []);
+
+  const removeItem = useCallback((i: number) => {
+    setQueue((prev) => removeAt(prev, i));
+  }, []);
+
+  const editItem = useCallback((i: number, value: string) => {
+    setQueue((prev) => editAt(prev, i, value));
+  }, []);
+
+  const clear = useCallback(() => setQueue([]), []);
+
+  const flush = useCallback(async () => {
+    if (flushingRef.current) return;
+    if (!isLive || isBusy) return;
+
+    setQueue((prev) => {
+      const next = prev[0];
+      if (next === undefined) return prev;
+
+      flushingRef.current = true;
+      // Fire-and-forget the submit, then slice on success.
+      void submit(next)
+        .then(() => {
+          setQueue((q) => q.slice(1));
+        })
+        .catch(() => {
+          // Keep entry in queue on failure; the UI will show error state.
+        })
+        .finally(() => {
+          flushingRef.current = false;
+        });
+
+      return prev;
+    });
+  }, [submit, isLive, isBusy]);
+
+  return { entries: queue, enqueue, moveItemUp, moveItemDown, removeItem, editItem, clear, flush };
+}

--- a/dashboard/src/hooks/use-queue.ts
+++ b/dashboard/src/hooks/use-queue.ts
@@ -155,7 +155,7 @@ export function useQueue({ submit, isLive }: UseQueueOpts): UseQueueResult {
         setQueue(next);
       })
       .catch(() => {
-        // Keep entry in queue on failure; the UI will show error state.
+        // Keep entry in queue on failure so the user can retry or remove it.
       })
       .finally(() => {
         flushingRef.current = false;

--- a/dashboard/src/hooks/use-queue.ts
+++ b/dashboard/src/hooks/use-queue.ts
@@ -10,9 +10,20 @@
  * boundaries. POST /prompt answers 202 on ACCEPTANCE, not completion, so a
  * while(queue.length) drain would empty the list instantly. Holding the rest
  * until the turn finishes is what lets entries dwell long enough to reorder.
+ *
+ * Each entry carries a stable numeric `id` so that after the in-flight POST
+ * succeeds the correct entry is removed by identity, not by position.
  */
 
 import { useCallback, useRef, useState } from 'react';
+
+// ---- queue entry type -------------------------------------------------------
+
+/** A queued prompt with a stable identity. */
+export interface QueueEntry {
+  id: number;
+  text: string;
+}
 
 // ---- pure list operations (from queue-reorder.ts) ---------------------------
 
@@ -49,10 +60,10 @@ function removeAt<T>(list: readonly T[], index: number): T[] {
   return next;
 }
 
-function editAt<T>(list: readonly T[], index: number, value: T): T[] {
+function editAt(list: readonly QueueEntry[], index: number, text: string): QueueEntry[] {
   if (!isInBounds(list, index)) return list.slice();
   const next = list.slice();
-  next[index] = value;
+  next[index] = { ...next[index]! , text };
   return next;
 }
 
@@ -63,28 +74,28 @@ interface UseQueueOpts {
   submit: (text: string) => Promise<void>;
   /** Whether the active session can be driven from this process. */
   isLive: boolean;
-  /** Whether a turn is already running. */
-  isBusy: boolean;
 }
 
 export interface UseQueueResult {
-  entries: readonly string[];
+  entries: readonly QueueEntry[];
   enqueue: (text: string) => void;
   moveItemUp: (index: number) => void;
   moveItemDown: (index: number) => void;
   removeItem: (index: number) => void;
-  editItem: (index: number, value: string) => void;
+  editItem: (index: number, text: string) => void;
   clear: () => void;
   /** Attempt to flush the next queued entry. Call on turn-boundary events. */
   flush: () => Promise<void>;
 }
 
-export function useQueue({ submit, isLive, isBusy }: UseQueueOpts): UseQueueResult {
-  const [queue, setQueue] = useState<string[]>([]);
+export function useQueue({ submit, isLive }: UseQueueOpts): UseQueueResult {
+  const [queue, setQueue] = useState<QueueEntry[]>([]);
   const flushingRef = useRef(false);
+  const nextIdRef = useRef(0);
 
   const enqueue = useCallback((text: string) => {
-    setQueue((prev) => [...prev, text]);
+    const id = nextIdRef.current++;
+    setQueue((prev) => [...prev, { id, text }]);
   }, []);
 
   const moveItemUp = useCallback((i: number) => {
@@ -99,25 +110,29 @@ export function useQueue({ submit, isLive, isBusy }: UseQueueOpts): UseQueueResu
     setQueue((prev) => removeAt(prev, i));
   }, []);
 
-  const editItem = useCallback((i: number, value: string) => {
-    setQueue((prev) => editAt(prev, i, value));
+  const editItem = useCallback((i: number, text: string) => {
+    setQueue((prev) => editAt(prev, i, text));
   }, []);
 
   const clear = useCallback(() => setQueue([]), []);
 
   const flush = useCallback(async () => {
     if (flushingRef.current) return;
-    if (!isLive || isBusy) return;
+    if (!isLive) return;
 
     setQueue((prev) => {
-      const next = prev[0];
-      if (next === undefined) return prev;
+      const head = prev[0];
+      if (head === undefined) return prev;
+
+      const headId = head.id;
+      const headText = head.text;
 
       flushingRef.current = true;
-      // Fire-and-forget the submit, then slice on success.
-      void submit(next)
+      // Fire-and-forget the submit, then remove by id on success.
+      void submit(headText)
         .then(() => {
-          setQueue((q) => q.slice(1));
+          // Remove the entry that was submitted, identified by its stable id.
+          setQueue((q) => q.filter((entry) => entry.id !== headId));
         })
         .catch(() => {
           // Keep entry in queue on failure; the UI will show error state.
@@ -128,7 +143,7 @@ export function useQueue({ submit, isLive, isBusy }: UseQueueOpts): UseQueueResu
 
       return prev;
     });
-  }, [submit, isLive, isBusy]);
+  }, [submit, isLive]);
 
   return { entries: queue, enqueue, moveItemUp, moveItemDown, removeItem, editItem, clear, flush };
 }

--- a/dashboard/src/hooks/use-transcript.ts
+++ b/dashboard/src/hooks/use-transcript.ts
@@ -73,20 +73,12 @@ export function useTranscript(sessionId: string | null): UseTranscriptResult {
     setLiveTurns(0);
   }, [sessionId]);
 
-  // Feed new SSE events into the transcript.
-  useEffect(() => {
-    if (events.length === 0) return;
-
-    // Only process events that arrived since our last render. Because
-    // useSseStream accumulates ALL events, we track how many we've seen.
-    // We use a ref to avoid this effect depending on items/totals state.
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- processedCount is intentionally a ref
-  }, [events]);
-
-  // A ref-based approach: process events incrementally without depending on
-  // items or totals as effect deps (which would cause infinite re-renders).
+  // Feed new SSE events into the transcript incrementally. We track how many
+  // events we have processed via a ref to avoid depending on items/totals as
+  // effect deps (which would cause infinite re-renders).
   const processedCountRef = useRef(0);
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- processedCountRef is intentionally a ref; adding it would cause infinite re-renders
   useEffect(() => {
     const newEvents = events.slice(processedCountRef.current);
     if (newEvents.length === 0) return;

--- a/dashboard/src/hooks/use-transcript.ts
+++ b/dashboard/src/hooks/use-transcript.ts
@@ -41,6 +41,14 @@ export interface UseTranscriptResult {
    * SSE connection status (which stays `open` even when the agent is idle).
    */
   turnActive: boolean;
+  /**
+   * Count of live (non-replay) `done` records received since session load.
+   * Unlike `totals.turns` — which counts ALL done records including historical
+   * replay frames — this only increments on frames where `replay` is false.
+   * Use this as the flush trigger to avoid spurious queue flushes during
+   * the initial replay burst on session load.
+   */
+  liveTurns: number;
 }
 
 export function useTranscript(sessionId: string | null): UseTranscriptResult {
@@ -49,6 +57,7 @@ export function useTranscript(sessionId: string | null): UseTranscriptResult {
   const [items, setItems] = useState<TranscriptItem[]>([]);
   const [totals, setTotals] = useState<SessionTotals>(EMPTY_TOTALS);
   const [turnActive, setTurnActive] = useState(false);
+  const [liveTurns, setLiveTurns] = useState(0);
 
   // Stable tool index across renders — keyed by toolUseId for correlation.
   // Reset when sessionId changes.
@@ -61,6 +70,7 @@ export function useTranscript(sessionId: string | null): UseTranscriptResult {
     setItems([]);
     setTotals(EMPTY_TOTALS);
     setTurnActive(false);
+    setLiveTurns(0);
   }, [sessionId]);
 
   // Feed new SSE events into the transcript.
@@ -87,17 +97,24 @@ export function useTranscript(sessionId: string | null): UseTranscriptResult {
     let deltaTotals: SessionTotals = EMPTY_TOTALS;
     let hasMutation = false;
     let nextTurnActive: boolean | null = null;
+    let liveTurnsDelta = 0;
 
     for (const raw of newEvents) {
       // Each SSE frame is { record: LedgerRecordLike, replay: boolean }.
       const frame = raw as { record?: unknown; replay?: boolean };
       const record = (frame.record ?? raw) as LedgerRecordLike;
+      const isReplay = frame.replay === true;
 
       // Track turn activity: user records start a turn; done/error records end it.
       if (record.kind === 'user') {
         nextTurnActive = true;
       } else if (record.kind === 'done' || record.kind === 'error') {
         nextTurnActive = false;
+      }
+
+      // Count live (non-replay) done records for the flush trigger.
+      if (record.kind === 'done' && !isReplay) {
+        liveTurnsDelta += 1;
       }
 
       // Accumulate totals from done records.
@@ -140,6 +157,10 @@ export function useTranscript(sessionId: string | null): UseTranscriptResult {
     if (nextTurnActive !== null) {
       setTurnActive(nextTurnActive);
     }
+
+    if (liveTurnsDelta > 0) {
+      setLiveTurns((prev) => prev + liveTurnsDelta);
+    }
   }, [events]);
 
   // Reset processed count on session change (after items/totals are cleared).
@@ -147,5 +168,5 @@ export function useTranscript(sessionId: string | null): UseTranscriptResult {
     processedCountRef.current = 0;
   }, [sessionId]);
 
-  return { items, totals, status, error, turnActive };
+  return { items, totals, status, error, turnActive, liveTurns };
 }

--- a/dashboard/src/hooks/use-transcript.ts
+++ b/dashboard/src/hooks/use-transcript.ts
@@ -34,6 +34,13 @@ export interface UseTranscriptResult {
   totals: SessionTotals;
   status: StreamStatus;
   error: string | null;
+  /**
+   * True while the agent is actively processing a turn.
+   * Set to true on `user` ledger records, cleared on `done` or `error` records.
+   * Use this to drive the Composer's busy state instead of deriving from
+   * SSE connection status (which stays `open` even when the agent is idle).
+   */
+  turnActive: boolean;
 }
 
 export function useTranscript(sessionId: string | null): UseTranscriptResult {
@@ -41,6 +48,7 @@ export function useTranscript(sessionId: string | null): UseTranscriptResult {
 
   const [items, setItems] = useState<TranscriptItem[]>([]);
   const [totals, setTotals] = useState<SessionTotals>(EMPTY_TOTALS);
+  const [turnActive, setTurnActive] = useState(false);
 
   // Stable tool index across renders — keyed by toolUseId for correlation.
   // Reset when sessionId changes.
@@ -52,6 +60,7 @@ export function useTranscript(sessionId: string | null): UseTranscriptResult {
     toolIndexRef.current = new Map();
     setItems([]);
     setTotals(EMPTY_TOTALS);
+    setTurnActive(false);
   }, [sessionId]);
 
   // Feed new SSE events into the transcript.
@@ -77,11 +86,19 @@ export function useTranscript(sessionId: string | null): UseTranscriptResult {
     const newItems: TranscriptItem[] = [];
     let deltaTotals: SessionTotals = EMPTY_TOTALS;
     let hasMutation = false;
+    let nextTurnActive: boolean | null = null;
 
     for (const raw of newEvents) {
       // Each SSE frame is { record: LedgerRecordLike, replay: boolean }.
       const frame = raw as { record?: unknown; replay?: boolean };
       const record = (frame.record ?? raw) as LedgerRecordLike;
+
+      // Track turn activity: user records start a turn; done/error records end it.
+      if (record.kind === 'user') {
+        nextTurnActive = true;
+      } else if (record.kind === 'done' || record.kind === 'error') {
+        nextTurnActive = false;
+      }
 
       // Accumulate totals from done records.
       deltaTotals = accumulateTotals(deltaTotals, record);
@@ -119,6 +136,10 @@ export function useTranscript(sessionId: string | null): UseTranscriptResult {
         cacheReadTokens: (prev.cacheReadTokens ?? 0) + (deltaTotals.cacheReadTokens ?? 0),
       }));
     }
+
+    if (nextTurnActive !== null) {
+      setTurnActive(nextTurnActive);
+    }
   }, [events]);
 
   // Reset processed count on session change (after items/totals are cleared).
@@ -126,5 +147,5 @@ export function useTranscript(sessionId: string | null): UseTranscriptResult {
     processedCountRef.current = 0;
   }, [sessionId]);
 
-  return { items, totals, status, error };
+  return { items, totals, status, error, turnActive };
 }


### PR DESCRIPTION
## Summary

Ports the 3 remaining old-webui panels that had no React equivalents to the new dashboard, closing the feature gap identified in the Phase 5 migration.

## New components

### AtFilePopover (`at-file-popover.tsx`)
`@` button in the composer toolbar opens a popover for typing file paths. Inserts `@path` token at the cursor position in the textarea. Path validation matches the old `at-file-panel.ts` gate (absolute, home-relative, explicit-relative, or bare relative paths).

### ModelSelector (`model-selector.tsx`)
Styled `<select>` dropdown fetching from `GET /api/models` with a static fallback (`[sonnet, haiku, opus]`). Includes a `ModelBadge` pill component for use in session cards. Wired into the composer toolbar left of the textarea.

### QueuePanel (`queue-panel.tsx`) + useQueue hook (`use-queue.ts`)
Mid-run message queue with reorder (up/down), inline edit, and remove controls. Key behaviors:
- **One-at-a-time drain** on turn boundaries -- preserves the invariant that entries dwell long enough to be reordered (the whole point of a queue vs a send loop)
- **Enter queues when busy** -- when a turn is running, Enter adds to the queue instead of sending directly
- **Flush on turn boundary** -- `app.tsx` watches the `isBusy` transition and calls `queue.flush()` when a turn completes
- Pure immutable list operations ported from `queue-reorder.ts`

## Wiring

- `composer.tsx`: New toolbar row with @-file button + model selector to the left of the textarea. Queue panel renders above the input when entries exist. `insertAtCursor` helper for @-file token injection.
- `app.tsx`: `useQueue` hook instantiated with session submit function. Flush-on-turn-boundary effect. Model selection state. New props passed to Composer.

## Verification

- `tsc --noEmit` (strict) -- clean
- `pnpm lint` -- clean
- `pnpm build` (Vite bundle) -- succeeds
- `pnpm audit:filesize:check` -- all files under 350-LOC ceiling
- Existing queue-reorder and composer-wiring tests pass (31/31)

## Notes

- **Model selector is UI-only for now** -- selected model is tracked in state but `POST /api/sessions/:id/prompt` doesn't currently accept a model parameter. Wiring into session creation needs a server-side route change.
- **No new component tests** -- the React dashboard has near-zero component test coverage (pre-existing gap). Tests for these 3 panels would be a natural follow-up.
