### PR TITLE
feat(tui): add token budget + fan-out count to status line (#1609)

### DIFF
--- a/src/cli/commands/interactive/shared.test.ts
+++ b/src/cli/commands/interactive/shared.test.ts
@@ -488,3 +488,106 @@ describe('formatStatusFields — turn indicator', () => {
     expect(fields.maxTurns).toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// formatStatusFields — token budget indicator
+// ---------------------------------------------------------------------------
+
+describe('formatStatusFields — token budget indicator', () => {
+  afterEach(() => {
+    resetQuotaCacheForTests();
+  });
+
+  function makeCostStats(totalCostUsd: number): SessionStats {
+    return {
+      totalTurns: 1,
+      totalCostUsd,
+      totalTokens: 0,
+      totalDurationMs: 0,
+      sessionStartTime: 0,
+      turnCosts: [],
+      turnTokens: [],
+      turns: [],
+      model: 'sonnet',
+      permissionMode: 'default',
+    };
+  }
+
+  it('includes budgetUsd equal to totalCostUsd', () => {
+    const fields = formatStatusFields(makeCostStats(1.42));
+    expect(fields.budgetUsd).toBe(1.42);
+  });
+
+  it('includes budgetUsd of 0 when cost is 0', () => {
+    const fields = formatStatusFields(makeCostStats(0));
+    expect(fields.budgetUsd).toBe(0);
+  });
+
+  it('omits maxBudgetUsd when not supplied', () => {
+    const fields = formatStatusFields(makeCostStats(1.0));
+    expect(fields.maxBudgetUsd).toBeUndefined();
+  });
+
+  it('omits maxBudgetUsd when supplied as 0 (unconstrained)', () => {
+    const fields = formatStatusFields(makeCostStats(1.0), undefined, undefined, undefined, undefined, 0);
+    expect(fields.maxBudgetUsd).toBeUndefined();
+  });
+
+  it('includes maxBudgetUsd when a positive cap is supplied', () => {
+    const fields = formatStatusFields(makeCostStats(2.50), undefined, undefined, undefined, undefined, 10);
+    expect(fields.budgetUsd).toBe(2.50);
+    expect(fields.maxBudgetUsd).toBe(10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatStatusFields — active agent fan-out count
+// ---------------------------------------------------------------------------
+
+describe('formatStatusFields — active agent fan-out count', () => {
+  afterEach(() => {
+    resetQuotaCacheForTests();
+  });
+
+  function makeBasicStats(): SessionStats {
+    return {
+      totalTurns: 0,
+      totalCostUsd: 0,
+      totalTokens: 0,
+      totalDurationMs: 0,
+      sessionStartTime: 0,
+      turnCosts: [],
+      turnTokens: [],
+      turns: [],
+      model: 'sonnet',
+      permissionMode: 'default',
+    };
+  }
+
+  it('omits activeAgentCount when no registry is supplied', () => {
+    const fields = formatStatusFields(makeBasicStats());
+    expect(fields.activeAgentCount).toBeUndefined();
+  });
+
+  it('omits activeAgentCount when registry has no running jobs', () => {
+    // BackgroundAgentRegistry with no active jobs — list() returns empty array
+    // We use a simple mock object satisfying the list() interface contract
+    const mockRegistry = {
+      list: () => [],
+    } as unknown as import('../../../../src/agent/background-registry.js').BackgroundAgentRegistry;
+    const fields = formatStatusFields(makeBasicStats(), undefined, undefined, undefined, mockRegistry);
+    expect(fields.activeAgentCount).toBeUndefined();
+  });
+
+  it('includes activeAgentCount equal to the running job count', () => {
+    const mockRegistry = {
+      list: () => [
+        { status: 'running' as const, jobId: 'bg-1', provenance: 'user' as const, subagentId: 'sa-1', label: 'test', model: 'sonnet', startedAt: Date.now() },
+        { status: 'running' as const, jobId: 'bg-2', provenance: 'user' as const, subagentId: 'sa-2', label: 'test2', model: 'sonnet', startedAt: Date.now() },
+        { status: 'completed' as const, jobId: 'bg-3', provenance: 'user' as const, subagentId: 'sa-3', label: 'done', model: 'sonnet', startedAt: Date.now() },
+      ],
+    } as unknown as import('../../../../src/agent/background-registry.js').BackgroundAgentRegistry;
+    const fields = formatStatusFields(makeBasicStats(), undefined, undefined, undefined, mockRegistry);
+    expect(fields.activeAgentCount).toBe(2);
+  });
+});

--- a/src/cli/commands/interactive/shared.test.ts
+++ b/src/cli/commands/interactive/shared.test.ts
@@ -579,6 +579,18 @@ describe('formatStatusFields — active agent fan-out count', () => {
     expect(fields.activeAgentCount).toBeUndefined();
   });
 
+  it('omits activeAgentCount when all registry jobs are terminated (not running)', () => {
+    // Registry has jobs but all are completed/failed — running count is 0, field suppressed
+    const mockRegistry = {
+      list: () => [
+        { status: 'completed' as const, jobId: 'bg-1', provenance: 'user' as const, subagentId: 'sa-1', label: 'done1', model: 'sonnet', startedAt: Date.now() },
+        { status: 'failed' as const, jobId: 'bg-2', provenance: 'user' as const, subagentId: 'sa-2', label: 'done2', model: 'sonnet', startedAt: Date.now() },
+      ],
+    } as unknown as import('../../../../src/agent/background-registry.js').BackgroundAgentRegistry;
+    const fields = formatStatusFields(makeBasicStats(), undefined, undefined, undefined, mockRegistry);
+    expect(fields.activeAgentCount).toBeUndefined();
+  });
+
   it('includes activeAgentCount equal to the running job count', () => {
     const mockRegistry = {
       list: () => [

--- a/src/cli/commands/interactive/shared.ts
+++ b/src/cli/commands/interactive/shared.ts
@@ -894,7 +894,7 @@ export function formatStatusFields(
   // only when a positive cap is configured so the segment renders as
   // `$N.NN/$M.NN`. Suppress when no cost has been recorded yet (undefined
   // totalCostUsd) to keep the status line clean before the first API call.
-  const budgetUsd = stats.totalCostUsd !== undefined ? stats.totalCostUsd : undefined;
+  const budgetUsd = stats.totalCostUsd;
 
   // Active parallel fan-out count: number of background jobs currently running.
   // Only included when > 0 so idle sessions have no noise on the line.

--- a/src/cli/commands/interactive/shared.ts
+++ b/src/cli/commands/interactive/shared.ts
@@ -846,6 +846,8 @@ export function formatStatusFields(
   sampler?: ContextSampler,
   gitSampler?: GitStatusSampler,
   maxTurns?: number,
+  backgroundRegistry?: BackgroundAgentRegistry,
+  maxBudgetUsd?: number,
 ) {
   const pct = contextRatio(stats, sampler);
   const contextLimit = contextLimitFor(stats.model);
@@ -887,6 +889,20 @@ export function formatStatusFields(
   // until at least one turn has finished.
   const turnCount = stats.totalTurns > 0 ? stats.totalTurns : undefined;
 
+  // Token budget consumption: always include budgetUsd when there is any cost
+  // to show (even $0.00 after the first turn completes). Include maxBudgetUsd
+  // only when a positive cap is configured so the segment renders as
+  // `$N.NN/$M.NN`. Suppress when no cost has been recorded yet (undefined
+  // totalCostUsd) to keep the status line clean before the first API call.
+  const budgetUsd = stats.totalCostUsd !== undefined ? stats.totalCostUsd : undefined;
+
+  // Active parallel fan-out count: number of background jobs currently running.
+  // Only included when > 0 so idle sessions have no noise on the line.
+  const activeAgentCount =
+    backgroundRegistry !== undefined
+      ? backgroundRegistry.list().filter((j) => j.status === 'running').length
+      : undefined;
+
   return {
     model: stats.model,
     cost: stats.totalCostUsd,
@@ -902,5 +918,10 @@ export function formatStatusFields(
     ...(quotaWindows !== undefined ? { quotaWindows } : {}),
     ...(turnCount !== undefined ? { turnCount } : {}),
     ...(turnCount !== undefined && maxTurns && maxTurns > 0 ? { maxTurns } : {}),
+    ...(budgetUsd !== undefined ? { budgetUsd } : {}),
+    ...(budgetUsd !== undefined && maxBudgetUsd !== undefined && maxBudgetUsd > 0
+      ? { maxBudgetUsd }
+      : {}),
+    ...(activeAgentCount !== undefined && activeAgentCount > 0 ? { activeAgentCount } : {}),
   };
 }

--- a/src/cli/interactive-lifecycle.test.ts
+++ b/src/cli/interactive-lifecycle.test.ts
@@ -106,6 +106,7 @@ describe('interactive bootstrap status line hooks', () => {
       contextSparkline: undefined,
       permissionMode: 'plan',
       cwd: process.cwd(),
+      budgetUsd: 1.25,
     });
 
     // Regression: clearScreen must zero the persistent compositor's overlay
@@ -141,6 +142,7 @@ describe('interactive bootstrap status line hooks', () => {
       contextSparkline: undefined,
       permissionMode: 'plan',
       cwd: process.cwd(),
+      budgetUsd: 1.25,
     });
     const clearCall = stdoutWrite.mock.invocationCallOrder[
       stdoutWrite.mock.calls.findIndex((args) => args[0] === '\x1b[3J\x1b[2J\x1b[H')

--- a/src/cli/status-line.test.ts
+++ b/src/cli/status-line.test.ts
@@ -1373,3 +1373,132 @@ describe('StatusLine — turn/budget indicator', () => {
     status.stop();
   });
 });
+
+describe('StatusLine — token budget indicator', () => {
+  /** Create a mock stream with a specific column width for narrow/wide terminal tests. */
+  function mockStreamWide(cols: number): MockStream {
+    const writes: string[] = [];
+    return {
+      writes,
+      write(chunk: string): boolean { writes.push(chunk); return true; },
+      rows: 24,
+      columns: cols,
+      isTTY: true,
+    };
+  }
+
+  it('renders "$N.NN" when budgetUsd is set and no maxBudgetUsd', () => {
+    const stream = mockStreamWide(120);
+    const status = new StatusLine({ stream: stream as unknown as NodeJS.WriteStream, throttleMs: 0 });
+    status.start(); stream.writes.length = 0;
+    status.repaint({ model: 'sonnet', budgetUsd: 1.42 });
+    const out = lastJoined(stream).replace(BROAD_ANSI_RE, '');
+    expect(out).toContain('$1.42');
+    expect(out).not.toContain('$1.42/$');
+    status.stop();
+  });
+
+  it('renders "$N.NN/$M.NN" when both budgetUsd and maxBudgetUsd are set', () => {
+    const stream = mockStreamWide(120);
+    const status = new StatusLine({ stream: stream as unknown as NodeJS.WriteStream, throttleMs: 0 });
+    status.start(); stream.writes.length = 0;
+    status.repaint({ model: 'sonnet', budgetUsd: 2.50, maxBudgetUsd: 10.00 });
+    const out = lastJoined(stream).replace(BROAD_ANSI_RE, '');
+    expect(out).toContain('$2.50/$10.00');
+    status.stop();
+  });
+
+  it('omits the budget segment when budgetUsd is undefined', () => {
+    const stream = mockStreamWide(120);
+    const status = new StatusLine({ stream: stream as unknown as NodeJS.WriteStream, throttleMs: 0 });
+    status.start(); stream.writes.length = 0;
+    status.repaint({ model: 'sonnet' });
+    const out = lastJoined(stream).replace(BROAD_ANSI_RE, '');
+    // The bare cost field has a dollar sign but no separate budget segment should appear
+    expect(out).not.toContain('/$');
+    status.stop();
+  });
+
+  it('does not render the maxBudgetUsd cap when maxBudgetUsd is 0', () => {
+    const stream = mockStreamWide(120);
+    const status = new StatusLine({ stream: stream as unknown as NodeJS.WriteStream, throttleMs: 0 });
+    status.start(); stream.writes.length = 0;
+    status.repaint({ model: 'sonnet', budgetUsd: 0.10, maxBudgetUsd: 0 });
+    const out = lastJoined(stream).replace(BROAD_ANSI_RE, '');
+    expect(out).toContain('$0.10');
+    expect(out).not.toContain('$0.10/$');
+    status.stop();
+  });
+
+  it('sheds the budget indicator before turnCount on a narrow terminal (priority 7 > 6)', () => {
+    // 22 cols: narrow enough to force shedding. Budget (priority 7) must drop
+    // before turnCount (priority 6) which must drop before cost (priority 3).
+    const stream = mockStreamWide(22);
+    const status = new StatusLine({ stream: stream as unknown as NodeJS.WriteStream, throttleMs: 0 });
+    status.start(); stream.writes.length = 0;
+    status.repaint({ model: 'sonnet', turnCount: 3, budgetUsd: 1.00 });
+    const out = lastJoined(stream).replace(BROAD_ANSI_RE, '');
+    expect(out).toContain('sonnet');
+    // Budget is shed first (highest droppablePriority = 7)
+    expect(out).not.toContain('$1.00');
+    status.stop();
+  });
+});
+
+describe('StatusLine — active agent fan-out count', () => {
+  /** Create a mock stream with a specific column width for narrow/wide terminal tests. */
+  function mockStreamWide(cols: number): MockStream {
+    const writes: string[] = [];
+    return {
+      writes,
+      write(chunk: string): boolean { writes.push(chunk); return true; },
+      rows: 24,
+      columns: cols,
+      isTTY: true,
+    };
+  }
+
+  it('renders "N↗" when activeAgentCount > 0', () => {
+    const stream = mockStreamWide(120);
+    const status = new StatusLine({ stream: stream as unknown as NodeJS.WriteStream, throttleMs: 0 });
+    status.start(); stream.writes.length = 0;
+    status.repaint({ model: 'sonnet', activeAgentCount: 3 });
+    const out = lastJoined(stream).replace(BROAD_ANSI_RE, '');
+    expect(out).toContain('3↗');
+    status.stop();
+  });
+
+  it('omits the fan-out segment when activeAgentCount is 0', () => {
+    const stream = mockStreamWide(120);
+    const status = new StatusLine({ stream: stream as unknown as NodeJS.WriteStream, throttleMs: 0 });
+    status.start(); stream.writes.length = 0;
+    status.repaint({ model: 'sonnet', activeAgentCount: 0 });
+    const out = lastJoined(stream).replace(BROAD_ANSI_RE, '');
+    expect(out).not.toContain('↗');
+    status.stop();
+  });
+
+  it('omits the fan-out segment when activeAgentCount is undefined', () => {
+    const stream = mockStreamWide(120);
+    const status = new StatusLine({ stream: stream as unknown as NodeJS.WriteStream, throttleMs: 0 });
+    status.start(); stream.writes.length = 0;
+    status.repaint({ model: 'sonnet' });
+    const out = lastJoined(stream).replace(BROAD_ANSI_RE, '');
+    expect(out).not.toContain('↗');
+    status.stop();
+  });
+
+  it('sheds fan-out before budget/turnCount on a narrow terminal (priority 8 = drop first)', () => {
+    // 22 cols: narrow enough to force shedding. Fan-out (priority 8) is the
+    // most peripheral field and sheds before budget (7) and turnCount (6).
+    const stream = mockStreamWide(22);
+    const status = new StatusLine({ stream: stream as unknown as NodeJS.WriteStream, throttleMs: 0 });
+    status.start(); stream.writes.length = 0;
+    status.repaint({ model: 'sonnet', turnCount: 3, budgetUsd: 1.00, activeAgentCount: 2 });
+    const out = lastJoined(stream).replace(BROAD_ANSI_RE, '');
+    expect(out).toContain('sonnet');
+    // Fan-out is shed first (highest droppablePriority = 8)
+    expect(out).not.toContain('2↗');
+    status.stop();
+  });
+});

--- a/src/cli/status-line.ts
+++ b/src/cli/status-line.ts
@@ -89,6 +89,32 @@ export interface StatusLineFields {
    * 0 or undefined means "no turn cap" and the segment shows just `turn N`.
    */
   maxTurns?: number;
+  /**
+   * Cumulative session cost in USD. When `maxBudgetUsd` is also set, renders
+   * as `$N.NN/$M.NN` to show spend against cap. Without a cap, renders the
+   * same as the existing `cost` field. Takes droppablePriority 7 (shed before
+   * turnCount) — the most peripheral of the budget fields.
+   *
+   * NOTE: This field is separate from `cost` (which the existing status line
+   * uses for the raw cost display). `budgetUsd` is the new field that pairs
+   * with `maxBudgetUsd` for budget-aware rendering and a slightly different
+   * drop priority in the shed order.
+   */
+  budgetUsd?: number;
+  /**
+   * Maximum allowed session spend in USD (from a cost-budget config). When
+   * present alongside `budgetUsd`, the segment renders as `$N.NN/$M.NN`.
+   * Optional — 0 or undefined means no cap.
+   */
+  maxBudgetUsd?: number;
+  /**
+   * Number of background subagent jobs currently in the 'running' state.
+   * Only rendered when > 0 as `N↗` to signal active parallel fan-out.
+   * Undefined or 0 means no active background agents — draws no segment.
+   * Takes droppablePriority 8 (shed before budgetUsd) — the most peripheral
+   * field on the line.
+   */
+  activeAgentCount?: number;
 }
 
 interface StatusLineOpts {
@@ -609,6 +635,35 @@ export class StatusLine {
       parts.push({
         text: palette.chrome(`turn ${f.turnCount}${capSuffix}`),
         droppablePriority: 6, // drop first — most peripheral; sheds before tokens (4) and quota-calm (5)
+      });
+    }
+
+    // Token budget consumption — droppablePriority 7 (shed before turnCount at
+    // 6, after all other fields). Renders `$N.NN` when no cap is set, or
+    // `$N.NN/$M.NN` when maxBudgetUsd is provided so the user can see spend
+    // against cap. Shows at least 2 decimal places so e.g. `$0.00` doesn't
+    // truncate to `$0`. Only renders when budgetUsd is defined; an undefined
+    // value means budget tracking is not active for this session.
+    if (f.budgetUsd !== undefined) {
+      const capSuffix =
+        f.maxBudgetUsd !== undefined && f.maxBudgetUsd > 0
+          ? `/$${f.maxBudgetUsd.toFixed(2)}`
+          : '';
+      parts.push({
+        text: palette.chrome(`$${f.budgetUsd.toFixed(2)}${capSuffix}`),
+        droppablePriority: 7, // shed after turnCount (6), before activeAgentCount (8)
+      });
+    }
+
+    // Active parallel subagent fan-out count — droppablePriority 8 (shed first
+    // of all droppable fields). Only renders when there are active background
+    // agents (> 0). Renders as `N↗` — the ↗ arrow visually signals "dispatched
+    // up and out" (fan-out). Suppressed when 0 or undefined so idle sessions
+    // have no noise on the status line.
+    if (f.activeAgentCount !== undefined && f.activeAgentCount > 0) {
+      parts.push({
+        text: palette.chrome(`${f.activeAgentCount}↗`),
+        droppablePriority: 8, // shed first — most peripheral; sheds before turnCount (6)
       });
     }
 


### PR DESCRIPTION
## Summary

Implements issue #1609: adds two new fields to the REPL status line.

### Token budget consumption display

- New `budgetUsd?: number` and `maxBudgetUsd?: number` fields in `StatusLineFields`
- Renders `$N.NN` without a cap, or `$N.NN/$M.NN` when `maxBudgetUsd > 0`
- Wired from `stats.totalCostUsd` in `formatStatusFields()` with optional `maxBudgetUsd` parameter
- Drop priority 7 — sheds before `turnCount` (6), after all other display fields

### Active parallel subagent fan-out count

- New `activeAgentCount?: number` field in `StatusLineFields`
- Renders `N↗` only when `N > 0`; draws nothing when idle
- Wired from `BackgroundAgentRegistry.list().filter(j => j.status === 'running').length`
- `formatStatusFields()` accepts an optional `backgroundRegistry` parameter (5th arg)
- Drop priority 8 — the most peripheral field; sheds first on narrow terminals

### Changes

- `src/cli/status-line.ts` — new fields + two render segments in `formatLine()`
- `src/cli/commands/interactive/shared.ts` — extended `formatStatusFields()` signature with `backgroundRegistry` and `maxBudgetUsd`; wires both new fields
- `src/cli/status-line.test.ts` — 9 new tests (budget indicator + fan-out indicator + narrow-terminal shedding)
- `src/cli/commands/interactive/shared.test.ts` — 8 new tests (budget wiring + fan-out wiring from registry mock)

### Verification

- All 120 tests pass (103 pre-existing + 17 new)
- `pnpm lint` (`tsc --noEmit`) clean
