### PR TITLE
fix(dashboard): replace emoji logo with Handoff Arc brand mark

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="color-scheme" content="dark light" />
   <meta name="afk-token" content="__AFK_WEB_TOKEN__" />
-  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#x1f300;</text></svg>" />
+  <link rel="icon" href="/brand-mark.svg" type="image/svg+xml" />
   <title>AFK Dashboard</title>
 </head>
 <body class="bg-background text-foreground antialiased">

--- a/dashboard/public/brand-mark.svg
+++ b/dashboard/public/brand-mark.svg
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Agent AFK — navbar brand glyph ("Handoff Arc"), transparent variant.
+  Matches the inline mark in agentafk.com's navbar: gradient arc, two
+  endpoint nodes, and the orange "ping" in the gap. Served as a standalone
+  file (referenced via <img>) so its gradient ids stay scoped to this
+  document — the docs nav renders the title in several places, and inlining
+  the SVG would collide duplicate gradient ids and drop the arc/ping fills.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Agent AFK">
+  <defs>
+    <linearGradient id="arc" x1="14" y1="48" x2="50" y2="48" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#8a8aa0"/>
+      <stop offset="50%" stop-color="#74bc90"/>
+      <stop offset="100%" stop-color="#5cb87f"/>
+    </linearGradient>
+    <radialGradient id="ping" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#ffc2a1"/>
+      <stop offset="55%" stop-color="#f97316"/>
+      <stop offset="100%" stop-color="#d65a0e"/>
+    </radialGradient>
+  </defs>
+
+  <!-- Arc: endpoints (14,48) -> (50,48), r=24, large-arc, clockwise (90° gap at bottom) -->
+  <path d="M 14 48 A 24 24 0 1 1 50 48"
+        fill="none"
+        stroke="url(#arc)"
+        stroke-width="7"
+        stroke-linecap="round"/>
+
+  <!-- Endpoint nodes -->
+  <circle cx="14" cy="48" r="4.5" fill="#8a8aa0"/>
+  <circle cx="50" cy="48" r="4.5" fill="#5cb87f"/>
+
+  <!-- Ping in the gap, on the imagined completed circle -->
+  <circle cx="32" cy="56" r="5" fill="url(#ping)"/>
+</svg>

--- a/dashboard/src/components/sidebar.tsx
+++ b/dashboard/src/components/sidebar.tsx
@@ -51,7 +51,7 @@ export function Sidebar({
       <div className="flex h-12 items-center justify-between border-b px-3">
         {!collapsed && (
           <div className="flex items-center gap-2">
-            <span className="text-lg">🌀</span>
+            <img src="/brand-mark.svg" alt="AFK" width={24} height={24} />
             <span className="text-sm font-semibold tracking-tight">AFK</span>
           </div>
         )}


### PR DESCRIPTION
Replace the placeholder cyclone emoji in the web dashboard with the actual Agent AFK "Handoff Arc" brand mark.

## Changes

- **`dashboard/public/brand-mark.svg`** (new) — the same glyph used on docs.agentafk.com, copied from `website/public/`
- **`dashboard/src/components/sidebar.tsx`** — swap `🌀` emoji span for `<img src="/brand-mark.svg">` at 24x24
- **`dashboard/index.html`** — swap inline data-URI emoji favicon for an SVG `<link>` pointing at the brand mark

## Verification

- `pnpm lint` passes
- `pnpm build:web-ui` produces the bundle with `brand-mark.svg` at the asset root
- CSP (`img-src 'self'`) and the web-server's `.svg` content-type handler already cover the new asset
