### PR TITLE
feat(dashboard): overhaul chat UI with topology spine

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -18,8 +18,8 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^7.6.0",
     "remark-gfm": "^4.0.1",
+    "shiki": "^4.4.3",
     "tailwind-merge": "^3.0.2"
   },
   "devDependencies": {

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
+      shiki:
+        specifier: ^4.4.3
+        version: 4.4.3
       tailwind-merge:
         specifier: ^3.0.2
         version: 3.6.0
@@ -678,6 +681,37 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@shikijs/core@4.4.3':
+    resolution: {integrity: sha512-QCR4q2ZO/ILJEuwiBMel4wdcTDb1JGwfjKTxPDF6x8ixOaluPrVqIn06C99AcRPhmYlBR56d/Fb+GN58GzExpg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-javascript@4.4.3':
+    resolution: {integrity: sha512-FbOjFJp9VLdo1Wevs10BBtVxiTWwNLqZh5Gkhjgda/ioL15YOgeSl9n+6XMa3qRlPQzfhFNe641SrynFHYG0nQ==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-oniguruma@4.4.3':
+    resolution: {integrity: sha512-EcOQkxdxGQrc1Row/cC2c96/v1dbZqGnEVu1qTuT/MJmp6+cXCvQussowVmCv5Tqr3KuY3c7IbM6HTW3LJ1k9w==}
+    engines: {node: '>=20'}
+
+  '@shikijs/langs@4.4.3':
+    resolution: {integrity: sha512-ePic0yfAJGOF83D5wBHK/00EjK65oahBYxFk5epgq33WRv7X9UuxLEV8PtR0szC0z8dl7INIpIodB99JRFlR+A==}
+    engines: {node: '>=20'}
+
+  '@shikijs/primitive@4.4.3':
+    resolution: {integrity: sha512-m0wBeLDQDeIxRdUmrCPdQqfuUamDwRL5isCfYbguKD6NiaKpVbsv+3J81DyIKgNW5h4WAIIr8T4EkgQrBBxvaQ==}
+    engines: {node: '>=20'}
+
+  '@shikijs/themes@4.4.3':
+    resolution: {integrity: sha512-w8UHjeUnIR965KMWJHUPXOc2mNJUnK3vpVLYLvw5IYU2mnTTJ89E24OrJDBNiJDQ0qzb0tc4l7mrIXx5cFeIyw==}
+    engines: {node: '>=20'}
+
+  '@shikijs/types@4.4.3':
+    resolution: {integrity: sha512-UEJxmRR++MAGR6hugn0vgVS2W/6lWAts84FFSrnlH9sP0LNol7E5+NQ792pH8liWUhyMyjhTgSUH3k7iD7tc5g==}
+    engines: {node: '>=20'}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
   '@tailwindcss/node@4.3.3':
     resolution: {integrity: sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==}
 
@@ -1097,6 +1131,9 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
@@ -1109,6 +1146,9 @@ packages:
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -1426,6 +1466,12 @@ packages:
   nwsapi@2.2.27:
     resolution: {integrity: sha512-gQPNF78qebCQ6tvVFBYrvJdBNOrYZm90ZlXgpIFm06p6qHDHq/XC4TnJftN6OMbxVE0UTBAoRgcsDeJBBooITw==}
 
+  oniguruma-parser@0.12.2:
+    resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
+
+  oniguruma-to-es@4.3.6:
+    resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
+
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
@@ -1534,6 +1580,15 @@ packages:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
 
@@ -1570,6 +1625,10 @@ packages:
 
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
+  shiki@4.4.3:
+    resolution: {integrity: sha512-Mb/GvXPHBAXdgGIcnfU5L3ldpn1XcxrGkPHwqgRx17/I2XRfqlFKk2vGkHWINn1kdXvzJZeuO3is6I9KLPFm0g==}
+    engines: {node: '>=20'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -2301,6 +2360,46 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.63.1':
     optional: true
 
+  '@shikijs/core@4.4.3':
+    dependencies:
+      '@shikijs/primitive': 4.4.3
+      '@shikijs/types': 4.4.3
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@4.4.3':
+    dependencies:
+      '@shikijs/types': 4.4.3
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.6
+
+  '@shikijs/engine-oniguruma@4.4.3':
+    dependencies:
+      '@shikijs/types': 4.4.3
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@4.4.3':
+    dependencies:
+      '@shikijs/types': 4.4.3
+
+  '@shikijs/primitive@4.4.3':
+    dependencies:
+      '@shikijs/types': 4.4.3
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+
+  '@shikijs/themes@4.4.3':
+    dependencies:
+      '@shikijs/types': 4.4.3
+
+  '@shikijs/types@4.4.3':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
   '@tailwindcss/node@4.3.3':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -2702,6 +2801,20 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.9
@@ -2731,6 +2844,8 @@ snapshots:
       whatwg-encoding: 3.1.1
 
   html-url-attributes@3.0.1: {}
+
+  html-void-elements@3.0.0: {}
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -3231,6 +3346,14 @@ snapshots:
 
   nwsapi@2.2.27: {}
 
+  oniguruma-parser@0.12.2: {}
+
+  oniguruma-to-es@4.3.6:
+    dependencies:
+      oniguruma-parser: 0.12.2
+      regex: 6.1.0
+      regex-recursion: 6.0.2
+
   parse-entities@4.0.2:
     dependencies:
       '@types/unist': 2.0.11
@@ -3344,6 +3467,16 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
+
   remark-gfm@4.0.1:
     dependencies:
       '@types/mdast': 4.0.4
@@ -3423,6 +3556,17 @@ snapshots:
   semver@6.3.1: {}
 
   set-cookie-parser@2.7.2: {}
+
+  shiki@4.4.3:
+    dependencies:
+      '@shikijs/core': 4.4.3
+      '@shikijs/engine-javascript': 4.4.3
+      '@shikijs/engine-oniguruma': 4.4.3
+      '@shikijs/langs': 4.4.3
+      '@shikijs/themes': 4.4.3
+      '@shikijs/types': 4.4.3
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
 
   siginfo@2.0.0: {}
 

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -29,9 +29,6 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.18)(react@19.2.8)
-      react-router-dom:
-        specifier: ^7.6.0
-        version: 7.18.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -1009,10 +1006,6 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  cookie@1.1.1:
-    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
-    engines: {node: '>=18'}
-
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
@@ -1545,23 +1538,6 @@ packages:
       '@types/react':
         optional: true
 
-  react-router-dom@7.18.3:
-    resolution: {integrity: sha512-ytVbyBBM7vMfRCam25r0WMhSVSom909A8p+8m0/f1w853dz/xfFu6etAT2SEbVoSnI+ZoPRDqIsQXVT89gp7kg==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
-
-  react-router@7.18.3:
-    resolution: {integrity: sha512-gyXgtdr5uACJ5b1Q4udzjVV+tb/rlHIMJKuJ0e89R4Kzgz47z/rgP0dIKxktqIEUhDHluGTPJJH/wRha7CyqsA==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
-    peerDependenciesMeta:
-      react-dom:
-        optional: true
-
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
     engines: {node: '>=10'}
@@ -1622,9 +1598,6 @@ packages:
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
-
-  set-cookie-parser@2.7.2:
-    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   shiki@4.4.3:
     resolution: {integrity: sha512-Mb/GvXPHBAXdgGIcnfU5L3ldpn1XcxrGkPHwqgRx17/I2XRfqlFKk2vGkHWINn1kdXvzJZeuO3is6I9KLPFm0g==}
@@ -2692,8 +2665,6 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  cookie@1.1.1: {}
-
   css.escape@1.5.1: {}
 
   cssstyle@4.6.0:
@@ -3438,20 +3409,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.18
 
-  react-router-dom@7.18.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
-    dependencies:
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-      react-router: 7.18.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-
-  react-router@7.18.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
-    dependencies:
-      cookie: 1.1.1
-      react: 19.2.8
-      set-cookie-parser: 2.7.2
-    optionalDependencies:
-      react-dom: 19.2.8(react@19.2.8)
-
   react-style-singleton@2.2.3(@types/react@19.2.18)(react@19.2.8):
     dependencies:
       get-nonce: 1.0.1
@@ -3554,8 +3511,6 @@ snapshots:
   scheduler@0.27.0: {}
 
   semver@6.3.1: {}
-
-  set-cookie-parser@2.7.2: {}
 
   shiki@4.4.3:
     dependencies:

--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -41,7 +41,12 @@ function Dashboard() {
 
   const selectedSession = sessions.find((s) => s.id === selectedSessionId);
   const { items, totals, status, turnActive, liveTurns } = useTranscript(selectedSessionId);
-  const { containerRef, scrollToBottom, showScrollButton } = useScrollPin();
+  const { containerRef, scrollToBottom, isPinned, showScrollButton } = useScrollPin();
+
+  // Auto-scroll when new transcript items arrive and user is pinned to the bottom.
+  useEffect(() => {
+    if (isPinned) scrollToBottom();
+  }, [items.length, isPinned, scrollToBottom]);
 
   const handleNavigate = (nav: string) => {
     setActiveNav(nav as NavItem);

--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
+import { Plus, ArrowDown } from 'lucide-react';
 import { Sidebar } from './components/sidebar';
 import { CommandPalette } from './components/command-palette';
 import { KeyboardShortcuts } from './components/keyboard-shortcuts';
@@ -40,7 +41,7 @@ function Dashboard() {
 
   const selectedSession = sessions.find((s) => s.id === selectedSessionId);
   const { items, totals, status, turnActive, liveTurns } = useTranscript(selectedSessionId);
-  const { containerRef } = useScrollPin();
+  const { containerRef, scrollToBottom, showScrollButton } = useScrollPin();
 
   const handleNavigate = (nav: string) => {
     setActiveNav(nav as NavItem);
@@ -54,6 +55,15 @@ function Dashboard() {
 
   const isBusy = turnActive;
   const [selectedModel, setSelectedModel] = useState('sonnet');
+
+  const handleNewSession = useCallback(async () => {
+    try {
+      const result = await apiFetch<{ id: string }>('/api/sessions', { method: 'POST' });
+      setSelectedSessionId(result.id);
+    } catch {
+      // best-effort
+    }
+  }, []);
 
   // Abort controller ref: abort in-flight POSTs when the session changes.
   const abortRef = useRef<AbortController | null>(null);
@@ -147,6 +157,15 @@ function Dashboard() {
             )}
           </div>
           <div className="flex items-center gap-3">
+            {activeNav === 'sessions' && (
+              <button
+                onClick={() => void handleNewSession()}
+                title="New Session"
+                className="flex items-center justify-center h-7 w-7 rounded-md hover:bg-accent transition-colors text-muted-foreground hover:text-foreground"
+              >
+                <Plus className="h-4 w-4" />
+              </button>
+            )}
             {activeNav === 'sessions' && selectedSession && (
               <SessionMeter totals={totals} />
             )}
@@ -157,7 +176,18 @@ function Dashboard() {
         </header>
 
         {/* Content area */}
-        <div ref={containerRef} className="relative flex flex-1 flex-col overflow-y-auto">
+        <div className="relative flex flex-1 flex-col overflow-hidden">
+          {/* New messages floating button */}
+          {showScrollButton && activeNav === 'sessions' && (
+            <button
+              onClick={scrollToBottom}
+              className="animate-fade-in fixed bottom-24 left-1/2 z-20 -translate-x-1/2 flex items-center gap-1.5 rounded-full bg-brand px-3 py-1.5 text-xs font-medium text-primary-foreground shadow-lg hover:bg-brand/90 transition-colors"
+            >
+              <ArrowDown className="size-3" />
+              New messages
+            </button>
+          )}
+          <div ref={containerRef} className="relative flex flex-1 flex-col overflow-y-auto">
           <div className="flex-1">
             {activeNav === 'sessions' && (
               <SessionContent
@@ -177,7 +207,7 @@ function Dashboard() {
 
           {/* Composer + approvals (sessions view only, live sessions) */}
           {activeNav === 'sessions' && selectedSession && selectedSession.mode === 'live' && (
-            <div className="shrink-0 border-t bg-card">
+            <div className="shrink-0">
               {approvals.length > 0 && (
                 <ApprovalCards approvals={approvals} />
               )}
@@ -191,6 +221,7 @@ function Dashboard() {
               />
             </div>
           )}
+          </div>
         </div>
       </main>
     </div>

--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -58,8 +58,8 @@ function Dashboard() {
 
   const handleNewSession = useCallback(async () => {
     try {
-      const result = await apiFetch<{ id: string }>('/api/sessions', { method: 'POST' });
-      setSelectedSessionId(result.id);
+      const result = await apiFetch<{ session: { id: string } }>('/api/sessions', { method: 'POST' });
+      setSelectedSessionId(result.session.id);
     } catch {
       // best-effort
     }

--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -197,6 +197,7 @@ function Dashboard() {
                 items={items}
                 totals={totals}
                 status={status}
+                turnActive={turnActive}
               />
             )}
             {activeNav === 'memory' && <MemoryView />}
@@ -242,6 +243,7 @@ function SessionContent({
   items,
   totals,
   status,
+  turnActive,
 }: {
   loading: boolean;
   sessions: SessionSummary[];
@@ -249,6 +251,7 @@ function SessionContent({
   items: TranscriptItem[];
   totals: SessionTotals;
   status: string;
+  turnActive: boolean;
 }) {
   if (loading && !sessions.length) {
     return (
@@ -271,7 +274,7 @@ function SessionContent({
     );
   }
   if (selectedSession && items.length > 0) {
-    return <TranscriptView items={items} totals={totals} />;
+    return <TranscriptView items={items} totals={totals} turnActive={turnActive} />;
   }
   if (selectedSession) {
     return (

--- a/dashboard/src/components/code-block.tsx
+++ b/dashboard/src/components/code-block.tsx
@@ -1,0 +1,119 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { Copy, Check } from 'lucide-react';
+import type { Highlighter } from 'shiki';
+
+// Contract: highlighterRef holds a singleton promise so multiple CodeBlock mounts
+// never race to create separate Highlighter instances. The ref is module-scope to
+// survive component unmounts while the page is still active.
+let highlighterPromise: Promise<Highlighter> | null = null;
+
+function getHighlighter(): Promise<Highlighter> {
+  if (!highlighterPromise) {
+    highlighterPromise = import('shiki').then(({ createHighlighter }) =>
+      createHighlighter({
+        themes: ['github-dark'],
+        langs: [
+          'typescript', 'javascript', 'tsx', 'jsx',
+          'json', 'bash', 'sh', 'python', 'rust',
+          'css', 'html', 'markdown', 'yaml', 'toml',
+          'sql', 'go', 'java', 'c', 'cpp', 'ruby',
+        ],
+      })
+    );
+  }
+  return highlighterPromise;
+}
+
+interface CodeBlockProps {
+  code: string;
+  language?: string;
+}
+
+export function CodeBlock({ code, language }: CodeBlockProps) {
+  const [html, setHtml] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    getHighlighter().then((highlighter) => {
+      if (cancelled) return;
+
+      // Resolve to a supported language or fall back to plain text.
+      const supportedLangs = highlighter.getLoadedLanguages();
+      const lang = language && supportedLangs.includes(language as Parameters<typeof highlighter.codeToHtml>[1]['lang'])
+        ? (language as Parameters<typeof highlighter.codeToHtml>[1]['lang'])
+        : 'text';
+
+      try {
+        const highlighted = highlighter.codeToHtml(code, {
+          lang,
+          theme: 'github-dark',
+        });
+        if (!cancelled) setHtml(highlighted);
+      } catch {
+        // Highlighting failed — leave html null so the fallback <pre> renders.
+      }
+    }).catch(() => {
+      // Highlighter load failed — fallback stays visible.
+    });
+
+    return () => { cancelled = true; };
+  }, [code, language]);
+
+  // Cleanup copy timer on unmount.
+  useEffect(() => {
+    return () => {
+      if (copyTimerRef.current !== null) clearTimeout(copyTimerRef.current);
+    };
+  }, []);
+
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(code).then(() => {
+      setCopied(true);
+      if (copyTimerRef.current !== null) clearTimeout(copyTimerRef.current);
+      copyTimerRef.current = setTimeout(() => setCopied(false), 2000);
+    }).catch(() => {
+      // Clipboard write failed silently — no UI change.
+    });
+  }, [code]);
+
+  return (
+    <div className="relative group rounded-md bg-secondary overflow-hidden mb-2">
+      {/* Language label */}
+      {language && (
+        <div className="text-[10px] text-muted-foreground px-3 pt-1.5 select-none">
+          {language}
+        </div>
+      )}
+
+      {/* Copy button — revealed on group hover */}
+      <button
+        onClick={handleCopy}
+        aria-label="Copy code"
+        className="absolute top-1.5 right-2 z-10 opacity-0 group-hover:opacity-100 transition-opacity rounded p-1 text-muted-foreground hover:text-foreground hover:bg-white/10"
+      >
+        {copied
+          ? <Check size={13} strokeWidth={2.5} />
+          : <Copy size={13} strokeWidth={2} />
+        }
+      </button>
+
+      {/* Highlighted HTML or fallback */}
+      {html !== null ? (
+        <div
+          className="overflow-x-auto text-xs leading-5 [&>pre]:p-3 [&>pre]:m-0 [&>pre]:bg-transparent! [&>pre]:font-mono"
+          // Contract: html comes exclusively from shiki's codeToHtml — it never
+          // contains user-supplied content verbatim (code is syntax-tokenised).
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
+      ) : (
+        <pre className="overflow-x-auto p-3 font-mono text-xs leading-5 text-foreground">
+          <code>{code}</code>
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/components/composer.tsx
+++ b/dashboard/src/components/composer.tsx
@@ -180,64 +180,76 @@ export function Composer({
   }, []);
 
   return (
-    <div className={cn('relative flex flex-col gap-2', disabled && 'opacity-50')}>
-      {queue && <QueuePanel queue={queue} />}
-      <SlashAutocomplete
-        query={slashQuery ?? ''}
-        commands={commands}
-        onSelect={selectCommand}
-        visible={acVisible}
-      />
-      <div className="flex items-end gap-2">
-        {/* Toolbar: @-file + model selector */}
-        <div className="flex shrink-0 items-center gap-1">
-          <AtFilePopover onInsert={insertAtCursor} />
-          {onModelSelect && (
-            <ModelSelector
-              onSelect={onModelSelect}
-              current={currentModel}
-            />
+    <>
+      {/* Gradient fade — blends scroll content into the frosted composer */}
+      <div className="pointer-events-none h-8 bg-gradient-to-t from-background/80 to-transparent" />
+      <div
+        className={cn(
+          'relative flex flex-col gap-2',
+          'border-t border-border/50 px-4 py-3',
+          'backdrop-blur-xl bg-background/80',
+          'shadow-[0_-4px_16px_-4px_rgba(0,0,0,0.1)]',
+          disabled && 'opacity-50',
+        )}
+      >
+        {queue && <QueuePanel queue={queue} />}
+        <SlashAutocomplete
+          query={slashQuery ?? ''}
+          commands={commands}
+          onSelect={selectCommand}
+          visible={acVisible}
+        />
+        <div className="flex items-end gap-2">
+          {/* Toolbar: @-file + model selector */}
+          <div className="flex shrink-0 items-center gap-1">
+            <AtFilePopover onInsert={insertAtCursor} />
+            {onModelSelect && (
+              <ModelSelector
+                onSelect={onModelSelect}
+                current={currentModel}
+              />
+            )}
+          </div>
+          <textarea
+            ref={textareaRef}
+            rows={1}
+            value={text}
+            disabled={disabled || submitting}
+            onChange={(e) => setText(e.target.value)}
+            onKeyDown={onKeyDown}
+            placeholder={disabled ? 'Read-only session' : 'Send a message… (/ for commands)'}
+            className={cn(
+              'flex-1 resize-none rounded-xl border border-input bg-background',
+              'px-3 py-2 text-sm leading-5 shadow-sm',
+              'placeholder:text-muted-foreground',
+              'focus:outline-none focus:ring-2 focus:ring-ring',
+              'disabled:cursor-not-allowed',
+            )}
+          />
+          {isBusy ? (
+            <button
+              onClick={() => void interrupt()}
+              title="Stop"
+              className="shrink-0 flex items-center justify-center h-9 w-9 rounded-lg bg-destructive text-destructive-foreground hover:bg-destructive/90 transition-colors"
+            >
+              <Square className="h-4 w-4 fill-current" />
+            </button>
+          ) : (
+            <button
+              onClick={() => void submit()}
+              disabled={!text.trim() || submitting || disabled}
+              title="Send"
+              className={cn(
+                'shrink-0 flex items-center justify-center h-9 w-9 rounded-lg',
+                'bg-primary text-primary-foreground hover:bg-primary/90 transition-colors',
+                'disabled:opacity-40 disabled:cursor-not-allowed',
+              )}
+            >
+              <Send className="h-4 w-4" />
+            </button>
           )}
         </div>
-        <textarea
-          ref={textareaRef}
-          rows={1}
-          value={text}
-          disabled={disabled || submitting}
-          onChange={(e) => setText(e.target.value)}
-          onKeyDown={onKeyDown}
-          placeholder={disabled ? 'Read-only session' : 'Send a message… (/ for commands)'}
-          className={cn(
-            'flex-1 resize-none rounded-lg border border-input bg-background',
-            'px-3 py-2 text-sm leading-5 shadow-sm',
-            'placeholder:text-muted-foreground',
-            'focus:outline-none focus:ring-2 focus:ring-ring',
-            'disabled:cursor-not-allowed',
-          )}
-        />
-        {isBusy ? (
-          <button
-            onClick={() => void interrupt()}
-            title="Stop"
-            className="shrink-0 flex items-center justify-center h-9 w-9 rounded-lg bg-destructive text-destructive-foreground hover:bg-destructive/90 transition-colors"
-          >
-            <Square className="h-4 w-4 fill-current" />
-          </button>
-        ) : (
-          <button
-            onClick={() => void submit()}
-            disabled={!text.trim() || submitting || disabled}
-            title="Send"
-            className={cn(
-              'shrink-0 flex items-center justify-center h-9 w-9 rounded-lg',
-              'bg-primary text-primary-foreground hover:bg-primary/90 transition-colors',
-              'disabled:opacity-40 disabled:cursor-not-allowed',
-            )}
-          >
-            <Send className="h-4 w-4" />
-          </button>
-        )}
       </div>
-    </div>
+    </>
   );
 }

--- a/dashboard/src/components/markdown-content.tsx
+++ b/dashboard/src/components/markdown-content.tsx
@@ -2,6 +2,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { cn } from '@/lib/utils';
 import type { Components } from 'react-markdown';
+import { CodeBlock } from './code-block';
 
 const components: Components = {
   h1: ({ children }) => <h1 className="mb-3 text-xl font-bold">{children}</h1>,
@@ -50,18 +51,13 @@ const components: Components = {
       </code>
     );
   },
-  pre: ({ children, ...props }) => {
-    // Extract language from nested code className
-    const codeEl = (children as React.ReactElement | null);
-    const lang = /language-(\w+)/.exec((codeEl?.props as { className?: string } | undefined)?.className ?? '')?.[1];
-    return (
-      <pre {...props} className="mb-2 overflow-x-auto rounded bg-secondary p-3 font-mono text-xs leading-5">
-        {lang && (
-          <div className="mb-1 text-[10px] text-muted-foreground">{lang}</div>
-        )}
-        {children}
-      </pre>
-    );
+  pre: ({ children }) => {
+    // Extract language and raw code text from the nested <code> element that
+    // react-markdown always wraps inside <pre> for fenced code blocks.
+    const codeEl = children as React.ReactElement<{ className?: string; children?: React.ReactNode }> | null;
+    const lang = /language-(\w+)/.exec(codeEl?.props?.className ?? '')?.[1];
+    const code = String(codeEl?.props?.children ?? '').replace(/\n$/, '');
+    return <CodeBlock code={code} language={lang} />;
   },
 };
 

--- a/dashboard/src/components/message-actions.tsx
+++ b/dashboard/src/components/message-actions.tsx
@@ -39,7 +39,7 @@ export function MessageActions({
       setCopied(true);
       if (copyTimerRef.current !== null) clearTimeout(copyTimerRef.current);
       copyTimerRef.current = setTimeout(() => setCopied(false), 2000);
-    });
+    }).catch(() => {});
   }
 
   return (

--- a/dashboard/src/components/message-actions.tsx
+++ b/dashboard/src/components/message-actions.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Check, Copy } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
@@ -25,11 +25,20 @@ export function MessageActions({
   className?: string;
 }) {
   const [copied, setCopied] = useState(false);
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Cleanup copy timer on unmount to avoid setState on an unmounted component.
+  useEffect(() => {
+    return () => {
+      if (copyTimerRef.current !== null) clearTimeout(copyTimerRef.current);
+    };
+  }, []);
 
   function handleCopy() {
     navigator.clipboard.writeText(text).then(() => {
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      if (copyTimerRef.current !== null) clearTimeout(copyTimerRef.current);
+      copyTimerRef.current = setTimeout(() => setCopied(false), 2000);
     });
   }
 

--- a/dashboard/src/components/message-actions.tsx
+++ b/dashboard/src/components/message-actions.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import { Check, Copy } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+// ---------------------------------------------------------------------------
+// MessageActions
+// ---------------------------------------------------------------------------
+
+/**
+ * Hover-revealed action bar positioned at the top-right of a message row.
+ *
+ * The parent row must carry the `group relative` Tailwind classes so that
+ * `group-hover:opacity-100` fires correctly and absolute positioning is
+ * scoped to the row.
+ *
+ * TODO: add a timestamp display once the transcript items carry timestamp data.
+ */
+export function MessageActions({
+  kind,
+  text,
+  className,
+}: {
+  kind: 'user' | 'assistant';
+  text: string;
+  className?: string;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  function handleCopy() {
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
+
+  return (
+    <div
+      className={cn(
+        'absolute top-1 right-1',
+        'opacity-0 group-hover:opacity-100 transition-opacity duration-150',
+        className,
+      )}
+    >
+      <div className="flex items-center gap-0.5 rounded-md border border-border bg-card px-1 py-0.5 shadow-sm">
+        {kind === 'assistant' && (
+          <IconButton
+            onClick={handleCopy}
+            title={copied ? 'Copied!' : 'Copy'}
+          >
+            {copied ? (
+              <Check className="h-3.5 w-3.5 text-status-running" />
+            ) : (
+              <Copy className="h-3.5 w-3.5" />
+            )}
+          </IconButton>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// IconButton (internal helper)
+// ---------------------------------------------------------------------------
+
+function IconButton({
+  onClick,
+  title,
+  children,
+}: {
+  onClick: () => void;
+  title?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      className="h-6 w-6 rounded flex items-center justify-center hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
+    >
+      {children}
+    </button>
+  );
+}

--- a/dashboard/src/components/message-row.tsx
+++ b/dashboard/src/components/message-row.tsx
@@ -1,0 +1,98 @@
+import { cn } from '@/lib/utils';
+import { AlertCircle, Info } from 'lucide-react';
+import { MarkdownContent } from './markdown-content';
+import { MessageActions } from './message-actions';
+import type { TranscriptItem } from './transcript-view';
+
+// ---------------------------------------------------------------------------
+// UserMessage
+// ---------------------------------------------------------------------------
+
+/** Right-aligned user turn. No bubble — just label + plain text. */
+export function UserMessage({ text }: { text: string }) {
+  return (
+    <div className="group relative flex flex-col items-end gap-1">
+      <span className="text-[11px] font-medium uppercase tracking-widest text-muted-foreground/50">
+        You
+      </span>
+      <p className="max-w-2xl text-sm leading-relaxed text-foreground whitespace-pre-wrap text-right">
+        {text}
+      </p>
+      <MessageActions kind="user" text={text} />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// AssistantRow
+// ---------------------------------------------------------------------------
+
+/**
+ * Left-aligned assistant turn. Full-width prose column capped at max-w-3xl.
+ * Renders content via MarkdownContent for proper GFM support.
+ */
+export function AssistantRow({ text }: { text: string }) {
+  return (
+    <div className="group relative flex flex-col gap-1">
+      <span className="text-[11px] font-medium uppercase tracking-widest text-brand/60">
+        Agent
+      </span>
+      <div className="max-w-3xl">
+        <MarkdownContent text={text} />
+      </div>
+      <MessageActions kind="assistant" text={text} />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ErrorItem
+// ---------------------------------------------------------------------------
+
+/** Destructive-tinted card for runtime errors surfaced in the transcript. */
+export function ErrorItem({ message }: { message: string }) {
+  return (
+    <div className="flex items-start gap-2.5 rounded-xl border border-destructive/20 bg-destructive/5 px-4 py-3">
+      <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-status-failed" />
+      <p className="text-sm leading-relaxed text-status-failed">{message}</p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// NoticeItem
+// ---------------------------------------------------------------------------
+
+/** Compact muted info row for system notices. */
+export function NoticeItem({ text }: { text: string }) {
+  return (
+    <div className="flex items-start gap-2 rounded-md border border-border bg-muted/30 px-3 py-2">
+      <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+      <p className="text-xs text-muted-foreground">{text}</p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// BgJobItem
+// ---------------------------------------------------------------------------
+
+/** Compact background-job status row. Keeps the existing design. */
+export function BgJobItem({ item }: { item: Extract<TranscriptItem, { kind: 'bg_job' }> }) {
+  return (
+    <div className="flex items-center gap-2 rounded-md border border-border bg-muted/30 px-3 py-1.5">
+      <span className="text-[10px] text-muted-foreground">BG</span>
+      <span className="text-xs text-foreground">{item.label}</span>
+      <span
+        className={cn(
+          'ml-auto font-mono text-[10px] capitalize',
+          item.status === 'completed' ? 'text-status-running' : '',
+          item.status === 'failed' ? 'text-status-failed' : '',
+          item.status === 'running' ? 'text-status-blocked' : '',
+        )}
+      >
+        {item.status}
+      </span>
+    </div>
+  );
+}

--- a/dashboard/src/components/message-row.tsx
+++ b/dashboard/src/components/message-row.tsx
@@ -1,6 +1,7 @@
 import { cn } from '@/lib/utils';
 import { AlertCircle, Info } from 'lucide-react';
 import { MarkdownContent } from './markdown-content';
+import { StreamingText } from './streaming-text';
 import { MessageActions } from './message-actions';
 import type { TranscriptItem } from './transcript-view';
 
@@ -31,14 +32,18 @@ export function UserMessage({ text }: { text: string }) {
  * Left-aligned assistant turn. Full-width prose column capped at max-w-3xl.
  * Renders content via MarkdownContent for proper GFM support.
  */
-export function AssistantRow({ text }: { text: string }) {
+export function AssistantRow({ text, isStreaming = false }: { text: string; isStreaming?: boolean }) {
   return (
     <div className="group relative flex flex-col gap-1">
       <span className="text-[11px] font-medium uppercase tracking-widest text-brand/60">
         Agent
       </span>
       <div className="max-w-3xl">
-        <MarkdownContent text={text} />
+        {isStreaming ? (
+          <StreamingText text={text} isStreaming={true} />
+        ) : (
+          <MarkdownContent text={text} />
+        )}
       </div>
       <MessageActions kind="assistant" text={text} />
     </div>

--- a/dashboard/src/components/streaming-text.tsx
+++ b/dashboard/src/components/streaming-text.tsx
@@ -1,0 +1,187 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { MarkdownContent } from './markdown-content';
+
+// Contract: cursor blink uses step-end so the transition is instantaneous
+// (on/off) rather than a fade, matching terminal cursor behaviour.
+const BLINK_STYLE = `
+@keyframes blink-cursor {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0; }
+}
+.streaming-cursor {
+  display: inline-block;
+  width: 0.125rem;    /* w-0.5 */
+  height: 1.1em;
+  background: var(--color-brand, #6366f1);
+  vertical-align: text-bottom;
+  animation: blink-cursor 530ms step-end infinite;
+}
+`;
+
+/** A blinking vertical-bar cursor. Renders nothing when not needed. */
+export function StreamingCursor() {
+  return (
+    <>
+      <style>{BLINK_STYLE}</style>
+      <span className="streaming-cursor" aria-hidden="true" />
+    </>
+  );
+}
+
+// Contract: CODE_FENCE_RE matches either ``` or ~~~~ at the start of a line
+// (possibly preceded by spaces). Used to detect partial fence markers.
+const CODE_FENCE_RE = /^[ \t]*(`{3,}|~{4,})/;
+
+/**
+ * Returns an adjusted display length that never cuts off inside a code-fence
+ * marker. If the slice [0, rawLen] would land mid-line and that partial line
+ * starts a code fence, we extend to the end of that line so the fence is never
+ * partially visible.
+ */
+function fenceSafeLength(text: string, rawLen: number): number {
+  if (rawLen >= text.length) return rawLen;
+
+  // Find the start of the current (partial) line.
+  const lineStart = text.lastIndexOf('\n', rawLen - 1) + 1; // 0 if no newline
+  const partialLine = text.slice(lineStart, rawLen);
+
+  if (CODE_FENCE_RE.test(partialLine)) {
+    // Extend to the end of this line (or end of text).
+    const lineEnd = text.indexOf('\n', rawLen);
+    return lineEnd === -1 ? text.length : lineEnd + 1;
+  }
+
+  return rawLen;
+}
+
+export interface StreamingTextProps {
+  text: string;
+  isStreaming: boolean;
+  /** Characters per second. Defaults to 80. */
+  speed?: number;
+  onComplete?: () => void;
+}
+
+/**
+ * Renders text character-by-character via rAF, then delegates to
+ * `<MarkdownContent>` for the visible slice. Shows a blinking cursor while
+ * text is still arriving or the animation hasn't caught up.
+ *
+ * Invariant: `displayedLength` only ever increases — never resets mid-stream.
+ * Invariant: rAF loop is the ONLY writer of `displayedLengthRef`; React state
+ *   is updated at most once per ~16ms frame to avoid excessive re-renders.
+ * Invariant: `cancelAnimationFrame` is called on unmount via the cleanup
+ *   returned by the useEffect that owns the loop.
+ */
+export function StreamingText({
+  text,
+  isStreaming,
+  speed = 80,
+  onComplete,
+}: StreamingTextProps) {
+  // Displayed slice length tracked in ref (written every frame) + state
+  // (drives re-render). We only call setState when the value actually changes
+  // so React batches naturally around 16ms frame boundaries.
+  const displayedLengthRef = useRef(0);
+  const [displayedLength, setDisplayedLength] = useState(0);
+
+  // rAF handle — stored in ref so cleanup can reach it.
+  const rafRef = useRef<number | null>(null);
+
+  // Last timestamp from rAF, used to compute per-frame character advance.
+  const lastTimestampRef = useRef<number | null>(null);
+
+  // Whether onComplete has already been called for this message.
+  const completedRef = useRef(false);
+
+  // Stable callback so useEffect deps don't change on every render.
+  const onCompleteRef = useRef(onComplete);
+  useEffect(() => { onCompleteRef.current = onComplete; }, [onComplete]);
+
+  // Edge case: if the component mounts with text already present and streaming
+  // is already false (e.g. a replayed/historical message), skip animation and
+  // show the full text immediately.
+  const skipAnimation = !isStreaming && displayedLengthRef.current === 0 && text.length > 0;
+
+  const startLoop = useCallback(() => {
+    // Don't double-schedule.
+    if (rafRef.current !== null) return;
+
+    function tick(timestamp: number) {
+      const last = lastTimestampRef.current ?? timestamp;
+      const elapsed = timestamp - last;
+      lastTimestampRef.current = timestamp;
+
+      const charsPerMs = speed / 1000;
+      const advance = Math.max(1, Math.floor(charsPerMs * elapsed));
+
+      const currentLen = displayedLengthRef.current;
+      const targetLen = text.length; // captured via closure — latest prop value
+
+      if (currentLen < targetLen) {
+        const rawNext = Math.min(currentLen + advance, targetLen);
+        const next = fenceSafeLength(text, rawNext);
+        displayedLengthRef.current = next;
+        setDisplayedLength(next);
+      }
+
+      const caught = displayedLengthRef.current >= text.length;
+
+      if (caught && !isStreaming) {
+        // Animation complete.
+        rafRef.current = null;
+        lastTimestampRef.current = null;
+        if (!completedRef.current) {
+          completedRef.current = true;
+          onCompleteRef.current?.();
+        }
+        return; // stop loop
+      }
+
+      // Continue — either still catching up or isStreaming (more text may arrive).
+      rafRef.current = requestAnimationFrame(tick);
+    }
+
+    rafRef.current = requestAnimationFrame(tick);
+  }, [speed, text, isStreaming]);
+
+  useEffect(() => {
+    // Fast path: historical/replayed message — render full text immediately.
+    if (skipAnimation) {
+      displayedLengthRef.current = text.length;
+      setDisplayedLength(text.length);
+      if (!completedRef.current) {
+        completedRef.current = true;
+        onCompleteRef.current?.();
+      }
+      return;
+    }
+
+    // If there's new text to animate (either new streaming tokens or initial
+    // mount with partial text), kick off the rAF loop.
+    if (displayedLengthRef.current < text.length || isStreaming) {
+      startLoop();
+    }
+
+    return () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+    };
+  // Re-run when text grows (streaming tokens) or streaming flips off.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [text, isStreaming, skipAnimation]);
+
+  // Determine what to show.
+  const effectiveLength = skipAnimation ? text.length : displayedLength;
+  const visibleText = text.slice(0, effectiveLength);
+  const showCursor = effectiveLength < text.length || isStreaming;
+
+  return (
+    <span className="streaming-text-root">
+      <MarkdownContent text={visibleText} />
+      {showCursor && <StreamingCursor />}
+    </span>
+  );
+}

--- a/dashboard/src/components/streaming-text.tsx
+++ b/dashboard/src/components/streaming-text.tsx
@@ -98,6 +98,11 @@ export function StreamingText({
   const onCompleteRef = useRef(onComplete);
   useEffect(() => { onCompleteRef.current = onComplete; }, [onComplete]);
 
+  // Speed ref: updated every render so the running rAF loop always reads the
+  // current value rather than the value captured at loop creation time.
+  const speedRef = useRef(speed);
+  useEffect(() => { speedRef.current = speed; });
+
   // Edge case: if the component mounts with text already present and streaming
   // is already false (e.g. a replayed/historical message), skip animation and
   // show the full text immediately.
@@ -112,7 +117,7 @@ export function StreamingText({
       const elapsed = timestamp - last;
       lastTimestampRef.current = timestamp;
 
-      const charsPerMs = speed / 1000;
+      const charsPerMs = speedRef.current / 1000;
       const advance = Math.max(1, Math.floor(charsPerMs * elapsed));
 
       const currentLen = displayedLengthRef.current;
@@ -143,7 +148,7 @@ export function StreamingText({
     }
 
     rafRef.current = requestAnimationFrame(tick);
-  }, [speed, text, isStreaming]);
+  }, [text, isStreaming]);
 
   useEffect(() => {
     // Fast path: historical/replayed message — render full text immediately.

--- a/dashboard/src/components/thinking-panel.tsx
+++ b/dashboard/src/components/thinking-panel.tsx
@@ -1,18 +1,77 @@
-/** Collapsible thinking block — dimmed italic text, no markdown. */
-export function ThinkingPanel({ text }: { text: string }) {
+/** Collapsible thinking block — Brain icon, streaming state, truncation. */
+import { useState } from "react";
+import { Brain } from "lucide-react";
+
+const TRUNCATE_AT = 200;
+
+export function ThinkingPanel({
+  text,
+  isStreaming = false,
+}: {
+  text: string;
+  isStreaming?: boolean;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  const truncatable = text.length > TRUNCATE_AT;
+  const displayText =
+    truncatable && !expanded ? text.slice(0, TRUNCATE_AT) + "…" : text;
+
   return (
-    <details className="group rounded-md border border-border/50 bg-muted/30">
-      <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2 text-xs text-muted-foreground select-none hover:text-foreground">
-        {/* Chevron via CSS rotation */}
-        <span className="inline-block transition-transform group-open:rotate-90">
-          ▶
-        </span>
-        Thinking…
+    <details className="group rounded-md border border-border/30 bg-muted/20">
+      <summary className="flex cursor-pointer list-none items-center gap-1.5 px-3 py-2 text-xs text-muted-foreground select-none hover:text-foreground">
+        {/* Brain icon — pulses while still streaming */}
+        <Brain
+          className={[
+            "h-3.5 w-3.5 shrink-0 text-brand/60",
+            isStreaming ? "animate-pulse" : "",
+          ]
+            .filter(Boolean)
+            .join(" ")}
+        />
+
+        <span className="font-medium">Thinking</span>
+
+        {/* Character count badge */}
+        {text.length > 0 && (
+          <span className="text-[10px] text-muted-foreground/50 tabular-nums">
+            {text.length.toLocaleString()} chars
+          </span>
+        )}
+
+        {/* Three animated dots while streaming */}
+        {isStreaming && (
+          <span className="ml-0.5 flex items-center gap-px">
+            {[0, 150, 300].map((delay) => (
+              <span
+                key={delay}
+                className="inline-block h-1 w-1 rounded-full bg-muted-foreground/50 animate-shimmer-pulse"
+                style={{ animationDelay: `${delay}ms` }}
+              />
+            ))}
+          </span>
+        )}
       </summary>
-      <div className="border-t border-border/50 px-3 py-2">
-        <p className="whitespace-pre-wrap font-serif text-xs italic text-muted-foreground">
-          {text}
+
+      {/* Content area */}
+      <div className="border-t border-border/30 px-3 py-2">
+        <p className="whitespace-pre-wrap break-words text-xs italic leading-relaxed text-muted-foreground/70">
+          {displayText}
         </p>
+
+        {/* Show more / Show less toggle */}
+        {truncatable && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.preventDefault();
+              setExpanded((v) => !v);
+            }}
+            className="mt-1.5 text-[10px] text-brand/60 hover:text-brand/80 transition-colors"
+          >
+            {expanded ? "Show less" : "Show more"}
+          </button>
+        )}
       </div>
     </details>
   );

--- a/dashboard/src/components/tool-call-card.tsx
+++ b/dashboard/src/components/tool-call-card.tsx
@@ -21,6 +21,7 @@ import { DiffViewer } from './diff-viewer';
 type Status = 'running' | 'ok' | 'error';
 
 export interface ToolCallCardProps {
+  toolUseId?: string;
   name: string;
   inputPreview: string;
   status: Status;

--- a/dashboard/src/components/tool-call-card.tsx
+++ b/dashboard/src/components/tool-call-card.tsx
@@ -1,9 +1,26 @@
+import { useState, useEffect, useRef } from 'react';
+import {
+  FileSearch,
+  FilePen,
+  Terminal,
+  GitBranch,
+  Globe,
+  ExternalLink,
+  Database,
+  Wrench,
+  Loader2,
+  CheckCircle2,
+  AlertCircle,
+  ChevronRight,
+} from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { DiffViewer } from './diff-viewer';
 
+// ── Types ────────────────────────────────────────────────────────────────────
+
 type Status = 'running' | 'ok' | 'error';
 
-interface ToolCallCardProps {
+export interface ToolCallCardProps {
   name: string;
   inputPreview: string;
   status: Status;
@@ -13,28 +30,87 @@ interface ToolCallCardProps {
   durationMs?: number;
 }
 
-function StatusDot({ status }: { status: Status }) {
-  return (
-    <span
-      className={cn(
-        'mt-0.5 inline-block h-2 w-2 shrink-0 rounded-full',
-        status === 'ok' && 'bg-status-running',
-        status === 'error' && 'bg-status-failed',
-        status === 'running' && 'animate-pulse bg-status-blocked',
-      )}
-      aria-label={status}
-    />
-  );
+// ── Category icon map ─────────────────────────────────────────────────────────
+
+// Contract: every tool name maps to exactly one icon + color pair.
+// "default" key is the fallback for unmapped tool names.
+const CATEGORY_MAP: Record<string, { Icon: React.ElementType; colorClass: string }> = {
+  read_file:       { Icon: FileSearch,   colorClass: 'text-cat-read'    },
+  glob:            { Icon: FileSearch,   colorClass: 'text-cat-read'    },
+  grep:            { Icon: FileSearch,   colorClass: 'text-cat-read'    },
+  list_directory:  { Icon: FileSearch,   colorClass: 'text-cat-read'    },
+  json_query:      { Icon: FileSearch,   colorClass: 'text-cat-read'    },
+  write_file:      { Icon: FilePen,      colorClass: 'text-cat-write'   },
+  edit_file:       { Icon: FilePen,      colorClass: 'text-cat-write'   },
+  patch_apply:     { Icon: FilePen,      colorClass: 'text-cat-write'   },
+  bash:            { Icon: Terminal,     colorClass: 'text-cat-shell'   },
+  test_run:        { Icon: Terminal,     colorClass: 'text-cat-shell'   },
+  agent:           { Icon: GitBranch,    colorClass: 'text-cat-agent'   },
+  compose:         { Icon: GitBranch,    colorClass: 'text-cat-agent'   },
+  skill:           { Icon: GitBranch,    colorClass: 'text-cat-agent'   },
+  browser_open:    { Icon: Globe,        colorClass: 'text-cat-browser' },
+  browser_act:     { Icon: Globe,        colorClass: 'text-cat-browser' },
+  browser_observe: { Icon: Globe,        colorClass: 'text-cat-browser' },
+  browser_screenshot: { Icon: Globe,    colorClass: 'text-cat-browser' },
+  web_scrape:      { Icon: ExternalLink, colorClass: 'text-cat-web'    },
+  web_request:     { Icon: ExternalLink, colorClass: 'text-cat-web'    },
+  memory_search:   { Icon: Database,     colorClass: 'text-cat-mcp'    },
+  memory_update:   { Icon: Database,     colorClass: 'text-cat-mcp'    },
+  state_get:       { Icon: Database,     colorClass: 'text-cat-mcp'    },
+  state_put:       { Icon: Database,     colorClass: 'text-cat-mcp'    },
+};
+
+function getCategoryIcon(name: string) {
+  return CATEGORY_MAP[name] ?? { Icon: Wrench, colorClass: 'text-cat-other' };
 }
 
-function DurationBadge({ ms }: { ms: number }) {
-  const s = (ms / 1000).toFixed(1);
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function StatusIcon({ status }: { status: Status }) {
+  if (status === 'running') {
+    return <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin-slow text-status-blocked" aria-label="running" />;
+  }
+  if (status === 'ok') {
+    return <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-status-running" aria-label="ok" />;
+  }
+  return <AlertCircle className="h-3.5 w-3.5 shrink-0 text-status-failed" aria-label="error" />;
+}
+
+function DurationBadge({ ms, live }: { ms?: number; live?: number }) {
+  const display = ms !== undefined
+    ? `${(ms / 1000).toFixed(1)}s`
+    : live !== undefined
+    ? `...${live}s`
+    : null;
+
+  if (display === null) return null;
+
   return (
     <span className="rounded bg-secondary px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
-      {s}s
+      {display}
     </span>
   );
 }
+
+// ── Animated collapse via CSS grid trick ──────────────────────────────────────
+
+// Invariant: outer div uses `grid` with `grid-template-rows`; inner div uses
+// `min-h-0` so the overflow is contained. Transition is on `grid-template-rows`
+// which browsers can animate without triggering a layout recalc each frame.
+function Collapse({ open, children }: { open: boolean; children: React.ReactNode }) {
+  return (
+    <div
+      className={cn(
+        'grid transition-[grid-template-rows] duration-200 ease-out',
+        open ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]',
+      )}
+    >
+      <div className="min-h-0 overflow-hidden">{children}</div>
+    </div>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
 
 /** Collapsible card for a single tool invocation. */
 export function ToolCallCard({
@@ -46,52 +122,101 @@ export function ToolCallCard({
   diff,
   durationMs,
 }: ToolCallCardProps) {
+  const [outputOpen, setOutputOpen] = useState(false);
+  const [inputExpanded, setInputExpanded] = useState(false);
+  const [liveSeconds, setLiveSeconds] = useState(0);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Live elapsed counter — only ticks while running and no final duration yet.
+  useEffect(() => {
+    if (status === 'running' && durationMs === undefined) {
+      intervalRef.current = setInterval(() => {
+        setLiveSeconds((s) => s + 1);
+      }, 1000);
+    } else {
+      if (intervalRef.current !== null) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    }
+    return () => {
+      if (intervalRef.current !== null) clearInterval(intervalRef.current);
+    };
+  }, [status, durationMs]);
+
+  const { Icon, colorClass } = getCategoryIcon(name);
   const hasOutput = diff || outputUnavailable || (output && output.trim().length > 0);
+  const trimmedInput = inputPreview.trim();
 
   return (
-    <div className={cn(
-      'rounded-md border bg-card',
-      status === 'error' ? 'border-status-failed/40' : 'border-border',
-    )}>
-      {/* Header — always visible */}
-      <div className="flex items-start gap-2 px-3 py-2">
-        <StatusDot status={status} />
+    <div
+      className={cn(
+        'rounded-md border bg-card text-sm',
+        status === 'error' ? 'border-status-failed/40' : 'border-border',
+      )}
+    >
+      {/* ── Header ─────────────────────────────────────────────────────── */}
+      <div className="flex items-center gap-2 px-3 py-2">
+        <Icon className={cn('h-3.5 w-3.5 shrink-0', colorClass)} />
         <span className="font-mono text-xs font-medium text-foreground">{name}</span>
-        {durationMs !== undefined && (
-          <span className="ml-auto"><DurationBadge ms={durationMs} /></span>
-        )}
+        <div className="ml-auto flex items-center gap-1.5">
+          <DurationBadge ms={durationMs} live={status === 'running' ? liveSeconds : undefined} />
+          <StatusIcon status={status} />
+        </div>
       </div>
 
-      {/* Input preview — always visible, truncated */}
-      {inputPreview.trim().length > 0 && (
-        <div className="border-t border-border/50 px-3 py-1.5">
-          <p className="line-clamp-2 font-mono text-[11px] text-muted-foreground">
-            {inputPreview}
+      {/* ── Input preview ───────────────────────────────────────────────── */}
+      {trimmedInput.length > 0 && (
+        <button
+          type="button"
+          onClick={() => setInputExpanded((v) => !v)}
+          className="w-full border-t border-border/50 px-3 py-1.5 text-left"
+          aria-expanded={inputExpanded}
+        >
+          <p
+            className={cn(
+              'font-mono text-[11px] text-muted-foreground',
+              !inputExpanded && 'line-clamp-2',
+            )}
+          >
+            {trimmedInput}
           </p>
-        </div>
+        </button>
       )}
 
-      {/* Output — collapsible via <details> */}
+      {/* ── Output section ──────────────────────────────────────────────── */}
       {hasOutput && (
-        <details className="group border-t border-border/50">
-          <summary className="flex cursor-pointer list-none items-center gap-1 px-3 py-1.5 text-[11px] text-muted-foreground select-none hover:text-foreground">
-            <span className="inline-block transition-transform group-open:rotate-90">▶</span>
+        <div className="border-t border-border/50">
+          <button
+            type="button"
+            onClick={() => setOutputOpen((v) => !v)}
+            className="flex w-full cursor-pointer items-center gap-1 px-3 py-1.5 text-[11px] text-muted-foreground select-none hover:text-foreground"
+            aria-expanded={outputOpen}
+          >
+            <ChevronRight
+              className={cn(
+                'h-3 w-3 shrink-0 transition-transform duration-150',
+                outputOpen && 'rotate-90',
+              )}
+            />
             Output
-          </summary>
-          <div className="px-3 pb-2 pt-1">
-            {outputUnavailable && (
-              <p className="text-[11px] italic text-muted-foreground">
-                Output not available (replayed session)
-              </p>
-            )}
-            {diff && <DiffViewer diff={diff} />}
-            {!diff && output && (
-              <pre className="overflow-x-auto whitespace-pre-wrap font-mono text-[11px] text-foreground">
-                {output}
-              </pre>
-            )}
-          </div>
-        </details>
+          </button>
+          <Collapse open={outputOpen}>
+            <div className="px-3 pb-2 pt-1">
+              {outputUnavailable && (
+                <p className="text-[11px] italic text-muted-foreground">
+                  Output not available (replayed session)
+                </p>
+              )}
+              {diff && <DiffViewer diff={diff} />}
+              {!diff && output && (
+                <pre className="overflow-x-auto whitespace-pre-wrap font-mono text-[11px] text-foreground">
+                  {output}
+                </pre>
+              )}
+            </div>
+          </Collapse>
+        </div>
       )}
     </div>
   );

--- a/dashboard/src/components/tool-group.tsx
+++ b/dashboard/src/components/tool-group.tsx
@@ -172,7 +172,7 @@ export function ToolGroup({ tools, isActive }: ToolGroupProps) {
       <Collapse open={open}>
         <div className="flex flex-col gap-1.5 border-t border-border/50 p-2">
           {tools.map((tool, i) => (
-            <ToolCallCard key={i} {...tool} />
+            <ToolCallCard key={tool.toolUseId ?? i} {...tool} />
           ))}
         </div>
       </Collapse>

--- a/dashboard/src/components/tool-group.tsx
+++ b/dashboard/src/components/tool-group.tsx
@@ -1,0 +1,181 @@
+import { useState, useEffect, useRef } from 'react';
+import { CheckCircle2, AlertCircle, ChevronDown } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { ToolCallCard, type ToolCallCardProps } from './tool-call-card';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface ToolGroupProps {
+  tools: ToolCallCardProps[];
+  isActive: boolean;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function sumDurations(tools: ToolCallCardProps[]): number | undefined {
+  const values = tools.map((t) => t.durationMs).filter((ms): ms is number => ms !== undefined);
+  return values.length > 0 ? values.reduce((a, b) => a + b, 0) : undefined;
+}
+
+function formatMs(ms: number): string {
+  return ms >= 1000 ? `${(ms / 1000).toFixed(1)}s` : `${ms}ms`;
+}
+
+// ── Animated collapse (same CSS grid technique as ToolCallCard) ───────────────
+
+// Invariant: grid-rows transition is hardware-accelerated; inner div uses
+// min-h-0 to contain overflow without explicit height calculations.
+function Collapse({ open, children }: { open: boolean; children: React.ReactNode }) {
+  return (
+    <div
+      className={cn(
+        'grid transition-[grid-template-rows] duration-200 ease-out',
+        open ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]',
+      )}
+    >
+      <div className="min-h-0 overflow-hidden">{children}</div>
+    </div>
+  );
+}
+
+// ── Header states ─────────────────────────────────────────────────────────────
+
+function RunningHeader({ tools }: { tools: ToolCallCardProps[] }) {
+  const runningIdx = tools.findIndex((t) => t.status === 'running');
+  const current = runningIdx >= 0 ? runningIdx + 1 : tools.length;
+
+  return (
+    <span className="animate-shimmer-pulse font-medium text-status-blocked">
+      Running tool {current} of {tools.length}...
+    </span>
+  );
+}
+
+function CompleteHeader({ tools }: { tools: ToolCallCardProps[] }) {
+  const total = sumDurations(tools);
+  return (
+    <span className="flex items-center gap-1.5 font-medium text-status-running">
+      <CheckCircle2 className="h-3.5 w-3.5 shrink-0" />
+      Tools complete ✓{total !== undefined && ` ${formatMs(total)}`}
+    </span>
+  );
+}
+
+function ErrorHeader({ tools }: { tools: ToolCallCardProps[] }) {
+  const errorCount = tools.filter((t) => t.status === 'error').length;
+  return (
+    <span className="flex items-center gap-1.5 font-medium text-status-failed">
+      <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+      {errorCount} error{errorCount !== 1 ? 's' : ''}
+    </span>
+  );
+}
+
+// ── Live elapsed for active groups with no durations yet ──────────────────────
+
+function LiveElapsed({ isActive }: { isActive: boolean }) {
+  const [seconds, setSeconds] = useState(0);
+  const ref = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (isActive) {
+      ref.current = setInterval(() => setSeconds((s) => s + 1), 1000);
+    } else {
+      if (ref.current !== null) {
+        clearInterval(ref.current);
+        ref.current = null;
+      }
+    }
+    return () => {
+      if (ref.current !== null) clearInterval(ref.current);
+    };
+  }, [isActive]);
+
+  if (!isActive) return null;
+  return (
+    <span className="rounded bg-secondary px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+      ...{seconds}s
+    </span>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+/**
+ * Groups a set of ToolCallCards under a collapsible header that summarises the
+ * overall state (running / complete / error) and total elapsed time.
+ *
+ * Invariant: body auto-expands while isActive and auto-collapses when the group
+ * transitions to complete — unless the user has manually toggled it (userToggled
+ * tracks that override so we respect their intent).
+ */
+export function ToolGroup({ tools, isActive }: ToolGroupProps) {
+  // Track whether the user has explicitly toggled so auto-collapse is opt-outable.
+  const [userToggled, setUserToggled] = useState(false);
+  const [open, setOpen] = useState(isActive);
+
+  // Auto-manage open state unless the user has taken control.
+  useEffect(() => {
+    if (userToggled) return;
+    setOpen(isActive);
+  }, [isActive, userToggled]);
+
+  function handleToggle() {
+    setUserToggled(true);
+    setOpen((v) => !v);
+  }
+
+  const hasError = tools.some((t) => t.status === 'error');
+  const totalDuration = sumDurations(tools);
+
+  return (
+    <div className="rounded-md border border-border bg-card">
+      {/* ── Group header ─────────────────────────────────────────────────── */}
+      <button
+        type="button"
+        onClick={handleToggle}
+        className="flex w-full items-center gap-2 px-3 py-2 text-xs select-none hover:bg-muted/30"
+        aria-expanded={open}
+      >
+        <ChevronDown
+          className={cn(
+            'h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform duration-150',
+            !open && '-rotate-90',
+          )}
+        />
+
+        <span className="flex-1 text-left">
+          {hasError ? (
+            <ErrorHeader tools={tools} />
+          ) : isActive ? (
+            <RunningHeader tools={tools} />
+          ) : (
+            <CompleteHeader tools={tools} />
+          )}
+        </span>
+
+        {/* Duration badge — live while active, final sum when done */}
+        {isActive && totalDuration === undefined ? (
+          <LiveElapsed isActive={isActive} />
+        ) : totalDuration !== undefined && !isActive ? (
+          <span className="rounded bg-secondary px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+            {formatMs(totalDuration)}
+          </span>
+        ) : null}
+
+        <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+          {tools.length} tool{tools.length !== 1 ? 's' : ''}
+        </span>
+      </button>
+
+      {/* ── Collapsible tool list ─────────────────────────────────────────── */}
+      <Collapse open={open}>
+        <div className="flex flex-col gap-1.5 border-t border-border/50 p-2">
+          {tools.map((tool, i) => (
+            <ToolCallCard key={i} {...tool} />
+          ))}
+        </div>
+      </Collapse>
+    </div>
+  );
+}

--- a/dashboard/src/components/topology-node.tsx
+++ b/dashboard/src/components/topology-node.tsx
@@ -1,0 +1,319 @@
+/**
+ * TopologyNode — recursive spine node renderer.
+ *
+ * Renders one SpineNode and its children using div-based tree connectors.
+ * Tree structure:
+ *   [connector] [icon] [label] [badges] [duration]
+ *               [children indented under vertical spine line]
+ *
+ * Contract: children are always rendered; collapse only applies to agent
+ * nodes whose `isActive` is false. Root and tool nodes are always expanded.
+ */
+
+import { useState } from 'react';
+import {
+  FileSearch,
+  FilePen,
+  Terminal,
+  GitBranch,
+  Sparkles,
+  Network,
+  Plug,
+  ExternalLink,
+  Globe,
+  ListTodo,
+  Wrench,
+  ChevronRight,
+  ChevronDown,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { formatSpineDuration, formatSpineCost } from '@/lib/topology';
+import type { SpineNode, ToolCategory } from '@/lib/topology-types';
+
+// ---------------------------------------------------------------------------
+// Category icon map
+// ---------------------------------------------------------------------------
+
+const CATEGORY_ICON: Record<ToolCategory, React.ElementType> = {
+  read:    FileSearch,
+  write:   FilePen,
+  shell:   Terminal,
+  agent:   GitBranch,
+  skill:   Sparkles,
+  dag:     Network,
+  mcp:     Plug,
+  web:     ExternalLink,
+  browser: Globe,
+  plan:    ListTodo,
+  other:   Wrench,
+};
+
+const CATEGORY_COLOR: Record<ToolCategory, string> = {
+  read:    'text-cat-read',
+  write:   'text-cat-write',
+  shell:   'text-cat-shell',
+  agent:   'text-cat-agent',
+  skill:   'text-cat-skill',
+  dag:     'text-cat-dag',
+  mcp:     'text-cat-mcp',
+  web:     'text-cat-web',
+  browser: 'text-cat-browser',
+  plan:    'text-cat-plan',
+  other:   'text-cat-other',
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function countDescendantTools(node: SpineNode): number {
+  let count = 0;
+  for (const child of node.children) {
+    if (child.kind === 'tool') count++;
+    count += countDescendantTools(child);
+  }
+  return count;
+}
+
+function sumDescendantDuration(node: SpineNode): number {
+  let total = node.durationMs ?? 0;
+  for (const child of node.children) {
+    total += sumDescendantDuration(child);
+  }
+  return total;
+}
+
+// ---------------------------------------------------------------------------
+// NodeIcon — icon with status-driven styling
+// ---------------------------------------------------------------------------
+
+interface NodeIconProps {
+  category: ToolCategory;
+  status: SpineNode['status'];
+}
+
+function NodeIcon({ category, status }: NodeIconProps) {
+  const Icon = CATEGORY_ICON[category];
+  const colorClass = CATEGORY_COLOR[category];
+  return (
+    <Icon
+      className={cn(
+        'h-3.5 w-3.5 shrink-0',
+        colorClass,
+        status === 'running'   && 'animate-shimmer-pulse',
+        status === 'error'     && 'text-status-failed',
+        status === 'cancelled' && 'opacity-50',
+      )}
+      aria-hidden
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CloserLine — summary footer for completed agent nodes
+// ---------------------------------------------------------------------------
+
+interface CloserLineProps {
+  node: SpineNode;
+}
+
+function CloserLine({ node }: CloserLineProps) {
+  if (node.status === 'running' || node.children.length === 0) return null;
+
+  if (node.status === 'error') {
+    return (
+      <div className="mt-0.5 pl-5 text-[11px] text-status-failed">
+        Failed
+      </div>
+    );
+  }
+
+  if (node.status === 'cancelled') {
+    return (
+      <div className="mt-0.5 pl-5 text-[11px] text-muted-foreground">
+        Cancelled
+      </div>
+    );
+  }
+
+  const toolCount = countDescendantTools(node);
+  const totalMs   = node.durationMs ?? sumDescendantDuration(node);
+  const costUsd   = node.costUsd;
+
+  const parts: string[] = [];
+  if (toolCount > 0) parts.push(`${toolCount} tool${toolCount !== 1 ? 's' : ''}`);
+  if (totalMs > 0)   parts.push(formatSpineDuration(totalMs));
+  if (costUsd != null && costUsd > 0) parts.push(formatSpineCost(costUsd));
+
+  return (
+    <div className="mt-0.5 pl-5 text-[11px] text-muted-foreground">
+      Done{parts.length > 0 ? ` (${parts.join(' · ')})` : ''}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// TopologyNode — one node + its subtree
+// ---------------------------------------------------------------------------
+
+export interface TopologyNodeProps {
+  node: SpineNode;
+  /** Depth for indentation; root nodes start at 0. */
+  depth?: number;
+  /** True when this is the last child in its parent's list. */
+  isLast?: boolean;
+}
+
+export function TopologyNode({ node, depth = 0, isLast: _isLast = false }: TopologyNodeProps) {
+  // Agent nodes with children are collapsible.
+  // Default: expanded when active, collapsed when done.
+  const isCollapsible = node.kind === 'agent' && node.children.length > 0;
+  const [expanded, setExpanded] = useState<boolean>(node.isActive);
+
+  const hasChildren = node.children.length > 0;
+  const isAgent = node.kind === 'agent';
+
+  // Chevron for collapsible agent nodes
+  const ChevronIcon = expanded ? ChevronDown : ChevronRight;
+
+  return (
+    <div className={cn('relative', depth > 0 && 'pl-3')}>
+      {/* ── Header row ─────────────────────────────────────── */}
+      <div
+        className={cn(
+          'flex items-center gap-1.5 py-0.5 group',
+          isCollapsible && 'cursor-pointer select-none',
+        )}
+        onClick={isCollapsible ? () => setExpanded(e => !e) : undefined}
+        role={isCollapsible ? 'button' : undefined}
+        aria-expanded={isCollapsible ? expanded : undefined}
+      >
+        {/* Collapse chevron — only on collapsible agent nodes */}
+        {isCollapsible ? (
+          <ChevronIcon className="h-3 w-3 shrink-0 text-muted-foreground/50" />
+        ) : (
+          <span className="h-3 w-3 shrink-0" aria-hidden />
+        )}
+
+        {/* Category icon with status styling */}
+        <NodeIcon category={node.category} status={node.status} />
+
+        {/* Label */}
+        <span
+          className={cn(
+            'text-[12px] font-mono leading-none',
+            node.status === 'cancelled' && 'opacity-50',
+            node.status === 'error'     && 'text-status-failed',
+            node.status === 'running'   && 'text-foreground',
+            node.status === 'ok'        && 'text-foreground/80',
+          )}
+        >
+          {node.label}
+        </span>
+
+        {/* ── Badges ── */}
+
+        {/* Model badge (agents only) */}
+        {isAgent && node.model && (
+          <span className="bg-secondary rounded px-1 py-0.5 text-[10px] font-mono text-muted-foreground">
+            {node.model}
+          </span>
+        )}
+
+        {/* Agent type badge */}
+        {isAgent && node.agentType && (
+          <span className="bg-secondary rounded px-1 py-0.5 text-[10px] font-mono text-muted-foreground">
+            {node.agentType}
+          </span>
+        )}
+
+        {/* Turn count */}
+        {isAgent && node.turnCount != null && node.turnCount > 0 && (
+          <span className="text-[10px] font-mono text-muted-foreground">
+            {node.turnCount} turn{node.turnCount !== 1 ? 's' : ''}
+          </span>
+        )}
+
+        {/* Duration */}
+        {node.durationMs != null && node.durationMs > 0 && (
+          <span className="text-[10px] font-mono text-muted-foreground tabular-nums">
+            {formatSpineDuration(node.durationMs)}
+          </span>
+        )}
+
+        {/* Cost (agents only) */}
+        {isAgent && node.costUsd != null && node.costUsd > 0 && (
+          <span className="text-[10px] font-mono text-muted-foreground">
+            {formatSpineCost(node.costUsd)}
+          </span>
+        )}
+      </div>
+
+      {/* ── Preview line (agents only) ─────────────────────── */}
+      {isAgent && node.preview && (
+        <div className="pl-5 text-[11px] italic text-muted-foreground/60 line-clamp-1 leading-tight">
+          {node.preview}
+        </div>
+      )}
+
+      {/* ── Closer summary (completed agents with children) ── */}
+      {isAgent && !expanded && hasChildren && (
+        <CloserLine node={node} />
+      )}
+
+      {/* ── Children subtree ───────────────────────────────── */}
+      {hasChildren && expanded && (
+        <div
+          className={cn(
+            'relative mt-0.5 ml-[22px]',
+            // Vertical spine line down the left of the children block.
+            // The line stops short of the last child's connector.
+            'border-l-2 border-spine',
+          )}
+        >
+          {node.children.map((child, idx) => {
+            const childIsLast = idx === node.children.length - 1;
+            return (
+              <div key={child.id} className="relative">
+                {/* Horizontal connector stub from the spine to the child */}
+                <div
+                  className={cn(
+                    'absolute left-0 top-[10px] h-0 w-3',
+                    'border-t-2 border-spine',
+                    // For the last child, clip the vertical spine at the connector.
+                    // We do this by overlaying a background-colored block below the connector.
+                    childIsLast && 'last-child-clip',
+                  )}
+                  aria-hidden
+                />
+                {/* For the last child: hide the vertical line below the connector */}
+                {childIsLast && (
+                  <div
+                    className="absolute left-[-2px] top-[10px] bottom-0 w-[2px] bg-background"
+                    aria-hidden
+                  />
+                )}
+                <div className="pl-3">
+                  <TopologyNode
+                    node={child}
+                    depth={depth + 1}
+                    isLast={childIsLast}
+                  />
+                </div>
+              </div>
+            );
+          })}
+          {/* Closer line shown when expanded and agent is done */}
+          {isAgent && node.status !== 'running' && (
+            <CloserLine node={node} />
+          )}
+        </div>
+      )}
+
+      {/* Closer for collapsed agents (no children rendered) */}
+      {isAgent && (!hasChildren || !expanded) && node.status !== 'running' && (
+        !hasChildren ? <CloserLine node={node} /> : null
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/components/topology-spine.tsx
+++ b/dashboard/src/components/topology-spine.tsx
@@ -1,0 +1,61 @@
+/**
+ * TopologySpine — top-level spine container.
+ *
+ * Renders a forest of SpineNode roots as a vertical execution trace.
+ * Each root is rendered by TopologyNode. The container adds a subtle
+ * left border for visual continuity and a small section header.
+ *
+ * Contract: an empty `nodes` array renders the header but no tree rows —
+ * callers decide whether to hide the whole panel when there is nothing to show.
+ */
+
+import { cn } from '@/lib/utils';
+import { TopologyNode } from './topology-node';
+import type { SpineNode } from '@/lib/topology-types';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface TopologySpineProps {
+  nodes: SpineNode[];
+  className?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function TopologySpine({ nodes, className }: TopologySpineProps) {
+  return (
+    <div
+      className={cn(
+        'relative pl-3 border-l-2 border-spine/40',
+        className,
+      )}
+    >
+      {/* Section header */}
+      <div className="mb-1 text-[10px] uppercase tracking-widest text-muted-foreground/40 select-none">
+        Execution
+      </div>
+
+      {/* Tree roots */}
+      {nodes.length === 0 ? (
+        <div className="text-[11px] text-muted-foreground/30 italic py-1">
+          No activity yet
+        </div>
+      ) : (
+        <div className="flex flex-col gap-0.5">
+          {nodes.map((node, idx) => (
+            <TopologyNode
+              key={node.id}
+              node={node}
+              depth={0}
+              isLast={idx === nodes.length - 1}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/components/transcript-spine.tsx
+++ b/dashboard/src/components/transcript-spine.tsx
@@ -1,0 +1,104 @@
+/**
+ * Spine-enhanced transcript rendering.
+ *
+ * Groups contiguous tool + subagent items into topology spine trees,
+ * keeping text items (user, assistant, thinking, error, notice) as-is.
+ * This replaces the flat tool-card + subagent-card rendering with
+ * a hierarchical execution view.
+ */
+import { useMemo } from 'react';
+import type { TranscriptItem } from './transcript-view';
+import { TopologySpine } from './topology-spine';
+import { buildSpineTree } from '@/lib/topology';
+import type { SpineNode } from '@/lib/topology-types';
+
+// Items that represent execution (grouped into spine blocks)
+const EXECUTION_KINDS = new Set(['tool', 'subagent']);
+
+// Items that are prose/text (rendered individually)
+const TEXT_KINDS = new Set(['user', 'assistant', 'thinking', 'error', 'notice', 'bg_job']);
+
+/**
+ * A rendered slot is either a single text item or a group of execution
+ * items that should render as a topology spine.
+ */
+type SpineSlot =
+  | { kind: 'text'; item: TranscriptItem }
+  | { kind: 'execution'; items: TranscriptItem[]; id: string; spineNodes: SpineNode[] };
+
+/**
+ * Group transcript items into spine slots. Contiguous runs of tool +
+ * subagent items are merged into a single execution block and fed
+ * through the topology tree builder.
+ */
+export function groupIntoSpineSlots(items: TranscriptItem[]): SpineSlot[] {
+  const slots: SpineSlot[] = [];
+  let i = 0;
+
+  while (i < items.length) {
+    const item = items[i];
+    if (item === undefined) { i++; continue; }
+
+    if (TEXT_KINDS.has(item.kind)) {
+      slots.push({ kind: 'text', item });
+      i++;
+      continue;
+    }
+
+    // Collect contiguous execution items (tools + subagents).
+    const run: TranscriptItem[] = [];
+    while (i < items.length) {
+      const cur = items[i];
+      if (cur === undefined || !EXECUTION_KINDS.has(cur.kind)) break;
+      run.push(cur);
+      i++;
+    }
+
+    if (run.length > 0) {
+      const spineNodes = buildSpineTree(run);
+      slots.push({
+        kind: 'execution',
+        items: run,
+        id: run[0]!.id,
+        spineNodes,
+      });
+    }
+  }
+
+  return slots;
+}
+
+interface SpineTranscriptProps {
+  slots: SpineSlot[];
+  renderTextItem: (item: TranscriptItem, idx: number) => React.ReactNode;
+}
+
+/**
+ * Render transcript items with spine-grouped execution blocks.
+ * Text items are rendered via the provided callback; execution blocks
+ * are rendered as TopologySpine components.
+ */
+export function SpineTranscript({ slots, renderTextItem }: SpineTranscriptProps) {
+  return (
+    <>
+      {slots.map((slot, idx) => {
+        if (slot.kind === 'text') {
+          return renderTextItem(slot.item, idx);
+        }
+        return (
+          <div key={slot.id} className="py-2 px-1">
+            <TopologySpine nodes={slot.spineNodes} />
+          </div>
+        );
+      })}
+    </>
+  );
+}
+
+/**
+ * Hook to compute spine slots from transcript items.
+ * Memoized to avoid recomputing on every render.
+ */
+export function useSpineSlots(items: TranscriptItem[]): SpineSlot[] {
+  return useMemo(() => groupIntoSpineSlots(items), [items]);
+}

--- a/dashboard/src/components/transcript-spine.tsx
+++ b/dashboard/src/components/transcript-spine.tsx
@@ -20,7 +20,7 @@ import type { SpineNode } from '@/lib/topology-types';
 const EXECUTION_KINDS = new Set(['tool', 'subagent', 'notice']);
 
 // Items that are prose/text (rendered individually)
-const TEXT_KINDS = new Set(['user', 'assistant', 'thinking', 'error', 'notice', 'bg_job']);
+const TEXT_KINDS = new Set(['user', 'assistant', 'thinking', 'error', 'bg_job']);
 
 /**
  * A rendered slot is either a single text item or a group of execution

--- a/dashboard/src/components/transcript-spine.tsx
+++ b/dashboard/src/components/transcript-spine.tsx
@@ -12,8 +12,12 @@ import { TopologySpine } from './topology-spine';
 import { buildSpineTree } from '@/lib/topology';
 import type { SpineNode } from '@/lib/topology-types';
 
-// Items that represent execution (grouped into spine blocks)
-const EXECUTION_KINDS = new Set(['tool', 'subagent']);
+// Items that represent execution (grouped into spine blocks).
+// 'notice' is included so that activity notices between a tool call and its
+// dispatched subagent do not break the contiguous execution run. The tree
+// builder filters by kind === 'tool' | 'subagent', so notices pass through
+// harmlessly without affecting topology linking.
+const EXECUTION_KINDS = new Set(['tool', 'subagent', 'notice']);
 
 // Items that are prose/text (rendered individually)
 const TEXT_KINDS = new Set(['user', 'assistant', 'thinking', 'error', 'notice', 'bg_job']);

--- a/dashboard/src/components/transcript-view.tsx
+++ b/dashboard/src/components/transcript-view.tsx
@@ -1,12 +1,17 @@
-import { useMemo } from 'react';
-import { cn } from '@/lib/utils';
-import { AlertCircle, Info } from 'lucide-react';
-import { MarkdownContent } from './markdown-content';
+import { useMemo, useCallback } from 'react';
 import { ThinkingPanel } from './thinking-panel';
 import { ToolCallCard } from './tool-call-card';
 import { SubagentTree } from './subagent-card';
 import { SessionMeter } from './session-meter';
 import { buildTree } from '@/hooks/use-subagent-tree';
+import { SpineTranscript, useSpineSlots } from './transcript-spine';
+import {
+  UserMessage,
+  AssistantRow,
+  ErrorItem,
+  NoticeItem,
+  BgJobItem,
+} from './message-row';
 
 // Re-export so consumers import from one place.
 export type { SessionTotals } from './session-meter';
@@ -41,6 +46,9 @@ export type TranscriptItem =
       durationMs?: number;
       totalCostUsd?: number;
       promptHead?: string;
+      turnCount?: number;
+      stopReason?: string;
+      parentToolUseId?: string;
     }
   | { kind: 'bg_job'; id: string; jobId: string; status: string; label: string };
 
@@ -49,68 +57,19 @@ import type { SessionTotals } from './session-meter';
 interface TranscriptViewProps {
   items: TranscriptItem[];
   totals?: SessionTotals;
-}
-
-function UserMessage({ text }: { text: string }) {
-  return (
-    <div className="flex gap-2">
-      <div className="w-0.5 shrink-0 rounded-full bg-brand" />
-      <p className="text-sm text-foreground leading-relaxed whitespace-pre-wrap">{text}</p>
-    </div>
-  );
-}
-
-function ErrorItem({ message }: { message: string }) {
-  return (
-    <div className="flex items-start gap-2 rounded-md border border-status-failed/40 bg-status-failed/5 px-3 py-2">
-      <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-status-failed" />
-      <p className="text-sm text-status-failed">{message}</p>
-    </div>
-  );
-}
-
-function NoticeItem({ text }: { text: string }) {
-  return (
-    <div className="flex items-start gap-2 rounded-md border border-border bg-muted/40 px-3 py-2">
-      <Info className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
-      <p className="text-xs text-muted-foreground">{text}</p>
-    </div>
-  );
-}
-
-function BgJobItem({ item }: { item: Extract<TranscriptItem, { kind: 'bg_job' }> }) {
-  return (
-    <div className="flex items-center gap-2 rounded-md border border-border bg-muted/30 px-3 py-1.5">
-      <span className="text-[10px] text-muted-foreground">BG</span>
-      <span className="text-xs text-foreground">{item.label}</span>
-      <span className={cn(
-        'ml-auto font-mono text-[10px] capitalize',
-        item.status === 'completed' ? 'text-status-running' : '',
-        item.status === 'failed' ? 'text-status-failed' : '',
-        item.status === 'running' ? 'text-status-blocked' : '',
-      )}>{item.status}</span>
-    </div>
-  );
+  /** When true, render execution blocks as topology spine trees. */
+  spineMode?: boolean;
 }
 
 // ---------------------------------------------------------------------------
-// Subagent group rendering
+// Legacy flat grouping (subagent-only groups)
 // ---------------------------------------------------------------------------
 
-/**
- * A "rendered slot" is either a non-subagent item or a contiguous run of
- * subagent items that should be displayed as a single tree block.
- *
- * Contract: subagent items that share the same parentage cluster naturally
- * because the ledger emits them in dispatch order. Grouping them into one
- * SubagentTree means parent→child relationships render correctly even when the
- * parent and child events appear in the same contiguous run.
- */
 type Slot =
   | { kind: 'item'; item: TranscriptItem }
   | { kind: 'subagent-group'; items: Extract<TranscriptItem, { kind: 'subagent' }>[]; id: string };
 
-function groupItems(items: TranscriptItem[]): Slot[] {
+export function groupItems(items: TranscriptItem[]): Slot[] {
   const slots: Slot[] = [];
   let i = 0;
 
@@ -124,7 +83,6 @@ function groupItems(items: TranscriptItem[]): Slot[] {
       continue;
     }
 
-    // Collect the contiguous subagent run.
     const subagentRun: Extract<TranscriptItem, { kind: 'subagent' }>[] = [];
     while (i < items.length) {
       const cur = items[i];
@@ -133,7 +91,6 @@ function groupItems(items: TranscriptItem[]): Slot[] {
       i++;
     }
 
-    // Use the first item's id as the stable group key.
     slots.push({ kind: 'subagent-group', items: subagentRun, id: subagentRun[0]!.id });
   }
 
@@ -141,56 +98,96 @@ function groupItems(items: TranscriptItem[]): Slot[] {
 }
 
 // ---------------------------------------------------------------------------
+// Shared item renderer (text items only in spine mode, all in flat mode)
+// ---------------------------------------------------------------------------
+
+export function renderNonSubagentItem(item: TranscriptItem): React.ReactNode {
+  switch (item.kind) {
+    case 'user':      return <UserMessage text={item.text} />;
+    case 'assistant': return <AssistantRow text={item.text} />;
+    case 'thinking':  return <ThinkingPanel text={item.text} />;
+    case 'tool':      return <ToolCallCard {...item} />;
+    case 'error':     return <ErrorItem message={item.message} />;
+    case 'notice':    return <NoticeItem text={item.text} />;
+    case 'bg_job':    return <BgJobItem item={item} />;
+    case 'subagent':  return null;
+  }
+}
+
+function renderTextItem(item: TranscriptItem): React.ReactNode {
+  switch (item.kind) {
+    case 'user':      return <UserMessage text={item.text} />;
+    case 'assistant': return <AssistantRow text={item.text} />;
+    case 'thinking':  return <ThinkingPanel text={item.text} />;
+    case 'error':     return <ErrorItem message={item.message} />;
+    case 'notice':    return <NoticeItem text={item.text} />;
+    case 'bg_job':    return <BgJobItem item={item} />;
+    default:          return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Main view
 // ---------------------------------------------------------------------------
 
 /** Root transcript container. Maps TranscriptItem[] to per-kind components. */
-export function TranscriptView({ items, totals }: TranscriptViewProps) {
-  const slots = useMemo(() => groupItems(items), [items]);
+export function TranscriptView({ items, totals, spineMode = true }: TranscriptViewProps) {
+  const flatSlots = useMemo(() => groupItems(items), [items]);
+  const spineSlots = useSpineSlots(items);
+
+  const renderSpineTextItem = useCallback(
+    (item: TranscriptItem, idx: number) => {
+      const isTurnStart = item.kind === 'user' && idx > 0;
+      return (
+        <div key={item.id}>
+          {isTurnStart && (
+            <div className="my-6 border-t border-border/40" aria-hidden="true" />
+          )}
+          <div className="py-2 px-1">{renderTextItem(item)}</div>
+        </div>
+      );
+    },
+    [],
+  );
 
   return (
-    <div className="flex flex-col gap-3">
+    <div className="flex flex-col gap-0 max-w-4xl mx-auto w-full">
       {totals && (
         <SessionMeter
           totals={totals}
-          className="sticky top-0 z-10 rounded-md border border-border bg-card px-3 py-1.5"
+          className="sticky top-0 z-10 mb-4 rounded-md border border-border bg-card px-3 py-1.5"
         />
       )}
       {items.length === 0 ? (
         <p className="py-12 text-center text-sm text-muted-foreground">
           No transcript items yet.
         </p>
+      ) : spineMode ? (
+        <SpineTranscript slots={spineSlots} renderTextItem={renderSpineTextItem} />
       ) : (
-        slots.map((slot) => {
+        flatSlots.map((slot, idx) => {
           if (slot.kind === 'item') {
             const { item } = slot;
+            const isTurnStart = item.kind === 'user' && idx > 0;
             return (
               <div key={item.id}>
-                {renderNonSubagentItem(item)}
+                {isTurnStart && (
+                  <div className="my-6 border-t border-border/40" aria-hidden="true" />
+                )}
+                <div className="py-2 px-1">
+                  {renderNonSubagentItem(item)}
+                </div>
               </div>
             );
           }
-
-          // Subagent group: build tree from the group then render.
           const roots = buildTree(slot.items);
           return (
-            <SubagentTree key={slot.id} roots={roots} />
+            <div key={slot.id} className="py-2 px-1">
+              <SubagentTree roots={roots} />
+            </div>
           );
         })
       )}
     </div>
   );
-}
-
-function renderNonSubagentItem(item: TranscriptItem): React.ReactNode {
-  switch (item.kind) {
-    case 'user':      return <UserMessage text={item.text} />;
-    case 'assistant': return <MarkdownContent text={item.text} />;
-    case 'thinking':  return <ThinkingPanel text={item.text} />;
-    case 'tool':      return <ToolCallCard {...item} />;
-    case 'error':     return <ErrorItem message={item.message} />;
-    case 'notice':    return <NoticeItem text={item.text} />;
-    case 'bg_job':    return <BgJobItem item={item} />;
-    case 'subagent':  return null; // handled by groupItems above
-  }
 }

--- a/dashboard/src/components/transcript-view.tsx
+++ b/dashboard/src/components/transcript-view.tsx
@@ -59,6 +59,8 @@ interface TranscriptViewProps {
   totals?: SessionTotals;
   /** When true, render execution blocks as topology spine trees. */
   spineMode?: boolean;
+  /** When true, the last assistant message is actively streaming. */
+  turnActive?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -101,10 +103,10 @@ export function groupItems(items: TranscriptItem[]): Slot[] {
 // Shared item renderer (text items only in spine mode, all in flat mode)
 // ---------------------------------------------------------------------------
 
-export function renderNonSubagentItem(item: TranscriptItem): React.ReactNode {
+export function renderNonSubagentItem(item: TranscriptItem, isStreaming = false): React.ReactNode {
   switch (item.kind) {
     case 'user':      return <UserMessage text={item.text} />;
-    case 'assistant': return <AssistantRow text={item.text} />;
+    case 'assistant': return <AssistantRow text={item.text} isStreaming={isStreaming} />;
     case 'thinking':  return <ThinkingPanel text={item.text} />;
     case 'tool':      return <ToolCallCard {...item} />;
     case 'error':     return <ErrorItem message={item.message} />;
@@ -114,10 +116,10 @@ export function renderNonSubagentItem(item: TranscriptItem): React.ReactNode {
   }
 }
 
-function renderTextItem(item: TranscriptItem): React.ReactNode {
+function renderTextItem(item: TranscriptItem, isStreaming = false): React.ReactNode {
   switch (item.kind) {
     case 'user':      return <UserMessage text={item.text} />;
-    case 'assistant': return <AssistantRow text={item.text} />;
+    case 'assistant': return <AssistantRow text={item.text} isStreaming={isStreaming} />;
     case 'thinking':  return <ThinkingPanel text={item.text} />;
     case 'error':     return <ErrorItem message={item.message} />;
     case 'notice':    return <NoticeItem text={item.text} />;
@@ -131,23 +133,32 @@ function renderTextItem(item: TranscriptItem): React.ReactNode {
 // ---------------------------------------------------------------------------
 
 /** Root transcript container. Maps TranscriptItem[] to per-kind components. */
-export function TranscriptView({ items, totals, spineMode = true }: TranscriptViewProps) {
+export function TranscriptView({ items, totals, spineMode = true, turnActive = false }: TranscriptViewProps) {
   const flatSlots = useMemo(() => groupItems(items), [items]);
   const spineSlots = useSpineSlots(items);
+
+  // Find the id of the last assistant item — only that one gets streaming animation.
+  const lastAssistantId = useMemo(() => {
+    for (let i = items.length - 1; i >= 0; i--) {
+      if (items[i]?.kind === 'assistant') return items[i]!.id;
+    }
+    return null;
+  }, [items]);
 
   const renderSpineTextItem = useCallback(
     (item: TranscriptItem, idx: number) => {
       const isTurnStart = item.kind === 'user' && idx > 0;
+      const streaming = turnActive && item.id === lastAssistantId;
       return (
         <div key={item.id}>
           {isTurnStart && (
             <div className="my-6 border-t border-border/40" aria-hidden="true" />
           )}
-          <div className="py-2 px-1">{renderTextItem(item)}</div>
+          <div className="py-2 px-1">{renderTextItem(item, streaming)}</div>
         </div>
       );
     },
-    [],
+    [turnActive, lastAssistantId],
   );
 
   return (
@@ -169,13 +180,14 @@ export function TranscriptView({ items, totals, spineMode = true }: TranscriptVi
           if (slot.kind === 'item') {
             const { item } = slot;
             const isTurnStart = item.kind === 'user' && idx > 0;
+            const streaming = turnActive && item.id === lastAssistantId;
             return (
               <div key={item.id}>
                 {isTurnStart && (
                   <div className="my-6 border-t border-border/40" aria-hidden="true" />
                 )}
                 <div className="py-2 px-1">
-                  {renderNonSubagentItem(item)}
+                  {renderNonSubagentItem(item, streaming)}
                 </div>
               </div>
             );

--- a/dashboard/src/globals.css
+++ b/dashboard/src/globals.css
@@ -48,6 +48,20 @@
   /* Brand */
   --color-brand: hsl(var(--brand));
 
+  /* Topology spine category colors */
+  --color-cat-read: hsl(var(--cat-read));
+  --color-cat-write: hsl(var(--cat-write));
+  --color-cat-shell: hsl(var(--cat-shell));
+  --color-cat-agent: hsl(var(--cat-agent));
+  --color-cat-skill: hsl(var(--cat-skill));
+  --color-cat-dag: hsl(var(--cat-dag));
+  --color-cat-mcp: hsl(var(--cat-mcp));
+  --color-cat-web: hsl(var(--cat-web));
+  --color-cat-browser: hsl(var(--cat-browser));
+  --color-cat-plan: hsl(var(--cat-plan));
+  --color-cat-other: hsl(var(--cat-other));
+  --color-spine: hsl(var(--spine));
+
   /* Radius */
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
@@ -93,6 +107,20 @@
     --status-done: 212 100% 68%;
     --status-failed: 3 93% 63%;
     --status-blocked: 39 67% 69%;
+
+    /* Topology categories */
+    --cat-read: 187 70% 35%;
+    --cat-write: 30 70% 45%;
+    --cat-shell: 40 80% 40%;
+    --cat-agent: 262 50% 50%;
+    --cat-skill: 330 50% 48%;
+    --cat-dag: 210 70% 45%;
+    --cat-mcp: 170 50% 38%;
+    --cat-web: 20 70% 48%;
+    --cat-browser: 142 50% 38%;
+    --cat-plan: 215 15% 55%;
+    --cat-other: 215 15% 55%;
+    --spine: 215 15% 80%;
   }
 
   .dark {
@@ -121,6 +149,20 @@
     --status-done: 212 100% 68%;
     --status-failed: 3 93% 63%;
     --status-blocked: 39 67% 69%;
+
+    /* Topology categories */
+    --cat-read: 187 80% 58%;      /* cyan - file reads */
+    --cat-write: 39 67% 69%;      /* amber - file writes */
+    --cat-shell: 48 100% 72%;     /* bright yellow - bash/shell */
+    --cat-agent: 262 60% 68%;     /* purple - subagent dispatch */
+    --cat-skill: 330 60% 65%;     /* pink - skill invocation */
+    --cat-dag: 210 80% 65%;       /* blue - DAG compose */
+    --cat-mcp: 170 60% 55%;       /* teal - MCP tools */
+    --cat-web: 20 76% 60%;        /* brand orange - web/http */
+    --cat-browser: 142 60% 55%;   /* green - browser tools */
+    --cat-plan: 215 8% 53%;       /* muted grey - plan mode */
+    --cat-other: 215 8% 53%;      /* muted grey - uncategorized */
+    --spine: 215 15% 25%;         /* dim border for spine lines */
   }
 }
 
@@ -142,6 +184,14 @@
   .animate-fade-in {
     animation: fade-in 0.15s ease-out;
   }
+
+  /* Tool call animations */
+  .animate-shimmer-pulse {
+    animation: shimmer-pulse 2s ease-in-out infinite;
+  }
+  .animate-spin-slow {
+    animation: spin 2s linear infinite;
+  }
 }
 
 @keyframes slide-in-right {
@@ -154,9 +204,16 @@
   to { opacity: 1; }
 }
 
+@keyframes shimmer-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .animate-slide-in-right,
   .animate-fade-in {
     animation: none;
   }
+  .animate-shimmer-pulse { animation: none; }
+  .animate-spin-slow { animation: none; }
 }

--- a/dashboard/src/hooks/use-scroll-pin.ts
+++ b/dashboard/src/hooks/use-scroll-pin.ts
@@ -15,20 +15,26 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 const PINNED_THRESHOLD_PX = 50;
 
+/** Distance from bottom beyond which the "New messages" button is shown. */
+const SHOW_BUTTON_THRESHOLD_PX = 200;
+
 export interface UseScrollPinResult {
   /** Attach this to the scrollable container element. */
   containerRef: React.RefObject<HTMLDivElement | null>;
-  /** Scroll to the bottom of the container. */
+  /** Scroll to the bottom of the container. Always works, regardless of pin state. */
   scrollToBottom: () => void;
   /** Whether the container is currently pinned to the bottom. */
   isPinned: boolean;
+  /** True when user is far enough from the bottom to show the "New messages" button. */
+  showScrollButton: boolean;
 }
 
 export function useScrollPin(): UseScrollPinResult {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [isPinned, setIsPinned] = useState(true);
+  const [showScrollButton, setShowScrollButton] = useState(false);
 
-  // Track pin state on scroll.
+  // Track pin state and button visibility on scroll.
   useEffect(() => {
     const el = containerRef.current;
     if (el === null) return;
@@ -37,6 +43,7 @@ export function useScrollPin(): UseScrollPinResult {
       if (el === null) return;
       const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
       setIsPinned(distanceFromBottom <= PINNED_THRESHOLD_PX);
+      setShowScrollButton(distanceFromBottom > SHOW_BUTTON_THRESHOLD_PX);
     }
 
     el.addEventListener('scroll', handleScroll, { passive: true });
@@ -46,9 +53,8 @@ export function useScrollPin(): UseScrollPinResult {
   const scrollToBottom = useCallback(() => {
     const el = containerRef.current;
     if (el === null) return;
-    if (!isPinned) return;
     el.scrollTop = el.scrollHeight;
-  }, [isPinned]);
+  }, []);
 
-  return { containerRef, scrollToBottom, isPinned };
+  return { containerRef, scrollToBottom, isPinned, showScrollButton };
 }

--- a/dashboard/src/lib/topology-types.ts
+++ b/dashboard/src/lib/topology-types.ts
@@ -15,9 +15,11 @@ export type ToolCategory =
 /**
  * A node in the topology spine tree.
  *
- * Invariant: `children` contains only nodes that were dispatched by this node
- * (subagent → subagent relationship via parentId). Root-level nodes have no
- * such link. Tool nodes are always standalone leaves.
+ * Invariant: `children` contains only nodes that were dispatched by this node.
+ * The primary linkage is parentToolUseId (subagent → tool node that called
+ * agent/compose). The secondary linkage is parentId (subagent → parent
+ * subagent, agent→agent nesting). Root-level nodes have no such link. Tool
+ * nodes that did not dispatch a subagent appear as standalone leaves.
  */
 export interface SpineNode {
   /** Stable unique id for React keys. */

--- a/dashboard/src/lib/topology-types.ts
+++ b/dashboard/src/lib/topology-types.ts
@@ -16,8 +16,8 @@ export type ToolCategory =
  * A node in the topology spine tree.
  *
  * Invariant: `children` contains only nodes that were dispatched by this node
- * (tool → subagent relationship via parentToolUseId, or subagent → subagent
- * via parentId). Root-level nodes have no such link.
+ * (subagent → subagent relationship via parentId). Root-level nodes have no
+ * such link. Tool nodes are always standalone leaves.
  */
 export interface SpineNode {
   /** Stable unique id for React keys. */

--- a/dashboard/src/lib/topology-types.ts
+++ b/dashboard/src/lib/topology-types.ts
@@ -1,0 +1,54 @@
+/** Tool category for icon + color mapping. */
+export type ToolCategory =
+  | 'read'
+  | 'write'
+  | 'shell'
+  | 'agent'
+  | 'skill'
+  | 'dag'
+  | 'mcp'
+  | 'web'
+  | 'browser'
+  | 'plan'
+  | 'other';
+
+/**
+ * A node in the topology spine tree.
+ *
+ * Invariant: `children` contains only nodes that were dispatched by this node
+ * (tool → subagent relationship via parentToolUseId, or subagent → subagent
+ * via parentId). Root-level nodes have no such link.
+ */
+export interface SpineNode {
+  /** Stable unique id for React keys. */
+  id: string;
+  kind: 'tool' | 'agent' | 'root';
+  /** Tool name or agent label. */
+  label: string;
+  category: ToolCategory;
+  status: 'running' | 'ok' | 'error' | 'cancelled';
+  /**
+   * For tool nodes: inputPreview of the tool call.
+   * For agent nodes: promptHead of the subagent.
+   */
+  preview?: string;
+  /** Elapsed milliseconds. */
+  durationMs?: number;
+  /** USD cost (agent nodes only). */
+  costUsd?: number;
+  /** Model used (agent nodes only). */
+  model?: string;
+  /** Agent type resolved label (agent nodes only, e.g. "research"). */
+  agentType?: string;
+  /** Number of conversation turns the subagent ran (agent nodes only). */
+  turnCount?: number;
+  /** Child nodes dispatched by this node. */
+  children: SpineNode[];
+  /** True when this node has no terminal status yet. */
+  isActive: boolean;
+  /**
+   * The toolUseId if this is a tool node, or subagentId if an agent node.
+   * Used as the linkage key between parent tools and child agents.
+   */
+  sourceId?: string;
+}

--- a/dashboard/src/lib/topology.ts
+++ b/dashboard/src/lib/topology.ts
@@ -1,0 +1,315 @@
+/**
+ * Topology spine data model — pure functions, no React.
+ *
+ * Builds a hierarchical SpineNode tree from a flat TranscriptItem array.
+ * The tree mirrors what the TUI's topology spine renders: tool calls are
+ * leaves; subagents that were dispatched by a tool call are children of that
+ * tool node; top-level subagents (no parentToolUseId) and tool calls that
+ * did not dispatch a subagent are roots.
+ *
+ * Invariant: `parentToolUseId` is the primary linkage. When it is absent (older
+ * sessions), subagents fall back to parentId-only nesting (agent→agent), or
+ * appear flat if neither link is present. Out-of-order SSE is handled by a
+ * two-pass approach: first pass builds nodes, second pass re-parents orphans.
+ */
+
+import type { TranscriptItem, ToolCallItem, SubagentItem } from '@/lib/ledger-adapter';
+import type { SpineNode, ToolCategory } from '@/lib/topology-types';
+
+// ---------------------------------------------------------------------------
+// Tool categorization
+// ---------------------------------------------------------------------------
+
+// Contract: every name in each set is lower-cased. Matching is exact (Map
+// lookup), with a prefix check for 'mcp__' before falling through to 'other'.
+const READ_TOOLS = new Set([
+  'read_file', 'glob', 'grep', 'list_directory', 'json_query',
+  'read_witness', 'search_witness', 'get_facet', 'clipboard_read',
+]);
+
+const WRITE_TOOLS = new Set([
+  'write_file', 'edit_file', 'patch_apply', 'clipboard_write', 'procedure_write',
+]);
+
+const SHELL_TOOLS = new Set(['bash', 'test_run', 'wait_for']);
+
+const AGENT_TOOLS = new Set(['agent', 'send_message_to_agent', 'cancel_background_job']);
+
+const SKILL_TOOLS = new Set(['skill']);
+
+const DAG_TOOLS = new Set(['compose']);
+
+const WEB_TOOLS = new Set(['web_scrape', 'web_request']);
+
+const BROWSER_TOOLS = new Set([
+  'browser_open', 'browser_act', 'browser_observe', 'browser_screenshot', 'browser_close',
+]);
+
+// Storage tools — grouped under 'other' per spec.
+const STORAGE_TOOLS = new Set([
+  'memory_search', 'memory_update',
+  'state_get', 'state_put', 'state_cas', 'state_delete', 'state_query',
+  'workspace_publish', 'workspace_query',
+]);
+
+/**
+ * Map a raw tool name to its display category.
+ *
+ * Contract: returns 'other' for any unrecognized name. MCP tools are
+ * identified by the 'mcp__' prefix (two underscores) before the server name.
+ */
+export function categorizeToolName(name: string): ToolCategory {
+  if (READ_TOOLS.has(name))    return 'read';
+  if (WRITE_TOOLS.has(name))   return 'write';
+  if (SHELL_TOOLS.has(name))   return 'shell';
+  if (AGENT_TOOLS.has(name))   return 'agent';
+  if (SKILL_TOOLS.has(name))   return 'skill';
+  if (DAG_TOOLS.has(name))     return 'dag';
+  if (WEB_TOOLS.has(name))     return 'web';
+  if (BROWSER_TOOLS.has(name)) return 'browser';
+  if (STORAGE_TOOLS.has(name)) return 'other';
+  if (name.startsWith('mcp__')) return 'mcp';
+  return 'other';
+}
+
+// ---------------------------------------------------------------------------
+// Duration + cost formatters
+// ---------------------------------------------------------------------------
+
+/**
+ * Format elapsed milliseconds in compact human-readable form.
+ *
+ * Contract: matches TUI spine format exactly.
+ *   <1000 ms  -> "<1s"
+ *   1-60 s    -> "X.Xs"
+ *   60+ s     -> "Xm Xs"
+ */
+export function formatSpineDuration(ms: number): string {
+  if (ms < 1000) return '<1s';
+  const totalSec = ms / 1000;
+  if (totalSec < 60) return `${totalSec.toFixed(1)}s`;
+  const minutes = Math.floor(totalSec / 60);
+  const seconds = Math.floor(totalSec % 60);
+  return `${minutes}m ${seconds}s`;
+}
+
+/**
+ * Format a USD cost value for display in the spine.
+ *
+ * Contract: values below $0.001 show as "<$0.001"; others show 3 decimal
+ * places (e.g. "$0.023").
+ */
+export function formatSpineCost(usd: number): string {
+  if (usd < 0.001) return '<$0.001';
+  return `$${usd.toFixed(3)}`;
+}
+
+// ---------------------------------------------------------------------------
+// SpineNode factories
+// ---------------------------------------------------------------------------
+
+function toolNodeStatus(status: ToolCallItem['status']): SpineNode['status'] {
+  if (status === 'error') return 'error';
+  if (status === 'ok')    return 'ok';
+  return 'running';
+}
+
+function subagentNodeStatus(status: string): SpineNode['status'] {
+  if (status === 'succeeded') return 'ok';
+  if (status === 'failed')    return 'error';
+  if (status === 'cancelled') return 'cancelled';
+  return 'running';
+}
+
+/** Build a SpineNode for a tool-call item. */
+function makeToolNode(tool: ToolCallItem): SpineNode {
+  const status = toolNodeStatus(tool.status);
+  return {
+    id: tool.id,
+    kind: 'tool',
+    label: tool.name,
+    category: categorizeToolName(tool.name),
+    status,
+    preview: tool.inputPreview,
+    durationMs: tool.durationMs,
+    children: [],
+    isActive: status === 'running',
+    sourceId: tool.toolUseId,
+  };
+}
+
+/** Build a SpineNode for a subagent item. */
+function makeAgentNode(sub: SubagentItem): SpineNode {
+  const status = subagentNodeStatus(sub.status);
+  return {
+    id: sub.id,
+    kind: 'agent',
+    label: sub.label,
+    category: 'agent',
+    status,
+    preview: sub.promptHead,
+    durationMs: sub.durationMs,
+    costUsd: sub.totalCostUsd,
+    model: sub.model,
+    agentType: sub.agentType,
+    turnCount: sub.turnCount,
+    children: [],
+    isActive: status === 'running',
+    sourceId: sub.subagentId,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main tree builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the topology spine tree from a flat TranscriptItem list.
+ *
+ * Algorithm:
+ *   1. Separate items into tool items and subagent items.
+ *   2. Build lookup maps: toolUseId → ToolCallItem, subagentId → SubagentItem.
+ *   3. Create SpineNodes for all tools and subagents.
+ *   4. Link subagent nodes to their dispatching tool node via parentToolUseId
+ *      (primary), or to a parent subagent node via parentId (secondary).
+ *   5. Tool nodes that have a subagent child become 'agent'-kind containers.
+ *      Pure tool nodes (no dispatched subagent) remain 'tool'-kind.
+ *   6. Second pass: re-parent any orphaned nodes whose parent appeared later.
+ *   7. Return root nodes (no parent link, or parent not found after both passes).
+ *
+ * Invariant: parentToolUseId is preferred over parentId when both are present.
+ * When neither is present, the subagent appears as a flat root item.
+ *
+ * Contract: items are processed in order — tools before subagents that
+ * reference them is the common case (SSE order). Out-of-order items are
+ * handled by the second pass.
+ */
+export function buildSpineTree(items: TranscriptItem[]): SpineNode[] {
+  // --- Pass 1: collect raw items ---
+  const toolItems: ToolCallItem[] = [];
+  const subagentItems: SubagentItem[] = [];
+
+  for (const item of items) {
+    if (item.kind === 'tool')     toolItems.push(item);
+    if (item.kind === 'subagent') subagentItems.push(item);
+  }
+
+  // Build lookup maps for O(1) linking.
+  const toolByUseId  = new Map<string, ToolCallItem>();
+  const subById      = new Map<string, SubagentItem>();
+
+  for (const t of toolItems) {
+    if (t.toolUseId) toolByUseId.set(t.toolUseId, t);
+  }
+  for (const s of subagentItems) {
+    subById.set(s.subagentId, s);
+  }
+
+  // --- Pass 2: build SpineNodes ---
+  // nodeByToolId: spine node for each tool item (keyed by item.id)
+  const nodeByToolId    = new Map<string, SpineNode>();
+  // nodeBySubId: spine node for each subagent (keyed by subagentId)
+  const nodeBySubId     = new Map<string, SpineNode>();
+  // Track which tool nodes have been claimed by a subagent (and should be
+  // promoted to agent-kind containers rather than standalone tool nodes).
+  const toolClaimedByAgent = new Set<string>(); // item.id of claimed tool nodes
+
+  for (const t of toolItems) {
+    nodeByToolId.set(t.id, makeToolNode(t));
+  }
+  for (const s of subagentItems) {
+    nodeBySubId.set(s.subagentId, makeAgentNode(s));
+  }
+
+  // --- Pass 3: link subagents to parent tool or parent subagent ---
+  const roots: SpineNode[] = [];
+  const orphanedAgentNodes: SpineNode[] = []; // may be re-parented in pass 4
+
+  for (const s of subagentItems) {
+    const agentNode = nodeBySubId.get(s.subagentId);
+    if (!agentNode) continue;
+
+    // Primary link: parentToolUseId → find the tool node that dispatched this.
+    if (s.parentToolUseId) {
+      const parentTool = toolByUseId.get(s.parentToolUseId);
+      if (parentTool) {
+        const parentToolNode = nodeByToolId.get(parentTool.id);
+        if (parentToolNode) {
+          // Promote the tool node to an agent-kind container.
+          parentToolNode.kind = 'agent';
+          parentToolNode.children.push(agentNode);
+          toolClaimedByAgent.add(parentTool.id);
+          continue;
+        }
+      }
+      // parentToolUseId set but tool node not yet seen — defer to pass 4.
+      orphanedAgentNodes.push(agentNode);
+      continue;
+    }
+
+    // Secondary link: parentId → nest under a parent subagent node.
+    if (s.parentId) {
+      const parentSubNode = nodeBySubId.get(s.parentId);
+      if (parentSubNode) {
+        parentSubNode.children.push(agentNode);
+        continue;
+      }
+      // Parent subagent not yet seen — defer to pass 4.
+      orphanedAgentNodes.push(agentNode);
+      continue;
+    }
+
+    // No link: flat root agent.
+    roots.push(agentNode);
+  }
+
+  // --- Pass 4: re-parent orphaned agent nodes ---
+  // Handles out-of-order SSE where a subagent arrived before its parent node.
+  const stillOrphaned: SpineNode[] = [];
+  for (const agentNode of orphanedAgentNodes) {
+    // Find the original SubagentItem to re-read its link fields.
+    const s = subagentItems.find((x) => x.subagentId === agentNode.sourceId);
+    if (!s) { roots.push(agentNode); continue; }
+
+    let placed = false;
+
+    if (s.parentToolUseId) {
+      const parentTool = toolByUseId.get(s.parentToolUseId);
+      if (parentTool) {
+        const parentToolNode = nodeByToolId.get(parentTool.id);
+        if (parentToolNode) {
+          parentToolNode.kind = 'agent';
+          parentToolNode.children.push(agentNode);
+          toolClaimedByAgent.add(parentTool.id);
+          placed = true;
+        }
+      }
+    }
+
+    if (!placed && s.parentId) {
+      const parentSubNode = nodeBySubId.get(s.parentId);
+      if (parentSubNode) {
+        parentSubNode.children.push(agentNode);
+        placed = true;
+      }
+    }
+
+    if (!placed) stillOrphaned.push(agentNode);
+  }
+
+  // Remaining orphans become roots.
+  for (const node of stillOrphaned) {
+    roots.push(node);
+  }
+
+  // --- Pass 5: add unclaimed tool nodes as roots ---
+  // Tools that were not claimed by any subagent appear as standalone tool leaves.
+  for (const t of toolItems) {
+    if (!toolClaimedByAgent.has(t.id)) {
+      const toolNode = nodeByToolId.get(t.id);
+      if (toolNode) roots.push(toolNode);
+    }
+  }
+
+  return roots;
+}

--- a/dashboard/src/lib/topology.ts
+++ b/dashboard/src/lib/topology.ts
@@ -3,14 +3,13 @@
  *
  * Builds a hierarchical SpineNode tree from a flat TranscriptItem array.
  * The tree mirrors what the TUI's topology spine renders: tool calls are
- * leaves; subagents that were dispatched by a tool call are children of that
- * tool node; top-level subagents (no parentToolUseId) and tool calls that
- * did not dispatch a subagent are roots.
+ * leaves; subagents are nested under their parent subagent node via parentId;
+ * top-level subagents (no parentId) appear as roots alongside standalone
+ * tool leaves.
  *
- * Invariant: `parentToolUseId` is the primary linkage. When it is absent (older
- * sessions), subagents fall back to parentId-only nesting (agent→agent), or
- * appear flat if neither link is present. Out-of-order SSE is handled by a
- * two-pass approach: first pass builds nodes, second pass re-parents orphans.
+ * Invariant: `parentId` is the sole linkage mechanism. When it is absent,
+ * the subagent appears as a flat root item. Out-of-order SSE is handled by
+ * a two-pass approach: first pass builds nodes, second pass re-parents orphans.
  */
 
 import type { TranscriptItem, ToolCallItem, SubagentItem } from '@/lib/ledger-adapter';
@@ -168,17 +167,17 @@ function makeAgentNode(sub: SubagentItem): SpineNode {
  *
  * Algorithm:
  *   1. Separate items into tool items and subagent items.
- *   2. Build lookup maps: toolUseId → ToolCallItem, subagentId → SubagentItem.
+ *   2. Build a lookup map: subagentId → SubagentItem.
  *   3. Create SpineNodes for all tools and subagents.
- *   4. Link subagent nodes to their dispatching tool node via parentToolUseId
- *      (primary), or to a parent subagent node via parentId (secondary).
- *   5. Tool nodes that have a subagent child become 'agent'-kind containers.
- *      Pure tool nodes (no dispatched subagent) remain 'tool'-kind.
+ *   4. Link subagent nodes to their parent subagent node via parentId.
+ *      Subagents with no parentId are roots.
+ *   5. Tool nodes appear as standalone leaves (they are never parents of
+ *      agents in this data model — there is no parentToolUseId field).
  *   6. Second pass: re-parent any orphaned nodes whose parent appeared later.
  *   7. Return root nodes (no parent link, or parent not found after both passes).
  *
- * Invariant: parentToolUseId is preferred over parentId when both are present.
- * When neither is present, the subagent appears as a flat root item.
+ * Invariant: parentId is the sole linkage mechanism. When absent, the
+ * subagent appears as a flat root item.
  *
  * Contract: items are processed in order — tools before subagents that
  * reference them is the common case (SSE order). Out-of-order items are
@@ -194,34 +193,20 @@ export function buildSpineTree(items: TranscriptItem[]): SpineNode[] {
     if (item.kind === 'subagent') subagentItems.push(item);
   }
 
-  // Build lookup maps for O(1) linking.
-  const toolByUseId  = new Map<string, ToolCallItem>();
-  const subById      = new Map<string, SubagentItem>();
-
-  for (const t of toolItems) {
-    if (t.toolUseId) toolByUseId.set(t.toolUseId, t);
-  }
-  for (const s of subagentItems) {
-    subById.set(s.subagentId, s);
-  }
-
   // --- Pass 2: build SpineNodes ---
-  // nodeByToolId: spine node for each tool item (keyed by item.id)
-  const nodeByToolId    = new Map<string, SpineNode>();
   // nodeBySubId: spine node for each subagent (keyed by subagentId)
-  const nodeBySubId     = new Map<string, SpineNode>();
-  // Track which tool nodes have been claimed by a subagent (and should be
-  // promoted to agent-kind containers rather than standalone tool nodes).
-  const toolClaimedByAgent = new Set<string>(); // item.id of claimed tool nodes
+  const nodeBySubId = new Map<string, SpineNode>();
 
   for (const t of toolItems) {
-    nodeByToolId.set(t.id, makeToolNode(t));
+    // Tool nodes are roots by default; we'll add them in pass 5.
+    // Build them here so nodeByToolId is available if needed in future passes.
+    void t; // tool nodes handled in pass 5
   }
   for (const s of subagentItems) {
     nodeBySubId.set(s.subagentId, makeAgentNode(s));
   }
 
-  // --- Pass 3: link subagents to parent tool or parent subagent ---
+  // --- Pass 3: link subagents to parent subagent via parentId ---
   const roots: SpineNode[] = [];
   const orphanedAgentNodes: SpineNode[] = []; // may be re-parented in pass 4
 
@@ -229,25 +214,7 @@ export function buildSpineTree(items: TranscriptItem[]): SpineNode[] {
     const agentNode = nodeBySubId.get(s.subagentId);
     if (!agentNode) continue;
 
-    // Primary link: parentToolUseId → find the tool node that dispatched this.
-    if (s.parentToolUseId) {
-      const parentTool = toolByUseId.get(s.parentToolUseId);
-      if (parentTool) {
-        const parentToolNode = nodeByToolId.get(parentTool.id);
-        if (parentToolNode) {
-          // Promote the tool node to an agent-kind container.
-          parentToolNode.kind = 'agent';
-          parentToolNode.children.push(agentNode);
-          toolClaimedByAgent.add(parentTool.id);
-          continue;
-        }
-      }
-      // parentToolUseId set but tool node not yet seen — defer to pass 4.
-      orphanedAgentNodes.push(agentNode);
-      continue;
-    }
-
-    // Secondary link: parentId → nest under a parent subagent node.
+    // Link: parentId → nest under a parent subagent node.
     if (s.parentId) {
       const parentSubNode = nodeBySubId.get(s.parentId);
       if (parentSubNode) {
@@ -273,20 +240,7 @@ export function buildSpineTree(items: TranscriptItem[]): SpineNode[] {
 
     let placed = false;
 
-    if (s.parentToolUseId) {
-      const parentTool = toolByUseId.get(s.parentToolUseId);
-      if (parentTool) {
-        const parentToolNode = nodeByToolId.get(parentTool.id);
-        if (parentToolNode) {
-          parentToolNode.kind = 'agent';
-          parentToolNode.children.push(agentNode);
-          toolClaimedByAgent.add(parentTool.id);
-          placed = true;
-        }
-      }
-    }
-
-    if (!placed && s.parentId) {
+    if (s.parentId) {
       const parentSubNode = nodeBySubId.get(s.parentId);
       if (parentSubNode) {
         parentSubNode.children.push(agentNode);
@@ -302,13 +256,11 @@ export function buildSpineTree(items: TranscriptItem[]): SpineNode[] {
     roots.push(node);
   }
 
-  // --- Pass 5: add unclaimed tool nodes as roots ---
-  // Tools that were not claimed by any subagent appear as standalone tool leaves.
+  // --- Pass 5: add all tool nodes as roots ---
+  // Tool nodes are standalone leaves — they are not parents of agents in this
+  // data model (there is no parentToolUseId field on SubagentItem).
   for (const t of toolItems) {
-    if (!toolClaimedByAgent.has(t.id)) {
-      const toolNode = nodeByToolId.get(t.id);
-      if (toolNode) roots.push(toolNode);
-    }
+    roots.push(makeToolNode(t));
   }
 
   return roots;

--- a/dashboard/src/lib/topology.ts
+++ b/dashboard/src/lib/topology.ts
@@ -3,13 +3,14 @@
  *
  * Builds a hierarchical SpineNode tree from a flat TranscriptItem array.
  * The tree mirrors what the TUI's topology spine renders: tool calls are
- * leaves; subagents are nested under their parent subagent node via parentId;
- * top-level subagents (no parentId) appear as roots alongside standalone
- * tool leaves.
+ * leaves; subagents that were dispatched by a tool call are children of that
+ * tool node; top-level subagents (no parentToolUseId) and tool calls that
+ * did not dispatch a subagent are roots.
  *
- * Invariant: `parentId` is the sole linkage mechanism. When it is absent,
- * the subagent appears as a flat root item. Out-of-order SSE is handled by
- * a two-pass approach: first pass builds nodes, second pass re-parents orphans.
+ * Invariant: `parentToolUseId` is the primary linkage. When it is absent (older
+ * sessions), subagents fall back to parentId-only nesting (agent→agent), or
+ * appear flat if neither link is present. Out-of-order SSE is handled by a
+ * two-pass approach: first pass builds nodes, second pass re-parents orphans.
  */
 
 import type { TranscriptItem, ToolCallItem, SubagentItem } from '@/lib/ledger-adapter';
@@ -166,62 +167,96 @@ function makeAgentNode(sub: SubagentItem): SpineNode {
  * Build the topology spine tree from a flat TranscriptItem list.
  *
  * Algorithm:
- *   1. Separate items into tool items and subagent items.
- *   2. Build a lookup map: subagentId → SubagentItem.
+ *   1. Separate items into tool items and subagent items; record input position
+ *      for each (used to sort roots into SSE arrival order at the end).
+ *   2. Build lookup maps: toolUseId → ToolCallItem (toolByUseId) and
+ *      item.id → SpineNode for tool nodes (nodeByToolId).
  *   3. Create SpineNodes for all tools and subagents.
- *   4. Link subagent nodes to their parent subagent node via parentId.
- *      Subagents with no parentId are roots.
- *   5. Tool nodes appear as standalone leaves (they are never parents of
- *      agents in this data model — there is no parentToolUseId field).
- *   6. Second pass: re-parent any orphaned nodes whose parent appeared later.
- *   7. Return root nodes (no parent link, or parent not found after both passes).
+ *   4. Link subagent nodes via parentToolUseId → tool node (primary). When the
+ *      tool node is found it is promoted to kind='agent' and the subagent
+ *      becomes its child; the tool is marked as "claimed".
+ *   5. Fallback: parentId → nest under a parent subagent node (agent→agent).
+ *   6. Second pass: re-parent any orphaned nodes using the same two-step logic.
+ *   7. Pass 5: add ONLY unclaimed tool nodes as roots.
+ *   8. Sort all roots by input position to preserve SSE arrival order.
  *
- * Invariant: parentId is the sole linkage mechanism. When absent, the
- * subagent appears as a flat root item.
+ * Invariant: parentToolUseId is the primary linkage mechanism. When absent
+ * (older sessions), parentId is the secondary linkage. When neither is present
+ * the subagent appears as a flat root item.
  *
  * Contract: items are processed in order — tools before subagents that
  * reference them is the common case (SSE order). Out-of-order items are
  * handled by the second pass.
  */
 export function buildSpineTree(items: TranscriptItem[]): SpineNode[] {
-  // --- Pass 1: collect raw items ---
+  // --- Pass 1: collect raw items + track input positions ---
   const toolItems: ToolCallItem[] = [];
   const subagentItems: SubagentItem[] = [];
+  // Track input position for SSE-order root sorting.
+  const inputPosition = new Map<string, number>();
 
-  for (const item of items) {
-    if (item.kind === 'tool')     toolItems.push(item);
-    if (item.kind === 'subagent') subagentItems.push(item);
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    if (item === undefined) continue;
+    if (item.kind === 'tool') {
+      toolItems.push(item);
+      inputPosition.set(item.id, i);
+    }
+    if (item.kind === 'subagent') {
+      subagentItems.push(item);
+      inputPosition.set(item.id, i);
+    }
+  }
+
+  // Build lookup maps for O(1) linking.
+  const toolByUseId = new Map<string, ToolCallItem>();
+  for (const t of toolItems) {
+    if (t.toolUseId) toolByUseId.set(t.toolUseId, t);
   }
 
   // --- Pass 2: build SpineNodes ---
-  // nodeBySubId: spine node for each subagent (keyed by subagentId)
+  const nodeByToolId = new Map<string, SpineNode>();
   const nodeBySubId = new Map<string, SpineNode>();
+  const toolClaimedByAgent = new Set<string>();
 
   for (const t of toolItems) {
-    // Tool nodes are roots by default; we'll add them in pass 5.
-    // Build them here so nodeByToolId is available if needed in future passes.
-    void t; // tool nodes handled in pass 5
+    nodeByToolId.set(t.id, makeToolNode(t));
   }
   for (const s of subagentItems) {
     nodeBySubId.set(s.subagentId, makeAgentNode(s));
   }
 
-  // --- Pass 3: link subagents to parent subagent via parentId ---
+  // --- Pass 3: link subagents to parent tool or parent subagent ---
   const roots: SpineNode[] = [];
-  const orphanedAgentNodes: SpineNode[] = []; // may be re-parented in pass 4
+  const orphanedAgentNodes: SpineNode[] = [];
 
   for (const s of subagentItems) {
     const agentNode = nodeBySubId.get(s.subagentId);
     if (!agentNode) continue;
 
-    // Link: parentId → nest under a parent subagent node.
+    // Primary link: parentToolUseId → find the tool node that dispatched this.
+    if (s.parentToolUseId) {
+      const parentTool = toolByUseId.get(s.parentToolUseId);
+      if (parentTool) {
+        const parentToolNode = nodeByToolId.get(parentTool.id);
+        if (parentToolNode) {
+          parentToolNode.kind = 'agent';
+          parentToolNode.children.push(agentNode);
+          toolClaimedByAgent.add(parentTool.id);
+          continue;
+        }
+      }
+      orphanedAgentNodes.push(agentNode);
+      continue;
+    }
+
+    // Secondary link: parentId → nest under a parent subagent node.
     if (s.parentId) {
       const parentSubNode = nodeBySubId.get(s.parentId);
       if (parentSubNode) {
         parentSubNode.children.push(agentNode);
         continue;
       }
-      // Parent subagent not yet seen — defer to pass 4.
       orphanedAgentNodes.push(agentNode);
       continue;
     }
@@ -234,13 +269,25 @@ export function buildSpineTree(items: TranscriptItem[]): SpineNode[] {
   // Handles out-of-order SSE where a subagent arrived before its parent node.
   const stillOrphaned: SpineNode[] = [];
   for (const agentNode of orphanedAgentNodes) {
-    // Find the original SubagentItem to re-read its link fields.
     const s = subagentItems.find((x) => x.subagentId === agentNode.sourceId);
     if (!s) { roots.push(agentNode); continue; }
 
     let placed = false;
 
-    if (s.parentId) {
+    if (s.parentToolUseId) {
+      const parentTool = toolByUseId.get(s.parentToolUseId);
+      if (parentTool) {
+        const parentToolNode = nodeByToolId.get(parentTool.id);
+        if (parentToolNode) {
+          parentToolNode.kind = 'agent';
+          parentToolNode.children.push(agentNode);
+          toolClaimedByAgent.add(parentTool.id);
+          placed = true;
+        }
+      }
+    }
+
+    if (!placed && s.parentId) {
       const parentSubNode = nodeBySubId.get(s.parentId);
       if (parentSubNode) {
         parentSubNode.children.push(agentNode);
@@ -251,17 +298,22 @@ export function buildSpineTree(items: TranscriptItem[]): SpineNode[] {
     if (!placed) stillOrphaned.push(agentNode);
   }
 
-  // Remaining orphans become roots.
   for (const node of stillOrphaned) {
     roots.push(node);
   }
 
-  // --- Pass 5: add all tool nodes as roots ---
-  // Tool nodes are standalone leaves — they are not parents of agents in this
-  // data model (there is no parentToolUseId field on SubagentItem).
+  // --- Pass 5: add unclaimed tool nodes as roots ---
+  // Only tool nodes that were NOT claimed by a subagent appear as standalone
+  // roots. Claimed nodes are already nested under their dispatching subagent.
   for (const t of toolItems) {
-    roots.push(makeToolNode(t));
+    if (!toolClaimedByAgent.has(t.id)) {
+      const toolNode = nodeByToolId.get(t.id);
+      if (toolNode) roots.push(toolNode);
+    }
   }
+
+  // Sort roots by input position to preserve SSE arrival order.
+  roots.sort((a, b) => (inputPosition.get(a.id) ?? 0) - (inputPosition.get(b.id) ?? 0));
 
   return roots;
 }

--- a/src/agent/session-ledger-project.ts
+++ b/src/agent/session-ledger-project.ts
@@ -72,6 +72,16 @@ export type LedgerPayload =
       errorClass?: string;
       errorMessage?: string;
       promptHead?: string;
+      /** Number of turns completed (present on succeeded events). */
+      turnCount?: number;
+      /** Provider stop reason from the last turn (present on succeeded events). */
+      stopReason?: string;
+      /**
+       * tool_use_id of the dispatching `agent`/`compose` call — links a subagent
+       * to the tool row that spawned it for topology rendering. Present on 'started'
+       * events only.
+       */
+      parentToolUseId?: string;
     }
   /** Background-job state transition (Wave 0-C / Wave 1). */
   | { kind: 'background_job'; jobId: string; status: string; label?: string }
@@ -191,6 +201,9 @@ export function projectOutputEvent(event: OutputEvent): LedgerPayload | null {
         ...(event.errorClass !== undefined ? { errorClass: event.errorClass } : {}),
         ...(event.errorMessage !== undefined ? { errorMessage: event.errorMessage } : {}),
         ...(event.promptHead !== undefined ? { promptHead: event.promptHead } : {}),
+        ...(event.turnCount != null ? { turnCount: event.turnCount } : {}),
+        ...(event.stopReason ? { stopReason: event.stopReason } : {}),
+        ...(event.parentToolUseId ? { parentToolUseId: event.parentToolUseId } : {}),
       };
     case 'background_job':
       return {

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -493,6 +493,8 @@ export class SubagentManager {
             subagentId: id,
             status: terminalStatus,
             ...(handle._lastDurationMs !== undefined ? { durationMs: handle._lastDurationMs } : {}),
+            ...(handle._currentTrace.turnCount > 0 ? { turnCount: handle._currentTrace.turnCount } : {}),
+            ...(handle._lastStopReason !== undefined ? { stopReason: handle._lastStopReason } : {}),
           });
           // Populate the completed cache BEFORE removing from active so that
           // the memory-first /tasks:view path can access the handle after
@@ -593,6 +595,7 @@ export class SubagentManager {
       ...(effectiveChildModel !== undefined ? { model: String(effectiveChildModel) } : {}),
       ...(effectiveAgentType !== undefined ? { agentType: effectiveAgentType } : {}),
       ...(options.promptHead !== undefined ? { promptHead: options.promptHead } : {}),
+      ...(options.parentId ? { parentToolUseId: options.parentId } : {}),
     });
 
     return handle;

--- a/src/agent/types/session-types.ts
+++ b/src/agent/types/session-types.ts
@@ -175,6 +175,16 @@ export type OutputEvent =
       errorClass?: string;
       errorMessage?: string;
       promptHead?: string;
+      /** Number of turns the subagent completed (present on succeeded events). */
+      turnCount?: number;
+      /** Provider stop reason from the subagent's last turn (present on succeeded events). */
+      stopReason?: string;
+      /**
+       * The tool_use_id of the `agent` / `compose` call that dispatched this
+       * subagent — links a subagent card to the tool row that spawned it,
+       * enabling topology rendering. Present on 'started' events only.
+       */
+      parentToolUseId?: string;
     }
   // Background-job state marker (Wave 0-C). Surfaces job transitions
   // (started / completed / failed / cancelled / delivered) to live UIs

--- a/src/web-server/shared/ledger-adapter.ts
+++ b/src/web-server/shared/ledger-adapter.ts
@@ -56,6 +56,12 @@ export type TranscriptItem =
       /** Total cost in USD from the terminal lifecycle event. */
       totalCostUsd?: number;
       promptHead?: string;
+      /** Number of conversation turns the subagent ran. */
+      turnCount?: number;
+      /** How the subagent stopped (e.g. 'end_turn', 'max_tokens'). */
+      stopReason?: string;
+      /** The toolUseId of the agent/compose call that spawned this subagent. */
+      parentToolUseId?: string;
     }
   | { kind: 'bg_job'; id: string; jobId: string; status: string; label: string };
 
@@ -317,6 +323,10 @@ export function ledgerRecordToItem(
           if (dur !== undefined) existing.durationMs = dur;
           const cost = num(record['totalCostUsd']);
           if (cost !== undefined) existing.totalCostUsd = cost;
+          const turns = num(record['turnCount']);
+          if (turns !== undefined) existing.turnCount = turns;
+          const stop = str(record['stopReason']);
+          if (stop !== undefined) existing.stopReason = stop;
           return undefined; // patched in place — no new item
         }
       }
@@ -333,6 +343,9 @@ export function ledgerRecordToItem(
         durationMs: num(record['durationMs']),
         totalCostUsd: num(record['totalCostUsd']),
         promptHead: str(record['promptHead']),
+        turnCount: num(record['turnCount']),
+        stopReason: str(record['stopReason']),
+        parentToolUseId: str(record['parentToolUseId']),
       };
 
       subagentIndex?.set(subId, item);


### PR DESCRIPTION
## What

Major overhaul of the web dashboard chat UI to match modern chat aesthetics (inspired by AgentGRAI-web) and port the TUI's topology spine as a distinctive web feature.

## Changes

### Chat Layout
- Full-width prose column with centered `max-w-4xl` layout
- Right-aligned user messages ("You" label), left-aligned assistant messages ("Agent" label) — no bubbles
- Turn separators between conversation turns
- Hover-revealed message actions (copy for assistant messages)

### Code & Markdown
- Syntax-highlighted code blocks via **shiki** with language label and hover copy button
- Async highlighter singleton — languages lazy-loaded per grammar

### Streaming Animation
- `requestAnimationFrame`-based character-by-character text reveal with blinking cursor
- Code-fence-aware: never splits mid-fence marker
- Only the last assistant message animates during active turns; replayed messages render instantly

### Tool Call Cards (rewrite)
- Category-aware icons (read/write/shell/agent/browser/etc.) with color coding
- CSS grid animated expand/collapse (no framer-motion)
- Shimmer-pulse running state with live elapsed timer
- Tool group wrapper with "Running tool N of M..." header and auto-collapse on completion

### Thinking Panel
- Brain icon with pulse animation during streaming
- Three-dot streaming indicator
- Character count badge
- Truncation at 200 chars with Show more/less toggle

### Topology Spine (new)
Port of the TUI's execution spine to the web:
- Hierarchical tree showing agent dispatches with nested tool calls
- Div-based connecting lines (vertical spine + horizontal stubs) — pure CSS, no SVG
- Category-colored icons matching the TUI palette (cyan=read, amber=write, yellow=shell, purple=agent, etc.)
- Collapsible agent nodes with closer summary lines ("Done (N tools · Xs · $X.XXX)")
- Spine mode enabled by default with fallback to flat view

### SSE Data Enrichment
- `turnCount`, `stopReason`, `parentToolUseId` added to subagent_lifecycle records
- All new fields are optional — zero breaking changes to existing consumers
- Enables richer topology tree building (linking subagents to their dispatch tool)

### Chrome & Polish
- Frosted glass input bar with `backdrop-blur-xl` and gradient fade
- New Session button in header
- Floating "New messages" scroll-to-bottom button
- Removed unused `react-router-dom` dependency

## File inventory

**10 new files** (all under 350 LOC):
- `message-row.tsx` (98) — extracted user/assistant/error/notice/bg-job components
- `code-block.tsx` (119) — shiki-powered syntax highlighting + copy button
- `streaming-text.tsx` (187) — rAF streaming animation + blinking cursor
- `tool-group.tsx` (181) — collapsible tool group wrapper
- `topology-types.ts` (54) — SpineNode + ToolCategory types
- `topology.ts` (315) — tree builder, category classifier, formatters
- `topology-spine.tsx` (61) — top-level spine container
- `topology-node.tsx` (319) — recursive tree node renderer
- `transcript-spine.tsx` (104) — spine-mode transcript grouping
- `message-actions.tsx` (85) — hover-revealed copy action

**14 modified files** across dashboard and agent core.

## Verification

- `pnpm build` ✓
- Web-server tests: 257/257 pass
- Dashboard tests: 23/23 pass
- TypeScript: zero new errors (2 pre-existing in unrelated test/settings files)
- All files under 350-LOC ceiling
