### PR TITLE
fix(browser): add debug logging for closeTab window.close() limitation (#1628)

### DIFF
--- a/src/browser/agent-browser/client.ts
+++ b/src/browser/agent-browser/client.ts
@@ -14,6 +14,7 @@
  */
 
 import type { AgentBrowserConnection } from './connection.js';
+import { debugLog } from '../../utils/debug.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -138,9 +139,13 @@ export class AgentBrowserClient {
     return { tabId: result.id };
   }
 
+  // window.close() is a no-op on non-script-opened WebKit tabs; tab leaks are expected
+  // until Agent Browser exposes a native close endpoint.
   async closeTab(tabId: string): Promise<void> {
     // v0.3.0 does not support tabs.close -- best-effort via navigation.
-    await this.call('page.eval', { id: tabId, script: 'window.close()' }).catch(() => {});
+    await this.call('page.eval', { id: tabId, script: 'window.close()' }).catch((err: unknown) => {
+      debugLog('[browser/agent-browser] closeTab window.close() failed (tab leak expected)', { tabId, err });
+    });
   }
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add debug-level logging and documentation to the `closeTab` method in the Agent Browser client.

**Closes #1628**

## Changes

- Replace silent `.catch(() => {})` on the `window.close()` eval with a catch that emits a `debugLog` message (visible when `AFK_DEBUG=1` or `DEBUG=1`)
- Add code comment above `closeTab` documenting the `window.close()` limitation (no-op on non-script-opened WebKit tabs)
- Uses the existing `debugLog` utility from `src/utils/debug.ts`, matching the pattern in `src/browser/playwright/launcher.ts`

## Verification

- `pnpm lint`: clean
- `vitest run src/browser/agent-browser/`: 33/33 tests pass
