### PR TITLE
fix(browser): drop envelope fallback in call<T>() for void-result methods (#1629)

### DIFF
--- a/src/browser/agent-browser/client.test.ts
+++ b/src/browser/agent-browser/client.test.ts
@@ -2,7 +2,8 @@
  * Unit tests for src/browser/agent-browser/client.ts
  *
  * Covers:
- * 1. Envelope unwrapping -- `ok: true` with `result` payload returns the payload directly
+ * 1. Envelope unwrapping -- `ok: true` with `result` payload returns the payload directly;
+ *    void-result methods (`ok: true`, no `result` key) return `undefined` (not the envelope)
  * 2. `ok: false` error path -- throws with structured `code`/`message` from server error
  * 3. `ok: false` edge cases -- `{ok: false, error: null}`, `{ok: false}` (missing error field), `{ok: 0}` (non-boolean falsy)
  * 4. `listTabs` -- returns array directly (not `{tabs:[...]}`), objects have `isLoading: boolean` and optional `isActive`
@@ -119,13 +120,23 @@ describe('AgentBrowserClient', () => {
       });
     });
 
-    it('falls back to envelope when result field is omitted (backward compatibility)', async () => {
-      const rawEnvelope = { ok: true, legacyData: 'fallback' };
-      mockFetchResponse(200, rawEnvelope);
+    it('returns undefined for void-result methods when result key is absent', async () => {
+      // v0.3.0 void-result response: { ok: true } with no `result` key.
+      // The caller receives `undefined`, NOT the envelope object. This guards
+      // against callers typed as Promise<void> silently receiving { ok: true }.
+      mockFetchResponse(200, { ok: true });
 
       const res = await client.evalScript('tab-1', '1 + 1');
 
-      expect(res).toEqual(rawEnvelope);
+      expect(res).toBeUndefined();
+    });
+
+    it('returns undefined for void-result methods when result is explicitly undefined', async () => {
+      mockFetchResponse(200, { ok: true, result: undefined });
+
+      const res = await client.evalScript('tab-1', 'void 0');
+
+      expect(res).toBeUndefined();
     });
   });
 

--- a/src/browser/agent-browser/client.ts
+++ b/src/browser/agent-browser/client.ts
@@ -104,6 +104,15 @@ export class AgentBrowserClient {
 
       // v0.3.0 wraps every response in { ok, result, error }. Unwrap the
       // envelope so callers receive the payload directly.
+      //
+      // Contract (v0.3.0+): `result` is the canonical payload key. For void-
+      // result methods (e.g. page.eval with no return value, page.click),
+      // `result` is absent or `undefined`, so `envelope['result']` evaluates to
+      // `undefined` — which is the correct value for `Promise<void>` callers.
+      //
+      // We do NOT fall back to the full envelope object (`?? envelope`) because
+      // that would silently hand callers the `{ ok: true }` wrapper instead of
+      // `undefined`, breaking any code that checks for a falsy return.
       const envelope = (await res.json()) as Record<string, unknown>;
       if (envelope['ok'] === false) {
         const err = envelope['error'] as Record<string, unknown> | undefined;
@@ -113,7 +122,7 @@ export class AgentBrowserClient {
           `Agent Browser ${method} failed: [${String(code)}] ${String(msg)}`,
         );
       }
-      return (envelope['result'] ?? envelope) as T;
+      return envelope['result'] as T;
     } finally {
       clearTimeout(timer);
     }


### PR DESCRIPTION
## Summary

Fix the `call<T>()` envelope unwrapping in `AgentBrowserClient` to return `undefined` instead of the raw `{ ok: true }` wrapper for void-result methods.

**Closes #1629**

## Problem

When Agent Browser v0.3.0 returns `{ ok: true }` with no `result` key (valid for void-result methods like `page.eval`), `envelope['result']` is `undefined`, so `?? envelope` falls through to the full envelope object. Callers typed as `Promise<T>` silently receive `{ ok: true }` instead of `undefined`.

## Fix

- Drop the `?? envelope` fallback: `return envelope['result'] as T`
- For void-result methods, `undefined as T` is correct
- Added detailed contract comment explaining the v0.3.0+ unwrapping semantics
- Updated tests: the old "backward compatibility fallback" test now asserts `undefined` is returned for void-result envelopes
- Added test for `result: undefined` explicitly present

## Verification

- `pnpm lint`: clean
- Browser tests: 33/33 pass (updated backward-compat test + new void-result test)
