### PR TITLE
ci(windows): add end-to-end CLI smoke test (#1603)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,6 +255,54 @@ jobs:
       - name: Test (no coverage gate — see job comment)
         run: pnpm test
 
+      - name: Build publish bundle (esbuild)
+        run: pnpm build:dist
+
+      - name: Smoke test — CLI --version (mandatory, issue #1603)
+        # Mirrors the equivalent step in the `publish-bundle` job but runs on
+        # Windows so we exercise shell resolution, path handling, and config
+        # loading on win32. A dummy API key bypasses the startup credential
+        # check (see the publish-bundle job comment for rationale — same quirk).
+        # Uses PowerShell (the default Windows shell on GitHub Actions) so we
+        # can capture stdout/stderr and inspect the exit code in one block.
+        shell: pwsh
+        env:
+          ANTHROPIC_API_KEY: sk-ant-dummy-not-used-version-only
+        run: |
+          $output = node dist/cli.mjs --version 2>&1
+          $exitCode = $LASTEXITCODE
+          Write-Host "afk --version exit code: $exitCode"
+          Write-Host "afk --version output: $output"
+          if ($exitCode -ne 0) {
+            Write-Host "::error::dist/cli.mjs --version exited $exitCode on Windows — integration broken"
+            exit 1
+          }
+          if ($output -notmatch '\d+\.\d+\.\d+') {
+            Write-Host "::error::dist/cli.mjs --version printed no semver on Windows"
+            exit 1
+          }
+          Write-Host "Windows CLI smoke test passed."
+
+      - name: Smoke test — CLI chat (conditional on API key, issue #1603)
+        # Only runs when ANTHROPIC_API_KEY is available as a repository secret.
+        # Skip gracefully (grey step) when no key is present — the mandatory
+        # --version step above already exercises the full boot path. This step
+        # goes one layer deeper: a real API round-trip through the Windows stack.
+        if: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+        shell: pwsh
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          $output = node dist/cli.mjs chat "respond with exactly the word OK" --model haiku -f json 2>&1
+          $exitCode = $LASTEXITCODE
+          Write-Host "afk chat exit code: $exitCode"
+          Write-Host "afk chat output: $output"
+          if ($exitCode -ne 0) {
+            Write-Host "::error::afk chat exited $exitCode on Windows"
+            exit 1
+          }
+          Write-Host "Windows chat smoke test passed."
+
   # Real-PTY scrollback harness (issue #541). Isolated from the main `test` job
   # because it depends on the native `node-pty` module (compiled from source on
   # Linux via pnpm.onlyBuiltDependencies — the same path better-sqlite3 already


### PR DESCRIPTION
## Summary

Add end-to-end CLI smoke tests to the Windows CI job so we catch integration failures beyond unit tests.

**Closes #1603**

## Changes

Added two new steps to the Windows CI job in `.github/workflows/ci.yml`:

1. **Build publish bundle** (`pnpm build:dist`) - required for CLI invocation
2. **Smoke test - CLI --version (mandatory)** - runs `node dist/cli.mjs --version` on Windows, validates semver output, uses PowerShell (the default Windows GHA shell). A dummy API key bypasses the startup credential check.
3. **Smoke test - CLI chat (conditional)** - runs a real API round-trip (`afk chat "respond with exactly the word OK" --model haiku -f json`) only when `ANTHROPIC_API_KEY` is available as a repo secret. Skips gracefully when no key is present.

## Design

- The `--version` check is mandatory and blocks the PR
- The `chat` test is conditional (`if: secrets.ANTHROPIC_API_KEY != ''`)
- Uses PowerShell syntax (`$LASTEXITCODE`, `Write-Host`, `-notmatch`) since that's the default Windows shell on GitHub Actions
- Mirrors the equivalent step in the `publish-bundle` job but exercises the Windows stack

## Verification

- YAML syntax validated
- `pnpm lint`: clean
