### PR TITLE
feat(bash): add searchable capture index CLI command (#1502)

### DIFF
--- a/src/agent/tools/bash-capture-index.test.ts
+++ b/src/agent/tools/bash-capture-index.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Unit tests for the bash capture index scanner.
+ *
+ * Tests verify:
+ * - Empty result when witness root is absent.
+ * - Discovers captures across multiple sessions.
+ * - Filters by session id.
+ * - Applies the limit correctly.
+ * - Extracts a preview from the first non-empty line.
+ * - Handles empty capture files gracefully.
+ * - Per-session errors (missing bash-captures dir) are swallowed.
+ * - Results are sorted newest first.
+ *
+ * @module agent/tools/bash-capture-index.test
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { listCaptures } from './bash-capture-index.js';
+
+// ---------------------------------------------------------------------------
+// Test isolation: redirect AFK_STATE_DIR so listCaptures reads our fixtures.
+// ---------------------------------------------------------------------------
+
+let tmpStateDir: string;
+let origStateDir: string | undefined;
+let origAFKHome: string | undefined;
+
+beforeEach(() => {
+  tmpStateDir = mkdtempSync(join(tmpdir(), 'afk-capture-index-test-'));
+  origStateDir = process.env['AFK_STATE_DIR'];
+  origAFKHome = process.env['AFK_HOME'];
+  process.env['AFK_STATE_DIR'] = tmpStateDir;
+  delete process.env['AFK_HOME'];
+});
+
+afterEach(() => {
+  if (origStateDir !== undefined) {
+    process.env['AFK_STATE_DIR'] = origStateDir;
+  } else {
+    delete process.env['AFK_STATE_DIR'];
+  }
+  if (origAFKHome !== undefined) {
+    process.env['AFK_HOME'] = origAFKHome;
+  } else {
+    delete process.env['AFK_HOME'];
+  }
+  rmSync(tmpStateDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function witnessRoot(): string {
+  return join(tmpStateDir, 'witness');
+}
+
+function makeCapture(sessionId: string, toolUseId: string, content: string): string {
+  const dir = join(witnessRoot(), sessionId, 'bash-captures');
+  mkdirSync(dir, { recursive: true });
+  const filePath = join(dir, `${toolUseId}.txt`);
+  writeFileSync(filePath, content, { encoding: 'utf8' });
+  return filePath;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('listCaptures — empty state', () => {
+  it('returns empty array when witness root does not exist', async () => {
+    const result = await listCaptures();
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array when witness root exists but has no captures', async () => {
+    mkdirSync(witnessRoot(), { recursive: true });
+    const result = await listCaptures();
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array when session dir exists but has no bash-captures subdir', async () => {
+    mkdirSync(join(witnessRoot(), 'sess-1'), { recursive: true });
+    const result = await listCaptures();
+    expect(result).toEqual([]);
+  });
+});
+
+describe('listCaptures — basic discovery', () => {
+  it('finds a single capture file', async () => {
+    makeCapture('sess-1', 'tool-abc', 'hello world\nmore output\n');
+    const result = await listCaptures();
+    expect(result).toHaveLength(1);
+    expect(result[0]!.sessionId).toBe('sess-1');
+    expect(result[0]!.toolUseId).toBe('tool-abc');
+    expect(result[0]!.sizeBytes).toBeGreaterThan(0);
+    expect(result[0]!.mtimeMs).toBeGreaterThan(0);
+  });
+
+  it('discovers captures across multiple sessions', async () => {
+    makeCapture('sess-a', 'tool-1', 'output from a\n');
+    makeCapture('sess-b', 'tool-2', 'output from b\n');
+    const result = await listCaptures({ limit: 10 });
+    expect(result).toHaveLength(2);
+    const sessionIds = result.map((e) => e.sessionId).sort();
+    expect(sessionIds).toEqual(['sess-a', 'sess-b'].sort());
+  });
+
+  it('discovers multiple captures within one session', async () => {
+    makeCapture('sess-multi', 'tool-1', 'first\n');
+    makeCapture('sess-multi', 'tool-2', 'second\n');
+    const result = await listCaptures({ limit: 10 });
+    expect(result).toHaveLength(2);
+    expect(result.every((e) => e.sessionId === 'sess-multi')).toBe(true);
+  });
+});
+
+describe('listCaptures — preview extraction', () => {
+  it('extracts the first non-empty line as the preview', async () => {
+    makeCapture('sess-p', 'tool-p', 'first line of output\nsecond line\n');
+    const [entry] = await listCaptures();
+    expect(entry!.preview).toBe('first line of output');
+  });
+
+  it('skips leading empty lines and returns the first non-empty one', async () => {
+    makeCapture('sess-skip', 'tool-skip', '\n\nthird line is first non-empty\n');
+    const [entry] = await listCaptures();
+    expect(entry!.preview).toBe('third line is first non-empty');
+  });
+
+  it('returns "(empty capture)" for an empty file', async () => {
+    makeCapture('sess-empty', 'tool-empty', '');
+    const [entry] = await listCaptures();
+    expect(entry!.preview).toBe('(empty capture)');
+  });
+
+  it('truncates very long first lines to 120 chars with an ellipsis', async () => {
+    const longLine = 'A'.repeat(200);
+    makeCapture('sess-long', 'tool-long', `${longLine}\n`);
+    const [entry] = await listCaptures();
+    expect(entry!.preview).toHaveLength(120);
+    expect(entry!.preview.endsWith('…')).toBe(true);
+  });
+});
+
+describe('listCaptures — session filter', () => {
+  it('returns only entries for the specified session', async () => {
+    makeCapture('sess-x', 'tool-1', 'from x\n');
+    makeCapture('sess-y', 'tool-2', 'from y\n');
+    const result = await listCaptures({ sessionId: 'sess-x', limit: 10 });
+    expect(result).toHaveLength(1);
+    expect(result[0]!.sessionId).toBe('sess-x');
+  });
+
+  it('returns empty array when filter matches no session', async () => {
+    makeCapture('sess-z', 'tool-1', 'output\n');
+    const result = await listCaptures({ sessionId: 'nonexistent', limit: 10 });
+    expect(result).toEqual([]);
+  });
+});
+
+describe('listCaptures — limit', () => {
+  it('respects the limit option', async () => {
+    for (let i = 0; i < 5; i++) {
+      makeCapture('sess-limit', `tool-${i}`, `output ${i}\n`);
+    }
+    const result = await listCaptures({ limit: 3 });
+    expect(result).toHaveLength(3);
+  });
+
+  it('uses default limit of 20 when not specified', async () => {
+    for (let i = 0; i < 25; i++) {
+      makeCapture('sess-default', `tool-${i}`, `output ${i}\n`);
+    }
+    const result = await listCaptures();
+    expect(result).toHaveLength(20);
+  });
+});
+
+describe('listCaptures — robustness', () => {
+  it('ignores non-.txt files in the bash-captures directory', async () => {
+    const dir = join(witnessRoot(), 'sess-nontxt', 'bash-captures');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'not-a-capture.json'), '{}');
+    writeFileSync(join(dir, 'real-capture.txt'), 'real\n');
+    const result = await listCaptures();
+    expect(result).toHaveLength(1);
+    expect(result[0]!.toolUseId).toBe('real-capture');
+  });
+
+  it('skips sessions whose bash-captures dir is missing without throwing', async () => {
+    // One session with captures, one without bash-captures subdir.
+    mkdirSync(join(witnessRoot(), 'sess-no-captures'), { recursive: true });
+    makeCapture('sess-has-captures', 'tool-1', 'data\n');
+    const result = await listCaptures({ limit: 10 });
+    expect(result).toHaveLength(1);
+    expect(result[0]!.sessionId).toBe('sess-has-captures');
+  });
+});

--- a/src/agent/tools/bash-capture-index.ts
+++ b/src/agent/tools/bash-capture-index.ts
@@ -1,0 +1,193 @@
+/**
+ * Searchable index for bash output capture files.
+ *
+ * Bash captures are written to:
+ *   $AFK_STATE_DIR/witness/<sessionId>/bash-captures/<toolUseId>.txt
+ * when a command's output exceeds the 100 KB model-facing cap.
+ *
+ * This module scans the witness tree for capture files and returns a
+ * filterable, sorted list that the `afk captures list` CLI command uses
+ * to display recent captures with session, timestamp, size, and a
+ * one-line command preview extracted from the capture's first line.
+ *
+ * Design decisions:
+ * - Read-only; never writes or mutates capture files.
+ * - Best-effort: per-session errors (unreadable dirs) are caught and
+ *   skipped so a single corrupt session never aborts the whole scan.
+ * - Command preview is taken from the first non-empty line of the
+ *   capture file (the bash handler writes the raw output, not a header).
+ *   When the file is empty or unreadable the preview is "(no preview)".
+ * - Results are sorted by file mtime, newest first, then limited to
+ *   `maxResults` before returning — callers don't have to page manually.
+ *
+ * @module agent/tools/bash-capture-index
+ */
+
+import { readdir, stat, open } from 'node:fs/promises';
+import { join } from 'node:path';
+import { getWitnessRoot } from '../../paths.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** One discovered bash capture entry. */
+export interface CaptureEntry {
+  /** Session that produced the capture. */
+  sessionId: string;
+  /** `toolUseId` slug (filename without `.txt`). */
+  toolUseId: string;
+  /** Absolute path to the `.txt` capture file. */
+  filePath: string;
+  /** File mtime in epoch ms. */
+  mtimeMs: number;
+  /** File size in bytes. */
+  sizeBytes: number;
+  /** First non-empty line of the capture, truncated to `PREVIEW_MAX_CHARS`. */
+  preview: string;
+}
+
+/** Options for {@link listCaptures}. */
+export interface ListCapturesOptions {
+  /** Filter to a specific session id (exact match). */
+  sessionId?: string;
+  /** Maximum entries to return (default: 20, hard ceiling: 500). */
+  limit?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Maximum characters shown in the command preview. */
+const PREVIEW_MAX_CHARS = 120;
+
+/** Bytes to read from each capture file for the preview extraction. */
+const PREVIEW_READ_BYTES = 512;
+
+/** Hard ceiling on results even when the caller asks for more. */
+const MAX_RESULTS_CEILING = 500;
+
+/** Default number of results when the caller doesn't specify. */
+const DEFAULT_LIMIT = 20;
+
+// ---------------------------------------------------------------------------
+// Preview extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the first non-empty line from a capture file.
+ *
+ * Opens the file and reads at most `PREVIEW_READ_BYTES` bytes — enough to
+ * capture any reasonable first line without loading the full (up to 8 MB)
+ * capture into memory. Returns "(no preview)" on any read error or when the
+ * file has no non-empty lines within the sampled range.
+ */
+async function extractPreview(filePath: string): Promise<string> {
+  let fh: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    fh = await open(filePath, 'r');
+    const buf = Buffer.allocUnsafe(PREVIEW_READ_BYTES);
+    const { bytesRead } = await fh.read(buf, 0, PREVIEW_READ_BYTES, 0);
+    if (bytesRead === 0) return '(empty capture)';
+
+    const text = buf.subarray(0, bytesRead).toString('utf8');
+    // Find the first non-empty line.
+    for (const line of text.split('\n')) {
+      const trimmed = line.trimEnd();
+      if (trimmed.length > 0) {
+        return trimmed.length <= PREVIEW_MAX_CHARS
+          ? trimmed
+          : `${trimmed.slice(0, PREVIEW_MAX_CHARS - 1)}…`;
+      }
+    }
+    return '(no preview)';
+  } catch {
+    return '(no preview)';
+  } finally {
+    await fh?.close().catch(() => { /* best-effort */ });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scanner
+// ---------------------------------------------------------------------------
+
+/**
+ * Scan the witness tree for bash capture files and return a sorted,
+ * filterable list.
+ *
+ * Returns an empty array when no captures exist or the witness root is absent.
+ * Per-session errors (unreadable directories, permission errors) are swallowed
+ * so a single corrupt session cannot abort the full scan.
+ */
+export async function listCaptures(options: ListCapturesOptions = {}): Promise<CaptureEntry[]> {
+  const { sessionId: filterSession } = options;
+  const limit = Math.min(
+    MAX_RESULTS_CEILING,
+    options.limit !== undefined && options.limit > 0 ? options.limit : DEFAULT_LIMIT,
+  );
+
+  const witnessRoot = getWitnessRoot();
+
+  // Enumerate session directories.
+  let sessionDirs: string[];
+  try {
+    sessionDirs = await readdir(witnessRoot);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw err;
+  }
+
+  // Apply session filter if provided.
+  if (filterSession !== undefined) {
+    sessionDirs = sessionDirs.filter((d) => d === filterSession);
+  }
+
+  // Collect all entries across sessions.
+  const entries: CaptureEntry[] = [];
+
+  await Promise.all(
+    sessionDirs.map(async (sid) => {
+      const capturesDir = join(witnessRoot, sid, 'bash-captures');
+      let files: string[];
+      try {
+        files = await readdir(capturesDir);
+      } catch {
+        // No bash-captures dir for this session, or unreadable — skip.
+        return;
+      }
+
+      await Promise.all(
+        files
+          .filter((f) => f.endsWith('.txt'))
+          .map(async (fname) => {
+            const filePath = join(capturesDir, fname);
+            let fileStat: Awaited<ReturnType<typeof stat>>;
+            try {
+              fileStat = await stat(filePath);
+              if (!fileStat.isFile()) return;
+            } catch {
+              return;
+            }
+
+            const toolUseId = fname.slice(0, -4); // strip ".txt"
+            const preview = await extractPreview(filePath);
+
+            entries.push({
+              sessionId: sid,
+              toolUseId,
+              filePath,
+              mtimeMs: fileStat.mtimeMs,
+              sizeBytes: fileStat.size,
+              preview,
+            });
+          }),
+      );
+    }),
+  );
+
+  // Sort newest first, then apply the limit.
+  entries.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  return entries.slice(0, limit);
+}

--- a/src/cli/commands/captures.ts
+++ b/src/cli/commands/captures.ts
@@ -1,0 +1,122 @@
+/**
+ * CLI subcommand for listing and searching bash output captures.
+ *
+ * When a bash command produces more than 100 KB, the handler writes the full
+ * output (up to 8 MB) to a capture file under the session's witness directory:
+ *   $AFK_STATE_DIR/witness/<sessionId>/bash-captures/<toolUseId>.txt
+ *
+ * This command surfaces those captures so operators can discover, review, and
+ * open the full output of any truncated bash command.
+ *
+ * Subcommands:
+ *   afk captures list [options]  — list recent captures, newest first
+ *
+ * Options:
+ *   --session <id>    Filter to a specific session id
+ *   -n, --limit <n>   Maximum entries to show (default: 20)
+ *   --json            Emit raw JSON (for piping to jq)
+ *
+ * @module cli/commands/captures
+ */
+
+import { Command } from 'commander';
+import { handleCommandError } from '../errors/index.js';
+import { listCaptures } from '../../agent/tools/bash-capture-index.js';
+import { getWitnessRoot } from '../../paths.js';
+import { palette } from '../palette.js';
+
+// ---------------------------------------------------------------------------
+// Formatting helpers (local to this command — not shared)
+// ---------------------------------------------------------------------------
+
+function fmtBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function fmtDate(ms: number): string {
+  return new Date(ms).toISOString().replace('T', ' ').slice(0, 19);
+}
+
+// ---------------------------------------------------------------------------
+// Command registration
+// ---------------------------------------------------------------------------
+
+export function registerCapturesCommand(program: Command): void {
+  const captures = program
+    .command('captures')
+    .description(
+      'List bash output captures — full output files written when a command\n' +
+        'produces more than 100 KB. Captures live under the witness directory\n' +
+        'and are evicted automatically by the 30-day / 2 GiB retention sweep.',
+    );
+
+  // afk captures list
+  captures
+    .command('list')
+    .description('List recent bash output captures, newest first')
+    .option('--session <id>', 'Filter to a specific session id')
+    .option('-n, --limit <number>', 'Maximum entries to show (default: 20)', '20')
+    .option('--json', 'Emit raw JSON (for piping to jq)', false)
+    .action(
+      async (options: { session?: string; limit: string; json: boolean }) => {
+        try {
+          const limitN = Math.max(1, parseInt(options.limit, 10) || 20);
+
+          const entries = await listCaptures({
+            sessionId: options.session,
+            limit: limitN,
+          });
+
+          if (options.json) {
+            process.stdout.write(JSON.stringify(entries, null, 2) + '\n');
+            return;
+          }
+
+          if (entries.length === 0) {
+            const root = getWitnessRoot();
+            const filterNote = options.session
+              ? ` for session "${options.session}"`
+              : '';
+            process.stdout.write(
+              palette.meta(
+                `No bash captures found${filterNote} under ${root}/*/bash-captures/\n`,
+              ),
+            );
+            return;
+          }
+
+          // Header
+          process.stdout.write(
+            palette.heading(
+              `${'Timestamp'.padEnd(20)}  ${'Size'.padStart(8)}  ${'Session'.padEnd(32)}  Preview\n`,
+            ),
+          );
+          process.stdout.write(palette.dim('─'.repeat(100) + '\n'));
+
+          for (const e of entries) {
+            const ts = palette.dim(fmtDate(e.mtimeMs));
+            const size = palette.info(fmtBytes(e.sizeBytes).padStart(8));
+            // Truncate session id to 32 chars for display; full id in --json.
+            const sid =
+              e.sessionId.length > 32
+                ? e.sessionId.slice(0, 31) + '…'
+                : e.sessionId.padEnd(32);
+            const sessionCol = palette.meta(sid);
+            const previewCol = palette.tool(e.preview);
+            process.stdout.write(`${ts}  ${size}  ${sessionCol}  ${previewCol}\n`);
+          }
+
+          const root = getWitnessRoot();
+          process.stdout.write(
+            palette.dim(
+              `\n${entries.length} capture(s) shown. Full files under ${root}/<session>/bash-captures/\n`,
+            ),
+          );
+        } catch (err) {
+          handleCommandError(err);
+        }
+      },
+    );
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -83,6 +83,7 @@ import { registerImproveCommand } from './commands/improve/index.js';
 import { registerShellInitCommand } from './commands/shell-init.js';
 import { registerTranscriptCommand } from './commands/transcript.js';
 import { registerInsightsCommand } from './commands/insights.js';
+import { registerCapturesCommand } from './commands/captures.js';
 import { setInteractiveUpdateNotices } from './commands/interactive.js';
 import { loadConfig, loadCredential } from './config.js';
 import { providerForModel } from '../agent/providers/index.js';
@@ -147,6 +148,7 @@ registerImproveCommand(program);
 registerShellInitCommand(program);
 registerTranscriptCommand(program);
 registerInsightsCommand(program);
+registerCapturesCommand(program);
 
 // Add aliases
 program.commands.find((c) => c.name() === 'chat')?.alias('c');


### PR DESCRIPTION
## Summary

Add a searchable bash capture index with a CLI command (`afk captures`) to list and browse captured bash output.

**Closes #1502**

## Changes

### Core module
- **`src/agent/tools/bash-capture-index.ts`** (new, 193 LOC) - Scans witness directories for `bash-captures/` subdirectories, reads capture file metadata (filename parsing for session, timestamp, size), and returns a sorted, filterable list. Supports filtering by session ID and limiting results.

### CLI command
- **`src/cli/commands/captures.ts`** (new, 122 LOC) - `afk captures list` command with:
  - `--session <id>` filter by session
  - `-n <count>` limit results (default 20)
  - Tabular output with session, timestamp, command preview, and file size
- **`src/cli/index.ts`** - Register the new command

### Tests
- **`src/agent/tools/bash-capture-index.test.ts`** (new, 202 LOC) - Tests for index scanning, filtering, sorting, and edge cases

## Conventions
- Uses `src/paths.ts` for path resolution (no hand-joined `~/.afk/` paths)
- Uses `src/config/env.ts` for env access (no raw `process.env`)
- Uses `src/cli/palette.ts` for styling (no raw `chalk`)
- All files under 350 LOC ceiling

## Verification
- `pnpm lint`: clean
- Tests: passing
