### PR TITLE
fix(windows): replace POSIX path assumptions with platform-agnostic APIs (#1600)

### DIFF
--- a/src/agent/marketplaces/resolve.ts
+++ b/src/agent/marketplaces/resolve.ts
@@ -129,7 +129,7 @@ function isRelativeOrLocal(source: string): boolean {
   return (
     source.startsWith('./') ||
     source.startsWith('../') ||
-    source.startsWith('/') ||
+    isAbsolute(source) ||
     source.startsWith('~')
   );
 }

--- a/src/agent/memory/memory-store.ts
+++ b/src/agent/memory/memory-store.ts
@@ -25,7 +25,7 @@ import {
   copyFileSync,
   renameSync,
 } from 'fs';
-import { join, basename, resolve, relative } from 'path';
+import { join, basename, resolve, relative, isAbsolute } from 'path';
 import { getMemoryDir } from '../../paths.js';
 import { debugLog } from '../../utils/debug.js';
 import { parseJsonlLines } from '../../utils/jsonl.js';
@@ -908,7 +908,7 @@ function isValidWALEntry(entry: unknown): entry is WALEntry {
 
 function assertWithinDir(filePath: string, dir: string): void {
   const rel = relative(dir, filePath);
-  if (rel.startsWith('..') || rel.startsWith('/')) {
+  if (rel.startsWith('..') || isAbsolute(rel)) {
     throw new Error('Path traversal detected');
   }
 }

--- a/src/agent/plugins/source.ts
+++ b/src/agent/plugins/source.ts
@@ -152,7 +152,7 @@ function looksLikePath(raw: string): boolean {
     raw.startsWith('./') ||
     raw.startsWith('../') ||
     raw.startsWith('~') ||
-    raw.startsWith('/')
+    isAbsolute(raw)
   );
 }
 

--- a/src/agent/session/prompt-dump.ts
+++ b/src/agent/session/prompt-dump.ts
@@ -10,8 +10,7 @@
 
 import { env } from '../../config/env.js';
 import { mkdirSync, appendFileSync, existsSync } from 'fs';
-import { resolve } from 'path';
-import { dirname } from 'path';
+import { resolve, dirname, isAbsolute } from 'path';
 import { looksLikeFilesystemPath } from '../redact-secrets.js';
 
 export type PromptShape = 'string' | 'string[]' | 'preset' | 'undefined';
@@ -97,7 +96,7 @@ function pathGuardedRedact(m: RegExpMatchArray): string {
       ? value.slice(1, -1)
       : value;
   const hasPathName = /(?:^|_)(?:PATH|FILE)(?:_|$)/i.test(name);
-  const hasPathPrefix = pathValue.startsWith('/') || pathValue.startsWith('~/');
+  const hasPathPrefix = isAbsolute(pathValue) || pathValue.startsWith('~/');
   // Secondary guard: real filesystem paths almost always have at least one segment
   // containing an uppercase letter, a digit, a dot, or a hyphen — characters that
   // appear naturally in directory names (e.g. `Users`, `.config`, `token.json`,
@@ -110,7 +109,7 @@ function pathGuardedRedact(m: RegExpMatchArray): string {
   // genuine filesystem paths. The guard is intentionally loose — `/usr/local/bin`
   // fails it (all lowercase, no digits/dots/hyphens), so those are redacted, which
   // is the safe side when the name already matched a secret keyword.
-  const segments = pathValue.split('/').filter(Boolean);
+  const segments = pathValue.split(/[\\/]/).filter(Boolean);
   const hasPathSignal = segments.some((s) => /[A-Z0-9.\-]/.test(s));
   if (hasPathName && hasPathPrefix && hasPathSignal && looksLikeFilesystemPath(pathValue)) {
     return `${name}=${value}`;

--- a/src/agent/tools/handlers/_cwd-utils.ts
+++ b/src/agent/tools/handlers/_cwd-utils.ts
@@ -307,7 +307,7 @@ export function extractCandidatePaths(command: string): string[] {
       .replace(/^['"]/, '')
       .replace(/['";,)]+$/, '');
     if (token.length === 0) continue;
-    const isAbsolute = token.startsWith('/');
+    const isAbsolute = path.isAbsolute(token);
     const isHomeRelative = token === '~' || token.startsWith('~/');
     if (!isAbsolute && !isHomeRelative) continue;
     if (seen.has(token)) continue;

--- a/src/agent/tools/handlers/test-run.ts
+++ b/src/agent/tools/handlers/test-run.ts
@@ -14,6 +14,7 @@
  */
 
 import { spawn } from 'child_process';
+import { dirname } from 'path';
 import type { ToolHandler, ToolHandlerContext } from '../types.js';
 import { discoverTestCommand, type DiscoveredRunner } from './test-run-discovery.js';
 import { detectTestResult } from './test-runner-detector.js';
@@ -104,8 +105,10 @@ function buildArgv(
     }
     case 'go-test': {
       if (file) {
-        // go test takes a package path, not a file; use the file's dir
-        const pkg = file.includes('/') ? file.split('/').slice(0, -1).join('/') || './...' : './...';
+        // go test takes a package path, not a file; use the file's dir.
+        // path.dirname() handles both / and \ separators (Windows-safe).
+        const dir = dirname(file);
+        const pkg = dir === '.' ? './...' : dir;
         argv[argv.length - 1] = pkg; // replace ./...
       }
       if (name) argv.push('-run', name);

--- a/src/improve/scan/reader.ts
+++ b/src/improve/scan/reader.ts
@@ -22,7 +22,7 @@
  */
 
 import { readFileSync, readdirSync, statSync } from 'fs';
-import { join } from 'path';
+import { join, sep } from 'path';
 import { TraceEventSchema } from '../../agent/trace/events.js';
 import type { TraceEvent } from '../../agent/trace/types.js';
 import { getWitnessRoot } from '../paths.js';
@@ -255,7 +255,7 @@ function pathRelativeTo(absolutePath: string, root: string): string {
   if (!root) return absolutePath;
   if (absolutePath.startsWith(root)) {
     let rel = absolutePath.slice(root.length);
-    if (rel.startsWith('/')) rel = rel.slice(1);
+    if (rel.startsWith('/') || rel.startsWith(sep)) rel = rel.slice(1);
     return rel;
   }
   return absolutePath;


### PR DESCRIPTION
## Summary

Systematic audit and fix of POSIX path assumptions in production code under `src/`.

**Addresses #1600**

## Changes (7 files, 15 insertions, 13 deletions)

| File | What was fixed |
|------|---------------|
| `src/agent/marketplaces/resolve.ts` | `startsWith('/')` for absolute path detection -> `isAbsolute()` |
| `src/agent/memory/memory-store.ts` | Path traversal check `startsWith('/')` -> `isAbsolute()` |
| `src/agent/plugins/source.ts` | `looksLikePath()` used `startsWith('/')` -> `isAbsolute()` |
| `src/agent/session/prompt-dump.ts` | Path prefix check `startsWith('/')` -> `isAbsolute()`; path splitting `split('/')` -> `split(/[\\/]/)` |
| `src/agent/tools/handlers/_cwd-utils.ts` | `token.startsWith('/')` -> `path.isAbsolute(token)` |
| `src/agent/tools/handlers/test-run.ts` | Go test file-to-package extraction via `split('/')` -> `path.dirname()` |
| `src/improve/scan/reader.ts` | Relative path extraction `startsWith('/')` -> checks both `/` and `path.sep` |

## What was NOT changed (and why)

- URL paths, import specifiers, and API route strings (`/api/...`) - these are protocol paths, not filesystem paths
- Test files - excluded per issue scope
- Instances already using `path.*` APIs correctly
- `os.tmpdir()` - no hardcoded `/tmp` found in production code

## Verification

- `pnpm lint`: clean
- All existing tests pass
